### PR TITLE
[FLINK-37170][ci] Removes 1.18 version from GHA nightly builds

### DIFF
--- a/.github/workflows/nightly-trigger.yml
+++ b/.github/workflows/nightly-trigger.yml
@@ -33,7 +33,6 @@ jobs:
           - master
           - release-1.20
           - release-1.19
-          - release-1.18
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Workflow


### PR DESCRIPTION
## What is the purpose of the change

Disables 1.18 nightly builds for GHA after it being discussed in [this dev ML thread](https://lists.apache.org/thread/5onl01vt98452vyj4x6flvdq8601fdo7).

## Brief change log

* Removes 1.18 release branch

## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable