### PR TITLE
[FLINK-36707][table] Integrate PTF type inference into Calcite

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/FunctionResultTemplate.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/FunctionResultTemplate.java
@@ -21,7 +21,6 @@ package org.apache.flink.table.types.extraction;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.inference.StateTypeStrategy;
-import org.apache.flink.table.types.inference.StateTypeStrategyWrapper;
 import org.apache.flink.table.types.inference.TypeStrategies;
 import org.apache.flink.table.types.inference.TypeStrategy;
 
@@ -122,7 +121,7 @@ interface FunctionResultTemplate {
         }
 
         private static StateTypeStrategy createStateTypeStrategy(DataType dataType) {
-            return StateTypeStrategyWrapper.of(TypeStrategies.explicit(dataType));
+            return StateTypeStrategy.of(TypeStrategies.explicit(dataType));
         }
 
         private static TypeStrategy createTypeStrategy(DataType dataType) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/TypeInferenceExtractor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/TypeInferenceExtractor.java
@@ -38,7 +38,6 @@ import org.apache.flink.table.types.extraction.FunctionResultTemplate.FunctionSt
 import org.apache.flink.table.types.inference.InputTypeStrategies;
 import org.apache.flink.table.types.inference.InputTypeStrategy;
 import org.apache.flink.table.types.inference.StateTypeStrategy;
-import org.apache.flink.table.types.inference.StateTypeStrategyWrapper;
 import org.apache.flink.table.types.inference.StaticArgument;
 import org.apache.flink.table.types.inference.TypeInference;
 import org.apache.flink.table.types.inference.TypeStrategies;
@@ -321,7 +320,7 @@ public final class TypeInferenceExtractor {
                                         e -> e.getKey().toInputTypeStrategy(),
                                         e -> e.getValue().toAccumulatorTypeStrategy()));
         final StateTypeStrategy accumulatorStrategy =
-                StateTypeStrategyWrapper.of(TypeStrategies.mapping(mappings));
+                StateTypeStrategy.of(TypeStrategies.mapping(mappings));
         final Set<String> stateNames =
                 stateMapping.values().stream()
                         .map(FunctionStateTemplate::toAccumulatorStateName)

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/CallContext.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/CallContext.java
@@ -23,6 +23,8 @@ import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.DataTypeFactory;
 import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.functions.ProcessTableFunction;
+import org.apache.flink.table.functions.TableSemantics;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
 
