### PR TITLE
[FLINK-37183][clients] Fix symbolic links not being followed in "usrlib"

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/DefaultPackagedProgramRetriever.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/DefaultPackagedProgramRetriever.java
@@ -35,6 +35,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -237,7 +238,7 @@ public class DefaultPackagedProgramRetriever implements PackagedProgramRetriever
             return Collections.emptyList();
         }
 
-        try (Stream<Path> files = Files.walk(userLibDir.toPath())) {
+        try (Stream<Path> files = Files.walk(userLibDir.toPath(), FileVisitOption.FOLLOW_LINKS)) {
             return getClasspathsFromArtifacts(files, jarFile);
         }
     }

--- a/flink-clients/src/test/java/org/apache/flink/client/testjar/ClasspathProviderExtension.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/testjar/ClasspathProviderExtension.java
@@ -43,6 +43,8 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * {@code ClasspathProviderExtension} offers utility methods for creating a classpath based on
  * actual jars.
@@ -88,6 +90,24 @@ public class ClasspathProviderExtension implements BeforeEachCallback, AfterEach
                     copyJar(JOB_LIB_JAR_PATH, directory);
                     copyJar(JOB_JAR_PATH, directory);
                     createTestFile(directory);
+                },
+                JOB_JAR_PATH.toFile());
+    }
+
+    public static ClasspathProviderExtension createWithSymlink() {
+        return new ClasspathProviderExtension(
+                "_user_dir_with_symlink",
+                directory -> {
+                    final File actualUsrLib = new File(directory, "usrlib");
+                    final File symLinkDir = new File(directory, "symlink");
+                    assertThat(actualUsrLib.mkdirs()).isTrue();
+                    assertThat(symLinkDir.mkdirs()).isTrue();
+
+                    copyJar(JOB_LIB_JAR_PATH, symLinkDir);
+                    copyJar(JOB_JAR_PATH, actualUsrLib);
+
+                    Files.createSymbolicLink(
+                            actualUsrLib.toPath().resolve("symlink"), symLinkDir.toPath());
                 },
                 JOB_JAR_PATH.toFile());
     }


### PR DESCRIPTION
## What is the purpose of the change

When we switched from using Files.list to Files.walk to determine the classpath for usrlib, we stopped following symbolic links automatically. By adding an option to the Files.walk method we once again follow symbolic links.

## Brief change log

- Symbolic links are once again being followed in usrlib

## Verifying this change

This change added tests and can be verified as follows:

  - *Added red-green test for an usrlib with symlinks*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
