### PR TITLE
[FLINK-36739] Update the NodeJS to v22.11.0 (LTS)

### DIFF
--- a/flink-runtime-web/pom.xml
+++ b/flink-runtime-web/pom.xml
@@ -258,8 +258,8 @@ under the License.
 							<goal>install-node-and-npm</goal>
 						</goals>
 						<configuration>
-							<nodeVersion>v16.13.2</nodeVersion>
-							<npmVersion>8.1.2</npmVersion>
+							<nodeVersion>v22.11.0</nodeVersion>
+							<npmVersion>10.9.0</npmVersion>
 						</configuration>
 					</execution>
 					<execution>


### PR DESCRIPTION
Unmodified backport of https://github.com/apache/flink/pull/25794 to 1.19
Depends on https://github.com/apache/flink/pull/25941