### PR TITLE
[FLINK-37137][runtime] Fix unstable test testGenerateStreamGraphJson

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobgraph/jsonplan/JsonGeneratorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobgraph/jsonplan/JsonGeneratorTest.java
@@ -180,8 +180,9 @@ public class JsonGeneratorTest {
         expectedJobVertexIds.add(null);
         validateStreamGraph(streamGraph, parsedStreamGraph, expectedJobVertexIds);
 
-        jobVertexIdMap.put(1, new JobVertexID());
-        jobVertexIdMap.put(2, new JobVertexID());
+        for (StreamNode node : streamGraph.getStreamNodes()) {
+            jobVertexIdMap.put(node.getId(), new JobVertexID());
+        }
         streamGraphJson = JsonPlanGenerator.generateStreamGraphJson(streamGraph, jobVertexIdMap);
 
         parsedStreamGraph = mapper.readValue(streamGraphJson, StreamGraphJsonSchema.class);


### PR DESCRIPTION
## What is the purpose of the change

This pull request try to fix unstable test `org.apache.flink.runtime.jobgraph.jsonplan.JsonGeneratorTest#testGenerateStreamGraphJson`.


## Brief change log

  - Replace the hard-coded stream node ID with one retrieved from the stream graph in the test.

## Verifying this change

This change is already covered by existing tests `org.apache.flink.runtime.jobgraph.jsonplan.JsonGeneratorTest#testGenerateStreamGraphJson`.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
