### PR TITLE
[FLINK-37082][table-planner] Disable adaptive join optimization when enable batch job progress recovery.

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/AdaptiveJoinProcessor.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/AdaptiveJoinProcessor.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.plan.nodes.exec.processor;
 
+import org.apache.flink.configuration.BatchExecutionOptions;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.TableException;
@@ -149,8 +150,12 @@ public class AdaptiveJoinProcessor implements ExecNodeGraphProcessor {
                         .orElse(JobManagerOptions.SchedulerType.AdaptiveBatch);
         boolean isAdaptiveBatchSchedulerEnabled =
                 schedulerType == JobManagerOptions.SchedulerType.AdaptiveBatch;
-
-        return isAdaptiveJoinEnabled && isAdaptiveBatchSchedulerEnabled;
+        // Currently, adaptive join optimization and batch job progress recovery cannot be enabled
+        // simultaneously so we should disable it here.
+        // TODO: If job recovery for adaptive execution is supported in the future, this logic will
+        //  need to be removed.
+        boolean isJobRecoveryEnabled = tableConfig.get(BatchExecutionOptions.JOB_RECOVERY_ENABLED);
+        return isAdaptiveJoinEnabled && isAdaptiveBatchSchedulerEnabled && !isJobRecoveryEnabled;
     }
 
     private boolean areAllInputsHashShuffle(ExecNode<?> node) {

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/adaptive/AdaptiveJoinTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/adaptive/AdaptiveJoinTest.xml
@@ -228,4 +228,27 @@ MultipleInput(readOrder=[0,1,1,2], members=[\nHashJoin(joinType=[InnerJoin], whe
 ]]>
 		</Resource>
 	</TestCase>
+	<TestCase name="testAdaptiveJoinWithBatchJobRecovery">
+		<Resource name="sql">
+			<![CDATA[SELECT * FROM T1, T2 WHERE a1 = a2]]>
+		</Resource>
+		<Resource name="ast">
+			<![CDATA[
+LogicalProject(a1=[$0], b1=[$1], c1=[$2], d1=[$3], a2=[$4], b2=[$5], c2=[$6], d2=[$7])
++- LogicalFilter(condition=[=($0, $4)])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1, c1, d1)]]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2, d2)]]])
+]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+HashJoin(joinType=[InnerJoin], where=[(a1 = a2)], select=[a1, b1, c1, d1, a2, b2, c2, d2], build=[left])
+:- Exchange(distribution=[hash[a1]])
+:  +- LegacyTableSourceScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1, c1, d1)]]], fields=[a1, b1, c1, d1])
++- Exchange(distribution=[hash[a2]])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2, d2)]]], fields=[a2, b2, c2, d2])
+]]>
+		</Resource>
+	</TestCase>
 </Root>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/adaptive/AdaptiveJoinTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/adaptive/AdaptiveJoinTest.scala
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.table.planner.plan.batch.sql.adaptive
 
+import org.apache.flink.configuration.BatchExecutionOptions
 import org.apache.flink.table.api._
 import org.apache.flink.table.api.config.{ExecutionConfigOptions, OptimizerConfigOptions}
 import org.apache.flink.table.planner.utils.TableTestBase
@@ -118,6 +119,18 @@ class AdaptiveJoinTest extends TableTestBase {
         |  (SELECT d2 FROM T JOIN T2 ON d2 = a) t2
         |ON t1.a = t2.d2
         |""".stripMargin
+    util.verifyExecPlan(sql)
+  }
+
+  // Currently, adaptive join optimization and batch job progress recovery cannot be enabled
+  // simultaneously so we should disable it here.
+  // TODO: If job recovery for adaptive execution is supported in the future, this logic will
+  //  need to be removed.
+  @Test
+  def testAdaptiveJoinWithBatchJobRecovery(): Unit = {
+    util.tableEnv.getConfig
+      .set(BatchExecutionOptions.JOB_RECOVERY_ENABLED, Boolean.box(true))
+    val sql = "SELECT * FROM T1, T2 WHERE a1 = a2"
     util.verifyExecPlan(sql)
   }
 }


### PR DESCRIPTION
## What is the purpose of the change

Enabling Batch job progress recovery and adaptive batch execution to work together will be supported in future versions.

To prevent issues with job recovery when users configure Batch job progress recovery, we will temporarily disable adaptive join optimization in scenarios where Batch job progress recovery is enabled.

## Brief change log

  - *Disable adaptive join optimization when enable batch job progress recovery.*


## Verifying this change

This change added tests and can be verified as follows:

  - *Test with ut AdaptiveJoinTest::testAdaptiveJoinWithBatchJobRecovery.*
  - *Enable the config option `execution.batch.job-recovery.enabled` and check whether adaptive join optimization is disabled.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
