### PR TITLE
[BP-1.19][FLINK-34194] Update CI to Ubuntu 22.04 (Jammy)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,7 +48,7 @@ jobs:
           fi
       - name: Build documentation
         run: |
-          docker run --rm --volume "$PWD:/root/flink" chesnay/flink-ci:java_8_11_17_21_maven_386 bash -c "cd /root/flink && ./.github/workflows/docs.sh"
+          docker run --rm --volume "$PWD:/root/flink" chesnay/flink-ci:java_8_11_17_21_maven_386_jammy bash -c "cd /root/flink && ./.github/workflows/docs.sh"
       - name: Upload documentation
         uses: burnett01/rsync-deployments@5.2
         with:

--- a/.github/workflows/template.flink-ci.yml
+++ b/.github/workflows/template.flink-ci.yml
@@ -72,7 +72,7 @@ jobs:
     name: "Compile"
     runs-on: ubuntu-22.04
     container:
-      image: mapohl/flink-ci:FLINK-34194
+      image: chesnay/flink-ci:java_8_11_17_21_maven_386_jammy
       # --init makes the process in the container being started as an init process which will clean up any daemon processes during shutdown
       # --privileged allows writing coredumps in docker (FLINK-16973)
       options: --init --privileged
@@ -133,7 +133,7 @@ jobs:
     needs: compile
     runs-on: ubuntu-22.04
     container:
-      image: mapohl/flink-ci:FLINK-34194
+      image: chesnay/flink-ci:java_8_11_17_21_maven_386_jammy
       # --init makes the process in the container being started as an init process which will clean up any daemon processes during shutdown
       # --privileged allows writing coredumps in docker (FLINK-16973)
       options: --init --privileged
@@ -173,7 +173,7 @@ jobs:
     needs: compile
     runs-on: ubuntu-22.04
     container:
-      image: mapohl/flink-ci:FLINK-34194
+      image: chesnay/flink-ci:java_8_11_17_21_maven_386_jammy
       # --init makes the process in the container being started as an init process which will clean up any daemon processes during shutdown
       # --privileged allows writing coredumps in docker (FLINK-16973)
       options: --init --privileged

--- a/.github/workflows/template.pre-compile-checks.yml
+++ b/.github/workflows/template.pre-compile-checks.yml
@@ -43,7 +43,7 @@ jobs:
     name: "Basic QA"
     runs-on: ubuntu-22.04
     container:
-      image: mapohl/flink-ci:FLINK-34194
+      image: chesnay/flink-ci:java_8_11_17_21_maven_386_jammy
       # --init makes the process in the container being started as an init process which will clean up any daemon processes during shutdown
       # --privileged allows writing coredumps in docker (FLINK-16973)
       options: --init --privileged

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ resources:
   # Container with SSL to have the same environment everywhere.
   # see https://github.com/apache/flink-connector-shared-utils/tree/ci_utils
   - container: flink-build-container
-    image: chesnay/flink-ci:java_8_11_17_21_maven_386
+    image: chesnay/flink-ci:java_8_11_17_21_maven_386_jammy
     # On AZP provided machines, set this flag to allow writing coredumps in docker
     options: --privileged
 
@@ -73,16 +73,16 @@ stages:
         parameters: # see template file for a definition of the parameters.
           stage_name: ci_build
           test_pool_definition:
-            vmImage: 'ubuntu-20.04'
+            vmImage: 'ubuntu-22.04'
           e2e_pool_definition:
-            vmImage: 'ubuntu-20.04'
+            vmImage: 'ubuntu-22.04'
           environment: PROFILE="-Dflink.hadoop.version=2.10.2"
           run_end_to_end: false
           container: flink-build-container
           jdk: 8
       - job: docs_404_check # run on a MSFT provided machine
         pool:
-          vmImage: 'ubuntu-20.04'
+          vmImage: 'ubuntu-22.04'
         steps:
           - task: GoTool@0
             inputs:

--- a/tools/azure-pipelines/build-apache-repo.yml
+++ b/tools/azure-pipelines/build-apache-repo.yml
@@ -39,7 +39,7 @@ resources:
   # Container with SSL to have the same environment everywhere.
   # see https://github.com/apache/flink-connector-shared-utils/tree/ci_utils
   - container: flink-build-container
-    image: chesnay/flink-ci:java_8_11_17_21_maven_386
+    image: chesnay/flink-ci:java_8_11_17_21_maven_386_jammy
 
 variables:
   MAVEN_CACHE_FOLDER: $(Pipeline.Workspace)/.m2/repository
@@ -68,14 +68,14 @@ stages:
           test_pool_definition:
             name: Default
           e2e_pool_definition:
