### PR TITLE
[FLINK-36496][table] Remove deprecated method CatalogFunction#isGeneric

### DIFF
--- a/flink-python/docs/reference/pyflink.table/catalog.rst
+++ b/flink-python/docs/reference/pyflink.table/catalog.rst
@@ -142,7 +142,6 @@ Represents a partition object in catalog.
     CatalogFunction.copy
     CatalogFunction.get_description
     CatalogFunction.get_detailed_description
-    CatalogFunction.is_generic
     CatalogFunction.get_function_language
 
 

--- a/flink-python/pyflink/table/catalog.py
+++ b/flink-python/pyflink/table/catalog.py
@@ -1089,16 +1089,6 @@ class CatalogFunction(object):
         else:
             return None
 
-    def is_generic(self) -> bool:
-        """
-        Whether or not is the function a flink UDF.
-
-        :return: Whether is the function a flink UDF.
-
-        .. versionadded:: 1.10.0
-        """
-        return self._j_catalog_function.isGeneric()
-
     def get_function_language(self):
         """
         Get the language used for the function definition.

--- a/flink-python/pyflink/table/tests/test_catalog.py
+++ b/flink-python/pyflink/table/tests/test_catalog.py
@@ -74,7 +74,6 @@ class CatalogTestBase(PyFlinkTestCase):
 
     def check_catalog_function_equals(self, f1, f2):
         self.assertEqual(f1.get_class_name(), f2.get_class_name())
-        self.assertEqual(f1.is_generic(), f2.is_generic())
         self.assertEqual(f1.get_function_language(), f2.get_function_language())
 
     def check_catalog_partition_equals(self, p1, p2):

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogFunctionImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogFunctionImpl.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.catalog;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.table.functions.UserDefinedFunction;
 import org.apache.flink.table.resource.ResourceUri;
 import org.apache.flink.util.StringUtils;
 
@@ -75,23 +74,6 @@ public class CatalogFunctionImpl implements CatalogFunction {
     @Override
     public Optional<String> getDetailedDescription() {
         return Optional.of("This is a user-defined function");
-    }
-
-    @Override
-    public boolean isGeneric() {
-        if (functionLanguage == FunctionLanguage.PYTHON) {
-            return true;
-        }
-        try {
-            ClassLoader cl = Thread.currentThread().getContextClassLoader();
-            Class c = Class.forName(className, true, cl);
-            if (UserDefinedFunction.class.isAssignableFrom(c)) {
-                return true;
-            }
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException(String.format("Can't resolve udf class %s", className), e);
-        }
-        return false;
     }
 
     @Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
@@ -876,12 +876,6 @@ public final class FunctionCatalog {
         }
 
         @Override
-        public boolean isGeneric() {
-            throw new UnsupportedOperationException(
-                    "This CatalogFunction is a InlineCatalogFunction. This method should not be called.");
-        }
-
-        @Override
         public FunctionLanguage getFunctionLanguage() {
             return FunctionLanguage.JAVA;
         }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogFunction.java
@@ -57,16 +57,6 @@ public interface CatalogFunction {
     Optional<String> getDetailedDescription();
 
     /**
-     * Distinguish if the function is a generic function.
-     *
-     * @return whether the function is a generic function
-     * @deprecated There is no replacement for this function, as now functions have type inference
-     *     strategies
-     */
-    @Deprecated
-    boolean isGeneric();
-
-    /**
      * Get the language used for the definition of function.
      *
      * @return the language type of the function definition

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTest.java
@@ -1739,7 +1739,6 @@ public abstract class CatalogTest {
 
     protected void checkEquals(CatalogFunction f1, CatalogFunction f2) {
         assertThat(f2.getClassName()).isEqualTo(f1.getClassName());
-        assertThat(f2.isGeneric()).isEqualTo(f1.isGeneric());
         assertThat(f2.getFunctionLanguage()).isEqualTo(f1.getFunctionLanguage());
     }
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/functions/UserDefinedFunctionHelperTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/functions/UserDefinedFunctionHelperTest.java
@@ -251,11 +251,6 @@ class UserDefinedFunctionHelperTest {
         }
 
         @Override
-        public boolean isGeneric() {
-            return false;
-        }
-
-        @Override
         public FunctionLanguage getFunctionLanguage() {
             return FunctionLanguage.JAVA;
         }


### PR DESCRIPTION
## What is the purpose of the change

Remove deprecated method CatalogFunction#isGeneric

## Brief change log

  - Remove deprecated method CatalogFunction#isGeneric

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? 