@@ -44,7 +46,8 @@ public interface CallContext {
 
     /**
      * Returns {@code true} if the argument at the given position is a literal and {@code null},
-     * {@code false} otherwise.
+     * {@code false} otherwise. If the argument is declared as optional and has no value, true is
+     * returned.
      *
      * <p>Use {@link #isArgumentLiteral(int)} before to check if the argument is actually a literal.
      */
@@ -60,6 +63,17 @@ public interface CallContext {
      * <p>Use {@link #isArgumentLiteral(int)} before to check if the argument is actually a literal.
      */
     <T> Optional<T> getArgumentValue(int pos, Class<T> clazz);
+
+    /**
+     * Returns information about the table that has been passed to a table argument.
+     *
+     * <p>Semantics are only available for table arguments (i.e. arguments of a {@link
+     * ProcessTableFunction} that are annotated with {@code @ArgumentHint(TABLE_AS_SET)} or
+     * {@code @ArgumentHint(TABLE_AS_ROW)}).
+     */
+    default Optional<TableSemantics> getTableSemantics(int pos) {
+        return Optional.empty();
+    }
 
     /**
      * Returns the function's name usually referencing the function in a catalog.

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/DefaultStateTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/DefaultStateTypeStrategy.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.types.inference;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.util.Preconditions;
 
@@ -26,18 +26,14 @@ import java.util.Objects;
 import java.util.Optional;
 
 /** A helper class that wraps a {@link TypeStrategy} into a {@link StateTypeStrategy}. */
-@PublicEvolving
-public class StateTypeStrategyWrapper implements StateTypeStrategy {
+@Internal
+class DefaultStateTypeStrategy implements StateTypeStrategy {
 
     private final TypeStrategy typeStrategy;
 
-    private StateTypeStrategyWrapper(TypeStrategy typeStrategy) {
+    DefaultStateTypeStrategy(TypeStrategy typeStrategy) {
         this.typeStrategy =
                 Preconditions.checkNotNull(typeStrategy, "Type strategy must not be null.");
-    }
-
-    public static StateTypeStrategyWrapper of(TypeStrategy typeStrategy) {
-        return new StateTypeStrategyWrapper(typeStrategy);
     }
 
     @Override
@@ -50,8 +46,8 @@ public class StateTypeStrategyWrapper implements StateTypeStrategy {
         if (this == o) {
             return true;
         }
-        if (o instanceof StateTypeStrategyWrapper) {
-            return Objects.equals(typeStrategy, ((StateTypeStrategyWrapper) o).typeStrategy);
+        if (o instanceof DefaultStateTypeStrategy) {
+            return Objects.equals(typeStrategy, ((DefaultStateTypeStrategy) o).typeStrategy);
         }
         if (o instanceof TypeStrategy) {
             return Objects.equals(typeStrategy, o);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/StateTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/StateTypeStrategy.java
@@ -23,5 +23,10 @@ import org.apache.flink.annotation.PublicEvolving;
 /** Strategy for inferring a function call's intermediate result data type (i.e. state entry). */
 @PublicEvolving
 public interface StateTypeStrategy extends TypeStrategy {
+
+    static StateTypeStrategy of(TypeStrategy typeStrategy) {
+        return new DefaultStateTypeStrategy(typeStrategy);
+    }
+
     // marker interface which will be filled with additional contracts in the future
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/StaticArgument.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/StaticArgument.java
@@ -173,6 +173,10 @@ public class StaticArgument {
         return traits;
     }
 
+    public boolean is(StaticArgumentTrait trait) {
+        return traits.contains(trait);
+    }
+
     @Override
     public String toString() {
         final StringBuilder s = new StringBuilder();
@@ -181,13 +185,18 @@ public class StaticArgument {
         // (myTypedTable ROW<i INT> {TABLE BY ROW})
         // (myUntypedTable {TABLE BY ROW})
         s.append(name);
+        s.append(" =>");
         if (dataType != null) {
             s.append(" ");
             s.append(dataType);
         }
         if (!traits.equals(EnumSet.of(StaticArgumentTrait.SCALAR))) {
             s.append(" ");
-            s.append(traits.stream().map(Enum::name).collect(Collectors.joining(", ", "{", "}")));
+            s.append(
+                    traits.stream()
+                            .map(Enum::name)
+                            .map(n -> n.replace('_', ' '))
+                            .collect(Collectors.joining(", ", "{", "}")));
         }
         return s.toString();
     }
@@ -218,7 +227,7 @@ public class StaticArgument {
             throw new ValidationException(
                     String.format(
                             "Invalid argument name '%s'. An argument must follow "
-                                    + "the pattern [a-zA-Z_$][a-zA-Z_$0-9].",
+                                    + "the pattern [a-zA-Z_$][a-zA-Z_$0-9]*.",
                             name));
         }
     }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/SystemTypeInference.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/SystemTypeInference.java
@@ -1,0 +1,324 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.DataTypes.Field;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.functions.FunctionKind;
+import org.apache.flink.table.functions.ProcessTableFunction;
+import org.apache.flink.table.functions.TableSemantics;
+import org.apache.flink.table.types.DataType;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Extends the {@link TypeInference} function-aware by additional system columns and validation.
+ *
+ * <p>During planning system columns are available and can be accessed in SQL, during runtime those
+ * columns are not passed or returned by the eval() method. They are handled with custom code paths.
+ *
+ * <p>For example, for {@link ProcessTableFunction}, this utility class implicitly adds the optional
+ * {@code uid} and {@code on_time} args and an additional {@code rowtime} column in the output.
+ * Additionally, it adds a validation layer for complex {@link StaticArgument}s.
+ */
+@Internal
+public class SystemTypeInference {
+
+    private static final List<StaticArgument> PROCESS_TABLE_FUNCTION_SYSTEM_ARGS =
+            List.of(StaticArgument.scalar("uid", DataTypes.STRING(), true));
+
+    /** Format of unique identifiers for {@link ProcessTableFunction}. */
+    private static final Predicate<String> UID_FORMAT =
+            Pattern.compile("^[a-zA-Z_][a-zA-Z-_0-9]*$").asPredicate();
+
+    public static TypeInference of(FunctionKind functionKind, TypeInference origin) {
+        final TypeInference.Builder builder = TypeInference.newBuilder();
+
+        final List<StaticArgument> defaultArgs =
+                applyDefaultArgs(builder, functionKind, origin.getStaticArguments().orElse(null));
+        builder.inputTypeStrategy(origin.getInputTypeStrategy());
+        builder.stateTypeStrategies(origin.getStateTypeStrategies());
+        builder.outputTypeStrategy(origin.getOutputTypeStrategy());
+
+        final List<StaticArgument> systemArgs = applySystemArgs(builder, functionKind, defaultArgs);
+        applySystemInputStrategy(builder, functionKind, systemArgs, origin);
+        applySystemOutputStrategy(builder, functionKind, origin);
+
+        return builder.build();
+    }
+
+    // --------------------------------------------------------------------------------------------
+
+    private static @Nullable List<StaticArgument> applyDefaultArgs(
+            TypeInference.Builder builder,
+            FunctionKind functionKind,
+            @Nullable List<StaticArgument> defaultArgs) {
+        if (defaultArgs == null) {
+            return null;
+        }
+        if (functionKind != FunctionKind.PROCESS_TABLE) {
+            checkScalarArgsOnly(defaultArgs);
+        }
+        builder.staticArguments(defaultArgs);
+        return defaultArgs;
+    }
+
+    private static void checkScalarArgsOnly(List<StaticArgument> defaultArgs) {
+        defaultArgs.forEach(
+                arg -> {
+                    if (!arg.is(StaticArgumentTrait.SCALAR)) {
+                        throw new ValidationException(
+                                String.format(
+                                        "Only scalar arguments are supported at this location. "
+                                                + "But argument '%s' declared the following traits: %s",
+                                        arg.getName(), arg.getTraits()));
+                    }
+                });
+    }
+
+    private static @Nullable List<StaticArgument> applySystemArgs(
+            TypeInference.Builder builder,
+            FunctionKind functionKind,
+            @Nullable List<StaticArgument> defaultArgs) {
+        if (functionKind != FunctionKind.PROCESS_TABLE) {
+            return defaultArgs;
+        }
+        if (defaultArgs == null) {
+            throw new ValidationException(
+                    "Function requires a static signature that is not overloaded and doesn't contain varargs.");
+        }
+
+        checkReservedArgs(defaultArgs);
+
+        final List<StaticArgument> newStaticArgs = new ArrayList<>(defaultArgs);
+        newStaticArgs.addAll(PROCESS_TABLE_FUNCTION_SYSTEM_ARGS);
+        builder.staticArguments(newStaticArgs);
+        return newStaticArgs;
+    }
+
+    private static void checkReservedArgs(List<StaticArgument> staticArgs) {
+        final Set<String> declaredArgs =
+                staticArgs.stream().map(StaticArgument::getName).collect(Collectors.toSet());
+        final Set<String> reservedArgs =
+                PROCESS_TABLE_FUNCTION_SYSTEM_ARGS.stream()
+                        .map(StaticArgument::getName)
+                        .collect(Collectors.toSet());
+        if (reservedArgs.stream().anyMatch(declaredArgs::contains)) {
+            throw new ValidationException(
+                    "Function signature must not declare system arguments. "
+                            + "Reserved argument names are: "
+                            + reservedArgs);
+        }
+    }
+
+    private static void applySystemInputStrategy(
+            TypeInference.Builder builder,
+            FunctionKind functionKind,
+            @Nullable List<StaticArgument> staticArgs,
+            TypeInference origin) {
+        if (functionKind != FunctionKind.PROCESS_TABLE) {
+            return;
+        }
+        builder.inputTypeStrategy(
+                new SystemInputStrategy(staticArgs, origin.getInputTypeStrategy()));
+    }
+
+    private static void applySystemOutputStrategy(
+            TypeInference.Builder builder, FunctionKind functionKind, TypeInference origin) {
+        if (functionKind != FunctionKind.TABLE && functionKind != FunctionKind.PROCESS_TABLE) {
+            return;
+        }
+        builder.outputTypeStrategy(new SystemOutputStrategy(origin.getOutputTypeStrategy()));
+    }
+
+    private static class SystemOutputStrategy implements TypeStrategy {
+
+        private final TypeStrategy origin;
+
+        private SystemOutputStrategy(TypeStrategy origin) {
+            this.origin = origin;
+        }
+
+        @Override
+        public Optional<DataType> inferType(CallContext callContext) {
+            return origin.inferType(callContext)
+                    .map(
+                            dataType -> {
+                                final List<DataType> fieldTypes =
+                                        DataType.getFieldDataTypes(dataType);
+                                final List<String> fieldNames = DataType.getFieldNames(dataType);
+                                final List<Field> fields = new ArrayList<>();
+                                if (fieldTypes.isEmpty()) {
+                                    // Before the system type inference was introduced, SQL and
+                                    // Table API chose a different default field name.
+                                    // EXPR$0 is chosen for best-effort backwards compatibility for
+                                    // SQL users.
+                                    fields.add(DataTypes.FIELD("EXPR$0", dataType));
+                                } else {
+                                    IntStream.range(0, fieldTypes.size())
+                                            .mapToObj(
+                                                    pos ->
+                                                            DataTypes.FIELD(
+                                                                    fieldNames.get(pos),
+                                                                    fieldTypes.get(pos)))
+                                            .forEach(fields::add);
+                                }
+
+                                return DataTypes.ROW(fields).notNull();
+                            });
+        }
+    }
+
+    private static class SystemInputStrategy implements InputTypeStrategy {
+
+        private final List<StaticArgument> staticArgs;
+        private final InputTypeStrategy origin;
+
+        private SystemInputStrategy(List<StaticArgument> staticArgs, InputTypeStrategy origin) {
+            this.staticArgs = staticArgs;
+            this.origin = origin;
+        }
+
+        @Override
+        public ArgumentCount getArgumentCount() {
+            // Static arguments declare the count
+            return InputTypeStrategies.WILDCARD.getArgumentCount();
+        }
+
+        @Override
+        public Optional<List<DataType>> inferInputTypes(
+                CallContext callContext, boolean throwOnFailure) {
+            final List<DataType> args = callContext.getArgumentDataTypes();
+
+            // Access the original input type strategy to give the function a chance to perform
+            // validation
+            final List<DataType> inferredDataTypes =
+                    origin.inferInputTypes(callContext, throwOnFailure).orElse(null);
+
+            // Check that the input type strategy doesn't influence the static arguments
+            if (inferredDataTypes == null || !inferredDataTypes.equals(args)) {
+                throw new ValidationException(
+                        "Process table functions must declare a static signature "
+                                + "that is not overloaded and doesn't contain varargs.");
+            }
+
+            checkUidColumn(callContext);
+            checkMultipleTableArgs(callContext);
+            checkTableArgTraits(staticArgs, callContext);
+
+            return Optional.of(inferredDataTypes);
+        }
+
+        @Override
+        public List<Signature> getExpectedSignatures(FunctionDefinition definition) {
+            // Access the original input type strategy to give the function a chance to return a
+            // valid signature
+            return origin.getExpectedSignatures(definition);
+        }
+
+        private static void checkUidColumn(CallContext callContext) {
+            final List<DataType> args = callContext.getArgumentDataTypes();
+
+            // Verify the uid format if provided
+            int uidPos = args.size() - 1;
+            if (!callContext.isArgumentNull(uidPos)) {
+                final String uid = callContext.getArgumentValue(uidPos, String.class).orElse("");
+                if (!UID_FORMAT.test(uid)) {
+                    throw new ValidationException(
+                            "Invalid unique identifier for process table function. The 'uid' argument "
+                                    + "must be a string literal that follows the pattern [a-zA-Z_][a-zA-Z-_0-9]*. "
+                                    + "But found: "
+                                    + uid);
+                }
+            }
+        }
+
+        private static void checkMultipleTableArgs(CallContext callContext) {
+            final List<DataType> args = callContext.getArgumentDataTypes();
+
+            final List<TableSemantics> tableSemantics =
+                    IntStream.range(0, args.size())
+                            .mapToObj(pos -> callContext.getTableSemantics(pos).orElse(null))
+                            .collect(Collectors.toList());
+            if (tableSemantics.stream().filter(Objects::nonNull).count() > 1) {
+                throw new ValidationException(
+                        "Currently, only signatures with at most one table argument are supported.");
+            }
+        }
+
+        private static void checkTableArgTraits(
+                List<StaticArgument> staticArgs, CallContext callContext) {
+            IntStream.range(0, staticArgs.size())
+                    .forEach(
+                            pos -> {
+                                final StaticArgument staticArg = staticArgs.get(pos);
+                                if (!staticArg.is(StaticArgumentTrait.TABLE)) {
+                                    return;
+                                }
+                                final TableSemantics semantics =
+                                        callContext.getTableSemantics(pos).orElse(null);
+                                if (semantics == null) {
+                                    throw new ValidationException(
+                                            String.format(
+                                                    "Table expected for argument '%s'.",
+                                                    staticArg.getName()));
+                                }
+                                checkRowSemantics(staticArg, semantics);
+                                checkSetSemantics(staticArg, semantics);
+                            });
+        }
+
+        private static void checkRowSemantics(StaticArgument staticArg, TableSemantics semantics) {
+            if (!staticArg.is(StaticArgumentTrait.TABLE_AS_ROW)) {
+                return;
+            }
+            if (semantics.partitionByColumns().length > 0
+                    || semantics.orderByColumns().length > 0) {
+                throw new ValidationException(
+                        "PARTITION BY or ORDER BY are not supported for table arguments with row semantics.");
+            }
+        }
+
+        private static void checkSetSemantics(StaticArgument staticArg, TableSemantics semantics) {
+            if (!staticArg.is(StaticArgumentTrait.TABLE_AS_SET)) {
+                return;
+            }
+            if (semantics.partitionByColumns().length == 0
+                    && !staticArg.is(StaticArgumentTrait.OPTIONAL_PARTITION_BY)) {
+                throw new ValidationException(
+                        String.format(
+                                "Table argument '%s' requires a PARTITION BY clause for parallel processing.",
+                                staticArg.getName()));
+            }
+        }
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeInference.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeInference.java
@@ -160,7 +160,7 @@ public final class TypeInference {
                         .collect(Collectors.toList());
         if (!invalidStateEntries.isEmpty()) {
             throw new ValidationException(
-                    "Invalid state names. A state entry must follow the pattern [a-zA-Z_$][a-zA-Z_$0-9]. But found: "
+                    "Invalid state names. A state entry must follow the pattern [a-zA-Z_$][a-zA-Z_$0-9]*. But found: "
                             + invalidStateEntries);
         }
     }
@@ -233,8 +233,7 @@ public final class TypeInference {
         public Builder accumulatorTypeStrategy(TypeStrategy accumulatorTypeStrategy) {
             Preconditions.checkNotNull(
                     accumulatorTypeStrategy, "Accumulator type strategy must not be null.");
-            this.stateTypeStrategies.put(
-                    "acc", StateTypeStrategyWrapper.of(accumulatorTypeStrategy));
+            this.stateTypeStrategies.put("acc", StateTypeStrategy.of(accumulatorTypeStrategy));
             return this;
         }
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/utils/AdaptedCallContext.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/utils/AdaptedCallContext.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.types.inference.utils;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.catalog.DataTypeFactory;
 import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.functions.TableSemantics;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.inference.CallContext;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -89,6 +90,12 @@ public final class AdaptedCallContext implements CallContext {
             return Optional.empty();
         }
         return originalContext.getArgumentValue(pos, clazz);
+    }
+
+    @Override
+    public Optional<TableSemantics> getTableSemantics(int pos) {
+        // table arguments remain regardless of casting
+        return originalContext.getTableSemantics(pos);
     }
 
     @Override

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/TypeInferenceExtractorTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/TypeInferenceExtractorTest.java
@@ -41,7 +41,6 @@ import org.apache.flink.table.types.inference.ArgumentTypeStrategy;
 import org.apache.flink.table.types.inference.InputTypeStrategies;
 import org.apache.flink.table.types.inference.InputTypeStrategy;
 import org.apache.flink.table.types.inference.StateTypeStrategy;
-import org.apache.flink.table.types.inference.StateTypeStrategyWrapper;
 import org.apache.flink.table.types.inference.StaticArgument;
 import org.apache.flink.table.types.inference.StaticArgumentTrait;
 import org.apache.flink.table.types.inference.TypeInference;
@@ -1252,7 +1251,7 @@ class TypeInferenceExtractorTest {
         }
 
         TestSpec expectAccumulator(TypeStrategy typeStrategy) {
-            this.expectedStateStrategies.put("acc", StateTypeStrategyWrapper.of(typeStrategy));
+            this.expectedStateStrategies.put("acc", StateTypeStrategy.of(typeStrategy));
             return this;
         }
 
@@ -1262,7 +1261,7 @@ class TypeInferenceExtractorTest {
         }
 
         TestSpec expectState(String name, TypeStrategy typeStrategy) {
-            this.expectedStateStrategies.put(name, StateTypeStrategyWrapper.of(typeStrategy));
+            this.expectedStateStrategies.put(name, StateTypeStrategy.of(typeStrategy));
             return this;
         }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql/validate/ProcedureNamespace.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql/validate/ProcedureNamespace.java
@@ -70,26 +70,9 @@ public final class ProcedureNamespace extends AbstractNamespace {
         }
         final SqlTableFunction tableFunction = (SqlTableFunction) operator;
         final SqlReturnTypeInference rowTypeInference = tableFunction.getRowTypeInference();
-        final RelDataType rowRelDataType =
-                requireNonNull(
-                        rowTypeInference.inferReturnType(callBinding),
-                        () -> "got null from inferReturnType for call " + callBinding.getCall());
-        // For BridgingSqlFunction the type can still be atomic
-        // and will be wrapped with a proper field alias
-        return toStruct(rowRelDataType, getNode());
-    }
-
-    /** Converts a type to a struct if it is not already. */
-    protected RelDataType toStruct(RelDataType type, SqlNode unnest) {
-        if (type.isStruct()) {
-            return validator.getTypeFactory().createTypeWithNullability(type, false);
-        }
-        return validator
-                .getTypeFactory()
-                .builder()
-                .kind(type.getStructKind())
-                .add(validator.deriveAlias(unnest, 0), type)
-                .build();
+        return requireNonNull(
+                rowTypeInference.inferReturnType(callBinding),
+                () -> "got null from inferReturnType for call " + callBinding.getCall());
     }
 
     public SqlNode getNode() {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/FlinkSqlCallBinding.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/FlinkSqlCallBinding.java
@@ -42,14 +42,14 @@ import java.util.List;
 /** Binding supports to rewrite the DEFAULT operator. */
 public class FlinkSqlCallBinding extends SqlCallBinding {
 
-    private final List<RelDataType> fixArgumentTypes;
+    private final List<RelDataType> fixedArgumentTypes;
 
     private final List<SqlNode> rewrittenOperands;
 
     public FlinkSqlCallBinding(
             SqlValidator validator, @Nullable SqlValidatorScope scope, SqlCall call) {
         super(validator, scope, call);
-        this.fixArgumentTypes = getFixArgumentTypes();
+        this.fixedArgumentTypes = getFixedArgumentTypes();
         this.rewrittenOperands = getRewrittenOperands();
     }
 
@@ -75,7 +75,7 @@ public class FlinkSqlCallBinding extends SqlCallBinding {
 
         SqlNode operand = rewrittenOperands.get(ordinal);
         if (operand.getKind() == SqlKind.DEFAULT) {
-            return fixArgumentTypes.get(ordinal);
+            return fixedArgumentTypes.get(ordinal);
         }
 
         final RelDataType type = SqlTypeUtil.deriveType(this, operand);
@@ -84,10 +84,10 @@ public class FlinkSqlCallBinding extends SqlCallBinding {
     }
 
     public boolean isFixedParameters() {
-        return !fixArgumentTypes.isEmpty();
+        return !fixedArgumentTypes.isEmpty();
     }
 
-    private List<RelDataType> getFixArgumentTypes() {
+    private List<RelDataType> getFixedArgumentTypes() {
         SqlOperandTypeChecker sqlOperandTypeChecker = getOperator().getOperandTypeChecker();
         if (sqlOperandTypeChecker instanceof SqlOperandMetadata
                 && sqlOperandTypeChecker.isFixedParameters()) {
@@ -106,7 +106,7 @@ public class FlinkSqlCallBinding extends SqlCallBinding {
             if (operand instanceof SqlCall
                     && ((SqlCall) operand).getOperator() == SqlStdOperatorTable.DEFAULT) {
                 rewrittenOperands.add(
-                        new SqlDefaultOperator(fixArgumentTypes.get(rewrittenOperands.size()))
+                        new SqlDefaultOperator(fixedArgumentTypes.get(rewrittenOperands.size()))
                                 .createCall(SqlParserPos.ZERO));
             } else {
                 rewrittenOperands.add(operand);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/catalog/FunctionCatalogOperatorTable.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/catalog/FunctionCatalogOperatorTable.java
@@ -190,7 +190,7 @@ public class FunctionCatalogOperatorTable implements SqlOperatorTable {
 
         final FunctionKind kind = definition.getKind();
 
-        if (kind == FunctionKind.TABLE) {
+        if (kind == FunctionKind.TABLE || kind == FunctionKind.PROCESS_TABLE) {
             return true;
         } else if (kind == FunctionKind.SCALAR
                 || kind == FunctionKind.ASYNC_SCALAR

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/bridging/BridgingSqlAggFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/bridging/BridgingSqlAggFunction.java
@@ -34,10 +34,7 @@ import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.util.Optionality;
 
-import java.util.List;
-
 import static org.apache.flink.table.planner.functions.bridging.BridgingUtils.createName;
-import static org.apache.flink.table.planner.functions.bridging.BridgingUtils.createParamTypes;
 import static org.apache.flink.table.planner.functions.bridging.BridgingUtils.createSqlFunctionCategory;
 import static org.apache.flink.table.planner.functions.bridging.BridgingUtils.createSqlIdentifier;
 import static org.apache.flink.table.planner.functions.bridging.BridgingUtils.createSqlOperandTypeChecker;
@@ -59,8 +56,6 @@ public final class BridgingSqlAggFunction extends SqlAggFunction {
     private final ContextResolvedFunction resolvedFunction;
 
     private final TypeInference typeInference;
-
-    private final List<RelDataType> paramTypes;
 
     private BridgingSqlAggFunction(
             DataTypeFactory dataTypeFactory,
@@ -87,7 +82,6 @@ public final class BridgingSqlAggFunction extends SqlAggFunction {
         this.typeFactory = typeFactory;
         this.resolvedFunction = resolvedFunction;
         this.typeInference = typeInference;
-        this.paramTypes = createParamTypes(typeFactory, typeInference);
     }
 
     /**
@@ -150,19 +144,6 @@ public final class BridgingSqlAggFunction extends SqlAggFunction {
 
     public TypeInference getTypeInference() {
         return typeInference;
-    }
-
-    @Override
-    public List<RelDataType> getParamTypes() {
-        return paramTypes;
-    }
-
-    @Override
-    public List<String> getParamNames() {
-        if (typeInference.getNamedArguments().isPresent()) {
-            return typeInference.getNamedArguments().get();
-        }
-        return super.getParamNames();
     }
 
     @Override

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/bridging/BridgingSqlFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/bridging/BridgingSqlFunction.java
@@ -32,21 +32,28 @@ import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.planner.calcite.RexFactory;
 import org.apache.flink.table.planner.utils.ShortcutUtils;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.StaticArgument;
+import org.apache.flink.table.types.inference.StaticArgumentTrait;
+import org.apache.flink.table.types.inference.SystemTypeInference;
 import org.apache.flink.table.types.inference.TypeInference;
 
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rel.type.StructKind;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlTableFunction;
+import org.apache.calcite.sql.TableCharacteristic;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
 import org.apache.calcite.tools.RelBuilder;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.table.planner.functions.bridging.BridgingUtils.createName;
-import static org.apache.flink.table.planner.functions.bridging.BridgingUtils.createParamTypes;
 import static org.apache.flink.table.planner.functions.bridging.BridgingUtils.createSqlFunctionCategory;
 import static org.apache.flink.table.planner.functions.bridging.BridgingUtils.createSqlIdentifier;
 import static org.apache.flink.table.planner.functions.bridging.BridgingUtils.createSqlOperandTypeChecker;
@@ -67,7 +74,8 @@ public class BridgingSqlFunction extends SqlFunction {
     private final FlinkTypeFactory typeFactory;
     private final RexFactory rexFactory;
     private final ContextResolvedFunction resolvedFunction;
-    private final TypeInference typeInference;
+
+    protected final TypeInference typeInference;
 
     private BridgingSqlFunction(
             DataTypeFactory dataTypeFactory,
@@ -86,7 +94,6 @@ public class BridgingSqlFunction extends SqlFunction {
                         dataTypeFactory, resolvedFunction.getDefinition(), typeInference),
                 createSqlOperandTypeChecker(
                         dataTypeFactory, resolvedFunction.getDefinition(), typeInference),
-                createParamTypes(typeFactory, typeInference),
                 createSqlFunctionCategory(resolvedFunction));
 
         this.dataTypeFactory = dataTypeFactory;
@@ -118,20 +125,29 @@ public class BridgingSqlFunction extends SqlFunction {
         checkState(
                 functionKind == FunctionKind.SCALAR
                         || functionKind == FunctionKind.ASYNC_SCALAR
-                        || functionKind == FunctionKind.TABLE,
+                        || functionKind == FunctionKind.TABLE
+                        || functionKind == FunctionKind.PROCESS_TABLE,
                 "Scalar or table function kind expected.");
 
-        if (functionKind == FunctionKind.TABLE) {
+        final TypeInference systemTypeInference =
+                SystemTypeInference.of(functionKind, typeInference);
+
+        if (functionKind == FunctionKind.TABLE || functionKind == FunctionKind.PROCESS_TABLE) {
             return new BridgingSqlFunction.WithTableFunction(
                     dataTypeFactory,
                     typeFactory,
                     rexFactory,
                     kind,
                     resolvedFunction,
-                    typeInference);
+                    systemTypeInference);
         }
         return new BridgingSqlFunction(
-                dataTypeFactory, typeFactory, rexFactory, kind, resolvedFunction, typeInference);
+                dataTypeFactory,
+                typeFactory,
+                rexFactory,
+                kind,
+                resolvedFunction,
+                systemTypeInference);
     }
 
     /** Creates an instance of a scalar or table function during translation. */
@@ -193,14 +209,6 @@ public class BridgingSqlFunction extends SqlFunction {
     }
 
     @Override
-    public List<String> getParamNames() {
-        if (typeInference.getNamedArguments().isPresent()) {
-            return typeInference.getNamedArguments().get();
-        }
-        return super.getParamNames();
-    }
-
-    @Override
     public boolean isDeterministic() {
         return resolvedFunction.getDefinition().isDeterministic();
     }
@@ -218,19 +226,58 @@ public class BridgingSqlFunction extends SqlFunction {
                 RexFactory rexFactory,
                 SqlKind kind,
                 ContextResolvedFunction resolvedFunction,
-                TypeInference typeInference) {
-            super(dataTypeFactory, typeFactory, rexFactory, kind, resolvedFunction, typeInference);
+                TypeInference systemTypeInference) {
+            super(
+                    dataTypeFactory,
+                    typeFactory,
+                    rexFactory,
+                    kind,
+                    resolvedFunction,
+                    systemTypeInference);
         }
 
         /**
-         * The conversion to a row type is handled on the caller side. This allows us to perform it
-         * SQL/Table API-specific. This is in particular important to set the aliases of fields
-         * correctly (see {@link FlinkRelBuilder#pushFunctionScan(RelBuilder, SqlOperator, int,
-         * Iterable, List)}).
+         * The conversion to a row type is handled by the system type inference.
+         *
+         * @see FlinkRelBuilder#pushFunctionScan(RelBuilder, SqlOperator, int, Iterable, List)
          */
         @Override
         public SqlReturnTypeInference getRowTypeInference() {
-            return getReturnTypeInference();
+            final SqlReturnTypeInference inference = getReturnTypeInference();
+            assert inference != null;
+            return (opBinding) -> {
+                final RelDataType relDataType = inference.inferReturnType(opBinding);
+                assert relDataType != null;
+                final List<RelDataTypeField> fields = relDataType.getFieldList();
+                return opBinding
+                        .getTypeFactory()
+                        .createStructType(
+                                StructKind.FULLY_QUALIFIED,
+                                fields.stream()
+                                        .map(RelDataTypeField::getType)
+                                        .collect(Collectors.toList()),
+                                fields.stream()
+                                        .map(RelDataTypeField::getName)
+                                        .collect(Collectors.toList()));
+            };
+        }
+
+        @Override
+        public @Nullable TableCharacteristic tableCharacteristic(int ordinal) {
+            final List<StaticArgument> args = typeInference.getStaticArguments().orElse(null);
+            if (args == null || ordinal >= args.size()) {
+                return null;
+            }
+            final StaticArgument arg = args.get(ordinal);
+            final TableCharacteristic.Semantics semantics;
+            if (arg.is(StaticArgumentTrait.TABLE_AS_ROW)) {
+                semantics = TableCharacteristic.Semantics.ROW;
+            } else if (arg.is(StaticArgumentTrait.TABLE_AS_SET)) {
+                semantics = TableCharacteristic.Semantics.SET;
+            } else {
+                return null;
+            }
+            return TableCharacteristic.builder(semantics).build();
         }
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/bridging/BridgingUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/bridging/BridgingUtils.java
@@ -31,13 +31,11 @@ import org.apache.flink.table.functions.TableAggregateFunctionDefinition;
 import org.apache.flink.table.functions.TableFunctionDefinition;
 import org.apache.flink.table.functions.UserDefinedFunction;
 import org.apache.flink.table.functions.UserDefinedFunctionHelper;
-import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.planner.functions.inference.TypeInferenceOperandChecker;
 import org.apache.flink.table.planner.functions.inference.TypeInferenceOperandInference;
 import org.apache.flink.table.planner.functions.inference.TypeInferenceReturnInference;
 import org.apache.flink.table.types.inference.TypeInference;
 
-import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.parser.SqlParserPos;
@@ -47,9 +45,7 @@ import org.apache.calcite.sql.type.SqlReturnTypeInference;
 
 import javax.annotation.Nullable;
 
-import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /** Utilities for bridging {@link FunctionDefinition} with Calcite's representation of functions. */
 final class BridgingUtils {
@@ -160,21 +156,6 @@ final class BridgingUtils {
             FunctionDefinition definition,
             TypeInference typeInference) {
         return new TypeInferenceOperandChecker(dataTypeFactory, definition, typeInference);
-    }
-
-    static @Nullable List<RelDataType> createParamTypes(
-            FlinkTypeFactory typeFactory, TypeInference typeInference) {
-        return typeInference
-                .getTypedArguments()
-                .map(
-                        dataTypes ->
-                                dataTypes.stream()
-                                        .map(
-                                                dataType ->
-                                                        typeFactory.createFieldTypeFromLogicalType(
-                                                                dataType.getLogicalType()))
-                                        .collect(Collectors.toList()))
-                .orElse(null);
     }
 
     static SqlFunctionCategory createSqlFunctionCategory(ContextResolvedFunction resolvedFunction) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/inference/CallBindingCallContext.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/inference/CallBindingCallContext.java
@@ -19,18 +19,27 @@
 package org.apache.flink.table.planner.functions.inference;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.DataTypeFactory;
+import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.functions.TableSemantics;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.inference.CallContext;
+import org.apache.flink.table.types.inference.StaticArgument;
+import org.apache.flink.table.types.inference.StaticArgumentTrait;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.utils.TypeConversions;
 
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCallBinding;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlUtil;
 import org.apache.calcite.sql.type.SqlTypeName;
 
@@ -48,28 +57,24 @@ import java.util.Optional;
 public final class CallBindingCallContext extends AbstractSqlCallContext {
 
     private final List<SqlNode> adaptedArguments;
-
     private final List<DataType> argumentDataTypes;
-
-    private final SqlCallBinding binding;
-
     private final @Nullable DataType outputType;
+    private final @Nullable List<StaticArgument> staticArguments;
 
     public CallBindingCallContext(
             DataTypeFactory dataTypeFactory,
             FunctionDefinition definition,
             SqlCallBinding binding,
-            @Nullable RelDataType outputType) {
+            @Nullable RelDataType outputType,
+            @Nullable List<StaticArgument> staticArguments) {
         super(
                 dataTypeFactory,
                 definition,
                 binding.getOperator().getNameAsId().toString(),
                 binding.getGroupCount() > 0);
-
         this.adaptedArguments = binding.operands(); // reorders the operands
-        this.binding = binding;
         this.argumentDataTypes =
-                new AbstractList<DataType>() {
+                new AbstractList<>() {
                     @Override
                     public DataType get(int pos) {
                         final LogicalType logicalType =
@@ -83,6 +88,7 @@ public final class CallBindingCallContext extends AbstractSqlCallContext {
                     }
                 };
         this.outputType = convertOutputType(binding, outputType);
+        this.staticArguments = staticArguments;
     }
 
     @Override
@@ -92,7 +98,8 @@ public final class CallBindingCallContext extends AbstractSqlCallContext {
 
     @Override
     public boolean isArgumentNull(int pos) {
-        return SqlUtil.isNullLiteral(adaptedArguments.get(pos), false);
+        return SqlUtil.isNullLiteral(adaptedArguments.get(pos), false)
+                || adaptedArguments.get(pos).getKind() == SqlKind.DEFAULT;
     }
 
     @Override
@@ -109,6 +116,22 @@ public final class CallBindingCallContext extends AbstractSqlCallContext {
     }
 
     @Override
+    public Optional<TableSemantics> getTableSemantics(int pos) {
+        final StaticArgument staticArg =
+                Optional.ofNullable(staticArguments).map(args -> args.get(pos)).orElse(null);
+        if (staticArg == null || !staticArg.is(StaticArgumentTrait.TABLE)) {
+            return Optional.empty();
+        }
+        final SqlNode sqlNode = adaptedArguments.get(pos);
+        if (!sqlNode.isA(SqlKind.QUERY) && noSetSemantics(sqlNode)) {
+            return Optional.empty();
+        }
+        return Optional.of(
+                CallBindingTableSemantics.create(
+                        argumentDataTypes.get(pos), staticArguments.get(pos), sqlNode));
+    }
+
+    @Override
     public List<DataType> getArgumentDataTypes() {
         return argumentDataTypes;
     }
@@ -118,6 +141,114 @@ public final class CallBindingCallContext extends AbstractSqlCallContext {
         return Optional.ofNullable(outputType);
     }
 
+    // --------------------------------------------------------------------------------------------
+    // TableSemantics
+    // --------------------------------------------------------------------------------------------
+
+    private static class CallBindingTableSemantics implements TableSemantics {
+
+        private final DataType dataType;
+        private final int[] partitionByColumns;
+
+        public static CallBindingTableSemantics create(
+                DataType tableDataType, StaticArgument staticArg, SqlNode sqlNode) {
+            checkNoOrderBy(sqlNode);
+            return new CallBindingTableSemantics(
+                    createDataType(tableDataType, staticArg),
+                    createPartitionByColumns(tableDataType, sqlNode));
+        }
+
+        private static void checkNoOrderBy(SqlNode sqlNode) {
+            final SqlNodeList orderByList = getSemanticsComponent(sqlNode, 2);
+            if (orderByList == null) {
+                return;
+            }
+            if (!orderByList.isEmpty()) {
+                throw new ValidationException("ORDER BY clause is currently not supported.");
+            }
+        }
+
+        private static @Nullable SqlNodeList getSemanticsComponent(SqlNode sqlNode, int pos) {
+            if (noSetSemantics(sqlNode)) {
+                return null;
+            }
+            // 0 => query, 1 => PARTITION BY, 2 => ORDER BY
+            final List<SqlNode> setSemantics = ((SqlCall) sqlNode).getOperandList();
+            return (SqlNodeList) setSemantics.get(pos);
+        }
+
+        private static DataType createDataType(DataType tableDataType, StaticArgument staticArg) {
+            final DataType dataType = staticArg.getDataType().orElse(null);
+            if (dataType != null) {
+                // Typed table argument
+                return dataType;
+            }
+            // Untyped table arguments
+            return tableDataType;
+        }
+
+        private static int[] createPartitionByColumns(DataType tableDataType, SqlNode sqlNode) {
+            final SqlNodeList partitionByList = getSemanticsComponent(sqlNode, 1);
+            if (partitionByList == null) {
+                return new int[0];
+            }
+            final List<String> tableColumns = DataType.getFieldNames(tableDataType);
+            return partitionByList.stream()
+                    .map(n -> ((SqlIdentifier) n).getSimple())
+                    .map(
+                            c -> {
+                                final int pos = tableColumns.indexOf(c);
+                                if (pos < 0) {
+                                    throw new ValidationException(
+                                            String.format(
+                                                    "Invalid column '%s' for PARTITION BY clause. "
+                                                            + "Available columns are: %s",
+                                                    c, tableColumns));
+                                }
+                                return pos;
+                            })
+                    .mapToInt(Integer::intValue)
+                    .toArray();
+        }
+
+        private CallBindingTableSemantics(DataType dataType, int[] partitionByColumns) {
+            this.dataType = dataType;
+            this.partitionByColumns = partitionByColumns;
+        }
+
+        @Override
+        public DataType dataType() {
+            return dataType;
+        }
+
+        @Override
+        public int[] partitionByColumns() {
+            return partitionByColumns;
+        }
+
+        @Override
+        public int[] orderByColumns() {
+            return new int[0];
+        }
+
+        @Override
+        public int timeColumn() {
+            return -1;
+        }
+
+        @Override
+        public List<String> coPartitionArgs() {
+            return List.of();
+        }
+
+        @Override
+        public Optional<ChangelogMode> changelogMode() {
+            return Optional.empty();
+        }
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Helper methods
     // --------------------------------------------------------------------------------------------
 
     private static @Nullable DataType convertOutputType(
@@ -130,5 +261,9 @@ public final class CallBindingCallContext extends AbstractSqlCallContext {
             final LogicalType logicalType = FlinkTypeFactory.toLogicalType(returnType);
             return TypeConversions.fromLogicalToDataType(logicalType);
         }
+    }
+
+    private static boolean noSetSemantics(SqlNode sqlNode) {
+        return sqlNode.getKind() != SqlKind.SET_SEMANTICS_TABLE;
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/inference/OperatorBindingCallContext.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/inference/OperatorBindingCallContext.java
@@ -43,9 +43,7 @@ import static org.apache.flink.table.types.utils.TypeConversions.fromLogicalToDa
 public final class OperatorBindingCallContext extends AbstractSqlCallContext {
 
     private final SqlOperatorBinding binding;
-
     private final List<DataType> argumentDataTypes;
-
     private final @Nullable DataType outputDataType;
 
     public OperatorBindingCallContext(
@@ -61,7 +59,7 @@ public final class OperatorBindingCallContext extends AbstractSqlCallContext {
 
         this.binding = binding;
         this.argumentDataTypes =
-                new AbstractList<DataType>() {
+                new AbstractList<>() {
                     @Override
                     public DataType get(int pos) {
                         LogicalType logicalType =

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.java
@@ -1,0 +1,326 @@
+package org.apache.flink.table.planner.plan.stream.sql;
+
+import org.apache.flink.table.annotation.ArgumentHint;
+import org.apache.flink.table.annotation.ArgumentTrait;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.catalog.DataTypeFactory;
+import org.apache.flink.table.functions.ProcessTableFunction;
+import org.apache.flink.table.functions.ScalarFunction;
+import org.apache.flink.table.functions.TableFunction;
+import org.apache.flink.table.planner.utils.TableTestBase;
+import org.apache.flink.table.planner.utils.TableTestUtil;
+import org.apache.flink.table.types.inference.StaticArgument;
+import org.apache.flink.table.types.inference.StaticArgumentTrait;
+import org.apache.flink.table.types.inference.TypeInference;
+import org.apache.flink.types.Row;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumSet;
+import java.util.Optional;
+
+import static org.apache.flink.table.annotation.ArgumentTrait.OPTIONAL_PARTITION_BY;
+import static org.apache.flink.table.annotation.ArgumentTrait.TABLE_AS_ROW;
+import static org.apache.flink.table.annotation.ArgumentTrait.TABLE_AS_SET;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for the type inference and planning part of {@link ProcessTableFunction}. */
+public class ProcessTableFunctionTest extends TableTestBase {
+
+    private TableTestUtil util;
+
+    @BeforeEach
+    void setup() {
+        util = streamTestUtil(TableConfig.getDefault());
+        util.tableEnv().executeSql("CREATE VIEW t1 AS SELECT 'Bob' AS name, 12 AS score");
+        util.tableEnv().executeSql("CREATE VIEW t2 AS SELECT 'Bob' AS name, 12 AS different");
+        util.tableEnv().executeSql("CREATE VIEW t3 AS SELECT 'Bob' AS name, TRUE AS isValid");
+    }
+
+    @Test
+    void testScalarArgsNoUid() {
+        util.addTemporarySystemFunction("f", ScalarArgsFunction.class);
+        util.verifyRelPlan("SELECT * FROM f(i => 1, b => true)");
+    }
+
+    @Test
+    void testScalarArgsWithUid() {
+        util.addTemporarySystemFunction("f", ScalarArgsFunction.class);
+        // argument 'uid' is also reordered
+        util.verifyRelPlan("SELECT * FROM f(uid => 'my-uid', i => 1, b => true)");
+    }
+
+    @Test
+    void testUnknownScalarArg() {
+        util.addTemporarySystemFunction("f", ScalarArgsFunction.class);
+        // argument 'invalid' is ignored
+        util.verifyRelPlan("SELECT * FROM f(i => 1, b => true, invalid => 'invalid')");
+    }
+
+    @Test
+    void testInvalidUid() {
+        util.addTemporarySystemFunction("f", ScalarArgsFunction.class);
+        assertThatThrownBy(
+                        () -> util.verifyRelPlan("SELECT * FROM f(uid => '%', i => 1, b => true)"))
+                .hasRootCauseMessage(
+                        "Invalid unique identifier for process table function. "
+                                + "The 'uid' argument must be a string literal that follows the pattern [a-zA-Z_][a-zA-Z-_0-9]*. "
+                                + "But found: %");
+    }
+
+    @Test
+    void testTableAsRow() {
+        util.addTemporarySystemFunction("f", TableAsRowFunction.class);
+        assertReachesOptimizer("SELECT * FROM f(r => TABLE t1, i => 1)");
+    }
+
+    @Test
+    void testTypedTableAsRow() {
+        util.addTemporarySystemFunction("f", TypedTableAsRowFunction.class);
+        assertReachesOptimizer("SELECT * FROM f(u => TABLE t1, i => 1)");
+    }
+
+    @Test
+    void testTypedTableAsRowIgnoringColumnNames() {
+        util.addTemporarySystemFunction("f", TypedTableAsRowFunction.class);
+        // function expects <STRING name, INT score>
+        // but table is <STRING name, INT different>
+        assertReachesOptimizer("SELECT * FROM f(u => TABLE t2, i => 1)");
+    }
+
+    @Test
+    void testTypedTableAsRowWithInvalidInput() {
+        util.addTemporarySystemFunction("f", TypedTableAsRowFunction.class);
+        // function expects <STRING name, INT score>
+        assertThatThrownBy(() -> util.verifyRelPlan("SELECT * FROM f(u => TABLE t3, i => 1)"))
+                .hasMessageContaining(
+                        "No match found for function signature "
+                                + "f(<RecordType(CHAR(3) name, BOOLEAN isValid)>, <NUMERIC>, <CHARACTER>)");
+    }
+
+    @Test
+    void testTableAsSet() {
+        util.addTemporarySystemFunction("f", TableAsSetFunction.class);
+        assertReachesOptimizer("SELECT * FROM f(r => TABLE t1 PARTITION BY name, i => 1)");
+    }
+
+    @Test
+    void testTableAsSetWithInvalidPartitionBy() {
+        util.addTemporarySystemFunction("f", TableAsSetFunction.class);
+        assertThatThrownBy(() -> util.verifyRelPlan("SELECT * FROM f(r => TABLE t1, i => 1)"))
+                .hasRootCauseMessage(
+                        "Table argument 'r' requires a PARTITION BY clause for parallel processing.");
+    }
+
+    @Test
+    void testTableAsSetOptionalPartitionBy() {
+        util.addTemporarySystemFunction("f", TableAsSetOptionalPartitionFunction.class);
+        assertReachesOptimizer("SELECT * FROM f(r => TABLE t1, i => 1)");
+    }
+
+    @Test
+    void testTypedTableAsSet() {
+        util.addTemporarySystemFunction("f", TypedTableAsSetFunction.class);
+        assertReachesOptimizer("SELECT * FROM f(u => TABLE t1 PARTITION BY name, i => 1)");
+    }
+
+    @Test
+    void testTypedTableAsSetWithInvalidInput() {
+        util.addTemporarySystemFunction("f", TypedTableAsSetFunction.class);
+        // function expects <STRING name, INT score>
+        assertThatThrownBy(
+                        () ->
+                                util.verifyRelPlan(
+                                        "SELECT * FROM f(u => TABLE t3 PARTITION BY name, i => 1)"))
+                .hasMessageContaining(
+                        "No match found for function signature "
+                                + "f(<RecordType(CHAR(3) name, BOOLEAN isValid)>, <NUMERIC>, <CHARACTER>)");
+    }
+
+    @Test
+    void testEmptyArgs() {
+        util.addTemporarySystemFunction("f", EmptyArgFunction.class);
+        util.verifyRelPlan("SELECT * FROM f(uid => 'my-ptf')");
+    }
+
+    @Test
+    void testPojoArgs() {
+        util.addTemporarySystemFunction("f", PojoArgsFunction.class);
+        util.addTemporarySystemFunction("pojoCreator", PojoCreatingFunction.class);
+        assertReachesOptimizer(
+                "SELECT * FROM f(input => TABLE t1, scalar => pojoCreator('Bob', 12), uid => 'my-ptf')");
+    }
+
+    @Test
+    void testInvalidTableFunction() {
+        util.addTemporarySystemFunction("f", NoProcessTableFunction.class);
+        assertThatThrownBy(() -> util.verifyRelPlan("SELECT * FROM f(r => TABLE t1)"))
+                .hasRootCauseMessage(
+                        "Only scalar arguments are supported at this location. "
+                                + "But argument 'r' declared the following traits: [TABLE, TABLE_AS_ROW]");
+    }
+
+    @Test
+    void testReservedArg() {
+        util.addTemporarySystemFunction("f", ReservedArgFunction.class);
+        assertThatThrownBy(() -> util.verifyRelPlan("SELECT * FROM f(uid => 'my-ptf')"))
+                .hasRootCauseMessage(
+                        "Function signature must not declare system arguments. Reserved argument names are: [uid]");
+    }
+
+    @Test
+    void testInvalidMultiTable() {
+        util.addTemporarySystemFunction("f", MultiTableFunction.class);
+        assertThatThrownBy(
+                        () -> util.verifyRelPlan("SELECT * FROM f(r1 => TABLE t1, r2 => TABLE t1)"))
+                .hasRootCauseMessage(
+                        "Currently, only signatures with at most one table argument are supported.");
+    }
+
+    @Test
+    void testInvalidRowInsteadOfTable() {
+        util.addTemporarySystemFunction("f", TableAsRowFunction.class);
+        assertThatThrownBy(() -> util.verifyRelPlan("SELECT * FROM f(r => ROW(42), i => 1)"))
+                .hasRootCauseMessage(
+                        "Invalid argument value. Argument 'r' expects a table to be passed.");
+    }
+
+    @Test
+    void testInvalidSetSemantics() {
+        util.addTemporarySystemFunction("f", TableAsRowFunction.class);
+        assertThatThrownBy(
+                        () ->
+                                util.verifyRelPlan(
+                                        "SELECT * FROM f(r => TABLE t1 PARTITION BY name, i => 1)"))
+                .hasRootCauseMessage(
+                        "Only tables with set semantics may be partitioned. "
+                                + "Invalid PARTITION BY clause in the 0-th operand of table function 'f'");
+    }
+
+    @Test
+    void testInvalidPartitionByClause() {
+        util.addTemporarySystemFunction("f", TableAsSetFunction.class);
+        assertThatThrownBy(
+                        () ->
+                                util.verifyRelPlan(
+                                        "SELECT * FROM f(r => TABLE t1 PARTITION BY invalid, i => 1)"))
+                .hasRootCauseMessage(
+                        "Invalid column 'invalid' for PARTITION BY clause. Available columns are: [name, score]");
+    }
+
+    @Test
+    void testUnsupportedOrderByClause() {
+        util.addTemporarySystemFunction("f", TableAsSetFunction.class);
+        assertThatThrownBy(
+                        () ->
+                                util.verifyRelPlan(
+                                        "SELECT * FROM f(r => TABLE t1 PARTITION BY name ORDER BY score, i => 1)"))
+                .hasRootCauseMessage("ORDER BY clause is currently not supported.");
+    }
+
+    private void assertReachesOptimizer(String sql) {
+        assertThatThrownBy(() -> util.verifyRelPlan(sql))
+                .hasMessageContaining(
+                        "This exception indicates that the query uses an unsupported SQL feature.");
+    }
+
+    /** Testing function. */
+    public static class ScalarArgsFunction extends ProcessTableFunction<String> {
+        @SuppressWarnings("unused")
+        public void eval(Integer i, Boolean b) {}
+    }
+
+    /** Testing function. */
+    public static class TableAsRowFunction extends ProcessTableFunction<String> {
+        @SuppressWarnings("unused")
+        public void eval(@ArgumentHint(ArgumentTrait.TABLE_AS_ROW) Row r, Integer i) {}
+    }
+
+    /** Testing function. */
+    public static class TypedTableAsRowFunction extends ProcessTableFunction<String> {
+        @SuppressWarnings("unused")
+        public void eval(@ArgumentHint(ArgumentTrait.TABLE_AS_ROW) User u, Integer i) {}
+    }
+
+    /** Testing function. */
+    public static class TableAsSetFunction extends ProcessTableFunction<String> {
+        @SuppressWarnings("unused")
+        public void eval(@ArgumentHint(TABLE_AS_SET) Row r, Integer i) {}
+    }
+
+    /** Testing function. */
+    public static class MultiTableFunction extends ProcessTableFunction<String> {
+        @SuppressWarnings("unused")
+        public void eval(
+                @ArgumentHint({TABLE_AS_SET, OPTIONAL_PARTITION_BY}) Row r1,
+                @ArgumentHint({TABLE_AS_SET, OPTIONAL_PARTITION_BY}) Row r2) {}
+    }
+
+    /** Testing function. */
+    public static class TypedTableAsSetFunction extends ProcessTableFunction<String> {
+        @SuppressWarnings("unused")
+        public void eval(@ArgumentHint(TABLE_AS_SET) User u, Integer i) {}
+    }
+
+    /** Testing function. */
+    public static class TableAsSetOptionalPartitionFunction extends ProcessTableFunction<String> {
+        @SuppressWarnings("unused")
+        public void eval(@ArgumentHint({TABLE_AS_SET, OPTIONAL_PARTITION_BY}) Row r, Integer i) {}
+    }
+
+    /** Testing function. */
+    public static class NoProcessTableFunction extends TableFunction<String> {
+
+        @Override
+        public TypeInference getTypeInference(DataTypeFactory typeFactory) {
+            return TypeInference.newBuilder()
+                    .staticArguments(
+                            StaticArgument.table(
+                                    "r",
+                                    Row.class,
+                                    false,
+                                    EnumSet.of(StaticArgumentTrait.TABLE_AS_ROW)))
+                    .outputTypeStrategy(callContext -> Optional.of(DataTypes.STRING()))
+                    .build();
+        }
+
+        @SuppressWarnings("unused")
+        public void eval(Row r) {}
+    }
+
+    /** Testing function. */
+    public static class ReservedArgFunction extends ProcessTableFunction<String> {
+        @SuppressWarnings("unused")
+        public void eval(String uid) {}
+    }
+
+    /** Testing function. */
+    public static class EmptyArgFunction extends ProcessTableFunction<String> {
+        @SuppressWarnings("unused")
+        public void eval() {}
+    }
+
+    /** Testing function. */
+    public static class PojoArgsFunction extends ProcessTableFunction<String> {
+        public void eval(@ArgumentHint(TABLE_AS_ROW) User input, User scalar) {}
+    }
+
+    public static class PojoCreatingFunction extends ScalarFunction {
+        public User eval(String s, Integer i) {
+            return new User(s, i);
+        }
+    }
+
+    /** POJO for typed tables. */
+    public static class User {
+        public String s;
+        public Integer i;
+
+        public User(String s, Integer i) {
+            this.s = s;
+            this.i = i;
+        }
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.table.planner.plan.stream.sql;
 
 import org.apache.flink.table.annotation.ArgumentHint;
@@ -8,6 +26,7 @@ import org.apache.flink.table.catalog.DataTypeFactory;
 import org.apache.flink.table.functions.ProcessTableFunction;
 import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.table.functions.TableFunction;
+import org.apache.flink.table.functions.UserDefinedFunction;
 import org.apache.flink.table.planner.utils.TableTestBase;
 import org.apache.flink.table.planner.utils.TableTestUtil;
 import org.apache.flink.table.types.inference.StaticArgument;
@@ -17,10 +36,14 @@ import org.apache.flink.types.Row;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.EnumSet;
 import java.util.Optional;
+import java.util.stream.Stream;
 
+import static org.apache.flink.core.testutils.FlinkAssertions.anyCauseMatches;
 import static org.apache.flink.table.annotation.ArgumentTrait.OPTIONAL_PARTITION_BY;
 import static org.apache.flink.table.annotation.ArgumentTrait.TABLE_AS_ROW;
 import static org.apache.flink.table.annotation.ArgumentTrait.TABLE_AS_SET;
@@ -60,17 +83,6 @@ public class ProcessTableFunctionTest extends TableTestBase {
     }
 
     @Test
-    void testInvalidUid() {
-        util.addTemporarySystemFunction("f", ScalarArgsFunction.class);
-        assertThatThrownBy(
-                        () -> util.verifyRelPlan("SELECT * FROM f(uid => '%', i => 1, b => true)"))
-                .hasRootCauseMessage(
-                        "Invalid unique identifier for process table function. "
-                                + "The 'uid' argument must be a string literal that follows the pattern [a-zA-Z_][a-zA-Z-_0-9]*. "
-                                + "But found: %");
-    }
-
-    @Test
     void testTableAsRow() {
         util.addTemporarySystemFunction("f", TableAsRowFunction.class);
         assertReachesOptimizer("SELECT * FROM f(r => TABLE t1, i => 1)");
@@ -91,27 +103,9 @@ public class ProcessTableFunctionTest extends TableTestBase {
     }
 
     @Test
-    void testTypedTableAsRowWithInvalidInput() {
-        util.addTemporarySystemFunction("f", TypedTableAsRowFunction.class);
-        // function expects <STRING name, INT score>
-        assertThatThrownBy(() -> util.verifyRelPlan("SELECT * FROM f(u => TABLE t3, i => 1)"))
-                .hasMessageContaining(
-                        "No match found for function signature "
-                                + "f(<RecordType(CHAR(3) name, BOOLEAN isValid)>, <NUMERIC>, <CHARACTER>)");
-    }
-
-    @Test
     void testTableAsSet() {
         util.addTemporarySystemFunction("f", TableAsSetFunction.class);
         assertReachesOptimizer("SELECT * FROM f(r => TABLE t1 PARTITION BY name, i => 1)");
-    }
-
-    @Test
-    void testTableAsSetWithInvalidPartitionBy() {
-        util.addTemporarySystemFunction("f", TableAsSetFunction.class);
-        assertThatThrownBy(() -> util.verifyRelPlan("SELECT * FROM f(r => TABLE t1, i => 1)"))
-                .hasRootCauseMessage(
-                        "Table argument 'r' requires a PARTITION BY clause for parallel processing.");
     }
 
     @Test
@@ -124,19 +118,6 @@ public class ProcessTableFunctionTest extends TableTestBase {
     void testTypedTableAsSet() {
         util.addTemporarySystemFunction("f", TypedTableAsSetFunction.class);
         assertReachesOptimizer("SELECT * FROM f(u => TABLE t1 PARTITION BY name, i => 1)");
-    }
-
-    @Test
-    void testTypedTableAsSetWithInvalidInput() {
-        util.addTemporarySystemFunction("f", TypedTableAsSetFunction.class);
-        // function expects <STRING name, INT score>
-        assertThatThrownBy(
-                        () ->
-                                util.verifyRelPlan(
-                                        "SELECT * FROM f(u => TABLE t3 PARTITION BY name, i => 1)"))
-                .hasMessageContaining(
-                        "No match found for function signature "
-                                + "f(<RecordType(CHAR(3) name, BOOLEAN isValid)>, <NUMERIC>, <CHARACTER>)");
     }
 
     @Test
@@ -153,71 +134,79 @@ public class ProcessTableFunctionTest extends TableTestBase {
                 "SELECT * FROM f(input => TABLE t1, scalar => pojoCreator('Bob', 12), uid => 'my-ptf')");
     }
 
-    @Test
-    void testInvalidTableFunction() {
-        util.addTemporarySystemFunction("f", NoProcessTableFunction.class);
-        assertThatThrownBy(() -> util.verifyRelPlan("SELECT * FROM f(r => TABLE t1)"))
-                .hasRootCauseMessage(
+    @ParameterizedTest
+    @MethodSource("errorSpecs")
+    void testErrorBehavior(ErrorSpec spec) {
+        util.addTemporarySystemFunction("f", spec.functionClass);
+        assertThatThrownBy(() -> util.verifyRelPlan(spec.sql))
+                .satisfies(anyCauseMatches(spec.errorMessage));
+    }
+
+    private static Stream<ErrorSpec> errorSpecs() {
+        return Stream.of(
+                ErrorSpec.of(
+                        "invalid uid",
+                        ScalarArgsFunction.class,
+                        "SELECT * FROM f(uid => '%', i => 1, b => true)",
+                        "Invalid unique identifier for process table function. "
+                                + "The 'uid' argument must be a string literal that follows the pattern [a-zA-Z_][a-zA-Z-_0-9]*. "
+                                + "But found: %"),
+                ErrorSpec.of(
+                        "typed table as row with invalid input",
+                        TypedTableAsRowFunction.class,
+                        // function expects <STRING name, INT score>
+                        "SELECT * FROM f(u => TABLE t3, i => 1)",
+                        "No match found for function signature "
+                                + "f(<RecordType(CHAR(3) name, BOOLEAN isValid)>, <NUMERIC>, <CHARACTER>)"),
+                ErrorSpec.of(
+                        "table as set with missing partition by",
+                        TableAsSetFunction.class,
+                        "SELECT * FROM f(r => TABLE t1, i => 1)",
+                        "Table argument 'r' requires a PARTITION BY clause for parallel processing."),
+                ErrorSpec.of(
+                        "typed table as set with invalid input",
+                        TypedTableAsSetFunction.class,
+                        // function expects <STRING name, INT score>
+                        "SELECT * FROM f(u => TABLE t3 PARTITION BY name, i => 1)",
+                        "No match found for function signature "
+                                + "f(<RecordType(CHAR(3) name, BOOLEAN isValid)>, <NUMERIC>, <CHARACTER>)"),
+                ErrorSpec.of(
+                        "table function instead of process table function",
+                        NoProcessTableFunction.class,
+                        "SELECT * FROM f(r => TABLE t1)",
                         "Only scalar arguments are supported at this location. "
-                                + "But argument 'r' declared the following traits: [TABLE, TABLE_AS_ROW]");
-    }
-
-    @Test
-    void testReservedArg() {
-        util.addTemporarySystemFunction("f", ReservedArgFunction.class);
-        assertThatThrownBy(() -> util.verifyRelPlan("SELECT * FROM f(uid => 'my-ptf')"))
-                .hasRootCauseMessage(
-                        "Function signature must not declare system arguments. Reserved argument names are: [uid]");
-    }
-
-    @Test
-    void testInvalidMultiTable() {
-        util.addTemporarySystemFunction("f", MultiTableFunction.class);
-        assertThatThrownBy(
-                        () -> util.verifyRelPlan("SELECT * FROM f(r1 => TABLE t1, r2 => TABLE t1)"))
-                .hasRootCauseMessage(
-                        "Currently, only signatures with at most one table argument are supported.");
-    }
-
-    @Test
-    void testInvalidRowInsteadOfTable() {
-        util.addTemporarySystemFunction("f", TableAsRowFunction.class);
-        assertThatThrownBy(() -> util.verifyRelPlan("SELECT * FROM f(r => ROW(42), i => 1)"))
-                .hasRootCauseMessage(
-                        "Invalid argument value. Argument 'r' expects a table to be passed.");
-    }
-
-    @Test
-    void testInvalidSetSemantics() {
-        util.addTemporarySystemFunction("f", TableAsRowFunction.class);
-        assertThatThrownBy(
-                        () ->
-                                util.verifyRelPlan(
-                                        "SELECT * FROM f(r => TABLE t1 PARTITION BY name, i => 1)"))
-                .hasRootCauseMessage(
+                                + "But argument 'r' declared the following traits: [TABLE, TABLE_AS_ROW]"),
+                ErrorSpec.of(
+                        "reserved args",
+                        ReservedArgFunction.class,
+                        "SELECT * FROM f(uid => 'my-ptf')",
+                        "Function signature must not declare system arguments. Reserved argument names are: [uid]"),
+                ErrorSpec.of(
+                        "multiple table args",
+                        MultiTableFunction.class,
+                        "SELECT * FROM f(r1 => TABLE t1, r2 => TABLE t1)",
+                        "Currently, only signatures with at most one table argument are supported."),
+                ErrorSpec.of(
+                        "row instead of table",
+                        TableAsRowFunction.class,
+                        "SELECT * FROM f(r => ROW(42), i => 1)",
+                        "Invalid argument value. Argument 'r' expects a table to be passed."),
+                ErrorSpec.of(
+                        "table as row partition by",
+                        TableAsRowFunction.class,
+                        "SELECT * FROM f(r => TABLE t1 PARTITION BY name, i => 1)",
                         "Only tables with set semantics may be partitioned. "
-                                + "Invalid PARTITION BY clause in the 0-th operand of table function 'f'");
-    }
-
-    @Test
-    void testInvalidPartitionByClause() {
-        util.addTemporarySystemFunction("f", TableAsSetFunction.class);
-        assertThatThrownBy(
-                        () ->
-                                util.verifyRelPlan(
-                                        "SELECT * FROM f(r => TABLE t1 PARTITION BY invalid, i => 1)"))
-                .hasRootCauseMessage(
-                        "Invalid column 'invalid' for PARTITION BY clause. Available columns are: [name, score]");
-    }
-
-    @Test
-    void testUnsupportedOrderByClause() {
-        util.addTemporarySystemFunction("f", TableAsSetFunction.class);
-        assertThatThrownBy(
-                        () ->
-                                util.verifyRelPlan(
-                                        "SELECT * FROM f(r => TABLE t1 PARTITION BY name ORDER BY score, i => 1)"))
-                .hasRootCauseMessage("ORDER BY clause is currently not supported.");
+                                + "Invalid PARTITION BY clause in the 0-th operand of table function 'f'"),
+                ErrorSpec.of(
+                        "invalid partition by clause",
+                        TableAsSetFunction.class,
+                        "SELECT * FROM f(r => TABLE t1 PARTITION BY invalid, i => 1)",
+                        "Invalid column 'invalid' for PARTITION BY clause. Available columns are: [name, score]"),
+                ErrorSpec.of(
+                        "unsupported order by",
+                        TableAsSetFunction.class,
+                        "SELECT * FROM f(r => TABLE t1 PARTITION BY name ORDER BY score, i => 1)",
+                        "ORDER BY clause is currently not supported."));
     }
 
     private void assertReachesOptimizer(String sql) {
@@ -304,6 +293,7 @@ public class ProcessTableFunctionTest extends TableTestBase {
 
     /** Testing function. */
     public static class PojoArgsFunction extends ProcessTableFunction<String> {
+        @SuppressWarnings("unused")
         public void eval(@ArgumentHint(TABLE_AS_ROW) User input, User scalar) {}
     }
 
@@ -321,6 +311,37 @@ public class ProcessTableFunctionTest extends TableTestBase {
         public User(String s, Integer i) {
             this.s = s;
             this.i = i;
+        }
+    }
+
+    private static class ErrorSpec {
+        private final String description;
+        private final Class<? extends UserDefinedFunction> functionClass;
+        private final String sql;
+        private final String errorMessage;
+
+        private ErrorSpec(
+                String description,
+                Class<? extends UserDefinedFunction> functionClass,
+                String sql,
+                String errorMessage) {
+            this.description = description;
+            this.functionClass = functionClass;
+            this.sql = sql;
+            this.errorMessage = errorMessage;
+        }
+
+        static ErrorSpec of(
+                String description,
+                Class<? extends UserDefinedFunction> functionClass,
+                String sql,
+                String errorMessage) {
+            return new ErrorSpec(description, functionClass, sql, errorMessage);
+        }
+
+        @Override
+        public String toString() {
+            return description;
         }
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/FunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/FunctionITCase.java
@@ -1172,7 +1172,7 @@ public class FunctionITCase extends StreamingTestBase {
                                                         + " NamedArgumentsScalarFunction(in2 => i2, in1 => i1) as s1 FROM TestTable")
                                         .await())
                 .hasMessageContaining(
-                        "SQL validation failed. Could not find the argument names. Currently named arguments are not supported for varArgs and multi different argument names with overload function");
+                        "SQL validation failed. Unsupported function signature. Function must not be overloaded or use varargs.");
     }
 
     @Test

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/ProcedureITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/ProcedureITCase.java
@@ -192,7 +192,7 @@ class ProcedureITCase extends StreamingTestBase {
                                                 "call `system`.named_args_overload(d => 19, c => 'yuxia')"))
                 .isInstanceOf(ValidationException.class)
                 .hasMessageContaining(
-                        "Currently named arguments are not supported for varArgs and multi different argument names with overload function");
+                        "Unsupported function signature. Function must not be overloaded or use varargs.");
     }
 
     @Test

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/common/ViewsExpandingTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/common/ViewsExpandingTest.xml
@@ -52,29 +52,6 @@ DataStreamScan(table=[[default_catalog, default_database, t1]], fields=[a, b, c]
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testViewExpandingWithLateralTableFunction[1]">
-    <Resource name="sql">
-      <![CDATA[select * from tmp_view]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalProject(f0=[$0], f1=[$1])
-+- LogicalProject(f0=[$0], f1=[$1])
-   +- LogicalCorrelate(correlation=[$cor1], joinType=[inner], requiredColumns=[{0}])
-      :- LogicalProject(f0=[AS($0, _UTF-16LE'f0')])
-      :  +- LogicalValues(tuples=[[{ _UTF-16LE'danny#21' }, { _UTF-16LE'julian#55' }, { _UTF-16LE'fabian#30' }]])
-      +- LogicalTableFunctionScan(invocation=[myFunc($cor1.f0)], rowType=[*org.apache.flink.table.planner.utils.SimpleUser<`name` STRING, `age` INT NOT NULL>* NOT NULL])
-]]>
-    </Resource>
-    <Resource name="optimized exec plan">
-      <![CDATA[
-Calc(select=[f0, name AS f1])
-+- Correlate(invocation=[myFunc($cor1.f0)], correlate=[table(myFunc($cor1.f0))], select=[f0,name,age], rowType=[RecordType(VARCHAR(9) f0, VARCHAR(2147483647) name, INTEGER age)], joinType=[INNER])
-   +- Calc(select=[f0])
-      +- Values(tuples=[[{ _UTF-16LE'danny#21' }, { _UTF-16LE'julian#55' }, { _UTF-16LE'fabian#30' }]], values=[f0])
-]]>
-    </Resource>
-  </TestCase>
   <TestCase name="testSqlExpanding[1]">
     <Resource name="sql">
       <![CDATA[SELECT * FROM view3]]>
@@ -137,6 +114,52 @@ DataStreamScan(table=[[default_catalog, default_database, t1]], fields=[a, b, c]
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testViewExpandingWithLateralTableFunction[1]">
+    <Resource name="sql">
+      <![CDATA[select * from tmp_view]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(f0=[$0], f1=[$1])
++- LogicalProject(f0=[$0], f1=[$1])
+   +- LogicalCorrelate(correlation=[$cor1], joinType=[inner], requiredColumns=[{0}])
+      :- LogicalProject(f0=[AS($0, _UTF-16LE'f0')])
+      :  +- LogicalValues(tuples=[[{ _UTF-16LE'danny#21' }, { _UTF-16LE'julian#55' }, { _UTF-16LE'fabian#30' }]])
+      +- LogicalTableFunctionScan(invocation=[myFunc($cor1.f0)], rowType=[RecordType(VARCHAR(2147483647) name, INTEGER age)])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[f0, name AS f1])
++- Correlate(invocation=[myFunc($cor1.f0)], correlate=[table(myFunc($cor1.f0))], select=[f0,name,age], rowType=[RecordType(VARCHAR(9) f0, VARCHAR(2147483647) name, INTEGER age)], joinType=[INNER])
+   +- Calc(select=[f0])
+      +- Values(tuples=[[{ _UTF-16LE'danny#21' }, { _UTF-16LE'julian#55' }, { _UTF-16LE'fabian#30' }]], values=[f0])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testViewExpandingWithLateralTableFunction[2]">
+    <Resource name="sql">
+      <![CDATA[select * from tmp_view]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(f0=[$0], f1=[$1])
++- LogicalProject(f0=[$0], f1=[$1])
+   +- LogicalCorrelate(correlation=[$cor1], joinType=[inner], requiredColumns=[{0}])
+      :- LogicalProject(f0=[AS($0, _UTF-16LE'f0')])
+      :  +- LogicalValues(tuples=[[{ _UTF-16LE'danny#21' }, { _UTF-16LE'julian#55' }, { _UTF-16LE'fabian#30' }]])
+      +- LogicalTableFunctionScan(invocation=[myFunc($cor1.f0)], rowType=[RecordType(VARCHAR(2147483647) name, INTEGER age)])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[f0, name AS f1])
++- Correlate(invocation=[myFunc($cor1.f0)], correlate=[table(myFunc($cor1.f0))], select=[f0,name,age], rowType=[RecordType(VARCHAR(9) f0, VARCHAR(2147483647) name, INTEGER age)], joinType=[INNER])
+   +- Calc(select=[f0])
+      +- Values(tuples=[[{ _UTF-16LE'danny#21' }, { _UTF-16LE'julian#55' }, { _UTF-16LE'fabian#30' }]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testViewExpandingWithMismatchRowType[1]">
     <Resource name="sql">
       <![CDATA[select * from view1]]>
@@ -156,29 +179,6 @@ Calc(select=[CAST(a AS INTEGER) AS a, b, CAST(EXPR$2 AS INTEGER) AS c])
    +- Exchange(distribution=[hash[a, b]])
       +- LocalHashAggregate(groupBy=[a, b], select=[a, b, Partial_COUNT(c) AS count$0])
          +- BoundedStreamScan(table=[[default_catalog, default_database, t1]], fields=[a, b, c])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testViewExpandingWithLateralTableFunction[2]">
-    <Resource name="sql">
-      <![CDATA[select * from tmp_view]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalProject(f0=[$0], f1=[$1])
-+- LogicalProject(f0=[$0], f1=[$1])
-   +- LogicalCorrelate(correlation=[$cor1], joinType=[inner], requiredColumns=[{0}])
-      :- LogicalProject(f0=[AS($0, _UTF-16LE'f0')])
-      :  +- LogicalValues(tuples=[[{ _UTF-16LE'danny#21' }, { _UTF-16LE'julian#55' }, { _UTF-16LE'fabian#30' }]])
-      +- LogicalTableFunctionScan(invocation=[myFunc($cor1.f0)], rowType=[*org.apache.flink.table.planner.utils.SimpleUser<`name` STRING, `age` INT NOT NULL>* NOT NULL])
-]]>
-    </Resource>
-    <Resource name="optimized exec plan">
-      <![CDATA[
-Calc(select=[f0, name AS f1])
-+- Correlate(invocation=[myFunc($cor1.f0)], correlate=[table(myFunc($cor1.f0))], select=[f0,name,age], rowType=[RecordType(VARCHAR(9) f0, VARCHAR(2147483647) name, INTEGER age)], joinType=[INNER])
-   +- Calc(select=[f0])
-      +- Values(tuples=[[{ _UTF-16LE'danny#21' }, { _UTF-16LE'julian#55' }, { _UTF-16LE'fabian#30' }]])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/operator/StreamOperatorNameTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/operator/StreamOperatorNameTest.xml
@@ -624,116 +624,6 @@ GroupAggregate(groupBy=[a], select=[a, MAX(b) AS b])
 }]]>
     </Resource>
   </TestCase>
-  <TestCase name="testWindowDeduplicate[isNameSimplifyEnabled=true]">
-    <Resource name="explain">
-      <![CDATA[== Abstract Syntax Tree ==
-LogicalProject(window_start=[$6], window_end=[$7], a=[$0], b=[$1], c=[$2])
-+- LogicalFilter(condition=[<=($9, 1)])
-   +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], rowtime=[$4], proctime=[$5], window_start=[$6], window_end=[$7], window_time=[$8], rownum=[ROW_NUMBER() OVER (PARTITION BY $0, $6, $7 ORDER BY $4 DESC NULLS LAST)])
-      +- LogicalTableFunctionScan(invocation=[TUMBLE(DESCRIPTOR($4), 900000:INTERVAL MINUTE)], rowType=[RecordType(BIGINT a, INTEGER b, VARCHAR(2147483647) c, BIGINT d, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP(3) *ROWTIME* window_time)])
-         +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], rowtime=[$4], proctime=[$5])
-            +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($4, 1000:INTERVAL SECOND)])
-               +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], rowtime=[$4], proctime=[PROCTIME()])
-                  +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-
-== Optimized Physical Plan ==
-Calc(select=[window_start, window_end, a, b, c])
-+- WindowDeduplicate(window=[TUMBLE(win_start=[window_start], win_end=[window_end], size=[15 min])], keep=[LastRow], partitionKeys=[a], orderKey=[rowtime], order=[ROWTIME])
-   +- Exchange(distribution=[hash[a]])
-      +- Calc(select=[a, b, c, rowtime, window_start, window_end])
-         +- WindowTableFunction(window=[TUMBLE(time_col=[rowtime], size=[15 min])])
-            +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
-               +- Calc(select=[a, b, c, d, rowtime, PROCTIME() AS proctime])
-                  +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, rowtime])
-
-== Optimized Execution Plan ==
-Calc(select=[window_start, window_end, a, b, c])
-+- WindowDeduplicate(window=[TUMBLE(win_start=[window_start], win_end=[window_end], size=[15 min])], keep=[LastRow], partitionKeys=[a], orderKey=[rowtime], order=[ROWTIME])
-   +- Exchange(distribution=[hash[a]])
-      +- Calc(select=[a, b, c, rowtime, window_start, window_end])
-         +- WindowTableFunction(window=[TUMBLE(time_col=[rowtime], size=[15 min])])
-            +- WatermarkAssigner(rowtime=[rowtime], watermark=[(rowtime - 1000:INTERVAL SECOND)])
-               +- Calc(select=[a, b, c, d, rowtime, PROCTIME() AS proctime])
-                  +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, rowtime])
-
-== Physical Execution Plan ==
-{
-  "nodes" : [ {
-    "id" : ,
-    "type" : "Source: MyTable[]",
-    "pact" : "Data Source",
-    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, rowtime])",
-    "parallelism" : 1
-  }, {
-    "id" : ,
-    "type" : "Calc[]",
-    "pact" : "Operator",
-    "contents" : "[]:Calc(select=[a, b, c, d, rowtime, PROCTIME() AS proctime])",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  }, {
-    "id" : ,
-    "type" : "WatermarkAssigner[]",
-    "pact" : "Operator",
-    "contents" : "[]:WatermarkAssigner(rowtime=[rowtime], watermark=[(rowtime - 1000:INTERVAL SECOND)])",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  }, {
-    "id" : ,
-    "type" : "WindowTableFunction[]",
-    "pact" : "Operator",
-    "contents" : "[]:WindowTableFunction(window=[TUMBLE(time_col=[rowtime], size=[15 min])])",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  }, {
-    "id" : ,
-    "type" : "Calc[]",
-    "pact" : "Operator",
-    "contents" : "[]:Calc(select=[a, b, c, rowtime, window_start, window_end])",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  }, {
-    "id" : ,
-    "type" : "WindowDeduplicate[]",
-    "pact" : "Operator",
-    "contents" : "[]:WindowDeduplicate(window=[TUMBLE(win_start=[window_start], win_end=[window_end], size=[15 min])], keep=[LastRow], partitionKeys=[a], orderKey=[rowtime], order=[ROWTIME])",
-    "parallelism" : 2,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "HASH",
-      "side" : "second"
-    } ]
-  }, {
-    "id" : ,
-    "type" : "Calc[]",
-    "pact" : "Operator",
-    "contents" : "[]:Calc(select=[window_start, window_end, a, b, c])",
-    "parallelism" : 2,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  } ]
-}]]>
-    </Resource>
-  </TestCase>
   <TestCase name="testGroupAggregate[isNameSimplifyEnabled=true]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
@@ -768,75 +658,6 @@ GroupAggregate(groupBy=[a], select=[a, MAX(b) AS b])
     "predecessors" : [ {
       "id" : ,
       "ship_strategy" : "HASH",
-      "side" : "second"
-    } ]
-  } ]
-}]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testGroupWindowAggregate[isNameSimplifyEnabled=false]">
-    <Resource name="explain">
-      <![CDATA[== Abstract Syntax Tree ==
-LogicalProject(b=[$0], window_end=[TUMBLE_END($1)], EXPR$2=[$2])
-+- LogicalAggregate(group=[{0, 1}], EXPR$2=[COUNT()])
-   +- LogicalProject(b=[$1], $f1=[$TUMBLE($4, 900000:INTERVAL MINUTE)])
-      +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($4, 1000:INTERVAL SECOND)])
-         +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], rowtime=[$4], proctime=[PROCTIME()])
-            +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-
-== Optimized Physical Plan ==
-Calc(select=[b, w$end AS window_end, EXPR$2])
-+- GroupWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w$, rowtime, 900000)], properties=[w$start, w$end, w$rowtime, w$proctime], select=[b, COUNT(*) AS EXPR$2, start('w$) AS w$start, end('w$) AS w$end, rowtime('w$) AS w$rowtime, proctime('w$) AS w$proctime])
-   +- Exchange(distribution=[hash[b]])
-      +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
-         +- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[b, rowtime], metadata=[]]], fields=[b, rowtime])
-
-== Optimized Execution Plan ==
-Calc(select=[b, w$end AS window_end, EXPR$2])
-+- GroupWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w$, rowtime, 900000)], properties=[w$start, w$end, w$rowtime, w$proctime], select=[b, COUNT(*) AS EXPR$2, start('w$) AS w$start, end('w$) AS w$end, rowtime('w$) AS w$rowtime, proctime('w$) AS w$proctime])
-   +- Exchange(distribution=[hash[b]])
-      +- WatermarkAssigner(rowtime=[rowtime], watermark=[(rowtime - 1000:INTERVAL SECOND)])
-         +- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[b, rowtime], metadata=[]]], fields=[b, rowtime])
-
-== Physical Execution Plan ==
-{
-  "nodes" : [ {
-    "id" : ,
-    "type" : "Source: TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[b, rowtime], metadata=[]]], fields=[b, rowtime])",
-    "pact" : "Data Source",
-    "contents" : "TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[b, rowtime], metadata=[]]], fields=[b, rowtime])",
-    "parallelism" : 1
-  }, {
-    "id" : ,
-    "type" : "WatermarkAssigner(rowtime=[rowtime], watermark=[(rowtime - 1000:INTERVAL SECOND)])",
-    "pact" : "Operator",
-    "contents" : "WatermarkAssigner(rowtime=[rowtime], watermark=[(rowtime - 1000:INTERVAL SECOND)])",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  }, {
-    "id" : ,
-    "type" : "GroupWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w$, rowtime, 900000)], properties=[w$start, w$end, w$rowtime, w$proctime], select=[b, COUNT(*) AS EXPR$2, start('w$) AS w$start, end('w$) AS w$end, rowtime('w$) AS w$rowtime, proctime('w$) AS w$proctime])",
-    "pact" : "Operator",
-    "contents" : "GroupWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w$, rowtime, 900000)], properties=[w$start, w$end, w$rowtime, w$proctime], select=[b, COUNT(*) AS EXPR$2, start('w$) AS w$start, end('w$) AS w$end, rowtime('w$) AS w$rowtime, proctime('w$) AS w$proctime])",
-    "parallelism" : 2,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "HASH",
-      "side" : "second"
-    } ]
-  }, {
-    "id" : ,
-    "type" : "Calc(select=[b, w$end AS window_end, EXPR$2])",
-    "pact" : "Operator",
-    "contents" : "Calc(select=[b, w$end AS window_end, EXPR$2])",
-    "parallelism" : 2,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
       "side" : "second"
     } ]
   } ]
@@ -902,6 +723,75 @@ Calc(select=[b, w$end AS window_end, EXPR$2])
     "type" : "Calc[]",
     "pact" : "Operator",
     "contents" : "[]:Calc(select=[b, w$end AS window_end, EXPR$2])",
+    "parallelism" : 2,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testGroupWindowAggregate[isNameSimplifyEnabled=false]">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalProject(b=[$0], window_end=[TUMBLE_END($1)], EXPR$2=[$2])
++- LogicalAggregate(group=[{0, 1}], EXPR$2=[COUNT()])
+   +- LogicalProject(b=[$1], $f1=[$TUMBLE($4, 900000:INTERVAL MINUTE)])
+      +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($4, 1000:INTERVAL SECOND)])
+         +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], rowtime=[$4], proctime=[PROCTIME()])
+            +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+
+== Optimized Physical Plan ==
+Calc(select=[b, w$end AS window_end, EXPR$2])
++- GroupWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w$, rowtime, 900000)], properties=[w$start, w$end, w$rowtime, w$proctime], select=[b, COUNT(*) AS EXPR$2, start('w$) AS w$start, end('w$) AS w$end, rowtime('w$) AS w$rowtime, proctime('w$) AS w$proctime])
+   +- Exchange(distribution=[hash[b]])
+      +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
+         +- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[b, rowtime], metadata=[]]], fields=[b, rowtime])
+
+== Optimized Execution Plan ==
+Calc(select=[b, w$end AS window_end, EXPR$2])
++- GroupWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w$, rowtime, 900000)], properties=[w$start, w$end, w$rowtime, w$proctime], select=[b, COUNT(*) AS EXPR$2, start('w$) AS w$start, end('w$) AS w$end, rowtime('w$) AS w$rowtime, proctime('w$) AS w$proctime])
+   +- Exchange(distribution=[hash[b]])
+      +- WatermarkAssigner(rowtime=[rowtime], watermark=[(rowtime - 1000:INTERVAL SECOND)])
+         +- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[b, rowtime], metadata=[]]], fields=[b, rowtime])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[b, rowtime], metadata=[]]], fields=[b, rowtime])",
+    "pact" : "Data Source",
+    "contents" : "TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[b, rowtime], metadata=[]]], fields=[b, rowtime])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "WatermarkAssigner(rowtime=[rowtime], watermark=[(rowtime - 1000:INTERVAL SECOND)])",
+    "pact" : "Operator",
+    "contents" : "WatermarkAssigner(rowtime=[rowtime], watermark=[(rowtime - 1000:INTERVAL SECOND)])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "GroupWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w$, rowtime, 900000)], properties=[w$start, w$end, w$rowtime, w$proctime], select=[b, COUNT(*) AS EXPR$2, start('w$) AS w$start, end('w$) AS w$end, rowtime('w$) AS w$rowtime, proctime('w$) AS w$proctime])",
+    "pact" : "Operator",
+    "contents" : "GroupWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w$, rowtime, 900000)], properties=[w$start, w$end, w$rowtime, w$proctime], select=[b, COUNT(*) AS EXPR$2, start('w$) AS w$start, end('w$) AS w$end, rowtime('w$) AS w$rowtime, proctime('w$) AS w$proctime])",
+    "parallelism" : 2,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "HASH",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Calc(select=[b, w$end AS window_end, EXPR$2])",
+    "pact" : "Operator",
+    "contents" : "Calc(select=[b, w$end AS window_end, EXPR$2])",
     "parallelism" : 2,
     "predecessors" : [ {
       "id" : ,
@@ -1834,126 +1724,6 @@ Join(joinType=[InnerJoin], where=[(a = d0)], select=[a, b, c, d, a0, b0, c0, d0]
 }]]>
     </Resource>
   </TestCase>
