### PR TITLE
[FLINK-37108] Use-non terminal savepoint in source/sink suite [1.20]

### DIFF
--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/testsuites/SinkTestSuiteBase.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/testsuites/SinkTestSuiteBase.java
@@ -284,7 +284,9 @@ public abstract class SinkTestSuiteBase<T extends Comparable<T>> {
             savepointPath =
                     jobClient
                             .stopWithSavepoint(
-                                    true, testEnv.getCheckpointUri(), SavepointFormatType.CANONICAL)
+                                    false,
+                                    testEnv.getCheckpointUri(),
+                                    SavepointFormatType.CANONICAL)
                             .get(30, TimeUnit.SECONDS);
             waitForJobStatus(jobClient, Collections.singletonList(JobStatus.FINISHED));
         } catch (Exception e) {

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/testsuites/SourceTestSuiteBase.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/testsuites/SourceTestSuiteBase.java
@@ -339,7 +339,7 @@ public abstract class SourceTestSuiteBase<T> {
         String savepointPath =
                 jobClient
                         .stopWithSavepoint(
-                                true, testEnv.getCheckpointUri(), SavepointFormatType.CANONICAL)
+                                false, testEnv.getCheckpointUri(), SavepointFormatType.CANONICAL)
                         .get(30, TimeUnit.SECONDS);
         waitForJobStatus(jobClient, singletonList(JobStatus.FINISHED));
 


### PR DESCRIPTION
Unchanged backport of #25973.