### PR TITLE
[hotfix][javadoc] Use correct syntax for `TRIM` in `SqlCallSyntax` javadoc

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/SqlCallSyntax.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/SqlCallSyntax.java
@@ -221,7 +221,7 @@ public interface SqlCallSyntax {
     /**
      * Special sql syntax for TRIM.
      *
-     * <p>Example: TRIM BOTH ' ' FROM 0;
+     * <p>Example: TRIM(BOTH ' ' FROM ' 0 ');
      */
     SqlCallSyntax TRIM =
             (sqlName, operands) -> {


### PR DESCRIPTION

## What is the purpose of the change
This is a follow up for https://github.com/apache/flink/pull/25791
where SqlCallSyntax was fixed for `trim` however 
javadoc example was not


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
