### PR TITLE
[FLINK-36477][table] Remove deprecated method BaseExpressions#cast

### DIFF
--- a/flink-python/pyflink/table/table_config.py
+++ b/flink-python/pyflink/table/table_config.py
@@ -151,50 +151,6 @@ class TableConfig(object):
         else:
             raise Exception("TableConfig.max_generated_code_length should be a int value!")
 
-    def set_idle_state_retention_time(self,
-                                      min_time: datetime.timedelta,
-                                      max_time: datetime.timedelta):
-        """
-        Specifies a minimum and a maximum time interval for how long idle state, i.e., state which
-        was not updated, will be retained.
-
-        State will never be cleared until it was idle for less than the minimum time and will never
-        be kept if it was idle for more than the maximum time.
-
-        When new data arrives for previously cleaned-up state, the new data will be handled as if it
-        was the first data. This can result in previous results being overwritten.
-
-        Set to 0 (zero) to never clean-up the state.
-
-        Example:
-        ::
-
-            >>> table_config = TableConfig() \\
-            ...     .set_idle_state_retention_time(datetime.timedelta(days=1),
-            ...                                    datetime.timedelta(days=3))
-
-        .. note::
-
-            Cleaning up state requires additional bookkeeping which becomes less expensive for
-            larger differences of minTime and maxTime. The difference between minTime and maxTime
-            must be at least 5 minutes.
-
-            Method set_idle_state_retention_time is deprecated now. The suggested way to set idle
-            state retention time is :func:`~pyflink.table.TableConfig.set_idle_state_retention`
-            Currently, setting max_time will not work and the max_time is directly derived from the
-            min_time as 1.5 x min_time.
-
-        :param min_time: The minimum time interval for which idle state is retained. Set to
-                         0 (zero) to never clean-up the state.
-        :param max_time: The maximum time interval for which idle state is retained. Must be at
-                         least 5 minutes greater than minTime. Set to
-                         0 (zero) to never clean-up the state.
-        """
-        j_duration_class = get_gateway().jvm.java.time.Duration
-        j_min_time = j_duration_class.ofSeconds(long(round(min_time.total_seconds())))
-        j_max_time = j_duration_class.ofSeconds(long(round(max_time.total_seconds())))
-        self._j_table_config.setIdleStateRetentionTime(j_min_time, j_max_time)
-
     def set_idle_state_retention(self, duration: datetime.timedelta):
         """
         Specifies a retention time interval for how long idle state, i.e., state which

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/EnvironmentSettings.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/EnvironmentSettings.java
@@ -21,7 +21,6 @@ package org.apache.flink.table.api;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.api.config.TableConfigOptions;
 import org.apache.flink.table.catalog.CatalogStore;
 import org.apache.flink.table.functions.UserDefinedFunction;
@@ -103,27 +102,6 @@ public class EnvironmentSettings {
     /** Creates a builder for creating an instance of {@link EnvironmentSettings}. */
     public static Builder newInstance() {
         return new Builder();
-    }
-
-    /**
-     * Creates an instance of {@link EnvironmentSettings} from configuration.
-     *
-     * @deprecated use {@link Builder#withConfiguration(Configuration)} instead.
-     */
-    @Deprecated
-    public static EnvironmentSettings fromConfiguration(ReadableConfig configuration) {
-        return new EnvironmentSettings(
-                (Configuration) configuration, Thread.currentThread().getContextClassLoader());
-    }
-
-    /**
-     * Convert the environment setting to the {@link Configuration}.
-     *
-     * @deprecated use {@link #getConfiguration} instead.
-     */
-    @Deprecated
-    public Configuration toConfiguration() {
-        return configuration;
     }
 
     /** Get the underlying {@link Configuration}. */

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableConfig.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableConfig.java
@@ -96,9 +96,8 @@ import static org.apache.flink.table.api.internal.TableConfigValidation.validate
 @PublicEvolving
 public final class TableConfig implements WritableConfig, ReadableConfig {
 
-    /** Please use {@link TableConfig#getDefault()} instead. */
-    @Deprecated
-    public TableConfig() {}
+    /** Please use {@link TableConfig#getDefault()} to get the default {@link TableConfig}. */
+    private TableConfig() {}
 
     // Note to implementers:
     // TableConfig is a ReadableConfig which is built once the TableEnvironment is created and
@@ -354,43 +353,6 @@ public final class TableConfig implements WritableConfig, ReadableConfig {
     public void setMaxGeneratedCodeLength(Integer maxGeneratedCodeLength) {
         this.configuration.set(
                 TableConfigOptions.MAX_LENGTH_GENERATED_CODE, maxGeneratedCodeLength);
-    }
-
-    /**
-     * Specifies a minimum and a maximum time interval for how long idle state, i.e., state which
-     * was not updated, will be retained. State will never be cleared until it was idle for less
-     * than the minimum time and will never be kept if it was idle for more than the maximum time.
-     *
-     * <p>When new data arrives for previously cleaned-up state, the new data will be handled as if
-     * it was the first data. This can result in previous results being overwritten.
-     *
-     * <p>Set to 0 (zero) to never clean-up the state.
-     *
-     * <p>NOTE: Cleaning up state requires additional bookkeeping which becomes less expensive for
-     * larger differences of minTime and maxTime. The difference between minTime and maxTime must be
-     * at least 5 minutes.
-     *
-     * <p>NOTE: Currently maxTime will be ignored and it will automatically derived from minTime as
-     * 1.5 x minTime.
-     *
-     * @param minTime The minimum time interval for which idle state is retained. Set to 0 (zero) to
-     *     never clean-up the state.
-     * @param maxTime The maximum time interval for which idle state is retained. Must be at least 5
-     *     minutes greater than minTime. Set to 0 (zero) to never clean-up the state.
-     * @deprecated use {@link #setIdleStateRetention(Duration)} instead.
-     */
-    @Deprecated
-    public void setIdleStateRetentionTime(Duration minTime, Duration maxTime) {
-        if (maxTime.minus(minTime).toMillis() < 300000
-                && !(maxTime.toMillis() == 0 && minTime.toMillis() == 0)) {
-            throw new IllegalArgumentException(
-                    "Difference between minTime: "
-                            + minTime
-                            + " and maxTime: "
-                            + maxTime
-                            + " should be at least 5 minutes.");
-        }
-        setIdleStateRetention(minTime);
     }
 
     /**

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableResult.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableResult.java
@@ -21,7 +21,6 @@ package org.apache.flink.table.api;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.table.catalog.ResolvedSchema;
-import org.apache.flink.table.legacy.api.TableSchema;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CloseableIterator;
 
@@ -127,19 +126,6 @@ public interface TableResult {
      * <p>The schema of SELECT is the selected field names and types.
      */
     ResolvedSchema getResolvedSchema();
-
-    /**
-     * Returns the schema of the result.
-     *
-     * @deprecated This method has been deprecated as part of FLIP-164. {@link TableSchema} has been
-     *     replaced by two more dedicated classes {@link Schema} and {@link ResolvedSchema}. Use
-     *     {@link Schema} for declaration in APIs. {@link ResolvedSchema} is offered by the
-     *     framework after resolution and validation.
-     */
-    @Deprecated
-    default TableSchema getTableSchema() {
-        return TableSchema.fromResolvedSchema(getResolvedSchema());
-    }
 
     /**
      * Return the {@link ResultKind} which represents the result type.

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -20,7 +20,6 @@ package org.apache.flink.table.api.internal;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Expressions;
 import org.apache.flink.table.api.JsonExistsOnError;
@@ -614,19 +613,6 @@ public abstract class BaseExpressions<InType, OutType> {
      */
     public OutType tryCast(DataType toType) {
         return toApiSpecificExpression(unresolvedCall(TRY_CAST, toExpr(), typeLiteral(toType)));
-    }
-
-    /**
-     * @deprecated This method will be removed in future versions as it uses the old type system. It
-     *     is recommended to use {@link #cast(DataType)} instead which uses the new type system
-     *     based on {@link org.apache.flink.table.api.DataTypes}. Please make sure to use either the
-     *     old or the new type system consistently to avoid unintended behavior. See the website
-     *     documentation for more information.
-     */
-    @Deprecated
-    public OutType cast(TypeInformation<?> toType) {
-        return toApiSpecificExpression(
-                unresolvedCall(CAST, toExpr(), typeLiteral(fromLegacyInfoToDataType(toType))));
     }
 
     /** Specifies ascending order of an expression i.e. a field for orderBy unresolvedCall. */


### PR DESCRIPTION
## What is the purpose of the change

This PR is based on the previous one (https://github.com/apache/flink/pull/25514), and I have included @corgy-w (corgy-w@qq.com) as a co-author in the commit message.

This PR includes multi removal work for deprecated public methods as below:

- [[FLINK-36477](https://issues.apache.org/jira/browse/FLINK-36477)](https://issues.apache.org/jira/browse/FLINK-36477) Remove deprecated method BaseExpressions#cast in table-api-java
- [[FLINK-36478](https://issues.apache.org/jira/browse/FLINK-36478)](https://issues.apache.org/jira/browse/FLINK-36478) Remove deprecated methods EnvironmentSettings#fromConfiguration and EnvironmentSettings#toConfiguration
- [[FLINK-36480](https://issues.apache.org/jira/browse/FLINK-36480)](https://issues.apache.org/jira/browse/FLINK-36480) Remove all deprecated methods in TableConfig
- [[FLINK-36483](https://issues.apache.org/jira/browse/FLINK-36483)](https://issues.apache.org/jira/browse/FLINK-36483) Remove deprecated method TableResult#getTableSchema

## Brief change log

- [[FLINK-36477](https://issues.apache.org/jira/browse/FLINK-36477)](https://issues.apache.org/jira/browse/FLINK-36477) Remove deprecated method BaseExpressions#cast in table-api-java
- [[FLINK-36478](https://issues.apache.org/jira/browse/FLINK-36478)](https://issues.apache.org/jira/browse/FLINK-36478) Remove deprecated methods EnvironmentSettings#fromConfiguration and EnvironmentSettings#toConfiguration
- [[FLINK-36480](https://issues.apache.org/jira/browse/FLINK-36480)](https://issues.apache.org/jira/browse/FLINK-36480) Remove all deprecated methods in TableConfig
- [[FLINK-36483](https://issues.apache.org/jira/browse/FLINK-36483)](https://issues.apache.org/jira/browse/FLINK-36483) Remove deprecated method TableResult#getTableSchema

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? 

