### PR TITLE
[FLINK-37130] Provide a util converting future of StateIterator to Iterable

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/state/InternalStateIterator.java
+++ b/flink-core/src/main/java/org/apache/flink/core/state/InternalStateIterator.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.state;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.state.v2.StateIterator;
+
+/**
+ * The Internal definition of {@link InternalStateIterator}, add some method that will be used by
+ * framework.
+ */
+@Internal
+public interface InternalStateIterator<T> extends StateIterator<T> {
+
+    /** Return whether this iterator has more elements to load. */
+    boolean hasNextLoading();
+
+    /** Return the already loaded elements in cache. */
+    Iterable<T> getCurrentCache();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/adaptor/CompleteStateIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/adaptor/CompleteStateIterator.java
@@ -19,7 +19,7 @@
 package org.apache.flink.runtime.state.v2.adaptor;
 
 import org.apache.flink.api.common.state.v2.StateFuture;
-import org.apache.flink.api.common.state.v2.StateIterator;
+import org.apache.flink.core.state.InternalStateIterator;
 import org.apache.flink.core.state.StateFutureUtils;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.function.FunctionWithException;
@@ -32,7 +32,7 @@ import java.util.Collection;
 import java.util.Collections;
 
 /** A {@link org.apache.flink.api.common.state.v2.StateIterator} that has all elements. */
-public class CompleteStateIterator<T> implements StateIterator<T> {
+public class CompleteStateIterator<T> implements InternalStateIterator<T> {
 
     final Iterable<T> iterable;
     final boolean empty;
@@ -82,5 +82,15 @@ public class CompleteStateIterator<T> implements StateIterator<T> {
     @Override
     public boolean isEmpty() {
         return empty;
+    }
+
+    @Override
+    public boolean hasNextLoading() {
+        return false;
+    }
+
+    @Override
+    public Iterable<T> getCurrentCache() {
+        return iterable;
     }
 }

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStListIterator.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStListIterator.java
@@ -37,7 +37,7 @@ public class ForStListIterator<V> extends AbstractStateIterator<V> {
     }
 
     @Override
-    protected boolean hasNext() {
+    public boolean hasNextLoading() {
         return false;
     }
 

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStMapIterator.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStMapIterator.java
@@ -32,7 +32,7 @@ public class ForStMapIterator<T> extends AbstractStateIterator<T> {
 
     /**
      * Whether the iterator has encountered the end, which determines the return value of {@link
-     * #hasNext}.
+     * #hasNextLoading}.
      */
     private boolean encounterEnd;
 
@@ -60,7 +60,7 @@ public class ForStMapIterator<T> extends AbstractStateIterator<T> {
     }
 
     @Override
-    protected boolean hasNext() {
+    public boolean hasNextLoading() {
         return !encounterEnd;
     }
 


### PR DESCRIPTION
## What is the purpose of the change

We have identified a need to process full data from an iterator, but the current async partial loading interface is not user-friendly. Therefore, this PR provides a utility to convert the future of `StateIterator` to `Iterable` for the convenience of the user.

## Brief change log

 - Add `StateFutureUtils#toIterable`.
 - Change `AsyncStateWindowJoinOperator`  to apply the optimization.


## Verifying this change

This change added tests `AbstractStateIteratorTest#testPartialLoadingWithConversionToIterable`


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
