### PR TITLE
[FLINK-37164][Runtime] Speed up state v2 synchronous methods execution

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/StateExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/StateExecutor.java
@@ -46,6 +46,13 @@ public interface StateExecutor {
     StateRequestContainer createStateRequestContainer();
 
     /**
+     * Execute a single state request *synchronously*. This is for synchronous APIs.
+     *
+     * @param stateRequest the request to run.
+     */
+    void executeRequestSync(StateRequest<?, ?, ?, ?> stateRequest);
+
+    /**
      * Check if this executor is fully loaded. Will be invoked to determine whether to give more
      * requests to run or wait for a while.
      *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/StateRequest.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/StateRequest.java
@@ -44,6 +44,8 @@ public class StateRequest<K, N, IN, OUT> implements Serializable {
     /** The type of this request. */
     private final StateRequestType type;
 
+    private final boolean sync;
+
     /** The payload(input) of this request. */
     @Nullable private final IN payload;
 
@@ -58,11 +60,13 @@ public class StateRequest<K, N, IN, OUT> implements Serializable {
     public StateRequest(
             @Nullable State state,
             StateRequestType type,
+            boolean sync,
             @Nullable IN payload,
             InternalStateFuture<OUT> stateFuture,
             RecordContext<K> context) {
         this.state = state;
         this.type = type;
+        this.sync = sync;
         this.payload = payload;
         this.stateFuture = stateFuture;
         this.context = context;
@@ -77,6 +81,10 @@ public class StateRequest<K, N, IN, OUT> implements Serializable {
     @Nullable
     public IN getPayload() {
         return payload;
+    }
+
+    public boolean isSync() {
+        return sync;
     }
 
     @Nullable

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/StateRequestBuffer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/StateRequestBuffer.java
@@ -148,14 +148,9 @@ public class StateRequestBuffer<K> implements Closeable {
     }
 
     void enqueueToActive(StateRequest<K, ?, ?, ?> request) {
-        if (request.getRequestType() == StateRequestType.SYNC_POINT) {
-            request.getFuture().complete(null);
-        } else {
-            activeQueue.add(request);
-            if (bufferTimeout > 0 && seqAndTimeout == null) {
-                seqAndTimeout =
-                        Tuple2.of(currentSeq.get(), System.currentTimeMillis() + bufferTimeout);
-            }
+        activeQueue.add(request);
+        if (bufferTimeout > 0 && seqAndTimeout == null) {
+            seqAndTimeout = Tuple2.of(currentSeq.get(), System.currentTimeMillis() + bufferTimeout);
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/MockStateExecutor.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/MockStateExecutor.java
@@ -31,7 +31,7 @@ public class MockStateExecutor implements StateExecutor {
         Preconditions.checkArgument(stateRequestContainer instanceof MockStateRequestContainer);
         for (StateRequest<?, ?, ?, ?> request :
                 ((MockStateRequestContainer) stateRequestContainer).getStateRequestList()) {
-            request.getFuture().complete(null);
+            executeRequestSync(request);
         }
         return CompletableFuture.completedFuture(null);
     }
@@ -39,6 +39,11 @@ public class MockStateExecutor implements StateExecutor {
     @Override
     public StateRequestContainer createStateRequestContainer() {
         return new MockStateRequestContainer();
+    }
+
+    @Override
+    public void executeRequestSync(StateRequest<?, ?, ?, ?> stateRequest) {
+        stateRequest.getFuture().complete(null);
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AbstractAggregatingStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AbstractAggregatingStateTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.api.common.state.v2.AggregatingStateDescriptor;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.state.InternalStateFuture;
 import org.apache.flink.runtime.asyncprocessing.AsyncExecutionController;
 import org.apache.flink.runtime.asyncprocessing.MockStateRequestContainer;
 import org.apache.flink.runtime.asyncprocessing.StateExecutor;
@@ -233,22 +234,7 @@ class AbstractAggregatingStateTest extends AbstractKeyedStateTestBase {
                 StateRequestContainer stateRequestContainer) {
             for (StateRequest stateRequest :
                     ((MockStateRequestContainer) stateRequestContainer).getStateRequestList()) {
-                String key = (String) stateRequest.getRecordContext().getKey();
-                String namespace = (String) stateRequest.getNamespace();
-                if (stateRequest.getRequestType() == StateRequestType.AGGREGATING_ADD) {
-                    if (stateRequest.getPayload() == null) {
-                        hashMap.remove(Tuple2.of(key, namespace));
-                        stateRequest.getFuture().complete(null);
-                    } else {
-                        hashMap.put(Tuple2.of(key, namespace), (Integer) stateRequest.getPayload());
-                        stateRequest.getFuture().complete(null);
-                    }
-                } else if (stateRequest.getRequestType() == StateRequestType.AGGREGATING_GET) {
-                    Integer val = hashMap.get(Tuple2.of(key, namespace));
-                    stateRequest.getFuture().complete(val);
-                } else {
-                    throw new UnsupportedOperationException("Unsupported type");
-                }
+                executeRequestSync(stateRequest);
             }
             CompletableFuture<Void> future = new CompletableFuture<>();
             future.complete(null);
@@ -258,6 +244,26 @@ class AbstractAggregatingStateTest extends AbstractKeyedStateTestBase {
         @Override
         public StateRequestContainer createStateRequestContainer() {
             return new MockStateRequestContainer();
+        }
+
+        @Override
+        public void executeRequestSync(StateRequest<?, ?, ?, ?> stateRequest) {
+            String key = (String) stateRequest.getRecordContext().getKey();
+            String namespace = (String) stateRequest.getNamespace();
+            if (stateRequest.getRequestType() == StateRequestType.AGGREGATING_ADD) {
+                if (stateRequest.getPayload() == null) {
+                    hashMap.remove(Tuple2.of(key, namespace));
+                    stateRequest.getFuture().complete(null);
+                } else {
+                    hashMap.put(Tuple2.of(key, namespace), (Integer) stateRequest.getPayload());
+                    stateRequest.getFuture().complete(null);
+                }
+            } else if (stateRequest.getRequestType() == StateRequestType.AGGREGATING_GET) {
+                Integer val = hashMap.get(Tuple2.of(key, namespace));
+                ((InternalStateFuture<Integer>) stateRequest.getFuture()).complete(val);
+            } else {
+                throw new UnsupportedOperationException("Unsupported type");
+            }
         }
 
         @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AbstractReducingStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AbstractReducingStateTest.java
@@ -187,6 +187,11 @@ public class AbstractReducingStateTest extends AbstractKeyedStateTestBase {
         }
 
         @Override
+        public void executeRequestSync(StateRequest<?, ?, ?, ?> stateRequest) {
+            throw new UnsupportedOperationException("Unsupported synchronous execution");
+        }
+
+        @Override
         public boolean fullyLoaded() {
             return false;
         }

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStStateRequestClassifier.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStStateRequestClassifier.java
@@ -46,7 +46,14 @@ public class ForStStateRequestClassifier implements StateRequestContainer {
 
     @Override
     public void offer(StateRequest<?, ?, ?, ?> stateRequest) {
-        convertStateRequestsToForStDBRequests(stateRequest);
+        Object forstDbRequest = convertRequests(stateRequest);
+        if (forstDbRequest instanceof ForStDBGetRequest) {
+            dbGetRequests.add((ForStDBGetRequest<?, ?, ?, ?>) forstDbRequest);
+        } else if (forstDbRequest instanceof ForStDBPutRequest) {
+            dbPutRequests.add((ForStDBPutRequest<?, ?, ?>) forstDbRequest);
+        } else {
+            dbIterRequests.add((ForStDBIterRequest<?, ?, ?, ?, ?>) forstDbRequest);
+        }
     }
 
     @Override
@@ -55,7 +62,7 @@ public class ForStStateRequestClassifier implements StateRequestContainer {
     }
 
     @SuppressWarnings("ConstantConditions")
-    private void convertStateRequestsToForStDBRequests(StateRequest<?, ?, ?, ?> stateRequest) {
+    public static Object convertRequests(StateRequest<?, ?, ?, ?> stateRequest) {
         StateRequestType stateRequestType = stateRequest.getRequestType();
         switch (stateRequestType) {
             case VALUE_GET:
@@ -68,8 +75,7 @@ public class ForStStateRequestClassifier implements StateRequestContainer {
                 {
                     ForStInnerTable<?, ?, ?> innerTable =
                             (ForStInnerTable<?, ?, ?>) stateRequest.getState();
-                    dbGetRequests.add(innerTable.buildDBGetRequest(stateRequest));
-                    return;
+                    return innerTable.buildDBGetRequest(stateRequest);
                 }
             case VALUE_UPDATE:
             case LIST_UPDATE:
@@ -82,8 +88,7 @@ public class ForStStateRequestClassifier implements StateRequestContainer {
                 {
                     ForStInnerTable<?, ?, ?> innerTable =
                             (ForStInnerTable<?, ?, ?>) stateRequest.getState();
-                    dbPutRequests.add(innerTable.buildDBPutRequest(stateRequest));
-                    return;
+                    return innerTable.buildDBPutRequest(stateRequest);
                 }
             case MAP_ITER:
             case MAP_ITER_KEY:
@@ -92,28 +97,24 @@ public class ForStStateRequestClassifier implements StateRequestContainer {
                 {
                     ForStMapState<?, ?, ?, ?> forStMapState =
                             (ForStMapState<?, ?, ?, ?>) stateRequest.getState();
-                    dbIterRequests.add(forStMapState.buildDBIterRequest(stateRequest));
-                    return;
+                    return forStMapState.buildDBIterRequest(stateRequest);
                 }
             case MAP_PUT_ALL:
                 {
                     ForStMapState<?, ?, ?, ?> forStMapState =
                             (ForStMapState<?, ?, ?, ?>) stateRequest.getState();
-                    dbPutRequests.add(forStMapState.buildDBBunchPutRequest(stateRequest));
-                    return;
+                    return forStMapState.buildDBBunchPutRequest(stateRequest);
                 }
             case CLEAR:
                 {
                     if (stateRequest.getState() instanceof ForStMapState) {
                         ForStMapState<?, ?, ?, ?> forStMapState =
                                 (ForStMapState<?, ?, ?, ?>) stateRequest.getState();
-                        dbPutRequests.add(forStMapState.buildDBBunchPutRequest(stateRequest));
-                        return;
+                        return forStMapState.buildDBBunchPutRequest(stateRequest);
                     } else if (stateRequest.getState() instanceof ForStInnerTable) {
                         ForStInnerTable<?, ?, ?> innerTable =
                                 (ForStInnerTable<?, ?, ?>) stateRequest.getState();
-                        dbPutRequests.add(innerTable.buildDBPutRequest(stateRequest));
-                        return;
+                        return innerTable.buildDBPutRequest(stateRequest);
                     } else {
                         throw new UnsupportedOperationException(
                                 "The State "
@@ -123,8 +124,7 @@ public class ForStStateRequestClassifier implements StateRequestContainer {
                 }
             case CUSTOMIZED:
                 {
-                    handleCustomizedStateRequests(stateRequest);
-                    return;
+                    return handleCustomizedStateRequests(stateRequest);
                 }
             default:
                 throw new UnsupportedOperationException(
@@ -133,7 +133,7 @@ public class ForStStateRequestClassifier implements StateRequestContainer {
     }
 
     @SuppressWarnings("unchecked")
-    private void handleCustomizedStateRequests(StateRequest<?, ?, ?, ?> stateRequest) {
+    private static Object handleCustomizedStateRequests(StateRequest<?, ?, ?, ?> stateRequest) {
         Tuple2<ForStStateRequestType, ?> payload =
                 (Tuple2<ForStStateRequestType, ?>) stateRequest.getPayload();
         ForStStateRequestType requestType = payload.f0;
@@ -142,15 +142,13 @@ public class ForStStateRequestClassifier implements StateRequestContainer {
                 {
                     ForStListState<?, ?, ?> forStListState =
                             (ForStListState<?, ?, ?>) stateRequest.getState();
-                    dbGetRequests.add(forStListState.buildDBGetRequest(stateRequest));
-                    return;
+                    return forStListState.buildDBGetRequest(stateRequest);
                 }
             case MERGE_ALL_RAW:
                 {
                     ForStListState<?, ?, ?> forStListState =
                             (ForStListState<?, ?, ?>) stateRequest.getState();
-                    dbPutRequests.add(forStListState.buildDBPutRequest(stateRequest));
-                    return;
+                    return forStListState.buildDBPutRequest(stateRequest);
                 }
             default:
                 throw new UnsupportedOperationException(

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStStateExecutorTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStStateExecutorTest.java
@@ -349,7 +349,8 @@ class ForStStateExecutorTest extends ForStDBOperationTestBase {
         RecordContext<K> recordContext =
                 new RecordContext<>(record, key, t -> {}, keyGroup, new Epoch(0), 0);
         TestStateFuture stateFuture = new TestStateFuture<>();
-        return new StateRequest<>(innerTable, requestType, value, stateFuture, recordContext);
+        return new StateRequest<>(
+                innerTable, requestType, false, value, stateFuture, recordContext);
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
@@ -363,6 +364,7 @@ class ForStStateExecutorTest extends ForStDBOperationTestBase {
         RecordContext<K> recordContext =
                 new RecordContext<>(record, key, t -> {}, keyGroup, new Epoch(0), 0);
         TestStateFuture stateFuture = new TestStateFuture<>();
-        return new StateRequest<>(innerTable, requestType, value, stateFuture, recordContext);
+        return new StateRequest<>(
+                innerTable, requestType, false, value, stateFuture, recordContext);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Currently, if user enables the async state processing, and use one state backends supporting async state access (e.g. ForSt State Backend), but invokes synchronous methods (e.g. `get()`, `add()`), there is performance issue for state access. The default implementation of synchronous methods for the case above is submitting a async state access and wait. This PR applies an optimization that bypass all the async executions and just access the state in synchronous way.


## Brief change log

 - Provide `sync` flag in `StateRequest` and if it is ready to execute, fire it synchronously.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
