### PR TITLE
[FLINK-37205][python] Correct the state cache behavior during bump be…

### DIFF
--- a/flink-python/pyflink/fn_execution/beam/beam_sdk_worker_main.py
+++ b/flink-python/pyflink/fn_execution/beam/beam_sdk_worker_main.py
@@ -15,19 +15,47 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+import re
 import sys
 
 # force to register the operations to SDK Harness
+from apache_beam.options.pipeline_options import DebugOptions
+
 import pyflink.fn_execution.beam.beam_operations # noqa # pylint: disable=unused-import
 
 # force to register the coders to SDK Harness
 import pyflink.fn_execution.beam.beam_coders # noqa # pylint: disable=unused-import
 
-import apache_beam.runners.worker.sdk_worker_main
+import apache_beam
 
 # disable bundle processor shutdown
-from apache_beam.runners.worker import sdk_worker
+from apache_beam.runners.worker import sdk_worker, sdk_worker_main, statecache
 sdk_worker.DEFAULT_BUNDLE_PROCESSOR_CACHE_SHUTDOWN_THRESHOLD_S = 86400 * 30
+
+
+# Currently PyFlink only support count-based state cache strategy
+def get_deep_size(*objs):
+    return 1
+
+
+def get_state_cache_size(options):
+    """
+    Return the maximum size of state cache in count.
+    """
+    experiments = options.view_as(DebugOptions).experiments or []
+    for experiment in experiments:
+        # There should only be 1 match so returning from the loop
+        if re.match(r'state_cache_size=', experiment):
+            return int(
+                re.match(r'state_cache_size=(?P<state_cache_size>.*)',
+                         experiment).group('state_cache_size'))
+    return 0
+
+
+statecache.get_deep_size = get_deep_size
+sdk_worker_main._get_state_cache_size = get_state_cache_size
+# since Beam 2.52.0, _get_state_cache_size is renamed to _get_state_cache_size_bytes
+sdk_worker_main._get_state_cache_size_bytes = get_state_cache_size
 
 
 def print_to_logging(logging_func, msg, *args, **kwargs):

--- a/flink-python/pyflink/fn_execution/beam/beam_sdk_worker_main.py
+++ b/flink-python/pyflink/fn_execution/beam/beam_sdk_worker_main.py
@@ -19,7 +19,7 @@ import re
 import sys
 
 # force to register the operations to SDK Harness
-from apache_beam.options.pipeline_options import DebugOptions
+from apache_beam.options.pipeline_options import DebugOptions, PipelineOptions
 
 import pyflink.fn_execution.beam.beam_operations # noqa # pylint: disable=unused-import
 
@@ -42,7 +42,11 @@ def get_state_cache_size(options):
     """
     Return the maximum size of state cache in count.
     """
-    experiments = options.view_as(DebugOptions).experiments or []
+    if isinstance(options, PipelineOptions):
+        experiments = options.view_as(DebugOptions).experiments or []
+    else:
+        experiments = options
+
     for experiment in experiments:
         # There should only be 1 match so returning from the loop
         if re.match(r'state_cache_size=', experiment):


### PR DESCRIPTION
…am version

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
