### PR TITLE
[FLINK-37025] Fix generating watermarks in SQL on-periodic

### DIFF
--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/generated/GeneratedWatermarkGeneratorSupplier.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/generated/GeneratedWatermarkGeneratorSupplier.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.watermark.WatermarkParams;
 
 import javax.annotation.Nullable;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -84,7 +85,8 @@ public class GeneratedWatermarkGeneratorSupplier implements WatermarkGeneratorSu
 
     /** Wrapper of the code-generated {@link WatermarkGenerator}. */
     public static class DefaultWatermarkGenerator
-            implements org.apache.flink.api.common.eventtime.WatermarkGenerator<RowData> {
+            implements org.apache.flink.api.common.eventtime.WatermarkGenerator<RowData>,
+                    Serializable {
         private static final long serialVersionUID = 1L;
 
         private final WatermarkGenerator innerWatermarkGenerator;
@@ -102,7 +104,7 @@ public class GeneratedWatermarkGeneratorSupplier implements WatermarkGeneratorSu
         public void onEvent(RowData event, long eventTimestamp, WatermarkOutput output) {
             try {
                 Long watermark = innerWatermarkGenerator.currentWatermark(event);
-                if (watermark != null) {
+                if (watermark != null && watermark > currentWatermark) {
                     currentWatermark = watermark;
                     if (watermarkEmitStrategy.isOnEvent()) {
                         output.emitWatermark(new Watermark(currentWatermark));


### PR DESCRIPTION
## What is the purpose of the change

This fixes generating watermarks in SQL

## Verifying this change

Added a test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? **(not applicable** / docs / JavaDocs / not documented)