-  <TestCase name="testLegacySourceSink[isNameSimplifyEnabled=false]">
-    <Resource name="explain">
-      <![CDATA[== Abstract Syntax Tree ==
-LogicalLegacySink(name=[`default_catalog`.`default_database`.`MySink`], fields=[name, id, amount, price])
-+- LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MySource, source: [filterPushedDown=[false], filter=[]]]])
-
-== Optimized Physical Plan ==
-LegacySink(name=[`default_catalog`.`default_database`.`MySink`], fields=[name, id, amount, price])
-+- LegacyTableSourceScan(table=[[default_catalog, default_database, MySource, source: [filterPushedDown=[false], filter=[]]]], fields=[name, id, amount, price])
-
-== Optimized Execution Plan ==
-LegacySink(name=[`default_catalog`.`default_database`.`MySink`], fields=[name, id, amount, price])
-+- LegacyTableSourceScan(table=[[default_catalog, default_database, MySource, source: [filterPushedDown=[false], filter=[]]]], fields=[name, id, amount, price])
-
-== Physical Execution Plan ==
-{
-  "nodes" : [ {
-    "id" : ,
-    "type" : "Source: Collection Source",
-    "pact" : "Data Source",
-    "contents" : "Source: Collection Source",
-    "parallelism" : 1
-  }, {
-    "id" : ,
-    "type" : "SourceConversion(table=[default_catalog.default_database.MySource, source: [filterPushedDown=[false], filter=[]]], fields=[name, id, amount, price])",
-    "pact" : "Operator",
-    "contents" : "SourceConversion(table=[default_catalog.default_database.MySource, source: [filterPushedDown=[false], filter=[]]], fields=[name, id, amount, price])",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  }, {
-    "id" : ,
-    "type" : "SinkConversion To Row",
-    "pact" : "Operator",
-    "contents" : "SinkConversion To Row",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  }, {
-    "id" : ,
-    "type" : "Sink: TestingAppendTableSink",
-    "pact" : "Data Sink",
-    "contents" : "Sink: TestingAppendTableSink",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  } ]
-}]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testLegacySourceSink[isNameSimplifyEnabled=true]">
-    <Resource name="explain">
-      <![CDATA[== Abstract Syntax Tree ==
-LogicalLegacySink(name=[`default_catalog`.`default_database`.`MySink`], fields=[name, id, amount, price])
-+- LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MySource, source: [filterPushedDown=[false], filter=[]]]])
-
-== Optimized Physical Plan ==
-LegacySink(name=[`default_catalog`.`default_database`.`MySink`], fields=[name, id, amount, price])
-+- LegacyTableSourceScan(table=[[default_catalog, default_database, MySource, source: [filterPushedDown=[false], filter=[]]]], fields=[name, id, amount, price])
-
-== Optimized Execution Plan ==
-LegacySink(name=[`default_catalog`.`default_database`.`MySink`], fields=[name, id, amount, price])
-+- LegacyTableSourceScan(table=[[default_catalog, default_database, MySource, source: [filterPushedDown=[false], filter=[]]]], fields=[name, id, amount, price])
-
-== Physical Execution Plan ==
-{
-  "nodes" : [ {
-    "id" : ,
-    "type" : "Source: Collection Source",
-    "pact" : "Data Source",
-    "contents" : "Source: Collection Source",
-    "parallelism" : 1
-  }, {
-    "id" : ,
-    "type" : "SourceConversion[]",
-    "pact" : "Operator",
-    "contents" : "[]:SourceConversion(table=[default_catalog.default_database.MySource, source: [filterPushedDown=[false], filter=[]]], fields=[name, id, amount, price])",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  }, {
-    "id" : ,
-    "type" : "SinkConversion[]",
-    "pact" : "Operator",
-    "contents" : "[]:SinkConversion To Row",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  }, {
-    "id" : ,
-    "type" : "Sink: TestingAppendTableSink",
-    "pact" : "Data Sink",
-    "contents" : "Sink: TestingAppendTableSink",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  } ]
-}]]>
-    </Resource>
-  </TestCase>
   <TestCase name="testLocalGlobalWindowAggregate[isNameSimplifyEnabled=false]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
