### PR TITLE
[FLINK-37181][build] Fix MacOS sha256sum tool compile error

### DIFF
--- a/mvnw
+++ b/mvnw
@@ -284,11 +284,11 @@ done <"$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.properties"
 if [ -n "$wrapperSha256Sum" ]; then
   wrapperSha256Result=false
   if command -v sha256sum >/dev/null; then
-    if echo "$wrapperSha256Sum  $wrapperJarPath" | sha256sum -c >/dev/null 2>&1; then
+    if echo "$wrapperSha256Sum  $wrapperJarPath" | sha256sum -c - >/dev/null 2>&1; then
       wrapperSha256Result=true
     fi
   elif command -v shasum >/dev/null; then
-    if echo "$wrapperSha256Sum  $wrapperJarPath" | shasum -a 256 -c >/dev/null 2>&1; then
+    if echo "$wrapperSha256Sum  $wrapperJarPath" | shasum -a 256 -c - >/dev/null 2>&1; then
       wrapperSha256Result=true
     fi
   else


### PR DESCRIPTION
## What is the purpose of the change

The maven command is failing in the following way due to a wrongly working MacOS tool called sha256sum:
```
Running `/Users/gaborsomogyi/flink/mvnw`...
Error: Failed to validate Maven wrapper SHA-256, your Maven wrapper might be compromised.
Investigate or delete /Users/gaborsomogyi/flink/.mvn/wrapper/maven-wrapper.jar to attempt a clean download.
If you updated your Maven version, you need to update the specified wrapperSha256Sum property.
```

The issue is that `sha256sum` is not working as described in the manual:
```
In all cases, each file listed on the command line is processed separately.  If no files are listed on the command line, or a file name is given as -, input is taken from stdin instead.
```

Manual test:
```
$ echo '3d8f20ce6103913be8b52aef6d994e0c54705fb527324ceb9b835b338739c7a8  /Users/gaborsomogyi/flink/.mvn/wrapper/maven-wrapper.jar' | sha256sum -c    
usage: sha256sum [-bctwz] [files ...]
$ echo '3d8f20ce6103913be8b52aef6d994e0c54705fb527324ceb9b835b338739c7a8  /Users/gaborsomogyi/flink/.mvn/wrapper/maven-wrapper.jar' | sha256sum -c -  
/Users/gaborsomogyi/flink/.mvn/wrapper/maven-wrapper.jar: OK
```

In short `sha256sum` works only when file name is given as `-` so in this PR I've added explicit file name.

## Brief change log

Added explicit file name to `sha256sum` and `shasum`.

## Verifying this change

Manually on MacOS and linux.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
