### PR TITLE
[FLINK-37090][e2e] Add adaptive broadcast join to e2e tpc-ds tests.

### DIFF
--- a/flink-end-to-end-tests/test-scripts/test_tpcds.sh
+++ b/flink-end-to-end-tests/test-scripts/test_tpcds.sh
@@ -72,6 +72,8 @@ function run_test() {
         set_config_key "execution.batch.speculative.block-slow-node-duration" "0s"
         set_config_key "slow-task-detector.execution-time.baseline-ratio" "0.0"
         set_config_key "slow-task-detector.execution-time.baseline-lower-bound" "0s"
+        set_config_key "table.optimizer.adaptive-broadcast-join.strategy" "auto"
+        set_config_key "table.optimizer.join.broadcast-threshold" "10485760L"
     else
         echo "ERROR: Scheduler ${scheduler} is unsupported for tpcds test. Aborting..."
         exit 1


### PR DESCRIPTION
## What is the purpose of the change

Add adaptive broadcast join to e2e tpc-ds tests.

In this case, we will set the AdaptiveBroadcastJoinStrategy to RUNTIME_ONLY, significantly increasing the likelihood of triggering adaptive broadcast join.

## Brief change log

  - *Add adaptive broadcast join to e2e tpc-ds tests.*


## Verifying this change
This change is already covered by existing tests, such as *test_tpcds.sh*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
