### PR TITLE
[FLINK-37030] Support lazy initialization for state serializer in State V2

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/AggregatingStateDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/AggregatingStateDescriptor.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.state.v2;
 
 import org.apache.flink.api.common.functions.AggregateFunction;
-import org.apache.flink.api.common.serialization.SerializerConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 
@@ -53,23 +52,6 @@ public class AggregatingStateDescriptor<IN, ACC, OUT> extends StateDescriptor<AC
             @Nonnull AggregateFunction<IN, ACC, OUT> aggregateFunction,
             @Nonnull TypeInformation<ACC> typeInfo) {
         super(stateId, typeInfo);
-        this.aggregateFunction = checkNotNull(aggregateFunction);
-    }
-
-    /**
-     * Create a new state descriptor with the given name, function, and type.
-     *
-     * @param stateId The (unique) name for the state.
-     * @param aggregateFunction The {@code AggregateFunction} used to aggregate the state.
-     * @param typeInfo The type of the accumulator. The accumulator is stored in the state.
-     * @param serializerConfig The serializer related config used to generate TypeSerializer.
-     */
-    public AggregatingStateDescriptor(
-            @Nonnull String stateId,
-            @Nonnull AggregateFunction<IN, ACC, OUT> aggregateFunction,
-            @Nonnull TypeInformation<ACC> typeInfo,
-            SerializerConfig serializerConfig) {
-        super(stateId, typeInfo, serializerConfig);
         this.aggregateFunction = checkNotNull(aggregateFunction);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/DefaultKeyedStateStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/DefaultKeyedStateStore.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.state.v2;
 
+import org.apache.flink.api.common.functions.SerializerFactory;
 import org.apache.flink.api.common.state.v2.AggregatingState;
 import org.apache.flink.api.common.state.v2.ListState;
 import org.apache.flink.api.common.state.v2.MapState;
@@ -34,15 +35,20 @@ import javax.annotation.Nonnull;
 public class DefaultKeyedStateStore implements KeyedStateStore {
 
     private final AsyncKeyedStateBackend<?> asyncKeyedStateBackend;
+    protected final SerializerFactory serializerFactory;
 
-    public DefaultKeyedStateStore(@Nonnull AsyncKeyedStateBackend asyncKeyedStateBackend) {
+    public DefaultKeyedStateStore(
+            @Nonnull AsyncKeyedStateBackend asyncKeyedStateBackend,
+            SerializerFactory serializerFactory) {
         this.asyncKeyedStateBackend = Preconditions.checkNotNull(asyncKeyedStateBackend);
+        this.serializerFactory = Preconditions.checkNotNull(serializerFactory);
     }
 
     @Override
     public <T> ValueState<T> getValueState(@Nonnull ValueStateDescriptor<T> stateProperties) {
         Preconditions.checkNotNull(stateProperties, "The state properties must not be null");
         try {
+            stateProperties.initializeSerializerUnlessSet(serializerFactory);
             return asyncKeyedStateBackend.getOrCreateKeyedState(
                     VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateProperties);
         } catch (Exception e) {
@@ -54,6 +60,7 @@ public class DefaultKeyedStateStore implements KeyedStateStore {
     public <T> ListState<T> getListState(@Nonnull ListStateDescriptor<T> stateProperties) {
         Preconditions.checkNotNull(stateProperties, "The state properties must not be null");
         try {
+            stateProperties.initializeSerializerUnlessSet(serializerFactory);
             return asyncKeyedStateBackend.getOrCreateKeyedState(
                     VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateProperties);
         } catch (Exception e) {
@@ -66,6 +73,7 @@ public class DefaultKeyedStateStore implements KeyedStateStore {
             @Nonnull MapStateDescriptor<UK, UV> stateProperties) {
         Preconditions.checkNotNull(stateProperties, "The state properties must not be null");
         try {
+            stateProperties.initializeSerializerUnlessSet(serializerFactory);
             return asyncKeyedStateBackend.getOrCreateKeyedState(
                     VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateProperties);
         } catch (Exception e) {
@@ -78,6 +86,7 @@ public class DefaultKeyedStateStore implements KeyedStateStore {
             @Nonnull ReducingStateDescriptor<T> stateProperties) {
         Preconditions.checkNotNull(stateProperties, "The state properties must not be null");
         try {
+            stateProperties.initializeSerializerUnlessSet(serializerFactory);
             return asyncKeyedStateBackend.getOrCreateKeyedState(
                     VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateProperties);
         } catch (Exception e) {
@@ -90,6 +99,7 @@ public class DefaultKeyedStateStore implements KeyedStateStore {
             @Nonnull AggregatingStateDescriptor<IN, ACC, OUT> stateProperties) {
         Preconditions.checkNotNull(stateProperties, "The state properties must not be null");
         try {
+            stateProperties.initializeSerializerUnlessSet(serializerFactory);
             return asyncKeyedStateBackend.getOrCreateKeyedState(
                     VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateProperties);
         } catch (Exception e) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/ListStateDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/ListStateDescriptor.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.state.v2;
 
-import org.apache.flink.api.common.serialization.SerializerConfig;
 import org.apache.flink.api.common.state.v2.ListState;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -41,21 +40,6 @@ public class ListStateDescriptor<T> extends StateDescriptor<T> {
      */
     public ListStateDescriptor(@Nonnull String stateId, @Nonnull TypeInformation<T> typeInfo) {
         super(stateId, typeInfo);
-    }
-
-    /**
-     * Creates a new {@code ListStateDescriptor} with the given stateId and type.
-     *
-     * @param stateId The (unique) stateId for the state.
-     * @param typeInfo The type of the values in the state.
-     * @param serializerConfig The serializer related config used to generate {@code
-     *     TypeSerializer}.
-     */
-    public ListStateDescriptor(
-            @Nonnull String stateId,
-            @Nonnull TypeInformation<T> typeInfo,
-            SerializerConfig serializerConfig) {
-        super(stateId, typeInfo, serializerConfig);
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/ReducingStateDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/ReducingStateDescriptor.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.state.v2;
 
 import org.apache.flink.api.common.functions.ReduceFunction;
-import org.apache.flink.api.common.serialization.SerializerConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 
@@ -48,22 +47,6 @@ public class ReducingStateDescriptor<T> extends StateDescriptor<T> {
             @Nonnull ReduceFunction<T> reduceFunction,
             @Nonnull TypeInformation<T> typeInfo) {
         super(name, typeInfo);
-        this.reduceFunction = checkNotNull(reduceFunction);
-    }
-
-    /**
-     * Creates a new {@code ReducingStateDescriptor} with the given name and default value.
-     *
-     * @param name The (unique) name for the state.
-     * @param reduceFunction The {@code ReduceFunction} used to aggregate the state.
-     * @param typeInfo The type of the values in the state.
-     */
-    public ReducingStateDescriptor(
-            @Nonnull String name,
-            @Nonnull ReduceFunction<T> reduceFunction,
-            @Nonnull TypeInformation<T> typeInfo,
-            SerializerConfig serializerConfig) {
-        super(name, typeInfo, serializerConfig);
         this.reduceFunction = checkNotNull(reduceFunction);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/StateDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/StateDescriptor.java
@@ -19,13 +19,14 @@
 package org.apache.flink.runtime.state.v2;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.serialization.SerializerConfig;
-import org.apache.flink.api.common.serialization.SerializerConfigImpl;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.functions.SerializerFactory;
 import org.apache.flink.api.common.state.StateTtlConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import java.io.Serializable;
 
@@ -55,7 +56,7 @@ public abstract class StateDescriptor<T> implements Serializable {
     @Nonnull private final String stateId;
 
     /** The serializer for the type. */
-    @Nonnull private final TypeSerializer<T> typeSerializer;
+    @Nonnull private final StateSerializerReference<T> typeSerializer;
 
     /** The configuration of state time-to-live(TTL), it is disabled by default. */
     @Nonnull private StateTtlConfig ttlConfig = StateTtlConfig.DISABLED;
@@ -68,25 +69,9 @@ public abstract class StateDescriptor<T> implements Serializable {
      * @param stateId The stateId of the {@code StateDescriptor}.
      * @param typeInfo The type information for the values in the state.
      */
-    protected StateDescriptor(@Nonnull String stateId, TypeInformation<T> typeInfo) {
-        this(stateId, typeInfo, new SerializerConfigImpl());
-    }
-
-    /**
-     * Create a new {@code StateDescriptor} with the given stateId and the given type information.
-     *
-     * @param stateId The stateId of the {@code StateDescriptor}.
-     * @param typeInfo The type information for the values in the state.
-     * @param serializerConfig The serializer related config used to generate {@code
-     *     TypeSerializer}.
-     */
-    protected StateDescriptor(
-            @Nonnull String stateId,
-            @Nonnull TypeInformation<T> typeInfo,
-            SerializerConfig serializerConfig) {
-        this.stateId = checkNotNull(stateId, "stateId must not be null");
-        checkNotNull(typeInfo, "type information must not be null");
-        this.typeSerializer = typeInfo.createSerializer(serializerConfig);
+    protected StateDescriptor(@Nonnull String stateId, @Nonnull TypeInformation<T> typeInfo) {
+        this.stateId = checkNotNull(stateId, "state id must not be null");
+        this.typeSerializer = new StateSerializerReference<>(typeInfo);
     }
 
     /**
@@ -97,7 +82,7 @@ public abstract class StateDescriptor<T> implements Serializable {
      */
     protected StateDescriptor(@Nonnull String stateId, TypeSerializer<T> serializer) {
         this.stateId = checkNotNull(stateId, "stateId must not be null");
-        this.typeSerializer = checkNotNull(serializer, "type serializer must not be null");
+        this.typeSerializer = new StateSerializerReference<>(serializer);
     }
 
     // ------------------------------------------------------------------------
@@ -126,7 +111,45 @@ public abstract class StateDescriptor<T> implements Serializable {
 
     @Nonnull
     public TypeSerializer<T> getSerializer() {
-        return typeSerializer.duplicate();
+        TypeSerializer<T> serializer = typeSerializer.get();
+        if (serializer != null) {
+            return serializer.duplicate();
+        } else {
+            throw new IllegalStateException("Serializer not yet initialized.");
+        }
+    }
+
+    @Internal
+    @Nullable
+    public TypeInformation<T> getTypeInformation() {
+        return typeSerializer.getTypeInformation();
+    }
+
+    // ------------------------------------------------------------------------
+
+    /**
+     * Checks whether the serializer has been initialized. Serializer initialization is lazy, to
+     * allow parametrization of serializers with an {@link ExecutionConfig} via {@link
+     * #initializeSerializerUnlessSet(ExecutionConfig)}.
+     *
+     * @return True if the serializers have been initialized, false otherwise.
+     */
+    public boolean isSerializerInitialized() {
+        return typeSerializer.isInitialized();
+    }
+
+    /**
+     * Initializes the serializer, unless it has been initialized before.
+     *
+     * @param executionConfig The execution config to use when creating the serializer.
+     */
+    public void initializeSerializerUnlessSet(ExecutionConfig executionConfig) {
+        typeSerializer.initializeUnlessSet(executionConfig);
+    }
+
+    @Internal
+    public void initializeSerializerUnlessSet(SerializerFactory serializerFactory) {
+        typeSerializer.initializeUnlessSet(serializerFactory);
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/StateDescriptorUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/StateDescriptorUtils.java
@@ -25,41 +25,20 @@ package org.apache.flink.runtime.state.v2;
 public class StateDescriptorUtils {
     private StateDescriptorUtils() {}
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     public static org.apache.flink.api.common.state.StateDescriptor transformFromV2ToV1(
             StateDescriptor stateDescriptor) {
         switch (stateDescriptor.getType()) {
             case VALUE:
-                ValueStateDescriptor valueStateDesc = (ValueStateDescriptor) stateDescriptor;
-                return new org.apache.flink.api.common.state.ValueStateDescriptor(
-                        valueStateDesc.getStateId(), valueStateDesc.getSerializer());
-
+                return transformFromV2ToV1((ValueStateDescriptor) stateDescriptor);
             case MAP:
-                MapStateDescriptor mapStateDesc = (MapStateDescriptor) stateDescriptor;
-                return new org.apache.flink.api.common.state.MapStateDescriptor<>(
-                        mapStateDesc.getStateId(),
-                        mapStateDesc.getUserKeySerializer(),
-                        mapStateDesc.getSerializer());
-
+                return transformFromV2ToV1((MapStateDescriptor) stateDescriptor);
             case LIST:
-                ListStateDescriptor listStateDesc = (ListStateDescriptor) stateDescriptor;
-                return new org.apache.flink.api.common.state.ListStateDescriptor<>(
-                        listStateDesc.getStateId(), listStateDesc.getSerializer());
-
+                return transformFromV2ToV1((ListStateDescriptor) stateDescriptor);
             case REDUCING:
-                ReducingStateDescriptor reducingStateDesc =
-                        (ReducingStateDescriptor) stateDescriptor;
-                return new org.apache.flink.api.common.state.ReducingStateDescriptor(
-                        reducingStateDesc.getStateId(),
-                        reducingStateDesc.getReduceFunction(),
-                        reducingStateDesc.getSerializer());
-
+                return transformFromV2ToV1((ReducingStateDescriptor) stateDescriptor);
             case AGGREGATING:
-                AggregatingStateDescriptor aggregatingStateDesc =
-                        (AggregatingStateDescriptor) stateDescriptor;
-                return new org.apache.flink.api.common.state.AggregatingStateDescriptor(
-                        aggregatingStateDesc.getStateId(),
-                        aggregatingStateDesc.getAggregateFunction(),
-                        aggregatingStateDesc.getSerializer());
+                return transformFromV2ToV1((AggregatingStateDescriptor) stateDescriptor);
             default:
                 throw new IllegalArgumentException(
                         "Unsupported state type: " + stateDescriptor.getType());
@@ -68,40 +47,71 @@ public class StateDescriptorUtils {
 
     public static <V> org.apache.flink.api.common.state.ValueStateDescriptor<V> transformFromV2ToV1(
             ValueStateDescriptor<V> stateDescriptor) {
-        return new org.apache.flink.api.common.state.ValueStateDescriptor<>(
-                stateDescriptor.getStateId(), stateDescriptor.getSerializer());
+        if (stateDescriptor.isSerializerInitialized()) {
+            return new org.apache.flink.api.common.state.ValueStateDescriptor<>(
+                    stateDescriptor.getStateId(), stateDescriptor.getSerializer());
+        } else {
+            return new org.apache.flink.api.common.state.ValueStateDescriptor<>(
+                    stateDescriptor.getStateId(), stateDescriptor.getTypeInformation());
+        }
     }
 
     public static <UK, UV>
             org.apache.flink.api.common.state.MapStateDescriptor<UK, UV> transformFromV2ToV1(
                     MapStateDescriptor<UK, UV> stateDescriptor) {
-        return new org.apache.flink.api.common.state.MapStateDescriptor<>(
-                stateDescriptor.getStateId(),
-                stateDescriptor.getUserKeySerializer(),
-                stateDescriptor.getSerializer());
+        if (stateDescriptor.isSerializerInitialized()) {
+            return new org.apache.flink.api.common.state.MapStateDescriptor<>(
+                    stateDescriptor.getStateId(),
+                    stateDescriptor.getUserKeySerializer(),
+                    stateDescriptor.getSerializer());
+        } else {
+            return new org.apache.flink.api.common.state.MapStateDescriptor<>(
+                    stateDescriptor.getStateId(),
+                    stateDescriptor.getUserKeyTypeInformation(),
+                    stateDescriptor.getTypeInformation());
+        }
     }
 
     public static <V> org.apache.flink.api.common.state.ListStateDescriptor<V> transformFromV2ToV1(
             ListStateDescriptor<V> stateDescriptor) {
-        return new org.apache.flink.api.common.state.ListStateDescriptor<>(
-                stateDescriptor.getStateId(), stateDescriptor.getSerializer());
+        if (stateDescriptor.isSerializerInitialized()) {
+            return new org.apache.flink.api.common.state.ListStateDescriptor<>(
+                    stateDescriptor.getStateId(), stateDescriptor.getSerializer());
+        } else {
+            return new org.apache.flink.api.common.state.ListStateDescriptor<>(
+                    stateDescriptor.getStateId(), stateDescriptor.getTypeInformation());
+        }
     }
 
     public static <V>
             org.apache.flink.api.common.state.ReducingStateDescriptor<V> transformFromV2ToV1(
                     ReducingStateDescriptor<V> stateDescriptor) {
-        return new org.apache.flink.api.common.state.ReducingStateDescriptor<>(
-                stateDescriptor.getStateId(),
-                stateDescriptor.getReduceFunction(),
-                stateDescriptor.getSerializer());
+        if (stateDescriptor.isSerializerInitialized()) {
+            return new org.apache.flink.api.common.state.ReducingStateDescriptor<>(
+                    stateDescriptor.getStateId(),
+                    stateDescriptor.getReduceFunction(),
+                    stateDescriptor.getSerializer());
+        } else {
+            return new org.apache.flink.api.common.state.ReducingStateDescriptor<>(
+                    stateDescriptor.getStateId(),
+                    stateDescriptor.getReduceFunction(),
+                    stateDescriptor.getTypeInformation());
+        }
     }
 
     public static <IN, ACC, OUT>
             org.apache.flink.api.common.state.AggregatingStateDescriptor<IN, ACC, OUT>
                     transformFromV2ToV1(AggregatingStateDescriptor<IN, ACC, OUT> stateDescriptor) {
-        return new org.apache.flink.api.common.state.AggregatingStateDescriptor<>(
-                stateDescriptor.getStateId(),
-                stateDescriptor.getAggregateFunction(),
-                stateDescriptor.getSerializer());
+        if (stateDescriptor.isSerializerInitialized()) {
+            return new org.apache.flink.api.common.state.AggregatingStateDescriptor<>(
+                    stateDescriptor.getStateId(),
+                    stateDescriptor.getAggregateFunction(),
+                    stateDescriptor.getSerializer());
+        } else {
+            return new org.apache.flink.api.common.state.AggregatingStateDescriptor<>(
+                    stateDescriptor.getStateId(),
+                    stateDescriptor.getAggregateFunction(),
+                    stateDescriptor.getTypeInformation());
+        }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/StateSerializerReference.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/StateSerializerReference.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.v2;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.functions.SerializerFactory;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * A reference to a serializer. This also provides functions for lazy initialization.
+ *
+ * @param <T> the type for serialization.
+ */
+public class StateSerializerReference<T> extends AtomicReference<TypeSerializer<T>> {
+    private static final Logger LOG = LoggerFactory.getLogger(StateSerializerReference.class);
+
+    /**
+     * The type information describing the value type. Only used to if the serializer is created
+     * lazily.
+     */
+    @Nullable private final TypeInformation<T> typeInfo;
+
+    public StateSerializerReference(TypeInformation<T> typeInfo) {
+        super(null);
+        this.typeInfo = checkNotNull(typeInfo, "type information must not be null");
+    }
+
+    public StateSerializerReference(TypeSerializer<T> typeSerializer) {
+        super(checkNotNull(typeSerializer, "type serializer must not be null"));
+        this.typeInfo = null;
+    }
+
+    public TypeInformation<T> getTypeInformation() {
+        return typeInfo;
+    }
+
+    /**
+     * Checks whether the serializer has been initialized. Serializer initialization is lazy, to
+     * allow parametrization of serializers with an {@link ExecutionConfig} via {@link
+     * #initializeUnlessSet(ExecutionConfig)}.
+     *
+     * @return True if the serializers have been initialized, false otherwise.
+     */
+    public boolean isInitialized() {
+        return get() != null;
+    }
+
+    /**
+     * Initializes the serializer, unless it has been initialized before.
+     *
+     * @param executionConfig The execution config to use when creating the serializer.
+     */
+    public void initializeUnlessSet(ExecutionConfig executionConfig) {
+        initializeUnlessSet(
+                new SerializerFactory() {
+                    @Override
+                    public <T> TypeSerializer<T> createSerializer(
+                            TypeInformation<T> typeInformation) {
+                        return typeInformation.createSerializer(
+                                executionConfig == null
+                                        ? null
+                                        : executionConfig.getSerializerConfig());
+                    }
+                });
+    }
+
+    @Internal
+    public void initializeUnlessSet(SerializerFactory serializerFactory) {
+        if (get() == null) {
+            checkState(typeInfo != null, "type information should not be null.");
+            // try to instantiate and set the serializer
+            TypeSerializer<T> serializer = serializerFactory.createSerializer(typeInfo);
+            // use cas to assure the singleton
+            if (!compareAndSet(null, serializer)) {
+                LOG.debug("Someone else beat us at initializing the serializer.");
+            }
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/ValueStateDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/ValueStateDescriptor.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.state.v2;
 
-import org.apache.flink.api.common.serialization.SerializerConfig;
 import org.apache.flink.api.common.state.v2.ValueState;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -41,21 +40,6 @@ public class ValueStateDescriptor<T> extends StateDescriptor<T> {
      */
     public ValueStateDescriptor(@Nonnull String stateId, @Nonnull TypeInformation<T> typeInfo) {
         super(stateId, typeInfo);
-    }
-
-    /**
-     * Creates a new {@code ValueStateDescriptor} with the given stateId and type.
-     *
-     * @param stateId The (unique) stateId for the state.
-     * @param typeInfo The type of the values in the state.
-     * @param serializerConfig The serializer related config used to generate {@code
-     *     TypeSerializer}.
-     */
-    public ValueStateDescriptor(
-            @Nonnull String stateId,
-            @Nonnull TypeInformation<T> typeInfo,
-            SerializerConfig serializerConfig) {
-        super(stateId, typeInfo, serializerConfig);
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandler.java
@@ -125,7 +125,15 @@ public class StreamOperatorStateHandler {
         this.keyedStateStoreV2 =
                 asyncKeyedStateBackend != null
                         ? new org.apache.flink.runtime.state.v2.DefaultKeyedStateStore(
-                                asyncKeyedStateBackend)
+                                asyncKeyedStateBackend,
+                                new SerializerFactory() {
+                                    @Override
+                                    public <T> TypeSerializer<T> createSerializer(
+                                            TypeInformation<T> typeInformation) {
+                                        return typeInformation.createSerializer(
+                                                executionConfig.getSerializerConfig());
+                                    }
+                                })
                         : null;
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContext.java
@@ -272,6 +272,7 @@ public class StreamingRuntimeContext extends AbstractRuntimeUDFContext {
             org.apache.flink.runtime.state.v2.ValueStateDescriptor<T> stateProperties) {
         org.apache.flink.runtime.state.v2.KeyedStateStore keyedStateStore =
                 checkPreconditionsAndGetKeyedStateStoreV2(stateProperties);
+        stateProperties.initializeSerializerUnlessSet(this::createSerializer);
         return keyedStateStore.getValueState(stateProperties);
     }
 
@@ -279,6 +280,7 @@ public class StreamingRuntimeContext extends AbstractRuntimeUDFContext {
             org.apache.flink.runtime.state.v2.ListStateDescriptor<T> stateProperties) {
         org.apache.flink.runtime.state.v2.KeyedStateStore keyedStateStore =
                 checkPreconditionsAndGetKeyedStateStoreV2(stateProperties);
+        stateProperties.initializeSerializerUnlessSet(this::createSerializer);
         return keyedStateStore.getListState(stateProperties);
     }
 
@@ -286,6 +288,7 @@ public class StreamingRuntimeContext extends AbstractRuntimeUDFContext {
             org.apache.flink.runtime.state.v2.MapStateDescriptor<UK, UV> stateProperties) {
         org.apache.flink.runtime.state.v2.KeyedStateStore keyedStateStore =
                 checkPreconditionsAndGetKeyedStateStoreV2(stateProperties);
+        stateProperties.initializeSerializerUnlessSet(this::createSerializer);
         return keyedStateStore.getMapState(stateProperties);
     }
 
@@ -293,6 +296,7 @@ public class StreamingRuntimeContext extends AbstractRuntimeUDFContext {
             org.apache.flink.runtime.state.v2.ReducingStateDescriptor<T> stateProperties) {
         org.apache.flink.runtime.state.v2.KeyedStateStore keyedStateStore =
                 checkPreconditionsAndGetKeyedStateStoreV2(stateProperties);
+        stateProperties.initializeSerializerUnlessSet(this::createSerializer);
         return keyedStateStore.getReducingState(stateProperties);
     }
 
@@ -302,6 +306,7 @@ public class StreamingRuntimeContext extends AbstractRuntimeUDFContext {
                             stateProperties) {
         org.apache.flink.runtime.state.v2.KeyedStateStore keyedStateStore =
                 checkPreconditionsAndGetKeyedStateStoreV2(stateProperties);
+        stateProperties.initializeSerializerUnlessSet(this::createSerializer);
         return keyedStateStore.getAggregatingState(stateProperties);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestUtils.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.state;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -138,6 +139,7 @@ public class StateBackendTestUtils {
                         TypeSerializer<N> namespaceSerializer,
                         org.apache.flink.runtime.state.v2.StateDescriptor<SV> stateDesc)
                         throws Exception {
+            stateDesc.initializeSerializerUnlessSet(new ExecutionConfig());
             return (S) innerStateSupplier.get();
         }
 
@@ -148,6 +150,7 @@ public class StateBackendTestUtils {
                 @Nonnull TypeSerializer<N> namespaceSerializer,
                 @Nonnull org.apache.flink.runtime.state.v2.StateDescriptor<SV> stateDesc)
                 throws Exception {
+            stateDesc.initializeSerializerUnlessSet(new ExecutionConfig());
             return (S) innerStateSupplier.get();
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/StateDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/StateDescriptorTest.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.runtime.state.v2;
 
-import org.apache.flink.api.common.serialization.SerializerConfigImpl;
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.state.StateTtlConfig;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -45,6 +45,7 @@ class StateDescriptorTest {
         // we use Kryo here, because it meets these conditions
         TestStateDescriptor<String> descr =
                 new TestStateDescriptor<>("foobar", new GenericTypeInfo<>(String.class));
+        descr.initializeSerializerUnlessSet(new ExecutionConfig());
 
         TypeSerializer<String> serializerA = descr.getSerializer();
         TypeSerializer<String> serializerB = descr.getSerializer();
@@ -109,7 +110,7 @@ class StateDescriptorTest {
         private static final long serialVersionUID = 1L;
 
         TestStateDescriptor(String name, TypeInformation<T> typeInfo) {
-            super(name, typeInfo, new SerializerConfigImpl());
+            super(name, typeInfo);
         }
 
         @Override
@@ -123,7 +124,7 @@ class StateDescriptorTest {
         private static final long serialVersionUID = 1L;
 
         OtherTestStateDescriptor(String name, TypeInformation<T> typeInfo) {
-            super(name, typeInfo, new SerializerConfigImpl());
+            super(name, typeInfo);
         }
 
         @Override

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContextTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContextTest.java
@@ -259,7 +259,7 @@ class StreamingRuntimeContextTest {
         StreamingRuntimeContext context = createRuntimeContext(descriptorCapture, config, true);
         org.apache.flink.runtime.state.v2.ValueStateDescriptor<TaskInfo> descr =
                 new org.apache.flink.runtime.state.v2.ValueStateDescriptor<>(
-                        "name", TypeInformation.of(TaskInfo.class), serializerConfig);
+                        "name", TypeInformation.of(TaskInfo.class));
         context.getValueState(descr);
 
         org.apache.flink.runtime.state.v2.ValueStateDescriptor<?> descrIntercepted =
@@ -283,7 +283,7 @@ class StreamingRuntimeContextTest {
         StreamingRuntimeContext context = createRuntimeContext(descriptorCapture, config, true);
         org.apache.flink.runtime.state.v2.ListStateDescriptor<TaskInfo> descr =
                 new org.apache.flink.runtime.state.v2.ListStateDescriptor<>(
-                        "name", TypeInformation.of(TaskInfo.class), serializerConfig);
+                        "name", TypeInformation.of(TaskInfo.class));
         context.getListState(descr);
 
         org.apache.flink.runtime.state.v2.ListStateDescriptor<?> descrIntercepted =
@@ -309,8 +309,7 @@ class StreamingRuntimeContextTest {
                 new org.apache.flink.runtime.state.v2.MapStateDescriptor<>(
                         "name",
                         TypeInformation.of(String.class),
-                        TypeInformation.of(TaskInfo.class),
-                        serializerConfig);
+                        TypeInformation.of(TaskInfo.class));
         context.getMapState(descr);
 
         org.apache.flink.runtime.state.v2.MapStateDescriptor<?, ?> descrIntercepted =
@@ -339,7 +338,7 @@ class StreamingRuntimeContextTest {
 
         org.apache.flink.runtime.state.v2.ReducingStateDescriptor<TaskInfo> descr =
                 new org.apache.flink.runtime.state.v2.ReducingStateDescriptor<>(
-                        "name", reducer, TypeInformation.of(TaskInfo.class), serializerConfig);
+                        "name", reducer, TypeInformation.of(TaskInfo.class));
 
         context.getReducingState(descr);
 
@@ -371,10 +370,7 @@ class StreamingRuntimeContextTest {
         org.apache.flink.runtime.state.v2.AggregatingStateDescriptor<String, TaskInfo, String>
                 descr =
                         new org.apache.flink.runtime.state.v2.AggregatingStateDescriptor<>(
-                                "name",
-                                aggregate,
-                                TypeInformation.of(TaskInfo.class),
-                                serializerConfig);
+                                "name", aggregate, TypeInformation.of(TaskInfo.class));
 
         context.getAggregatingState(descr);
 
@@ -505,7 +501,15 @@ class StreamingRuntimeContextTest {
             operator.getRuntimeContext()
                     .setKeyedStateStoreV2(
                             new org.apache.flink.runtime.state.v2.DefaultKeyedStateStore(
-                                    asyncKeyedStateBackend));
+                                    asyncKeyedStateBackend,
+                                    new SerializerFactory() {
+                                        @Override
+                                        public <T> TypeSerializer<T> createSerializer(
+                                                TypeInformation<T> typeInformation) {
+                                            return typeInformation.createSerializer(
+                                                    config.getSerializerConfig());
+                                        }
+                                    }));
         }
 
         return operator;

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackendBuilder.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackendBuilder.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.state.forst;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.fs.Path;
@@ -107,6 +108,7 @@ public class ForStKeyedStateBackendBuilder<K>
 
     private final int numberOfKeyGroups;
     private final KeyGroupRange keyGroupRange;
+    private final ExecutionConfig executionConfig;
     private final TtlTimeProvider ttlTimeProvider;
 
     private final Collection<KeyedStateHandle> restoreStateHandles;
@@ -139,6 +141,7 @@ public class ForStKeyedStateBackendBuilder<K>
             TypeSerializer<K> keySerializer,
             int numberOfKeyGroups,
             KeyGroupRange keyGroupRange,
+            ExecutionConfig executionConfig,
             ForStPriorityQueueConfig priorityQueueConfig,
             TtlTimeProvider ttlTimeProvider,
             MetricGroup metricGroup,
@@ -153,6 +156,7 @@ public class ForStKeyedStateBackendBuilder<K>
                 StateSerializerProvider.fromNewRegisteredSerializer(keySerializer);
         this.numberOfKeyGroups = numberOfKeyGroups;
         this.keyGroupRange = keyGroupRange;
+        this.executionConfig = executionConfig;
         this.priorityQueueConfig = priorityQueueConfig;
         this.ttlTimeProvider = ttlTimeProvider;
         this.metricGroup = metricGroup;
@@ -303,6 +307,7 @@ public class ForStKeyedStateBackendBuilder<K>
                 optionsContainer.getRemoteBasePath());
         return new ForStKeyedStateBackend<>(
                 backendUID,
+                executionConfig,
                 this.optionsContainer,
                 keyGroupPrefixBytes,
                 this.keySerializerProvider.currentSchemaSerializer(),

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStStateBackend.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStStateBackend.java
@@ -413,6 +413,7 @@ public class ForStStateBackend extends AbstractManagedMemoryStateBackend
                                 parameters.getKeySerializer(),
                                 parameters.getNumberOfKeyGroups(),
                                 parameters.getKeyGroupRange(),
+                                env.getExecutionConfig(),
                                 priorityQueueConfig,
                                 parameters.getTtlTimeProvider(),
                                 parameters.getMetricGroup(),

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStDBOperationTestBase.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStDBOperationTestBase.java
@@ -21,7 +21,6 @@ package org.apache.flink.state.forst;
 import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.api.common.state.v2.State;
 import org.apache.flink.api.common.state.v2.StateFuture;
-import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
@@ -128,7 +127,7 @@ public class ForStDBOperationTestBase {
             throws Exception {
         ColumnFamilyHandle cf = createColumnFamilyHandle(stateName);
         ValueStateDescriptor<String> valueStateDescriptor =
-                new ValueStateDescriptor<>(stateName, BasicTypeInfo.STRING_TYPE_INFO);
+                new ValueStateDescriptor<>(stateName, StringSerializer.INSTANCE);
         Supplier<SerializedCompositeKeyBuilder<Integer>> serializedKeyBuilder =
                 () -> new SerializedCompositeKeyBuilder<>(IntSerializer.INSTANCE, 2, 32);
         Supplier<DataOutputSerializer> valueSerializerView = () -> new DataOutputSerializer(32);
@@ -149,7 +148,7 @@ public class ForStDBOperationTestBase {
             throws Exception {
         ColumnFamilyHandle cf = createColumnFamilyHandle(stateName);
         ListStateDescriptor<String> valueStateDescriptor =
-                new ListStateDescriptor<>(stateName, BasicTypeInfo.STRING_TYPE_INFO);
+                new ListStateDescriptor<>(stateName, StringSerializer.INSTANCE);
         Supplier<SerializedCompositeKeyBuilder<Integer>> serializedKeyBuilder =
                 () -> new SerializedCompositeKeyBuilder<>(IntSerializer.INSTANCE, 2, 32);
         Supplier<DataOutputSerializer> valueSerializerView = () -> new DataOutputSerializer(32);
@@ -193,7 +192,7 @@ public class ForStDBOperationTestBase {
                                 return a + b;
                             }
                         },
-                        BasicTypeInfo.INT_TYPE_INFO);
+                        IntSerializer.INSTANCE);
         Supplier<SerializedCompositeKeyBuilder<String>> serializedKeyBuilder =
                 () -> new SerializedCompositeKeyBuilder<>(StringSerializer.INSTANCE, 2, 32);
         Supplier<DataOutputSerializer> valueSerializerView = () -> new DataOutputSerializer(32);
@@ -216,7 +215,7 @@ public class ForStDBOperationTestBase {
         ColumnFamilyHandle cf = createColumnFamilyHandle(stateName);
         MapStateDescriptor<String, String> mapStateDescriptor =
                 new MapStateDescriptor<>(
-                        stateName, BasicTypeInfo.STRING_TYPE_INFO, BasicTypeInfo.STRING_TYPE_INFO);
+                        stateName, StringSerializer.INSTANCE, StringSerializer.INSTANCE);
         Supplier<SerializedCompositeKeyBuilder<Integer>> serializedKeyBuilder =
                 () -> new SerializedCompositeKeyBuilder<>(IntSerializer.INSTANCE, 2, 32);
         Supplier<DataOutputSerializer> valueSerializerView = () -> new DataOutputSerializer(32);

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStListStateTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStListStateTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.state.forst;
 
-import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.runtime.state.v2.ListStateDescriptor;
 import org.apache.flink.runtime.state.v2.internal.InternalListState;
@@ -35,7 +34,7 @@ public class ForStListStateTest extends ForStStateTestBase {
     @Test
     public void testMergeNamespace() throws Exception {
         ListStateDescriptor<Integer> descriptor =
-                new ListStateDescriptor<>("testState", BasicTypeInfo.INT_TYPE_INFO);
+                new ListStateDescriptor<>("testState", IntSerializer.INSTANCE);
         InternalListState<String, Integer, Integer> listState =
                 keyedBackend.createState(1, IntSerializer.INSTANCE, descriptor);
 


### PR DESCRIPTION
## What is the purpose of the change

This PR enables the lazy-initialization for state serializer in state v2. This is useful for datastream api, and is also a pre-work for exposing state v2 api to user. 

## Brief change log

The code is very similar with those in state v1 descriptors.

 - Implement constructor with `TypeInformation` for `StateDescriptor`s.
 - Invoke `initializeSerializerUnlessSet` wherever necessary.

## Verifying this change

This change is already covered by existing tests `StreamingRuntimeContextTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: yes
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
