### PR TITLE
[FLINK-37135] Introduce Join extension for DataStream V2

### DIFF
--- a/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/builtin/BuiltinFuncs.java
+++ b/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/builtin/BuiltinFuncs.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.datastream.api.builtin;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.datastream.api.extension.join.JoinFunction;
+import org.apache.flink.datastream.api.extension.join.JoinType;
+import org.apache.flink.datastream.api.function.TwoInputNonBroadcastStreamProcessFunction;
+import org.apache.flink.datastream.api.stream.KeyedPartitionStream;
+import org.apache.flink.datastream.api.stream.NonKeyedPartitionStream;
+
+/** Built-in functions for all extension of datastream v2. */
+@Experimental
+public class BuiltinFuncs {
+
+    // =================== Join ===========================
+
+    static final Class<?> JOIN_FUNCS_INSTANCE;
+
+    static {
+        try {
+            JOIN_FUNCS_INSTANCE =
+                    Class.forName("org.apache.flink.datastream.impl.builtin.BuiltinJoinFuncs");
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException("Please ensure that flink-datastream in your class path");
+        }
+    }
+
+    /**
+     * Wrap the JoinFunction and INNER JoinType within a ProcessFunction to perform the Join
+     * operation. Note that the wrapped process function should only be used with KeyedStream.
+     */
+    public static <IN1, IN2, OUT> TwoInputNonBroadcastStreamProcessFunction<IN1, IN2, OUT> join(
+            JoinFunction<IN1, IN2, OUT> joinFunction) {
+        return join(joinFunction, JoinType.INNER);
+    }
+
+    /**
+     * Wrap the JoinFunction and JoinType within a ProcessFunction to perform the Join operation.
+     * Note that the wrapped process function should only be used with KeyedStream.
+     */
+    public static <IN1, IN2, OUT> TwoInputNonBroadcastStreamProcessFunction<IN1, IN2, OUT> join(
+            JoinFunction<IN1, IN2, OUT> joinFunction, JoinType joinType) {
+        try {
+            return (TwoInputNonBroadcastStreamProcessFunction<IN1, IN2, OUT>)
+                    JOIN_FUNCS_INSTANCE
+                            .getMethod("join", JoinFunction.class, JoinType.class)
+                            .invoke(null, joinFunction, joinType);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /** Inner join two {@link KeyedPartitionStream}. */
+    public static <KEY, T1, T2, OUT> NonKeyedPartitionStream<OUT> join(
+            KeyedPartitionStream<KEY, T1> leftStream,
+            KeyedPartitionStream<KEY, T2> rightStream,
+            JoinFunction<T1, T2, OUT> joinFunction) {
+        return join(leftStream, rightStream, joinFunction, JoinType.INNER);
+    }
+
+    /** Join two {@link KeyedPartitionStream} with the type of {@link JoinType}. */
+    public static <KEY, T1, T2, OUT> NonKeyedPartitionStream<OUT> join(
+            KeyedPartitionStream<KEY, T1> leftStream,
+            KeyedPartitionStream<KEY, T2> rightStream,
+            JoinFunction<T1, T2, OUT> joinFunction,
+            JoinType joinType) {
+        return leftStream.connectAndProcess(rightStream, join(joinFunction, joinType));
+    }
+
+    /**
+     * Inner join two {@link NonKeyedPartitionStream}. The two streams will be redistributed by
+     * {@link KeySelector} respectively.
+     */
+    public static <KEY, T1, T2, OUT> NonKeyedPartitionStream<OUT> join(
+            NonKeyedPartitionStream<T1> leftStream,
+            KeySelector<T1, KEY> leftKeySelector,
+            NonKeyedPartitionStream<T2> rightStream,
+            KeySelector<T2, KEY> rightKeySelector,
+            JoinFunction<T1, T2, OUT> joinFunction) {
+        return join(
+                leftStream,
+                leftKeySelector,
+                rightStream,
+                rightKeySelector,
+                joinFunction,
+                JoinType.INNER);
+    }
+
+    /**
+     * Join two {@link NonKeyedPartitionStream} with the type of {@link JoinType}. The two streams
+     * will be redistributed by {@link KeySelector} respectively.
+     */
+    public static <KEY, T1, T2, OUT> NonKeyedPartitionStream<OUT> join(
+            NonKeyedPartitionStream<T1> leftStream,
+            KeySelector<T1, KEY> leftKeySelector,
+            NonKeyedPartitionStream<T2> rightStream,
+            KeySelector<T2, KEY> rightKeySelector,
+            JoinFunction<T1, T2, OUT> joinFunction,
+            JoinType joinType) {
+        return join(
+                leftStream.keyBy(leftKeySelector),
+                rightStream.keyBy(rightKeySelector),
+                joinFunction,
+                joinType);
+    }
+}

--- a/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/extension/join/JoinFunction.java
+++ b/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/extension/join/JoinFunction.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.datastream.api.extension.join;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.api.common.functions.Function;
+import org.apache.flink.datastream.api.common.Collector;
+import org.apache.flink.datastream.api.context.RuntimeContext;
+
+/**
+ * A functional interface that defines a join operation between two input records of types {@code
+ * IN1} and {@code IN2}. Note that this is specifically used in non-broadcast joins.
+ *
+ * <p>This interface is used to process a pair of records from two different data streams and
+ * produce an output record of type {@code OUT}. Implementations of this interface can be used to
+ * define custom join logic in stream processing frameworks.
+ *
+ * @param <IN1> the type of the first input record
+ * @param <IN2> the type of the second input record
+ * @param <OUT> the type of the output record
+ */
+@FunctionalInterface
+@Experimental
+public interface JoinFunction<IN1, IN2, OUT> extends Function {
+    void processRecord(IN1 leftRecord, IN2 rightRecord, Collector<OUT> output, RuntimeContext ctx)
+            throws Exception;
+}

--- a/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/extension/join/JoinType.java
+++ b/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/extension/join/JoinType.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.datastream.api.extension.join;
+
+import org.apache.flink.annotation.Experimental;
+
+/**
+ * The type/algorithm of join operation. Currently, we only support regular Join (Non-Window Join).
+ * Outer joins require the ability to determine when there is no more data for a specific join key,
+ * which is not feasible for non-window join over unbounded streams. Therefore, we have only
+ * introduced the INNER join type and plan to introduce more join types as needed in the future.
+ */
+@Experimental
+public enum JoinType {
+    INNER,
+}

--- a/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/function/ApplyPartitionFunction.java
+++ b/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/function/ApplyPartitionFunction.java
@@ -33,5 +33,5 @@ public interface ApplyPartitionFunction<OUT> extends Function {
      * @param collector to output data.
      * @param ctx runtime context in which this function is executed.
      */
-    void apply(Collector<OUT> collector, PartitionedContext ctx) throws Exception;
+    void apply(Collector<OUT> collector, PartitionedContext<OUT> ctx) throws Exception;
 }

--- a/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/function/OneInputStreamProcessFunction.java
+++ b/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/function/OneInputStreamProcessFunction.java
@@ -47,7 +47,8 @@ public interface OneInputStreamProcessFunction<IN, OUT> extends ProcessFunction 
      * @param output to emit processed records.
      * @param ctx runtime context in which this function is executed.
      */
-    void processRecord(IN record, Collector<OUT> output, PartitionedContext ctx) throws Exception;
+    void processRecord(IN record, Collector<OUT> output, PartitionedContext<OUT> ctx)
+            throws Exception;
 
     /**
      * This is a life-cycle method indicates that this function will no longer receive any data from
@@ -64,7 +65,8 @@ public interface OneInputStreamProcessFunction<IN, OUT> extends ProcessFunction 
      * @param output to emit record.
      * @param ctx runtime context in which this function is executed.
      */
-    default void onProcessingTimer(long timestamp, Collector<OUT> output, PartitionedContext ctx) {}
+    default void onProcessingTimer(
+            long timestamp, Collector<OUT> output, PartitionedContext<OUT> ctx) {}
 
     /** Callback function when receive watermark. */
     default WatermarkHandlingResult onWatermark(

--- a/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/function/TwoInputBroadcastStreamProcessFunction.java
+++ b/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/function/TwoInputBroadcastStreamProcessFunction.java
@@ -51,7 +51,7 @@ public interface TwoInputBroadcastStreamProcessFunction<IN1, IN2, OUT> extends P
      * @param ctx runtime context in which this function is executed.
      */
     void processRecordFromNonBroadcastInput(
-            IN1 record, Collector<OUT> output, PartitionedContext ctx) throws Exception;
+            IN1 record, Collector<OUT> output, PartitionedContext<OUT> ctx) throws Exception;
 
     /**
      * Process record from broadcast input. In general, the broadcast side is not allowed to
@@ -87,7 +87,8 @@ public interface TwoInputBroadcastStreamProcessFunction<IN1, IN2, OUT> extends P
      * @param output to emit record.
      * @param ctx runtime context in which this function is executed.
      */
-    default void onProcessingTimer(long timestamp, Collector<OUT> output, PartitionedContext ctx) {}
+    default void onProcessingTimer(
+            long timestamp, Collector<OUT> output, PartitionedContext<OUT> ctx) {}
 
     /**
      * Callback function when receive the watermark from broadcast input.

--- a/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/function/TwoInputNonBroadcastStreamProcessFunction.java
+++ b/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/function/TwoInputNonBroadcastStreamProcessFunction.java
@@ -47,7 +47,7 @@ public interface TwoInputNonBroadcastStreamProcessFunction<IN1, IN2, OUT> extend
      * @param output to emit processed records.
      * @param ctx runtime context in which this function is executed.
      */
-    void processRecordFromFirstInput(IN1 record, Collector<OUT> output, PartitionedContext ctx)
+    void processRecordFromFirstInput(IN1 record, Collector<OUT> output, PartitionedContext<OUT> ctx)
             throws Exception;
 
     /**
@@ -57,8 +57,8 @@ public interface TwoInputNonBroadcastStreamProcessFunction<IN1, IN2, OUT> extend
      * @param output to emit processed records.
      * @param ctx runtime context in which this function is executed.
      */
-    void processRecordFromSecondInput(IN2 record, Collector<OUT> output, PartitionedContext ctx)
-            throws Exception;
+    void processRecordFromSecondInput(
+            IN2 record, Collector<OUT> output, PartitionedContext<OUT> ctx) throws Exception;
 
     /**
      * This is a life-cycle method indicates that this function will no longer receive any data from
@@ -83,7 +83,8 @@ public interface TwoInputNonBroadcastStreamProcessFunction<IN1, IN2, OUT> extend
      * @param output to emit record.
      * @param ctx runtime context in which this function is executed.
      */
-    default void onProcessingTimer(long timestamp, Collector<OUT> output, PartitionedContext ctx) {}
+    default void onProcessingTimer(
+            long timestamp, Collector<OUT> output, PartitionedContext<OUT> ctx) {}
 
     /**
      * Callback function when receive the watermark from the first input.

--- a/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/function/TwoOutputApplyPartitionFunction.java
+++ b/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/function/TwoOutputApplyPartitionFunction.java
@@ -37,6 +37,6 @@ public interface TwoOutputApplyPartitionFunction<OUT1, OUT2> extends Function {
     void apply(
             Collector<OUT1> firstOutput,
             Collector<OUT2> secondOutput,
-            TwoOutputPartitionedContext ctx)
+            TwoOutputPartitionedContext<OUT1, OUT2> ctx)
             throws Exception;
 }

--- a/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/function/TwoOutputStreamProcessFunction.java
+++ b/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/function/TwoOutputStreamProcessFunction.java
@@ -52,7 +52,7 @@ public interface TwoOutputStreamProcessFunction<IN, OUT1, OUT2> extends ProcessF
             IN record,
             Collector<OUT1> output1,
             Collector<OUT2> output2,
-            TwoOutputPartitionedContext ctx)
+            TwoOutputPartitionedContext<OUT1, OUT2> ctx)
             throws Exception;
 
     /**
@@ -75,7 +75,7 @@ public interface TwoOutputStreamProcessFunction<IN, OUT1, OUT2> extends ProcessF
             long timestamp,
             Collector<OUT1> output1,
             Collector<OUT2> output2,
-            TwoOutputPartitionedContext ctx) {}
+            TwoOutputPartitionedContext<OUT1, OUT2> ctx) {}
 
     /**
      * Callback function when receive the watermark from the input.

--- a/flink-datastream/src/main/java/org/apache/flink/datastream/impl/builtin/BuiltinJoinFuncs.java
+++ b/flink-datastream/src/main/java/org/apache/flink/datastream/impl/builtin/BuiltinJoinFuncs.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.datastream.impl.builtin;
+
+import org.apache.flink.datastream.api.builtin.BuiltinFuncs;
+import org.apache.flink.datastream.api.extension.join.JoinFunction;
+import org.apache.flink.datastream.api.extension.join.JoinType;
+import org.apache.flink.datastream.api.function.TwoInputNonBroadcastStreamProcessFunction;
+import org.apache.flink.datastream.impl.extension.join.operators.TwoInputNonBroadcastJoinProcessFunction;
+
+/** Join-related implementations in {@link BuiltinFuncs}. */
+public class BuiltinJoinFuncs {
+
+    /**
+     * Wrap the JoinFunction and JoinType within a ProcessFunction to perform the Join operation.
+     * Note that the wrapped process function should only be used with KeyedStream.
+     */
+    public static <IN1, IN2, OUT> TwoInputNonBroadcastStreamProcessFunction<IN1, IN2, OUT> join(
+            JoinFunction<IN1, IN2, OUT> joinFunction, JoinType joinType) {
+        return new TwoInputNonBroadcastJoinProcessFunction<>(joinFunction, joinType);
+    }
+}

--- a/flink-datastream/src/main/java/org/apache/flink/datastream/impl/extension/join/operators/TwoInputNonBroadcastJoinProcessFunction.java
+++ b/flink-datastream/src/main/java/org/apache/flink/datastream/impl/extension/join/operators/TwoInputNonBroadcastJoinProcessFunction.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.datastream.impl.extension.join.operators;
+
+import org.apache.flink.datastream.api.common.Collector;
+import org.apache.flink.datastream.api.context.PartitionedContext;
+import org.apache.flink.datastream.api.extension.join.JoinFunction;
+import org.apache.flink.datastream.api.extension.join.JoinType;
+import org.apache.flink.datastream.api.function.TwoInputNonBroadcastStreamProcessFunction;
+
+/**
+ * Wrap the user-defined {@link JoinFunction} as {@link TwoInputNonBroadcastStreamProcessFunction}
+ * to execute the Join operation within Join extension.
+ */
+public class TwoInputNonBroadcastJoinProcessFunction<IN1, IN2, OUT>
+        implements TwoInputNonBroadcastStreamProcessFunction<IN1, IN2, OUT> {
+
+    private final JoinFunction<IN1, IN2, OUT> joinFunction;
+
+    private final JoinType joinType;
+
+    public TwoInputNonBroadcastJoinProcessFunction(
+            JoinFunction<IN1, IN2, OUT> joinFunction, JoinType joinType) {
+        this.joinFunction = joinFunction;
+        this.joinType = joinType;
+    }
+
+    @Override
+    public void processRecordFromFirstInput(
+            IN1 record, Collector<OUT> output, PartitionedContext<OUT> ctx) throws Exception {}
+
+    @Override
+    public void processRecordFromSecondInput(
+            IN2 record, Collector<OUT> output, PartitionedContext<OUT> ctx) throws Exception {}
+
+    public JoinFunction<IN1, IN2, OUT> getJoinFunction() {
+        return joinFunction;
+    }
+
+    public JoinType getJoinType() {
+        return joinType;
+    }
+}

--- a/flink-datastream/src/main/java/org/apache/flink/datastream/impl/extension/join/operators/TwoInputNonBroadcastJoinProcessOperator.java
+++ b/flink-datastream/src/main/java/org/apache/flink/datastream/impl/extension/join/operators/TwoInputNonBroadcastJoinProcessOperator.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.datastream.impl.extension.join.operators;
+
+import org.apache.flink.api.common.state.v2.ListState;
+import org.apache.flink.datastream.api.extension.join.JoinType;
+import org.apache.flink.datastream.api.function.TwoInputNonBroadcastStreamProcessFunction;
+import org.apache.flink.datastream.api.stream.KeyedPartitionStream;
+import org.apache.flink.datastream.impl.operators.KeyedTwoInputNonBroadcastProcessOperator;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.runtime.state.VoidNamespaceSerializer;
+import org.apache.flink.runtime.state.v2.ListStateDescriptor;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * Operator for executing the Join operation in Join extension. Note that this should be executed
+ * with two {@link KeyedPartitionStream}.
+ */
+public class TwoInputNonBroadcastJoinProcessOperator<K, IN1, IN2, OUT>
+        extends KeyedTwoInputNonBroadcastProcessOperator<K, IN1, IN2, OUT> {
+
+    private final TwoInputNonBroadcastJoinProcessFunction<IN1, IN2, OUT> joinProcessFunction;
+
+    private final ListStateDescriptor<IN1> leftStateDescriptor;
+
+    private final ListStateDescriptor<IN2> rightStateDescriptor;
+
+    /** The state that stores the left input records. */
+    private transient ListState<IN1> leftState;
+
+    /** The state that stores the right input records. */
+    private transient ListState<IN2> rightState;
+
+    public TwoInputNonBroadcastJoinProcessOperator(
+            TwoInputNonBroadcastStreamProcessFunction<IN1, IN2, OUT> userFunction,
+            ListStateDescriptor<IN1> leftStateDescriptor,
+            ListStateDescriptor<IN2> rightStateDescriptor) {
+        super(userFunction);
+        this.joinProcessFunction =
+                (TwoInputNonBroadcastJoinProcessFunction<IN1, IN2, OUT>) userFunction;
+        checkArgument(
+                joinProcessFunction.getJoinType() == JoinType.INNER,
+                "Currently only support INNER join.");
+        this.leftStateDescriptor = leftStateDescriptor;
+        this.rightStateDescriptor = rightStateDescriptor;
+    }
+
+    @Override
+    public void open() throws Exception {
+        super.open();
+        leftState =
+                getOrCreateKeyedState(
+                        VoidNamespace.INSTANCE,
+                        VoidNamespaceSerializer.INSTANCE,
+                        leftStateDescriptor);
+        rightState =
+                getOrCreateKeyedState(
+                        VoidNamespace.INSTANCE,
+                        VoidNamespaceSerializer.INSTANCE,
+                        rightStateDescriptor);
+    }
+
+    @Override
+    public void processElement1(StreamRecord<IN1> element) throws Exception {
+        collector.setTimestampFromStreamRecord(element);
+        IN1 leftRecord = element.getValue();
+        Iterable<IN2> rightRecords = rightState.get();
+        if (rightRecords != null) {
+            for (IN2 rightRecord : rightRecords) {
+                joinProcessFunction
+                        .getJoinFunction()
+                        .processRecord(leftRecord, rightRecord, collector, partitionedContext);
+            }
+        }
+        leftState.add(leftRecord);
+    }
+
+    @Override
+    public void processElement2(StreamRecord<IN2> element) throws Exception {
+        collector.setTimestampFromStreamRecord(element);
+        Iterable<IN1> leftRecords = leftState.get();
+        IN2 rightRecord = element.getValue();
+        if (leftRecords != null) {
+            for (IN1 leftRecord : leftState.get()) {
+                joinProcessFunction
+                        .getJoinFunction()
+                        .processRecord(leftRecord, rightRecord, collector, partitionedContext);
+            }
+        }
+        rightState.add(rightRecord);
+    }
+}

--- a/flink-datastream/src/main/java/org/apache/flink/datastream/impl/utils/StreamUtils.java
+++ b/flink-datastream/src/main/java/org/apache/flink/datastream/impl/utils/StreamUtils.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.connector.dsv2.WrappedSink;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.datastream.api.extension.join.JoinFunction;
 import org.apache.flink.datastream.api.function.OneInputStreamProcessFunction;
 import org.apache.flink.datastream.api.function.TwoInputBroadcastStreamProcessFunction;
 import org.apache.flink.datastream.api.function.TwoInputNonBroadcastStreamProcessFunction;
@@ -33,6 +34,7 @@ import org.apache.flink.datastream.api.function.TwoOutputStreamProcessFunction;
 import org.apache.flink.datastream.api.stream.GlobalStream.ProcessConfigurableAndGlobalStream;
 import org.apache.flink.datastream.api.stream.KeyedPartitionStream.ProcessConfigurableAndKeyedPartitionStream;
 import org.apache.flink.datastream.api.stream.NonKeyedPartitionStream.ProcessConfigurableAndNonKeyedPartitionStream;
+import org.apache.flink.datastream.impl.extension.join.operators.TwoInputNonBroadcastJoinProcessFunction;
 import org.apache.flink.datastream.impl.stream.AbstractDataStream;
 import org.apache.flink.datastream.impl.stream.GlobalStreamImpl;
 import org.apache.flink.datastream.impl.stream.KeyedPartitionStreamImpl;
@@ -84,6 +86,21 @@ public final class StreamUtils {
                     TwoInputNonBroadcastStreamProcessFunction<IN1, IN2, OUT> processFunction,
                     TypeInformation<IN1> in1TypeInformation,
                     TypeInformation<IN2> in2TypeInformation) {
+        if (processFunction instanceof TwoInputNonBroadcastJoinProcessFunction) {
+            return TypeExtractor.getBinaryOperatorReturnType(
+                    ((TwoInputNonBroadcastJoinProcessFunction<IN1, IN2, OUT>) processFunction)
+                            .getJoinFunction(),
+                    JoinFunction.class,
+                    0,
+                    1,
+                    2,
+                    TypeExtractor.NO_INDEX,
+                    in1TypeInformation,
+                    in2TypeInformation,
+                    Utils.getCallLocationName(),
+                    true);
+        }
+
         return TypeExtractor.getBinaryOperatorReturnType(
                 processFunction,
                 TwoInputNonBroadcastStreamProcessFunction.class,

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/ExecutionEnvironmentImplTest.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/ExecutionEnvironmentImplTest.java
@@ -113,7 +113,7 @@ class ExecutionEnvironmentImplTest {
                 new OneInputStreamProcessFunction<Long, Long>() {
                     @Override
                     public void processRecord(
-                            Long record, Collector<Long> output, PartitionedContext ctx)
+                            Long record, Collector<Long> output, PartitionedContext<Long> ctx)
                             throws Exception {
                         // do nothing.
                     }

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/attribute/StreamingJobGraphGeneratorWithAttributeTest.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/attribute/StreamingJobGraphGeneratorWithAttributeTest.java
@@ -212,7 +212,7 @@ class StreamingJobGraphGeneratorWithAttributeTest {
 
         @Override
         public void processRecord(
-                Integer record, Collector<Integer> output, PartitionedContext ctx) {
+                Integer record, Collector<Integer> output, PartitionedContext<Integer> ctx) {
             output.collect(record + 1);
         }
     }
@@ -221,7 +221,7 @@ class StreamingJobGraphGeneratorWithAttributeTest {
 
         @Override
         public void processRecord(
-                Integer record, Collector<Integer> output, PartitionedContext ctx) {
+                Integer record, Collector<Integer> output, PartitionedContext<Integer> ctx) {
             if (record != 2) {
                 output.collect(record + 1);
             }
@@ -237,7 +237,7 @@ class StreamingJobGraphGeneratorWithAttributeTest {
                 Integer record,
                 Collector<Integer> output1,
                 Collector<Integer> output2,
-                TwoOutputPartitionedContext ctx) {
+                TwoOutputPartitionedContext<Integer, Integer> ctx) {
             output1.collect(record + 1);
             output2.collect(record - 1);
         }

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/functions/ProcessFunctionTest.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/functions/ProcessFunctionTest.java
@@ -59,7 +59,9 @@ public class ProcessFunctionTest {
 
                     @Override
                     public void processRecord(
-                            Integer record, Collector<Integer> output, PartitionedContext ctx)
+                            Integer record,
+                            Collector<Integer> output,
+                            PartitionedContext<Integer> ctx)
                             throws Exception {}
 
                     @Override
@@ -94,7 +96,9 @@ public class ProcessFunctionTest {
 
                     @Override
                     public void processRecordFromNonBroadcastInput(
-                            Integer record, Collector<Integer> output, PartitionedContext ctx)
+                            Integer record,
+                            Collector<Integer> output,
+                            PartitionedContext<Integer> ctx)
                             throws Exception {}
 
                     @Override
@@ -134,12 +138,16 @@ public class ProcessFunctionTest {
 
                     @Override
                     public void processRecordFromFirstInput(
-                            Integer record, Collector<Integer> output, PartitionedContext ctx)
+                            Integer record,
+                            Collector<Integer> output,
+                            PartitionedContext<Integer> ctx)
                             throws Exception {}
 
                     @Override
                     public void processRecordFromSecondInput(
-                            Integer record, Collector<Integer> output, PartitionedContext ctx)
+                            Integer record,
+                            Collector<Integer> output,
+                            PartitionedContext<Integer> ctx)
                             throws Exception {}
 
                     @Override
@@ -179,7 +187,7 @@ public class ProcessFunctionTest {
                             Integer record,
                             Collector<Integer> output1,
                             Collector<Integer> output2,
-                            TwoOutputPartitionedContext ctx)
+                            TwoOutputPartitionedContext<Integer, Integer> ctx)
                             throws Exception {}
 
                     @Override

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/KeyedProcessOperatorTest.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/KeyedProcessOperatorTest.java
@@ -46,7 +46,7 @@ class KeyedProcessOperatorTest {
                             public void processRecord(
                                     Integer record,
                                     Collector<Integer> output,
-                                    PartitionedContext ctx) {
+                                    PartitionedContext<Integer> ctx) {
                                 output.collect(record + 1);
                             }
                         });
@@ -78,7 +78,7 @@ class KeyedProcessOperatorTest {
                             public void processRecord(
                                     Integer record,
                                     Collector<Integer> output,
-                                    PartitionedContext ctx) {
+                                    PartitionedContext<Integer> ctx) {
                                 // do nothing.
                             }
 
@@ -125,7 +125,7 @@ class KeyedProcessOperatorTest {
                             public void processRecord(
                                     Integer record,
                                     Collector<Integer> output,
-                                    PartitionedContext ctx) {
+                                    PartitionedContext<Integer> ctx) {
                                 // forward the record to check input key.
                                 output.collect(record);
                             }

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/KeyedTwoInputBroadcastProcessOperatorTest.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/KeyedTwoInputBroadcastProcessOperatorTest.java
@@ -50,7 +50,7 @@ class KeyedTwoInputBroadcastProcessOperatorTest {
                             public void processRecordFromNonBroadcastInput(
                                     Integer record,
                                     Collector<Long> output,
-                                    PartitionedContext ctx) {
+                                    PartitionedContext<Long> ctx) {
                                 fromNonBroadcastInput.add(record);
                             }
 
@@ -89,7 +89,7 @@ class KeyedTwoInputBroadcastProcessOperatorTest {
                             public void processRecordFromNonBroadcastInput(
                                     Integer record,
                                     Collector<Long> output,
-                                    PartitionedContext ctx) {
+                                    PartitionedContext<Long> ctx) {
                                 //  do nothing.
                             }
 
@@ -161,7 +161,7 @@ class KeyedTwoInputBroadcastProcessOperatorTest {
                             public void processRecordFromNonBroadcastInput(
                                     Integer record,
                                     Collector<Long> output,
-                                    PartitionedContext ctx) {
+                                    PartitionedContext<Long> ctx) {
                                 output.collect(Long.valueOf(record));
                             }
 

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/KeyedTwoInputNonBroadcastProcessOperatorTest.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/KeyedTwoInputNonBroadcastProcessOperatorTest.java
@@ -46,13 +46,15 @@ class KeyedTwoInputNonBroadcastProcessOperatorTest {
                             public void processRecordFromFirstInput(
                                     Integer record,
                                     Collector<Long> output,
-                                    PartitionedContext ctx) {
+                                    PartitionedContext<Long> ctx) {
                                 output.collect(Long.valueOf(record));
                             }
 
                             @Override
                             public void processRecordFromSecondInput(
-                                    Long record, Collector<Long> output, PartitionedContext ctx) {
+                                    Long record,
+                                    Collector<Long> output,
+                                    PartitionedContext<Long> ctx) {
                                 output.collect(record);
                             }
                         });
@@ -89,13 +91,15 @@ class KeyedTwoInputNonBroadcastProcessOperatorTest {
                             public void processRecordFromFirstInput(
                                     Integer record,
                                     Collector<Long> output,
-                                    PartitionedContext ctx) {
+                                    PartitionedContext<Long> ctx) {
                                 // do nothing.
                             }
 
                             @Override
                             public void processRecordFromSecondInput(
-                                    Long record, Collector<Long> output, PartitionedContext ctx) {
+                                    Long record,
+                                    Collector<Long> output,
+                                    PartitionedContext<Long> ctx) {
                                 // do nothing.
                             }
 
@@ -164,13 +168,15 @@ class KeyedTwoInputNonBroadcastProcessOperatorTest {
                             public void processRecordFromFirstInput(
                                     Integer record,
                                     Collector<Long> output,
-                                    PartitionedContext ctx) {
+                                    PartitionedContext<Long> ctx) {
                                 output.collect(Long.valueOf(record));
                             }
 
                             @Override
                             public void processRecordFromSecondInput(
-                                    Long record, Collector<Long> output, PartitionedContext ctx) {
+                                    Long record,
+                                    Collector<Long> output,
+                                    PartitionedContext<Long> ctx) {
                                 output.collect(record);
                             }
                         },

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/KeyedTwoOutputProcessOperatorTest.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/KeyedTwoOutputProcessOperatorTest.java
@@ -52,7 +52,7 @@ class KeyedTwoOutputProcessOperatorTest {
                                     Integer record,
                                     Collector<Integer> output1,
                                     Collector<Long> output2,
-                                    TwoOutputPartitionedContext ctx) {
+                                    TwoOutputPartitionedContext<Integer, Long> ctx) {
                                 output1.collect(record);
                                 output2.collect((long) (record * 2));
                             }
@@ -93,7 +93,7 @@ class KeyedTwoOutputProcessOperatorTest {
                                     Integer record,
                                     Collector<Integer> output1,
                                     Collector<Long> output2,
-                                    TwoOutputPartitionedContext ctx) {
+                                    TwoOutputPartitionedContext<Integer, Long> ctx) {
                                 // do nothing.
                             }
 
@@ -147,7 +147,7 @@ class KeyedTwoOutputProcessOperatorTest {
                                     Integer record,
                                     Collector<Integer> output1,
                                     Collector<Long> output2,
-                                    TwoOutputPartitionedContext ctx) {
+                                    TwoOutputPartitionedContext<Integer, Long> ctx) {
                                 if (emitToFirstOutput.get()) {
                                     output1.collect(record);
                                 } else {

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/MockFreqCountProcessFunction.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/MockFreqCountProcessFunction.java
@@ -44,7 +44,8 @@ public class MockFreqCountProcessFunction
     }
 
     @Override
-    public void processRecord(Integer record, Collector<Integer> output, PartitionedContext ctx)
+    public void processRecord(
+            Integer record, Collector<Integer> output, PartitionedContext<Integer> ctx)
             throws Exception {
         Optional<MapState<Integer, Integer>> stateOptional =
                 ctx.getStateManager().getState(mapStateDeclaration);

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/MockGlobalDecuplicateCountProcessFunction.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/MockGlobalDecuplicateCountProcessFunction.java
@@ -47,7 +47,8 @@ public class MockGlobalDecuplicateCountProcessFunction
     }
 
     @Override
-    public void processRecord(Integer record, Collector<Integer> output, PartitionedContext ctx)
+    public void processRecord(
+            Integer record, Collector<Integer> output, PartitionedContext<Integer> ctx)
             throws Exception {
         Optional<BroadcastState<Integer, Integer>> stateOptional =
                 ctx.getStateManager().getState(broadcastStateDeclaration);

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/MockGlobalListAppenderProcessFunction.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/MockGlobalListAppenderProcessFunction.java
@@ -62,7 +62,8 @@ public class MockGlobalListAppenderProcessFunction
     }
 
     @Override
-    public void processRecord(Integer record, Collector<Integer> output, PartitionedContext ctx)
+    public void processRecord(
+            Integer record, Collector<Integer> output, PartitionedContext<Integer> ctx)
             throws Exception {
         Optional<ListState<Integer>> stateOptional =
                 ctx.getStateManager().getState(listStateDeclaration);

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/MockListAppenderProcessFunction.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/MockListAppenderProcessFunction.java
@@ -61,7 +61,8 @@ public class MockListAppenderProcessFunction
     }
 
     @Override
-    public void processRecord(Integer record, Collector<Integer> output, PartitionedContext ctx)
+    public void processRecord(
+            Integer record, Collector<Integer> output, PartitionedContext<Integer> ctx)
             throws Exception {
         Optional<ListState<Integer>> stateOptional =
                 ctx.getStateManager().getState(listStateDeclaration);

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/MockMultiplierProcessFunction.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/MockMultiplierProcessFunction.java
@@ -44,7 +44,8 @@ public class MockMultiplierProcessFunction
     }
 
     @Override
-    public void processRecord(Integer record, Collector<Integer> output, PartitionedContext ctx)
+    public void processRecord(
+            Integer record, Collector<Integer> output, PartitionedContext<Integer> ctx)
             throws Exception {
         Optional<ValueState<Integer>> stateOptional =
                 ctx.getStateManager().getState(valueStateDeclaration);

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/MockRecudingMultiplierProcessFunction.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/MockRecudingMultiplierProcessFunction.java
@@ -53,7 +53,8 @@ public class MockRecudingMultiplierProcessFunction
     }
 
     @Override
-    public void processRecord(Integer record, Collector<Integer> output, PartitionedContext ctx)
+    public void processRecord(
+            Integer record, Collector<Integer> output, PartitionedContext<Integer> ctx)
             throws Exception {
         Optional<ReducingState<Integer>> stateOptional =
                 ctx.getStateManager().getState(reducingStateDeclaration);

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/MockSumAggregateProcessFunction.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/MockSumAggregateProcessFunction.java
@@ -69,7 +69,8 @@ public class MockSumAggregateProcessFunction
     }
 
     @Override
-    public void processRecord(Integer record, Collector<Integer> output, PartitionedContext ctx)
+    public void processRecord(
+            Integer record, Collector<Integer> output, PartitionedContext<Integer> ctx)
             throws Exception {
         Optional<AggregatingState<Integer, Integer>> stateOptional =
                 ctx.getStateManager().getState(aggregatingStateDeclaration);

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/ProcessOperatorTest.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/ProcessOperatorTest.java
@@ -65,7 +65,7 @@ class ProcessOperatorTest {
                             public void processRecord(
                                     Integer record,
                                     Collector<String> output,
-                                    PartitionedContext ctx) {
+                                    PartitionedContext<String> ctx) {
                                 //  do nothing.
                             }
 

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/TwoInputBroadcastProcessOperatorTest.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/TwoInputBroadcastProcessOperatorTest.java
@@ -48,7 +48,7 @@ class TwoInputBroadcastProcessOperatorTest {
                             public void processRecordFromNonBroadcastInput(
                                     Integer record,
                                     Collector<Long> output,
-                                    PartitionedContext ctx) {
+                                    PartitionedContext<Long> ctx) {
                                 fromNonBroadcastInput.add(Long.valueOf(record));
                             }
 
@@ -84,7 +84,7 @@ class TwoInputBroadcastProcessOperatorTest {
                             public void processRecordFromNonBroadcastInput(
                                     Integer record,
                                     Collector<Long> output,
-                                    PartitionedContext ctx) {
+                                    PartitionedContext<Long> ctx) {
                                 // do nothing.
                             }
 

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/TwoInputNonBroadcastProcessOperatorTest.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/TwoInputNonBroadcastProcessOperatorTest.java
@@ -43,13 +43,15 @@ class TwoInputNonBroadcastProcessOperatorTest {
                             public void processRecordFromFirstInput(
                                     Integer record,
                                     Collector<Long> output,
-                                    PartitionedContext ctx) {
+                                    PartitionedContext<Long> ctx) {
                                 output.collect(Long.valueOf(record));
                             }
 
                             @Override
                             public void processRecordFromSecondInput(
-                                    Long record, Collector<Long> output, PartitionedContext ctx) {
+                                    Long record,
+                                    Collector<Long> output,
+                                    PartitionedContext<Long> ctx) {
                                 output.collect(record);
                             }
                         });
@@ -82,14 +84,18 @@ class TwoInputNonBroadcastProcessOperatorTest {
                         new TwoInputNonBroadcastStreamProcessFunction<Integer, Long, Long>() {
                             @Override
                             public void processRecordFromFirstInput(
-                                    Integer record, Collector<Long> output, PartitionedContext ctx)
+                                    Integer record,
+                                    Collector<Long> output,
+                                    PartitionedContext<Long> ctx)
                                     throws Exception {
                                 // do nothing.
                             }
 
                             @Override
                             public void processRecordFromSecondInput(
-                                    Long record, Collector<Long> output, PartitionedContext ctx)
+                                    Long record,
+                                    Collector<Long> output,
+                                    PartitionedContext<Long> ctx)
                                     throws Exception {
                                 // do nothing.
                             }

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/TwoOutputProcessOperatorTest.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/TwoOutputProcessOperatorTest.java
@@ -48,7 +48,7 @@ class TwoOutputProcessOperatorTest {
                                     Integer record,
                                     Collector<Integer> output1,
                                     Collector<Long> output2,
-                                    TwoOutputPartitionedContext ctx) {
+                                    TwoOutputPartitionedContext<Integer, Long> ctx) {
                                 output1.collect(record);
                                 output2.collect((long) (record * 2));
                             }
@@ -86,7 +86,7 @@ class TwoOutputProcessOperatorTest {
                                     Integer record,
                                     Collector<Integer> output1,
                                     Collector<Long> output2,
-                                    TwoOutputPartitionedContext ctx) {
+                                    TwoOutputPartitionedContext<Integer, Long> ctx) {
                                 // do nothing.
                             }
 

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/stream/StreamTestUtils.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/stream/StreamTestUtils.java
@@ -81,7 +81,8 @@ public final class StreamTestUtils {
         }
 
         @Override
-        public void processRecord(Integer record, Collector<Long> output, PartitionedContext ctx) {
+        public void processRecord(
+                Integer record, Collector<Long> output, PartitionedContext<Long> ctx) {
             // do nothing.
         }
     }
@@ -110,7 +111,7 @@ public final class StreamTestUtils {
                 Integer record,
                 Collector<Integer> output1,
                 Collector<Long> output2,
-                TwoOutputPartitionedContext ctx) {
+                TwoOutputPartitionedContext<Integer, Long> ctx) {
             //  do nothing.
         }
     }
@@ -139,13 +140,14 @@ public final class StreamTestUtils {
 
         @Override
         public void processRecordFromFirstInput(
-                Integer record, Collector<Long> output, PartitionedContext ctx) {
+                Integer record, Collector<Long> output, PartitionedContext<Long> ctx) {
             // do nothing.
         }
 
         @Override
         public void processRecordFromSecondInput(
-                Long record, Collector<Long> output, PartitionedContext ctx) throws Exception {
+                Long record, Collector<Long> output, PartitionedContext<Long> ctx)
+                throws Exception {
             // do nothing.
         }
     }
@@ -174,7 +176,7 @@ public final class StreamTestUtils {
 
         @Override
         public void processRecordFromNonBroadcastInput(
-                Long record, Collector<Long> output, PartitionedContext ctx) {
+                Long record, Collector<Long> output, PartitionedContext<Long> ctx) {
             // do nothing.
         }
 

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/utils/StreamUtilsTest.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/utils/StreamUtilsTest.java
@@ -53,7 +53,9 @@ class StreamUtilsTest {
                         new OneInputStreamProcessFunction<Integer, Long>() {
                             @Override
                             public void processRecord(
-                                    Integer record, Collector<Long> output, PartitionedContext ctx)
+                                    Integer record,
+                                    Collector<Long> output,
+                                    PartitionedContext<Long> ctx)
                                     throws Exception {
                                 // ignore
                             }
@@ -83,14 +85,16 @@ class StreamUtilsTest {
                             public void processRecordFromFirstInput(
                                     Integer record,
                                     Collector<String> output,
-                                    PartitionedContext ctx)
+                                    PartitionedContext<String> ctx)
                                     throws Exception {
                                 // ignore
                             }
 
                             @Override
                             public void processRecordFromSecondInput(
-                                    Long record, Collector<String> output, PartitionedContext ctx)
+                                    Long record,
+                                    Collector<String> output,
+                                    PartitionedContext<String> ctx)
                                     throws Exception {
                                 // ignore
                             }
@@ -106,7 +110,7 @@ class StreamUtilsTest {
                             public void processRecordFromNonBroadcastInput(
                                     Integer record,
                                     Collector<String> output,
-                                    PartitionedContext ctx)
+                                    PartitionedContext<String> ctx)
                                     throws Exception {
                                 // ignore
                             }
@@ -133,7 +137,7 @@ class StreamUtilsTest {
                                     Integer record,
                                     Collector<Long> output1,
                                     Collector<String> output2,
-                                    TwoOutputPartitionedContext ctx)
+                                    TwoOutputPartitionedContext<Long, String> ctx)
                                     throws Exception {
                                 // ignore
                             }

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/utils/WatermarkUtilsTest.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/utils/WatermarkUtilsTest.java
@@ -119,7 +119,7 @@ class WatermarkUtilsTest {
                             public void processRecord(
                                     Integer record,
                                     Collector<Integer> output,
-                                    PartitionedContext ctx)
+                                    PartitionedContext<Integer> ctx)
                                     throws Exception {}
 
                             @Override
@@ -137,7 +137,7 @@ class WatermarkUtilsTest {
                                             Integer record,
                                             Collector<Integer> output1,
                                             Collector<Integer> output2,
-                                            TwoOutputPartitionedContext ctx)
+                                            TwoOutputPartitionedContext<Integer, Integer> ctx)
                                             throws Exception {}
 
                                     @Override

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/api/datastream/JoinITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/api/datastream/JoinITCase.java
@@ -1,0 +1,387 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.streaming.api.datastream;
+
+import org.apache.flink.api.connector.dsv2.DataStreamV2SourceUtils;
+import org.apache.flink.api.connector.dsv2.WrappedSink;
+import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.api.connector.sink2.WriterInitContext;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.datastream.api.ExecutionEnvironment;
+import org.apache.flink.datastream.api.builtin.BuiltinFuncs;
+import org.apache.flink.datastream.api.common.Collector;
+import org.apache.flink.datastream.api.context.PartitionedContext;
+import org.apache.flink.datastream.api.context.RuntimeContext;
+import org.apache.flink.datastream.api.extension.join.JoinFunction;
+import org.apache.flink.datastream.api.extension.join.JoinType;
+import org.apache.flink.datastream.api.function.OneInputStreamProcessFunction;
+import org.apache.flink.datastream.api.function.TwoInputNonBroadcastStreamProcessFunction;
+import org.apache.flink.datastream.api.stream.KeyedPartitionStream;
+import org.apache.flink.datastream.api.stream.NonKeyedPartitionStream;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test the Join extension on DataStream V2. */
+class JoinITCase implements Serializable {
+    private transient ExecutionEnvironment env;
+    private static List<String> sinkResults;
+
+    @BeforeEach
+    void before() throws Exception {
+        env = ExecutionEnvironment.getInstance();
+        sinkResults = new ArrayList<>();
+    }
+
+    @AfterEach
+    void after() throws Exception {
+        sinkResults.clear();
+    }
+
+    @Test
+    void testInnerJoinWithSameKey() throws Exception {
+        NonKeyedPartitionStream<KeyAndValue> source1 =
+                getSourceStream(
+                        Arrays.asList(
+                                KeyAndValue.of("key", 0),
+                                KeyAndValue.of("key", 1),
+                                KeyAndValue.of("key", 2)),
+                        "source1");
+        NonKeyedPartitionStream<KeyAndValue> source2 =
+                getSourceStream(
+                        Arrays.asList(
+                                KeyAndValue.of("key", 0),
+                                KeyAndValue.of("key", 1),
+                                KeyAndValue.of("key", 2)),
+                        "source2");
+
+        NonKeyedPartitionStream<String> joinedStream =
+                BuiltinFuncs.join(
+                        source1,
+                        (KeySelector<KeyAndValue, String>) keyAndValue -> keyAndValue.key,
+                        source2,
+                        (KeySelector<KeyAndValue, String>) keyAndValue -> keyAndValue.key,
+                        new TestJoinFunction(),
+                        JoinType.INNER);
+
+        joinedStream.toSink(new WrappedSink<>(new TestSink()));
+        env.execute("testInnerJoinWithSameKey");
+
+        expectInAnyOrder(
+                "key:0:0", "key:0:1", "key:0:2", "key:1:0", "key:1:1", "key:1:2", "key:2:0",
+                "key:2:1", "key:2:2");
+    }
+
+    @Test
+    void testInnerJoinWithMultipleKeys() throws Exception {
+        NonKeyedPartitionStream<KeyAndValue> source1 =
+                getSourceStream(
+                        Arrays.asList(
+                                KeyAndValue.of("key0", 0),
+                                KeyAndValue.of("key1", 1),
+                                KeyAndValue.of("key2", 2),
+                                KeyAndValue.of("key2", 3)),
+                        "source1");
+        NonKeyedPartitionStream<KeyAndValue> source2 =
+                getSourceStream(
+                        Arrays.asList(
+                                KeyAndValue.of("key2", 4),
+                                KeyAndValue.of("key2", 5),
+                                KeyAndValue.of("key0", 6),
+                                KeyAndValue.of("key1", 7)),
+                        "source2");
+
+        NonKeyedPartitionStream<String> joinedStream =
+                BuiltinFuncs.join(
+                        source1,
+                        (KeySelector<KeyAndValue, String>) keyAndValue -> keyAndValue.key,
+                        source2,
+                        (KeySelector<KeyAndValue, String>) keyAndValue -> keyAndValue.key,
+                        new TestJoinFunction(),
+                        JoinType.INNER);
+
+        joinedStream.toSink(new WrappedSink<>(new TestSink()));
+        env.execute("testInnerJoinWithMultipleKeys");
+
+        expectInAnyOrder("key0:0:6", "key1:1:7", "key2:2:4", "key2:2:5", "key2:3:4", "key2:3:5");
+    }
+
+    @Test
+    void testInnerJoinWhenLeftInputNoData() throws Exception {
+        NonKeyedPartitionStream<KeyAndValue> source1 =
+                getSourceStream(
+                        Arrays.asList(
+                                KeyAndValue.of("key0", 0),
+                                KeyAndValue.of("key1", 1),
+                                KeyAndValue.of("key2", 2),
+                                KeyAndValue.of("key2", 3)),
+                        "source1");
+        NonKeyedPartitionStream<KeyAndValue> source2 =
+                getSourceStream(new ArrayList<>(), "source2");
+
+        NonKeyedPartitionStream<String> joinedStream =
+                BuiltinFuncs.join(
+                        source1,
+                        (KeySelector<KeyAndValue, String>) keyAndValue -> keyAndValue.key,
+                        source2,
+                        (KeySelector<KeyAndValue, String>) keyAndValue -> keyAndValue.key,
+                        new TestJoinFunction(),
+                        JoinType.INNER);
+
+        joinedStream.toSink(new WrappedSink<>(new TestSink()));
+        env.execute("testInnerJoinWhenLeftInputNoData");
+
+        expectInAnyOrder();
+    }
+
+    @Test
+    void testInnerJoinWhenRightInputNoData() throws Exception {
+        NonKeyedPartitionStream<KeyAndValue> source1 =
+                getSourceStream(new ArrayList<>(), "source1");
+        NonKeyedPartitionStream<KeyAndValue> source2 =
+                getSourceStream(
+                        Arrays.asList(
+                                KeyAndValue.of("key0", 0),
+                                KeyAndValue.of("key1", 1),
+                                KeyAndValue.of("key2", 2),
+                                KeyAndValue.of("key2", 3)),
+                        "source2");
+
+        NonKeyedPartitionStream<String> joinedStream =
+                BuiltinFuncs.join(
+                        source1,
+                        (KeySelector<KeyAndValue, String>) keyAndValue -> keyAndValue.key,
+                        source2,
+                        (KeySelector<KeyAndValue, String>) keyAndValue -> keyAndValue.key,
+                        new TestJoinFunction(),
+                        JoinType.INNER);
+
+        joinedStream.toSink(new WrappedSink<>(new TestSink()));
+        env.execute("testInnerJoinWhenRightInputNoData");
+
+        expectInAnyOrder();
+    }
+
+    /** Test Join using {@link BuiltinFuncs#join(JoinFunction)}. */
+    @Test
+    void testJoinWithWrappedJoinProcessFunction() throws Exception {
+        NonKeyedPartitionStream<KeyAndValue> source1 =
+                getSourceStream(
+                        Arrays.asList(
+                                KeyAndValue.of("key", 0),
+                                KeyAndValue.of("key", 1),
+                                KeyAndValue.of("key", 2)),
+                        "source1");
+        NonKeyedPartitionStream<KeyAndValue> source2 =
+                getSourceStream(
+                        Arrays.asList(
+                                KeyAndValue.of("key", 0),
+                                KeyAndValue.of("key", 1),
+                                KeyAndValue.of("key", 2)),
+                        "source2");
+
+        KeyedPartitionStream<String, KeyAndValue> keyedStream1 =
+                source1.keyBy((KeySelector<KeyAndValue, String>) keyAndValue -> keyAndValue.key);
+        KeyedPartitionStream<String, KeyAndValue> keyedStream2 =
+                source2.keyBy((KeySelector<KeyAndValue, String>) keyAndValue -> keyAndValue.key);
+        TwoInputNonBroadcastStreamProcessFunction<KeyAndValue, KeyAndValue, String>
+                wrappedJoinProcessFunction = BuiltinFuncs.join(new TestJoinFunction());
+        NonKeyedPartitionStream<String> joinedStream =
+                keyedStream1.connectAndProcess(keyedStream2, wrappedJoinProcessFunction);
+
+        joinedStream.toSink(new WrappedSink<>(new TestSink()));
+        env.execute("testInnerJoinWithSameKey");
+
+        expectInAnyOrder(
+                "key:0:0", "key:0:1", "key:0:2", "key:1:0", "key:1:1", "key:1:2", "key:2:0",
+                "key:2:1", "key:2:2");
+    }
+
+    /**
+     * Test Join using {@link BuiltinFuncs#join(KeyedPartitionStream, KeyedPartitionStream,
+     * JoinFunction)}.
+     */
+    @Test
+    void testJoinWithKeyedStream() throws Exception {
+        NonKeyedPartitionStream<KeyAndValue> source1 =
+                getSourceStream(
+                        Arrays.asList(
+                                KeyAndValue.of("key", 0),
+                                KeyAndValue.of("key", 1),
+                                KeyAndValue.of("key", 2)),
+                        "source1");
+        NonKeyedPartitionStream<KeyAndValue> source2 =
+                getSourceStream(
+                        Arrays.asList(
+                                KeyAndValue.of("key", 0),
+                                KeyAndValue.of("key", 1),
+                                KeyAndValue.of("key", 2)),
+                        "source2");
+
+        KeyedPartitionStream<String, KeyAndValue> keyedStream1 =
+                source1.keyBy((KeySelector<KeyAndValue, String>) keyAndValue -> keyAndValue.key);
+        KeyedPartitionStream<String, KeyAndValue> keyedStream2 =
+                source2.keyBy((KeySelector<KeyAndValue, String>) keyAndValue -> keyAndValue.key);
+
+        NonKeyedPartitionStream<String> joinedStream =
+                BuiltinFuncs.join(keyedStream1, keyedStream2, new TestJoinFunction());
+
+        joinedStream.toSink(new WrappedSink<>(new TestSink()));
+        env.execute("testInnerJoinWithSameKey");
+
+        expectInAnyOrder(
+                "key:0:0", "key:0:1", "key:0:2", "key:1:0", "key:1:1", "key:1:2", "key:2:0",
+                "key:2:1", "key:2:2");
+    }
+
+    /**
+     * Test Join using {@link BuiltinFuncs#join(NonKeyedPartitionStream, KeySelector,
+     * NonKeyedPartitionStream, KeySelector, JoinFunction)}.
+     */
+    @Test
+    void testJoinWithNonKeyedStream() throws Exception {
+        NonKeyedPartitionStream<KeyAndValue> source1 =
+                getSourceStream(
+                        Arrays.asList(
+                                KeyAndValue.of("key", 0),
+                                KeyAndValue.of("key", 1),
+                                KeyAndValue.of("key", 2)),
+                        "source1");
+        NonKeyedPartitionStream<KeyAndValue> source2 =
+                getSourceStream(
+                        Arrays.asList(
+                                KeyAndValue.of("key", 0),
+                                KeyAndValue.of("key", 1),
+                                KeyAndValue.of("key", 2)),
+                        "source2");
+
+        NonKeyedPartitionStream<String> joinedStream =
+                BuiltinFuncs.join(
+                        source1,
+                        (KeySelector<KeyAndValue, String>) keyAndValue -> keyAndValue.key,
+                        source2,
+                        (KeySelector<KeyAndValue, String>) keyAndValue -> keyAndValue.key,
+                        new TestJoinFunction());
+
+        joinedStream.toSink(new WrappedSink<>(new TestSink()));
+        env.execute("testInnerJoinWithSameKey");
+
+        expectInAnyOrder(
+                "key:0:0", "key:0:1", "key:0:2", "key:1:0", "key:1:1", "key:1:2", "key:2:0",
+                "key:2:1", "key:2:2");
+    }
+
+    private static class KeyAndValue {
+        public final String key;
+        public final int value;
+
+        public KeyAndValue(String key, int value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        public static KeyAndValue of(String key, int value) {
+            return new KeyAndValue(key, value);
+        }
+    }
+
+    private NonKeyedPartitionStream<KeyAndValue> getSourceStream(
+            Collection<KeyAndValue> data, String sourceName) {
+        if (data.isEmpty()) {
+            return getEmptySourceStream(data, sourceName);
+        }
+        return env.fromSource(DataStreamV2SourceUtils.fromData(data), sourceName);
+    }
+
+    private NonKeyedPartitionStream<KeyAndValue> getEmptySourceStream(
+            Collection<KeyAndValue> data, String sourceName) {
+        // Since env#fromSource fails when the data is empty, we add a dummy record and then filter
+        // it out.
+        data.add(KeyAndValue.of("", -1));
+        NonKeyedPartitionStream<KeyAndValue> source =
+                env.fromSource(DataStreamV2SourceUtils.fromData(data), sourceName);
+        return source.process(
+                new OneInputStreamProcessFunction<KeyAndValue, KeyAndValue>() {
+                    @Override
+                    public void processRecord(
+                            KeyAndValue record,
+                            Collector<KeyAndValue> output,
+                            PartitionedContext<KeyAndValue> ctx)
+                            throws Exception {}
+                });
+    }
+
+    private static class TestJoinFunction
+            implements JoinFunction<KeyAndValue, KeyAndValue, String> {
+
+        @Override
+        public void processRecord(
+                KeyAndValue leftRecord,
+                KeyAndValue rightRecord,
+                Collector<String> output,
+                RuntimeContext ctx)
+                throws Exception {
+            assertThat(leftRecord.key).isNotNull();
+            assertThat(leftRecord.key).isEqualTo(rightRecord.key);
+            String result = leftRecord.key + ":" + leftRecord.value + ":" + rightRecord.value;
+            output.collect(result);
+        }
+    }
+
+    private static class TestSink implements Sink<String> {
+
+        @Override
+        public SinkWriter<String> createWriter(WriterInitContext context) throws IOException {
+            return new TestSinkWriter();
+        }
+    }
+
+    private static class TestSinkWriter implements SinkWriter<String> {
+        @Override
+        public void write(String element, Context context)
+                throws IOException, InterruptedException {
+            sinkResults.add(element);
+        }
+
+        @Override
+        public void flush(boolean endOfInput) throws IOException, InterruptedException {}
+
+        @Override
+        public void close() throws Exception {}
+    }
+
+    private static void expectInAnyOrder(String... expected) {
+        List<String> listExpected = Arrays.asList(expected);
+        Collections.sort(listExpected);
+        Collections.sort(sinkResults);
+        assertThat(listExpected).isEqualTo(sinkResults);
+    }
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/api/datastream/StatefulDataStreamV2ITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/api/datastream/StatefulDataStreamV2ITCase.java
@@ -166,7 +166,8 @@ class StatefulDataStreamV2ITCase {
         }
 
         @Override
-        public void processRecord(Long record, Collector<String> output, PartitionedContext ctx)
+        public void processRecord(
+                Long record, Collector<String> output, PartitionedContext<String> ctx)
                 throws Exception {
             Optional<AggregatingState<Long, Long>> maybeState =
                     ctx.getStateManager().getState(stateDeclaration);
@@ -191,7 +192,8 @@ class StatefulDataStreamV2ITCase {
         }
 
         @Override
-        public void processRecord(Long record, Collector<String> output, PartitionedContext ctx)
+        public void processRecord(
+                Long record, Collector<String> output, PartitionedContext<String> ctx)
                 throws Exception {
             Optional<ReducingState<Long>> maybeState =
                     ctx.getStateManager().getState(stateDeclaration);
@@ -219,7 +221,8 @@ class StatefulDataStreamV2ITCase {
         }
 
         @Override
-        public void processRecord(Long record, Collector<String> output, PartitionedContext ctx)
+        public void processRecord(
+                Long record, Collector<String> output, PartitionedContext<String> ctx)
                 throws Exception {
             Optional<MapState<Long, Long>> maybeState =
                     ctx.getStateManager().getState(stateDeclaration);
@@ -247,7 +250,8 @@ class StatefulDataStreamV2ITCase {
         }
 
         @Override
-        public void processRecord(Long record, Collector<String> output, PartitionedContext ctx)
+        public void processRecord(
+                Long record, Collector<String> output, PartitionedContext<String> ctx)
                 throws Exception {
             Optional<ListState<Long>> maybeState = ctx.getStateManager().getState(stateDeclaration);
             if (!maybeState.isPresent()) {
@@ -279,7 +283,8 @@ class StatefulDataStreamV2ITCase {
         }
 
         @Override
-        public void processRecord(Long record, Collector<String> output, PartitionedContext ctx)
+        public void processRecord(
+                Long record, Collector<String> output, PartitionedContext<String> ctx)
                 throws Exception {
             Optional<ValueState<Long>> maybeState =
                     ctx.getStateManager().getState(stateDeclaration);
@@ -308,7 +313,8 @@ class StatefulDataStreamV2ITCase {
         }
 
         @Override
-        public void processRecord(String record, Collector<Object> output, PartitionedContext ctx)
+        public void processRecord(
+                String record, Collector<Object> output, PartitionedContext<Object> ctx)
                 throws Exception {
             if (!allValues.contains(record)) {
                 throw new FlinkRuntimeException("Record not found: " + record);

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/api/datastream/WatermarkITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/api/datastream/WatermarkITCase.java
@@ -653,7 +653,7 @@ class WatermarkITCase {
         }
 
         @Override
-        public void processRecord(Long record, Collector<Long> output, PartitionedContext ctx)
+        public void processRecord(Long record, Collector<Long> output, PartitionedContext<Long> ctx)
                 throws Exception {
             receivedRecords.add(record);
             output.collect(record * 2);
@@ -722,7 +722,7 @@ class WatermarkITCase {
         }
 
         @Override
-        public void processRecord(Long record, Collector<Long> output, PartitionedContext ctx)
+        public void processRecord(Long record, Collector<Long> output, PartitionedContext<Long> ctx)
                 throws Exception {
             receivedRecords.add(record);
             output.collect(record + 1);
@@ -769,7 +769,7 @@ class WatermarkITCase {
         }
 
         @Override
-        public void processRecord(Long record, Collector<Long> output, PartitionedContext ctx)
+        public void processRecord(Long record, Collector<Long> output, PartitionedContext<Long> ctx)
                 throws Exception {
             receivedRecords.add(record);
         }


### PR DESCRIPTION
## What is the purpose of the change

Support Join Extension in DataStream V2 API

## Brief change log

More information see FLIP-500: 
https://cwiki.apache.org/confluence/x/ywz0Ew

## Verifying this change

This change added tests and can be verified as follows:
- Add integration test cases, org.apache.flink.test.streaming.api.datastream.JoinITCase
- Add unit test cases

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? I will add documentation in a future pull request.
