### PR TITLE
[FLINK-37182][tests] Remove temp partition files created during test. 

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionedFileWriteReadTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionedFileWriteReadTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
 import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
 import org.apache.flink.util.IOUtils;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -58,6 +59,15 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  */
 class PartitionedFileWriteReadTest {
     private @TempDir Path tempPath;
+    // We need a reference to the PartitionedFile to call deleteQuietly() after the test
+    private PartitionedFile partitionedFile;
+
+    @AfterEach
+    void tearDown() {
+        if (partitionedFile != null) {
+            partitionedFile.deleteQuietly();
+        }
+    }
 
     @Test
     void testWriteAndReadPartitionedFile() throws Exception {
@@ -77,18 +87,17 @@ class PartitionedFileWriteReadTest {
         }
 
         int[] writeOrder = DataBufferTest.getRandomSubpartitionOrder(numSubpartitions);
-        PartitionedFile partitionedFile =
-                createPartitionedFile(
-                        numSubpartitions,
-                        bufferSize,
-                        numBuffers,
-                        numRegions,
-                        buffersWritten,
-                        regionStat,
-                        createPartitionedFileWriter(numSubpartitions, writeOrder),
-                        subpartitionIndex -> subpartitionIndex,
-                        random.nextBoolean(),
-                        writeOrder);
+        createPartitionedFile(
+                numSubpartitions,
+                bufferSize,
+                numBuffers,
+                numRegions,
+                buffersWritten,
+                regionStat,
+                createPartitionedFileWriter(numSubpartitions, writeOrder),
+                subpartitionIndex -> subpartitionIndex,
+                random.nextBoolean(),
+                writeOrder);
 
         FileChannel dataFileChannel = openFileChannel(partitionedFile.getDataFilePath());
         FileChannel indexFileChannel = openFileChannel(partitionedFile.getIndexFilePath());
@@ -143,23 +152,20 @@ class PartitionedFileWriteReadTest {
                 randomSubpartitionOrder
                         ? DataBufferTest.getRandomSubpartitionOrder(numSubpartitions)
                         : new int[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-        PartitionedFile nonBroadcastPartitionedFile =
-                createPartitionedFile(
-                        numSubpartitions,
-                        bufferSize,
-                        numBuffers,
-                        numRegions,
-                        buffersWritten,
-                        regionStat,
-                        createPartitionedFileWriter(numSubpartitions, writeOrder),
-                        subpartitionIndex -> subpartitionIndex,
-                        broadcastRegion,
-                        writeOrder);
+        createPartitionedFile(
+                numSubpartitions,
+                bufferSize,
+                numBuffers,
+                numRegions,
+                buffersWritten,
+                regionStat,
+                createPartitionedFileWriter(numSubpartitions, writeOrder),
+                subpartitionIndex -> subpartitionIndex,
+                broadcastRegion,
+                writeOrder);
 
-        FileChannel dataFileChannel =
-                openFileChannel(nonBroadcastPartitionedFile.getDataFilePath());
-        FileChannel indexFileChannel =
-                openFileChannel(nonBroadcastPartitionedFile.getIndexFilePath());
+        FileChannel dataFileChannel = openFileChannel(partitionedFile.getDataFilePath());
+        FileChannel indexFileChannel = openFileChannel(partitionedFile.getIndexFilePath());
 
         verifyReadablePosition(
                 0,
@@ -167,7 +173,7 @@ class PartitionedFileWriteReadTest {
                 writeOrder[0],
                 dataFileChannel,
                 indexFileChannel,
-                nonBroadcastPartitionedFile,
+                partitionedFile,
                 regionStat,
                 broadcastRegion);
 
@@ -177,7 +183,7 @@ class PartitionedFileWriteReadTest {
                 writeOrder[0],
                 dataFileChannel,
                 indexFileChannel,
-                nonBroadcastPartitionedFile,
+                partitionedFile,
                 regionStat,
                 broadcastRegion);
 
@@ -187,7 +193,7 @@ class PartitionedFileWriteReadTest {
                 writeOrder[0],
                 dataFileChannel,
                 indexFileChannel,
-                nonBroadcastPartitionedFile,
+                partitionedFile,
                 regionStat,
                 broadcastRegion);
     }
@@ -278,18 +284,17 @@ class PartitionedFileWriteReadTest {
         }
 
         int[] writeOrder = DataBufferTest.getRandomSubpartitionOrder(numSubpartitions);
-        PartitionedFile partitionedFile =
-                createPartitionedFile(
-                        numSubpartitions,
-                        bufferSize,
-                        numBuffers,
-                        numRegions,
-                        buffersWritten,
-                        regionStat,
-                        createPartitionedFileWriter(numSubpartitions, writeOrder),
-                        subpartitionIndex -> subpartitionIndex / 2,
-                        false,
-                        writeOrder);
+        createPartitionedFile(
+                numSubpartitions,
+                bufferSize,
+                numBuffers,
+                numRegions,
+                buffersWritten,
+                regionStat,
+                createPartitionedFileWriter(numSubpartitions, writeOrder),
+                subpartitionIndex -> subpartitionIndex / 2,
+                false,
+                writeOrder);
 
         FileChannel dataFileChannel = openFileChannel(partitionedFile.getDataFilePath());
         FileChannel indexFileChannel = openFileChannel(partitionedFile.getIndexFilePath());
@@ -326,7 +331,7 @@ class PartitionedFileWriteReadTest {
         }
     }
 
-    private PartitionedFile createPartitionedFile(
+    private void createPartitionedFile(
             int numSubpartitions,
             int bufferSize,
             int numBuffers,
@@ -388,7 +393,7 @@ class PartitionedFileWriteReadTest {
                 }
             }
         }
-        return fileWriter.finish();
+        partitionedFile = fileWriter.finish();
     }
 
     private static long getTotalBytes(List<BufferWithSubpartition> bufferWithSubpartitions) {
@@ -456,7 +461,7 @@ class PartitionedFileWriteReadTest {
                 }
             }
         }
-        PartitionedFile partitionedFile = fileWriter.finish();
+        partitionedFile = fileWriter.finish();
 
         FileChannel dataFileChannel = openFileChannel(partitionedFile.getDataFilePath());
         FileChannel indexFileChannel = openFileChannel(partitionedFile.getIndexFilePath());
@@ -512,7 +517,7 @@ class PartitionedFileWriteReadTest {
                 }
             }
         }
