### PR TITLE
[WIP][hotfix] Add generics to places where PartitionedContext is used

### DIFF
--- a/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/function/ApplyPartitionFunction.java
+++ b/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/function/ApplyPartitionFunction.java
@@ -33,5 +33,5 @@ public interface ApplyPartitionFunction<OUT> extends Function {
      * @param collector to output data.
      * @param ctx runtime context in which this function is executed.
      */
-    void apply(Collector<OUT> collector, PartitionedContext ctx) throws Exception;
+    void apply(Collector<OUT> collector, PartitionedContext<OUT> ctx) throws Exception;
 }

--- a/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/function/OneInputStreamProcessFunction.java
+++ b/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/function/OneInputStreamProcessFunction.java
@@ -47,7 +47,8 @@ public interface OneInputStreamProcessFunction<IN, OUT> extends ProcessFunction 
      * @param output to emit processed records.
      * @param ctx runtime context in which this function is executed.
      */
-    void processRecord(IN record, Collector<OUT> output, PartitionedContext ctx) throws Exception;
+    void processRecord(IN record, Collector<OUT> output, PartitionedContext<OUT> ctx)
+            throws Exception;
 
     /**
      * This is a life-cycle method indicates that this function will no longer receive any data from
@@ -64,7 +65,8 @@ public interface OneInputStreamProcessFunction<IN, OUT> extends ProcessFunction 
      * @param output to emit record.
      * @param ctx runtime context in which this function is executed.
      */
-    default void onProcessingTimer(long timestamp, Collector<OUT> output, PartitionedContext ctx) {}
+    default void onProcessingTimer(
+            long timestamp, Collector<OUT> output, PartitionedContext<OUT> ctx) {}
 
     /** Callback function when receive watermark. */
     default WatermarkHandlingResult onWatermark(

--- a/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/function/TwoInputBroadcastStreamProcessFunction.java
+++ b/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/function/TwoInputBroadcastStreamProcessFunction.java
@@ -51,7 +51,7 @@ public interface TwoInputBroadcastStreamProcessFunction<IN1, IN2, OUT> extends P
      * @param ctx runtime context in which this function is executed.
      */
     void processRecordFromNonBroadcastInput(
-            IN1 record, Collector<OUT> output, PartitionedContext ctx) throws Exception;
+            IN1 record, Collector<OUT> output, PartitionedContext<OUT> ctx) throws Exception;
 
     /**
      * Process record from broadcast input. In general, the broadcast side is not allowed to
@@ -87,7 +87,8 @@ public interface TwoInputBroadcastStreamProcessFunction<IN1, IN2, OUT> extends P
      * @param output to emit record.
      * @param ctx runtime context in which this function is executed.
      */
-    default void onProcessingTimer(long timestamp, Collector<OUT> output, PartitionedContext ctx) {}
+    default void onProcessingTimer(
+            long timestamp, Collector<OUT> output, PartitionedContext<OUT> ctx) {}
 
     /**
      * Callback function when receive the watermark from broadcast input.

--- a/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/function/TwoInputNonBroadcastStreamProcessFunction.java
+++ b/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/function/TwoInputNonBroadcastStreamProcessFunction.java
@@ -47,7 +47,7 @@ public interface TwoInputNonBroadcastStreamProcessFunction<IN1, IN2, OUT> extend
      * @param output to emit processed records.
      * @param ctx runtime context in which this function is executed.
      */
-    void processRecordFromFirstInput(IN1 record, Collector<OUT> output, PartitionedContext ctx)
+    void processRecordFromFirstInput(IN1 record, Collector<OUT> output, PartitionedContext<OUT> ctx)
             throws Exception;
 
     /**
@@ -57,8 +57,8 @@ public interface TwoInputNonBroadcastStreamProcessFunction<IN1, IN2, OUT> extend
      * @param output to emit processed records.
      * @param ctx runtime context in which this function is executed.
      */
