### PR TITLE
[hotfix][doc] Fix typo in 'Full Window Partition Processing on DataStream' example code

### DIFF
--- a/docs/content/docs/dev/datastream/operators/full_window_partition.md
+++ b/docs/content/docs/dev/datastream/operators/full_window_partition.md
@@ -98,7 +98,7 @@ An example is as follows:
 ```java
 DataStream<Tuple2<Integer, Integer>> dataStream = //...
 PartitionWindowedStream<Tuple2<Integer, Integer>> partitionWindowedDataStream = dataStream.fullWindowPartition();
-DataStream<Integer> resultStream = partitionWindowedDataStream.aggregate(new ReduceFunction<>{...});
+DataStream<Integer> resultStream = partitionWindowedDataStream.reduce(new ReduceFunction<>{...});
 ```
 
 {{< top >}}


### PR DESCRIPTION
partitionWindowedDataStream.**aggregate**(new ReduceFunction<>{...}) should be partitionWindowedDataStream.**reduce**(new ReduceFunction<>{...})
