### PR TITLE
[FLINK-36181] Use Java 17 by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     name: "Default (Java 17)"
     uses: ./.github/workflows/template.flink-ci.yml
     with:
-      environment: 'PROFILE="-Dinclude_hadoop_aws -Djdk11 -Djdk17 -Pjava17-target"'
+      environment: 'PROFILE="-Dinclude_hadoop_aws -Djdk17 -Pjava17-target"'
       jdk_version: 17
     secrets:
       s3_bucket: ${{ secrets.IT_CASE_S3_BUCKET }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,11 @@ jobs:
     name: "Pre-compile Checks"
     uses: ./.github/workflows/template.pre-compile-checks.yml
   ci:
-    name: "Default (Java 11)"
+    name: "Default (Java 17)"
     uses: ./.github/workflows/template.flink-ci.yml
     with:
-      environment: 'PROFILE="-Dinclude_hadoop_aws"'
-      jdk_version: 11
+      environment: 'PROFILE="-Dinclude_hadoop_aws -Djdk11 -Djdk17 -Pjava17-target"'
+      jdk_version: 17
     secrets:
       s3_bucket: ${{ secrets.IT_CASE_S3_BUCKET }}
       s3_access_key: ${{ secrets.IT_CASE_S3_ACCESS_KEY }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,17 +28,6 @@ jobs:
     name: "Pre-compile Checks"
     uses: ./.github/workflows/template.pre-compile-checks.yml
 
-  java11:
-    name: "Java 11"
-    uses: ./.github/workflows/template.flink-ci.yml
-    with:
-      workflow-caller-id: java11
-      environment: 'PROFILE="-Dinclude_hadoop_aws -Djdk11 -Pjava11-target"'
-      jdk_version: 11
-    secrets:
-      s3_bucket: ${{ secrets.IT_CASE_S3_BUCKET }}
-      s3_access_key: ${{ secrets.IT_CASE_S3_ACCESS_KEY }}
-      s3_secret_key: ${{ secrets.IT_CASE_S3_SECRET_KEY }}
   java17:
     name: "Java 17"
     uses: ./.github/workflows/template.flink-ci.yml
@@ -66,8 +55,8 @@ jobs:
     uses: ./.github/workflows/template.flink-ci.yml
     with:
       workflow-caller-id: hadoop313
-      environment: 'PROFILE="-Dflink.hadoop.version=3.2.3 -Phadoop3-tests,hive3"'
-      jdk_version: 11
+      environment: 'PROFILE="-Dflink.hadoop.version=3.2.3 -Phadoop3-tests,hive3 -Djdk11 -Djdk17 -Pjava17-target"'
+      jdk_version: 17
     secrets:
       s3_bucket: ${{ secrets.IT_CASE_S3_BUCKET }}
       s3_access_key: ${{ secrets.IT_CASE_S3_ACCESS_KEY }}
@@ -77,8 +66,8 @@ jobs:
     uses: ./.github/workflows/template.flink-ci.yml
     with:
       workflow-caller-id: adaptive-scheduler
-      environment: 'PROFILE="-Penable-adaptive-scheduler"'
-      jdk_version: 11
+      environment: 'PROFILE="-Penable-adaptive-scheduler -Djdk11 -Djdk17 -Pjava17-target"'
+      jdk_version: 17
     secrets:
       s3_bucket: ${{ secrets.IT_CASE_S3_BUCKET }}
       s3_access_key: ${{ secrets.IT_CASE_S3_ACCESS_KEY }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,13 +28,13 @@ jobs:
     name: "Pre-compile Checks"
     uses: ./.github/workflows/template.pre-compile-checks.yml
 
-  java17:
-    name: "Java 17"
+  java11:
+    name: "Java 11"
     uses: ./.github/workflows/template.flink-ci.yml
     with:
-      workflow-caller-id: java17
-      environment: 'PROFILE="-Dinclude_hadoop_aws -Djdk11 -Djdk17 -Pjava17-target"'
-      jdk_version: 17
+      workflow-caller-id: java11
+      environment: 'PROFILE="-Dinclude_hadoop_aws -Djdk11 -Pjava11-target"'
+      jdk_version: 11
     secrets:
       s3_bucket: ${{ secrets.IT_CASE_S3_BUCKET }}
       s3_access_key: ${{ secrets.IT_CASE_S3_ACCESS_KEY }}
@@ -44,7 +44,7 @@ jobs:
     uses: ./.github/workflows/template.flink-ci.yml
     with:
       workflow-caller-id: java21
-      environment: 'PROFILE="-Dinclude_hadoop_aws -Djdk11 -Djdk17 -Djdk21 -Pjava21-target"'
+      environment: 'PROFILE="-Dinclude_hadoop_aws -Djdk21 -Pjava21-target"'
       jdk_version: 21
     secrets:
       s3_bucket: ${{ secrets.IT_CASE_S3_BUCKET }}
@@ -55,7 +55,7 @@ jobs:
     uses: ./.github/workflows/template.flink-ci.yml
     with:
       workflow-caller-id: hadoop313
-      environment: 'PROFILE="-Dflink.hadoop.version=3.2.3 -Phadoop3-tests,hive3 -Djdk11 -Djdk17 -Pjava17-target"'
+      environment: 'PROFILE="-Dflink.hadoop.version=3.2.3 -Phadoop3-tests,hive3 -Djdk17 -Pjava17-target"'
       jdk_version: 17
     secrets:
       s3_bucket: ${{ secrets.IT_CASE_S3_BUCKET }}
@@ -66,7 +66,7 @@ jobs:
     uses: ./.github/workflows/template.flink-ci.yml
     with:
       workflow-caller-id: adaptive-scheduler
-      environment: 'PROFILE="-Penable-adaptive-scheduler -Djdk11 -Djdk17 -Pjava17-target"'
+      environment: 'PROFILE="-Penable-adaptive-scheduler -Djdk17 -Pjava17-target"'
       jdk_version: 17
     secrets:
       s3_bucket: ${{ secrets.IT_CASE_S3_BUCKET }}

--- a/.github/workflows/template.flink-ci.yml
+++ b/.github/workflows/template.flink-ci.yml
@@ -30,7 +30,7 @@ on:
         type: string
       jdk_version:
         description: "The Java version to use."
-        default: 11
+        default: 17
         type: number
     secrets:
       s3_bucket:

--- a/.github/workflows/template.pre-compile-checks.yml
+++ b/.github/workflows/template.pre-compile-checks.yml
@@ -23,7 +23,7 @@ on:
     inputs:
       jdk_version:
         description: "The JDK version that shall be used as a default within the Flink CI Docker container."
-        default: "11"
+        default: "17"
         type: choice
         options: ["11", "17", "21"]
 
@@ -31,7 +31,7 @@ on:
     inputs:
       jdk_version:
         description: "The JDK version that shall be used as a default within the Flink CI Docker container."
-        default: 11
+        default: 17
         type: number
 
 permissions: read-all

--- a/README.md
+++ b/README.md
@@ -104,15 +104,46 @@ Prerequisites for building Flink:
 * Unix-like environment (we use Linux, Mac OS X, Cygwin, WSL)
 * Git
 * Maven (we require version 3.8.6)
-* Java 17 (by default. You can also use 21 or 11)
+* Java (version 11, 17, or 21)
+
+### Basic Build Instructions
+
+First, clone the repository:
 
 ```
 git clone https://github.com/apache/flink.git
 cd flink
-./mvnw clean package -DskipTests -Djdk17 -Pjava17-target # this will take up to 10 minutes
 ```
 
-Flink is now installed in `build-target`.
+Then, choose one of the following commands based on your preferred Java version:
+
+**For Java 11**
+
+```
+./mvnw clean package -DskipTests -Djdk11 -Pjava11-target
+```
+
+**For Java 17 (Default)**
+
+```
+./mvnw clean package -DskipTests -Djdk17 -Pjava17-target
+```
+
+**For Java 21**
+
+```
+./mvnw clean package -DskipTests -Djdk21 -Pjava21-target
+```
+
+The build process will take approximately 10 minutes to complete.
+Flink will be installed in `build-target`.
+
+### Notes
+
+* Make sure your JAVA_HOME environment variable points to the correct JDK version
+* The build command uses Maven wrapper (mvnw) which ensures the correct Maven version is used
+* The -DskipTests flag skips running tests to speed up the build process
+* Each Java version requires its corresponding profile (-Pjava<version>-target) and JDK flag (-Djdk<version>)
 
 ## Developing Flink
 

--- a/README.md
+++ b/README.md
@@ -104,12 +104,12 @@ Prerequisites for building Flink:
 * Unix-like environment (we use Linux, Mac OS X, Cygwin, WSL)
 * Git
 * Maven (we require version 3.8.6)
-* Java 11
+* Java 17 (by default. You can also use 21 or 11)
 
 ```
 git clone https://github.com/apache/flink.git
 cd flink
-./mvnw clean package -DskipTests # this will take up to 10 minutes
+./mvnw clean package -DskipTests -Djdk17 -Pjava17-target # this will take up to 10 minutes
 ```
 
 Flink is now installed in `build-target`.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -76,7 +76,7 @@ stages:
             vmImage: 'ubuntu-22.04'
           e2e_pool_definition:
             vmImage: 'ubuntu-22.04'
-          environment: PROFILE="-Dflink.hadoop.version=2.10.2 -Djdk11 -Djdk17 -Pjava17-target"
+          environment: PROFILE="-Dflink.hadoop.version=2.10.2 -Djdk17 -Pjava17-target"
           run_end_to_end: false
           container: flink-build-container
           jdk: 17

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -76,10 +76,10 @@ stages:
             vmImage: 'ubuntu-22.04'
           e2e_pool_definition:
             vmImage: 'ubuntu-22.04'
-          environment: PROFILE="-Dflink.hadoop.version=2.10.2"
+          environment: PROFILE="-Dflink.hadoop.version=2.10.2 -Djdk11 -Djdk17 -Pjava17-target"
           run_end_to_end: false
           container: flink-build-container
-          jdk: 11
+          jdk: 17
       - job: docs_404_check # run on a MSFT provided machine
         pool:
           vmImage: 'ubuntu-22.04'

--- a/flink-dist-scala/src/main/resources/META-INF/NOTICE
+++ b/flink-dist-scala/src/main/resources/META-INF/NOTICE
@@ -10,7 +10,7 @@ This project bundles the following dependencies under the Apache Software Licens
 
 The following dependencies all share the same BSD license which you find under licenses/LICENSE.scala.
 
-- org.scala-lang:scala-compiler:2.12.7
-- org.scala-lang:scala-library:2.12.7
-- org.scala-lang:scala-reflect:2.12.7
-- org.scala-lang.modules:scala-xml_2.12:1.0.6
+- org.scala-lang:scala-compiler:2.12.20
+- org.scala-lang:scala-library:2.12.20
+- org.scala-lang:scala-reflect:2.12.20
+- org.scala-lang.modules:scala-xml_2.12:2.3.0

--- a/flink-end-to-end-tests/test-scripts/common_docker.sh
+++ b/flink-end-to-end-tests/test-scripts/common_docker.sh
@@ -46,10 +46,10 @@ function build_image() {
     start_file_server
     local server_pid=$!
 
-    echo "Preparing Dockeriles"
+    echo "Preparing Dockerfiles"
     retry_times_with_exponential_backoff 5 git clone https://github.com/apache/flink-docker.git --branch dev-master --single-branch
 
-    local java_version=11
+    local java_version=17
     if [[ ${PROFILE} == *"jdk17"* ]]; then
         java_version=17
     fi

--- a/flink-rpc/flink-rpc-akka/pom.xml
+++ b/flink-rpc/flink-rpc-akka/pom.xml
@@ -38,8 +38,6 @@ under the License.
 
 	<properties>
 		<pekko.version>1.1.2</pekko.version>
-		<scala.binary.version>2.12</scala.binary.version>
-		<scala.version>2.12.16</scala.version>
 	</properties>
 
 	<dependencies>

--- a/flink-table/flink-table-planner-loader-bundle/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-table-planner-loader-bundle/src/main/resources/META-INF/NOTICE
@@ -6,6 +6,6 @@ The Apache Software Foundation (http://www.apache.org/).
 
 The following dependencies all share the same BSD license which you find under licenses/LICENSE.scala.
 
-- org.scala-lang:scala-compiler:2.12.7
-- org.scala-lang:scala-library:2.12.7
-- org.scala-lang:scala-reflect:2.12.7
+- org.scala-lang:scala-compiler:2.12.20
+- org.scala-lang:scala-library:2.12.20
+- org.scala-lang:scala-reflect:2.12.20

--- a/pom.xml
+++ b/pom.xml
@@ -1063,6 +1063,22 @@ under the License.
 		</profile>
 
 		<profile>
+			<id>java11-target</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-compiler-plugin</artifactId>
+						<configuration>
+							<source>11</source>
+							<target>11</target>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+
+		<profile>
 			<id>java17</id>
 			<activation>
 				<jdk>[17,)</jdk>

--- a/pom.xml
+++ b/pom.xml
@@ -133,9 +133,7 @@ under the License.
 		<maven.compiler.source>${target.java.version}</maven.compiler.source>
 		<maven.compiler.target>${target.java.version}</maven.compiler.target>
 		<scala.macros.version>2.1.1</scala.macros.version>
-		<!-- Default scala versions, must be overwritten by build profiles, so we set something
-		invalid here -->
-		<scala.version>2.12.7</scala.version>
+		<scala.version>2.12.20</scala.version>
 		<scala.binary.version>2.12</scala.binary.version>
 		<chill.version>0.7.6</chill.version>
 		<!-- keep FlinkTestcontainersConfigurator.configureZookeeperContainer in sync -->
@@ -944,7 +942,7 @@ under the License.
 		<profile>
 			<id>scala-2.12</id>
 			<properties>
-				<scala.version>2.12.7</scala.version>
+				<scala.version>2.12.20</scala.version>
 				<scala.binary.version>2.12</scala.binary.version>
 			</properties>
 			<activation>
@@ -1072,7 +1070,7 @@ under the License.
 
 			<properties>
 				<!-- Bump Scala because 2.12.7 doesn't compile on Java 17. -->
-				<scala.version>2.12.15</scala.version>
+				<scala.version>2.12.20</scala.version>
 				<surefire.excludedGroups.jdk>org.apache.flink.testutils.junit.FailsOnJava17</surefire.excludedGroups.jdk>
 			</properties>
 
@@ -1129,8 +1127,8 @@ under the License.
 			</activation>
 
 			<properties>
-				<!-- Bump Scala because before 2.12.18 doesn't compile on Java 21. -->
-				<scala.version>2.12.18</scala.version>
+				<!-- Bump Scala because before 2.12.7 doesn't compile on Java 21. -->
+				<scala.version>2.12.20</scala.version>
 			</properties>
 
 			<build>

--- a/pom.xml
+++ b/pom.xml
@@ -1065,6 +1065,11 @@ under the License.
 
 		<profile>
 			<id>java11-target</id>
+
+			<properties>
+				<target.java.version>11</target.java.version>
+			</properties>
+
 			<build>
 				<plugins>
 					<plugin>
@@ -1426,7 +1431,7 @@ under the License.
 										<!-- versions for certain build tools are enforced to match the CI setup -->
 										<!-- the rules below should stay in sync with Flink Release wiki documentation and the CI scripts -->
 										<requireJavaVersion>
-											<version>[17.*)</version>
+											<version>[${target.java.version}.*)</version>
 										</requireJavaVersion>
 									</rules>
 								</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,7 @@ under the License.
 		<flink.shaded.jackson.version>2.15.3</flink.shaded.jackson.version>
 		<flink.shaded.jsonpath.version>2.7.0</flink.shaded.jsonpath.version>
 		<flink.markBundledAsOptional>true</flink.markBundledAsOptional>
+		<source.java.version>11</source.java.version>
 		<target.java.version>17</target.java.version>
 		<slf4j.version>1.7.36</slf4j.version>
 		<log4j.version>2.24.1</log4j.version>
@@ -2082,7 +2083,8 @@ under the License.
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>3.8.0</version>
 					<configuration>
-						<source>${target.java.version}</source>
+						<!-- Make sure that we only use Java 11 compatible APIs -->
+						<source>${source.java.version}</source>
 						<target>${target.java.version}</target>
 						<!-- The semantics of this option are reversed, see MCOMPILER-209. -->
 						<useIncrementalCompilation>false</useIncrementalCompilation>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@ under the License.
 		<flink.shaded.jackson.version>2.15.3</flink.shaded.jackson.version>
 		<flink.shaded.jsonpath.version>2.7.0</flink.shaded.jsonpath.version>
 		<flink.markBundledAsOptional>true</flink.markBundledAsOptional>
-		<target.java.version>11</target.java.version>
+		<target.java.version>17</target.java.version>
 		<slf4j.version>1.7.36</slf4j.version>
 		<log4j.version>2.24.1</log4j.version>
 		<!-- Overwrite default values from parent pom.
@@ -1386,7 +1386,7 @@ under the License.
 				</property>
 			</activation>
 			<properties>
-				<target.java.version>11</target.java.version>
+				<target.java.version>17</target.java.version>
 			</properties>
 			<build>
 				<plugins>
@@ -1418,7 +1418,7 @@ under the License.
 										<!-- versions for certain build tools are enforced to match the CI setup -->
 										<!-- the rules below should stay in sync with Flink Release wiki documentation and the CI scripts -->
 										<requireJavaVersion>
-											<version>[11.0.0,11.1.0)</version>
+											<version>[17.*)</version>
 										</requireJavaVersion>
 									</rules>
 								</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -1069,8 +1069,6 @@ under the License.
 			</activation>
 
 			<properties>
-				<!-- Bump Scala because 2.12.7 doesn't compile on Java 17. -->
-				<scala.version>2.12.20</scala.version>
 				<surefire.excludedGroups.jdk>org.apache.flink.testutils.junit.FailsOnJava17</surefire.excludedGroups.jdk>
 			</properties>
 
@@ -1125,11 +1123,6 @@ under the License.
 			<activation>
 				<jdk>[21,)</jdk>
 			</activation>
-
-			<properties>
-				<!-- Bump Scala because before 2.12.7 doesn't compile on Java 21. -->
-				<scala.version>2.12.20</scala.version>
-			</properties>
 
 			<build>
 				<pluginManagement>

--- a/tools/azure-pipelines/build-apache-repo.yml
+++ b/tools/azure-pipelines/build-apache-repo.yml
@@ -69,10 +69,10 @@ stages:
             name: Default
           e2e_pool_definition:
             vmImage: 'ubuntu-22.04'
-          environment: PROFILE="-Dflink.hadoop.version=2.10.2 -Djdk11 -Pjava11-target"
+          environment: PROFILE="-Dflink.hadoop.version=2.10.2 -Djdk11 -Djdk17 -Pjava17-target"
           run_end_to_end: false
           container: flink-build-container
-          jdk: 11
+          jdk: 17
       - job: docs_404_check # run on a MSFT provided machine
         pool:
           vmImage: 'ubuntu-22.04'
@@ -103,9 +103,9 @@ stages:
       - template: build-nightly-dist.yml
         parameters:
           stage_name: cron_snapshot_deployment
-          environment: PROFILE="-Djdk11 -Pjava11-target"
+          environment: PROFILE="-Djdk11 -Djdk17 -Pjava17-target"
           container: flink-build-container
-          jdk: 11
+          jdk: 17
       - template: jobs-template.yml
         parameters:
           stage_name: cron_azure
@@ -113,10 +113,10 @@ stages:
             vmImage: 'ubuntu-22.04'
           e2e_pool_definition:
             vmImage: 'ubuntu-22.04'
-          environment: PROFILE="-Dflink.hadoop.version=2.10.2 -Djdk11 -Pjava11-target"
+          environment: PROFILE="-Dflink.hadoop.version=2.10.2 -Djdk11 -Djdk17 -Pjava17-target"
           run_end_to_end: true
           container: flink-build-container
-          jdk: 11
+          jdk: 17
       - template: jobs-template.yml
         parameters:
           stage_name: cron_hadoop313
@@ -124,18 +124,7 @@ stages:
             name: Default
           e2e_pool_definition:
             vmImage: 'ubuntu-22.04'
-          environment: PROFILE="-Dflink.hadoop.version=3.2.3 -Phadoop3-tests,hive3 -Djdk11 -Pjava11-target"
-          run_end_to_end: true
-          container: flink-build-container
-          jdk: 11
-      - template: jobs-template.yml
-        parameters:
-          stage_name: cron_jdk17
-          test_pool_definition:
-            name: Default
-          e2e_pool_definition:
-            vmImage: 'ubuntu-22.04'
-          environment: PROFILE="-Dflink.hadoop.version=2.10.2 -Djdk11 -Djdk17 -Pjava17-target"
+          environment: PROFILE="-Dflink.hadoop.version=3.2.3 -Phadoop3-tests,hive3 -Djdk11 -Djdk17 -Pjava17-target"
           run_end_to_end: true
           container: flink-build-container
           jdk: 17
@@ -157,10 +146,10 @@ stages:
             name: Default
           e2e_pool_definition:
             vmImage: 'ubuntu-22.04'
-          environment: PROFILE="-Dflink.hadoop.version=2.10.2 -Penable-adaptive-scheduler -Djdk11 -Pjava11-target"
+          environment: PROFILE="-Dflink.hadoop.version=2.10.2 -Penable-adaptive-scheduler -Djdk11 -Djdk17 -Pjava17-target"
           run_end_to_end: true
           container: flink-build-container
-          jdk: 11
+          jdk: 17
       - job: docs_404_check # run on a MSFT provided machine
         pool:
           vmImage: 'ubuntu-22.04'
@@ -172,5 +161,5 @@ stages:
       - template: build-python-wheels.yml
         parameters:
           stage_name: cron_python_wheels
-          environment: PROFILE="-Dflink.hadoop.version=2.10.2"
+          environment: PROFILE="-Dflink.hadoop.version=2.10.2 -Djdk11 -Djdk17 -Pjava17-target"
           container: flink-build-container

--- a/tools/azure-pipelines/build-apache-repo.yml
+++ b/tools/azure-pipelines/build-apache-repo.yml
@@ -69,7 +69,7 @@ stages:
             name: Default
           e2e_pool_definition:
             vmImage: 'ubuntu-22.04'
-          environment: PROFILE="-Dflink.hadoop.version=2.10.2 -Djdk11 -Djdk17 -Pjava17-target"
+          environment: PROFILE="-Dflink.hadoop.version=2.10.2 -Djdk17 -Pjava17-target"
           run_end_to_end: false
           container: flink-build-container
           jdk: 17
@@ -103,7 +103,7 @@ stages:
       - template: build-nightly-dist.yml
         parameters:
           stage_name: cron_snapshot_deployment
-          environment: PROFILE="-Djdk11 -Djdk17 -Pjava17-target"
+          environment: PROFILE="-Djdk17 -Pjava17-target"
           container: flink-build-container
           jdk: 17
       - template: jobs-template.yml
@@ -113,7 +113,7 @@ stages:
             vmImage: 'ubuntu-22.04'
           e2e_pool_definition:
             vmImage: 'ubuntu-22.04'
-          environment: PROFILE="-Dflink.hadoop.version=2.10.2 -Djdk11 -Djdk17 -Pjava17-target"
+          environment: PROFILE="-Dflink.hadoop.version=2.10.2 -Djdk17 -Pjava17-target"
           run_end_to_end: true
           container: flink-build-container
           jdk: 17
@@ -124,10 +124,21 @@ stages:
             name: Default
           e2e_pool_definition:
             vmImage: 'ubuntu-22.04'
-          environment: PROFILE="-Dflink.hadoop.version=3.2.3 -Phadoop3-tests,hive3 -Djdk11 -Djdk17 -Pjava17-target"
+          environment: PROFILE="-Dflink.hadoop.version=3.2.3 -Phadoop3-tests,hive3 -Djdk17 -Pjava17-target"
           run_end_to_end: true
           container: flink-build-container
           jdk: 17
+      - template: jobs-template.yml
+        parameters:
+          stage_name: cron_jdk11
+          test_pool_definition:
+            name: Default
+          e2e_pool_definition:
+            vmImage: 'ubuntu-22.04'
+          environment: PROFILE="-Dflink.hadoop.version=2.10.2 -Djdk11 -Pjava11-target"
+          run_end_to_end: true
+          container: flink-build-container
+          jdk: 11
       - template: jobs-template.yml
         parameters:
           stage_name: cron_jdk21
@@ -135,7 +146,7 @@ stages:
             name: Default
           e2e_pool_definition:
             vmImage: 'ubuntu-22.04'
-          environment: PROFILE="-Dflink.hadoop.version=2.10.2 -Djdk11 -Djdk17 -Djdk21 -Pjava21-target"
+          environment: PROFILE="-Dflink.hadoop.version=2.10.2 -Djdk21 -Pjava21-target"
           run_end_to_end: true
           container: flink-build-container
           jdk: 21
@@ -146,7 +157,7 @@ stages:
             name: Default
           e2e_pool_definition:
             vmImage: 'ubuntu-22.04'
-          environment: PROFILE="-Dflink.hadoop.version=2.10.2 -Penable-adaptive-scheduler -Djdk11 -Djdk17 -Pjava17-target"
+          environment: PROFILE="-Dflink.hadoop.version=2.10.2 -Penable-adaptive-scheduler -Djdk17 -Pjava17-target"
           run_end_to_end: true
           container: flink-build-container
           jdk: 17
@@ -161,5 +172,5 @@ stages:
       - template: build-python-wheels.yml
         parameters:
           stage_name: cron_python_wheels
-          environment: PROFILE="-Dflink.hadoop.version=2.10.2 -Djdk11 -Djdk17 -Pjava17-target"
+          environment: PROFILE="-Dflink.hadoop.version=2.10.2 -Djdk17 -Pjava17-target"
           container: flink-build-container


### PR DESCRIPTION
## What is the purpose of the change

This PR changes Flink CI to run on Java 17 by default, effectively dropping support for Java 8. Since Java 11 is officially not deprecated, there's a separate Java profile to run JDK11 tests during the nightly cron builds. 

## Brief change log

* Changes CI to run on Java 17 by default, and removes Java 8 in the CI runs
* Bumps Scala to 2.12.20, since we're already in Flink 2.0 land and we can safely break this for the upgrade to Java 17. 
* Updates README

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): don't know
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? docs
