### PR TITLE
[FLINK-37173][build] Fix license check issue in JDK11 build

### DIFF
--- a/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/NOTICE
+++ b/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/NOTICE
@@ -17,11 +17,11 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.pekko:pekko-protobuf-v3_2.12:1.1.2
 - org.apache.pekko:pekko-slf4j_2.12:1.1.2
 - org.apache.pekko:pekko-stream_2.12:1.1.2
-- org.scala-lang:scala-library:2.12.16
 
 The following dependencies all share the same BSD license which you find under licenses/LICENSE.scala.
 
 - org.scala-lang.modules:scala-java8-compat_2.12:1.0.2
+- org.scala-lang:scala-library:2.12.20
 
 This project bundles the following dependencies under the Creative Commons CC0 "No Rights Reserved".
 


### PR DESCRIPTION
## What is the purpose of the change

*Fix license check issue in JDK11 build*


## Brief change log

  - *upgrade scala version in NOTICE file*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
