### PR TITLE
[FLINK-37003][Datastream] Implement async state version of Datastream Interval join

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/declare/ContextVariable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/declare/ContextVariable.java
@@ -48,6 +48,7 @@ public class ContextVariable<T> {
     }
 
     public void set(T newValue) {
+        initialized = true;
         manager.setVariableValue(ordinal, newValue);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperator.java
@@ -503,16 +503,20 @@ public abstract class AbstractAsyncStateStreamOperator<OUT> extends AbstractStre
     @Override
     public void finish() throws Exception {
         super.finish();
-        if (isAsyncStateProcessingEnabled()) {
-            asyncExecutionController.drainInflightRecords(0);
-        }
+        closeIfNeeded();
     }
 
     @Override
     public void close() throws Exception {
         super.close();
-        if (isAsyncStateProcessingEnabled()) {
-            asyncExecutionController.close();
+        closeIfNeeded();
+    }
+
+    private void closeIfNeeded() {
+        if (isAsyncStateProcessingEnabled()
+                && !getContainingTask().isFailing()
+                && !getContainingTask().isCanceled()) {
+            asyncExecutionController.drainInflightRecords(0);
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateUdfStreamOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateUdfStreamOperator.java
@@ -25,6 +25,8 @@ import org.apache.flink.api.common.functions.Function;
 import org.apache.flink.api.common.functions.util.FunctionUtils;
 import org.apache.flink.api.common.state.CheckpointListener;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.runtime.asyncprocessing.declare.DeclarationContext;
+import org.apache.flink.runtime.asyncprocessing.functions.AsyncStatefulRichFunction;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
@@ -60,6 +62,8 @@ public abstract class AbstractAsyncStateUdfStreamOperator<OUT, F extends Functio
 
     /** The user function. */
     protected final F userFunction;
+
+    protected transient DeclarationContext declarationContext;
 
     public AbstractAsyncStateUdfStreamOperator(F userFunction) {
         this.userFunction = requireNonNull(userFunction);
@@ -106,7 +110,13 @@ public abstract class AbstractAsyncStateUdfStreamOperator<OUT, F extends Functio
     @Override
     public void open() throws Exception {
         super.open();
-        FunctionUtils.openFunction(userFunction, DefaultOpenContext.INSTANCE);
+        declarationContext = new DeclarationContext(getDeclarationManager());
+        if (userFunction instanceof AsyncStatefulRichFunction) {
+            ((AsyncStatefulRichFunction) userFunction).open(declarationContext);
+        } else {
+            // normal user function open.
+            FunctionUtils.openFunction(userFunction, DefaultOpenContext.INSTANCE);
+        }
     }
 
     @Override
@@ -120,7 +130,12 @@ public abstract class AbstractAsyncStateUdfStreamOperator<OUT, F extends Functio
     @Override
     public void close() throws Exception {
         super.close();
-        FunctionUtils.closeFunction(userFunction);
+        if (userFunction instanceof AsyncStatefulRichFunction) {
+            ((AsyncStatefulRichFunction) userFunction).close();
+        } else {
+            // normal user function close.
+            FunctionUtils.closeFunction(userFunction);
+        }
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AsyncIntervalJoinOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AsyncIntervalJoinOperator.java
@@ -1,0 +1,430 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.asyncprocessing.operators;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.state.v2.MapState;
+import org.apache.flink.api.common.state.v2.StateFuture;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.ListSerializer;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.runtime.asyncprocessing.declare.DeclarationContext;
+import org.apache.flink.runtime.asyncprocessing.declare.DeclaredVariable;
+import org.apache.flink.runtime.state.v2.MapStateDescriptor;
+import org.apache.flink.streaming.api.functions.co.ProcessJoinFunction;
+import org.apache.flink.streaming.api.operators.InternalTimer;
+import org.apache.flink.streaming.api.operators.InternalTimerService;
+import org.apache.flink.streaming.api.operators.Triggerable;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.api.operators.co.IntervalJoinOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.OutputTag;
+import org.apache.flink.util.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * An {@link TwoInputStreamOperator operator} to execute time-bounded stream inner joins. This is
+ * the async state access version of {@link IntervalJoinOperator}.
+ *
+ * <p>By using a configurable lower and upper bound this operator will emit exactly those pairs (T1,
+ * T2) where t2.ts ∈ [T1.ts + lowerBound, T1.ts + upperBound]. Both the lower and the upper bound
+ * can be configured to be either inclusive or exclusive.
+ *
+ * <p>As soon as elements are joined they are passed to a user-defined {@link ProcessJoinFunction}.
+ *
+ * <p>The basic idea of this implementation is as follows: Whenever we receive an element at {@link
+ * #processElement1(StreamRecord)} (a.k.a. the left side), we add it to the left buffer. We then
+ * check the right buffer to see whether there are any elements that can be joined. If there are,
+ * they are joined and passed to the aforementioned function. The same happens the other way around
+ * when receiving an element on the right side.
+ *
+ * <p>Whenever a pair of elements is emitted it will be assigned the max timestamp of either of the
+ * elements.
+ *
+ * <p>In order to avoid the element buffers to grow indefinitely a cleanup timer is registered per
+ * element. This timer indicates when an element is not considered for joining anymore and can be
+ * removed from the state.
+ *
+ * @param <K> The type of the key based on which we join elements.
+ * @param <T1> The type of the elements in the left stream.
+ * @param <T2> The type of the elements in the right stream.
+ * @param <OUT> The output type created by the user-defined function.
+ */
+@Internal
+public class AsyncIntervalJoinOperator<K, T1, T2, OUT>
+        extends AbstractAsyncStateUdfStreamOperator<OUT, ProcessJoinFunction<T1, T2, OUT>>
+        implements TwoInputStreamOperator<T1, T2, OUT>, Triggerable<K, String> {
+
+    private static final long serialVersionUID = -5380774605111543477L;
+
+    private static final Logger logger = LoggerFactory.getLogger(AsyncIntervalJoinOperator.class);
+
+    private static final String LEFT_BUFFER = "LEFT_BUFFER";
+    private static final String RIGHT_BUFFER = "RIGHT_BUFFER";
+    private static final String CLEANUP_TIMER_NAME = "CLEANUP_TIMER";
+    private static final String CLEANUP_NAMESPACE_LEFT = "CLEANUP_LEFT";
+    private static final String CLEANUP_NAMESPACE_RIGHT = "CLEANUP_RIGHT";
+
+    private final long lowerBound;
+    private final long upperBound;
+    private final OutputTag<T1> leftLateDataOutputTag;
+    private final OutputTag<T2> rightLateDataOutputTag;
+    private final TypeSerializer<T1> leftTypeSerializer;
+    private final TypeSerializer<T2> rightTypeSerializer;
+
+    private transient MapState<Long, List<IntervalJoinOperator.BufferEntry<T1>>> leftBuffer;
+    private transient MapState<Long, List<IntervalJoinOperator.BufferEntry<T2>>> rightBuffer;
+
+    private transient DeclarationContext declarationContext;
+
+    // Shared timestamp variable for collector and context.
+    private transient DeclaredVariable<Long> resultTimestamp;
+    private transient DeclaredVariable<Long> leftTimestamp;
+    private transient DeclaredVariable<Long> rightTimestamp;
+
+    private transient TimestampedCollectorWithDeclaredVariable<OUT> collector;
+    private transient ContextImpl context;
+
+    private transient InternalTimerService<String> internalTimerService;
+
+    /**
+     * Creates a new IntervalJoinOperator.
+     *
+     * @param lowerBound The lower bound for evaluating if elements should be joined
+     * @param upperBound The upper bound for evaluating if elements should be joined
+     * @param lowerBoundInclusive Whether or not to include elements where the timestamp matches the
+     *     lower bound
+     * @param upperBoundInclusive Whether or not to include elements where the timestamp matches the
+     *     upper bound
+     * @param udf A user-defined {@link ProcessJoinFunction} that gets called whenever two elements
+     *     of T1 and T2 are joined
+     */
+    public AsyncIntervalJoinOperator(
+            long lowerBound,
+            long upperBound,
+            boolean lowerBoundInclusive,
+            boolean upperBoundInclusive,
+            OutputTag<T1> leftLateDataOutputTag,
+            OutputTag<T2> rightLateDataOutputTag,
+            TypeSerializer<T1> leftTypeSerializer,
+            TypeSerializer<T2> rightTypeSerializer,
+            ProcessJoinFunction<T1, T2, OUT> udf) {
+
+        super(Preconditions.checkNotNull(udf));
+
+        Preconditions.checkArgument(
+                lowerBound <= upperBound, "lowerBound <= upperBound must be fulfilled");
+
+        // Move buffer by +1 / -1 depending on inclusiveness in order not needing
+        // to check for inclusiveness later on
+        this.lowerBound = (lowerBoundInclusive) ? lowerBound : lowerBound + 1L;
+        this.upperBound = (upperBoundInclusive) ? upperBound : upperBound - 1L;
+
+        this.leftLateDataOutputTag = leftLateDataOutputTag;
+        this.rightLateDataOutputTag = rightLateDataOutputTag;
+        this.leftTypeSerializer = Preconditions.checkNotNull(leftTypeSerializer);
+        this.rightTypeSerializer = Preconditions.checkNotNull(rightTypeSerializer);
+    }
+
+    @Override
+    public void open() throws Exception {
+        super.open();
+        declarationContext = new DeclarationContext(getDeclarationManager());
+        this.leftBuffer =
+                getRuntimeContext()
+                        .getMapState(
+                                new MapStateDescriptor<>(
+                                        LEFT_BUFFER,
+                                        LongSerializer.INSTANCE,
+                                        new ListSerializer<>(
+                                                new IntervalJoinOperator.BufferEntrySerializer<>(
+                                                        leftTypeSerializer))));
+
+        this.rightBuffer =
+                getRuntimeContext()
+                        .getMapState(
+                                new MapStateDescriptor<>(
+                                        RIGHT_BUFFER,
+                                        LongSerializer.INSTANCE,
+                                        new ListSerializer<>(
+                                                new IntervalJoinOperator.BufferEntrySerializer<>(
+                                                        rightTypeSerializer))));
+
+        resultTimestamp =
+                declarationContext.declareVariable(
+                        LongSerializer.INSTANCE,
+                        "_AsyncIntervalJoinOperator$resultTime",
+                        () -> Long.MIN_VALUE);
+        leftTimestamp =
+                declarationContext.declareVariable(
+                        LongSerializer.INSTANCE,
+                        "_AsyncIntervalJoinOperator$leftTime",
+                        () -> Long.MIN_VALUE);
+        rightTimestamp =
+                declarationContext.declareVariable(
+                        LongSerializer.INSTANCE,
+                        "_AsyncIntervalJoinOperator$rightTime",
+                        () -> Long.MIN_VALUE);
+
+        collector = new TimestampedCollectorWithDeclaredVariable<>(output, resultTimestamp);
+        context = new ContextImpl(userFunction, resultTimestamp, leftTimestamp, rightTimestamp);
+        internalTimerService =
+                getInternalTimerService(CLEANUP_TIMER_NAME, StringSerializer.INSTANCE, this);
+    }
+
+    /**
+     * Process a {@link StreamRecord} from the left stream. Whenever an {@link StreamRecord} arrives
+     * at the left stream, it will get added to the left buffer. Possible join candidates for that
+     * element will be looked up from the right buffer and if the pair lies within the user defined
+     * boundaries, it gets passed to the {@link ProcessJoinFunction}.
+     *
+     * @param record An incoming record to be joined
+     * @throws Exception Can throw an Exception during state access
+     */
+    @Override
+    public void processElement1(StreamRecord<T1> record) throws Exception {
+        processElement(record, leftBuffer, rightBuffer, lowerBound, upperBound, true);
+    }
+
+    /**
+     * Process a {@link StreamRecord} from the right stream. Whenever a {@link StreamRecord} arrives
+     * at the right stream, it will get added to the right buffer. Possible join candidates for that
+     * element will be looked up from the left buffer and if the pair lies within the user defined
+     * boundaries, it gets passed to the {@link ProcessJoinFunction}.
+     *
+     * @param record An incoming record to be joined
+     * @throws Exception Can throw an exception during state access
+     */
+    @Override
+    public void processElement2(StreamRecord<T2> record) throws Exception {
+        processElement(record, rightBuffer, leftBuffer, -upperBound, -lowerBound, false);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <THIS, OTHER> void processElement(
+            final StreamRecord<THIS> record,
+            final MapState<Long, List<IntervalJoinOperator.BufferEntry<THIS>>> ourBuffer,
+            final MapState<Long, List<IntervalJoinOperator.BufferEntry<OTHER>>> otherBuffer,
+            final long relativeLowerBound,
+            final long relativeUpperBound,
+            final boolean isLeft)
+            throws Exception {
+
+        final THIS ourValue = record.getValue();
+        final long ourTimestamp = record.getTimestamp();
+
+        if (ourTimestamp == Long.MIN_VALUE) {
+            throw new FlinkException(
+                    "Long.MIN_VALUE timestamp: Elements used in "
+                            + "interval stream joins need to have timestamps meaningful timestamps.");
+        }
+
+        if (isLate(ourTimestamp)) {
+            sideOutput(ourValue, ourTimestamp, isLeft);
+            return;
+        }
+
+        addToBuffer(ourBuffer, ourValue, ourTimestamp)
+                .thenAccept(
+                        (empty) -> {
+                            for (Map.Entry<Long, List<IntervalJoinOperator.BufferEntry<OTHER>>>
+                                    bucket : otherBuffer.entries()) {
+                                final long timestamp = bucket.getKey();
+
+                                if (timestamp < ourTimestamp + relativeLowerBound
+                                        || timestamp > ourTimestamp + relativeUpperBound) {
+                                    continue;
+                                }
+
+                                for (IntervalJoinOperator.BufferEntry<OTHER> entry :
+                                        bucket.getValue()) {
+                                    if (isLeft) {
+                                        collect(
+                                                (T1) ourValue,
+                                                (T2) entry.getElement(),
+                                                ourTimestamp,
+                                                timestamp);
+                                    } else {
+                                        collect(
+                                                (T1) entry.getElement(),
+                                                (T2) ourValue,
+                                                timestamp,
+                                                ourTimestamp);
+                                    }
+                                }
+                            }
+
+                            long cleanupTime =
+                                    (relativeUpperBound > 0L)
+                                            ? ourTimestamp + relativeUpperBound
+                                            : ourTimestamp;
+                            if (isLeft) {
+                                internalTimerService.registerEventTimeTimer(
+                                        CLEANUP_NAMESPACE_LEFT, cleanupTime);
+                            } else {
+                                internalTimerService.registerEventTimeTimer(
+                                        CLEANUP_NAMESPACE_RIGHT, cleanupTime);
+                            }
+                        });
+    }
+
+    private boolean isLate(long timestamp) {
+        long currentWatermark = internalTimerService.currentWatermark();
+        return timestamp < currentWatermark;
+    }
+
+    /** Write skipped late arriving element to SideOutput. */
+    protected <T> void sideOutput(T value, long timestamp, boolean isLeft) {
+        if (isLeft) {
+            if (leftLateDataOutputTag != null) {
+                output.collect(leftLateDataOutputTag, new StreamRecord<>((T1) value, timestamp));
+            }
+        } else {
+            if (rightLateDataOutputTag != null) {
+                output.collect(rightLateDataOutputTag, new StreamRecord<>((T2) value, timestamp));
+            }
+        }
+    }
+
+    private void collect(T1 left, T2 right, long leftTime, long rightTime) throws Exception {
+        resultTimestamp.set(Math.max(leftTime, rightTime));
+        leftTimestamp.set(leftTime);
+        rightTimestamp.set(rightTime);
+
+        userFunction.processElement(left, right, context, collector);
+    }
+
+    private static <T> StateFuture<Void> addToBuffer(
+            final MapState<Long, List<IntervalJoinOperator.BufferEntry<T>>> buffer,
+            final T value,
+            final long timestamp) {
+        return buffer.asyncGet(timestamp)
+                .thenCompose(
+                        (elemsInBucket) -> {
+                            if (elemsInBucket == null) {
+                                elemsInBucket = new ArrayList<>();
+                            }
+                            elemsInBucket.add(new IntervalJoinOperator.BufferEntry<>(value, false));
+                            return buffer.asyncPut(timestamp, elemsInBucket);
+                        });
+    }
+
+    @Override
+    public void onEventTime(InternalTimer<K, String> timer) throws Exception {
+        long timerTimestamp = timer.getTimestamp();
+        String namespace = timer.getNamespace();
+
+        logger.trace("onEventTime @ {}", timerTimestamp);
+
+        switch (namespace) {
+            case CLEANUP_NAMESPACE_LEFT:
+                {
+                    long timestamp =
+                            (upperBound <= 0L) ? timerTimestamp : timerTimestamp - upperBound;
+                    logger.trace("Removing from left buffer @ {}", timestamp);
+                    leftBuffer.remove(timestamp);
+                    break;
+                }
+            case CLEANUP_NAMESPACE_RIGHT:
+                {
+                    long timestamp =
+                            (lowerBound <= 0L) ? timerTimestamp + lowerBound : timerTimestamp;
+                    logger.trace("Removing from right buffer @ {}", timestamp);
+                    rightBuffer.remove(timestamp);
+                    break;
+                }
+            default:
+                throw new RuntimeException("Invalid namespace " + namespace);
+        }
+    }
+
+    @Override
+    public void onProcessingTime(InternalTimer<K, String> timer) throws Exception {
+        // do nothing.
+    }
+
+    /**
+     * The context that is available during an invocation of {@link
+     * ProcessJoinFunction#processElement(Object, Object, ProcessJoinFunction.Context, Collector)}.
+     *
+     * <p>It gives access to the timestamps of the left element in the joined pair, the right one,
+     * and that of the joined pair. In addition, this context allows to emit elements on a side
+     * output.
+     */
+    private final class ContextImpl extends ProcessJoinFunction<T1, T2, OUT>.Context {
+
+        private final DeclaredVariable<Long> resultTimestamp;
+
+        private final DeclaredVariable<Long> leftTimestamp;
+
+        private final DeclaredVariable<Long> rightTimestamp;
+
+        private ContextImpl(
+                ProcessJoinFunction<T1, T2, OUT> func,
+                DeclaredVariable<Long> resultTimestamp,
+                DeclaredVariable<Long> leftTimestamp,
+                DeclaredVariable<Long> rightTimestamp) {
+            func.super();
+            this.resultTimestamp = resultTimestamp;
+            this.leftTimestamp = leftTimestamp;
+            this.rightTimestamp = rightTimestamp;
+        }
+
+        @Override
+        public long getLeftTimestamp() {
+            return leftTimestamp.get();
+        }
+
+        @Override
+        public long getRightTimestamp() {
+            return rightTimestamp.get();
+        }
+
+        @Override
+        public long getTimestamp() {
+            return resultTimestamp.get();
+        }
+
+        @Override
+        public <X> void output(OutputTag<X> outputTag, X value) {
+            Preconditions.checkArgument(outputTag != null, "OutputTag must not be null");
+            output.collect(outputTag, new StreamRecord<>(value, getTimestamp()));
+        }
+    }
+
+    @VisibleForTesting
+    MapState<Long, List<IntervalJoinOperator.BufferEntry<T1>>> getLeftBuffer() {
+        return leftBuffer;
+    }
+
+    @VisibleForTesting
+    MapState<Long, List<IntervalJoinOperator.BufferEntry<T2>>> getRightBuffer() {
+        return rightBuffer;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AsyncKeyedProcessOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AsyncKeyedProcessOperator.java
@@ -57,8 +57,6 @@ public class AsyncKeyedProcessOperator<K, IN, OUT>
 
     private transient OnTimerContextImpl onTimerContext;
 
-    private transient DeclarationContext declarationContext;
-
     private transient ThrowingConsumer<IN, Exception> processor;
     private transient ThrowingConsumer<Long, Exception> timerProcessor;
 
@@ -70,8 +68,6 @@ public class AsyncKeyedProcessOperator<K, IN, OUT>
     @SuppressWarnings({"unchecked", "rawtypes"})
     public void open() throws Exception {
         super.open();
-        declarationContext = new DeclarationContext(getDeclarationManager());
-        userFunction.open(declarationContext);
         sharedTimestamp =
                 declarationContext.declareVariable(
                         LongSerializer.INSTANCE,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/operators/AsyncIntervalJoinOperatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/operators/AsyncIntervalJoinOperatorTest.java
@@ -1,0 +1,981 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.asyncprocessing.operators;
+
+import org.apache.flink.api.common.serialization.SerializerConfigImpl;
+import org.apache.flink.api.common.state.v2.MapState;
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.streaming.api.functions.co.ProcessJoinFunction;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.TestHarnessUtil;
+import org.apache.flink.streaming.util.asyncprocessing.AsyncKeyedTwoInputStreamOperatorTestHarness;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.OutputTag;
+
+import org.apache.flink.shaded.guava32.com.google.common.collect.Iterables;
+import org.apache.flink.shaded.guava32.com.google.common.collect.Lists;
+
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ExecutorService;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link AsyncIntervalJoinOperator}. Those tests cover correctness and cleaning of state
+ */
+@ExtendWith(ParameterizedTestExtension.class)
+class AsyncIntervalJoinOperatorTest {
+
+    private final boolean lhsFasterThanRhs;
+
+    @Parameters(name = "lhs faster than rhs: {0}")
+    private static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {{true}, {false}});
+    }
+
+    public AsyncIntervalJoinOperatorTest(boolean lhsFasterThanRhs) {
+        this.lhsFasterThanRhs = lhsFasterThanRhs;
+    }
+
+    @TestTemplate
+    void testImplementationMirrorsCorrectly() throws Exception {
+
+        long lowerBound = 1;
+        long upperBound = 3;
+
+        boolean lowerBoundInclusive = true;
+        boolean upperBoundInclusive = false;
+
+        setupHarness(lowerBound, lowerBoundInclusive, upperBound, upperBoundInclusive)
+                .processElementsAndWatermarks(1, 4)
+                .andExpect(
+                        streamRecordOf(1, 2),
+                        streamRecordOf(1, 3),
+                        streamRecordOf(2, 3),
+                        streamRecordOf(2, 4),
+                        streamRecordOf(3, 4))
+                .noLateRecords()
+                .close();
+
+        setupHarness(-1 * upperBound, upperBoundInclusive, -1 * lowerBound, lowerBoundInclusive)
+                .processElementsAndWatermarks(1, 4)
+                .andExpect(
+                        streamRecordOf(2, 1),
+                        streamRecordOf(3, 1),
+                        streamRecordOf(3, 2),
+                        streamRecordOf(4, 2),
+                        streamRecordOf(4, 3))
+                .noLateRecords()
+                .close();
+    }
+
+    @TestTemplate // lhs - 2 <= rhs <= rhs + 2
+    void testNegativeInclusiveAndNegativeInclusive() throws Exception {
+
+        setupHarness(-2, true, -1, true)
+                .processElementsAndWatermarks(1, 4)
+                .andExpect(
+                        streamRecordOf(2, 1),
+                        streamRecordOf(3, 1),
+                        streamRecordOf(3, 2),
+                        streamRecordOf(4, 2),
+                        streamRecordOf(4, 3))
+                .noLateRecords()
+                .close();
+    }
+
+    @TestTemplate // lhs - 1 <= rhs <= rhs + 1
+    void testNegativeInclusiveAndPositiveInclusive() throws Exception {
+
+        setupHarness(-1, true, 1, true)
+                .processElementsAndWatermarks(1, 4)
+                .andExpect(
+                        streamRecordOf(1, 1),
+                        streamRecordOf(1, 2),
+                        streamRecordOf(2, 1),
+                        streamRecordOf(2, 2),
+                        streamRecordOf(2, 3),
+                        streamRecordOf(3, 2),
+                        streamRecordOf(3, 3),
+                        streamRecordOf(3, 4),
+                        streamRecordOf(4, 3),
+                        streamRecordOf(4, 4))
+                .noLateRecords()
+                .close();
+    }
+
+    @TestTemplate // lhs + 1 <= rhs <= lhs + 2
+    void testPositiveInclusiveAndPositiveInclusive() throws Exception {
+
+        setupHarness(1, true, 2, true)
+                .processElementsAndWatermarks(1, 4)
+                .andExpect(
+                        streamRecordOf(1, 2),
+                        streamRecordOf(1, 3),
+                        streamRecordOf(2, 3),
+                        streamRecordOf(2, 4),
+                        streamRecordOf(3, 4))
+                .noLateRecords()
+                .close();
+    }
+
+    @TestTemplate
+    void testNegativeExclusiveAndNegativeExlusive() throws Exception {
+
+        setupHarness(-3, false, -1, false)
+                .processElementsAndWatermarks(1, 4)
+                .andExpect(streamRecordOf(3, 1), streamRecordOf(4, 2))
+                .noLateRecords()
+                .close();
+    }
+
+    @TestTemplate
+    void testNegativeExclusiveAndPositiveExlusive() throws Exception {
+
+        setupHarness(-1, false, 1, false)
+                .processElementsAndWatermarks(1, 4)
+                .andExpect(
+                        streamRecordOf(1, 1),
+                        streamRecordOf(2, 2),
+                        streamRecordOf(3, 3),
+                        streamRecordOf(4, 4))
+                .noLateRecords()
+                .close();
+    }
+
+    @TestTemplate
+    void testPositiveExclusiveAndPositiveExlusive() throws Exception {
+
+        setupHarness(1, false, 3, false)
+                .processElementsAndWatermarks(1, 4)
+                .andExpect(streamRecordOf(1, 3), streamRecordOf(2, 4))
+                .noLateRecords()
+                .close();
+    }
+
+    @TestTemplate
+    void testStateCleanupNegativeInclusiveNegativeInclusive() throws Exception {
+
+        setupHarness(-1, true, 0, true)
+                .processElement1(1)
+                .processElement1(2)
+                .processElement1(3)
+                .processElement1(4)
+                .processElement1(5)
+                .processElement2(1)
+                .processElement2(2)
+                .processElement2(3)
+                .processElement2(4)
+                .processElement2(5) // fill both buffers with values
+                .processWatermark1(1)
+                .processWatermark2(1) // set common watermark to 1 and check that data is cleaned
+                .assertLeftBufferContainsOnly(2, 3, 4, 5)
+                .assertRightBufferContainsOnly(1, 2, 3, 4, 5)
+                .processWatermark1(4) // set common watermark to 4 and check that data is cleaned
+                .processWatermark2(4)
+                .assertLeftBufferContainsOnly(5)
+                .assertRightBufferContainsOnly(4, 5)
+                .processWatermark1(
+                        6) // set common watermark to 6 and check that data all buffers are empty
+                .processWatermark2(6)
+                .assertLeftBufferEmpty()
+                .assertRightBufferEmpty()
+                .close();
+    }
+
+    @TestTemplate
+    void testStateCleanupNegativePositiveNegativeExlusive() throws Exception {
+        setupHarness(-2, false, 1, false)
+                .processElement1(1)
+                .processElement1(2)
+                .processElement1(3)
+                .processElement1(4)
+                .processElement1(5)
+                .processElement2(1)
+                .processElement2(2)
+                .processElement2(3)
+                .processElement2(4)
+                .processElement2(5) // fill both buffers with values
+                .processWatermark1(1)
+                .processWatermark2(1) // set common watermark to 1 and check that data is cleaned
+                .assertLeftBufferContainsOnly(2, 3, 4, 5)
+                .assertRightBufferContainsOnly(1, 2, 3, 4, 5)
+                .processWatermark1(4) // set common watermark to 4 and check that data is cleaned
+                .processWatermark2(4)
+                .assertLeftBufferContainsOnly(5)
+                .assertRightBufferContainsOnly(4, 5)
+                .processWatermark1(
+                        6) // set common watermark to 6 and check that data all buffers are empty
+                .processWatermark2(6)
+                .assertLeftBufferEmpty()
+                .assertRightBufferEmpty()
+                .close();
+    }
+
+    @TestTemplate
+    void testStateCleanupPositiveInclusivePositiveInclusive() throws Exception {
+        setupHarness(0, true, 1, true)
+                .processElement1(1)
+                .processElement1(2)
+                .processElement1(3)
+                .processElement1(4)
+                .processElement1(5)
+                .processElement2(1)
+                .processElement2(2)
+                .processElement2(3)
+                .processElement2(4)
+                .processElement2(5) // fill both buffers with values
+                .processWatermark1(1)
+                .processWatermark2(1) // set common watermark to 1 and check that data is cleaned
+                .assertLeftBufferContainsOnly(1, 2, 3, 4, 5)
+                .assertRightBufferContainsOnly(2, 3, 4, 5)
+                .processWatermark1(4) // set common watermark to 4 and check that data is cleaned
+                .processWatermark2(4)
+                .assertLeftBufferContainsOnly(4, 5)
+                .assertRightBufferContainsOnly(5)
+                .processWatermark1(
+                        6) // set common watermark to 6 and check that data all buffers are empty
+                .processWatermark2(6)
+                .assertLeftBufferEmpty()
+                .assertRightBufferEmpty()
+                .close();
+    }
+
+    @TestTemplate
+    void testStateCleanupPositiveExlusivePositiveExclusive() throws Exception {
+        setupHarness(-1, false, 2, false)
+                .processElement1(1)
+                .processElement1(2)
+                .processElement1(3)
+                .processElement1(4)
+                .processElement1(5)
+                .processElement2(1)
+                .processElement2(2)
+                .processElement2(3)
+                .processElement2(4)
+                .processElement2(5) // fill both buffers with values
+                .processWatermark1(1)
+                .processWatermark2(1) // set common watermark to 1 and check that data is cleaned
+                .assertLeftBufferContainsOnly(1, 2, 3, 4, 5)
+                .assertRightBufferContainsOnly(2, 3, 4, 5)
+                .processWatermark1(4) // set common watermark to 4 and check that data is cleaned
+                .processWatermark2(4)
+                .assertLeftBufferContainsOnly(4, 5)
+                .assertRightBufferContainsOnly(5)
+                .processWatermark1(
+                        6) // set common watermark to 6 and check that data all buffers are empty
+                .processWatermark2(6)
+                .assertLeftBufferEmpty()
+                .assertRightBufferEmpty()
+                .close();
+    }
+
+    @TestTemplate
+    void testRestoreFromSnapshot() throws Exception {
+
+        // config
+        int lowerBound = -1;
+        boolean lowerBoundInclusive = true;
+        int upperBound = 1;
+        boolean upperBoundInclusive = true;
+
+        // create first test harness
+        OperatorSubtaskState handles;
+        List<StreamRecord<Tuple2<TestElem, TestElem>>> expectedOutput;
+
+        try (TestHarness testHarness =
+                createTestHarness(
+                        lowerBound, lowerBoundInclusive, upperBound, upperBoundInclusive)) {
+
+            testHarness.setup();
+            testHarness.open();
+
+            // process elements with first test harness
+            testHarness.processElement1(createStreamRecord(1, "lhs"));
+            testHarness.processWatermark1(new Watermark(1));
+
+            testHarness.processElement2(createStreamRecord(1, "rhs"));
+            testHarness.processWatermark2(new Watermark(1));
+
+            testHarness.processElement1(createStreamRecord(2, "lhs"));
+            testHarness.processWatermark1(new Watermark(2));
+
+            testHarness.processElement2(createStreamRecord(2, "rhs"));
+            testHarness.processWatermark2(new Watermark(2));
+
+            testHarness.processElement1(createStreamRecord(3, "lhs"));
+            testHarness.processWatermark1(new Watermark(3));
+
+            testHarness.processElement2(createStreamRecord(3, "rhs"));
+            testHarness.processWatermark2(new Watermark(3));
+
+            // snapshot and validate output
+            handles = testHarness.snapshot(0, 0);
+
+            expectedOutput =
+                    Lists.newArrayList(
+                            streamRecordOf(1, 1),
+                            streamRecordOf(1, 2),
+                            streamRecordOf(2, 1),
+                            streamRecordOf(2, 2),
+                            streamRecordOf(2, 3),
+                            streamRecordOf(3, 2),
+                            streamRecordOf(3, 3));
+
+            TestHarnessUtil.assertNoLateRecords(testHarness.getOutput());
+            assertOutput(expectedOutput, testHarness.getOutput());
+        }
+
+        try (TestHarness newTestHarness =
+                createTestHarness(
+                        lowerBound, lowerBoundInclusive, upperBound, upperBoundInclusive)) {
+            // create new test harness from snapshpt
+
+            newTestHarness.setup();
+            newTestHarness.initializeState(handles);
+            newTestHarness.open();
+
+            // process elements
+            newTestHarness.processElement1(createStreamRecord(4, "lhs"));
+            newTestHarness.processWatermark1(new Watermark(4));
+
+            newTestHarness.processElement2(createStreamRecord(4, "rhs"));
+            newTestHarness.processWatermark2(new Watermark(4));
+
+            // assert expected output
+            expectedOutput =
+                    Lists.newArrayList(
+                            streamRecordOf(3, 4), streamRecordOf(4, 3), streamRecordOf(4, 4));
+
+            TestHarnessUtil.assertNoLateRecords(newTestHarness.getOutput());
+            assertOutput(expectedOutput, newTestHarness.getOutput());
+        }
+    }
+
+    @TestTemplate
+    void testContextCorrectLeftTimestamp() throws Exception {
+
+        AsyncIntervalJoinOperator<String, TestElem, TestElem, Tuple2<TestElem, TestElem>> op =
+                new AsyncIntervalJoinOperator<>(
+                        -1,
+                        1,
+                        true,
+                        true,
+                        null,
+                        null,
+                        TestElem.serializer(),
+                        TestElem.serializer(),
+                        new ProcessJoinFunction<TestElem, TestElem, Tuple2<TestElem, TestElem>>() {
+                            @Override
+                            public void processElement(
+                                    TestElem left,
+                                    TestElem right,
+                                    Context ctx,
+                                    Collector<Tuple2<TestElem, TestElem>> out)
+                                    throws Exception {
+                                assertThat(ctx.getLeftTimestamp()).isEqualTo(left.ts);
+                            }
+                        });
+
+        try (TestHarness testHarness =
+                TestHarness.create(
+                        op,
+                        (elem) -> elem.key,
+                        (elem) -> elem.key,
+                        TypeInformation.of(String.class))) {
+
+            testHarness.setup();
+            testHarness.open();
+
+            processElementsAndWatermarks(testHarness);
+        }
+    }
+
+    @TestTemplate
+    void testReturnsCorrectTimestamp() throws Exception {
+        AsyncIntervalJoinOperator<String, TestElem, TestElem, Tuple2<TestElem, TestElem>> op =
+                new AsyncIntervalJoinOperator<>(
+                        -1,
+                        1,
+                        true,
+                        true,
+                        null,
+                        null,
+                        TestElem.serializer(),
+                        TestElem.serializer(),
+                        new ProcessJoinFunction<TestElem, TestElem, Tuple2<TestElem, TestElem>>() {
+
+                            private static final long serialVersionUID = 1L;
+
+                            @Override
+                            public void processElement(
+                                    TestElem left,
+                                    TestElem right,
+                                    Context ctx,
+                                    Collector<Tuple2<TestElem, TestElem>> out)
+                                    throws Exception {
+                                assertThat(ctx.getTimestamp())
+                                        .isEqualTo(Math.max(left.ts, right.ts));
+                            }
+                        });
+
+        try (TestHarness testHarness =
+                TestHarness.create(
+                        op,
+                        (elem) -> elem.key,
+                        (elem) -> elem.key,
+                        TypeInformation.of(String.class))) {
+
+            testHarness.setup();
+            testHarness.open();
+
+            processElementsAndWatermarks(testHarness);
+        }
+    }
+
+    @TestTemplate
+    void testContextCorrectRightTimestamp() throws Exception {
+
+        AsyncIntervalJoinOperator<String, TestElem, TestElem, Tuple2<TestElem, TestElem>> op =
+                new AsyncIntervalJoinOperator<>(
+                        -1,
+                        1,
+                        true,
+                        true,
+                        null,
+                        null,
+                        TestElem.serializer(),
+                        TestElem.serializer(),
+                        new ProcessJoinFunction<TestElem, TestElem, Tuple2<TestElem, TestElem>>() {
+                            @Override
+                            public void processElement(
+                                    TestElem left,
+                                    TestElem right,
+                                    Context ctx,
+                                    Collector<Tuple2<TestElem, TestElem>> out)
+                                    throws Exception {
+                                assertThat(ctx.getRightTimestamp()).isEqualTo(right.ts);
+                            }
+                        });
+
+        try (TestHarness testHarness =
+                TestHarness.create(
+                        op,
+                        (elem) -> elem.key,
+                        (elem) -> elem.key,
+                        TypeInformation.of(String.class))) {
+
+            testHarness.setup();
+            testHarness.open();
+
+            processElementsAndWatermarks(testHarness);
+        }
+    }
+
+    @TestTemplate
+    void testFailsWithNoTimestampsLeft() throws Exception {
+        try (TestHarness newTestHarness = createTestHarness(0L, true, 0L, true)) {
+
+            newTestHarness.setup();
+            newTestHarness.open();
+
+            // note that the StreamRecord has no timestamp in constructor
+            assertThatThrownBy(
+                            () ->
+                                    newTestHarness.processElement1(
+                                            new StreamRecord<>(new TestElem(0, "lhs"))))
+                    .isInstanceOf(FlinkException.class);
+        }
+    }
+
+    @TestTemplate // (expected = FlinkException.class)
+    void testFailsWithNoTimestampsRight() throws Exception {
+        try (TestHarness newTestHarness = createTestHarness(0L, true, 0L, true)) {
+
+            newTestHarness.setup();
+            newTestHarness.open();
+
+            // note that the StreamRecord has no timestamp in constructor
+            assertThatThrownBy(
+                            () ->
+                                    newTestHarness.processElement2(
+                                            new StreamRecord<>(new TestElem(0, "rhs"))))
+                    .isInstanceOf(FlinkException.class);
+        }
+    }
+
+    @TestTemplate
+    void testDiscardsLateData() throws Exception {
+        setupHarness(-1, true, 1, true)
+                .processElement1(1)
+                .processElement2(1)
+                .processElement1(2)
+                .processElement2(2)
+                .processElement1(3)
+                .processElement2(3)
+                .processWatermark1(3)
+                .processWatermark2(3)
+                .processElement1(1) // this element is late and should not be joined again
+                .processElement1(4)
+                .processElement2(4)
+                .processElement1(5)
+                .processElement2(5)
+                .andExpect(
+                        streamRecordOf(1, 1),
+                        streamRecordOf(1, 2),
+                        streamRecordOf(2, 1),
+                        streamRecordOf(2, 2),
+                        streamRecordOf(2, 3),
+                        streamRecordOf(3, 2),
+                        streamRecordOf(3, 3),
+                        streamRecordOf(3, 4),
+                        streamRecordOf(4, 3),
+                        streamRecordOf(4, 4),
+                        streamRecordOf(4, 5),
+                        streamRecordOf(5, 4),
+                        streamRecordOf(5, 5))
+                .noLateRecords()
+                .close();
+    }
+
+    @TestTemplate
+    void testLateData() throws Exception {
+        OutputTag<TestElem> leftLateTag = new OutputTag<TestElem>("left_late") {};
+        OutputTag<TestElem> rightLateTag = new OutputTag<TestElem>("right_late") {};
+        setupHarness(-1, true, 1, true, leftLateTag, rightLateTag)
+                .processElement1(3)
+                .processElement2(3)
+                .processWatermark1(3)
+                .processWatermark2(3)
+                .processElement1(4)
+                .processElement2(4)
+                .processElement1(1) // the left side element is late
+                .processElement2(2) // the right side element is late
+                .processElement1(5)
+                .processElement2(5)
+                .andExpect(
+                        streamRecordOf(3, 3),
+                        streamRecordOf(3, 4),
+                        streamRecordOf(4, 3),
+                        streamRecordOf(4, 4),
+                        streamRecordOf(4, 5),
+                        streamRecordOf(5, 4),
+                        streamRecordOf(5, 5))
+                .expectLateRecords(leftLateTag, createStreamRecord(1, "lhs"))
+                .expectLateRecords(rightLateTag, createStreamRecord(2, "rhs"))
+                .close();
+    }
+
+    private void assertEmpty(MapState<Long, ?> state) throws Exception {
+        assertThat(state.keys()).isEmpty();
+    }
+
+    private void assertContainsOnly(MapState<Long, ?> state, long... ts) throws Exception {
+        for (long t : ts) {
+            String message =
+                    "Keys not found in state. \n Expected: "
+                            + Arrays.toString(ts)
+                            + "\n Actual:   "
+                            + state.keys();
+            assertThat(state.contains(t)).as(message).isTrue();
+        }
+
+        String message =
+                "Too many objects in state. \n Expected: "
+                        + Arrays.toString(ts)
+                        + "\n Actual:   "
+                        + state.keys();
+        assertThat(state.keys()).as(message).hasSize(ts.length);
+    }
+
+    private <T1, T2> void assertOutput(
+            Iterable<StreamRecord<T1>> expectedOutput, Queue<T2> actualOutput) {
+
+        int actualSize =
+                actualOutput.stream()
+                        .filter(elem -> elem instanceof StreamRecord)
+                        .collect(Collectors.toList())
+                        .size();
+
+        int expectedSize = Iterables.size(expectedOutput);
+
+        assertThat(actualSize)
+                .as("Expected and actual size of stream records different")
+                .isEqualTo(expectedSize);
+
+        for (StreamRecord<T1> record : expectedOutput) {
+            assertThat(actualOutput.contains(record)).isTrue();
+        }
+    }
+
+    private TestHarness createTestHarness(
+            long lowerBound,
+            boolean lowerBoundInclusive,
+            long upperBound,
+            boolean upperBoundInclusive)
+            throws Exception {
+
+        AsyncIntervalJoinOperator<String, TestElem, TestElem, Tuple2<TestElem, TestElem>> operator =
+                new AsyncIntervalJoinOperator<>(
+                        lowerBound,
+                        upperBound,
+                        lowerBoundInclusive,
+                        upperBoundInclusive,
+                        null,
+                        null,
+                        TestElem.serializer(),
+                        TestElem.serializer(),
+                        new PassthroughFunction());
+
+        return TestHarness.create(
+                operator,
+                (elem) -> elem.key, // key
+                (elem) -> elem.key, // key
+                TypeInformation.of(String.class));
+    }
+
+    private JoinTestBuilder setupHarness(
+            long lowerBound,
+            boolean lowerBoundInclusive,
+            long upperBound,
+            boolean upperBoundInclusive,
+            OutputTag<TestElem> leftLateDataOutputTag,
+            OutputTag<TestElem> rightLateDataOutputTag)
+            throws Exception {
+
+        AsyncIntervalJoinOperator<String, TestElem, TestElem, Tuple2<TestElem, TestElem>> operator =
+                new AsyncIntervalJoinOperator<>(
+                        lowerBound,
+                        upperBound,
+                        lowerBoundInclusive,
+                        upperBoundInclusive,
+                        leftLateDataOutputTag,
+                        rightLateDataOutputTag,
+                        TestElem.serializer(),
+                        TestElem.serializer(),
+                        new PassthroughFunction());
+
+        TestHarness t =
+                TestHarness.create(
+                        operator,
+                        (elem) -> elem.key, // key
+                        (elem) -> elem.key, // key
+                        TypeInformation.of(String.class));
+
+        return new JoinTestBuilder(t, operator);
+    }
+
+    private JoinTestBuilder setupHarness(
+            long lowerBound,
+            boolean lowerBoundInclusive,
+            long upperBound,
+            boolean upperBoundInclusive)
+            throws Exception {
+
+        return setupHarness(
+                lowerBound, lowerBoundInclusive, upperBound, upperBoundInclusive, null, null);
+    }
+
+    private class JoinTestBuilder {
+
+        private AsyncIntervalJoinOperator<String, TestElem, TestElem, Tuple2<TestElem, TestElem>>
+                operator;
+        private TestHarness testHarness;
+
+        public JoinTestBuilder(
+                TestHarness t,
+                AsyncIntervalJoinOperator<String, TestElem, TestElem, Tuple2<TestElem, TestElem>>
+                        operator)
+                throws Exception {
+
+            this.testHarness = t;
+            this.operator = operator;
+            t.open();
+            t.setup();
+        }
+
+        public TestHarness get() {
+            return testHarness;
+        }
+
+        public JoinTestBuilder processElement1(int ts) throws Exception {
+            testHarness.processElement1(createStreamRecord(ts, "lhs"));
+            return this;
+        }
+
+        public JoinTestBuilder processElement2(int ts) throws Exception {
+            testHarness.processElement2(createStreamRecord(ts, "rhs"));
+            return this;
+        }
+
+        public JoinTestBuilder processWatermark1(int ts) throws Exception {
+            testHarness.processWatermark1(new Watermark(ts));
+            return this;
+        }
+
+        public JoinTestBuilder processWatermark2(int ts) throws Exception {
+            testHarness.processWatermark2(new Watermark(ts));
+            return this;
+        }
+
+        public JoinTestBuilder processElementsAndWatermarks(int from, int to) throws Exception {
+            if (lhsFasterThanRhs) {
+                // add to lhs
+                for (int i = from; i <= to; i++) {
+                    testHarness.processElement1(createStreamRecord(i, "lhs"));
+                    testHarness.processWatermark1(new Watermark(i));
+                }
+
+                // add to rhs
+                for (int i = from; i <= to; i++) {
+                    testHarness.processElement2(createStreamRecord(i, "rhs"));
+                    testHarness.processWatermark2(new Watermark(i));
+                }
+            } else {
+                // add to rhs
+                for (int i = from; i <= to; i++) {
+                    testHarness.processElement2(createStreamRecord(i, "rhs"));
+                    testHarness.processWatermark2(new Watermark(i));
+                }
+
+                // add to lhs
+                for (int i = from; i <= to; i++) {
+                    testHarness.processElement1(createStreamRecord(i, "lhs"));
+                    testHarness.processWatermark1(new Watermark(i));
+                }
+            }
+
+            return this;
+        }
+
+        @SafeVarargs
+        public final JoinTestBuilder andExpect(StreamRecord<Tuple2<TestElem, TestElem>>... elems) {
+            assertOutput(Lists.newArrayList(elems), testHarness.getOutput());
+            return this;
+        }
+
+        public JoinTestBuilder assertLeftBufferContainsOnly(long... timestamps) {
+
+            try {
+                assertContainsOnly(operator.getLeftBuffer(), timestamps);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            return this;
+        }
+
+        public JoinTestBuilder assertRightBufferContainsOnly(long... timestamps) {
+
+            try {
+                assertContainsOnly(operator.getRightBuffer(), timestamps);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            return this;
+        }
+
+        public JoinTestBuilder assertLeftBufferEmpty() {
+            try {
+                assertEmpty(operator.getLeftBuffer());
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            return this;
+        }
+
+        public JoinTestBuilder assertRightBufferEmpty() {
+            try {
+                assertEmpty(operator.getRightBuffer());
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            return this;
+        }
+
+        @SafeVarargs
+        public final JoinTestBuilder expectLateRecords(
+                OutputTag<TestElem> tag, StreamRecord<TestElem>... elems) {
+            assertOutput(Lists.newArrayList(elems), testHarness.getSideOutput(tag));
+            return this;
+        }
+
+        public JoinTestBuilder noLateRecords() {
+            TestHarnessUtil.assertNoLateRecords(this.testHarness.getOutput());
+            return this;
+        }
+
+        public void close() throws Exception {
+            testHarness.close();
+        }
+    }
+
+    private static class PassthroughFunction
+            extends ProcessJoinFunction<TestElem, TestElem, Tuple2<TestElem, TestElem>> {
+
+        @Override
+        public void processElement(
+                TestElem left,
+                TestElem right,
+                Context ctx,
+                Collector<Tuple2<TestElem, TestElem>> out)
+                throws Exception {
+            out.collect(Tuple2.of(left, right));
+        }
+    }
+
+    private StreamRecord<Tuple2<TestElem, TestElem>> streamRecordOf(long lhsTs, long rhsTs) {
+        TestElem lhs = new TestElem(lhsTs, "lhs");
+        TestElem rhs = new TestElem(rhsTs, "rhs");
+
+        long ts = Math.max(lhsTs, rhsTs);
+        return new StreamRecord<>(Tuple2.of(lhs, rhs), ts);
+    }
+
+    private static class TestElem {
+        String key;
+        long ts;
+        String source;
+
+        public TestElem(long ts, String source) {
+            this.key = "key";
+            this.ts = ts;
+            this.source = source;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            TestElem testElem = (TestElem) o;
+
+            if (ts != testElem.ts) {
+                return false;
+            }
+
+            if (key != null ? !key.equals(testElem.key) : testElem.key != null) {
+                return false;
+            }
+
+            return source != null ? source.equals(testElem.source) : testElem.source == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = key != null ? key.hashCode() : 0;
+            result = 31 * result + (int) (ts ^ (ts >>> 32));
+            result = 31 * result + (source != null ? source.hashCode() : 0);
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return this.source + ":" + this.ts;
+        }
+
+        public static TypeSerializer<TestElem> serializer() {
+            return TypeInformation.of(new TypeHint<AsyncIntervalJoinOperatorTest.TestElem>() {})
+                    .createSerializer(new SerializerConfigImpl());
+        }
+    }
+
+    private static StreamRecord<TestElem> createStreamRecord(long ts, String source) {
+        TestElem testElem = new TestElem(ts, source);
+        return new StreamRecord<>(testElem, ts);
+    }
+
+    private void processElementsAndWatermarks(TestHarness testHarness) throws Exception {
+        if (lhsFasterThanRhs) {
+            // add to lhs
+            for (int i = 1; i <= 4; i++) {
+                testHarness.processElement1(createStreamRecord(i, "lhs"));
+                testHarness.processWatermark1(new Watermark(i));
+            }
+
+            // add to rhs
+            for (int i = 1; i <= 4; i++) {
+                testHarness.processElement2(createStreamRecord(i, "rhs"));
+                testHarness.processWatermark2(new Watermark(i));
+            }
+        } else {
+            // add to rhs
+            for (int i = 1; i <= 4; i++) {
+                testHarness.processElement2(createStreamRecord(i, "rhs"));
+                testHarness.processWatermark2(new Watermark(i));
+            }
+
+            // add to lhs
+            for (int i = 1; i <= 4; i++) {
+                testHarness.processElement1(createStreamRecord(i, "lhs"));
+                testHarness.processWatermark1(new Watermark(i));
+            }
+        }
+    }
+
+    /** Custom test harness to avoid endless generics in all of the test code. */
+    private static class TestHarness
+            extends AsyncKeyedTwoInputStreamOperatorTestHarness<
+                    String, TestElem, TestElem, Tuple2<TestElem, TestElem>> {
+
+        public TestHarness(
+                ExecutorService executor,
+                TwoInputStreamOperator<TestElem, TestElem, Tuple2<TestElem, TestElem>> operator,
+                KeySelector<TestElem, String> keySelector1,
+                KeySelector<TestElem, String> keySelector2,
+                TypeInformation<String> keyType)
+                throws Exception {
+            super(executor, operator, keySelector1, keySelector2, keyType, 1, 1, 0);
+        }
+
+        public static TestHarness create(
+                TwoInputStreamOperator<TestElem, TestElem, Tuple2<TestElem, TestElem>> operator,
+                KeySelector<TestElem, String> keySelector1,
+                KeySelector<TestElem, String> keySelector2,
+                TypeInformation<String> keyType)
+                throws Exception {
+            return AsyncKeyedTwoInputStreamOperatorTestHarness.create(
+                    (executor) ->
+                            new TestHarness(
+                                    executor, operator, keySelector1, keySelector2, keyType));
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/util/asyncprocessing/AsyncKeyedOneInputStreamOperatorTestHarness.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/util/asyncprocessing/AsyncKeyedOneInputStreamOperatorTestHarness.java
@@ -36,6 +36,7 @@ import org.apache.flink.streaming.runtime.streamrecord.RecordAttributes;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.util.function.FunctionWithException;
 import org.apache.flink.util.function.RunnableWithException;
 import org.apache.flink.util.function.ThrowingConsumer;
 
@@ -46,6 +47,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import static org.apache.flink.streaming.util.asyncprocessing.AsyncProcessingTestUtil.drain;
+import static org.apache.flink.streaming.util.asyncprocessing.AsyncProcessingTestUtil.execute;
+import static org.apache.flink.streaming.util.asyncprocessing.AsyncProcessingTestUtil.unwrapAsyncException;
 import static org.apache.flink.util.Preconditions.checkState;
 import static org.assertj.core.api.Assertions.fail;
 
@@ -65,6 +68,23 @@ public class AsyncKeyedOneInputStreamOperatorTestHarness<K, IN, OUT>
 
     /** The executor service for async state processing. */
     private final ExecutorService executor;
+
+    /** Create an instance of the subclass of this class. */
+    public static <K, IN, OUT, OP extends AsyncKeyedOneInputStreamOperatorTestHarness<K, IN, OUT>>
+            OP create(FunctionWithException<ExecutorService, OP, Exception> constructor)
+                    throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        CompletableFuture<OP> future = new CompletableFuture<>();
+        executor.execute(
+                () -> {
+                    try {
+                        future.complete(constructor.apply(executor));
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+        return future.get();
+    }
 
     public static <K, IN, OUT> AsyncKeyedOneInputStreamOperatorTestHarness<K, IN, OUT> create(
             OneInputStreamOperator<IN, OUT> operator,
@@ -137,7 +157,7 @@ public class AsyncKeyedOneInputStreamOperatorTestHarness<K, IN, OUT>
 
     @Override
     public void processElement(StreamRecord<IN> element) throws Exception {
-        processElementInternal(element).get();
+        finishFuture(processElementInternal(element));
     }
 
     /**
@@ -165,7 +185,7 @@ public class AsyncKeyedOneInputStreamOperatorTestHarness<K, IN, OUT>
 
     @Override
     public void processWatermark(long watermark) throws Exception {
-        processWatermarkInternal(watermark).get();
+        finishFuture(processWatermarkInternal(watermark));
     }
 
     /** For internal testing. */
@@ -175,7 +195,7 @@ public class AsyncKeyedOneInputStreamOperatorTestHarness<K, IN, OUT>
 
     @Override
     public void processWatermarkStatus(WatermarkStatus status) throws Exception {
-        processWatermarkStatusInternal(status).get();
+        finishFuture(processWatermarkStatusInternal(status));
     }
 
     /** For internal testing. */
@@ -192,7 +212,7 @@ public class AsyncKeyedOneInputStreamOperatorTestHarness<K, IN, OUT>
 
     @Override
     public void processWatermark(Watermark mark) throws Exception {
-        processWatermarkInternal(mark).get();
+        finishFuture(processWatermarkInternal(mark));
     }
 
     @Override
@@ -216,7 +236,7 @@ public class AsyncKeyedOneInputStreamOperatorTestHarness<K, IN, OUT>
     }
 
     public void processLatencyMarker(LatencyMarker marker) throws Exception {
-        processLatencyMarkerInternal(marker).get();
+        finishFuture(processLatencyMarkerInternal(marker));
     }
 
     /** For internal testing. */
@@ -233,7 +253,7 @@ public class AsyncKeyedOneInputStreamOperatorTestHarness<K, IN, OUT>
 
     @Override
     public void processRecordAttributes(RecordAttributes recordAttributes) throws Exception {
-        processRecordAttributesInternal(recordAttributes).get();
+        finishFuture(processRecordAttributesInternal(recordAttributes));
     }
 
     @Override
@@ -279,8 +299,17 @@ public class AsyncKeyedOneInputStreamOperatorTestHarness<K, IN, OUT>
     }
 
     private void executeAndGet(RunnableWithException runnable) throws Exception {
-        execute(runnable).get();
-        checkEnvState();
+        finishFuture(execute(runnable));
+    }
+
+    private void finishFuture(CompletableFuture<Void> future) throws Exception {
+        try {
+            future.get();
+            checkEnvState();
+        } catch (Exception e) {
+            AsyncProcessingTestUtil.execute(executor, () -> mockTask.cleanUp(e)).get();
+            throw unwrapAsyncException(e);
+        }
     }
 
     private void checkEnvState() {

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/util/asyncprocessing/AsyncProcessingTestUtil.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/util/asyncprocessing/AsyncProcessingTestUtil.java
@@ -24,6 +24,7 @@ import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.util.function.RunnableWithException;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 
 /** Utility class for async test harness. */
@@ -54,5 +55,16 @@ public class AsyncProcessingTestUtil {
                     }
                 });
         return future;
+    }
+
+    public static Exception unwrapAsyncException(Exception t) {
+        while (t != null
+                && t.getCause() != null
+                && t.getCause() != t
+                && (t instanceof ExecutionException || t instanceof RuntimeException)
+                && t.getCause() instanceof Exception) {
+            t = (Exception) t.getCause();
+        }
+        return t;
     }
 }

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStMapState.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStMapState.java
@@ -175,15 +175,26 @@ public class ForStMapState<K, N, UK, UV> extends AbstractMapState<K, N, UK, UV>
     @Override
     @SuppressWarnings("unchecked")
     public ForStDBPutRequest<K, N, UV> buildDBPutRequest(StateRequest<?, ?, ?, ?> stateRequest) {
-        Preconditions.checkArgument(
-                stateRequest.getRequestType() == StateRequestType.MAP_PUT
-                        || stateRequest.getRequestType() == StateRequestType.MAP_REMOVE);
-        ContextKey<K, N> contextKey =
-                new ContextKey<>(
-                        (RecordContext<K>) stateRequest.getRecordContext(),
-                        (N) stateRequest.getNamespace(),
-                        ((Tuple2<UK, UV>) stateRequest.getPayload()).f0);
         Preconditions.checkNotNull(stateRequest.getPayload());
+        ContextKey<K, N> contextKey;
+        if (stateRequest.getRequestType() == StateRequestType.MAP_PUT) {
+            contextKey =
+                    new ContextKey<>(
+                            (RecordContext<K>) stateRequest.getRecordContext(),
+                            (N) stateRequest.getNamespace(),
+                            ((Tuple2<UK, UV>) stateRequest.getPayload()).f0);
+        } else if (stateRequest.getRequestType() == StateRequestType.MAP_REMOVE) {
+            contextKey =
+                    new ContextKey<>(
+                            (RecordContext<K>) stateRequest.getRecordContext(),
+                            (N) stateRequest.getNamespace(),
+                            stateRequest.getPayload());
+        } else {
+            throw new IllegalArgumentException(
+                    "The State type is: "
+                            + stateRequest.getRequestType().name()
+                            + ", which is not a valid put request.");
+        }
         UV value = null;
         if (stateRequest.getRequestType() == StateRequestType.MAP_PUT) {
             value = ((Tuple2<UK, UV>) stateRequest.getPayload()).f1;

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/IntervalJoinITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/IntervalJoinITCase.java
@@ -19,6 +19,8 @@ package org.apache.flink.test.streaming.runtime;
 
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.StateBackendOptions;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.KeyedStream;
 import org.apache.flink.streaming.api.datastream.UnsupportedTimeCharacteristicException;
@@ -30,31 +32,34 @@ import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.test.streaming.runtime.TimestampITCase.AscendingRecordTimestampsWatermarkStrategy;
 import org.apache.flink.util.Collector;
 
-import org.apache.flink.shaded.guava32.com.google.common.collect.Lists;
-
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.Serializable;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
+
+import static org.apache.flink.runtime.state.StateBackendLoader.FORST_STATE_BACKEND_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /** Integration tests for interval joins. */
 public class IntervalJoinITCase {
 
     private static List<String> testResults;
 
-    @Before
+    @BeforeEach
     public void setup() {
         testResults = new ArrayList<>();
     }
 
-    @Test
-    public void testCanJoinOverSameKey() throws Exception {
+    @ParameterizedTest(name = "Enable async state = {0}")
+    @ValueSource(booleans = {false, true})
+    public void testCanJoinOverSameKey(boolean enableAsyncState) throws Exception {
 
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setParallelism(1);
@@ -80,6 +85,12 @@ public class IntervalJoinITCase {
                                 Tuple2.of("key", 5))
                         .assignTimestampsAndWatermarks(new AscendingTuple2TimestampExtractor())
                         .keyBy(new Tuple2KeyExtractor());
+
+        if (enableAsyncState) {
+            streamOne.enableAsyncState();
+            streamTwo.enableAsyncState();
+            configAsyncState(env);
+        }
 
         streamOne
                 .intervalJoin(streamTwo)
@@ -110,8 +121,9 @@ public class IntervalJoinITCase {
                 "(key,5):(key,5)");
     }
 
-    @Test
-    public void testJoinsCorrectlyWithMultipleKeys() throws Exception {
+    @ParameterizedTest(name = "Enable async state = {0}")
+    @ValueSource(booleans = {false, true})
+    public void testJoinsCorrectlyWithMultipleKeys(boolean enableAsyncState) throws Exception {
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setParallelism(1);
 
@@ -136,6 +148,12 @@ public class IntervalJoinITCase {
                                 Tuple2.of("key2", 5))
                         .assignTimestampsAndWatermarks(new AscendingTuple2TimestampExtractor())
                         .keyBy(new Tuple2KeyExtractor());
+
+        if (enableAsyncState) {
+            streamOne.enableAsyncState();
+            streamTwo.enableAsyncState();
+            configAsyncState(env);
+        }
 
         streamOne
                 .intervalJoin(streamTwo)
@@ -179,61 +197,70 @@ public class IntervalJoinITCase {
         long serialVersionUID = 1L;
     }
 
-    @Test
-    public void testBoundedUnorderedStreamsStillJoinCorrectly() throws Exception {
+    @ParameterizedTest(name = "Enable async state = {0}")
+    @ValueSource(booleans = {false, true})
+    public void testBoundedUnorderedStreamsStillJoinCorrectly(boolean enableAsyncState)
+            throws Exception {
 
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setParallelism(1);
 
-        DataStream<Tuple2<String, Integer>> streamOne =
+        KeyedStream<Tuple2<String, Integer>, String> streamOne =
                 env.addSource(
-                        new SourceFunction<Tuple2<String, Integer>>() {
-                            @Override
-                            public void run(SourceContext<Tuple2<String, Integer>> ctx) {
-                                ctx.collectWithTimestamp(Tuple2.of("key", 5), 5L);
-                                ctx.collectWithTimestamp(Tuple2.of("key", 1), 1L);
-                                ctx.collectWithTimestamp(Tuple2.of("key", 4), 4L);
-                                ctx.collectWithTimestamp(Tuple2.of("key", 3), 3L);
-                                ctx.collectWithTimestamp(Tuple2.of("key", 2), 2L);
-                                ctx.emitWatermark(new Watermark(5));
-                                ctx.collectWithTimestamp(Tuple2.of("key", 9), 9L);
-                                ctx.collectWithTimestamp(Tuple2.of("key", 8), 8L);
-                                ctx.collectWithTimestamp(Tuple2.of("key", 7), 7L);
-                                ctx.collectWithTimestamp(Tuple2.of("key", 6), 6L);
-                            }
+                                new SourceFunction<Tuple2<String, Integer>>() {
+                                    @Override
+                                    public void run(SourceContext<Tuple2<String, Integer>> ctx) {
+                                        ctx.collectWithTimestamp(Tuple2.of("key", 5), 5L);
+                                        ctx.collectWithTimestamp(Tuple2.of("key", 1), 1L);
+                                        ctx.collectWithTimestamp(Tuple2.of("key", 4), 4L);
+                                        ctx.collectWithTimestamp(Tuple2.of("key", 3), 3L);
+                                        ctx.collectWithTimestamp(Tuple2.of("key", 2), 2L);
+                                        ctx.emitWatermark(new Watermark(5));
+                                        ctx.collectWithTimestamp(Tuple2.of("key", 9), 9L);
+                                        ctx.collectWithTimestamp(Tuple2.of("key", 8), 8L);
+                                        ctx.collectWithTimestamp(Tuple2.of("key", 7), 7L);
+                                        ctx.collectWithTimestamp(Tuple2.of("key", 6), 6L);
+                                    }
 
-                            @Override
-                            public void cancel() {
-                                // do nothing
-                            }
-                        });
+                                    @Override
+                                    public void cancel() {
+                                        // do nothing
+                                    }
+                                })
+                        .keyBy(new Tuple2KeyExtractor());
 
-        DataStream<Tuple2<String, Integer>> streamTwo =
+        KeyedStream<Tuple2<String, Integer>, String> streamTwo =
                 env.addSource(
-                        new SourceFunction<Tuple2<String, Integer>>() {
-                            @Override
-                            public void run(SourceContext<Tuple2<String, Integer>> ctx) {
-                                ctx.collectWithTimestamp(Tuple2.of("key", 2), 2L);
-                                ctx.collectWithTimestamp(Tuple2.of("key", 1), 1L);
-                                ctx.collectWithTimestamp(Tuple2.of("key", 3), 3L);
-                                ctx.collectWithTimestamp(Tuple2.of("key", 4), 4L);
-                                ctx.collectWithTimestamp(Tuple2.of("key", 5), 5L);
-                                ctx.emitWatermark(new Watermark(5));
-                                ctx.collectWithTimestamp(Tuple2.of("key", 8), 8L);
-                                ctx.collectWithTimestamp(Tuple2.of("key", 7), 7L);
-                                ctx.collectWithTimestamp(Tuple2.of("key", 9), 9L);
-                                ctx.collectWithTimestamp(Tuple2.of("key", 6), 6L);
-                            }
+                                new SourceFunction<Tuple2<String, Integer>>() {
+                                    @Override
+                                    public void run(SourceContext<Tuple2<String, Integer>> ctx) {
+                                        ctx.collectWithTimestamp(Tuple2.of("key", 2), 2L);
+                                        ctx.collectWithTimestamp(Tuple2.of("key", 1), 1L);
+                                        ctx.collectWithTimestamp(Tuple2.of("key", 3), 3L);
+                                        ctx.collectWithTimestamp(Tuple2.of("key", 4), 4L);
+                                        ctx.collectWithTimestamp(Tuple2.of("key", 5), 5L);
+                                        ctx.emitWatermark(new Watermark(5));
+                                        ctx.collectWithTimestamp(Tuple2.of("key", 8), 8L);
+                                        ctx.collectWithTimestamp(Tuple2.of("key", 7), 7L);
+                                        ctx.collectWithTimestamp(Tuple2.of("key", 9), 9L);
+                                        ctx.collectWithTimestamp(Tuple2.of("key", 6), 6L);
+                                    }
 
-                            @Override
-                            public void cancel() {
-                                // do nothing
-                            }
-                        });
+                                    @Override
+                                    public void cancel() {
+                                        // do nothing
+                                    }
+                                })
+                        .keyBy(new Tuple2KeyExtractor());
+
+        if (enableAsyncState) {
+            streamOne.enableAsyncState();
+            streamTwo.enableAsyncState();
+            configAsyncState(env);
+        }
 
         streamOne
-                .keyBy(new Tuple2KeyExtractor())
-                .intervalJoin(streamTwo.keyBy(new Tuple2KeyExtractor()))
+                .intervalJoin(streamTwo)
                 .between(Duration.ofMillis(-1), Duration.ofMillis(1))
                 .process(new CombineToStringJoinFunction())
                 .addSink(new ResultSink());
@@ -268,50 +295,67 @@ public class IntervalJoinITCase {
                 "(key,9):(key,9)");
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testFailsWithoutUpperBound() {
-        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        env.setParallelism(1);
+        assertThrows(
+                NullPointerException.class,
+                () -> {
+                    final StreamExecutionEnvironment env =
+                            StreamExecutionEnvironment.getExecutionEnvironment();
+                    env.setParallelism(1);
 
-        DataStream<Tuple2<String, Integer>> streamOne = env.fromData(Tuple2.of("1", 1));
-        DataStream<Tuple2<String, Integer>> streamTwo = env.fromData(Tuple2.of("1", 1));
+                    DataStream<Tuple2<String, Integer>> streamOne = env.fromData(Tuple2.of("1", 1));
+                    DataStream<Tuple2<String, Integer>> streamTwo = env.fromData(Tuple2.of("1", 1));
 
-        streamOne
-                .keyBy(new Tuple2KeyExtractor())
-                .intervalJoin(streamTwo.keyBy(new Tuple2KeyExtractor()))
-                .between(Duration.ofMillis(0), null);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void testFailsWithoutLowerBound() {
-        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        env.setParallelism(1);
-
-        DataStream<Tuple2<String, Integer>> streamOne = env.fromData(Tuple2.of("1", 1));
-        DataStream<Tuple2<String, Integer>> streamTwo = env.fromData(Tuple2.of("1", 1));
-
-        streamOne
-                .keyBy(new Tuple2KeyExtractor())
-                .intervalJoin(streamTwo.keyBy(new Tuple2KeyExtractor()))
-                .between(null, Duration.ofMillis(1));
+                    streamOne
+                            .keyBy(new Tuple2KeyExtractor())
+                            .intervalJoin(streamTwo.keyBy(new Tuple2KeyExtractor()))
+                            .between(Duration.ofMillis(0), null);
+                });
     }
 
     @Test
-    public void testBoundsCanBeExclusive() throws Exception {
+    public void testFailsWithoutLowerBound() {
+        assertThrows(
+                NullPointerException.class,
+                () -> {
+                    final StreamExecutionEnvironment env =
+                            StreamExecutionEnvironment.getExecutionEnvironment();
+                    env.setParallelism(1);
+
+                    DataStream<Tuple2<String, Integer>> streamOne = env.fromData(Tuple2.of("1", 1));
+                    DataStream<Tuple2<String, Integer>> streamTwo = env.fromData(Tuple2.of("1", 1));
+
+                    streamOne
+                            .keyBy(new Tuple2KeyExtractor())
+                            .intervalJoin(streamTwo.keyBy(new Tuple2KeyExtractor()))
+                            .between(null, Duration.ofMillis(1));
+                });
+    }
+
+    @ParameterizedTest(name = "Enable async state = {0}")
+    @ValueSource(booleans = {false, true})
+    public void testBoundsCanBeExclusive(boolean enableAsyncState) throws Exception {
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setParallelism(1);
 
-        DataStream<Tuple2<String, Integer>> streamOne =
+        KeyedStream<Tuple2<String, Integer>, String> streamOne =
                 env.fromData(Tuple2.of("key", 0), Tuple2.of("key", 1), Tuple2.of("key", 2))
-                        .assignTimestampsAndWatermarks(new AscendingTuple2TimestampExtractor());
+                        .assignTimestampsAndWatermarks(new AscendingTuple2TimestampExtractor())
+                        .keyBy(new Tuple2KeyExtractor());
 
-        DataStream<Tuple2<String, Integer>> streamTwo =
+        KeyedStream<Tuple2<String, Integer>, String> streamTwo =
                 env.fromData(Tuple2.of("key", 0), Tuple2.of("key", 1), Tuple2.of("key", 2))
-                        .assignTimestampsAndWatermarks(new AscendingTuple2TimestampExtractor());
+                        .assignTimestampsAndWatermarks(new AscendingTuple2TimestampExtractor())
+                        .keyBy(new Tuple2KeyExtractor());
 
+        if (enableAsyncState) {
+            streamOne.enableAsyncState();
+            streamTwo.enableAsyncState();
+            configAsyncState(env);
+        }
         streamOne
-                .keyBy(new Tuple2KeyExtractor())
-                .intervalJoin(streamTwo.keyBy(new Tuple2KeyExtractor()))
+                .intervalJoin(streamTwo)
                 .between(Duration.ofMillis(0), Duration.ofMillis(2))
                 .upperBoundExclusive()
                 .lowerBoundExclusive()
@@ -323,22 +367,67 @@ public class IntervalJoinITCase {
         expectInAnyOrder("(key,0):(key,1)", "(key,1):(key,2)");
     }
 
-    @Test
-    public void testBoundsCanBeInclusive() throws Exception {
+    @ParameterizedTest(name = "Enable async state = {0}")
+    @ValueSource(booleans = {false, true})
+    public void testBoundsCanBeInclusive(boolean enableAsyncState) throws Exception {
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setParallelism(1);
 
-        DataStream<Tuple2<String, Integer>> streamOne =
+        KeyedStream<Tuple2<String, Integer>, String> streamOne =
                 env.fromData(Tuple2.of("key", 0), Tuple2.of("key", 1), Tuple2.of("key", 2))
-                        .assignTimestampsAndWatermarks(new AscendingTuple2TimestampExtractor());
+                        .assignTimestampsAndWatermarks(new AscendingTuple2TimestampExtractor())
+                        .keyBy(new Tuple2KeyExtractor());
 
-        DataStream<Tuple2<String, Integer>> streamTwo =
+        KeyedStream<Tuple2<String, Integer>, String> streamTwo =
                 env.fromData(Tuple2.of("key", 0), Tuple2.of("key", 1), Tuple2.of("key", 2))
-                        .assignTimestampsAndWatermarks(new AscendingTuple2TimestampExtractor());
+                        .assignTimestampsAndWatermarks(new AscendingTuple2TimestampExtractor())
+                        .keyBy(new Tuple2KeyExtractor());
 
+        if (enableAsyncState) {
+            streamOne.enableAsyncState();
+            streamTwo.enableAsyncState();
+            configAsyncState(env);
+        }
         streamOne
-                .keyBy(new Tuple2KeyExtractor())
-                .intervalJoin(streamTwo.keyBy(new Tuple2KeyExtractor()))
+                .intervalJoin(streamTwo)
+                .between(Duration.ofMillis(0), Duration.ofMillis(2))
+                .process(new CombineToStringJoinFunction())
+                .addSink(new ResultSink());
+
+        env.execute();
+
+        expectInAnyOrder(
+                "(key,0):(key,0)",
+                "(key,0):(key,1)",
+                "(key,0):(key,2)",
+                "(key,1):(key,1)",
+                "(key,1):(key,2)",
+                "(key,2):(key,2)");
+    }
+
+    @ParameterizedTest(name = "Enable async state = {0}")
+    @ValueSource(booleans = {false, true})
+    public void testBoundsAreInclusiveByDefault(boolean enableAsyncState) throws Exception {
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+
+        KeyedStream<Tuple2<String, Integer>, String> streamOne =
+                env.fromData(Tuple2.of("key", 0), Tuple2.of("key", 1), Tuple2.of("key", 2))
+                        .assignTimestampsAndWatermarks(new AscendingTuple2TimestampExtractor())
+                        .keyBy(new Tuple2KeyExtractor());
+
+        KeyedStream<Tuple2<String, Integer>, String> streamTwo =
+                env.fromData(Tuple2.of("key", 0), Tuple2.of("key", 1), Tuple2.of("key", 2))
+                        .assignTimestampsAndWatermarks(new AscendingTuple2TimestampExtractor())
+                        .keyBy(new Tuple2KeyExtractor());
+
+        if (enableAsyncState) {
+            streamOne.enableAsyncState();
+            streamTwo.enableAsyncState();
+            configAsyncState(env);
+        }
+        streamOne
+                .intervalJoin(streamTwo)
                 .between(Duration.ofMillis(0), Duration.ofMillis(2))
                 .process(new CombineToStringJoinFunction())
                 .addSink(new ResultSink());
@@ -355,69 +444,49 @@ public class IntervalJoinITCase {
     }
 
     @Test
-    public void testBoundsAreInclusiveByDefault() throws Exception {
-        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        env.setParallelism(1);
+    public void testExecutionFailsInProcessingTime() {
+        assertThrows(
+                UnsupportedTimeCharacteristicException.class,
+                () -> {
+                    final StreamExecutionEnvironment env =
+                            StreamExecutionEnvironment.getExecutionEnvironment();
+                    env.setParallelism(1);
 
-        DataStream<Tuple2<String, Integer>> streamOne =
-                env.fromData(Tuple2.of("key", 0), Tuple2.of("key", 1), Tuple2.of("key", 2))
-                        .assignTimestampsAndWatermarks(new AscendingTuple2TimestampExtractor());
+                    DataStream<Tuple2<String, Integer>> streamOne = env.fromData(Tuple2.of("1", 1));
+                    DataStream<Tuple2<String, Integer>> streamTwo = env.fromData(Tuple2.of("1", 1));
 
-        DataStream<Tuple2<String, Integer>> streamTwo =
-                env.fromData(Tuple2.of("key", 0), Tuple2.of("key", 1), Tuple2.of("key", 2))
-                        .assignTimestampsAndWatermarks(new AscendingTuple2TimestampExtractor());
-
-        streamOne
-                .keyBy(new Tuple2KeyExtractor())
-                .intervalJoin(streamTwo.keyBy(new Tuple2KeyExtractor()))
-                .between(Duration.ofMillis(0), Duration.ofMillis(2))
-                .process(new CombineToStringJoinFunction())
-                .addSink(new ResultSink());
-
-        env.execute();
-
-        expectInAnyOrder(
-                "(key,0):(key,0)",
-                "(key,0):(key,1)",
-                "(key,0):(key,2)",
-                "(key,1):(key,1)",
-                "(key,1):(key,2)",
-                "(key,2):(key,2)");
-    }
-
-    @Test(expected = UnsupportedTimeCharacteristicException.class)
-    public void testExecutionFailsInProcessingTime() throws Exception {
-        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        env.setParallelism(1);
-
-        DataStream<Tuple2<String, Integer>> streamOne = env.fromData(Tuple2.of("1", 1));
-        DataStream<Tuple2<String, Integer>> streamTwo = env.fromData(Tuple2.of("1", 1));
-
-        streamOne
-                .keyBy(new Tuple2KeyExtractor())
-                .intervalJoin(streamTwo.keyBy(new Tuple2KeyExtractor()))
-                .inProcessingTime()
-                .between(Duration.ofMillis(0), Duration.ofMillis(0))
-                .process(
-                        new ProcessJoinFunction<
-                                Tuple2<String, Integer>, Tuple2<String, Integer>, String>() {
-                            @Override
-                            public void processElement(
-                                    Tuple2<String, Integer> left,
-                                    Tuple2<String, Integer> right,
-                                    Context ctx,
-                                    Collector<String> out)
-                                    throws Exception {
-                                out.collect(left + ":" + right);
-                            }
-                        });
+                    streamOne
+                            .keyBy(new Tuple2KeyExtractor())
+                            .intervalJoin(streamTwo.keyBy(new Tuple2KeyExtractor()))
+                            .inProcessingTime()
+                            .between(Duration.ofMillis(0), Duration.ofMillis(0))
+                            .process(
+                                    new ProcessJoinFunction<
+                                            Tuple2<String, Integer>,
+                                            Tuple2<String, Integer>,
+                                            String>() {
+                                        @Override
+                                        public void processElement(
+                                                Tuple2<String, Integer> left,
+                                                Tuple2<String, Integer> right,
+                                                Context ctx,
+                                                Collector<String> out)
+                                                throws Exception {
+                                            out.collect(left + ":" + right);
+                                        }
+                                    });
+                });
     }
 
     private static void expectInAnyOrder(String... expected) {
-        List<String> listExpected = Lists.newArrayList(expected);
-        Collections.sort(listExpected);
-        Collections.sort(testResults);
-        Assert.assertEquals(listExpected, testResults);
+        assertThat(testResults).containsExactlyInAnyOrder(expected);
+    }
+
+    private static void configAsyncState(StreamExecutionEnvironment env) {
+        // For async state, by default we will use the forst state backend.
+        Configuration config = Configuration.fromMap(env.getConfiguration().toMap());
+        config.set(StateBackendOptions.STATE_BACKEND, FORST_STATE_BACKEND_NAME);
+        env.configure(config);
     }
 
     private static class AscendingTuple2TimestampExtractor


### PR DESCRIPTION

## What is the purpose of the change

As part of FLIP-488, this PR introduced the built-in interval join operator for datastream with async state access.

 - Also a hotfix of forst map state is included, found by testing of interval join.


## Brief change log

 - A hotfix of forst map state
 - Introduce `AsyncIntervalJoinOperator`
 - Modifying the test harness
 - Introduce corresponding UT/ITs.

## Verifying this change

This change added tests and can be verified as follows:
 - `AsyncIntervalJoinOperatorTest`
 - `IntervalJoinITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not documented (later)
