### PR TITLE
[FLINK-37019][tests] Bump junit5 to 5.11.4

### DIFF
--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -50,7 +50,8 @@ under the License.
 			OperatorStateBackendTest
 			-->--add-opens=java.base/java.io=ALL-UNNAMED <!--
 			AsynchronousFileIOChannelTest
-			-->--add-opens=java.base/java.util.concurrent=ALL-UNNAMED
+			-->--add-opens=java.base/java.util.concurrent=ALL-UNNAMED <!--
+			-->-Djunit.platform.reflection.search.useLegacySemantics=true
 		</surefire.module.config>
 	</properties>
 

--- a/flink-table/flink-sql-gateway/pom.xml
+++ b/flink-table/flink-sql-gateway/pom.xml
@@ -39,7 +39,11 @@
 			SqlGatewayTest/CommonTestUtils.setEnv
 			-->--add-opens=java.base/java.util=ALL-UNNAMED <!--
 			OperationManager#getThreadInFuture
-			-->--add-opens=java.base/java.util.concurrent=ALL-UNNAMED
+			-->--add-opens=java.base/java.util.concurrent=ALL-UNNAMED <!--
+			SqlGatewayRestEndpointStatementITCase has to override AbstractSqlGatewayStatementITCase methods
+			JUnit changed this behavior since 5.11.x, to restore it back need this flag as mentioned at
+			https://junit.org/junit5/docs/current/user-guide/#extensions-supported-utilities-search-semantics
+			-->-Djunit.platform.reflection.search.useLegacySemantics=true
 		</surefire.module.config>
 	</properties>
 

--- a/flink-table/flink-sql-parser/pom.xml
+++ b/flink-table/flink-sql-parser/pom.xml
@@ -35,6 +35,12 @@ under the License.
 	<properties>
 		<!-- override parent pom -->
 		<test.excludedGroups/>
+		<surefire.module.config><!--
+			FlinkSqlParserImplTest has to override Calcite's SqlParserTest
+			JUnit changed this behavior since 5.11.x, to restore it back need this flag as mentioned at
+			https://junit.org/junit5/docs/current/user-guide/#extensions-supported-utilities-search-semantics
+			-->-Djunit.platform.reflection.search.useLegacySemantics=true
+		</surefire.module.config>
 	</properties>
 
 	<dependencies>

--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -50,7 +50,11 @@ under the License.
 			kryo MathContext
 			-->--add-opens=java.base/java.math=ALL-UNNAMED <!--
 			kryo ByteBuffer
-			-->--add-opens=java.base/java.nio=ALL-UNNAMED
+			-->--add-opens=java.base/java.nio=ALL-UNNAMED <!--
+			Multiple tests have to override TableTestBase methods and others
+			JUnit changed this behavior since 5.11.x, to restore it back need this flag as mentioned at
+			https://junit.org/junit5/docs/current/user-guide/#extensions-supported-utilities-search-semantics
+			-->-Djunit.platform.reflection.search.useLegacySemantics=true
 		</surefire.module.config>
 	</properties>
 

--- a/flink-yarn-tests/pom.xml
+++ b/flink-yarn-tests/pom.xml
@@ -44,7 +44,11 @@ under the License.
 			MiniYARNCluster
 			-->--add-opens=java.base/java.lang=ALL-UNNAMED <!--
 			YARNSessionFIFOSecuredITCase
-			-->--add-exports=java.security.jgss/sun.security.krb5=ALL-UNNAMED
+			-->--add-exports=java.security.jgss/sun.security.krb5=ALL-UNNAMED <!--
+			YARNSessionCapacitySchedulerITCase has to override YarnTestBase methods
+			JUnit changed this behavior since 5.11.x, to restore it back need this flag as mentioned at
+			https://junit.org/junit5/docs/current/user-guide/#extensions-supported-utilities-search-semantics
+			-->-Djunit.platform.reflection.search.useLegacySemantics=true
 		</surefire.module.config>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@ under the License.
 		<javax.activation.api.version>1.2.0</javax.activation.api.version>
 		<jaxb.api.version>2.3.1</jaxb.api.version>
 		<junit4.version>4.13.2</junit4.version>
-		<junit5.version>5.10.1</junit5.version>
+		<junit5.version>5.11.4</junit5.version>
 		<archunit.version>1.2.0</archunit.version>
 		<mockito.version>5.14.2</mockito.version>
 		<hamcrest.version>1.3</hamcrest.version>


### PR DESCRIPTION

## What is the purpose of the change

Among others there is now support of parameterized tests with @FieldSource
https://junit.org/junit5/docs/current/user-guide/#writing-tests-parameterized-tests-sources-FieldSource
## Brief change log

pom files


## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes )
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