@@ -2378,6 +2148,74 @@ Match(orderBy=[proctime ASC], measures=[FINAL(A".a) AS aid, FINAL(l.a) AS bid, F
 }]]>
     </Resource>
   </TestCase>
+  <TestCase name="testMatch[isNameSimplifyEnabled=true]">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalProject(aid=[$0], bid=[$1], cid=[$2])
++- LogicalMatch(partition=[[]], order=[[5 ASC-nulls-first]], outputFields=[[aid, bid, cid]], allRows=[false], after=[FLAG(SKIP TO NEXT ROW)], pattern=[((_UTF-16LE'A"', _UTF-16LE'l'), _UTF-16LE'C')], isStrictStarts=[false], isStrictEnds=[false], subsets=[[]], patternDefinitions=[[=(LAST(*.$0, 0), 1), =(LAST(*.$1, 0), 2), =(LAST(*.$2, 0), _UTF-16LE'c')]], inputFields=[[a, b, c, d, rowtime, proctime]])
+   +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($4, 1000:INTERVAL SECOND)])
+      +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], rowtime=[$4], proctime=[PROCTIME()])
+         +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+
+== Optimized Physical Plan ==
+Match(orderBy=[proctime ASC], measures=[FINAL(A".a) AS aid, FINAL(l.a) AS bid, FINAL(C.a) AS cid], rowsPerMatch=[ONE ROW PER MATCH], after=[SKIP TO NEXT ROW], pattern=[((_UTF-16LE'A"', _UTF-16LE'l'), _UTF-16LE'C')], define=[{A"==(LAST(*.$0, 0), 1), l==(LAST(*.$1, 0), 2), C==(LAST(*.$2, 0), _UTF-16LE'c')}])
++- Exchange(distribution=[single])
+   +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
+      +- Calc(select=[a, b, c, d, rowtime, PROCTIME() AS proctime])
+         +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, rowtime])
+
+== Optimized Execution Plan ==
+Match(orderBy=[proctime ASC], measures=[FINAL(A".a) AS aid, FINAL(l.a) AS bid, FINAL(C.a) AS cid], rowsPerMatch=[ONE ROW PER MATCH], after=[SKIP TO NEXT ROW], pattern=[((_UTF-16LE'A"', _UTF-16LE'l'), _UTF-16LE'C')], define=[{A"==(LAST(*.$0, 0), 1), l==(LAST(*.$1, 0), 2), C==(LAST(*.$2, 0), _UTF-16LE'c')}])
++- Exchange(distribution=[single])
+   +- WatermarkAssigner(rowtime=[rowtime], watermark=[(rowtime - 1000:INTERVAL SECOND)])
+      +- Calc(select=[a, b, c, d, rowtime, PROCTIME() AS proctime])
+         +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, rowtime])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: MyTable[]",
+    "pact" : "Data Source",
+    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, rowtime])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=[a, b, c, d, rowtime, PROCTIME() AS proctime])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "WatermarkAssigner[]",
+    "pact" : "Operator",
+    "contents" : "[]:WatermarkAssigner(rowtime=[rowtime], watermark=[(rowtime - 1000:INTERVAL SECOND)])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Match[]",
+    "pact" : "Operator",
+    "contents" : "[]:Match(orderBy=[proctime ASC], measures=[FINAL(A\".a) AS aid, FINAL(l.a) AS bid, FINAL(C.a) AS cid], rowsPerMatch=[ONE ROW PER MATCH], after=[SKIP TO NEXT ROW], pattern=[((_UTF-16LE'A\"', _UTF-16LE'l'), _UTF-16LE'C')], define=[{A\"==(LAST(*.$0, 0), 1), l==(LAST(*.$1, 0), 2), C==(LAST(*.$2, 0), _UTF-16LE'c')}])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "GLOBAL",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testOverAggregate[isNameSimplifyEnabled=false]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
@@ -2512,73 +2350,6 @@ Calc(select=[b, w0$o0 AS $1])
 }]]>
     </Resource>
   </TestCase>
