### PR TITLE
[FLINK-37139][table-planner] Improve AdaptiveSkewedJoinOptimizationStrategy to make it effective in more scenarios

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/AdaptiveGraphManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/AdaptiveGraphManager.java
@@ -618,6 +618,11 @@ public class AdaptiveGraphManager
                                     streamGraph.getStreamNode(edge.getSourceId()), streamGraph))
                     || isChainable(edge, streamGraph)) {
                 edge.setPartitioner(new ForwardPartitioner<>());
+                // Currently, there is no intra input key correlation for edge with
+                // ForwardForUnspecifiedPartitioner, and we need to modify it to false.
+                if (partitioner instanceof ForwardForUnspecifiedPartitioner) {
+                    edge.setIntraInputKeyCorrelated(false);
+                }
             }
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/StreamEdge.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/StreamEdge.java
@@ -30,7 +30,6 @@ import java.util.Objects;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
-import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * An edge in the streaming topology. One edge like this does not necessarily gets converted to a
@@ -291,8 +290,6 @@ public class StreamEdge implements Serializable {
     }
 
     public void setIntraInputKeyCorrelated(boolean intraInputKeyCorrelated) {
-        // We hope to strictly control the behavior of this modification to avoid unexpected errors.
-        checkState(interInputsKeysCorrelated, "interInputsKeysCorrelated must be true");
         this.intraInputKeyCorrelated = intraInputKeyCorrelated;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/util/ImmutableStreamEdge.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/util/ImmutableStreamEdge.java
@@ -22,7 +22,6 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.streaming.api.graph.StreamEdge;
 import org.apache.flink.streaming.runtime.partitioner.BroadcastPartitioner;
 import org.apache.flink.streaming.runtime.partitioner.ForwardForConsecutiveHashPartitioner;
-import org.apache.flink.streaming.runtime.partitioner.ForwardPartitioner;
 
 /** Helper class that provides read-only StreamEdge. */
 @Internal
@@ -53,8 +52,8 @@ public class ImmutableStreamEdge {
         return streamEdge.getPartitioner() instanceof ForwardForConsecutiveHashPartitioner;
     }
 
-    public boolean isExactForwardEdge() {
-        return streamEdge.getPartitioner().getClass().equals(ForwardPartitioner.class);
+    public boolean isIntraInputKeyCorrelated() {
+        return streamEdge.isIntraInputKeyCorrelated();
     }
 
     public boolean isBroadcastEdge() {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/adaptive/AdaptiveSkewedJoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/adaptive/AdaptiveSkewedJoinITCase.scala
@@ -81,6 +81,12 @@ class AdaptiveSkewedJoinITCase extends AdaptiveJoinITCase {
     checkResult(sql)
   }
 
+  @Test
+  def testJoinWithUnspecifiedForwardOutput(): Unit = {
+    val sql = "SELECT a1 as a, b1 as b, c1 as c, d1 as d FROM T1, T2 WHERE a1 = a2"
+    checkResult(sql)
+  }
+
   override def checkResult(sql: String): Unit = {
     tEnv.getConfig
       .set(


### PR DESCRIPTION
## What is the purpose of the change

Currently, the scenarios in which the AdaptiveSkewedJoinOptimizationStrategy is effective are too limited. For example, when there is an output edge of the forward for unspecified type, the optimization cannot be applied. However, this optimization wouldn't break the data correctness of this kind output edges. Therefore, we will optimize this scenario to enable the optimization to be effective in more scenarios.


## Brief change log

Improve AdaptiveSkewedJoinOptimizationStrategy to make it effective in more scenarios.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
