### PR TITLE
[FLINK-37172][table-runtime] Add logs in all existing async state ops to check if they are under async state when running

### DIFF
--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/aggregate/async/AsyncStateGroupAggFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/aggregate/async/AsyncStateGroupAggFunction.java
@@ -31,10 +31,15 @@ import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.util.Collector;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /** Aggregate Function used for the groupby (without window) aggregate with async state api. */
 public class AsyncStateGroupAggFunction extends GroupAggFunctionBase {
 
     private static final long serialVersionUID = 1L;
+
+    private static final Logger LOG = LoggerFactory.getLogger(AsyncStateGroupAggFunction.class);
 
     // stores the accumulators
     private transient ValueState<RowData> accState = null;
@@ -72,6 +77,8 @@ public class AsyncStateGroupAggFunction extends GroupAggFunctionBase {
     @Override
     public void open(OpenContext openContext) throws Exception {
         super.open(openContext);
+
+        LOG.info("Group agg is using async state");
 
         InternalTypeInfo<RowData> accTypeInfo = InternalTypeInfo.ofFields(accTypes);
         ValueStateDescriptor<RowData> accDesc = new ValueStateDescriptor<>("accState", accTypeInfo);

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/aggregate/asyncwindow/processors/AbstractAsyncStateSliceWindowAggProcessor.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/aggregate/asyncwindow/processors/AbstractAsyncStateSliceWindowAggProcessor.java
@@ -32,6 +32,9 @@ import org.apache.flink.table.runtime.operators.window.tvf.slicing.SliceAssigner
 import org.apache.flink.table.runtime.operators.window.tvf.slicing.SliceSharedAssigner;
 import org.apache.flink.table.runtime.operators.window.tvf.slicing.SlicingWindowTimerServiceImpl;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
@@ -45,6 +48,9 @@ import static org.apache.flink.table.runtime.util.TimeWindowUtil.isWindowFired;
 public abstract class AbstractAsyncStateSliceWindowAggProcessor
         extends AbstractAsyncStateWindowAggProcessor<Long>
         implements AsyncStateSlicingWindowProcessor<Long> {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(AbstractAsyncStateSliceWindowAggProcessor.class);
 
     protected final AsyncStateWindowBuffer.Factory windowBufferFactory;
     protected final SliceAssigner sliceAssigner;
@@ -80,6 +86,9 @@ public abstract class AbstractAsyncStateSliceWindowAggProcessor
     @Override
     public void open(AsyncStateContext<Long> context) throws Exception {
         super.open(context);
+
+        LOG.info("Slice window agg is using async state");
+
         this.windowBuffer =
                 windowBufferFactory.create(
                         ctx.getOperatorOwner(),

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/asyncprocessing/AsyncStateDeduplicateFunctionBase.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/asyncprocessing/AsyncStateDeduplicateFunctionBase.java
@@ -27,6 +27,9 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
 import org.apache.flink.table.runtime.operators.deduplicate.DeduplicateFunctionBase;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import static org.apache.flink.table.runtime.util.StateConfigUtil.createTtlConfig;
 
 /**
@@ -42,6 +45,9 @@ abstract class AsyncStateDeduplicateFunctionBase<T, K, IN, OUT>
 
     private static final long serialVersionUID = 1L;
 
+    private static final Logger LOG =
+            LoggerFactory.getLogger(AsyncStateDeduplicateFunctionBase.class);
+
     // state stores previous message under the key.
     protected ValueState<T> state;
 
@@ -53,6 +59,8 @@ abstract class AsyncStateDeduplicateFunctionBase<T, K, IN, OUT>
     @Override
     public void open(OpenContext openContext) throws Exception {
         super.open(openContext);
+
+        LOG.info("Deduplicate is using async state");
 
         ValueStateDescriptor<T> stateDesc =
                 new ValueStateDescriptor<>("deduplicate-state", typeInfo);

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/asyncprocessing/AsyncStateStreamingJoinOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/asyncprocessing/AsyncStateStreamingJoinOperator.java
@@ -34,6 +34,9 @@ import org.apache.flink.table.runtime.operators.join.stream.utils.JoinInputSideS
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.types.RowKind;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Streaming unbounded Join operator based on async state api, which supports INNER/LEFT/RIGHT/FULL
  * JOIN.
@@ -41,6 +44,9 @@ import org.apache.flink.types.RowKind;
 public class AsyncStateStreamingJoinOperator extends AbstractAsyncStateStreamingJoinOperator {
 
     private static final long serialVersionUID = 1L;
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(AsyncStateStreamingJoinOperator.class);
 
     // whether left side is outer side, e.g. left is outer but right is not when LEFT OUTER JOIN
     private final boolean leftIsOuter;
@@ -85,6 +91,8 @@ public class AsyncStateStreamingJoinOperator extends AbstractAsyncStateStreaming
     @Override
     public void open() throws Exception {
         super.open();
+
+        LOG.info("Join is using async state");
 
         this.outRow = new JoinedRowData();
         this.leftNullRow = new GenericRowData(leftType.toRowSize());

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/window/asyncprocessing/AsyncStateWindowJoinOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/window/asyncprocessing/AsyncStateWindowJoinOperator.java
@@ -48,6 +48,9 @@ import org.apache.flink.table.runtime.operators.window.tvf.common.WindowTimerSer
 import org.apache.flink.table.runtime.operators.window.tvf.slicing.SlicingWindowTimerServiceImpl;
 import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.time.ZoneId;
 
 /**
@@ -68,6 +71,8 @@ public class AsyncStateWindowJoinOperator extends AsyncStateTableStreamOperator<
                 KeyContext {
 
     private static final long serialVersionUID = 1L;
+
+    private static final Logger LOG = LoggerFactory.getLogger(AsyncStateWindowJoinOperator.class);
 
     private static final String LEFT_RECORDS_STATE_NAME = "left-records";
     private static final String RIGHT_RECORDS_STATE_NAME = "right-records";
@@ -118,6 +123,8 @@ public class AsyncStateWindowJoinOperator extends AsyncStateTableStreamOperator<
     @Override
     public void open() throws Exception {
         super.open();
+
+        LOG.info("Window join is using async state");
 
         this.collector = new TimestampedCollector<>(output);
         collector.eraseTimestamp();

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/async/AbstractAsyncStateTopNFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/async/AbstractAsyncStateTopNFunction.java
@@ -34,10 +34,15 @@ import org.apache.flink.table.runtime.operators.rank.RankRange;
 import org.apache.flink.table.runtime.operators.rank.RankType;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Objects;
 
 /** Base class for TopN Function with async state api. */
 public abstract class AbstractAsyncStateTopNFunction extends AbstractTopNFunction {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractAsyncStateTopNFunction.class);
 
     private ValueState<Long> rankEndState;
 
@@ -64,6 +69,8 @@ public abstract class AbstractAsyncStateTopNFunction extends AbstractTopNFunctio
     @Override
     public void open(OpenContext openContext) throws Exception {
         super.open(openContext);
+
+        LOG.info("Top-N is using async state");
 
         if (!isConstantRankEnd) {
             ValueStateDescriptor<Long> rankStateDesc =


### PR DESCRIPTION
## What is the purpose of the change

Add logs in all existing async state ops to check if they are under async state when running

## Brief change log

  - Add logs in all existing async state ops to check if they are under async state when running

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? 
