### PR TITLE
[FLINK-36507][table-common] Remove the deprecated method LogicalTypeParser#parse

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/descriptors/DescriptorProperties.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/descriptors/DescriptorProperties.java
@@ -627,7 +627,12 @@ public class DescriptorProperties {
     /** Returns the DataType under the given key if it exists. */
     public Optional<DataType> getOptionalDataType(String key) {
         return optionalGet(key)
-                .map(t -> TypeConversions.fromLogicalToDataType(LogicalTypeParser.parse(t)));
+                .map(
+                        t ->
+                                TypeConversions.fromLogicalToDataType(
+                                        LogicalTypeParser.parse(
+                                                t,
+                                                Thread.currentThread().getContextClassLoader())));
     }
 
     /** Returns the DataType under the given existing key. */
@@ -722,7 +727,10 @@ public class DescriptorProperties {
                 final String typeString =
                         optionalGet(typeKey).orElseThrow(exceptionSupplier(typeKey));
                 final DataType exprType =
-                        TypeConversions.fromLogicalToDataType(LogicalTypeParser.parse(typeString));
+                        TypeConversions.fromLogicalToDataType(
+                                LogicalTypeParser.parse(
+                                        typeString,
+                                        Thread.currentThread().getContextClassLoader()));
                 schemaBuilder.watermark(rowtime, exprString, exprType);
             }
         }
@@ -1367,7 +1375,9 @@ public class DescriptorProperties {
                     // we don't validate the string but let the parser do the work for us
                     // it throws a validation exception
                     v -> {
-                        LogicalType t = LogicalTypeParser.parse(v);
+                        LogicalType t =
+                                LogicalTypeParser.parse(
+                                        v, Thread.currentThread().getContextClassLoader());
                         if (t.getTypeRoot() == LogicalTypeRoot.UNRESOLVED) {
                             throw new ValidationException(
                                     "Could not parse type string '" + v + "'.");

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/descriptors/Schema.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/descriptors/Schema.java
@@ -147,7 +147,9 @@ public class Schema implements Descriptor {
 
     private static boolean isLegacyTypeString(String fieldType) {
         try {
-            LogicalType type = LogicalTypeParser.parse(fieldType);
+            LogicalType type =
+                    LogicalTypeParser.parse(
+                            fieldType, Thread.currentThread().getContextClassLoader());
             return type instanceof UnresolvedUserDefinedType;
         } catch (Exception e) {
             // if the parsing failed, fallback to the legacy parser

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeParser.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeParser.java
@@ -106,19 +106,6 @@ public final class LogicalTypeParser {
         return converter.parseTokens();
     }
 
-    /**
-     * Parses a type string. All types will be fully resolved except for {@link
-     * UnresolvedUserDefinedType}s.
-     *
-     * @param typeString a string like "ROW(field1 INT, field2 BOOLEAN)"
-     * @throws ValidationException in case of parsing errors.
-     * @deprecated You should use {@link #parse(String, ClassLoader)} to correctly load user types
-     */
-    @Deprecated
-    public static LogicalType parse(String typeString) {
-        return parse(typeString, Thread.currentThread().getContextClassLoader());
-    }
-
     // --------------------------------------------------------------------------------------------
     // Tokenizer
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeParserTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeParserTest.java
@@ -259,7 +259,10 @@ public class LogicalTypeParserTest {
     @MethodSource("testData")
     void testParsing(TestSpec testSpec) {
         if (testSpec.expectedType != null) {
-            assertThat(LogicalTypeParser.parse(testSpec.typeString))
+            assertThat(
+                            LogicalTypeParser.parse(
+                                    testSpec.typeString,
+                                    Thread.currentThread().getContextClassLoader()))
                     .isEqualTo(testSpec.expectedType);
         }
     }
@@ -271,7 +274,10 @@ public class LogicalTypeParserTest {
             if (!testSpec.expectedType.is(UNRESOLVED)
                     && testSpec.expectedType.getChildren().stream()
                             .noneMatch(t -> t.is(UNRESOLVED))) {
-                assertThat(LogicalTypeParser.parse(testSpec.expectedType.asSerializableString()))
+                assertThat(
+                                LogicalTypeParser.parse(
+                                        testSpec.expectedType.asSerializableString(),
+                                        Thread.currentThread().getContextClassLoader()))
                         .isEqualTo(testSpec.expectedType);
             }
         }
@@ -281,7 +287,11 @@ public class LogicalTypeParserTest {
     @MethodSource("testData")
     void testErrorMessage(TestSpec testSpec) {
         if (testSpec.expectedErrorMessage != null) {
-            assertThatThrownBy(() -> LogicalTypeParser.parse(testSpec.typeString))
+            assertThatThrownBy(
+                            () ->
+                                    LogicalTypeParser.parse(
+                                            testSpec.typeString,
+                                            Thread.currentThread().getContextClassLoader()))
                     .isInstanceOf(ValidationException.class)
                     .hasMessageContaining(testSpec.expectedErrorMessage);
         }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/utils/DataTypeFactoryMock.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/utils/DataTypeFactoryMock.java
@@ -57,7 +57,9 @@ public class DataTypeFactoryMock implements DataTypeFactory {
 
     @Override
     public DataType createDataType(String typeString) {
-        return TypeConversions.fromLogicalToDataType(LogicalTypeParser.parse(typeString));
+        return TypeConversions.fromLogicalToDataType(
+                LogicalTypeParser.parse(
+                        typeString, Thread.currentThread().getContextClassLoader()));
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

*Remove the deprecated method LogicalTypeParser#parse*

## Brief change log

  - *Remove the deprecated method LogicalTypeParser#parse*
  - *Adapt the related code and tests*

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? 