-  <TestCase name="testRank[isNameSimplifyEnabled=false]">
-    <Resource name="explain">
-      <![CDATA[== Abstract Syntax Tree ==
-LogicalProject(a=[$0], row_num=[$1])
-+- LogicalFilter(condition=[<=($1, $0)])
-   +- LogicalProject(a=[$0], row_num=[ROW_NUMBER() OVER (PARTITION BY $1 ORDER BY $0 NULLS FIRST)])
-      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-
-== Optimized Physical Plan ==
-Calc(select=[a, w0$o0])
-+- Rank(strategy=[AppendFastStrategy], rankType=[ROW_NUMBER], rankRange=[rankEnd=a], partitionBy=[b], orderBy=[a ASC], select=[a, b, w0$o0])
-   +- Exchange(distribution=[hash[b]])
-      +- Calc(select=[a, b])
-         +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d])
-
-== Optimized Execution Plan ==
-Calc(select=[a, w0$o0])
-+- Rank(strategy=[AppendFastStrategy], rankType=[ROW_NUMBER], rankRange=[rankEnd=a], partitionBy=[b], orderBy=[a ASC], select=[a, b, w0$o0])
-   +- Exchange(distribution=[hash[b]])
-      +- Calc(select=[a, b])
-         +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d])
-
-== Physical Execution Plan ==
-{
-  "nodes" : [ {
-    "id" : ,
-    "type" : "Source: TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d])",
-    "pact" : "Data Source",
-    "contents" : "TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d])",
-    "parallelism" : 1
-  }, {
-    "id" : ,
-    "type" : "Calc(select=[a, b])",
-    "pact" : "Operator",
-    "contents" : "Calc(select=[a, b])",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  }, {
-    "id" : ,
-    "type" : "Rank(strategy=[AppendFastStrategy], rankType=[ROW_NUMBER], rankRange=[rankEnd=a], partitionBy=[b], orderBy=[a ASC], select=[a, b, w0$o0])",
-    "pact" : "Operator",
-    "contents" : "Rank(strategy=[AppendFastStrategy], rankType=[ROW_NUMBER], rankRange=[rankEnd=a], partitionBy=[b], orderBy=[a ASC], select=[a, b, w0$o0])",
-    "parallelism" : 2,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "HASH",
-      "side" : "second"
-    } ]
-  }, {
-    "id" : ,
-    "type" : "Calc(select=[a, w0$o0])",
-    "pact" : "Operator",
-    "contents" : "Calc(select=[a, w0$o0])",
-    "parallelism" : 2,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  } ]
-}]]>
-    </Resource>
-  </TestCase>
   <TestCase name="testRank[isNameSimplifyEnabled=true]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
