### PR TITLE
[FLINK-37208][Runtime] Properly notify a new key is selected for async state operators

### DIFF
--- a/flink-datastream/src/main/java/org/apache/flink/datastream/impl/operators/BaseKeyedProcessOperator.java
+++ b/flink-datastream/src/main/java/org/apache/flink/datastream/impl/operators/BaseKeyedProcessOperator.java
@@ -26,7 +26,6 @@ import org.apache.flink.datastream.impl.common.KeyCheckedOutputCollector;
 import org.apache.flink.datastream.impl.common.OutputCollector;
 import org.apache.flink.datastream.impl.common.TimestampCollector;
 import org.apache.flink.datastream.impl.context.DefaultNonPartitionedContext;
-import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
 import javax.annotation.Nullable;
 
@@ -83,10 +82,8 @@ public class BaseKeyedProcessOperator<KEY, IN, OUT> extends ProcessOperator<IN, 
     }
 
     @Override
-    @SuppressWarnings({"rawtypes"})
-    public void setKeyContextElement1(StreamRecord record) throws Exception {
-        super.setKeyContextElement1(record);
-        keySet.add(getCurrentKey());
+    public void newKeySelected(Object newKey) {
+        keySet.add(newKey);
     }
 
     @Override

--- a/flink-datastream/src/main/java/org/apache/flink/datastream/impl/operators/BaseKeyedTwoInputNonBroadcastProcessOperator.java
+++ b/flink-datastream/src/main/java/org/apache/flink/datastream/impl/operators/BaseKeyedTwoInputNonBroadcastProcessOperator.java
@@ -26,7 +26,6 @@ import org.apache.flink.datastream.impl.common.KeyCheckedOutputCollector;
 import org.apache.flink.datastream.impl.common.OutputCollector;
 import org.apache.flink.datastream.impl.common.TimestampCollector;
 import org.apache.flink.datastream.impl.context.DefaultNonPartitionedContext;
-import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
 import javax.annotation.Nullable;
 
@@ -89,17 +88,8 @@ public class BaseKeyedTwoInputNonBroadcastProcessOperator<KEY, IN1, IN2, OUT>
     }
 
     @Override
-    @SuppressWarnings({"rawtypes"})
-    public void setKeyContextElement1(StreamRecord record) throws Exception {
-        super.setKeyContextElement1(record);
-        keySet.add(getCurrentKey());
-    }
-
-    @Override
-    @SuppressWarnings({"rawtypes"})
-    public void setKeyContextElement2(StreamRecord record) throws Exception {
-        super.setKeyContextElement2(record);
-        keySet.add(getCurrentKey());
+    public void newKeySelected(Object newKey) {
+        keySet.add(newKey);
     }
 
     @Override

--- a/flink-datastream/src/main/java/org/apache/flink/datastream/impl/operators/BaseKeyedTwoOutputProcessOperator.java
+++ b/flink-datastream/src/main/java/org/apache/flink/datastream/impl/operators/BaseKeyedTwoOutputProcessOperator.java
@@ -26,7 +26,6 @@ import org.apache.flink.datastream.impl.common.KeyCheckedOutputCollector;
 import org.apache.flink.datastream.impl.common.OutputCollector;
 import org.apache.flink.datastream.impl.common.TimestampCollector;
 import org.apache.flink.datastream.impl.context.DefaultTwoOutputNonPartitionedContext;
-import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.util.OutputTag;
 import org.apache.flink.util.Preconditions;
 
@@ -105,10 +104,8 @@ public class BaseKeyedTwoOutputProcessOperator<KEY, IN, OUT_MAIN, OUT_SIDE>
     }
 
     @Override
