### PR TITLE
[FLINK-37021][state/forst] Fix incorrect paths when reusing files for checkpoints.

### DIFF
--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStResourceContainer.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStResourceContainer.java
@@ -28,10 +28,8 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.memory.OpaqueMemoryResource;
 import org.apache.flink.runtime.state.CheckpointStorageAccess;
-import org.apache.flink.state.forst.datatransfer.DataTransferStrategy;
 import org.apache.flink.state.forst.fs.ForStFlinkFileSystem;
 import org.apache.flink.state.forst.fs.StringifiedForStFileSystem;
-import org.apache.flink.state.forst.fs.filemapping.FileOwnershipDecider;
 import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.Preconditions;
@@ -105,12 +103,6 @@ public final class ForStResourceContainer implements AutoCloseable {
 
     /** The ForSt file system. Null when remote dir is not set. */
     @Nullable private ForStFlinkFileSystem forStFileSystem;
-
-    private final RecoveryClaimMode claimMode;
-
-    private final FileOwnershipDecider fileOwnershipDecider;
-
-    private DataTransferStrategy dataTransferStrategy;
 
     /**
      * The shared resource among ForSt instances. This resource is not part of the 'handlesToClose',
@@ -193,8 +185,6 @@ public final class ForStResourceContainer implements AutoCloseable {
         this.remoteBasePath = remoteBasePath;
         this.remoteForStPath =
                 remoteBasePath != null ? new Path(remoteBasePath, DB_DIR_STRING) : null;
-        this.claimMode = claimMode;
-        this.fileOwnershipDecider = new FileOwnershipDecider(claimMode);
 
         this.enableStatistics = enableStatistics;
         this.handlesToClose = new ArrayList<>();
@@ -395,7 +385,6 @@ public final class ForStResourceContainer implements AutoCloseable {
                     ForStFlinkFileSystem.get(
                             remoteForStPath.toUri(),
                             localForStPath,
-                            fileOwnershipDecider,
                             ForStFlinkFileSystem.getFileBasedCache(
                                     cacheBasePath, cacheCapacity, cacheReservedSize, metricGroup));
         } else {
@@ -405,10 +394,6 @@ public final class ForStResourceContainer implements AutoCloseable {
 
     public @Nullable ForStFlinkFileSystem getFileSystem() {
         return forStFileSystem;
-    }
-
-    public DataTransferStrategy getDataTransferStrategy() {
-        return dataTransferStrategy;
     }
 
     private static void prepareDirectories(Path basePath, Path dbPath) throws IOException {

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/fs/ForStFlinkFileSystem.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/fs/ForStFlinkFileSystem.java
@@ -80,14 +80,12 @@ public class ForStFlinkFileSystem extends FileSystem {
             FileSystem delegateFS,
             String remoteBase,
             String localBase,
-            @Nullable FileOwnershipDecider fileOwnershipDecider,
             @Nullable FileBasedCache fileBasedCache) {
         this.localFS = FileSystem.getLocalFileSystem();
         this.delegateFS = delegateFS;
         this.remoteBase = remoteBase;
         this.fileBasedCache = fileBasedCache;
-        this.fileMappingManager =
-                new FileMappingManager(delegateFS, fileOwnershipDecider, remoteBase, localBase);
+        this.fileMappingManager = new FileMappingManager(delegateFS, remoteBase, localBase);
     }
 
     /**
@@ -101,26 +99,14 @@ public class ForStFlinkFileSystem extends FileSystem {
      */
     public static ForStFlinkFileSystem get(URI uri) throws IOException {
         return new ForStFlinkFileSystem(
-                FileSystem.get(uri),
-                uri.toString(),
-                System.getProperty("java.io.tmpdir"),
-                null,
-                null);
+                FileSystem.get(uri), uri.toString(), System.getProperty("java.io.tmpdir"), null);
     }
 
