### PR TITLE
[BP-1.19][FLINK-36348][test] Fix the Netty shuffle direct memory test by increase the direct memory of TM

### DIFF
--- a/flink-end-to-end-tests/test-scripts/test_netty_shuffle_memory_control.sh
+++ b/flink-end-to-end-tests/test-scripts/test_netty_shuffle_memory_control.sh
@@ -23,18 +23,15 @@ TEST=flink-netty-shuffle-memory-control-test
 TEST_PROGRAM_NAME=NettyShuffleMemoryControlTestProgram
 TEST_PROGRAM_JAR=${END_TO_END_DIR}/$TEST/target/$TEST_PROGRAM_NAME.jar
 
-set_config_key "taskmanager.memory.flink.size" "512m"
+set_config_key "taskmanager.memory.flink.size" "600m"
 set_config_key "taskmanager.memory.network.min" "128m"
 set_config_key "taskmanager.memory.network.max" "128m"
 
 # 20 slots per task manager.
 set_config_key "taskmanager.numberOfTaskSlots" "20"
 
-# Sets only one arena per TM for boosting the netty internal memory overhead.
-set_config_key "taskmanager.network.netty.num-arenas" "1"
-
-# Limits the direct memory to be one chunk (4M) plus some margins.
-set_config_key "taskmanager.memory.framework.off-heap.size" "7m"
+# Limits the direct memory to be one chunk (4M * 20) plus some margins.
+set_config_key "taskmanager.memory.framework.off-heap.size" "90m"
 
 # Starts the cluster which includes one TaskManager.
 start_cluster


### PR DESCRIPTION
Unmodified backport of https://github.com/apache/flink/commit/338d0246eccd66fbc5e20d433c8cdd090e91574e to release-1.19

Required to move ahead with Netty 4 upgrade, as discussed in the ML (Option 2):
https://lists.apache.org/thread/6lj5lbg18hz4n9zckn0b89p9mv9nz14g
