### PR TITLE
[FLINK-37184][connector/filesystem] Add ZStandard to supported standard decompressors

### DIFF
--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/compression/StandardDeCompressors.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/compression/StandardDeCompressors.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.io.compression.DeflateInflaterInputStreamFact
 import org.apache.flink.api.common.io.compression.GzipInflaterInputStreamFactory;
 import org.apache.flink.api.common.io.compression.InflaterInputStreamFactory;
 import org.apache.flink.api.common.io.compression.XZInputStreamFactory;
+import org.apache.flink.api.common.io.compression.ZStandardInputStreamFactory;
 
 import javax.annotation.Nullable;
 
@@ -43,7 +44,8 @@ public final class StandardDeCompressors {
                     DeflateInflaterInputStreamFactory.getInstance(),
                     GzipInflaterInputStreamFactory.getInstance(),
                     Bzip2InputStreamFactory.getInstance(),
-                    XZInputStreamFactory.getInstance());
+                    XZInputStreamFactory.getInstance(),
+                    ZStandardInputStreamFactory.getInstance());
 
     /** All common file extensions of supported file compression formats. */
     private static final Collection<String> COMMON_SUFFIXES =

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/compression/StandardDeCompressorsTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/compression/StandardDeCompressorsTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.src.compression;
+
+import org.apache.flink.api.common.io.compression.Bzip2InputStreamFactory;
+import org.apache.flink.api.common.io.compression.DeflateInflaterInputStreamFactory;
+import org.apache.flink.api.common.io.compression.GzipInflaterInputStreamFactory;
+import org.apache.flink.api.common.io.compression.InflaterInputStreamFactory;
+import org.apache.flink.api.common.io.compression.XZInputStreamFactory;
+import org.apache.flink.api.common.io.compression.ZStandardInputStreamFactory;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StandardDeCompressorsTest {
+
+    @Test
+    void testDeflateDeCompressor() {
+        assertThat(StandardDeCompressors.getCommonSuffixes()).contains("deflate");
+
+        InflaterInputStreamFactory<?> inputStreamFactory =
+                DeflateInflaterInputStreamFactory.getInstance();
+        assertThat(StandardDeCompressors.getDecompressorForExtension("deflate"))
+                .isEqualTo(inputStreamFactory);
+        assertThat(StandardDeCompressors.getDecompressorForFileName("file.pcap.deflate"))
+                .isEqualTo(inputStreamFactory);
+    }
+
+    @Test
+    void testGZIPDeCompressor() {
+        assertThat(StandardDeCompressors.getCommonSuffixes()).contains("gz").contains("gzip");
+
+        InflaterInputStreamFactory<?> inputStreamFactory =
+                GzipInflaterInputStreamFactory.getInstance();
+        assertThat(StandardDeCompressors.getDecompressorForExtension("gz"))
+                .isEqualTo(inputStreamFactory);
+        assertThat(StandardDeCompressors.getDecompressorForExtension("gzip"))
+                .isEqualTo(inputStreamFactory);
+        assertThat(StandardDeCompressors.getDecompressorForFileName("file.pcap.gz"))
+                .isEqualTo(inputStreamFactory);
+        assertThat(StandardDeCompressors.getDecompressorForFileName("file.pcap.gzip"))
+                .isEqualTo(inputStreamFactory);
+    }
+
+    @Test
+    void testBzip2DeCompressor() {
+        assertThat(StandardDeCompressors.getCommonSuffixes()).contains("bz2");
+
+        InflaterInputStreamFactory<?> inputStreamFactory = Bzip2InputStreamFactory.getInstance();
+        assertThat(StandardDeCompressors.getDecompressorForExtension("bz2"))
+                .isEqualTo(inputStreamFactory);
+        assertThat(StandardDeCompressors.getDecompressorForFileName("file.pcap.bz2"))
+                .isEqualTo(inputStreamFactory);
+    }
+
+    @Test
+    void testXZDeCompressor() {
+        assertThat(StandardDeCompressors.getCommonSuffixes()).contains("xz");
+
+        InflaterInputStreamFactory<?> inputStreamFactory = XZInputStreamFactory.getInstance();
+        assertThat(StandardDeCompressors.getDecompressorForExtension("xz"))
+                .isEqualTo(inputStreamFactory);
+        assertThat(StandardDeCompressors.getDecompressorForFileName("file.pcap.xz"))
+                .isEqualTo(inputStreamFactory);
+    }
+
+    @Test
+    void testZStandardDeCompressor() {
+        assertThat(StandardDeCompressors.getCommonSuffixes()).contains("zst");
+
+        InflaterInputStreamFactory<?> inputStreamFactory =
+                ZStandardInputStreamFactory.getInstance();
+        assertThat(StandardDeCompressors.getDecompressorForExtension("zst"))
+                .isEqualTo(inputStreamFactory);
+        assertThat(StandardDeCompressors.getDecompressorForFileName("file.pcap.zst"))
+                .isEqualTo(inputStreamFactory);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

* Support ZStandard decompression for input files of the new File API. When ZStandard was first added it was only added to the old File API, the new File API was left out.

## Brief change log

- *Added ZStandard to the list of decompressors in StandardDeCompressors*

## Verifying this change

- *Added unit test for StandardDeCompressors*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