-    void processRecordFromSecondInput(IN2 record, Collector<OUT> output, PartitionedContext ctx)
-            throws Exception;
+    void processRecordFromSecondInput(
+            IN2 record, Collector<OUT> output, PartitionedContext<OUT> ctx) throws Exception;
 
     /**
      * This is a life-cycle method indicates that this function will no longer receive any data from
@@ -83,7 +83,8 @@ public interface TwoInputNonBroadcastStreamProcessFunction<IN1, IN2, OUT> extend
      * @param output to emit record.
      * @param ctx runtime context in which this function is executed.
      */
-    default void onProcessingTimer(long timestamp, Collector<OUT> output, PartitionedContext ctx) {}
+    default void onProcessingTimer(
+            long timestamp, Collector<OUT> output, PartitionedContext<OUT> ctx) {}
 
     /**
      * Callback function when receive the watermark from the first input.

--- a/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/function/TwoOutputApplyPartitionFunction.java
+++ b/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/function/TwoOutputApplyPartitionFunction.java
@@ -37,6 +37,6 @@ public interface TwoOutputApplyPartitionFunction<OUT1, OUT2> extends Function {
     void apply(
             Collector<OUT1> firstOutput,
             Collector<OUT2> secondOutput,
-            TwoOutputPartitionedContext ctx)
+            TwoOutputPartitionedContext<OUT1, OUT2> ctx)
             throws Exception;
 }

--- a/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/function/TwoOutputStreamProcessFunction.java
+++ b/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/function/TwoOutputStreamProcessFunction.java
@@ -52,7 +52,7 @@ public interface TwoOutputStreamProcessFunction<IN, OUT1, OUT2> extends ProcessF
             IN record,
             Collector<OUT1> output1,
             Collector<OUT2> output2,
-            TwoOutputPartitionedContext ctx)
+            TwoOutputPartitionedContext<OUT1, OUT2> ctx)
             throws Exception;
 
     /**
@@ -75,7 +75,7 @@ public interface TwoOutputStreamProcessFunction<IN, OUT1, OUT2> extends ProcessF
             long timestamp,
             Collector<OUT1> output1,
             Collector<OUT2> output2,
-            TwoOutputPartitionedContext ctx) {}
+            TwoOutputPartitionedContext<OUT1, OUT2> ctx) {}
 
     /**
      * Callback function when receive the watermark from the input.

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/ExecutionEnvironmentImplTest.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/ExecutionEnvironmentImplTest.java
@@ -113,7 +113,7 @@ class ExecutionEnvironmentImplTest {
                 new OneInputStreamProcessFunction<Long, Long>() {
                     @Override
                     public void processRecord(
-                            Long record, Collector<Long> output, PartitionedContext ctx)
+                            Long record, Collector<Long> output, PartitionedContext<Long> ctx)
                             throws Exception {
                         // do nothing.
                     }

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/attribute/StreamingJobGraphGeneratorWithAttributeTest.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/attribute/StreamingJobGraphGeneratorWithAttributeTest.java
@@ -212,7 +212,7 @@ class StreamingJobGraphGeneratorWithAttributeTest {
 
         @Override
         public void processRecord(
-                Integer record, Collector<Integer> output, PartitionedContext ctx) {
+                Integer record, Collector<Integer> output, PartitionedContext<Integer> ctx) {
             output.collect(record + 1);
         }
     }
@@ -221,7 +221,7 @@ class StreamingJobGraphGeneratorWithAttributeTest {
 
         @Override
         public void processRecord(
-                Integer record, Collector<Integer> output, PartitionedContext ctx) {
+                Integer record, Collector<Integer> output, PartitionedContext<Integer> ctx) {
             if (record != 2) {
                 output.collect(record + 1);
             }
@@ -237,7 +237,7 @@ class StreamingJobGraphGeneratorWithAttributeTest {
                 Integer record,
                 Collector<Integer> output1,
                 Collector<Integer> output2,
-                TwoOutputPartitionedContext ctx) {
+                TwoOutputPartitionedContext<Integer, Integer> ctx) {
             output1.collect(record + 1);
             output2.collect(record - 1);
         }

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/functions/ProcessFunctionTest.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/functions/ProcessFunctionTest.java
@@ -59,7 +59,9 @@ public class ProcessFunctionTest {
 
                     @Override
                     public void processRecord(
-                            Integer record, Collector<Integer> output, PartitionedContext ctx)
+                            Integer record,
+                            Collector<Integer> output,
+                            PartitionedContext<Integer> ctx)
                             throws Exception {}
 
                     @Override
@@ -94,7 +96,9 @@ public class ProcessFunctionTest {
 
                     @Override
                     public void processRecordFromNonBroadcastInput(
-                            Integer record, Collector<Integer> output, PartitionedContext ctx)
+                            Integer record,
+                            Collector<Integer> output,
+                            PartitionedContext<Integer> ctx)
                             throws Exception {}
 
                     @Override
@@ -134,12 +138,16 @@ public class ProcessFunctionTest {
 
                     @Override
                     public void processRecordFromFirstInput(
-                            Integer record, Collector<Integer> output, PartitionedContext ctx)
+                            Integer record,
+                            Collector<Integer> output,
+                            PartitionedContext<Integer> ctx)
                             throws Exception {}
 
                     @Override
                     public void processRecordFromSecondInput(
-                            Integer record, Collector<Integer> output, PartitionedContext ctx)
+                            Integer record,
+                            Collector<Integer> output,
+                            PartitionedContext<Integer> ctx)
                             throws Exception {}
 
                     @Override
@@ -179,7 +187,7 @@ public class ProcessFunctionTest {
                             Integer record,
                             Collector<Integer> output1,
                             Collector<Integer> output2,
-                            TwoOutputPartitionedContext ctx)
+                            TwoOutputPartitionedContext<Integer, Integer> ctx)
                             throws Exception {}
 
                     @Override

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/KeyedProcessOperatorTest.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/KeyedProcessOperatorTest.java
@@ -46,7 +46,7 @@ class KeyedProcessOperatorTest {
                             public void processRecord(
                                     Integer record,
                                     Collector<Integer> output,
-                                    PartitionedContext ctx) {
+                                    PartitionedContext<Integer> ctx) {
                                 output.collect(record + 1);
                             }
                         });
@@ -78,7 +78,7 @@ class KeyedProcessOperatorTest {
                             public void processRecord(
                                     Integer record,
                                     Collector<Integer> output,
-                                    PartitionedContext ctx) {
+                                    PartitionedContext<Integer> ctx) {
                                 // do nothing.
                             }
 
@@ -125,7 +125,7 @@ class KeyedProcessOperatorTest {
                             public void processRecord(
                                     Integer record,
                                     Collector<Integer> output,
-                                    PartitionedContext ctx) {
+                                    PartitionedContext<Integer> ctx) {
                                 // forward the record to check input key.
                                 output.collect(record);
                             }

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/KeyedTwoInputBroadcastProcessOperatorTest.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/KeyedTwoInputBroadcastProcessOperatorTest.java
@@ -50,7 +50,7 @@ class KeyedTwoInputBroadcastProcessOperatorTest {
                             public void processRecordFromNonBroadcastInput(
                                     Integer record,
                                     Collector<Long> output,
-                                    PartitionedContext ctx) {
+                                    PartitionedContext<Long> ctx) {
                                 fromNonBroadcastInput.add(record);
                             }
 
@@ -89,7 +89,7 @@ class KeyedTwoInputBroadcastProcessOperatorTest {
                             public void processRecordFromNonBroadcastInput(
                                     Integer record,
                                     Collector<Long> output,
-                                    PartitionedContext ctx) {
+                                    PartitionedContext<Long> ctx) {
                                 //  do nothing.
                             }
 
@@ -161,7 +161,7 @@ class KeyedTwoInputBroadcastProcessOperatorTest {
                             public void processRecordFromNonBroadcastInput(
                                     Integer record,
                                     Collector<Long> output,
-                                    PartitionedContext ctx) {
+                                    PartitionedContext<Long> ctx) {
                                 output.collect(Long.valueOf(record));
                             }
 

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/KeyedTwoInputNonBroadcastProcessOperatorTest.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/KeyedTwoInputNonBroadcastProcessOperatorTest.java
@@ -46,13 +46,15 @@ class KeyedTwoInputNonBroadcastProcessOperatorTest {
                             public void processRecordFromFirstInput(
                                     Integer record,
                                     Collector<Long> output,
-                                    PartitionedContext ctx) {
+                                    PartitionedContext<Long> ctx) {
                                 output.collect(Long.valueOf(record));
                             }
 
                             @Override
                             public void processRecordFromSecondInput(
-                                    Long record, Collector<Long> output, PartitionedContext ctx) {
+                                    Long record,
+                                    Collector<Long> output,
+                                    PartitionedContext<Long> ctx) {
                                 output.collect(record);
                             }
                         });
@@ -89,13 +91,15 @@ class KeyedTwoInputNonBroadcastProcessOperatorTest {
                             public void processRecordFromFirstInput(
                                     Integer record,
                                     Collector<Long> output,
-                                    PartitionedContext ctx) {
+                                    PartitionedContext<Long> ctx) {
                                 // do nothing.
                             }
 
                             @Override
                             public void processRecordFromSecondInput(
-                                    Long record, Collector<Long> output, PartitionedContext ctx) {
+                                    Long record,
+                                    Collector<Long> output,
+                                    PartitionedContext<Long> ctx) {
                                 // do nothing.
                             }
 
@@ -164,13 +168,15 @@ class KeyedTwoInputNonBroadcastProcessOperatorTest {
                             public void processRecordFromFirstInput(
                                     Integer record,
                                     Collector<Long> output,
-                                    PartitionedContext ctx) {
+                                    PartitionedContext<Long> ctx) {
                                 output.collect(Long.valueOf(record));
                             }
 
                             @Override
                             public void processRecordFromSecondInput(
-                                    Long record, Collector<Long> output, PartitionedContext ctx) {
+                                    Long record,
+                                    Collector<Long> output,
+                                    PartitionedContext<Long> ctx) {
                                 output.collect(record);
                             }
                         },

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/KeyedTwoOutputProcessOperatorTest.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/KeyedTwoOutputProcessOperatorTest.java
@@ -52,7 +52,7 @@ class KeyedTwoOutputProcessOperatorTest {
                                     Integer record,
                                     Collector<Integer> output1,
                                     Collector<Long> output2,
-                                    TwoOutputPartitionedContext ctx) {
+                                    TwoOutputPartitionedContext<Integer, Long> ctx) {
                                 output1.collect(record);
                                 output2.collect((long) (record * 2));
                             }
@@ -93,7 +93,7 @@ class KeyedTwoOutputProcessOperatorTest {
                                     Integer record,
                                     Collector<Integer> output1,
                                     Collector<Long> output2,
-                                    TwoOutputPartitionedContext ctx) {
+                                    TwoOutputPartitionedContext<Integer, Long> ctx) {
                                 // do nothing.
                             }
 
@@ -147,7 +147,7 @@ class KeyedTwoOutputProcessOperatorTest {
                                     Integer record,
                                     Collector<Integer> output1,
                                     Collector<Long> output2,
-                                    TwoOutputPartitionedContext ctx) {
+                                    TwoOutputPartitionedContext<Integer, Long> ctx) {
                                 if (emitToFirstOutput.get()) {
                                     output1.collect(record);
                                 } else {

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/MockFreqCountProcessFunction.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/MockFreqCountProcessFunction.java
@@ -44,7 +44,8 @@ public class MockFreqCountProcessFunction
     }
 
     @Override
-    public void processRecord(Integer record, Collector<Integer> output, PartitionedContext ctx)
+    public void processRecord(
+            Integer record, Collector<Integer> output, PartitionedContext<Integer> ctx)
             throws Exception {
         Optional<MapState<Integer, Integer>> stateOptional =
                 ctx.getStateManager().getState(mapStateDeclaration);

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/MockGlobalDecuplicateCountProcessFunction.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/MockGlobalDecuplicateCountProcessFunction.java
@@ -47,7 +47,8 @@ public class MockGlobalDecuplicateCountProcessFunction
     }
 
     @Override
-    public void processRecord(Integer record, Collector<Integer> output, PartitionedContext ctx)
+    public void processRecord(
+            Integer record, Collector<Integer> output, PartitionedContext<Integer> ctx)
             throws Exception {
         Optional<BroadcastState<Integer, Integer>> stateOptional =
                 ctx.getStateManager().getState(broadcastStateDeclaration);

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/MockGlobalListAppenderProcessFunction.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/MockGlobalListAppenderProcessFunction.java
@@ -62,7 +62,8 @@ public class MockGlobalListAppenderProcessFunction
     }
 
     @Override
-    public void processRecord(Integer record, Collector<Integer> output, PartitionedContext ctx)
+    public void processRecord(
+            Integer record, Collector<Integer> output, PartitionedContext<Integer> ctx)
             throws Exception {
         Optional<ListState<Integer>> stateOptional =
                 ctx.getStateManager().getState(listStateDeclaration);

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/MockListAppenderProcessFunction.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/MockListAppenderProcessFunction.java
@@ -61,7 +61,8 @@ public class MockListAppenderProcessFunction
     }
 
     @Override
-    public void processRecord(Integer record, Collector<Integer> output, PartitionedContext ctx)
+    public void processRecord(
+            Integer record, Collector<Integer> output, PartitionedContext<Integer> ctx)
             throws Exception {
         Optional<ListState<Integer>> stateOptional =
                 ctx.getStateManager().getState(listStateDeclaration);

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/MockMultiplierProcessFunction.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/MockMultiplierProcessFunction.java
@@ -44,7 +44,8 @@ public class MockMultiplierProcessFunction
     }
 
     @Override
-    public void processRecord(Integer record, Collector<Integer> output, PartitionedContext ctx)
+    public void processRecord(
+            Integer record, Collector<Integer> output, PartitionedContext<Integer> ctx)
             throws Exception {
         Optional<ValueState<Integer>> stateOptional =
                 ctx.getStateManager().getState(valueStateDeclaration);

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/MockRecudingMultiplierProcessFunction.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/MockRecudingMultiplierProcessFunction.java
@@ -53,7 +53,8 @@ public class MockRecudingMultiplierProcessFunction
     }
 
     @Override
-    public void processRecord(Integer record, Collector<Integer> output, PartitionedContext ctx)
+    public void processRecord(
+            Integer record, Collector<Integer> output, PartitionedContext<Integer> ctx)
             throws Exception {
         Optional<ReducingState<Integer>> stateOptional =
                 ctx.getStateManager().getState(reducingStateDeclaration);

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/MockSumAggregateProcessFunction.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/MockSumAggregateProcessFunction.java
@@ -69,7 +69,8 @@ public class MockSumAggregateProcessFunction
     }
 
     @Override
-    public void processRecord(Integer record, Collector<Integer> output, PartitionedContext ctx)
+    public void processRecord(
+            Integer record, Collector<Integer> output, PartitionedContext<Integer> ctx)
             throws Exception {
         Optional<AggregatingState<Integer, Integer>> stateOptional =
                 ctx.getStateManager().getState(aggregatingStateDeclaration);

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/ProcessOperatorTest.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/ProcessOperatorTest.java
@@ -65,7 +65,7 @@ class ProcessOperatorTest {
                             public void processRecord(
                                     Integer record,
                                     Collector<String> output,
-                                    PartitionedContext ctx) {
+                                    PartitionedContext<String> ctx) {
                                 //  do nothing.
                             }
 

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/TwoInputBroadcastProcessOperatorTest.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/TwoInputBroadcastProcessOperatorTest.java
@@ -48,7 +48,7 @@ class TwoInputBroadcastProcessOperatorTest {
                             public void processRecordFromNonBroadcastInput(
                                     Integer record,
                                     Collector<Long> output,
-                                    PartitionedContext ctx) {
+                                    PartitionedContext<Long> ctx) {
                                 fromNonBroadcastInput.add(Long.valueOf(record));
                             }
 
@@ -84,7 +84,7 @@ class TwoInputBroadcastProcessOperatorTest {
                             public void processRecordFromNonBroadcastInput(
                                     Integer record,
                                     Collector<Long> output,
-                                    PartitionedContext ctx) {
+                                    PartitionedContext<Long> ctx) {
                                 // do nothing.
                             }
 

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/TwoInputNonBroadcastProcessOperatorTest.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/TwoInputNonBroadcastProcessOperatorTest.java
@@ -43,13 +43,15 @@ class TwoInputNonBroadcastProcessOperatorTest {
                             public void processRecordFromFirstInput(
                                     Integer record,
                                     Collector<Long> output,
-                                    PartitionedContext ctx) {
+                                    PartitionedContext<Long> ctx) {
                                 output.collect(Long.valueOf(record));
                             }
 
                             @Override
                             public void processRecordFromSecondInput(
-                                    Long record, Collector<Long> output, PartitionedContext ctx) {
+                                    Long record,
+                                    Collector<Long> output,
+                                    PartitionedContext<Long> ctx) {
                                 output.collect(record);
                             }
                         });
@@ -82,14 +84,18 @@ class TwoInputNonBroadcastProcessOperatorTest {
                         new TwoInputNonBroadcastStreamProcessFunction<Integer, Long, Long>() {
                             @Override
                             public void processRecordFromFirstInput(
-                                    Integer record, Collector<Long> output, PartitionedContext ctx)
+                                    Integer record,
+                                    Collector<Long> output,
+                                    PartitionedContext<Long> ctx)
                                     throws Exception {
                                 // do nothing.
                             }
 
                             @Override
                             public void processRecordFromSecondInput(
-                                    Long record, Collector<Long> output, PartitionedContext ctx)
+                                    Long record,
+                                    Collector<Long> output,
+                                    PartitionedContext<Long> ctx)
                                     throws Exception {
                                 // do nothing.
                             }

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/TwoOutputProcessOperatorTest.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/TwoOutputProcessOperatorTest.java
@@ -48,7 +48,7 @@ class TwoOutputProcessOperatorTest {
                                     Integer record,
                                     Collector<Integer> output1,
                                     Collector<Long> output2,
-                                    TwoOutputPartitionedContext ctx) {
+                                    TwoOutputPartitionedContext<Integer, Long> ctx) {
                                 output1.collect(record);
                                 output2.collect((long) (record * 2));
                             }
@@ -86,7 +86,7 @@ class TwoOutputProcessOperatorTest {
                                     Integer record,
                                     Collector<Integer> output1,
                                     Collector<Long> output2,
-                                    TwoOutputPartitionedContext ctx) {
+                                    TwoOutputPartitionedContext<Integer, Long> ctx) {
                                 // do nothing.
                             }
 

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/stream/StreamTestUtils.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/stream/StreamTestUtils.java
@@ -81,7 +81,8 @@ public final class StreamTestUtils {
         }
 
         @Override
-        public void processRecord(Integer record, Collector<Long> output, PartitionedContext ctx) {
+        public void processRecord(
+                Integer record, Collector<Long> output, PartitionedContext<Long> ctx) {
             // do nothing.
         }
     }
@@ -110,7 +111,7 @@ public final class StreamTestUtils {
                 Integer record,
                 Collector<Integer> output1,
                 Collector<Long> output2,
-                TwoOutputPartitionedContext ctx) {
+                TwoOutputPartitionedContext<Integer, Long> ctx) {
             //  do nothing.
         }
     }
@@ -139,13 +140,14 @@ public final class StreamTestUtils {
 
         @Override
         public void processRecordFromFirstInput(
-                Integer record, Collector<Long> output, PartitionedContext ctx) {
+                Integer record, Collector<Long> output, PartitionedContext<Long> ctx) {
             // do nothing.
         }
 
         @Override
         public void processRecordFromSecondInput(
-                Long record, Collector<Long> output, PartitionedContext ctx) throws Exception {
+                Long record, Collector<Long> output, PartitionedContext<Long> ctx)
+                throws Exception {
             // do nothing.
         }
     }
@@ -174,7 +176,7 @@ public final class StreamTestUtils {
 
         @Override
         public void processRecordFromNonBroadcastInput(
-                Long record, Collector<Long> output, PartitionedContext ctx) {
+                Long record, Collector<Long> output, PartitionedContext<Long> ctx) {
             // do nothing.
         }
 

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/utils/StreamUtilsTest.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/utils/StreamUtilsTest.java
@@ -53,7 +53,9 @@ class StreamUtilsTest {
                         new OneInputStreamProcessFunction<Integer, Long>() {
                             @Override
                             public void processRecord(
-                                    Integer record, Collector<Long> output, PartitionedContext ctx)
+                                    Integer record,
+                                    Collector<Long> output,
+                                    PartitionedContext<Long> ctx)
                                     throws Exception {
                                 // ignore
                             }
@@ -83,14 +85,16 @@ class StreamUtilsTest {
                             public void processRecordFromFirstInput(
                                     Integer record,
                                     Collector<String> output,
-                                    PartitionedContext ctx)
+                                    PartitionedContext<String> ctx)
                                     throws Exception {
                                 // ignore
                             }
 
                             @Override
                             public void processRecordFromSecondInput(
-                                    Long record, Collector<String> output, PartitionedContext ctx)
+                                    Long record,
+                                    Collector<String> output,
+                                    PartitionedContext<String> ctx)
                                     throws Exception {
                                 // ignore
                             }
@@ -106,7 +110,7 @@ class StreamUtilsTest {
                             public void processRecordFromNonBroadcastInput(
                                     Integer record,
                                     Collector<String> output,
-                                    PartitionedContext ctx)
+                                    PartitionedContext<String> ctx)
                                     throws Exception {
                                 // ignore
                             }
@@ -133,7 +137,7 @@ class StreamUtilsTest {
                                     Integer record,
                                     Collector<Long> output1,
                                     Collector<String> output2,
-                                    TwoOutputPartitionedContext ctx)
+                                    TwoOutputPartitionedContext<Long, String> ctx)
                                     throws Exception {
                                 // ignore
                             }

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/utils/WatermarkUtilsTest.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/utils/WatermarkUtilsTest.java
@@ -119,7 +119,7 @@ class WatermarkUtilsTest {
                             public void processRecord(
                                     Integer record,
                                     Collector<Integer> output,
-                                    PartitionedContext ctx)
+                                    PartitionedContext<Integer> ctx)
                                     throws Exception {}
 
                             @Override
@@ -137,7 +137,7 @@ class WatermarkUtilsTest {
                                             Integer record,
                                             Collector<Integer> output1,
                                             Collector<Integer> output2,
-                                            TwoOutputPartitionedContext ctx)
+                                            TwoOutputPartitionedContext<Integer, Integer> ctx)
                                             throws Exception {}
 
                                     @Override

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/api/datastream/StatefulDataStreamV2ITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/api/datastream/StatefulDataStreamV2ITCase.java
@@ -166,7 +166,8 @@ class StatefulDataStreamV2ITCase {
         }
 
         @Override
-        public void processRecord(Long record, Collector<String> output, PartitionedContext ctx)
+        public void processRecord(
+                Long record, Collector<String> output, PartitionedContext<String> ctx)
                 throws Exception {
             Optional<AggregatingState<Long, Long>> maybeState =
                     ctx.getStateManager().getState(stateDeclaration);
@@ -191,7 +192,8 @@ class StatefulDataStreamV2ITCase {
         }
 
         @Override
-        public void processRecord(Long record, Collector<String> output, PartitionedContext ctx)
+        public void processRecord(
+                Long record, Collector<String> output, PartitionedContext<String> ctx)
                 throws Exception {
             Optional<ReducingState<Long>> maybeState =
                     ctx.getStateManager().getState(stateDeclaration);
@@ -219,7 +221,8 @@ class StatefulDataStreamV2ITCase {
         }
 
         @Override
-        public void processRecord(Long record, Collector<String> output, PartitionedContext ctx)
+        public void processRecord(
+                Long record, Collector<String> output, PartitionedContext<String> ctx)
                 throws Exception {
             Optional<MapState<Long, Long>> maybeState =
                     ctx.getStateManager().getState(stateDeclaration);
@@ -247,7 +250,8 @@ class StatefulDataStreamV2ITCase {
         }
 
         @Override
-        public void processRecord(Long record, Collector<String> output, PartitionedContext ctx)
+        public void processRecord(
+                Long record, Collector<String> output, PartitionedContext<String> ctx)
                 throws Exception {
             Optional<ListState<Long>> maybeState = ctx.getStateManager().getState(stateDeclaration);
             if (!maybeState.isPresent()) {
@@ -279,7 +283,8 @@ class StatefulDataStreamV2ITCase {
         }
 
         @Override
-        public void processRecord(Long record, Collector<String> output, PartitionedContext ctx)
+        public void processRecord(
+                Long record, Collector<String> output, PartitionedContext<String> ctx)
                 throws Exception {
             Optional<ValueState<Long>> maybeState =
                     ctx.getStateManager().getState(stateDeclaration);
@@ -308,7 +313,8 @@ class StatefulDataStreamV2ITCase {
         }
 
         @Override
-        public void processRecord(String record, Collector<Object> output, PartitionedContext ctx)
+        public void processRecord(
+                String record, Collector<Object> output, PartitionedContext<Object> ctx)
                 throws Exception {
             if (!allValues.contains(record)) {
                 throw new FlinkRuntimeException("Record not found: " + record);

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/api/datastream/WatermarkITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/api/datastream/WatermarkITCase.java
@@ -653,7 +653,7 @@ class WatermarkITCase {
         }
 
         @Override
-        public void processRecord(Long record, Collector<Long> output, PartitionedContext ctx)
+        public void processRecord(Long record, Collector<Long> output, PartitionedContext<Long> ctx)
                 throws Exception {
             receivedRecords.add(record);
             output.collect(record * 2);
@@ -722,7 +722,7 @@ class WatermarkITCase {
         }
 
         @Override
-        public void processRecord(Long record, Collector<Long> output, PartitionedContext ctx)
+        public void processRecord(Long record, Collector<Long> output, PartitionedContext<Long> ctx)
                 throws Exception {
             receivedRecords.add(record);
             output.collect(record + 1);
@@ -769,7 +769,7 @@ class WatermarkITCase {
         }
 
         @Override
-        public void processRecord(Long record, Collector<Long> output, PartitionedContext ctx)
+        public void processRecord(Long record, Collector<Long> output, PartitionedContext<Long> ctx)
                 throws Exception {
             receivedRecords.add(record);
         }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
