### PR TITLE
[1.20][FLINK-37100][tests] Fix `test_netty_shuffle_memory_control.sh` with Netty4 RPC

### DIFF
--- a/flink-end-to-end-tests/test-scripts/test_netty_shuffle_memory_control.sh
+++ b/flink-end-to-end-tests/test-scripts/test_netty_shuffle_memory_control.sh
@@ -23,15 +23,18 @@ TEST=flink-netty-shuffle-memory-control-test
 TEST_PROGRAM_NAME=NettyShuffleMemoryControlTestProgram
 TEST_PROGRAM_JAR=${END_TO_END_DIR}/$TEST/target/$TEST_PROGRAM_NAME.jar
 
-set_config_key "taskmanager.memory.flink.size" "600m"
+set_config_key "taskmanager.memory.flink.size" "512m"
 set_config_key "taskmanager.memory.network.min" "128m"
 set_config_key "taskmanager.memory.network.max" "128m"
 
 # 20 slots per task manager.
 set_config_key "taskmanager.numberOfTaskSlots" "20"
 
-# Limits the direct memory to be one chunk (4M * 20) plus some margins.
-set_config_key "taskmanager.memory.framework.off-heap.size" "90m"
+# Sets only one arena per TM for boosting the netty internal memory overhead.
+set_config_key "taskmanager.network.netty.num-arenas" "1"
+
+# Limits the direct memory to be one chunk (4M) plus some margins.
+set_config_key "taskmanager.memory.framework.off-heap.size" "7m"
 
 # Starts the cluster which includes one TaskManager.
 start_cluster

--- a/flink-end-to-end-tests/test-scripts/test_netty_shuffle_memory_control.sh
+++ b/flink-end-to-end-tests/test-scripts/test_netty_shuffle_memory_control.sh
@@ -34,7 +34,7 @@ set_config_key "taskmanager.numberOfTaskSlots" "20"
 set_config_key "taskmanager.network.netty.num-arenas" "1"
 
 # Limits the direct memory to be one chunk (4M) plus some margins.
-set_config_key "taskmanager.memory.framework.off-heap.size" "7m"
+set_config_key "taskmanager.memory.framework.off-heap.size" "12m"
 
 # Starts the cluster which includes one TaskManager.
 start_cluster


### PR DESCRIPTION
## What is the purpose of the change

Fixes the test executed by `test_netty_shuffle_memory_control.sh` that can possibly fail the CI in case Netty4 cannot reserve enough memory, hence Pekko is not able to start up.

## Brief change log

- Reverted the commit backported from the 2.0 branch, which I believe invalidates the purpose of this test case.
- Increased the off-heap memory from 7BM to 12MB, which according to local testing has to be enough to stabilize the CI execution.

## Verifying this change

Existing test should succeed consistently in CI.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? handled in different PR
