### PR TITLE
[FLINK-36503][table] Remove deprecated method FunctionDefinitionFactory#createFunctionDefinition

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FunctionDefinitionFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FunctionDefinitionFactory.java
@@ -21,48 +21,23 @@ package org.apache.flink.table.factories;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.catalog.CatalogFunction;
 import org.apache.flink.table.functions.FunctionDefinition;
-import org.apache.flink.util.TemporaryClassLoaderContext;
 
 /** A factory to create {@link FunctionDefinition}. */
 @PublicEvolving
 public interface FunctionDefinitionFactory {
 
     /**
-     * Creates a {@link FunctionDefinition} from given {@link CatalogFunction}.
-     *
-     * @param name name of the {@link CatalogFunction}
-     * @param catalogFunction the catalog function
-     * @return a {@link FunctionDefinition}
-     * @deprecated Please implement {@link #createFunctionDefinition(String, CatalogFunction,
-     *     Context)} instead.
-     */
-    @Deprecated
-    default FunctionDefinition createFunctionDefinition(
-            String name, CatalogFunction catalogFunction) {
-        throw new RuntimeException(
-                "Please implement FunctionDefinitionFactory#createFunctionDefinition(String, CatalogFunction, Context) instead.");
-    }
-
-    /**
      * Creates a {@link FunctionDefinition} from given {@link CatalogFunction} with the given {@link
      * Context} containing the class loader of the current session, which is useful when it's needed
      * to load class from class name.
-     *
-     * <p>The default implementation will call {@link #createFunctionDefinition(String,
-     * CatalogFunction)} directly.
      *
      * @param name name of the {@link CatalogFunction}
      * @param catalogFunction the catalog function
      * @param context the {@link Context} for creating function definition
      * @return a {@link FunctionDefinition}
      */
-    default FunctionDefinition createFunctionDefinition(
-            String name, CatalogFunction catalogFunction, Context context) {
-        try (TemporaryClassLoaderContext ignored =
-                TemporaryClassLoaderContext.of(context.getClassLoader())) {
-            return createFunctionDefinition(name, catalogFunction);
-        }
-    }
+    FunctionDefinition createFunctionDefinition(
+            String name, CatalogFunction catalogFunction, Context context);
 
     /** Context provided when a function definition is created. */
     @PublicEvolving

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestFunctionDefinitionFactory.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestFunctionDefinitionFactory.java
@@ -25,14 +25,14 @@ import org.apache.flink.table.functions.UserDefinedFunctionHelper;
 
 /**
  * Use TestFunctionDefinitionFactory to test loading function to ensure the function can be loaded
- * correctly if only implement legacy interface {@link
- * FunctionDefinitionFactory#createFunctionDefinition(String, CatalogFunction)}.
+ * correctly with the classloader provided by {@link Context}.
  */
 public class TestFunctionDefinitionFactory implements FunctionDefinitionFactory {
 
+    @Override
     public FunctionDefinition createFunctionDefinition(
-            String name, CatalogFunction catalogFunction) {
+            String name, CatalogFunction catalogFunction, Context context) {
         return UserDefinedFunctionHelper.instantiateFunction(
-                Thread.currentThread().getContextClassLoader(), null, name, catalogFunction);
+                context.getClassLoader(), null, name, catalogFunction);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Remove deprecated method FunctionDefinitionFactory#createFunctionDefinition.

Note: I also delete the default implement in the new stack. You can see the previous discuss in https://lists.apache.org/thread/tlk64byvxtbkox3wyv2jfoqfdtf523bf

## Brief change log

  - Remove deprecated method FunctionDefinitionFactory#createFunctionDefinition

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? 
