### PR TITLE
[FLINK-37021][state/forst] Make Forst remote dir share with checkpoint

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageAccess.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageAccess.java
@@ -128,6 +128,10 @@ public class FsCheckpointStorageAccess extends AbstractFsCheckpointStorageAccess
         return checkpointsDirectory;
     }
 
+    public Path getSharedStateDirectory() {
+        return sharedStateDirectory;
+    }
+
     // ------------------------------------------------------------------------
     //  CheckpointStorage implementation
     // ------------------------------------------------------------------------

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStOptions.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStOptions.java
@@ -28,6 +28,7 @@ import org.apache.flink.configuration.description.Description;
 import org.apache.flink.configuration.description.TextElement;
 
 import static org.apache.flink.state.forst.ForStStateBackend.PriorityQueueStateType.ForStDB;
+import static org.apache.flink.state.forst.ForStStateBackend.REMOTE_SHORTCUT_CHECKPOINT;
 
 /** Configuration options for the ForStStateBackend. */
 @Experimental
@@ -55,8 +56,9 @@ public class ForStOptions {
                     .noDefaultValue()
                     .withDescription(
                             String.format(
-                                    "The remote directory where ForSt puts its SST files, fallback to %s if not configured.",
-                                    LOCAL_DIRECTORIES.key()));
+                                    "The remote directory where ForSt puts its SST files, fallback to %s if not configured."
+                                            + " Recognized shortcut name is '%s', which means that forst shares the directory with checkpoint.",
+                                    LOCAL_DIRECTORIES.key(), REMOTE_SHORTCUT_CHECKPOINT));
 
     public static final ConfigOption<String> CACHE_DIRECTORY =
             ConfigOptions.key("state.backend.forst.cache.dir")

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStStateBackendV2Test.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStStateBackendV2Test.java
@@ -18,12 +18,20 @@
 
 package org.apache.flink.state.forst;
 
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.operators.testutils.MockEnvironment;
 import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.ConfigurableStateBackend;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyedStateBackendParametersImpl;
 import org.apache.flink.runtime.state.storage.FileSystemCheckpointStorage;
 import org.apache.flink.runtime.state.storage.JobManagerCheckpointStorage;
+import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.runtime.state.v2.StateBackendTestV2Base;
 import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
@@ -31,17 +39,21 @@ import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 import org.apache.flink.testutils.junit.utils.TempDirUtils;
 import org.apache.flink.util.function.SupplierWithException;
 
+import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.apache.flink.state.forst.ForStConfigurableOptions.USE_DELETE_FILES_IN_RANGE_DURING_RESCALING;
 import static org.apache.flink.state.forst.ForStConfigurableOptions.USE_INGEST_DB_RESTORE_MODE;
 import static org.apache.flink.state.forst.ForStOptions.LOCAL_DIRECTORIES;
 import static org.apache.flink.state.forst.ForStOptions.REMOTE_DIRECTORY;
+import static org.apache.flink.state.forst.ForStStateBackend.REMOTE_SHORTCUT_CHECKPOINT;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 /** Tests for the async keyed state backend part of {@link ForStStateBackend}. */
 @ExtendWith(ParameterizedTestExtension.class)
@@ -109,5 +121,60 @@ class ForStStateBackendV2Test extends StateBackendTestV2Base<ForStStateBackend> 
         config.set(USE_INGEST_DB_RESTORE_MODE, useIngestDbRestoreMode);
         config.set(USE_DELETE_FILES_IN_RANGE_DURING_RESCALING, useDeleteFileInRange);
         return backend.configure(config, Thread.currentThread().getContextClassLoader());
+    }
+
+    @TestTemplate
+    void testRemoteDirShareCheckpointDirWithJobId() throws Exception {
+        testRemoteDirShareCheckpointDir(true);
+    }
+
+    @TestTemplate
+    void testRemoteDirShareCheckpointDirWOJob() throws Exception {
+        testRemoteDirShareCheckpointDir(false);
+    }
+
+    void testRemoteDirShareCheckpointDir(boolean createJob) throws Exception {
+        JobID jobID = new JobID();
+        String checkpointPath = TempDirUtils.newFolder(tempFolder).toURI().toString();
+        FileSystemCheckpointStorage checkpointStorage =
+                new FileSystemCheckpointStorage(new Path(checkpointPath), 0, -1);
+
+        Configuration config = new Configuration();
+        config.set(LOCAL_DIRECTORIES, tempFolderForForStLocal.toString());
+        config.set(REMOTE_DIRECTORY, REMOTE_SHORTCUT_CHECKPOINT);
+        config.set(CheckpointingOptions.CREATE_CHECKPOINT_SUB_DIR, createJob);
+
+        checkpointStorage =
+                checkpointStorage.configure(config, Thread.currentThread().getContextClassLoader());
+        MockEnvironment mockEnvironment =
+                MockEnvironment.builder().setTaskStateManager(getTestTaskStateManager()).build();
+        mockEnvironment.setCheckpointStorageAccess(
+                checkpointStorage.createCheckpointStorage(jobID));
+
+        ForStStateBackend backend = new ForStStateBackend();
+        backend = backend.configure(config, Thread.currentThread().getContextClassLoader());
+        KeyGroupRange keyGroupRange = KeyGroupRange.of(0, 127);
+        ForStKeyedStateBackend<Integer> keyedBackend =
+                backend.createAsyncKeyedStateBackend(
+                        new KeyedStateBackendParametersImpl<>(
+                                mockEnvironment,
+                                jobID,
+                                "test_op",
+                                IntSerializer.INSTANCE,
+                                keyGroupRange.getNumberOfKeyGroups(),
+                                keyGroupRange,
+                                env.getTaskKvStateRegistry(),
+                                TtlTimeProvider.DEFAULT,
+                                getMetricGroup(),
+                                getCustomInitializationMetrics(),
+                                Collections.emptyList(),
+                                new CloseableRegistry(),
+                                1.0d));
+
+        assertThat(keyedBackend.getRemoteBasePath().getParent())
+                .isEqualTo(
+                        new Path(
+                                checkpointStorage.getCheckpointPath(),
+                                createJob ? jobID + "/shared" : "/shared"));
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR makes Forst remote dir share with checkpoint.

## Brief change log

- Add `checkpoint-dir` shortcut for forst remote dir
- Expose `FsCheckpointStorageAccess#sharedStateDirectory`

## Verifying this change

This change added tests and can be verified as follows:
- `ForStStateBackendV2Test#testRemoteDirShareCheckpointDir`


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)
 

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)