### PR TITLE
[hotfix] Fix the issue related to mounting the Logback configuration.

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/FlinkConfMountDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/FlinkConfMountDecorator.java
@@ -57,8 +57,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.apache.flink.kubernetes.utils.Constants.CONFIG_FILE_LOG4J_NAME;
-import static org.apache.flink.kubernetes.utils.Constants.CONFIG_FILE_LOGBACK_NAME;
+import static org.apache.flink.kubernetes.utils.Constants.CONFIG_FILE_NAME_LIST;
 import static org.apache.flink.kubernetes.utils.Constants.CONFIG_MAP_PREFIX;
 import static org.apache.flink.kubernetes.utils.Constants.FLINK_CONF_VOLUME;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -179,15 +178,14 @@ public class FlinkConfMountDecorator extends AbstractKubernetesStepDecorator {
 
     private List<File> getLocalLogConfFiles() {
         final String confDir = kubernetesComponentConf.getConfigDirectory();
-        final File logbackFile = new File(confDir, CONFIG_FILE_LOGBACK_NAME);
-        final File log4jFile = new File(confDir, CONFIG_FILE_LOG4J_NAME);
 
         List<File> localLogConfFiles = new ArrayList<>();
-        if (logbackFile.exists()) {
-            localLogConfFiles.add(logbackFile);
-        }
-        if (log4jFile.exists()) {
-            localLogConfFiles.add(log4jFile);
+
+        for (String fileName : CONFIG_FILE_NAME_LIST) {
+            final File file = new File(confDir, fileName);
+            if (file.exists()) {
+                localLogConfFiles.add(file);
+            }
         }
 
         return localLogConfFiles;

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/Constants.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/Constants.java
@@ -18,6 +18,9 @@
 
 package org.apache.flink.kubernetes.utils;
 
+import java.util.Arrays;
+import java.util.List;
+
 /** Constants for kubernetes. */
 public class Constants {
 
@@ -30,6 +33,17 @@ public class Constants {
 
     public static final String CONFIG_FILE_LOGBACK_NAME = "logback-console.xml";
     public static final String CONFIG_FILE_LOG4J_NAME = "log4j-console.properties";
+
+    public static final List<String> CONFIG_FILE_NAME_LIST =
+            Arrays.asList(
+                    "logback.xml",
+                    "log4j.properties",
+                    "logback-console.xml",
+                    "log4j-console.properties",
+                    "logback-session.xml",
+                    "log4j-session.properties",
+                    "log4j-cli.properties");
+
     public static final String ENV_FLINK_LOG_DIR = "FLINK_LOG_DIR";
 
     public static final String MAIN_CONTAINER_NAME = "flink-main-container";


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0c3f6b25-7ead-4826-bc7f-77319c921da4)

Flink on Kubernetes has these configuration files mounted by default, but some are incomplete, leading to certain features being unavailable.

![image](https://github.com/user-attachments/assets/0eb35de0-3c7b-49ac-8cc0-132a70025fdc)

![image](https://github.com/user-attachments/assets/d6f9180a-c240-4d0f-ae49-ccda6d100278)