### PR TITLE
[FLINK-36506][table] Remove all deprecated methods in ColumnStats

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/plan/stats/ColumnStats.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/plan/stats/ColumnStats.java
@@ -44,48 +44,13 @@ public final class ColumnStats {
     /** max length of column values. */
     private final Integer maxLen;
 
-    /**
-     * Deprecated because not well supported comparable type, e.g. {@link java.util.Date}, {@link
-     * java.sql.Timestamp}.
-     */
-    @Deprecated private final Number maxValue;
-
     /** max value of column values, null if the value is unknown or not comparable. */
     private final Comparable<?> max;
-
-    /**
-     * Deprecated because not well supported comparable type, e.g. {@link java.util.Date}, {@link
-     * java.sql.Timestamp}.
-     */
-    @Deprecated private final Number minValue;
 
     /** min value of column values, null if the value is unknown or not comparable. */
     private final Comparable<?> min;
 
-    /**
-     * Deprecated because Number type max/min is not well supported comparable type, e.g. {@link
-     * java.util.Date}, {@link java.sql.Timestamp}. please use {@link ColumnStats.Builder} to
-     * construct ColumnStats instance.
-     */
-    @Deprecated
     public ColumnStats(
-            Long ndv, Long nullCount, Double avgLen, Integer maxLen, Number max, Number min) {
-        this.ndv = ndv;
-        this.nullCount = nullCount;
-        this.avgLen = avgLen;
-        this.maxLen = maxLen;
-        this.maxValue = max;
-        this.minValue = min;
-        this.max = null;
-        this.min = null;
-    }
-
-    /**
-     * Private because to avoid "cannot resolve constructor" error. please use {@link
-     * ColumnStats.Builder} to construct ColumnStats instance. could change to public if the
-     * deprecated constructor is removed in the future.
-     */
-    private ColumnStats(
             Long ndv,
             Long nullCount,
             Double avgLen,
@@ -98,8 +63,6 @@ public final class ColumnStats {
         this.maxLen = maxLen;
         this.max = max;
         this.min = min;
-        this.maxValue = null;
-        this.minValue = null;
     }
 
     public Long getNdv() {
@@ -118,40 +81,10 @@ public final class ColumnStats {
         return maxLen;
     }
 
-    /**
-     * Deprecated because Number type max/min is not well supported comparable type, e.g. {@link
-     * java.util.Date}, {@link java.sql.Timestamp}.
-     *
-     * <p>Returns null if this instance is constructed by {@link ColumnStats.Builder}.
-     */
-    @Deprecated
-    public Number getMaxValue() {
-        return maxValue;
-    }
-
-    /**
-     * Returns null if this instance is constructed by {@link ColumnStats#ColumnStats(Long, Long,
-     * Double, Integer, Number, Number)}.
-     */
     public Comparable<?> getMax() {
         return max;
     }
 
-    /**
-     * Deprecated because Number type max/min is not well supported comparable type, e.g. {@link
-     * java.util.Date}, {@link java.sql.Timestamp}.
-     *
-     * <p>Returns null if this instance is constructed by {@link ColumnStats.Builder}.
-     */
-    @Deprecated
-    public Number getMinValue() {
-        return minValue;
-    }
-
-    /**
-     * Returns null if this instance is constructed by {@link ColumnStats#ColumnStats(Long, Long,
-     * Double, Integer, Number, Number)}.
-     */
     public Comparable<?> getMin() {
         return min;
     }
@@ -173,14 +106,8 @@ public final class ColumnStats {
         if (max != null) {
             columnStats.add("max=" + max);
         }
-        if (maxValue != null) {
-            columnStats.add("max=" + maxValue);
-        }
         if (min != null) {
             columnStats.add("min=" + min);
-        }
-        if (minValue != null) {
-            columnStats.add("min=" + minValue);
         }
         String columnStatsStr = String.join(", ", columnStats);
         return "ColumnStats(" + columnStatsStr + ")";
@@ -192,18 +119,8 @@ public final class ColumnStats {
      * @return a deep copy
      */
     public ColumnStats copy() {
-        if (maxValue != null || minValue != null) {
-            return new ColumnStats(
-                    this.ndv,
-                    this.nullCount,
-                    this.avgLen,
-                    this.maxLen,
-                    this.maxValue,
-                    this.minValue);
-        } else {
-            return new ColumnStats(
-                    this.ndv, this.nullCount, this.avgLen, this.maxLen, this.max, this.min);
-        }
+        return new ColumnStats(
+                this.ndv, this.nullCount, this.avgLen, this.maxLen, this.max, this.min);
     }
 
     /**
@@ -228,17 +145,6 @@ public final class ColumnStats {
         Double avgLen = combineIfNonNull((a1, a2) -> (a1 + a2) / 2, this.avgLen, other.avgLen);
         Integer maxLen = combineIfNonNull(Math::max, this.maxLen, other.maxLen);
 
-        Number maxValue =
-                combineIfNonNull(
-                        (n1, n2) -> n1.doubleValue() > n2.doubleValue() ? n1 : n2,
-                        this.maxValue,
-                        other.maxValue);
-        Number minValue =
-                combineIfNonNull(
-                        (n1, n2) -> n1.doubleValue() < n2.doubleValue() ? n1 : n2,
-                        this.minValue,
-                        other.minValue);
-
         @SuppressWarnings("unchecked")
         Comparable max =
                 combineIfNonNull(
@@ -252,11 +158,7 @@ public final class ColumnStats {
                         this.min,
                         other.min);
 
-        if (max != null || min != null) {
-            return new ColumnStats(ndv, nullCount, avgLen, maxLen, max, min);
-        } else {
-            return new ColumnStats(ndv, nullCount, avgLen, maxLen, maxValue, minValue);
-        }
+        return new ColumnStats(ndv, nullCount, avgLen, maxLen, max, min);
     }
 
     @Override
@@ -272,15 +174,13 @@ public final class ColumnStats {
                 && Objects.equals(nullCount, that.nullCount)
                 && Objects.equals(avgLen, that.avgLen)
                 && Objects.equals(maxLen, that.maxLen)
-                && Objects.equals(maxValue, that.maxValue)
                 && Objects.equals(max, that.max)
-                && Objects.equals(minValue, that.minValue)
                 && Objects.equals(min, that.min);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(ndv, nullCount, avgLen, maxLen, maxValue, max, minValue, min);
+        return Objects.hash(ndv, nullCount, avgLen, maxLen, max, min);
     }
 
     private static <T> T combineIfNonNull(BinaryOperator<T> op, T t1, T t2) {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnInterval.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnInterval.scala
@@ -25,7 +25,6 @@ import org.apache.flink.table.planner.plan.nodes.physical.stream._
 import org.apache.flink.table.planner.plan.schema.FlinkPreparingTableBase
 import org.apache.flink.table.planner.plan.stats._
 import org.apache.flink.table.planner.plan.utils.{AggregateUtil, ColumnIntervalUtil, FlinkRelOptUtil, RankUtil}
-import org.apache.flink.table.planner.utils.ShortcutUtils
 import org.apache.flink.table.planner.utils.ShortcutUtils.unwrapTypeFactory
 import org.apache.flink.table.runtime.operators.rank.{ConstantRankRange, VariableRankRange}
 import org.apache.flink.util.Preconditions
@@ -73,31 +72,16 @@ class FlinkRelMdColumnInterval private extends MetadataHandler[ColumnInterval] {
     val statistic = relOptTable.getStatistic
     val colStats = statistic.getColumnStats(fieldName)
     if (colStats != null) {
-      val minValue = colStats.getMinValue
-      val maxValue = colStats.getMaxValue
       val min = colStats.getMin
       val max = colStats.getMax
 
-      Preconditions.checkArgument(
-        (minValue == null && maxValue == null) || (max == null && min == null))
-
-      if (minValue != null || maxValue != null) {
-        ValueInterval(convertNumberToBigDecimal(minValue), convertNumberToBigDecimal(maxValue))
-      } else if (max != null || min != null) {
+      if (max != null || min != null) {
         ValueInterval(convertNumberToBigDecimal(min), convertNumberToBigDecimal(max))
       } else {
         null
       }
     } else {
       null
-    }
-  }
-
-  private def convertNumberToBigDecimal(number: Number): Number = {
-    if (number != null) {
-      new JBigDecimal(number.toString)
-    } else {
-      number
     }
   }
 


### PR DESCRIPTION
## What is the purpose of the change

Remove all deprecated methods in ColumnStats

## Brief change log

  - Remove all deprecated methods in ColumnStats


## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? 
