### PR TITLE
[FLINK-36707][table] Add output strategy to SystemTypeInference

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/StaticArgumentTrait.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/StaticArgumentTrait.java
@@ -37,7 +37,8 @@ public enum StaticArgumentTrait {
     MODEL(),
     TABLE_AS_ROW(TABLE),
     TABLE_AS_SET(TABLE),
-    OPTIONAL_PARTITION_BY(TABLE_AS_SET);
+    OPTIONAL_PARTITION_BY(TABLE_AS_SET),
+    PASS_COLUMNS_THROUGH(TABLE);
 
     private final Set<StaticArgumentTrait> requirements;
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -1203,7 +1203,7 @@ public class SqlToRelConverter {
                 if (!config.isExpand()) {
                     return;
                 }
-                // fall through
+            // fall through
             case MULTISET_VALUE_CONSTRUCTOR:
                 rel = convertMultisets(ImmutableList.of(subQuery.node), bb);
                 subQuery.expr = bb.register(rel, JoinRelType.INNER);
@@ -2113,9 +2113,9 @@ public class SqlToRelConverter {
         }
         if (node instanceof SqlCall) {
             switch (kind) {
-                    // Do no change logic for AND, IN and NOT IN expressions;
-                    // but do change logic for OR, NOT and others;
-                    // EXISTS was handled already.
+                // Do no change logic for AND, IN and NOT IN expressions;
+                // but do change logic for OR, NOT and others;
+                // EXISTS was handled already.
                 case AND:
                 case IN:
                 case NOT_IN:
@@ -2246,7 +2246,7 @@ public class SqlToRelConverter {
         switch (aggCall.getKind()) {
             case IGNORE_NULLS:
                 ignoreNulls = true;
-                // fall through
+            // fall through
             case RESPECT_NULLS:
                 aggCall = aggCall.operand(0);
                 break;
@@ -5536,7 +5536,7 @@ public class SqlToRelConverter {
                     if (config.isExpand()) {
                         throw new RuntimeException(kind + " is only supported if expand = false");
                     }
-                    // fall through
+                // fall through
                 case CURSOR:
                 case IN:
                 case NOT_IN:
@@ -6166,7 +6166,7 @@ public class SqlToRelConverter {
                     return;
                 case IGNORE_NULLS:
                     ignoreNulls = true;
-                    // fall through
+                // fall through
                 case RESPECT_NULLS:
                     translateAgg(
                             call.operand(0),
@@ -6247,8 +6247,8 @@ public class SqlToRelConverter {
                                 call2, filter, distinctList, orderList, ignoreNulls, outerCall);
                         return;
                     }
-                    // "ARRAY_AGG" and "ARRAY_CONCAT_AGG" without "ORDER BY"
-                    // are handled normally; fall through.
+                // "ARRAY_AGG" and "ARRAY_CONCAT_AGG" without "ORDER BY"
+                // are handled normally; fall through.
 
                 default:
                     break;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -249,8 +249,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *   <li>Added in FLINK-32474: Lines 2499 ~ 2501
  *   <li>Added in FLINK-32474: Lines 2906 ~ 2918
  *   <li>Added in FLINK-32474: Lines 3019 ~ 3053
- *   <li>Added in FLINK-34312: Lines 5693 ~ 5696
- *   <li>Added in FLINK-34057, FLINK-34058, FLINK-34312: Lines 6144 ~ 6162
+ *   <li>Added in FLINK-34312: Lines 5804 ~ 5813
+ *   <li>Added in FLINK-34057, FLINK-34058, FLINK-34312: Lines 6263 ~ 66279
  * </ol>
  */
 @SuppressWarnings("UnstableApiUsage")
@@ -1203,7 +1203,7 @@ public class SqlToRelConverter {
                 if (!config.isExpand()) {
                     return;
                 }
-            // fall through
+                // fall through
             case MULTISET_VALUE_CONSTRUCTOR:
                 rel = convertMultisets(ImmutableList.of(subQuery.node), bb);
                 subQuery.expr = bb.register(rel, JoinRelType.INNER);
@@ -2113,9 +2113,9 @@ public class SqlToRelConverter {
         }
         if (node instanceof SqlCall) {
             switch (kind) {
-                // Do no change logic for AND, IN and NOT IN expressions;
-                // but do change logic for OR, NOT and others;
-                // EXISTS was handled already.
+                    // Do no change logic for AND, IN and NOT IN expressions;
+                    // but do change logic for OR, NOT and others;
+                    // EXISTS was handled already.
                 case AND:
                 case IN:
                 case NOT_IN:
@@ -2246,7 +2246,7 @@ public class SqlToRelConverter {
         switch (aggCall.getKind()) {
             case IGNORE_NULLS:
                 ignoreNulls = true;
-            // fall through
+                // fall through
             case RESPECT_NULLS:
                 aggCall = aggCall.operand(0);
                 break;
@@ -5536,7 +5536,7 @@ public class SqlToRelConverter {
                     if (config.isExpand()) {
                         throw new RuntimeException(kind + " is only supported if expand = false");
                     }
-                // fall through
+                    // fall through
                 case CURSOR:
                 case IN:
                 case NOT_IN:
@@ -5801,8 +5801,16 @@ public class SqlToRelConverter {
                 }
             }
             // ----- FLINK MODIFICATION BEGIN -----
-            return exprConverter.convertCall(
-                    this, new FlinkSqlCallBinding(validator(), scope, call).permutedCall());
+            final SqlCall permutedCall =
+                    new FlinkSqlCallBinding(validator(), scope, call).permutedCall();
+            final RelDataType typeIfKnown = validator().getValidatedNodeTypeIfKnown(call);
+            if (typeIfKnown != null) {
+                // Argument permutation should not affect the output type,
+                // reset it if it was known. Otherwise, the type inference would be called twice
+                // when converting to RexNode.
+                validator().setValidatedNodeType(permutedCall, typeIfKnown);
+            }
+            return exprConverter.convertCall(this, permutedCall);
             // ----- FLINK MODIFICATION END -----
         }
 
@@ -6158,7 +6166,7 @@ public class SqlToRelConverter {
                     return;
                 case IGNORE_NULLS:
                     ignoreNulls = true;
-                // fall through
+                    // fall through
                 case RESPECT_NULLS:
                     translateAgg(
                             call.operand(0),
@@ -6239,8 +6247,8 @@ public class SqlToRelConverter {
                                 call2, filter, distinctList, orderList, ignoreNulls, outerCall);
                         return;
                     }
-                // "ARRAY_AGG" and "ARRAY_CONCAT_AGG" without "ORDER BY"
-                // are handled normally; fall through.
+                    // "ARRAY_AGG" and "ARRAY_CONCAT_AGG" without "ORDER BY"
+                    // are handled normally; fall through.
 
                 default:
                     break;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -250,7 +250,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *   <li>Added in FLINK-32474: Lines 2906 ~ 2918
  *   <li>Added in FLINK-32474: Lines 3019 ~ 3053
  *   <li>Added in FLINK-34312: Lines 5804 ~ 5813
- *   <li>Added in FLINK-34057, FLINK-34058, FLINK-34312: Lines 6263 ~ 66279
+ *   <li>Added in FLINK-34057, FLINK-34058, FLINK-34312: Lines 6263 ~ 6279
  * </ol>
  */
 @SuppressWarnings("UnstableApiUsage")

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/FlinkSqlCallBinding.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/FlinkSqlCallBinding.java
@@ -105,9 +105,10 @@ public class FlinkSqlCallBinding extends SqlCallBinding {
         for (SqlNode operand : super.operands()) {
             if (operand instanceof SqlCall
                     && ((SqlCall) operand).getOperator() == SqlStdOperatorTable.DEFAULT) {
-                rewrittenOperands.add(
-                        new SqlDefaultOperator(fixedArgumentTypes.get(rewrittenOperands.size()))
-                                .createCall(SqlParserPos.ZERO));
+                final RelDataType argumentType = fixedArgumentTypes.get(rewrittenOperands.size());
+                final SqlCall defaultArg =
+                        new SqlDefaultOperator(argumentType).createCall(SqlParserPos.ZERO);
+                rewrittenOperands.add(defaultArg);
             } else {
                 rewrittenOperands.add(operand);
             }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/bridging/BridgingSqlFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/bridging/BridgingSqlFunction.java
@@ -279,5 +279,15 @@ public class BridgingSqlFunction extends SqlFunction {
             }
             return TableCharacteristic.builder(semantics).build();
         }
+
+        @Override
+        public boolean argumentMustBeScalar(int ordinal) {
+            final List<StaticArgument> args = typeInference.getStaticArguments().orElse(null);
+            if (args == null || ordinal >= args.size()) {
+                return true;
+            }
+            final StaticArgument arg = args.get(ordinal);
+            return !arg.is(StaticArgumentTrait.TABLE);
+        }
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/SqlDefaultOperator.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/SqlDefaultOperator.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.table.planner.functions.sql;
 
+import org.apache.flink.table.planner.calcite.FlinkSqlCallBinding;
+
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlKind;
@@ -29,7 +31,10 @@ import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.sql.validate.SqlValidatorScope;
 
-/** Default operator has specified type. */
+/**
+ * Marker for optional arguments inserted by {@link FlinkSqlCallBinding}. Compared to Calcite, this
+ * operator stores its type.
+ */
 public class SqlDefaultOperator extends SqlSpecialOperator {
 
     private final RelDataType returnType;


### PR DESCRIPTION
## What is the purpose of the change

The previous PR for FLINK-36707 forgot to update the system output type strategy. This PR adds support for passing columns through.


## Brief change log

- Allow partition columns pass through and explicit column pass through.
- Fix bug in the stack that called type inference two times.


## Verifying this change

This change added tests and can be verified as follows: `ProcessTableFunctionTest`

*More tests will follow, this is just the initial skeleton.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