@@ -2636,6 +2407,73 @@ Calc(select=[a, w0$o0])
     "type" : "Calc[]",
     "pact" : "Operator",
     "contents" : "[]:Calc(select=[a, w0$o0])",
+    "parallelism" : 2,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testRank[isNameSimplifyEnabled=false]">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalProject(a=[$0], row_num=[$1])
++- LogicalFilter(condition=[<=($1, $0)])
+   +- LogicalProject(a=[$0], row_num=[ROW_NUMBER() OVER (PARTITION BY $1 ORDER BY $0 NULLS FIRST)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+
+== Optimized Physical Plan ==
+Calc(select=[a, w0$o0])
++- Rank(strategy=[AppendFastStrategy], rankType=[ROW_NUMBER], rankRange=[rankEnd=a], partitionBy=[b], orderBy=[a ASC], select=[a, b, w0$o0])
+   +- Exchange(distribution=[hash[b]])
+      +- Calc(select=[a, b])
+         +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d])
+
+== Optimized Execution Plan ==
+Calc(select=[a, w0$o0])
++- Rank(strategy=[AppendFastStrategy], rankType=[ROW_NUMBER], rankRange=[rankEnd=a], partitionBy=[b], orderBy=[a ASC], select=[a, b, w0$o0])
+   +- Exchange(distribution=[hash[b]])
+      +- Calc(select=[a, b])
+         +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d])",
+    "pact" : "Data Source",
+    "contents" : "TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "Calc(select=[a, b])",
+    "pact" : "Operator",
+    "contents" : "Calc(select=[a, b])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Rank(strategy=[AppendFastStrategy], rankType=[ROW_NUMBER], rankRange=[rankEnd=a], partitionBy=[b], orderBy=[a ASC], select=[a, b, w0$o0])",
+    "pact" : "Operator",
+    "contents" : "Rank(strategy=[AppendFastStrategy], rankType=[ROW_NUMBER], rankRange=[rankEnd=a], partitionBy=[b], orderBy=[a ASC], select=[a, b, w0$o0])",
+    "parallelism" : 2,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "HASH",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Calc(select=[a, w0$o0])",
+    "pact" : "Operator",
+    "contents" : "Calc(select=[a, w0$o0])",
     "parallelism" : 2,
     "predecessors" : [ {
       "id" : ,
@@ -2759,7 +2597,7 @@ LogicalProject(EXPR$0=[*($0, $5)])
       :- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[$2])
       :  +- LogicalProject(amount=[$0], currency=[$1], rowtime=[$2], proctime=[PROCTIME()])
       :     +- LogicalTableScan(table=[[default_catalog, default_database, Orders]])
-      +- LogicalTableFunctionScan(invocation=[Rates($cor0.rowtime)], rowType=[RecordType:peek_no_expand(VARCHAR(2147483647) currency, INTEGER rate, TIMESTAMP(3) *ROWTIME* rowtime)])
+      +- LogicalTableFunctionScan(invocation=[Rates($cor0.rowtime)], rowType=[RecordType(VARCHAR(2147483647) currency, INTEGER rate, TIMESTAMP(3) *ROWTIME* rowtime)])
 
 == Optimized Physical Plan ==
 Calc(select=[*(amount, rate) AS EXPR$0])
@@ -2856,7 +2694,7 @@ LogicalProject(EXPR$0=[*($0, $5)])
       :- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[$2])
       :  +- LogicalProject(amount=[$0], currency=[$1], rowtime=[$2], proctime=[PROCTIME()])
       :     +- LogicalTableScan(table=[[default_catalog, default_database, Orders]])
-      +- LogicalTableFunctionScan(invocation=[Rates($cor0.rowtime)], rowType=[RecordType:peek_no_expand(VARCHAR(2147483647) currency, INTEGER rate, TIMESTAMP(3) *ROWTIME* rowtime)])
+      +- LogicalTableFunctionScan(invocation=[Rates($cor0.rowtime)], rowType=[RecordType(VARCHAR(2147483647) currency, INTEGER rate, TIMESTAMP(3) *ROWTIME* rowtime)])
 
 == Optimized Physical Plan ==
 Calc(select=[*(amount, rate) AS EXPR$0])
@@ -2938,74 +2776,6 @@ Calc(select=[(amount * rate) AS EXPR$0])
     "predecessors" : [ {
       "id" : ,
       "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  } ]
-}]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testMatch[isNameSimplifyEnabled=true]">
-    <Resource name="explain">
-      <![CDATA[== Abstract Syntax Tree ==
-LogicalProject(aid=[$0], bid=[$1], cid=[$2])
-+- LogicalMatch(partition=[[]], order=[[5 ASC-nulls-first]], outputFields=[[aid, bid, cid]], allRows=[false], after=[FLAG(SKIP TO NEXT ROW)], pattern=[((_UTF-16LE'A"', _UTF-16LE'l'), _UTF-16LE'C')], isStrictStarts=[false], isStrictEnds=[false], subsets=[[]], patternDefinitions=[[=(LAST(*.$0, 0), 1), =(LAST(*.$1, 0), 2), =(LAST(*.$2, 0), _UTF-16LE'c')]], inputFields=[[a, b, c, d, rowtime, proctime]])
-   +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($4, 1000:INTERVAL SECOND)])
-      +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], rowtime=[$4], proctime=[PROCTIME()])
-         +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-
-== Optimized Physical Plan ==
-Match(orderBy=[proctime ASC], measures=[FINAL(A".a) AS aid, FINAL(l.a) AS bid, FINAL(C.a) AS cid], rowsPerMatch=[ONE ROW PER MATCH], after=[SKIP TO NEXT ROW], pattern=[((_UTF-16LE'A"', _UTF-16LE'l'), _UTF-16LE'C')], define=[{A"==(LAST(*.$0, 0), 1), l==(LAST(*.$1, 0), 2), C==(LAST(*.$2, 0), _UTF-16LE'c')}])
-+- Exchange(distribution=[single])
-   +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
-      +- Calc(select=[a, b, c, d, rowtime, PROCTIME() AS proctime])
-         +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, rowtime])
-
-== Optimized Execution Plan ==
-Match(orderBy=[proctime ASC], measures=[FINAL(A".a) AS aid, FINAL(l.a) AS bid, FINAL(C.a) AS cid], rowsPerMatch=[ONE ROW PER MATCH], after=[SKIP TO NEXT ROW], pattern=[((_UTF-16LE'A"', _UTF-16LE'l'), _UTF-16LE'C')], define=[{A"==(LAST(*.$0, 0), 1), l==(LAST(*.$1, 0), 2), C==(LAST(*.$2, 0), _UTF-16LE'c')}])
-+- Exchange(distribution=[single])
-   +- WatermarkAssigner(rowtime=[rowtime], watermark=[(rowtime - 1000:INTERVAL SECOND)])
-      +- Calc(select=[a, b, c, d, rowtime, PROCTIME() AS proctime])
-         +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, rowtime])
-
-== Physical Execution Plan ==
-{
-  "nodes" : [ {
-    "id" : ,
-    "type" : "Source: MyTable[]",
-    "pact" : "Data Source",
-    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, rowtime])",
-    "parallelism" : 1
-  }, {
-    "id" : ,
-    "type" : "Calc[]",
-    "pact" : "Operator",
-    "contents" : "[]:Calc(select=[a, b, c, d, rowtime, PROCTIME() AS proctime])",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  }, {
-    "id" : ,
-    "type" : "WatermarkAssigner[]",
-    "pact" : "Operator",
-    "contents" : "[]:WatermarkAssigner(rowtime=[rowtime], watermark=[(rowtime - 1000:INTERVAL SECOND)])",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  }, {
-    "id" : ,
-    "type" : "Match[]",
-    "pact" : "Operator",
-    "contents" : "[]:Match(orderBy=[proctime ASC], measures=[FINAL(A\".a) AS aid, FINAL(l.a) AS bid, FINAL(C.a) AS cid], rowsPerMatch=[ONE ROW PER MATCH], after=[SKIP TO NEXT ROW], pattern=[((_UTF-16LE'A\"', _UTF-16LE'l'), _UTF-16LE'C')], define=[{A\"==(LAST(*.$0, 0), 1), l==(LAST(*.$1, 0), 2), C==(LAST(*.$2, 0), _UTF-16LE'c')}])",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "GLOBAL",
       "side" : "second"
     } ]
   } ]
@@ -3480,6 +3250,116 @@ Calc(select=[b, window_start, window_end, EXPR$3, EXPR$4])
 }]]>
     </Resource>
   </TestCase>
+  <TestCase name="testWindowDeduplicate[isNameSimplifyEnabled=true]">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalProject(window_start=[$6], window_end=[$7], a=[$0], b=[$1], c=[$2])
++- LogicalFilter(condition=[<=($9, 1)])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], rowtime=[$4], proctime=[$5], window_start=[$6], window_end=[$7], window_time=[$8], rownum=[ROW_NUMBER() OVER (PARTITION BY $0, $6, $7 ORDER BY $4 DESC NULLS LAST)])
+      +- LogicalTableFunctionScan(invocation=[TUMBLE(DESCRIPTOR($4), 900000:INTERVAL MINUTE)], rowType=[RecordType(BIGINT a, INTEGER b, VARCHAR(2147483647) c, BIGINT d, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP(3) *ROWTIME* window_time)])
+         +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], rowtime=[$4], proctime=[$5])
+            +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($4, 1000:INTERVAL SECOND)])
+               +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], rowtime=[$4], proctime=[PROCTIME()])
+                  +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+
+== Optimized Physical Plan ==
+Calc(select=[window_start, window_end, a, b, c])
++- WindowDeduplicate(window=[TUMBLE(win_start=[window_start], win_end=[window_end], size=[15 min])], keep=[LastRow], partitionKeys=[a], orderKey=[rowtime], order=[ROWTIME])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, b, c, rowtime, window_start, window_end])
+         +- WindowTableFunction(window=[TUMBLE(time_col=[rowtime], size=[15 min])])
+            +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
+               +- Calc(select=[a, b, c, d, rowtime, PROCTIME() AS proctime])
+                  +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, rowtime])
+
+== Optimized Execution Plan ==
+Calc(select=[window_start, window_end, a, b, c])
++- WindowDeduplicate(window=[TUMBLE(win_start=[window_start], win_end=[window_end], size=[15 min])], keep=[LastRow], partitionKeys=[a], orderKey=[rowtime], order=[ROWTIME])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, b, c, rowtime, window_start, window_end])
+         +- WindowTableFunction(window=[TUMBLE(time_col=[rowtime], size=[15 min])])
+            +- WatermarkAssigner(rowtime=[rowtime], watermark=[(rowtime - 1000:INTERVAL SECOND)])
+               +- Calc(select=[a, b, c, d, rowtime, PROCTIME() AS proctime])
+                  +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, rowtime])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: MyTable[]",
+    "pact" : "Data Source",
+    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, rowtime])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=[a, b, c, d, rowtime, PROCTIME() AS proctime])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "WatermarkAssigner[]",
+    "pact" : "Operator",
+    "contents" : "[]:WatermarkAssigner(rowtime=[rowtime], watermark=[(rowtime - 1000:INTERVAL SECOND)])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "WindowTableFunction[]",
+    "pact" : "Operator",
+    "contents" : "[]:WindowTableFunction(window=[TUMBLE(time_col=[rowtime], size=[15 min])])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=[a, b, c, rowtime, window_start, window_end])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "WindowDeduplicate[]",
+    "pact" : "Operator",
+    "contents" : "[]:WindowDeduplicate(window=[TUMBLE(win_start=[window_start], win_end=[window_end], size=[15 min])], keep=[LastRow], partitionKeys=[a], orderKey=[rowtime], order=[ROWTIME])",
+    "parallelism" : 2,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "HASH",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=[window_start, window_end, a, b, c])",
+    "parallelism" : 2,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testWindowDeduplicate[isNameSimplifyEnabled=false]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
@@ -3580,196 +3460,6 @@ Calc(select=[window_start, window_end, a, b, c])
     "type" : "Calc(select=[window_start, window_end, a, b, c])",
     "pact" : "Operator",
     "contents" : "Calc(select=[window_start, window_end, a, b, c])",
