### PR TITLE
[FLINK-37125] [conf] fixed env.log.max java.lang.NumberFormatException

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -240,6 +240,8 @@ fi
 
 if [ -z "${MAX_LOG_FILE_NUMBER}" ]; then
     MAX_LOG_FILE_NUMBER=$(readFromConfig ${KEY_ENV_LOG_MAX} ${DEFAULT_ENV_LOG_MAX} "${YAML_CONF}")
+    # Remove leading and ending single quotes (if present) of value
+    MAX_LOG_FILE_NUMBER="$( echo "${MAX_LOG_FILE_NUMBER}" | sed -e "s/^'//"  -e "s/'$//" )"
     export MAX_LOG_FILE_NUMBER
 fi
 


### PR DESCRIPTION

## What is the purpose of the change
**Fix for NumberFormatException in Log Configuration**
This PR resolves an issue where the log.max parameter in config.yaml was treated as a string, causing a java.lang.NumberFormatException when parsed by the DefaultRolloverStrategy plugin.

**Changes:**
Updated the config.sh script to clean up MAX_LOG_FILE_NUMBER by removing leading and trailing single quotes before parsing.

Testing:
Verified correct parsing of config env.log.max in a real Hadoop 3.3.6 cluster.
Confirmed the history server starts without errors after the change.

## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
