### PR TITLE
[FLINK-35512][tests] Do not depend on the `flink-clients` jar in `ArtifactFetchManagerTest`

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/program/artifact/ArtifactFetchManagerTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/artifact/ArtifactFetchManagerTest.java
@@ -95,10 +95,12 @@ class ArtifactFetchManagerTest {
     }
 
     @Test
-    void testFileSystemFetchWithAdditionalUri() throws Exception {
+    void testFileSystemFetchWithAdditionalUri(@TempDir Path pseudoJarDir) throws Exception {
         File sourceFile = TestingUtils.getClassFile(getClass());
         String uriStr = "file://" + sourceFile.toURI().getPath();
-        File additionalSrcFile = getFlinkClientsJar();
+        File additionalSrcFile =
+                Files.createTempFile(pseudoJarDir, "testFileSystemFetchWithAdditionalUri", ".jar")
+                        .toFile();
         String additionalUriStr = "file://" + additionalSrcFile.toURI().getPath();
 
         ArtifactFetchManager fetchMgr = new ArtifactFetchManager(configuration);
@@ -112,12 +114,12 @@ class ArtifactFetchManagerTest {
     }
 
     @Test
-    void testHttpFetch() throws Exception {
+    void testHttpFetch(@TempDir Path pseudoJarDir) throws Exception {
         configuration.set(ArtifactFetchOptions.RAW_HTTP_ENABLED, true);
         HttpServer httpServer = null;
         try {
             httpServer = startHttpServer();
-            File sourceFile = getFlinkClientsJar();
+            File sourceFile = Files.createTempFile(pseudoJarDir, "testHttpFetch", ".jar").toFile();
             httpServer.createContext(
                     "/download/" + sourceFile.getName(), new DummyHttpDownloadHandler(sourceFile));
             String uriStr =
@@ -138,10 +140,11 @@ class ArtifactFetchManagerTest {
     }
 
     @Test
-    void testMixedArtifactFetch() throws Exception {
+    void testMixedArtifactFetch(@TempDir Path pseudoJarDir) throws Exception {
         File sourceFile = TestingUtils.getClassFile(getClass());
         String uriStr = "file://" + sourceFile.toURI().getPath();
-        File sourceFile2 = getFlinkClientsJar();
+        File sourceFile2 =
+                Files.createTempFile(pseudoJarDir, "testMixedArtifactFetch", ".jar").toFile();
         String uriStr2 = "file://" + sourceFile2.toURI().getPath();
 
         ArtifactFetchManager fetchMgr = new ArtifactFetchManager(configuration);
@@ -228,15 +231,6 @@ class ArtifactFetchManagerTest {
             }
         }
         return httpServer;
-    }
-
-    private File getFlinkClientsJar() throws IOException {
-        return TestingUtils.getFileFromTargetDir(
-                ArtifactFetchManager.class,
-                p ->
-                        org.apache.flink.util.FileUtils.isJarFile(p)
-                                && p.toFile().getName().startsWith("flink-clients")
-                                && !p.toFile().getName().contains("test-utils"));
     }
 
     private static class DummyHttpDownloadHandler implements HttpHandler {

--- a/flink-core/src/test/java/org/apache/flink/testutils/TestingUtils.java
+++ b/flink-core/src/test/java/org/apache/flink/testutils/TestingUtils.java
@@ -80,7 +80,9 @@ public class TestingUtils {
 
         final Collection<Path> jarPaths =
                 org.apache.flink.util.FileUtils.listFilesInDirectory(mvnTargetDir, fileFilter);
-        assertThat(jarPaths).isNotEmpty();
+        assertThat(jarPaths)
+                .describedAs("Could not find any matching files in %s", mvnTargetDir)
+                .isNotEmpty();
 
         return jarPaths.iterator().next().toFile();
     }


### PR DESCRIPTION
Added the requested changes in https://github.com/apache/flink/pull/24931, keeping the original author.