-            vmImage: 'ubuntu-20.04'
+            vmImage: 'ubuntu-22.04'
           environment: PROFILE="-Dflink.hadoop.version=2.10.2"
           run_end_to_end: false
           container: flink-build-container
           jdk: 8
       - job: docs_404_check # run on a MSFT provided machine
         pool:
-          vmImage: 'ubuntu-20.04'
+          vmImage: 'ubuntu-22.04'
         steps:
           # Skip docs check if this is a pull request that doesn't contain a documentation change
           - task: GoTool@0
@@ -110,9 +110,9 @@ stages:
         parameters:
           stage_name: cron_azure
           test_pool_definition:
-            vmImage: 'ubuntu-20.04'
+            vmImage: 'ubuntu-22.04'
           e2e_pool_definition:
-            vmImage: 'ubuntu-20.04'
+            vmImage: 'ubuntu-22.04'
           environment: PROFILE="-Dflink.hadoop.version=2.10.2"
           run_end_to_end: true
           container: flink-build-container
@@ -123,7 +123,7 @@ stages:
           test_pool_definition:
             name: Default
           e2e_pool_definition:
-            vmImage: 'ubuntu-20.04'
+            vmImage: 'ubuntu-22.04'
           environment: PROFILE="-Dflink.hadoop.version=3.2.3 -Phadoop3-tests,hive3"
           run_end_to_end: true
           container: flink-build-container
@@ -134,7 +134,7 @@ stages:
           test_pool_definition:
             name: Default
           e2e_pool_definition:
-            vmImage: 'ubuntu-20.04'
+            vmImage: 'ubuntu-22.04'
           environment: PROFILE="-Dflink.hadoop.version=2.10.2 -Djdk11 -Pjava11-target"
           run_end_to_end: true
           container: flink-build-container
@@ -145,7 +145,7 @@ stages:
           test_pool_definition:
             name: Default
           e2e_pool_definition:
-            vmImage: 'ubuntu-20.04'
+            vmImage: 'ubuntu-22.04'
           environment: PROFILE="-Dflink.hadoop.version=2.10.2 -Djdk11 -Djdk17 -Pjava17-target"
           run_end_to_end: true
           container: flink-build-container
@@ -156,7 +156,7 @@ stages:
           test_pool_definition:
             name: Default
           e2e_pool_definition:
-            vmImage: 'ubuntu-20.04'
+            vmImage: 'ubuntu-22.04'
           environment: PROFILE="-Dflink.hadoop.version=2.10.2 -Djdk11 -Djdk17 -Djdk21 -Pjava21-target"
           run_end_to_end: true
           container: flink-build-container
@@ -167,14 +167,14 @@ stages:
           test_pool_definition:
             name: Default
           e2e_pool_definition:
-            vmImage: 'ubuntu-20.04'
+            vmImage: 'ubuntu-22.04'
           environment: PROFILE="-Dflink.hadoop.version=2.10.2 -Penable-adaptive-scheduler"
           run_end_to_end: true
           container: flink-build-container
           jdk: 8
       - job: docs_404_check # run on a MSFT provided machine
         pool:
-          vmImage: 'ubuntu-20.04'
+          vmImage: 'ubuntu-22.04'
         steps:
           - task: GoTool@0
             inputs:

--- a/tools/azure-pipelines/build-nightly-dist.yml
+++ b/tools/azure-pipelines/build-nightly-dist.yml
@@ -19,7 +19,7 @@ parameters:
 jobs:
   - job: ${{parameters.stage_name}}_binary
     pool:
-      vmImage: 'ubuntu-20.04'
+      vmImage: 'ubuntu-22.04'
     container: flink-build-container
     workspace:
       clean: all
@@ -69,7 +69,7 @@ jobs:
       #    artifact: nightly-release
   - job: ${{parameters.stage_name}}_maven
     pool:
-      vmImage: 'ubuntu-20.04'
+      vmImage: 'ubuntu-22.04'
     container: flink-build-container
     timeoutInMinutes: 240
     workspace:

--- a/tools/azure-pipelines/build-python-wheels.yml
+++ b/tools/azure-pipelines/build-python-wheels.yml
@@ -16,7 +16,7 @@
 jobs:
   - job: build_wheels_on_Linux
     pool:
-      vmImage: 'ubuntu-20.04'
+      vmImage: 'ubuntu-22.04'
     steps:
       - script: |
           cd flink-python


### PR DESCRIPTION
## What is the purpose of the change

This PR backport the changes done of the PR made by @zentol (https://github.com/apache/flink/pull/25708) in master for version 1.19.X to be used in dependencies upgrade.


## Brief change log

- Ubuntu CI image version is no more v18 but v22


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
