### PR TITLE
[FLINK-37089][Runtime] Advanced scheduling for derived async state processing

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionController.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionController.java
@@ -223,7 +223,10 @@ public class AsyncExecutionController<K> implements StateRequestHandler, Closeab
                     this::disposeContext,
                     KeyGroupRangeAssignment.assignToKeyGroup(key, maxParallelism),
                     epochManager.onEpoch(currentContext.getEpoch()),
-                    currentContext.getVariablesReference());
+                    currentContext.getVariablesReference(),
+                    // When inheriting, we increase the priority by 1 to ensure that the record is
+                    // processed right after the current record if possible.
+                    currentContext.getPriority() + 1);
         } else {
             return new RecordContext<>(
                     record == null ? RecordContext.EMPTY_RECORD : record,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/RecordContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/RecordContext.java
@@ -38,7 +38,7 @@ import java.util.function.Consumer;
  * @param <K> The type of the key inside the record.
  */
 public class RecordContext<K> extends ReferenceCounted<RecordContext.DisposerRunner> {
-    /** The empty record for timer and non-record input usage. */
+    /** The empty record for non-record input usage. */
     static final Object EMPTY_RECORD = new Object();
 
     /** The record to be processed. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/RecordContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/RecordContext.java
@@ -41,6 +41,8 @@ public class RecordContext<K> extends ReferenceCounted<RecordContext.DisposerRun
     /** The empty record for non-record input usage. */
     static final Object EMPTY_RECORD = new Object();
 
+    static final int PRIORITY_MIN = 0;
+
     /** The record to be processed. */
     private final Object record;
 
@@ -76,6 +78,8 @@ public class RecordContext<K> extends ReferenceCounted<RecordContext.DisposerRun
     /** The epoch of this context. */
     private final Epoch epoch;
 
+    private final int priority;
+
     public RecordContext(
             Object record,
             K key,
@@ -83,7 +87,14 @@ public class RecordContext<K> extends ReferenceCounted<RecordContext.DisposerRun
             int keyGroup,
             Epoch epoch,
             int variableCount) {
-        this(record, key, disposer, keyGroup, epoch, new AtomicReferenceArray<>(variableCount));
+        this(
+                record,
+                key,
+                disposer,
+                keyGroup,
+                epoch,
+                new AtomicReferenceArray<>(variableCount),
+                PRIORITY_MIN);
     }
 
     public RecordContext(
@@ -92,7 +103,26 @@ public class RecordContext<K> extends ReferenceCounted<RecordContext.DisposerRun
             Consumer<RecordContext<K>> disposer,
             int keyGroup,
             Epoch epoch,
-            AtomicReferenceArray<Object> variables) {
+            int variableCount,
+            int priority) {
+        this(
+                record,
+                key,
+                disposer,
+                keyGroup,
+                epoch,
+                new AtomicReferenceArray<>(variableCount),
+                priority);
+    }
+
+    public RecordContext(
+            Object record,
+            K key,
+            Consumer<RecordContext<K>> disposer,
+            int keyGroup,
+            Epoch epoch,
+            AtomicReferenceArray<Object> variables,
+            int priority) {
         super(0);
         this.record = record;
         this.key = key;
@@ -101,6 +131,7 @@ public class RecordContext<K> extends ReferenceCounted<RecordContext.DisposerRun
         this.keyGroup = keyGroup;
         this.epoch = epoch;
         this.contextVariables = variables;
+        this.priority = priority;
     }
 
     public Object getRecord() {
@@ -184,6 +215,10 @@ public class RecordContext<K> extends ReferenceCounted<RecordContext.DisposerRun
         return epoch;
     }
 
+    public int getPriority() {
+        return priority;
+    }
+
     @Override
     public int hashCode() {
         return Objects.hash(record, key);
@@ -223,6 +258,8 @@ public class RecordContext<K> extends ReferenceCounted<RecordContext.DisposerRun
                 + getReferenceCount()
                 + ", epoch="
                 + epoch.id
+                + ", priority="
+                + priority
                 + "}";
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Currently, there is a limit for in-flight records in async state processing. However, we allow developers to initialize a new processing in-middle of another. These derived processings are treated as normal ones for timers or upstreaming records, which is problematic:

- The new derived processing may increase the number of in-flight requests and cause force draining when it reaches the limit. But the draining may require the current processing also finish. This is a deadlock.
- The derived processing will queue behind normal processing, which is not the behavior the user wants. The derived ones should be fired right after the current processing or ASAP.

Thus, This PR changes the behavior in `AsyncExecutionController` and its related buffer:

- Avoid drain when creating derived processing.
- Provide priority for the queuing processing and make derived one have greater priority.

## Brief change log

 - Add an additional condition to skip the drain when inserting new record to `AEC`'s buffer.
 - Add priority to `RecordContext` and consider it when queue in blocking queue.

## Verifying this change

This change added tests and can be verified by `AbstractAsyncStateStreamOperatorTest#testManyAsyncProcessWithKey`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
