### PR TITLE
[FLINK-37207][runtime] Don't clear distributed cache in StreamExecutionEnvironment.configure

### DIFF
--- a/flink-python/src/main/java/org/apache/flink/python/util/PythonConfigUtil.java
+++ b/flink-python/src/main/java/org/apache/flink/python/util/PythonConfigUtil.java
@@ -84,11 +84,9 @@ public class PythonConfigUtil {
         env.getConfiguration()
                 .getOptional(PipelineOptions.CACHED_FILES)
                 .ifPresent(
-                        f -> {
-                            env.getCachedFiles().clear();
-                            env.getCachedFiles()
-                                    .addAll(DistributedCache.parseCachedFilesFromString(f));
-                        });
+                        f ->
+                                env.getCachedFiles()
+                                        .addAll(DistributedCache.parseCachedFilesFromString(f)));
 
         for (Transformation<?> transformation : env.getTransformations()) {
             alignTransformation(transformation);

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -727,10 +727,7 @@ public class StreamExecutionEnvironment implements AutoCloseable {
         configuration
                 .getOptional(PipelineOptions.CACHED_FILES)
                 .ifPresent(
-                        f -> {
-                            this.cacheFile.clear();
-                            this.cacheFile.addAll(DistributedCache.parseCachedFilesFromString(f));
-                        });
+                        f -> this.cacheFile.addAll(DistributedCache.parseCachedFilesFromString(f)));
 
         config.configure(configuration, classLoader);
         checkpointCfg.configure(configuration);


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fixes the issue that the distributed cache was cleared in StreamExecutionEnvironment.configure. It has side effect that distributed caches set before will be cleared. It may happen in the case that a job mixes use of the DataStream API and Java Table API and it has set distributed cache in the DataStream API. I encountered this issue in a PyFlink job which mixes use of DataStream API and Table API.*


## Brief change log

  - *Remove the cacheFile.clear in StreamExecutionEnvironment.configure*

## Verifying this change

This change is a trivial rework without any test coverage and verified locallly.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
