### PR TITLE
[hotfix] Add homepage link to .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,4 +1,5 @@
 github:
+  homepage: https://flink.apache.org/
   enabled_merge_buttons:
     squash: true
     merge: false


### PR DESCRIPTION
TRIVIAL AS IS. I want to click this URL at the right top corner today and noticed that it's missing.