### PR TITLE
[BP-2.0][FLINK-36838][state/forst] Fix the deadlock when quit forst state backend

### DIFF
--- a/flink-dist/src/main/resources/META-INF/NOTICE
+++ b/flink-dist/src/main/resources/META-INF/NOTICE
@@ -9,7 +9,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.google.code.findbugs:jsr305:1.3.9
 - com.twitter:chill-java:0.7.6
 - com.ververica:frocksdbjni:8.10.0-ververica-beta-1.0
-- com.ververica:forstjni:0.1.5
+- com.ververica:forstjni:0.1.6
 - commons-cli:commons-cli:1.5.0
 - commons-collections:commons-collections:3.2.2
 - commons-io:commons-io:2.15.1

--- a/flink-state-backends/flink-statebackend-forst/pom.xml
+++ b/flink-state-backends/flink-statebackend-forst/pom.xml
@@ -63,7 +63,7 @@ under the License.
 		<dependency>
 			<groupId>com.ververica</groupId>
 			<artifactId>forstjni</artifactId>
-			<version>0.1.5</version>
+			<version>0.1.6</version>
 		</dependency>
 
 		<!-- test dependencies -->


### PR DESCRIPTION
This is a backport PR to 2.0 for #26053 

## What is the purpose of the change

In #25732 we join the async background threads of ForSt to avoid deadlock when JVM quit. That is an incomplete solution which is also problematic. The background threads are shared among multiple ForSt instances, meaning that simply join those threads may cause background job unfinished in other instances.

The ForSt project has investigated the root cause and gave a solution (https://github.com/ververica/ForSt/pull/30). Thus we should bump the depended ForSt version and revert the thread joining in Flink.

## Brief change log

 - Bump ForSt version to 0.1.6
 - Revert the change of background thread joining


## Verifying this change

This change is already covered by IT case `ForStStateBackendV2Test`. If it can normally exit then the problem solved.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
