### PR TITLE
[FLINK-37138][sql-gateway]  Fix failed SqlYARNApplicationITCase in hadoop3 profile

### DIFF
--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/application/ScriptRunner.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/application/ScriptRunner.java
@@ -45,13 +45,12 @@ public class ScriptRunner {
     @VisibleForTesting
     public static void run(String script, OutputStream outputStream) throws Exception {
         DefaultContext defaultContext =
-                DefaultContext.load(
+                new DefaultContext(
                         (Configuration)
                                 StreamExecutionEnvironment.getExecutionEnvironment(
                                                 new Configuration())
                                         .getConfiguration(),
-                        Collections.emptyList(),
-                        false);
+                        Collections.emptyList());
         SessionContext sessionContext =
                 SessionContext.create(
                         defaultContext,

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@ under the License.
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<flink.hadoop.version>2.10.2</flink.hadoop.version>
+		<flink.hadoop.version>3.2.3</flink.hadoop.version>
 		<flink.XmxMax>3072m</flink.XmxMax>
 		<!-- XmxMax / forkCountITCase -->
 		<flink.XmxITCase>1536m</flink.XmxITCase>


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*YARN deployment doesn't the directories as flink-dist does. Actually, it uses the following structures*

```
.
└── ohmeatball
    ├── appcache
    │   └── application_1737534562065_0001
    │       ├── container_1737534562065_0001_01_000001
    │       │   ├── lib
    │       │   ├── opt
    │       │   ├── plugins
    │       │   │   ├── external-resource-gpu
    │       │   │   ├── metrics-datadog
    │       │   │   ├── metrics-graphite
    │       │   │   ├── metrics-influx
    │       │   │   ├── metrics-jmx
    │       │   │   ├── metrics-otel
    │       │   │   ├── metrics-prometheus
    │       │   │   ├── metrics-slf4j
    │       │   │   └── metrics-statsd
    │       │   └── tmp
    │       └── filecache
    │           ├── 10
    └── filecache

```

Actually the config.yaml is at the working directory(container_1737534562065_0001_01_000001). So sql-gateway should not load the conf from the `$FLINK_CONF_DIR`. Considering `YarnApplicationClusterEntryPoint` or `KubernetesApplicationClusterEntrypoint` boths read the conf and put its content in the `StreamExecutionEnvironment`,
we just get the conf from `StreamExecutionEnvironment`.