-        PartitionedFile partitionedFile = fileWriter.finish();
+        partitionedFile = fileWriter.finish();
 
         FileChannel dataFileChannel = openFileChannel(partitionedFile.getDataFilePath());
         FileChannel indexFileChannel = openFileChannel(partitionedFile.getIndexFilePath());
@@ -586,7 +591,7 @@ class PartitionedFileWriteReadTest {
                     .isInstanceOf(IllegalStateException.class);
 
         } finally {
-            partitionedFileWriter.finish();
+            partitionedFile = partitionedFileWriter.finish();
         }
     }
 
@@ -616,7 +621,7 @@ class PartitionedFileWriteReadTest {
         int bufferSize = 1024;
         int numSubpartitions = 2;
         int targetSubpartition = 1;
-        PartitionedFile partitionedFile = createEmptyPartitionedFile();
+        createEmptyPartitionedFile();
 
         List<Buffer>[] buffersRead = new List[numSubpartitions];
         for (int subpartition = 0; subpartition < numSubpartitions; ++subpartition) {
@@ -665,22 +670,21 @@ class PartitionedFileWriteReadTest {
         }
 
         int[] writeOrder = DataBufferTest.getRandomSubpartitionOrder(numSubpartitions);
-        PartitionedFile partitionedFile =
-                createPartitionedFile(
+        createPartitionedFile(
+                numSubpartitions,
+                bufferSize,
+                numBuffers,
+                numRegions,
+                buffersWritten,
+                regionStat,
+                createPartitionedFileWriter(
                         numSubpartitions,
-                        bufferSize,
-                        numBuffers,
-                        numRegions,
-                        buffersWritten,
-                        regionStat,
-                        createPartitionedFileWriter(
-                                numSubpartitions,
-                                PartitionedFile.INDEX_ENTRY_SIZE * numSubpartitions,
-                                PartitionedFile.INDEX_ENTRY_SIZE * numSubpartitions,
-                                writeOrder),
-                        subpartitionIndex -> subpartitionIndex,
-                        random.nextBoolean(),
-                        writeOrder);
+                        PartitionedFile.INDEX_ENTRY_SIZE * numSubpartitions,
+                        PartitionedFile.INDEX_ENTRY_SIZE * numSubpartitions,
+                        writeOrder),
+                subpartitionIndex -> subpartitionIndex,
+                random.nextBoolean(),
+                writeOrder);
 
         FileChannel dataFileChannel = openFileChannel(partitionedFile.getDataFilePath());
         FileChannel indexFileChannel = openFileChannel(partitionedFile.getIndexFilePath());
@@ -726,9 +730,9 @@ class PartitionedFileWriteReadTest {
         return Collections.singletonList(new BufferWithSubpartition(buffer, subpartitionIndex));
     }
 
-    private PartitionedFile createEmptyPartitionedFile() throws IOException {
+    private void createEmptyPartitionedFile() throws IOException {
         PartitionedFileWriter partitionedFileWriter = createPartitionedFileWriter(2, new int[0]);
-        return partitionedFileWriter.finish();
+        partitionedFile = partitionedFileWriter.finish();
     }
 
     private PartitionedFileWriter createPartitionedFileWriter(
@@ -755,7 +759,7 @@ class PartitionedFileWriteReadTest {
 
     private PartitionedFileWriter createAndFinishPartitionedFileWriter() throws IOException {
         PartitionedFileWriter partitionedFileWriter = createPartitionedFileWriter(1, new int[0]);
-        partitionedFileWriter.finish();
+        partitionedFile = partitionedFileWriter.finish();
         return partitionedFileWriter;
     }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This PR improves the `PartitionedFileWriteReadTest`. The test now removes partition files after it finishes. 


## Brief change log

- Call `partitionedFile.deleteQuietly();` after test finishes. 

## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

With the patch I confirm that the partition files are removed. 


## Does this pull request potentially affect one of the following parts:

This PR only contains test changes. 