-    public static ForStFlinkFileSystem get(
-            URI uri,
-            Path localBase,
-            FileOwnershipDecider fileOwnershipDecider,
-            FileBasedCache fileBasedCache)
+    public static ForStFlinkFileSystem get(URI uri, Path localBase, FileBasedCache fileBasedCache)
             throws IOException {
         Preconditions.checkNotNull(localBase, "localBase is null, remote uri: %s.", uri);
         return new ForStFlinkFileSystem(
-                FileSystem.get(uri),
-                uri.toString(),
-                localBase.toString(),
-                fileOwnershipDecider,
-                fileBasedCache);
+                FileSystem.get(uri), uri.toString(), localBase.toString(), fileBasedCache);
     }
 
     public static FileBasedCache getFileBasedCache(
@@ -193,7 +179,7 @@ public class ForStFlinkFileSystem extends FileSystem {
         CachedDataOutputStream cachedDataOutputStream =
                 createCachedDataOutputStream(dbFilePath, sourceRealPath, outputStream);
 
-        LOG.info(
+        LOG.trace(
                 "Create file: dbFilePath: {}, sourceRealPath: {}, cachedDataOutputStream: {}",
                 dbFilePath,
                 sourceRealPath,
@@ -352,11 +338,6 @@ public class ForStFlinkFileSystem extends FileSystem {
     public synchronized void registerReusedRestoredFile(
             String key, StreamStateHandle stateHandle, Path dbFilePath) {
         fileMappingManager.registerReusedRestoredFile(key, stateHandle, dbFilePath);
-    }
-
-    public synchronized @Nullable Path srcPath(Path path) {
-        MappingEntry mappingEntry = fileMappingManager.mappingEntry(path.toString());
-        return mappingEntry == null ? null : mappingEntry.getSourcePath();
     }
 
     public synchronized @Nullable MappingEntry getMappingEntry(Path path) {

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/fs/filemapping/FileOwnershipDecider.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/fs/filemapping/FileOwnershipDecider.java
@@ -17,78 +17,22 @@
 
 package org.apache.flink.state.forst.fs.filemapping;
 
-import org.apache.flink.core.execution.RecoveryClaimMode;
-import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.runtime.state.CheckpointStorageAccess;
-import org.apache.flink.runtime.state.filesystem.FsCheckpointStorageAccess;
-import org.apache.flink.runtime.state.filesystem.FsMergingCheckpointStorageAccess;
-
-import javax.annotation.Nullable;
-
-import java.io.IOException;
 
 public class FileOwnershipDecider {
 
     public static final String SST_SUFFIX = ".sst";
 
-    private final RecoveryClaimMode recoveryClaimMode;
+    private FileOwnershipDecider() {}
 
-    public static FileOwnershipDecider getDefault() {
-        return new FileOwnershipDecider(RecoveryClaimMode.DEFAULT);
-    }
-
-    private static boolean isDbPathUnderCheckpointPath(
-            @Nullable CheckpointStorageAccess checkpointStorageAccess,
-            @Nullable Path dbRemotePath) {
-        if (dbRemotePath == null) {
-            return false;
-        }
-
-        // For checkpoint other that FsCheckpointStorageAccess, we treat it as 'DB path not under
-        // checkpoint path', since we cannot reuse checkpoint files in such case.
-        // todo: Support enabling 'cp file reuse' with FsMergingCheckpointStorageAccess
-        if (!(checkpointStorageAccess instanceof FsCheckpointStorageAccess)
-                || checkpointStorageAccess instanceof FsMergingCheckpointStorageAccess) {
-            return false;
-        }
-
-        FsCheckpointStorageAccess fsCheckpointStorageAccess =
-                (FsCheckpointStorageAccess) checkpointStorageAccess;
-        FileSystem checkpointFS = fsCheckpointStorageAccess.getFileSystem();
-        FileSystem dbRemoteFS;
-        try {
-            dbRemoteFS = dbRemotePath.getFileSystem();
-        } catch (IOException e) {
-            throw new RuntimeException(
-                    "Failed to get FileSystem from dbRemotePath: " + dbRemotePath, e);
-        }
-
-        if (!checkpointFS.equals(dbRemoteFS)) {
-            // different file system
-            return false;
-        } else {
-            // same file system
-            String checkpointPathStr =
-                    fsCheckpointStorageAccess.getCheckpointsDirectory().getPath();
-            String dbRemotePathStr = dbRemotePath.getPath();
-            return checkpointPathStr.equals(dbRemotePathStr)
-                    || dbRemotePathStr.startsWith(checkpointPathStr);
-        }
-    }
-
-    public FileOwnershipDecider(RecoveryClaimMode recoveryClaimMode) {
-        this.recoveryClaimMode = recoveryClaimMode;
-    }
-
-    public FileOwnership decideForNewFile(Path filePath) {
+    public static FileOwnership decideForNewFile(Path filePath) {
         // local files are always privately owned by DB
         return shouldAlwaysBeLocal(filePath)
                 ? FileOwnership.PRIVATE_OWNED_BY_DB
                 : FileOwnership.SHAREABLE_OWNED_BY_DB;
     }
 
-    public FileOwnership decideForRestoredFile(Path filePath) {
+    public static FileOwnership decideForRestoredFile(Path filePath) {
         // local files are always privately owned by DB
         return shouldAlwaysBeLocal(filePath)
                 ? FileOwnership.PRIVATE_OWNED_BY_DB
@@ -101,10 +45,5 @@ public class FileOwnershipDecider {
 
     public static boolean shouldAlwaysBeLocal(Path filePath) {
         return !isSstFile(filePath);
-    }
-
-    @Override
-    public String toString() {
-        return "FileOwnershipDecider{" + "recoveryClaimMode=" + recoveryClaimMode + '}';
     }
 }

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/restore/ForStIncrementalRestoreOperation.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/restore/ForStIncrementalRestoreOperation.java
@@ -263,7 +263,7 @@ public class ForStIncrementalRestoreOperation<K> implements ForStRestoreOperatio
                         ForStStateDataTransfer.DEFAULT_THREAD_NUM,
                         optionsContainer.getFileSystem())) {
             transfer.transferAllStateDataToDirectory(
-                    specs, cancelStreamRegistry, RecoveryClaimMode.DEFAULT);
+                    specs, cancelStreamRegistry, recoveryClaimMode);
         }
     }
 

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/snapshot/ForStIncrementalSnapshotStrategy.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/snapshot/ForStIncrementalSnapshotStrategy.java
@@ -136,14 +136,16 @@ public class ForStIncrementalSnapshotStrategy<K> extends ForStNativeFullSnapshot
             case FORWARD_BACKWARD:
                 // incremental checkpoint, use origin PreviousSnapshot
                 break;
-            case FORWARD:
             case NO_SHARING:
-                // full checkpoint, use empty PreviousSnapshot
+                // savepoint, use empty PreviousSnapshot
                 snapshotResources.setPreviousSnapshot(EMPTY_PREVIOUS_SNAPSHOT);
                 break;
+            case FORWARD: // full checkpoint for IncrementalSnapshotStrategy is not supported
             default:
                 throw new IllegalArgumentException(
-                        "Unsupported sharing files strategy: " + sharingFilesStrategy);
+                        String.format(
+                                "Unsupported sharing files strategy for %s : %s",
+                                this.getClass().getName(), sharingFilesStrategy));
         }
 
         return new ForStIncrementalSnapshotOperation(
@@ -331,6 +333,7 @@ public class ForStIncrementalSnapshotStrategy<K> extends ForStNativeFullSnapshot
 
             List<HandleAndLocalPath> sstFilesTransferResult =
                     stateTransfer.transferFilesToCheckpointFs(
+                            sharingFilesStrategy,
                             classifiedFiles.f1,
                             checkpointStreamFactory,
                             stateScope,
@@ -345,6 +348,7 @@ public class ForStIncrementalSnapshotStrategy<K> extends ForStNativeFullSnapshot
 
             List<HandleAndLocalPath> miscFilesTransferResult =
                     stateTransfer.transferFilesToCheckpointFs(
+                            sharingFilesStrategy,
                             classifiedFiles.f2,
                             checkpointStreamFactory,
                             stateScope,
@@ -358,6 +362,7 @@ public class ForStIncrementalSnapshotStrategy<K> extends ForStNativeFullSnapshot
 
             HandleAndLocalPath manifestFileTransferResult =
                     stateTransfer.transferFileToCheckpointFs(
+                            sharingFilesStrategy,
                             classifiedFiles.f3,
                             snapshotResources.manifestFileSize,
                             checkpointStreamFactory,

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStResourceContainerTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStResourceContainerTest.java
@@ -347,7 +347,7 @@ public class ForStResourceContainerTest {
         DBOptions dbOptions2 =
                 new DBOptions().setCreateIfMissing(true).setAvoidFlushDuringShutdown(true);
         ForStFlinkFileSystem fileSystem =
-                ForStFlinkFileSystem.get(remoteBasePath.toUri(), localBasePath, null, null);
+                ForStFlinkFileSystem.get(remoteBasePath.toUri(), localBasePath, null);
         dbOptions2.setEnv(
                 new FlinkEnv(
                         remoteBasePath.toString(), new StringifiedForStFileSystem(fileSystem)));

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/datatransfer/ForStStateDataTransferTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/datatransfer/ForStStateDataTransferTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.fs.FileStatus;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.checkpoint.SnapshotType;
 import org.apache.flink.runtime.state.CheckpointStateOutputStream;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.CheckpointedStateScope;
@@ -108,6 +109,7 @@ class ForStStateDataTransferTest extends TestLogger {
             assertThatThrownBy(
                             () ->
                                     stateTransfer.transferFilesToCheckpointFs(
+                                            SnapshotType.SharingFilesStrategy.FORWARD_BACKWARD,
                                             filePaths,
                                             checkpointStreamFactory,
                                             CheckpointedStateScope.SHARED,
@@ -149,6 +151,7 @@ class ForStStateDataTransferTest extends TestLogger {
         CloseableRegistry tmpResourcesRegistry = new CloseableRegistry();
         try (ForStStateDataTransfer stateTransfer = new ForStStateDataTransfer(1)) {
             stateTransfer.transferFilesToCheckpointFs(
+                    SnapshotType.SharingFilesStrategy.FORWARD_BACKWARD,
                     filePaths,
                     checkpointStreamFactory,
                     CheckpointedStateScope.SHARED,
@@ -158,6 +161,7 @@ class ForStStateDataTransferTest extends TestLogger {
             assertThatThrownBy(
                             () ->
                                     stateTransfer.transferFilesToCheckpointFs(
+                                            SnapshotType.SharingFilesStrategy.FORWARD_BACKWARD,
                                             filePaths,
                                             new LastFailingCheckpointStateOutputStreamFactory(
                                                     checkpointStreamFactory,
@@ -179,6 +183,7 @@ class ForStStateDataTransferTest extends TestLogger {
             assertThatThrownBy(
                             () ->
                                     stateTransfer.transferFilesToCheckpointFs(
+                                            SnapshotType.SharingFilesStrategy.FORWARD_BACKWARD,
                                             Collections.singletonList(first),
                                             checkpointStreamFactory,
                                             CheckpointedStateScope.SHARED,
@@ -222,6 +227,7 @@ class ForStStateDataTransferTest extends TestLogger {
         try (ForStStateDataTransfer stateTransfer = new ForStStateDataTransfer(5)) {
             HandleAndLocalPath handleAndLocalPath =
                     stateTransfer.transferFileToCheckpointFs(
+                            SnapshotType.SharingFilesStrategy.FORWARD_BACKWARD,
                             sstFile,
                             headBytes,
                             checkpointStreamFactory,
@@ -264,6 +270,7 @@ class ForStStateDataTransferTest extends TestLogger {
         try (ForStStateDataTransfer stateTransfer = new ForStStateDataTransfer(5)) {
             List<HandleAndLocalPath> sstFiles =
                     stateTransfer.transferFilesToCheckpointFs(
+                            SnapshotType.SharingFilesStrategy.FORWARD_BACKWARD,
                             sstFilePaths,
                             checkpointStreamFactory,
                             CheckpointedStateScope.SHARED,

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/fs/FileMappingManagerTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/fs/FileMappingManagerTest.java
@@ -18,13 +18,11 @@
 
 package org.apache.flink.state.forst.fs;
 
-import org.apache.flink.core.execution.RecoveryClaimMode;
 import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.state.filesystem.FileStateHandle;
 import org.apache.flink.state.forst.fs.filemapping.FileMappingManager;
-import org.apache.flink.state.forst.fs.filemapping.FileOwnershipDecider;
 import org.apache.flink.state.forst.fs.filemapping.MappingEntry;
 import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
@@ -52,10 +50,6 @@ public class FileMappingManagerTest {
 
     @Parameter public boolean reuseCp;
 
-    FileOwnershipDecider createFileOwnershipDecider() {
-        return new FileOwnershipDecider(RecoveryClaimMode.CLAIM);
-    }
-
     private MappingEntry registerFile(FileMappingManager manager, Path filePath) {
         if (reuseCp) {
             return manager.registerReusedRestoredFile(
@@ -69,11 +63,7 @@ public class FileMappingManagerTest {
     void testFileLink() throws IOException {
         FileSystem localFS = FileSystem.getLocalFileSystem();
         FileMappingManager fileMappingManager =
-                new FileMappingManager(
-                        localFS,
-                        createFileOwnershipDecider(),
-                        tempDir.toString(),
-                        tempDir.toString());
+                new FileMappingManager(localFS, tempDir.toString(), tempDir.toString());
         String src = tempDir + "/source";
         FSDataOutputStream os = localFS.create(new Path(src), FileSystem.WriteMode.OVERWRITE);
         os.write(233);
@@ -92,11 +82,7 @@ public class FileMappingManagerTest {
         // link d->c
         FileSystem localFS = FileSystem.getLocalFileSystem();
         FileMappingManager fileMappingManager =
-                new FileMappingManager(
-                        localFS,
-                        createFileOwnershipDecider(),
-                        tempDir.toString(),
-                        tempDir.toString());
+                new FileMappingManager(localFS, tempDir.toString(), tempDir.toString());
         String src = tempDir + "/a";
         FSDataOutputStream os = localFS.create(new Path(src), FileSystem.WriteMode.OVERWRITE);
         os.write(233);
@@ -127,11 +113,7 @@ public class FileMappingManagerTest {
     void testFileDelete() throws IOException {
         FileSystem localFS = FileSystem.getLocalFileSystem();
         FileMappingManager fileMappingManager =
-                new FileMappingManager(
-                        localFS,
-                        createFileOwnershipDecider(),
-                        tempDir.toString(),
-                        tempDir.toString());
+                new FileMappingManager(localFS, tempDir.toString(), tempDir.toString());
         String src = tempDir + "/source";
         registerFile(fileMappingManager, new Path(src));
         Path srcFileRealPath = fileMappingManager.mappingEntry(src).getSourcePath();
@@ -160,10 +142,7 @@ public class FileMappingManagerTest {
         FileSystem localFS = FileSystem.getLocalFileSystem();
         FileMappingManager fileMappingManager =
                 new FileMappingManager(
-                        localFS,
-                        createFileOwnershipDecider(),
-                        tempDir.toString() + "/db",
-                        tempDir.toString() + "/db");
+                        localFS, tempDir.toString() + "/db", tempDir.toString() + "/db");
         String testDir = tempDir + "/testDir";
         localFS.mkdirs(new Path(testDir));
         String src = testDir + "/source";
@@ -190,10 +169,7 @@ public class FileMappingManagerTest {
         FileSystem localFS = FileSystem.getLocalFileSystem();
         FileMappingManager fileMappingManager =
                 new FileMappingManager(
-                        localFS,
-                        createFileOwnershipDecider(),
-                        tempDir.toString() + "/db",
-                        tempDir.toString() + "/db");
+                        localFS, tempDir.toString() + "/db", tempDir.toString() + "/db");
         String testDir = tempDir + "/testDir";
         localFS.mkdirs(new Path(testDir));
         String src = testDir + "/source";
@@ -245,10 +221,7 @@ public class FileMappingManagerTest {
         FileSystem localFS = FileSystem.getLocalFileSystem();
         FileMappingManager fileMappingManager =
                 new FileMappingManager(
-                        localFS,
-                        createFileOwnershipDecider(),
-                        tempDir.toString() + "/db",
-                        tempDir.toString() + "/db");
+                        localFS, tempDir.toString() + "/db", tempDir.toString() + "/db");
         String testDir = tempDir + "/testDir";
         localFS.mkdirs(new Path(testDir));
         String src = testDir + "/source";

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/fs/ForStFlinkFileSystemTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/fs/ForStFlinkFileSystemTest.java
@@ -86,7 +86,6 @@ public class ForStFlinkFileSystemTest {
                 ForStFlinkFileSystem.get(
                         new URI(tempDir.toString()),
                         new org.apache.flink.core.fs.Path(tempDir.toString()),
-                        null,
                         null);
         testReadAndWriteWithByteBuffer(fileSystem);
     }
@@ -98,7 +97,6 @@ public class ForStFlinkFileSystemTest {
                         new ByteBufferReadableLocalFileSystem(),
                         tempDir.toString(),
                         tempDir.toString(),
-                        null,
                         fileBasedCache);
         testReadAndWriteWithByteBuffer(fileSystem);
     }
@@ -178,7 +176,6 @@ public class ForStFlinkFileSystemTest {
                         new ByteBufferReadableLocalFileSystem(),
                         tempDir.toString(),
                         tempDir.toString(),
-                        null,
                         fileBasedCache);
 
         org.apache.flink.core.fs.Path testFilePath =
@@ -205,7 +202,6 @@ public class ForStFlinkFileSystemTest {
                         new ByteBufferReadableLocalFileSystem(),
                         remotePath.toString(),
                         localPath.toString(),
-                        null,
                         fileBasedCache);
         fileSystem.mkdirs(remotePath);
         fileSystem.mkdirs(localPath);
@@ -265,7 +261,6 @@ public class ForStFlinkFileSystemTest {
                         new ByteBufferReadableLocalFileSystem(),
                         remotePath.toString(),
                         localPath.toString(),
-                        null,
                         cache);
         fileSystem.mkdirs(remotePath);
         fileSystem.mkdirs(localPath);


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull request addresses several bugs in ForSt that may prevent proper file reuse, leading to slower or failed snapshot and restoration operations.


## Brief change log

  - Make ```DataTransferStrategyBuilder``` function properly.
    - Use ```URI``` to tell whether two ```FileSystem``` are the same.
    - Use 'Reuse' strategy for Restoration only in CLAIM mode
    - Use 'Reuse' strategy for Snapshot only when ```SharingFilesStrategy``` is 'FORWARD_BACKWARD'
  - Ensure we correctly distinguish between ```dbFilePath``` and ```realSourcePath```.
  - During Snapshots: do not copy file if it is already owned by JM.


## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
