### PR TITLE
[FLINK-37026] Add Stale PR GitHub Action workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,61 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This workflow labels and then closes stale PRs that haven't seen attention
+# for several months.
+
+name: Stale PRs
+on:
+  schedule:
+    #- cron: '15 6 * * *' # Run once a day at 6:15 UTC
+    - cron: '0 */6 * * *' # Initially we run every 6 hours until we have reached steady state
+  workflow_dispatch:
+    inputs:
+      operationsPerRun:
+        description: 'Max GitHub API operations'
+        required: true
+        default: 200 # Initially we set this at a high level to clear the backlog
+        type: number
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          operations-per-run: ${{ inputs.operationsPerRun || 500 }}
+          ascending: true
+          days-before-stale: 180 # This should eventually be reduced to 90
+          days-before-close: 90  # This should eventually be reduced to 30
+          stale-pr-label: 'stale'
+          stale-pr-message: |
+            This PR is being marked as stale since it has not had any activity in the last 180 days. 
+            If you would like to keep this PR alive, please leave a comment asking for a review. 
+            If the PR has merge conflicts, update it with the latest from the base branch.
+            <p>
+            If you are having difficulty finding a reviewer, please reach out to the 
+            [community](https://flink.apache.org/what-is-flink/community/).
+            <p>
+            If this PR is no longer valid or desired, please feel free to close it. 
+            If no activity occurs in the next 90 days, it will be automatically closed.
+          close-pr-label: 'closed-stale'
+          close-pr-message: |
+            This PR has been closed since it has not had any activity in 270 days. 
+            If you feel like this was a mistake, or you would like to continue working on it, 
+            please feel free to re-open the PR and ask for a review.


### PR DESCRIPTION
## What is the purpose of the change

This is the implementation of the [Stale PR GitHub Action Proposal](https://cwiki.apache.org/confluence/display/FLINK/Stale+PR+Cleanup).  This was [voted through](https://lists.apache.org/thread/kc90254wvo5q934doh8o4sbj1fgwvy76) on the dev mailing list.

The initial setting is for 6 months of inactivity to be marked as stale with 3 month to respond before the PR is closed. Ideally, once the initial backlog is cleared, we will reduces these down to 3 months and 1 month respectively, to match other Apache projects. 

There is also configuration for when the action is run and how many PRs it will process in one run. Initially I have set this to every 6 hours and 200 PRs per run, this will allow us to process the backlog in a few days. After which these can be reduced to daily, with a lower request limit (e.g. 50).

## Brief change log

- Enable Stale PR GitHub action workflow.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no