-    "parallelism" : 2,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  } ]
-}]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testWindowJoin[isNameSimplifyEnabled=false]">
-    <Resource name="explain">
-      <![CDATA[== Abstract Syntax Tree ==
-LogicalProject(a=[$0], window_start=[$1], window_end=[$2], cnt=[$3], uv=[$4], a0=[$5], cnt0=[$8], uv0=[$9])
-+- LogicalJoin(condition=[AND(=($1, $6), =($2, $7), =($0, $5))], joinType=[inner])
-   :- LogicalProject(a=[$0], window_start=[$1], window_end=[$2], cnt=[$4], uv=[$5])
-   :  +- LogicalAggregate(group=[{0, 1, 2, 3}], cnt=[COUNT()], uv=[COUNT(DISTINCT $4)])
-   :     +- LogicalProject(a=[$0], window_start=[$6], window_end=[$7], window_time=[$8], c=[$2])
-   :        +- LogicalTableFunctionScan(invocation=[TUMBLE(DESCRIPTOR($4), 900000:INTERVAL MINUTE)], rowType=[RecordType(BIGINT a, INTEGER b, VARCHAR(2147483647) c, BIGINT d, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP(3) *ROWTIME* window_time)])
-   :           +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], rowtime=[$4], proctime=[$5])
-   :              +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($4, 1000:INTERVAL SECOND)])
-   :                 +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], rowtime=[$4], proctime=[PROCTIME()])
-   :                    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-   +- LogicalProject(a=[$0], window_start=[$1], window_end=[$2], cnt=[$4], uv=[$5])
-      +- LogicalAggregate(group=[{0, 1, 2, 3}], cnt=[COUNT()], uv=[COUNT(DISTINCT $4)])
-         +- LogicalProject(a=[$0], window_start=[$6], window_end=[$7], window_time=[$8], c=[$2])
-            +- LogicalTableFunctionScan(invocation=[TUMBLE(DESCRIPTOR($4), 900000:INTERVAL MINUTE)], rowType=[RecordType(BIGINT a, INTEGER b, VARCHAR(2147483647) c, BIGINT d, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP(3) *ROWTIME* window_time)])
-               +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], rowtime=[$4], proctime=[$5])
-                  +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($4, 1000:INTERVAL SECOND)])
-                     +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], rowtime=[$4], proctime=[PROCTIME()])
-                        +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2]])
-
-== Optimized Physical Plan ==
-Calc(select=[a, window_start, window_end, cnt, uv, a0, cnt0, uv0])
-+- WindowJoin(leftWindow=[TUMBLE(win_start=[window_start], win_end=[window_end], size=[15 min])], rightWindow=[TUMBLE(win_start=[window_start], win_end=[window_end], size=[15 min])], joinType=[InnerJoin], where=[=(a, a0)], select=[a, window_start, window_end, cnt, uv, a0, window_start0, window_end0, cnt0, uv0])
-   :- Exchange(distribution=[hash[a]])
-   :  +- Calc(select=[a, window_start, window_end, cnt, uv])
-   :     +- GlobalWindowAggregate(groupBy=[a], window=[TUMBLE(slice_end=[$slice_end], size=[15 min])], select=[a, COUNT(count1$0) AS cnt, COUNT(distinct$0 count$1) AS uv, start('w$) AS window_start, end('w$) AS window_end, rowtime('w$) AS window_time])
-   :        +- Exchange(distribution=[hash[a]])
-   :           +- LocalWindowAggregate(groupBy=[a], window=[TUMBLE(time_col=[rowtime], size=[15 min])], select=[a, COUNT(*) AS count1$0, COUNT(distinct$0 c) AS count$1, DISTINCT(c) AS distinct$0, slice_end('w$) AS $slice_end])
-   :              +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
-   :                 +- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, c, rowtime], metadata=[]]], fields=[a, c, rowtime])
-   +- Exchange(distribution=[hash[a]])
-      +- Calc(select=[a, window_start, window_end, cnt, uv])
-         +- GlobalWindowAggregate(groupBy=[a], window=[TUMBLE(slice_end=[$slice_end], size=[15 min])], select=[a, COUNT(count1$0) AS cnt, COUNT(distinct$0 count$1) AS uv, start('w$) AS window_start, end('w$) AS window_end, rowtime('w$) AS window_time])
-            +- Exchange(distribution=[hash[a]])
-               +- LocalWindowAggregate(groupBy=[a], window=[TUMBLE(time_col=[rowtime], size=[15 min])], select=[a, COUNT(*) AS count1$0, COUNT(distinct$0 c) AS count$1, DISTINCT(c) AS distinct$0, slice_end('w$) AS $slice_end])
-                  +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
-                     +- TableSourceScan(table=[[default_catalog, default_database, MyTable2, project=[a, c, rowtime], metadata=[]]], fields=[a, c, rowtime])
-
-== Optimized Execution Plan ==
-Calc(select=[a, window_start, window_end, cnt, uv, a0, cnt0, uv0])
-+- WindowJoin(leftWindow=[TUMBLE(win_start=[window_start], win_end=[window_end], size=[15 min])], rightWindow=[TUMBLE(win_start=[window_start], win_end=[window_end], size=[15 min])], joinType=[InnerJoin], where=[(a = a0)], select=[a, window_start, window_end, cnt, uv, a0, window_start0, window_end0, cnt0, uv0])
-   :- Exchange(distribution=[hash[a]])
-   :  +- Calc(select=[a, window_start, window_end, cnt, uv])
-   :     +- GlobalWindowAggregate(groupBy=[a], window=[TUMBLE(slice_end=[$slice_end], size=[15 min])], select=[a, COUNT(count1$0) AS cnt, COUNT(distinct$0 count$1) AS uv, start('w$) AS window_start, end('w$) AS window_end, rowtime('w$) AS window_time])
-   :        +- Exchange(distribution=[hash[a]])
-   :           +- LocalWindowAggregate(groupBy=[a], window=[TUMBLE(time_col=[rowtime], size=[15 min])], select=[a, COUNT(*) AS count1$0, COUNT(distinct$0 c) AS count$1, DISTINCT(c) AS distinct$0, slice_end('w$) AS $slice_end])
-   :              +- WatermarkAssigner(rowtime=[rowtime], watermark=[(rowtime - 1000:INTERVAL SECOND)])
-   :                 +- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, c, rowtime], metadata=[]]], fields=[a, c, rowtime])
-   +- Exchange(distribution=[hash[a]])
-      +- Calc(select=[a, window_start, window_end, cnt, uv])
-         +- GlobalWindowAggregate(groupBy=[a], window=[TUMBLE(slice_end=[$slice_end], size=[15 min])], select=[a, COUNT(count1$0) AS cnt, COUNT(distinct$0 count$1) AS uv, start('w$) AS window_start, end('w$) AS window_end, rowtime('w$) AS window_time])
-            +- Exchange(distribution=[hash[a]])
-               +- LocalWindowAggregate(groupBy=[a], window=[TUMBLE(time_col=[rowtime], size=[15 min])], select=[a, COUNT(*) AS count1$0, COUNT(distinct$0 c) AS count$1, DISTINCT(c) AS distinct$0, slice_end('w$) AS $slice_end])
-                  +- WatermarkAssigner(rowtime=[rowtime], watermark=[(rowtime - 1000:INTERVAL SECOND)])
-                     +- TableSourceScan(table=[[default_catalog, default_database, MyTable2, project=[a, c, rowtime], metadata=[]]], fields=[a, c, rowtime])
-
-== Physical Execution Plan ==
-{
-  "nodes" : [ {
-    "id" : ,
-    "type" : "Source: TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, c, rowtime], metadata=[]]], fields=[a, c, rowtime])",
-    "pact" : "Data Source",
-    "contents" : "TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, c, rowtime], metadata=[]]], fields=[a, c, rowtime])",
-    "parallelism" : 1
-  }, {
-    "id" : ,
-    "type" : "WatermarkAssigner(rowtime=[rowtime], watermark=[(rowtime - 1000:INTERVAL SECOND)])",
-    "pact" : "Operator",
-    "contents" : "WatermarkAssigner(rowtime=[rowtime], watermark=[(rowtime - 1000:INTERVAL SECOND)])",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  }, {
-    "id" : ,
-    "type" : "LocalWindowAggregate(groupBy=[a], window=[TUMBLE(time_col=[rowtime], size=[15 min])], select=[a, COUNT(*) AS count1$0, COUNT(distinct$0 c) AS count$1, DISTINCT(c) AS distinct$0, slice_end('w$) AS $slice_end])",
-    "pact" : "Operator",
-    "contents" : "LocalWindowAggregate(groupBy=[a], window=[TUMBLE(time_col=[rowtime], size=[15 min])], select=[a, COUNT(*) AS count1$0, COUNT(distinct$0 c) AS count$1, DISTINCT(c) AS distinct$0, slice_end('w$) AS $slice_end])",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  }, {
-    "id" : ,
-    "type" : "GlobalWindowAggregate(groupBy=[a], window=[TUMBLE(slice_end=[$slice_end], size=[15 min])], select=[a, COUNT(count1$0) AS cnt, COUNT(distinct$0 count$1) AS uv, start('w$) AS window_start, end('w$) AS window_end, rowtime('w$) AS window_time])",
-    "pact" : "Operator",
-    "contents" : "GlobalWindowAggregate(groupBy=[a], window=[TUMBLE(slice_end=[$slice_end], size=[15 min])], select=[a, COUNT(count1$0) AS cnt, COUNT(distinct$0 count$1) AS uv, start('w$) AS window_start, end('w$) AS window_end, rowtime('w$) AS window_time])",
-    "parallelism" : 2,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "HASH",
-      "side" : "second"
-    } ]
-  }, {
-    "id" : ,
-    "type" : "Calc(select=[a, window_start, window_end, cnt, uv])",
-    "pact" : "Operator",
-    "contents" : "Calc(select=[a, window_start, window_end, cnt, uv])",
-    "parallelism" : 2,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  }, {
-    "id" : ,
-    "type" : "Source: TableSourceScan(table=[[default_catalog, default_database, MyTable2, project=[a, c, rowtime], metadata=[]]], fields=[a, c, rowtime])",
-    "pact" : "Data Source",
-    "contents" : "TableSourceScan(table=[[default_catalog, default_database, MyTable2, project=[a, c, rowtime], metadata=[]]], fields=[a, c, rowtime])",
-    "parallelism" : 1
-  }, {
-    "id" : ,
-    "type" : "WatermarkAssigner(rowtime=[rowtime], watermark=[(rowtime - 1000:INTERVAL SECOND)])",
-    "pact" : "Operator",
-    "contents" : "WatermarkAssigner(rowtime=[rowtime], watermark=[(rowtime - 1000:INTERVAL SECOND)])",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  }, {
-    "id" : ,
-    "type" : "LocalWindowAggregate(groupBy=[a], window=[TUMBLE(time_col=[rowtime], size=[15 min])], select=[a, COUNT(*) AS count1$0, COUNT(distinct$0 c) AS count$1, DISTINCT(c) AS distinct$0, slice_end('w$) AS $slice_end])",
-    "pact" : "Operator",
-    "contents" : "LocalWindowAggregate(groupBy=[a], window=[TUMBLE(time_col=[rowtime], size=[15 min])], select=[a, COUNT(*) AS count1$0, COUNT(distinct$0 c) AS count$1, DISTINCT(c) AS distinct$0, slice_end('w$) AS $slice_end])",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  }, {
-    "id" : ,
-    "type" : "GlobalWindowAggregate(groupBy=[a], window=[TUMBLE(slice_end=[$slice_end], size=[15 min])], select=[a, COUNT(count1$0) AS cnt, COUNT(distinct$0 count$1) AS uv, start('w$) AS window_start, end('w$) AS window_end, rowtime('w$) AS window_time])",
-    "pact" : "Operator",
-    "contents" : "GlobalWindowAggregate(groupBy=[a], window=[TUMBLE(slice_end=[$slice_end], size=[15 min])], select=[a, COUNT(count1$0) AS cnt, COUNT(distinct$0 count$1) AS uv, start('w$) AS window_start, end('w$) AS window_end, rowtime('w$) AS window_time])",
-    "parallelism" : 2,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "HASH",
-      "side" : "second"
-    } ]
-  }, {
-    "id" : ,
-    "type" : "Calc(select=[a, window_start, window_end, cnt, uv])",
-    "pact" : "Operator",
-    "contents" : "Calc(select=[a, window_start, window_end, cnt, uv])",
-    "parallelism" : 2,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  }, {
-    "id" : ,
-    "type" : "WindowJoin(leftWindow=[TUMBLE(win_start=[window_start], win_end=[window_end], size=[15 min])], rightWindow=[TUMBLE(win_start=[window_start], win_end=[window_end], size=[15 min])], joinType=[InnerJoin], where=[(a = a0)], select=[a, window_start, window_end, cnt, uv, a0, window_start0, window_end0, cnt0, uv0])",
-    "pact" : "Operator",
-    "contents" : "WindowJoin(leftWindow=[TUMBLE(win_start=[window_start], win_end=[window_end], size=[15 min])], rightWindow=[TUMBLE(win_start=[window_start], win_end=[window_end], size=[15 min])], joinType=[InnerJoin], where=[(a = a0)], select=[a, window_start, window_end, cnt, uv, a0, window_start0, window_end0, cnt0, uv0])",
-    "parallelism" : 2,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "HASH",
-      "side" : "second"
-    }, {
-      "id" : ,
-      "ship_strategy" : "HASH",
-      "side" : "second"
-    } ]
-  }, {
-    "id" : ,
-    "type" : "Calc(select=[a, window_start, window_end, cnt, uv, a0, cnt0, uv0])",
-    "pact" : "Operator",
-    "contents" : "Calc(select=[a, window_start, window_end, cnt, uv, a0, cnt0, uv0])",
     "parallelism" : 2,
     "predecessors" : [ {
       "id" : ,
@@ -3960,6 +3650,196 @@ Calc(select=[a, window_start, window_end, cnt, uv, a0, cnt0, uv0])
     "type" : "Calc[]",
     "pact" : "Operator",
     "contents" : "[]:Calc(select=[a, window_start, window_end, cnt, uv, a0, cnt0, uv0])",
+    "parallelism" : 2,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testWindowJoin[isNameSimplifyEnabled=false]">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalProject(a=[$0], window_start=[$1], window_end=[$2], cnt=[$3], uv=[$4], a0=[$5], cnt0=[$8], uv0=[$9])
++- LogicalJoin(condition=[AND(=($1, $6), =($2, $7), =($0, $5))], joinType=[inner])
+   :- LogicalProject(a=[$0], window_start=[$1], window_end=[$2], cnt=[$4], uv=[$5])
+   :  +- LogicalAggregate(group=[{0, 1, 2, 3}], cnt=[COUNT()], uv=[COUNT(DISTINCT $4)])
+   :     +- LogicalProject(a=[$0], window_start=[$6], window_end=[$7], window_time=[$8], c=[$2])
+   :        +- LogicalTableFunctionScan(invocation=[TUMBLE(DESCRIPTOR($4), 900000:INTERVAL MINUTE)], rowType=[RecordType(BIGINT a, INTEGER b, VARCHAR(2147483647) c, BIGINT d, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP(3) *ROWTIME* window_time)])
+   :           +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], rowtime=[$4], proctime=[$5])
+   :              +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($4, 1000:INTERVAL SECOND)])
+   :                 +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], rowtime=[$4], proctime=[PROCTIME()])
+   :                    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalProject(a=[$0], window_start=[$1], window_end=[$2], cnt=[$4], uv=[$5])
+      +- LogicalAggregate(group=[{0, 1, 2, 3}], cnt=[COUNT()], uv=[COUNT(DISTINCT $4)])
+         +- LogicalProject(a=[$0], window_start=[$6], window_end=[$7], window_time=[$8], c=[$2])
+            +- LogicalTableFunctionScan(invocation=[TUMBLE(DESCRIPTOR($4), 900000:INTERVAL MINUTE)], rowType=[RecordType(BIGINT a, INTEGER b, VARCHAR(2147483647) c, BIGINT d, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP(3) *ROWTIME* window_time)])
+               +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], rowtime=[$4], proctime=[$5])
+                  +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($4, 1000:INTERVAL SECOND)])
+                     +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], rowtime=[$4], proctime=[PROCTIME()])
+                        +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2]])
+
+== Optimized Physical Plan ==
+Calc(select=[a, window_start, window_end, cnt, uv, a0, cnt0, uv0])
++- WindowJoin(leftWindow=[TUMBLE(win_start=[window_start], win_end=[window_end], size=[15 min])], rightWindow=[TUMBLE(win_start=[window_start], win_end=[window_end], size=[15 min])], joinType=[InnerJoin], where=[=(a, a0)], select=[a, window_start, window_end, cnt, uv, a0, window_start0, window_end0, cnt0, uv0])
+   :- Exchange(distribution=[hash[a]])
+   :  +- Calc(select=[a, window_start, window_end, cnt, uv])
+   :     +- GlobalWindowAggregate(groupBy=[a], window=[TUMBLE(slice_end=[$slice_end], size=[15 min])], select=[a, COUNT(count1$0) AS cnt, COUNT(distinct$0 count$1) AS uv, start('w$) AS window_start, end('w$) AS window_end, rowtime('w$) AS window_time])
+   :        +- Exchange(distribution=[hash[a]])
+   :           +- LocalWindowAggregate(groupBy=[a], window=[TUMBLE(time_col=[rowtime], size=[15 min])], select=[a, COUNT(*) AS count1$0, COUNT(distinct$0 c) AS count$1, DISTINCT(c) AS distinct$0, slice_end('w$) AS $slice_end])
+   :              +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
+   :                 +- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, c, rowtime], metadata=[]]], fields=[a, c, rowtime])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, window_start, window_end, cnt, uv])
+         +- GlobalWindowAggregate(groupBy=[a], window=[TUMBLE(slice_end=[$slice_end], size=[15 min])], select=[a, COUNT(count1$0) AS cnt, COUNT(distinct$0 count$1) AS uv, start('w$) AS window_start, end('w$) AS window_end, rowtime('w$) AS window_time])
+            +- Exchange(distribution=[hash[a]])
+               +- LocalWindowAggregate(groupBy=[a], window=[TUMBLE(time_col=[rowtime], size=[15 min])], select=[a, COUNT(*) AS count1$0, COUNT(distinct$0 c) AS count$1, DISTINCT(c) AS distinct$0, slice_end('w$) AS $slice_end])
+                  +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
+                     +- TableSourceScan(table=[[default_catalog, default_database, MyTable2, project=[a, c, rowtime], metadata=[]]], fields=[a, c, rowtime])
+
+== Optimized Execution Plan ==
+Calc(select=[a, window_start, window_end, cnt, uv, a0, cnt0, uv0])
++- WindowJoin(leftWindow=[TUMBLE(win_start=[window_start], win_end=[window_end], size=[15 min])], rightWindow=[TUMBLE(win_start=[window_start], win_end=[window_end], size=[15 min])], joinType=[InnerJoin], where=[(a = a0)], select=[a, window_start, window_end, cnt, uv, a0, window_start0, window_end0, cnt0, uv0])
+   :- Exchange(distribution=[hash[a]])
+   :  +- Calc(select=[a, window_start, window_end, cnt, uv])
+   :     +- GlobalWindowAggregate(groupBy=[a], window=[TUMBLE(slice_end=[$slice_end], size=[15 min])], select=[a, COUNT(count1$0) AS cnt, COUNT(distinct$0 count$1) AS uv, start('w$) AS window_start, end('w$) AS window_end, rowtime('w$) AS window_time])
+   :        +- Exchange(distribution=[hash[a]])
+   :           +- LocalWindowAggregate(groupBy=[a], window=[TUMBLE(time_col=[rowtime], size=[15 min])], select=[a, COUNT(*) AS count1$0, COUNT(distinct$0 c) AS count$1, DISTINCT(c) AS distinct$0, slice_end('w$) AS $slice_end])
+   :              +- WatermarkAssigner(rowtime=[rowtime], watermark=[(rowtime - 1000:INTERVAL SECOND)])
+   :                 +- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, c, rowtime], metadata=[]]], fields=[a, c, rowtime])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, window_start, window_end, cnt, uv])
+         +- GlobalWindowAggregate(groupBy=[a], window=[TUMBLE(slice_end=[$slice_end], size=[15 min])], select=[a, COUNT(count1$0) AS cnt, COUNT(distinct$0 count$1) AS uv, start('w$) AS window_start, end('w$) AS window_end, rowtime('w$) AS window_time])
+            +- Exchange(distribution=[hash[a]])
+               +- LocalWindowAggregate(groupBy=[a], window=[TUMBLE(time_col=[rowtime], size=[15 min])], select=[a, COUNT(*) AS count1$0, COUNT(distinct$0 c) AS count$1, DISTINCT(c) AS distinct$0, slice_end('w$) AS $slice_end])
+                  +- WatermarkAssigner(rowtime=[rowtime], watermark=[(rowtime - 1000:INTERVAL SECOND)])
+                     +- TableSourceScan(table=[[default_catalog, default_database, MyTable2, project=[a, c, rowtime], metadata=[]]], fields=[a, c, rowtime])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, c, rowtime], metadata=[]]], fields=[a, c, rowtime])",
+    "pact" : "Data Source",
+    "contents" : "TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, c, rowtime], metadata=[]]], fields=[a, c, rowtime])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "WatermarkAssigner(rowtime=[rowtime], watermark=[(rowtime - 1000:INTERVAL SECOND)])",
+    "pact" : "Operator",
+    "contents" : "WatermarkAssigner(rowtime=[rowtime], watermark=[(rowtime - 1000:INTERVAL SECOND)])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "LocalWindowAggregate(groupBy=[a], window=[TUMBLE(time_col=[rowtime], size=[15 min])], select=[a, COUNT(*) AS count1$0, COUNT(distinct$0 c) AS count$1, DISTINCT(c) AS distinct$0, slice_end('w$) AS $slice_end])",
+    "pact" : "Operator",
+    "contents" : "LocalWindowAggregate(groupBy=[a], window=[TUMBLE(time_col=[rowtime], size=[15 min])], select=[a, COUNT(*) AS count1$0, COUNT(distinct$0 c) AS count$1, DISTINCT(c) AS distinct$0, slice_end('w$) AS $slice_end])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "GlobalWindowAggregate(groupBy=[a], window=[TUMBLE(slice_end=[$slice_end], size=[15 min])], select=[a, COUNT(count1$0) AS cnt, COUNT(distinct$0 count$1) AS uv, start('w$) AS window_start, end('w$) AS window_end, rowtime('w$) AS window_time])",
+    "pact" : "Operator",
+    "contents" : "GlobalWindowAggregate(groupBy=[a], window=[TUMBLE(slice_end=[$slice_end], size=[15 min])], select=[a, COUNT(count1$0) AS cnt, COUNT(distinct$0 count$1) AS uv, start('w$) AS window_start, end('w$) AS window_end, rowtime('w$) AS window_time])",
+    "parallelism" : 2,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "HASH",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Calc(select=[a, window_start, window_end, cnt, uv])",
+    "pact" : "Operator",
+    "contents" : "Calc(select=[a, window_start, window_end, cnt, uv])",
+    "parallelism" : 2,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Source: TableSourceScan(table=[[default_catalog, default_database, MyTable2, project=[a, c, rowtime], metadata=[]]], fields=[a, c, rowtime])",
+    "pact" : "Data Source",
+    "contents" : "TableSourceScan(table=[[default_catalog, default_database, MyTable2, project=[a, c, rowtime], metadata=[]]], fields=[a, c, rowtime])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "WatermarkAssigner(rowtime=[rowtime], watermark=[(rowtime - 1000:INTERVAL SECOND)])",
+    "pact" : "Operator",
+    "contents" : "WatermarkAssigner(rowtime=[rowtime], watermark=[(rowtime - 1000:INTERVAL SECOND)])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "LocalWindowAggregate(groupBy=[a], window=[TUMBLE(time_col=[rowtime], size=[15 min])], select=[a, COUNT(*) AS count1$0, COUNT(distinct$0 c) AS count$1, DISTINCT(c) AS distinct$0, slice_end('w$) AS $slice_end])",
+    "pact" : "Operator",
+    "contents" : "LocalWindowAggregate(groupBy=[a], window=[TUMBLE(time_col=[rowtime], size=[15 min])], select=[a, COUNT(*) AS count1$0, COUNT(distinct$0 c) AS count$1, DISTINCT(c) AS distinct$0, slice_end('w$) AS $slice_end])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "GlobalWindowAggregate(groupBy=[a], window=[TUMBLE(slice_end=[$slice_end], size=[15 min])], select=[a, COUNT(count1$0) AS cnt, COUNT(distinct$0 count$1) AS uv, start('w$) AS window_start, end('w$) AS window_end, rowtime('w$) AS window_time])",
+    "pact" : "Operator",
+    "contents" : "GlobalWindowAggregate(groupBy=[a], window=[TUMBLE(slice_end=[$slice_end], size=[15 min])], select=[a, COUNT(count1$0) AS cnt, COUNT(distinct$0 count$1) AS uv, start('w$) AS window_start, end('w$) AS window_end, rowtime('w$) AS window_time])",
+    "parallelism" : 2,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "HASH",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Calc(select=[a, window_start, window_end, cnt, uv])",
+    "pact" : "Operator",
+    "contents" : "Calc(select=[a, window_start, window_end, cnt, uv])",
+    "parallelism" : 2,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "WindowJoin(leftWindow=[TUMBLE(win_start=[window_start], win_end=[window_end], size=[15 min])], rightWindow=[TUMBLE(win_start=[window_start], win_end=[window_end], size=[15 min])], joinType=[InnerJoin], where=[(a = a0)], select=[a, window_start, window_end, cnt, uv, a0, window_start0, window_end0, cnt0, uv0])",
+    "pact" : "Operator",
+    "contents" : "WindowJoin(leftWindow=[TUMBLE(win_start=[window_start], win_end=[window_end], size=[15 min])], rightWindow=[TUMBLE(win_start=[window_start], win_end=[window_end], size=[15 min])], joinType=[InnerJoin], where=[(a = a0)], select=[a, window_start, window_end, cnt, uv, a0, window_start0, window_end0, cnt0, uv0])",
+    "parallelism" : 2,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "HASH",
+      "side" : "second"
+    }, {
+      "id" : ,
+      "ship_strategy" : "HASH",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Calc(select=[a, window_start, window_end, cnt, uv, a0, cnt0, uv0])",
+    "pact" : "Operator",
+    "contents" : "Calc(select=[a, window_start, window_end, cnt, uv, a0, cnt0, uv0])",
     "parallelism" : 2,
     "predecessors" : [ {
       "id" : ,

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/CalcPythonCorrelateTransposeRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/CalcPythonCorrelateTransposeRuleTest.xml
@@ -26,7 +26,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], x=[$3], y=[$4])
 +- LogicalFilter(condition=[AND(=($3, $0), =(pyFunc($3, $3), 2), =(+($4, 1), *($4, $4)))])
    +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1}])
       :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-      +- LogicalTableFunctionScan(invocation=[func(*($cor0.a, $cor0.a), $cor0.b)], rowType=[RecordType:peek_no_expand(INTEGER x, INTEGER y)])
+      +- LogicalTableFunctionScan(invocation=[func(*($cor0.a, $cor0.a), $cor0.b)], rowType=[RecordType(INTEGER x, INTEGER y)])
 ]]>
     </Resource>
     <Resource name="optimized rel plan">
@@ -36,7 +36,7 @@ FlinkLogicalCalc(select=[a, b, c, x, y], where=[AND(=(f0, 2), =(+(y, 1), *(y, y)
    +- FlinkLogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1}])
       :- FlinkLogicalCalc(select=[a, b, c, *(a, a) AS f0])
       :  +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])
-      +- FlinkLogicalTableFunctionScan(invocation=[func($3, $1)], rowType=[RecordType:peek_no_expand(INTEGER x, INTEGER y)])
+      +- FlinkLogicalTableFunctionScan(invocation=[func($3, $1)], rowType=[RecordType(INTEGER x, INTEGER y)])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PythonCorrelateSplitRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PythonCorrelateSplitRuleTest.xml
@@ -47,7 +47,7 @@ FlinkLogicalCalc(select=[a, b, c, EXPR$0])
 LogicalProject(a=[$0], b=[$1], c=[$2], x=[$3], y=[$4])
 +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1, 2}])
    :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-   +- LogicalTableFunctionScan(invocation=[func(*($cor0.a, $cor0.a), pyFunc($cor0.b, $cor0.c))], rowType=[RecordType:peek_no_expand(INTEGER x, INTEGER y)])
+   +- LogicalTableFunctionScan(invocation=[func(*($cor0.a, $cor0.a), pyFunc($cor0.b, $cor0.c))], rowType=[RecordType(INTEGER x, INTEGER y)])
 ]]>
     </Resource>
     <Resource name="optimized rel plan">
@@ -56,7 +56,7 @@ FlinkLogicalCalc(select=[a, b, c, x, y])
 +- FlinkLogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1, 2}])
    :- FlinkLogicalCalc(select=[a, b, c, *(a, a) AS f0])
    :  +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])
-   +- FlinkLogicalTableFunctionScan(invocation=[func($3, pyFunc($1, $2))], rowType=[RecordType:peek_no_expand(INTEGER x, INTEGER y)])
+   +- FlinkLogicalTableFunctionScan(invocation=[func($3, pyFunc($1, $2))], rowType=[RecordType(INTEGER x, INTEGER y)])
 ]]>
     </Resource>
   </TestCase>
@@ -92,7 +92,7 @@ FlinkLogicalCalc(select=[a, b, c, EXPR$0 AS x])
 LogicalProject(a=[$0], b=[$1], c=[$2], x=[$4], y=[$5])
 +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 2, 3}])
    :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-   +- LogicalTableFunctionScan(invocation=[func(*($cor0.d._1, $cor0.a), pyFunc($cor0.d._2, $cor0.c))], rowType=[RecordType:peek_no_expand(INTEGER x, INTEGER y)])