-    @SuppressWarnings({"rawtypes"})
-    public void setKeyContextElement1(StreamRecord record) throws Exception {
-        super.setKeyContextElement1(record);
-        keySet.add(getCurrentKey());
+    public void newKeySelected(Object newKey) {
+        keySet.add(newKey);
     }
 
     @Override

--- a/flink-datastream/src/main/java/org/apache/flink/datastream/impl/operators/KeyedTwoInputBroadcastProcessOperator.java
+++ b/flink-datastream/src/main/java/org/apache/flink/datastream/impl/operators/KeyedTwoInputBroadcastProcessOperator.java
@@ -34,7 +34,6 @@ import org.apache.flink.runtime.state.VoidNamespaceSerializer;
 import org.apache.flink.streaming.api.operators.InternalTimer;
 import org.apache.flink.streaming.api.operators.InternalTimerService;
 import org.apache.flink.streaming.api.operators.Triggerable;
-import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
 import javax.annotation.Nullable;
 
@@ -117,11 +116,8 @@ public class KeyedTwoInputBroadcastProcessOperator<KEY, IN1, IN2, OUT>
     }
 
     @Override
-    @SuppressWarnings({"rawtypes"})
-    // Only element from input1 should be considered as the other side is broadcast input.
-    public void setKeyContextElement1(StreamRecord record) throws Exception {
-        super.setKeyContextElement1(record);
-        keySet.add(getCurrentKey());
+    public void newKeySelected(Object newKey) {
+        keySet.add(newKey);
     }
 
     @Override

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/context/DefaultStateManagerTest.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/context/DefaultStateManagerTest.java
@@ -30,8 +30,8 @@ import org.apache.flink.datastream.impl.operators.MockRecudingMultiplierProcessF
 import org.apache.flink.datastream.impl.operators.MockSumAggregateProcessFunction;
 import org.apache.flink.streaming.api.operators.collect.utils.MockOperatorStateStore;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
-import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.MockStreamingRuntimeContext;
+import org.apache.flink.streaming.util.asyncprocessing.AsyncKeyedOneInputStreamOperatorTestHarness;
 
 import org.junit.jupiter.api.Test;
 
@@ -98,8 +98,8 @@ class DefaultStateManagerTest {
                 new KeyedProcessOperator<>(
                         function, (KeySelector<Integer, Integer>) value -> value);
 
-        try (KeyedOneInputStreamOperatorTestHarness<Integer, Integer, Integer> testHarness =
-                new KeyedOneInputStreamOperatorTestHarness<>(
+        try (AsyncKeyedOneInputStreamOperatorTestHarness<Integer, Integer, Integer> testHarness =
+                AsyncKeyedOneInputStreamOperatorTestHarness.create(
                         processOperator,
                         (KeySelector<Integer, Integer>) value -> value,
                         Types.INT)) {
@@ -120,8 +120,8 @@ class DefaultStateManagerTest {
         KeyedProcessOperator<Integer, Integer, Integer> processOperator =
                 new KeyedProcessOperator<>(function);
 
-        try (KeyedOneInputStreamOperatorTestHarness<Integer, Integer, Integer> testHarness =
-                new KeyedOneInputStreamOperatorTestHarness<>(
+        try (AsyncKeyedOneInputStreamOperatorTestHarness<Integer, Integer, Integer> testHarness =
+                AsyncKeyedOneInputStreamOperatorTestHarness.create(
                         processOperator,
                         (KeySelector<Integer, Integer>) value -> value,
                         Types.INT)) {
@@ -148,8 +148,8 @@ class DefaultStateManagerTest {
         KeyedProcessOperator<Integer, Integer, Integer> processOperator =
                 new KeyedProcessOperator<>(function);
 
-        try (KeyedOneInputStreamOperatorTestHarness<Integer, Integer, Integer> testHarness =
-                new KeyedOneInputStreamOperatorTestHarness<>(
+        try (AsyncKeyedOneInputStreamOperatorTestHarness<Integer, Integer, Integer> testHarness =
+                AsyncKeyedOneInputStreamOperatorTestHarness.create(
                         processOperator,
                         (KeySelector<Integer, Integer>) value -> value,
                         Types.INT)) {
@@ -175,8 +175,8 @@ class DefaultStateManagerTest {
         KeyedProcessOperator<Integer, Integer, Integer> processOperator =
                 new KeyedProcessOperator<>(function);
 
-        try (KeyedOneInputStreamOperatorTestHarness<Integer, Integer, Integer> testHarness =
-                new KeyedOneInputStreamOperatorTestHarness<>(
+        try (AsyncKeyedOneInputStreamOperatorTestHarness<Integer, Integer, Integer> testHarness =
+                AsyncKeyedOneInputStreamOperatorTestHarness.create(
                         processOperator,
                         (KeySelector<Integer, Integer>) value -> value,
                         Types.INT)) {
@@ -203,8 +203,8 @@ class DefaultStateManagerTest {
         KeyedProcessOperator<Integer, Integer, Integer> processOperator =
                 new KeyedProcessOperator<>(function);
 
-        try (KeyedOneInputStreamOperatorTestHarness<Integer, Integer, Integer> testHarness =
-                new KeyedOneInputStreamOperatorTestHarness<>(
+        try (AsyncKeyedOneInputStreamOperatorTestHarness<Integer, Integer, Integer> testHarness =
+                AsyncKeyedOneInputStreamOperatorTestHarness.create(
                         processOperator,
                         (KeySelector<Integer, Integer>) value -> value,
                         Types.INT)) {
@@ -231,8 +231,8 @@ class DefaultStateManagerTest {
         KeyedProcessOperator<Integer, Integer, Integer> processOperator =
                 new KeyedProcessOperator<>(function);
 
-        try (KeyedOneInputStreamOperatorTestHarness<Integer, Integer, Integer> testHarness =
-                new KeyedOneInputStreamOperatorTestHarness<>(
+        try (AsyncKeyedOneInputStreamOperatorTestHarness<Integer, Integer, Integer> testHarness =
+                AsyncKeyedOneInputStreamOperatorTestHarness.create(
                         processOperator,
                         (KeySelector<Integer, Integer>) value -> value,
                         Types.INT)) {
@@ -260,8 +260,8 @@ class DefaultStateManagerTest {
                 new KeyedProcessOperator<>(
                         function, (KeySelector<Integer, Integer>) value -> value);
 
-        try (KeyedOneInputStreamOperatorTestHarness<Integer, Integer, Integer> testHarness =
-                new KeyedOneInputStreamOperatorTestHarness<>(
+        try (AsyncKeyedOneInputStreamOperatorTestHarness<Integer, Integer, Integer> testHarness =
+                AsyncKeyedOneInputStreamOperatorTestHarness.create(
                         processOperator,
                         (KeySelector<Integer, Integer>) value -> value,
                         Types.INT)) {

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/KeyedProcessOperatorTest.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/KeyedProcessOperatorTest.java
@@ -25,7 +25,7 @@ import org.apache.flink.datastream.api.context.NonPartitionedContext;
 import org.apache.flink.datastream.api.context.PartitionedContext;
 import org.apache.flink.datastream.api.function.OneInputStreamProcessFunction;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
-import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.asyncprocessing.AsyncKeyedOneInputStreamOperatorTestHarness;
 
 import org.junit.jupiter.api.Test;
 
@@ -51,8 +51,8 @@ class KeyedProcessOperatorTest {
                             }
                         });
 
-        try (KeyedOneInputStreamOperatorTestHarness<Integer, Integer, Integer> testHarness =
-                new KeyedOneInputStreamOperatorTestHarness<>(
+        try (AsyncKeyedOneInputStreamOperatorTestHarness<Integer, Integer, Integer> testHarness =
+                AsyncKeyedOneInputStreamOperatorTestHarness.create(
                         processOperator,
                         (KeySelector<Integer, Integer>) value -> value,
                         Types.INT)) {
@@ -98,8 +98,8 @@ class KeyedProcessOperatorTest {
                             }
                         });
 
-        try (KeyedOneInputStreamOperatorTestHarness<Integer, Integer, Integer> testHarness =
-                new KeyedOneInputStreamOperatorTestHarness<>(
+        try (AsyncKeyedOneInputStreamOperatorTestHarness<Integer, Integer, Integer> testHarness =
+                AsyncKeyedOneInputStreamOperatorTestHarness.create(
                         processOperator,
                         (KeySelector<Integer, Integer>) value -> value,
                         Types.INT)) {
@@ -133,8 +133,8 @@ class KeyedProcessOperatorTest {
                         // -1 is an invalid key in this suite.
                         (ignore) -> -1);
 
-        try (KeyedOneInputStreamOperatorTestHarness<Integer, Integer, Integer> testHarness =
-                new KeyedOneInputStreamOperatorTestHarness<>(
+        try (AsyncKeyedOneInputStreamOperatorTestHarness<Integer, Integer, Integer> testHarness =
+                AsyncKeyedOneInputStreamOperatorTestHarness.create(
                         processOperator,
                         (KeySelector<Integer, Integer>) value -> value,
                         Types.INT)) {

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/KeyedTwoInputBroadcastProcessOperatorTest.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/KeyedTwoInputBroadcastProcessOperatorTest.java
@@ -25,7 +25,7 @@ import org.apache.flink.datastream.api.context.NonPartitionedContext;
 import org.apache.flink.datastream.api.context.PartitionedContext;
 import org.apache.flink.datastream.api.function.TwoInputBroadcastStreamProcessFunction;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
-import org.apache.flink.streaming.util.KeyedTwoInputStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.asyncprocessing.AsyncKeyedTwoInputStreamOperatorTestHarness;
 
 import org.junit.jupiter.api.Test;
 
@@ -61,8 +61,8 @@ class KeyedTwoInputBroadcastProcessOperatorTest {
                             }
                         });
 
-        try (KeyedTwoInputStreamOperatorTestHarness<Long, Integer, Long, Long> testHarness =
-                new KeyedTwoInputStreamOperatorTestHarness<>(
+        try (AsyncKeyedTwoInputStreamOperatorTestHarness<Long, Integer, Long, Long> testHarness =
+                AsyncKeyedTwoInputStreamOperatorTestHarness.create(
                         processOperator,
                         (KeySelector<Integer, Long>) (data) -> (long) (data + 1),
                         (KeySelector<Long, Long>) value -> value + 1,
@@ -130,11 +130,11 @@ class KeyedTwoInputBroadcastProcessOperatorTest {
                             }
                         });
 
-        try (KeyedTwoInputStreamOperatorTestHarness<Long, Integer, Long, Long> testHarness =
-                new KeyedTwoInputStreamOperatorTestHarness<>(
+        try (AsyncKeyedTwoInputStreamOperatorTestHarness<Long, Integer, Long, Long> testHarness =
+                AsyncKeyedTwoInputStreamOperatorTestHarness.create(
                         processOperator,
                         (KeySelector<Integer, Long>) Long::valueOf,
-                        (KeySelector<Long, Long>) value -> value,
+                        null,
                         Types.LONG)) {
             testHarness.open();
             testHarness.processElement1(new StreamRecord<>(1)); // key is 1L
@@ -175,8 +175,8 @@ class KeyedTwoInputBroadcastProcessOperatorTest {
                         // -1 is an invalid key in this suite.
                         (out) -> -1L);
 
-        try (KeyedTwoInputStreamOperatorTestHarness<Long, Integer, Long, Long> testHarness =
-                new KeyedTwoInputStreamOperatorTestHarness<>(
+        try (AsyncKeyedTwoInputStreamOperatorTestHarness<Long, Integer, Long, Long> testHarness =
+                AsyncKeyedTwoInputStreamOperatorTestHarness.create(
                         processOperator,
                         (KeySelector<Integer, Long>) Long::valueOf,
                         (KeySelector<Long, Long>) value -> value,

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/KeyedTwoInputNonBroadcastProcessOperatorTest.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/KeyedTwoInputNonBroadcastProcessOperatorTest.java
@@ -25,7 +25,7 @@ import org.apache.flink.datastream.api.context.NonPartitionedContext;
 import org.apache.flink.datastream.api.context.PartitionedContext;
 import org.apache.flink.datastream.api.function.TwoInputNonBroadcastStreamProcessFunction;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
-import org.apache.flink.streaming.util.KeyedTwoInputStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.asyncprocessing.AsyncKeyedTwoInputStreamOperatorTestHarness;
 
 import org.junit.jupiter.api.Test;
 
@@ -59,8 +59,8 @@ class KeyedTwoInputNonBroadcastProcessOperatorTest {
                             }
                         });
 
-        try (KeyedTwoInputStreamOperatorTestHarness<Long, Integer, Long, Long> testHarness =
-                new KeyedTwoInputStreamOperatorTestHarness<>(
+        try (AsyncKeyedTwoInputStreamOperatorTestHarness<Long, Integer, Long, Long> testHarness =
+                AsyncKeyedTwoInputStreamOperatorTestHarness.create(
                         processOperator,
                         (KeySelector<Integer, Long>) (data) -> (long) (data + 1),
                         (KeySelector<Long, Long>) value -> value + 1,
@@ -134,8 +134,8 @@ class KeyedTwoInputNonBroadcastProcessOperatorTest {
                             }
                         });
 
-        try (KeyedTwoInputStreamOperatorTestHarness<Long, Integer, Long, Long> testHarness =
-                new KeyedTwoInputStreamOperatorTestHarness<>(
+        try (AsyncKeyedTwoInputStreamOperatorTestHarness<Long, Integer, Long, Long> testHarness =
+                AsyncKeyedTwoInputStreamOperatorTestHarness.create(
                         processOperator,
                         (KeySelector<Integer, Long>) Long::valueOf,
                         (KeySelector<Long, Long>) value -> value,
@@ -183,8 +183,8 @@ class KeyedTwoInputNonBroadcastProcessOperatorTest {
                         // -1 is an invalid key in this suite.
                         (out) -> -1L);
 
-        try (KeyedTwoInputStreamOperatorTestHarness<Long, Integer, Long, Long> testHarness =
-                new KeyedTwoInputStreamOperatorTestHarness<>(
+        try (AsyncKeyedTwoInputStreamOperatorTestHarness<Long, Integer, Long, Long> testHarness =
+                AsyncKeyedTwoInputStreamOperatorTestHarness.create(
                         processOperator,
                         (KeySelector<Integer, Long>) Long::valueOf,
                         (KeySelector<Long, Long>) value -> value,
@@ -192,6 +192,14 @@ class KeyedTwoInputNonBroadcastProcessOperatorTest {
             testHarness.open();
             assertThatThrownBy(() -> testHarness.processElement1(new StreamRecord<>(1)))
                     .isInstanceOf(IllegalStateException.class);
+        }
+        try (AsyncKeyedTwoInputStreamOperatorTestHarness<Long, Integer, Long, Long> testHarness =
+                AsyncKeyedTwoInputStreamOperatorTestHarness.create(
+                        processOperator,
+                        (KeySelector<Integer, Long>) Long::valueOf,
+                        (KeySelector<Long, Long>) value -> value,
+                        Types.LONG)) {
+            testHarness.open();
             assertThatThrownBy(() -> testHarness.processElement2(new StreamRecord<>(1L)))
                     .isInstanceOf(IllegalStateException.class);
         }

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/KeyedTwoOutputProcessOperatorTest.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/operators/KeyedTwoOutputProcessOperatorTest.java
@@ -25,7 +25,7 @@ import org.apache.flink.datastream.api.context.TwoOutputNonPartitionedContext;
 import org.apache.flink.datastream.api.context.TwoOutputPartitionedContext;
 import org.apache.flink.datastream.api.function.TwoOutputStreamProcessFunction;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
-import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.asyncprocessing.AsyncKeyedOneInputStreamOperatorTestHarness;
 import org.apache.flink.util.OutputTag;
 
 import org.junit.jupiter.api.Test;
@@ -59,8 +59,8 @@ class KeyedTwoOutputProcessOperatorTest {
                         },
                         sideOutputTag);
 
-        try (KeyedOneInputStreamOperatorTestHarness<Integer, Integer, Integer> testHarness =
-                new KeyedOneInputStreamOperatorTestHarness<>(
+        try (AsyncKeyedOneInputStreamOperatorTestHarness<Integer, Integer, Integer> testHarness =
+                AsyncKeyedOneInputStreamOperatorTestHarness.create(
                         processOperator,
                         (KeySelector<Integer, Integer>) value -> value,
                         Types.INT)) {
@@ -116,8 +116,8 @@ class KeyedTwoOutputProcessOperatorTest {
                         },
                         sideOutputTag);
 
-        try (KeyedOneInputStreamOperatorTestHarness<Integer, Integer, Integer> testHarness =
-                new KeyedOneInputStreamOperatorTestHarness<>(
+        try (AsyncKeyedOneInputStreamOperatorTestHarness<Integer, Integer, Integer> testHarness =
+                AsyncKeyedOneInputStreamOperatorTestHarness.create(
                         processOperator,
                         (KeySelector<Integer, Integer>) value -> value,
                         Types.INT)) {
@@ -161,14 +161,21 @@ class KeyedTwoOutputProcessOperatorTest {
                         // -1 is an invalid key in this suite.
                         (KeySelector<Long, Integer>) value -> -1);
 
-        try (KeyedOneInputStreamOperatorTestHarness<Integer, Integer, Integer> testHarness =
-                new KeyedOneInputStreamOperatorTestHarness<>(
+        try (AsyncKeyedOneInputStreamOperatorTestHarness<Integer, Integer, Integer> testHarness =
+                AsyncKeyedOneInputStreamOperatorTestHarness.create(
                         processOperator,
                         (KeySelector<Integer, Integer>) value -> value,
                         Types.INT)) {
             testHarness.open();
             assertThatThrownBy(() -> testHarness.processElement(new StreamRecord<>(1)))
                     .isInstanceOf(IllegalStateException.class);
+        }
+        try (AsyncKeyedOneInputStreamOperatorTestHarness<Integer, Integer, Integer> testHarness =
+                AsyncKeyedOneInputStreamOperatorTestHarness.create(
+                        processOperator,
+                        (KeySelector<Integer, Integer>) value -> value,
+                        Types.INT)) {
+            testHarness.open();
             emitToFirstOutput.set(false);
             assertThatThrownBy(() -> testHarness.processElement(new StreamRecord<>(1)))
                     .isInstanceOf(IllegalStateException.class);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperator.java
@@ -166,6 +166,18 @@ public abstract class AbstractAsyncStateStreamOperator<OUT> extends AbstractStre
         // in Fig.5, each state request itself is also protected by a paired reference count.
         currentProcessingContext.retain();
         asyncExecutionController.setCurrentContext(currentProcessingContext);
+        newKeySelected(currentProcessingContext.getKey());
+    }
+
+    /**
+     * A hook that will be invoked after a new key is selected. It is not recommended to perform
+     * async state here. Only some synchronous logic is suggested.
+     *
+     * @param newKey the new key selected.
+     */
+    public void newKeySelected(Object newKey) {
+        // By default, do nothing.
+        // Subclass could override this method to do some operations when a new key is selected.
     }
 
     @Override
@@ -300,32 +312,36 @@ public abstract class AbstractAsyncStateStreamOperator<OUT> extends AbstractStre
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public void setKeyContextElement1(StreamRecord record) throws Exception {
+        // This method is invoked only when isAsyncStateProcessingEnabled() is false.
         super.setKeyContextElement1(record);
         if (stateKeySelector1 != null) {
-            setAsyncKeyedContextElement(record, stateKeySelector1);
+            newKeySelected(getCurrentKey());
         }
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public void setKeyContextElement2(StreamRecord record) throws Exception {
+        // This method is invoked only when isAsyncStateProcessingEnabled() is false.
         super.setKeyContextElement2(record);
         if (stateKeySelector2 != null) {
-            setAsyncKeyedContextElement(record, stateKeySelector2);
+            newKeySelected(getCurrentKey());
         }
     }
 
     @Override
     public Object getCurrentKey() {
-        RecordContext currentContext = asyncExecutionController.getCurrentContext();
-        if (currentContext == null) {
-            throw new UnsupportedOperationException(
-                    "Have not set the current key yet, this may because the operator has not "
-                            + "started to run, or you are invoking this under a non-keyed context.");
+        if (isAsyncStateProcessingEnabled()) {
+            RecordContext currentContext = asyncExecutionController.getCurrentContext();
+            if (currentContext == null) {
+                throw new UnsupportedOperationException(
+                        "Have not set the current key yet, this may because the operator has not "
+                                + "started to run, or you are invoking this under a non-keyed context.");
+            }
+            return currentContext.getKey();
+        } else {
+            return super.getCurrentKey();
         }
-        return currentContext.getKey();
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperatorV2.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperatorV2.java
@@ -163,17 +163,43 @@ public abstract class AbstractAsyncStateStreamOperatorV2<OUT> extends AbstractSt
         // in Fig.5, each state request itself is also protected by a paired reference count.
         currentProcessingContext.retain();
         asyncExecutionController.setCurrentContext(currentProcessingContext);
+        newKeySelected(currentProcessingContext.getKey());
+    }
+
+    /**
+     * A hook that will be invoked after a new key is selected. It is not recommended to perform
+     * async state here. Only some synchronous logic is suggested.
+     *
+     * @param newKey the new key selected.
+     */
+    public void newKeySelected(Object newKey) {
+        // By default, do nothing.
+        // Subclass could override this method to do some operations when a new key is selected.
+    }
+
+    @Override
+    protected <T> void internalSetKeyContextElement(
+            StreamRecord<T> record, KeySelector<T, ?> selector) throws Exception {
+        // This method is invoked only when isAsyncStateProcessingEnabled() is false.
+        super.internalSetKeyContextElement(record, selector);
+        if (selector != null) {
+            newKeySelected(getCurrentKey());
+        }
     }
 
     @Override
     public Object getCurrentKey() {
-        RecordContext currentContext = asyncExecutionController.getCurrentContext();
-        if (currentContext == null) {
-            throw new UnsupportedOperationException(
-                    "Have not set the current key yet, this may because the operator has not "
-                            + "started to run, or you are invoking this under a non-keyed context.");
+        if (isAsyncStateProcessingEnabled()) {
+            RecordContext currentContext = asyncExecutionController.getCurrentContext();
+            if (currentContext == null) {
+                throw new UnsupportedOperationException(
+                        "Have not set the current key yet, this may because the operator has not "
+                                + "started to run, or you are invoking this under a non-keyed context.");
+            }
+            return currentContext.getKey();
+        } else {
+            return super.getCurrentKey();
         }
-        return currentContext.getKey();
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AsyncStateProcessing.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AsyncStateProcessing.java
@@ -56,6 +56,11 @@ public interface AsyncStateProcessing {
             AsyncStateProcessingOperator asyncOperator,
             KeySelector<T, ?> keySelector,
             ThrowingConsumer<StreamRecord<T>, Exception> processor) {
+        if (keySelector == null) {
+            // A non-keyed input does not need to set the key context and perform async context
+            // switches.
+            return processor;
+        }
         switch (asyncOperator.getElementOrder()) {
             case RECORD_ORDER:
                 return (record) -> {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/operators/AsyncIntervalJoinOperatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/operators/AsyncIntervalJoinOperatorTest.java
@@ -412,7 +412,7 @@ class AsyncIntervalJoinOperatorTest {
                         });
 
         try (TestHarness testHarness =
-                TestHarness.create(
+                TestHarness.createOne(
                         op,
                         (elem) -> elem.key,
                         (elem) -> elem.key,
@@ -454,7 +454,7 @@ class AsyncIntervalJoinOperatorTest {
                         });
 
         try (TestHarness testHarness =
-                TestHarness.create(
+                TestHarness.createOne(
                         op,
                         (elem) -> elem.key,
                         (elem) -> elem.key,
@@ -493,7 +493,7 @@ class AsyncIntervalJoinOperatorTest {
                         });
 
         try (TestHarness testHarness =
-                TestHarness.create(
+                TestHarness.createOne(
                         op,
                         (elem) -> elem.key,
                         (elem) -> elem.key,
@@ -661,7 +661,7 @@ class AsyncIntervalJoinOperatorTest {
                         TestElem.serializer(),
                         new PassthroughFunction());
 
-        return TestHarness.create(
+        return TestHarness.createOne(
                 operator,
                 (elem) -> elem.key, // key
                 (elem) -> elem.key, // key
@@ -690,7 +690,7 @@ class AsyncIntervalJoinOperatorTest {
                         new PassthroughFunction());
 
         TestHarness t =
-                TestHarness.create(
+                TestHarness.createOne(
                         operator,
                         (elem) -> elem.key, // key
                         (elem) -> elem.key, // key
@@ -966,7 +966,7 @@ class AsyncIntervalJoinOperatorTest {
             super(executor, operator, keySelector1, keySelector2, keyType, 1, 1, 0);
         }
 
-        public static TestHarness create(
+        public static TestHarness createOne(
                 TwoInputStreamOperator<TestElem, TestElem, Tuple2<TestElem, TestElem>> operator,
                 KeySelector<TestElem, String> keySelector1,
                 KeySelector<TestElem, String> keySelector2,

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/util/asyncprocessing/AsyncKeyedTwoInputStreamOperatorTestHarness.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/util/asyncprocessing/AsyncKeyedTwoInputStreamOperatorTestHarness.java
@@ -93,6 +93,16 @@ public class AsyncKeyedTwoInputStreamOperatorTestHarness<K, IN1, IN2, OUT>
                     TwoInputStreamOperator<IN1, IN2, OUT> operator,
                     KeySelector<IN1, K> keySelector1,
                     KeySelector<IN2, K> keySelector2,
+                    TypeInformation<K> keyType)
+                    throws Exception {
+        return create(operator, keySelector1, keySelector2, keyType, 1, 1, 0);
+    }
+
+    public static <K, IN1, IN2, OUT>
+            AsyncKeyedTwoInputStreamOperatorTestHarness<K, IN1, IN2, OUT> create(
+                    TwoInputStreamOperator<IN1, IN2, OUT> operator,
+                    KeySelector<IN1, K> keySelector1,
+                    KeySelector<IN2, K> keySelector2,
                     TypeInformation<K> keyType,
                     int maxParallelism,
                     int numSubtasks,


### PR DESCRIPTION
## What is the purpose of the change

There lacks a hook to notify a new key is selected in async state operators. Thus the Datastream V2 keyed operators cannot work properly. This PR provides a `newKeySelected` and ensures this is properly implemented in Datastream V2 operators.

## Brief change log

 - Add `newKeySelected` in both `AbstractAsyncStateStreamOperator` and `AbstractAsyncStateStreamOperatorV2`
 - Implement `newKeySelected` in Datastream V2 operators.
 - Change related operator tests.

## Verifying this change

This change is already covered by existing tests.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
