### PR TITLE
[FLINK-37026] Fix the stale pr message formatting

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -48,10 +48,10 @@ jobs:
             This PR is being marked as stale since it has not had any activity in the last 180 days. 
             If you would like to keep this PR alive, please leave a comment asking for a review. 
             If the PR has merge conflicts, update it with the latest from the base branch.
-            <p>
+
             If you are having difficulty finding a reviewer, please reach out to the 
             [community](https://flink.apache.org/what-is-flink/community/).
-            <p>
+
             If this PR is no longer valid or desired, please feel free to close it. 
             If no activity occurs in the next 90 days, it will be automatically closed.
           close-pr-label: 'closed-stale'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -50,7 +50,7 @@ jobs:
             If the PR has merge conflicts, update it with the latest from the base branch.
 
             If you are having difficulty finding a reviewer, please reach out to the 
-            [community](https://flink.apache.org/what-is-flink/community/).
+            community, contact details can be found here: https://flink.apache.org/what-is-flink/community/
 
             If this PR is no longer valid or desired, please feel free to close it. 
             If no activity occurs in the next 90 days, it will be automatically closed.


### PR DESCRIPTION
## What is the purpose of the change

This fixes an issue with the formatting of the Stale PR messages introduced in #25953. 

## Brief change log

- Remove HTML tags from Stale PR message

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