+   +- LogicalTableFunctionScan(invocation=[func(*($cor0.d._1, $cor0.a), pyFunc($cor0.d._2, $cor0.c))], rowType=[RecordType(INTEGER x, INTEGER y)])
 ]]>
     </Resource>
     <Resource name="optimized rel plan">
@@ -101,7 +101,7 @@ FlinkLogicalCalc(select=[a, b, c, x, y])
 +- FlinkLogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 2, 3}])
    :- FlinkLogicalCalc(select=[a, b, c, d, *(d._1, a) AS f0, d._2 AS f1])
    :  +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d])
-   +- FlinkLogicalTableFunctionScan(invocation=[func($4, pyFunc($5, $2))], rowType=[RecordType:peek_no_expand(INTEGER x, INTEGER y)])
+   +- FlinkLogicalTableFunctionScan(invocation=[func($4, pyFunc($5, $2))], rowType=[RecordType(INTEGER x, INTEGER y)])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/SplitPythonConditionFromCorrelateRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/SplitPythonConditionFromCorrelateRuleTest.xml
@@ -26,7 +26,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], s=[$3], l=[$4])
 +- LogicalFilter(condition=[AND(=($4, $0), =($2, $3), =(pyFunc($4, $4), 2), =(+($4, 1), *($4, $4)))])
    +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{2}])
       :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-      +- LogicalTableFunctionScan(invocation=[func($cor0.c)], rowType=[RecordType:peek_no_expand(VARCHAR(2147483647) f0, INTEGER f1)])
+      +- LogicalTableFunctionScan(invocation=[func($cor0.c)], rowType=[RecordType(VARCHAR(2147483647) f0, INTEGER f1)])
 ]]>
     </Resource>
     <Resource name="optimized rel plan">
@@ -36,7 +36,7 @@ FlinkLogicalCalc(select=[a, b, c, f0, f1], where=[AND(=(f00, 2), =(f1, a), =(c, 
    +- FlinkLogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{2}])
       :- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])
       +- FlinkLogicalCalc(select=[f0, f1], where=[=(+(f1, 1), *(f1, f1))])
-         +- FlinkLogicalTableFunctionScan(invocation=[func($cor0.c)], rowType=[RecordType:peek_no_expand(VARCHAR(2147483647) f0, INTEGER f1)])
+         +- FlinkLogicalTableFunctionScan(invocation=[func($cor0.c)], rowType=[RecordType(VARCHAR(2147483647) f0, INTEGER f1)])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/MiniBatchIntervalInferTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/MiniBatchIntervalInferTest.xml
@@ -561,7 +561,7 @@ LogicalAggregate(group=[{0}], EXPR$1=[COUNT($1)])
          +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{4}])
             :- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($4, 0:INTERVAL MILLISECOND)])
             :  +- LogicalTableScan(table=[[default_catalog, default_database, MyDataStream1]])
-            +- LogicalTableFunctionScan(invocation=[Rates($cor0.rowtime)], rowType=[RecordType:peek_no_expand(INTEGER a, VARCHAR(2147483647) b, BIGINT c, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) *ROWTIME* rowtime)])
+            +- LogicalTableFunctionScan(invocation=[Rates($cor0.rowtime)], rowType=[RecordType(INTEGER a, VARCHAR(2147483647) b, BIGINT c, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) *ROWTIME* rowtime)])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testScalarArgsWithUid">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM f(uid => 'my-uid', i => 1, b => true)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(EXPR$0=[$0])
++- LogicalTableFunctionScan(invocation=[f(1, true, _UTF-16LE'my-uid')], rowType=[RecordType(VARCHAR(2147483647) EXPR$0)])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Correlate(invocation=[f(1, true, _UTF-16LE'my-uid')], correlate=[table(f(1,true,'my-uid'))], select=[EXPR$0], rowType=[RecordType(VARCHAR(2147483647) EXPR$0)], joinType=[INNER])
++- Values(tuples=[[{  }]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testEmptyArgs">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM f(uid => 'my-ptf')]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(EXPR$0=[$0])
++- LogicalTableFunctionScan(invocation=[f(_UTF-16LE'my-ptf')], rowType=[RecordType(VARCHAR(2147483647) EXPR$0)])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Correlate(invocation=[f(_UTF-16LE'my-ptf')], correlate=[table(f('my-ptf'))], select=[EXPR$0], rowType=[RecordType(VARCHAR(2147483647) EXPR$0)], joinType=[INNER])
++- Values(tuples=[[{  }]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUnknownScalarArg">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM f(i => 1, b => true, invalid => 'invalid')]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(EXPR$0=[$0])
++- LogicalTableFunctionScan(invocation=[f(1, true, DEFAULT())], rowType=[RecordType(VARCHAR(2147483647) EXPR$0)])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Correlate(invocation=[f(1, true, DEFAULT())], correlate=[table(f(1,true,DEFAULT()))], select=[EXPR$0], rowType=[RecordType(VARCHAR(2147483647) EXPR$0)], joinType=[INNER])
++- Values(tuples=[[{  }]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testScalarArgsNoUid">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM f(i => 1, b => true)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(EXPR$0=[$0])
++- LogicalTableFunctionScan(invocation=[f(1, true, DEFAULT())], rowType=[RecordType(VARCHAR(2147483647) EXPR$0)])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Correlate(invocation=[f(1, true, DEFAULT())], correlate=[table(f(1,true,DEFAULT()))], select=[EXPR$0], rowType=[RecordType(VARCHAR(2147483647) EXPR$0)], joinType=[INNER])
++- Values(tuples=[[{  }]])
+]]>
+    </Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/TemporalFunctionJoinTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/TemporalFunctionJoinTest.xml
@@ -26,7 +26,7 @@ LogicalProject(rate=[*($0, $4)])
 +- LogicalFilter(condition=[=($3, $1)])
    +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{2}])
       :- LogicalTableScan(table=[[default_catalog, default_database, Orders]])
-      +- LogicalTableFunctionScan(invocation=[Rates($cor0.o_rowtime)], rowType=[RecordType:peek_no_expand(VARCHAR(2147483647) currency, INTEGER rate, TIMESTAMP(3) *ROWTIME* rowtime)])
+      +- LogicalTableFunctionScan(invocation=[Rates($cor0.o_rowtime)], rowType=[RecordType(VARCHAR(2147483647) currency, INTEGER rate, TIMESTAMP(3) *ROWTIME* rowtime)])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
@@ -53,7 +53,7 @@ LogicalProject(rate=[$0], secondary_key=[$1], t3_comment=[$2], t3_secondary_key=
       :  +- LogicalFilter(condition=[AND(=($7, $3), OR(>($8, 120), =($9, $4)))])
       :     +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])
       :        :- LogicalTableScan(table=[[default_catalog, default_database, Orders]])
-      :        +- LogicalTableFunctionScan(invocation=[Rates($cor0.o_rowtime)], rowType=[RecordType:peek_no_expand(TIMESTAMP(3) *ROWTIME* rowtime, VARCHAR(2147483647) comment, VARCHAR(2147483647) currency, INTEGER rate, INTEGER secondary_key)])
+      :        +- LogicalTableFunctionScan(invocation=[Rates($cor0.o_rowtime)], rowType=[RecordType(TIMESTAMP(3) *ROWTIME* rowtime, VARCHAR(2147483647) comment, VARCHAR(2147483647) currency, INTEGER rate, INTEGER secondary_key)])
       +- LogicalTableScan(table=[[default_catalog, default_database, Table3]])
 ]]>
     </Resource>
@@ -86,7 +86,7 @@ LogicalProject(rate=[*($0, $4)])
       :- LogicalProject(o_amount=[$0], o_currency=[$1], o_rowtime=[$2])
       :  +- LogicalFilter(condition=[>($0, 1000)])
       :     +- LogicalTableScan(table=[[default_catalog, default_database, Orders]])
-      +- LogicalTableFunctionScan(invocation=[Rates($cor0.o_rowtime)], rowType=[RecordType:peek_no_expand(VARCHAR(2147483647) currency, INTEGER rate, TIMESTAMP(3) *ROWTIME* rowtime)])
+      +- LogicalTableFunctionScan(invocation=[Rates($cor0.o_rowtime)], rowType=[RecordType(VARCHAR(2147483647) currency, INTEGER rate, TIMESTAMP(3) *ROWTIME* rowtime)])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
@@ -111,7 +111,7 @@ LogicalProject(rate=[*($0, $4)])
 +- LogicalFilter(condition=[=($3, $1)])
    +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{2}])
       :- LogicalTableScan(table=[[default_catalog, default_database, ProctimeOrders]])
-      +- LogicalTableFunctionScan(invocation=[ProctimeRates($cor0.o_proctime)], rowType=[RecordType:peek_no_expand(VARCHAR(2147483647) currency, INTEGER rate, TIMESTAMP_LTZ(3) *PROCTIME* proctime)])
+      +- LogicalTableFunctionScan(invocation=[ProctimeRates($cor0.o_proctime)], rowType=[RecordType(VARCHAR(2147483647) currency, INTEGER rate, TIMESTAMP_LTZ(3) *PROCTIME* proctime)])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/table/CorrelateTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/table/CorrelateTest.xml
@@ -43,7 +43,7 @@ FROM MyTable, LATERAL TABLE(func1(c)) AS T
 LogicalProject(a=[$0], b=[$1], c=[$2], f0=[$3], f1=[$4], f2=[$5], f3=[$6], f4=[$7], f5=[$8], f6=[$9], f7=[$10], f8=[$11], f9=[$12], f10=[$13], f11=[$14])
 +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{2}])
    :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-   +- LogicalTableFunctionScan(invocation=[func1($cor0.c)], rowType=[*org.apache.flink.api.java.tuple.Tuple12<`f0` STRING, `f1` STRING, `f2` STRING, `f3` STRING, `f4` STRING, `f5` STRING, `f6` INT, `f7` INT, `f8` INT, `f9` INT, `f10` INT, `f11` INT>* NOT NULL])
+   +- LogicalTableFunctionScan(invocation=[func1($cor0.c)], rowType=[RecordType(VARCHAR(2147483647) f0, VARCHAR(2147483647) f1, VARCHAR(2147483647) f2, VARCHAR(2147483647) f3, VARCHAR(2147483647) f4, VARCHAR(2147483647) f5, INTEGER f6, INTEGER f7, INTEGER f8, INTEGER f9, INTEGER f10, INTEGER f11)])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">


### PR DESCRIPTION
## What is the purpose of the change

This integrates the new type inference of PTFs into Calcite and the existing planner classes around operand checking and return type inference. In particular the new inference is able to deal with table arguments coming from `StaticArgument` signatures. Some historical shortcomings have been fixed on the way.


## Brief change log
  - Introduce a system type inference within the planner for all functions
  - Let the system type inference wrap atomic types into rows if necessary for (process) table functions
  - Support table arguments for both tables with row and set semantics.
  - Add extensive validation for incorrect parameters


## Verifying this change

This change added tests and can be verified as follows: `ProcessTableFunctionTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
