### PR TITLE
[FLINK-36900][python] Migrate from conda to uv for managing Python environments for PyFlink

### DIFF
--- a/docs/content.zh/docs/deployment/resource-providers/standalone/docker.md
+++ b/docs/content.zh/docs/deployment/resource-providers/standalone/docker.md
@@ -464,8 +464,8 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN pip3 install apache-flink=={{< version >}}
 {{< /stable >}}
 {{< unstable >}}
-COPY apache-flink*.tar.gz /
-RUN pip3 install /apache-flink-libraries*.tar.gz && pip3 install /apache-flink*.tar.gz
+COPY apache_flink*.tar.gz /
+RUN pip3 install /apache_flink_libraries*.tar.gz && pip3 install /apache_flink*.tar.gz
 {{< /unstable >}}
 ```
 

--- a/docs/content/docs/deployment/resource-providers/standalone/docker.md
+++ b/docs/content/docs/deployment/resource-providers/standalone/docker.md
@@ -463,8 +463,8 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN pip3 install apache-flink=={{< version >}}
 {{< /stable >}}
 {{< unstable >}}
-COPY apache-flink*.tar.gz /
-RUN pip3 install /apache-flink-libraries*.tar.gz && pip3 install /apache-flink*.tar.gz
+COPY apache_flink*.tar.gz /
+RUN pip3 install /apache_flink_libraries*.tar.gz && pip3 install /apache_flink*.tar.gz
 {{< /unstable >}}
 ```
 

--- a/docs/content/docs/dev/python/faq.md
+++ b/docs/content/docs/dev/python/faq.md
@@ -51,7 +51,7 @@ After setting up a [python virtual environment](#preparing-python-virtual-enviro
 #### Local
 
 ```shell
-# activate the conda python virtual environment
+# activate the python virtual environment
 $ source venv/bin/activate
 $ python xxx.py
 ```

--- a/docs/static/downloads/setup-pyflink-virtual-env.sh
+++ b/docs/static/downloads/setup-pyflink-virtual-env.sh
@@ -14,28 +14,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 set -e
-# download miniconda.sh
+
 sys_os=$(uname -s)
 echo "Detected OS: ${sys_os}"
 sys_machine=$(uname -m)
 echo "Detected machine: ${sys_machine}"
 
-if [[ ${sys_os} == "Darwin" ]]; then
-    wget "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.5.2-0-MacOSX-${sys_machine}.sh" -O "miniconda.sh"
-elif [[ ${sys_os} == "Linux" ]]; then
-    wget "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.5.2-0-Linux-${sys_machine}.sh" -O "miniconda.sh"
-else
-    echo "Unsupported OS: ${sys_os}"
-    exit 1
-fi
+wget "https://github.com/astral-sh/uv/releases/download/0.5.23/uv-installer.sh" -O "uv-installer.sh"
+chmod +x uv-installer.sh
 
-# add the execution permission
-chmod +x miniconda.sh
+UV_UNMANAGED_INSTALL="uv-bin" ./uv-installer.sh
 
 # create python virtual environment
-./miniconda.sh -b -p venv
+uv-bin/uv venv venv
 
-# activate the conda python virtual environment
+# activate the python virtual environment
 source venv/bin/activate ""
 
 # install PyFlink dependency
@@ -47,11 +40,8 @@ else
     pip install "apache-flink==$1"
 fi
 
-# deactivate the conda python virtual environment
-conda deactivate
+# deactivate the python virtual environment
+deactivate
 
-# remove the cached packages
-rm -rf venv/pkgs
-
-# package the prepared conda python virtual environment
+# package the prepared python virtual environment
 zip -r venv.zip venv

--- a/flink-end-to-end-tests/test-scripts/test_kubernetes_pyflink_application.sh
+++ b/flink-end-to-end-tests/test-scripts/test_kubernetes_pyflink_application.sh
@@ -42,13 +42,13 @@ fi
 
 FLINK_PYTHON_DIR=`cd "${CURRENT_DIR}/../../flink-python" && pwd -P`
 
-CONDA_HOME="${FLINK_PYTHON_DIR}/dev/.conda"
+UV_HOME="${FLINK_PYTHON_DIR}/dev/.uv"
 
-"${FLINK_PYTHON_DIR}/dev/lint-python.sh" -s miniconda
+"${FLINK_PYTHON_DIR}/dev/lint-python.sh" -s uv
 
-PYTHON_EXEC="${CONDA_HOME}/bin/python"
+PYTHON_EXEC="${UV_HOME}/bin/python"
 
-source "${CONDA_HOME}/bin/activate"
+source "${UV_HOME}/bin/activate"
 
 cd "${FLINK_PYTHON_DIR}"
 
@@ -64,12 +64,10 @@ python setup.py sdist
 
 cd dev
 
-rm -rf .conda/pkgs
-
 deactivate
 
-PYFLINK_PACKAGE_FILE=$(basename "${FLINK_PYTHON_DIR}"/dist/apache-flink-*.tar.gz)
-PYFLINK_LIBRARIES_PACKAGE_FILE=$(basename "${FLINK_PYTHON_DIR}"/apache-flink-libraries/dist/apache-flink-libraries-*.tar.gz)
+PYFLINK_PACKAGE_FILE=$(basename "${FLINK_PYTHON_DIR}"/dist/apache_flink-*.tar.gz)
+PYFLINK_LIBRARIES_PACKAGE_FILE=$(basename "${FLINK_PYTHON_DIR}"/apache-flink-libraries/dist/apache_flink_libraries-*.tar.gz)
 echo ${PYFLINK_PACKAGE_FILE}
 echo ${PYFLINK_LIBRARIES_PACKAGE_FILE}
 # Create a new docker image that has python and PyFlink installed.
@@ -88,12 +86,12 @@ echo "COPY dev-requirements.txt /tmp/dev-requirements.txt" >> Dockerfile
 echo "RUN bash /tmp/lint-python.sh -s basic" >> Dockerfile
 echo "COPY ${PYFLINK_PACKAGE_FILE} ${PYFLINK_PACKAGE_FILE}" >> Dockerfile
 echo "COPY ${PYFLINK_LIBRARIES_PACKAGE_FILE} ${PYFLINK_LIBRARIES_PACKAGE_FILE}" >> Dockerfile
-echo "RUN /tmp/.conda/bin/python -m pip install -r /tmp/dev-requirements.txt"  >> Dockerfile
-echo "RUN /tmp/.conda/bin/python -m pip install ${PYFLINK_LIBRARIES_PACKAGE_FILE}" >> Dockerfile
-echo "RUN /tmp/.conda/bin/python -m pip install ${PYFLINK_PACKAGE_FILE}" >> Dockerfile
+echo "RUN /tmp/.uv/bin/python -m pip install -r /tmp/dev-requirements.txt"  >> Dockerfile
+echo "RUN /tmp/.uv/bin/python -m pip install ${PYFLINK_LIBRARIES_PACKAGE_FILE}" >> Dockerfile
+echo "RUN /tmp/.uv/bin/python -m pip install ${PYFLINK_PACKAGE_FILE}" >> Dockerfile
 echo "RUN rm ${PYFLINK_LIBRARIES_PACKAGE_FILE}" >> Dockerfile
 echo "RUN rm ${PYFLINK_PACKAGE_FILE}" >> Dockerfile
-echo "ENV PATH /tmp/.conda/bin:\$PATH" >> Dockerfile
+echo "ENV PATH /tmp/.uv/bin:\$PATH" >> Dockerfile
 docker build --no-cache --network="host" -t ${PYFLINK_IMAGE_NAME} .
 
 kubectl create clusterrolebinding ${CLUSTER_ROLE_BINDING} --clusterrole=edit --serviceaccount=default:default --namespace=default

--- a/flink-end-to-end-tests/test-scripts/test_pyflink.sh
+++ b/flink-end-to-end-tests/test-scripts/test_pyflink.sh
@@ -85,19 +85,19 @@ export FLINK_CONF_DIR="${TEST_DATA_DIR}/conf"
 
 FLINK_PYTHON_DIR=`cd "${CURRENT_DIR}/../../flink-python" && pwd -P`
 
-CONDA_HOME="${FLINK_PYTHON_DIR}/dev/.conda"
+UV_HOME="${FLINK_PYTHON_DIR}/dev/.uv"
 
-"${FLINK_PYTHON_DIR}/dev/lint-python.sh" -s miniconda
+"${FLINK_PYTHON_DIR}/dev/lint-python.sh" -s uv
 
-PYTHON_EXEC="${CONDA_HOME}/bin/python"
+PYTHON_EXEC="${UV_HOME}/bin/python"
 
-source "${CONDA_HOME}/bin/activate"
+source "${UV_HOME}/bin/activate"
 
 cd "${FLINK_PYTHON_DIR}"
 
 rm -rf dist
 
-pip install -r dev/dev-requirements.txt
+uv pip install -r dev/dev-requirements.txt
 
 python setup.py sdist
 
@@ -105,17 +105,15 @@ pushd apache-flink-libraries
 
 python setup.py sdist
 
-pip install dist/*
+uv pip install dist/*
 
 popd
 
-pip install dist/*
+uv pip install dist/*
 
 cd dev
 
-rm -rf .conda/pkgs
-
-zip -q -r "${TEST_DATA_DIR}/venv.zip" .conda
+zip -q -r "${TEST_DATA_DIR}/venv.zip" .uv
 
 deactivate
 
@@ -136,7 +134,7 @@ PYFLINK_CLIENT_EXECUTABLE=${PYTHON_EXEC} "${FLINK_DIR}/bin/flink" run \
     -pyfs "${FLINK_PYTHON_TEST_DIR}/python/add_one.py" \
     -pyreq "${REQUIREMENTS_PATH}" \
     -pyarch "${TEST_DATA_DIR}/venv.zip" \
-    -pyexec "venv.zip/.conda/bin/python" \
+    -pyexec "venv.zip/.uv/bin/python" \
     -py "${FLINK_PYTHON_TEST_DIR}/python/python_job.py" \
     pipeline.jars "file://${FLINK_PYTHON_TEST_DIR}/target/PythonUdfSqlJobExample.jar"
 
@@ -146,7 +144,7 @@ PYFLINK_CLIENT_EXECUTABLE=${PYTHON_EXEC} "${FLINK_DIR}/bin/flink" run \
     -pyfs "${FLINK_PYTHON_TEST_DIR}/python/add_one.py" \
     -pyreq "${REQUIREMENTS_PATH}" \
     -pyarch "${TEST_DATA_DIR}/venv.zip" \
-    -pyexec "venv.zip/.conda/bin/python" \
+    -pyexec "venv.zip/.uv/bin/python" \
     -py "${FLINK_PYTHON_TEST_DIR}/python/python_job.py" \
     pipeline.classpaths "file://${FLINK_PYTHON_TEST_DIR}/target/PythonUdfSqlJobExample.jar"
 
@@ -156,7 +154,7 @@ PYFLINK_CLIENT_EXECUTABLE=${PYTHON_EXEC} "${FLINK_DIR}/bin/flink" run \
     -pyfs "${FLINK_PYTHON_TEST_DIR}/python/add_one.py" \
     -pyreq "${REQUIREMENTS_PATH}" \
     -pyarch "${TEST_DATA_DIR}/venv.zip" \
-    -pyexec "venv.zip/.conda/bin/python" \
+    -pyexec "venv.zip/.uv/bin/python" \
     "${FLINK_PYTHON_TEST_DIR}/target/PythonUdfSqlJobExample.jar"
 
 echo "Test batch python udf sql job:\n"
@@ -165,7 +163,7 @@ PYFLINK_CLIENT_EXECUTABLE=${PYTHON_EXEC} "${FLINK_DIR}/bin/flink" run \
     -pyfs "${FLINK_PYTHON_TEST_DIR}/python/add_one.py" \
     -pyreq "${REQUIREMENTS_PATH}" \
     -pyarch "${TEST_DATA_DIR}/venv.zip" \
-    -pyexec "venv.zip/.conda/bin/python" \
+    -pyexec "venv.zip/.uv/bin/python" \
     -c org.apache.flink.python.tests.BatchPythonUdfSqlJob \
     "${FLINK_PYTHON_TEST_DIR}/target/PythonUdfSqlJobExample.jar"
 
@@ -192,7 +190,7 @@ JOB_ID=$($FLINK_DIR/bin/sql-client.sh \
   -pyfs "${FLINK_PYTHON_TEST_DIR}/python/add_one.py" \
   -pyreq "${REQUIREMENTS_PATH}" \
   -pyarch "${TEST_DATA_DIR}/venv.zip" \
-  -pyexec "venv.zip/.conda/bin/python" \
+  -pyexec "venv.zip/.uv/bin/python" \
   -f "$SUBMITTED_SQL" | grep "Job ID:" | sed 's/.* //g')
 
 wait_job_terminal_state "$JOB_ID" "FINISHED"
@@ -249,7 +247,8 @@ wait_job_terminal_state "$JOB_ID" "FINISHED"
 #     -pyfs "${FLINK_PYTHON_TEST_DIR}/python/datastream" \
 #     -pyreq "${REQUIREMENTS_PATH}" \
 #     -pyarch "${TEST_DATA_DIR}/venv.zip" \
-#     -pyexec "venv.zip/.conda/bin/python" \
+#     -pyexec "venv.zip/.uv/bin/python" \
+#     -pyclientexec "venv.zip/.uv/bin/python" \
 #     -pym "data_stream_job" \
 #     -j "${KAFKA_SQL_JAR}")
 

--- a/flink-end-to-end-tests/test-scripts/test_pyflink_yarn.sh
+++ b/flink-end-to-end-tests/test-scripts/test_pyflink_yarn.sh
@@ -39,44 +39,43 @@ docker cp "${FLINK_PYTHON_TEST_DIR}/target/PythonUdfSqlJobExample.jar" master:/t
 docker cp "${FLINK_PYTHON_TEST_DIR}/python/add_one.py" master:/tmp/
 docker cp "${REQUIREMENTS_PATH}" master:/tmp/
 docker cp "${FLINK_PYTHON_TEST_DIR}/python/python_job.py" master:/tmp/
-PYFLINK_PACKAGE_FILE=$(basename "${FLINK_PYTHON_DIR}"/dist/apache-flink-*.tar.gz)
-PYFLINK_LIBRARIES_PACKAGE_FILE=$(basename "${FLINK_PYTHON_DIR}"/apache-flink-libraries/dist/apache-flink-libraries-*.tar.gz)
+PYFLINK_PACKAGE_FILE=$(basename "${FLINK_PYTHON_DIR}"/dist/apache_flink-*.tar.gz)
+PYFLINK_LIBRARIES_PACKAGE_FILE=$(basename "${FLINK_PYTHON_DIR}"/apache-flink-libraries/dist/apache_flink_libraries-*.tar.gz)
 docker cp "${FLINK_PYTHON_DIR}/dist/${PYFLINK_PACKAGE_FILE}" master:/tmp/
 docker cp "${FLINK_PYTHON_DIR}/apache-flink-libraries/dist/${PYFLINK_LIBRARIES_PACKAGE_FILE}" master:/tmp/
 
 # prepare environment
 docker exec master bash -c "
-/tmp/lint-python.sh -s miniconda
-source /tmp/.conda/bin/activate
+/tmp/lint-python.sh -s uv
+source /tmp/.uv/bin/activate
 pip install -r /tmp/dev-requirements.txt
 pip install /tmp/${PYFLINK_LIBRARIES_PACKAGE_FILE}
 pip install /tmp/${PYFLINK_PACKAGE_FILE}
-conda install -y -q zip=3.0
-rm -rf /tmp/.conda/pkgs
+apt-get install -y zip
 cd /tmp
-zip -q -r /tmp/venv.zip .conda
+zip -q -r /tmp/venv.zip .uv
 "
 
 docker exec master bash -c "export HADOOP_CLASSPATH=\`hadoop classpath\` && \
-    export PYFLINK_CLIENT_EXECUTABLE=/tmp/.conda/bin/python && \
+    export PYFLINK_CLIENT_EXECUTABLE=/tmp/.uv/bin/python && \
     /home/hadoop-user/$FLINK_DIRNAME/bin/flink run -t yarn-application \
     -Djobmanager.memory.process.size=1500m \
     -Dtaskmanager.memory.process.size=1000m \
     -pyfs /tmp/add_one.py \
     -pyreq /tmp/requirements.txt \
     -pyarch /tmp/venv.zip \
-    -pyexec venv.zip/.conda/bin/python \
+    -pyexec venv.zip/.uv/bin/python \
     /tmp/PythonUdfSqlJobExample.jar"
 
 docker exec master bash -c "export HADOOP_CLASSPATH=\`hadoop classpath\` && \
-    export PYFLINK_CLIENT_EXECUTABLE=/tmp/.conda/bin/python && \
+    export PYFLINK_CLIENT_EXECUTABLE=/tmp/.uv/bin/python && \
     /home/hadoop-user/$FLINK_DIRNAME/bin/flink run -t yarn-application \
     -Djobmanager.memory.process.size=1500m \
     -Dtaskmanager.memory.process.size=1000m \
     -pyfs /tmp/add_one.py \
     -pyreq /tmp/requirements.txt \
     -pyarch /tmp/venv.zip \
-    -pyexec venv.zip/.conda/bin/python \
+    -pyexec venv.zip/.uv/bin/python \
     -py /tmp/python_job.py \
     pipeline.jars file:/tmp/PythonUdfSqlJobExample.jar"
 

--- a/flink-python/README.md
+++ b/flink-python/README.md
@@ -43,30 +43,30 @@ PyFlink depends on the following libraries to execute the above script:
 2. setuptools (>=37.0.0)
 3. pip (>=20.3)
 
-### Running Test Cases 
+### Running Test Cases
 
-Currently, we use conda and tox to verify the compatibility of the Flink Python API for multiple versions of Python and will integrate some useful plugins with tox, such as flake8.
+Currently, we use tox and to verify the compatibility of the Flink Python API for multiple versions of Python and will integrate some useful plugins with tox, such as flake8.
 We can enter the directory where this README.md file is located and run test cases by executing
 
 ```
 ./dev/lint-python.sh
 ```
 
-To use your system conda environment, you can set `FLINK_CONDA_HOME` variable:
+To use your system uv environment, you can set `FLINK_UV_HOME` variable:
 
 ```shell
-export FLINK_CONDA_HOME=$(dirname $(dirname $CONDA_EXE))
+export FLINK_UV_HOME=$(dirname $(dirname $(which uv)))
 ```
 
 Create a virtual environment:
 ```shell
-conda create -n pyflink_38 python=3.8
+uv venv pyflink_38 --python=3.8
 ```
 
 Then you can activate your environment and run tests, for example:
 
 ```shell
-conda activate pyflink_38
-pip install -r ./dev/dev-requirements.txt
+source pyflink_38/bin/activate
+uv pip install -r ./dev/dev-requirements.txt
 ./dev/lint-python.sh
 ```

--- a/flink-python/dev/build-wheels.sh
+++ b/flink-python/dev/build-wheels.sh
@@ -18,12 +18,14 @@ set -e -x
 ## 1. install python env
 dev/lint-python.sh -s py_env
 
-PY_ENV_DIR=`pwd`/dev/.conda/envs
+PY_ENV_DIR=`pwd`/dev/.uv/envs
 py_env=("3.8" "3.9" "3.10" "3.11")
 ## 2. install dependency
 for ((i=0;i<${#py_env[@]};i++)) do
+    source `pwd`/dev/.uv/envs/${py_env[i]}/bin/activate
     echo "Installing dependencies for environment: ${py_env[i]}"
-    ${PY_ENV_DIR}/${py_env[i]}/bin/pip install -r dev/dev-requirements.txt
+    uv pip install -r dev/dev-requirements.txt
+    deactivate
 done
 
 ## 3. build wheels
@@ -39,12 +41,10 @@ done
 ## 4. convert linux_x86_64 wheel to manylinux1 wheel in Linux
 if [[ "$(uname)" != "Darwin" ]]; then
     echo "Converting linux_x86_64 wheel to manylinux1"
-    source `pwd`/dev/.conda/bin/activate
-    # 4.1 install patchelf
-    conda install -c conda-forge patchelf=0.11 -y
-    # 4.2 install auditwheel
-    pip install auditwheel==3.2.0
-    # 4.3 convert Linux wheel
+    source `pwd`/dev/.uv/bin/activate
+    # 4.1 install patchelf and auditwheel
+    uv pip install patchelf==0.17.2.1 auditwheel==3.2.0
+    # 4.2 convert Linux wheel
     for wheel_file in dist/*.whl; do
         auditwheel repair ${wheel_file} -w dist
         rm -f ${wheel_file}

--- a/flink-python/dev/dev-requirements.txt
+++ b/flink-python/dev/dev-requirements.txt
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 pip>=20.3
-setuptools>=18.0
+setuptools>=75.3
 wheel
 apache-beam>=2.54.0,<=2.61.0
 cython>=0.29.24

--- a/flink-python/dev/lint-python.sh
+++ b/flink-python/dev/lint-python.sh
@@ -23,7 +23,7 @@
 # You can refer to the README.MD in ${flink-python} to learn how easy to run the script.
 #
 
-# Download some software, such as miniconda.sh
+# Download some software, such as the uv installer
 function download() {
     local DOWNLOAD_STATUS=
     if hash "wget" 2>/dev/null; then
@@ -126,9 +126,9 @@ function check_valid_stage() {
 function parse_component_args() {
     local REAL_COMPONENTS=()
     for component in ${INSTALLATION_COMPONENTS[@]}; do
-        # because all other components depends on conda, the install of conda is
+        # because all other components depends on uv, the install of uv is
         # required component.
-        if [[ "$component" == "basic" ]] || [[ "$component" == "miniconda" ]]; then
+        if [[ "$component" == "basic" ]] || [[ "$component" == "uv" ]]; then
             continue
         fi
         if [[ "$component" == "all" ]]; then
@@ -173,79 +173,57 @@ function install_brew() {
     fi
 }
 
-# Considering the file size of miniconda.sh,
-# "wget" is better than "curl" in the weak network environment.
-function install_wget() {
-    if [ $1 -eq 0 ]; then  # Darwin
-        install_brew
+# We are using uv as our package management and python version management tool.
+# The downstream scripts use uv to install packages, like tox and flake8, as well
+# as manage different Python virtual environments that have different version of
+# Python installed.
 
-        hash "wget" 2>/dev/null
+function install_uv() {
+    UV_INSTALL_URL="https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-installer.sh"
+    if [ ! -f "$UV_INSTALL" ]; then
+        print_function "STEP" "download uv from ${UV_INSTALL_URL}..."
+        download $UV_INSTALL_URL $UV_INSTALL_SH
+        chmod +x $UV_INSTALL_SH
         if [ $? -ne 0 ]; then
-            print_function "STEP" "install wget..."
-            brew install wget 2>&1 >/dev/null
-            if [ $? -ne 0 ]; then
-                echo "Failed to install wget"
-                exit 1
-            fi
-            print_function "STEP" "install wget... [SUCCESS]"
-        fi
-    fi
-}
-
-# The script choose miniconda as our package management tool.
-# The script use miniconda to create all kinds of python versions and
-# some packages including checks such as tox and flake8.
-
-function install_miniconda() {
-    local sys_machine=$(uname -m)
-    echo "Detected machine: ${sys_machine}"
-    OS_TO_CONDA_URL=("https://repo.anaconda.com/miniconda/Miniconda3-py310_23.5.2-0-MacOSX-${sys_machine}.sh" \
-        "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.5.2-0-Linux-${sys_machine}.sh")
-    if [ ! -f "$CONDA_INSTALL" ]; then
-        print_function "STEP" "download miniconda from ${OS_TO_CONDA_URL[$1]}..."
-        download ${OS_TO_CONDA_URL[$1]} $CONDA_INSTALL_SH
-        chmod +x $CONDA_INSTALL_SH
-        if [ $? -ne 0 ]; then
-            echo "Please manually chmod +x $CONDA_INSTALL_SH"
+            echo "Please manually chmod +x $UV_INSTALL_SH"
             exit 1
         fi
-        if [ -d "$CURRENT_DIR/.conda" ]; then
-            rm -rf "$CURRENT_DIR/.conda"
+        if [ -d "$CURRENT_DIR/.uv" ]; then
+            rm -rf "$CURRENT_DIR/.uv"
             if [ $? -ne 0 ]; then
-                echo "Please manually rm -rf $CURRENT_DIR/.conda directory.\
+                echo "Please manually rm -rf $CURRENT_DIR/.uv-bin directory.\
                 Then retry to exec the script."
                 exit 1
             fi
         fi
-        print_function "STEP" "download miniconda... [SUCCESS]"
+
+        UV_UNMANAGED_INSTALL="$CURRENT_DIR/download" $UV_INSTALL_SH
+        print_function "STEP" "download uv... [SUCCESS]"
     fi
 
-    if [ ! -d "$CURRENT_DIR/.conda" ]; then
-        print_function "STEP" "installing conda..."
-        $CONDA_INSTALL_SH -b -p $CURRENT_DIR/.conda 2>&1 >/dev/null
-
+    if [ ! -d "$CURRENT_DIR/.uv/venv" ]; then
+        print_function "STEP" "setup uv virtualenv"
+        # Create a Python 3.11 virtual environment as the base environment.
+        $CURRENT_DIR/download/uv venv "$CURRENT_DIR/.uv" --seed --python 3.11
+        print_function "STEP" "setup uv virtualenv... [SUCCESS]"
         # orjson depend on pip >= 20.3
         print_function "STEP" "upgrade pip..."
-        $CURRENT_DIR/.conda/bin/python -m pip install --upgrade pip 2>&1 >/dev/null
+        $CURRENT_DIR/.uv/bin/pip install --upgrade pip setuptools 2>&1 >/dev/null
         print_function "STEP" "upgrade pip... [SUCCESS]"
-
-        if [ $? -ne 0 ]; then
-            echo "install miniconda failed"
-            exit $CONDA_INSTALL_STATUS
-        fi
-        print_function "STEP" "install conda ... [SUCCESS]"
+        # move uv binaries into virtual env
+        mv "$CURRENT_DIR/download/uv" "$CURRENT_DIR/.uv/bin/"
     fi
 }
 
-# Install some kinds of py env.
+# Create different Python virtual environments for different Python versions
 function install_py_env() {
     py_env=("3.8" "3.9" "3.10" "3.11")
     for ((i=0;i<${#py_env[@]};i++)) do
-        if [ -d "$CURRENT_DIR/.conda/envs/${py_env[i]}" ]; then
-            rm -rf "$CURRENT_DIR/.conda/envs/${py_env[i]}"
+        if [ -d "$CURRENT_DIR/.uv/envs/${py_env[i]}" ]; then
+            rm -rf "$CURRENT_DIR/.uv/envs/${py_env[i]}"
             if [ $? -ne 0 ]; then
-                echo "rm -rf $CURRENT_DIR/.conda/envs/${py_env[i]} failed, please \
-                rm -rf $CURRENT_DIR/.conda/envs/${py_env[i]} manually.\
+                echo "rm -rf $CURRENT_DIR/.uv/envs/${py_env[i]} failed, please \
+                rm -rf $CURRENT_DIR/.uv/envs/${py_env[i]} manually.\
                 Then retry to exec the script."
                 exit 1
             fi
@@ -253,22 +231,24 @@ function install_py_env() {
         print_function "STEP" "installing python${py_env[i]}..."
         max_retry_times=3
         retry_times=0
-        install_command="$CONDA_PATH create --name ${py_env[i]} -y -q python=${py_env[i]}"
+        install_command="$UV_PATH venv $CURRENT_DIR/.uv/envs/${py_env[i]} -q --python=${py_env[i]} --seed"
         ${install_command} 2>&1 >/dev/null
         status=$?
         while [[ ${status} -ne 0 ]] && [[ ${retry_times} -lt ${max_retry_times} ]]; do
             retry_times=$((retry_times+1))
             # sleep 3 seconds and then reinstall.
             sleep 3
-            echo "conda install ${py_env[i]} retrying ${retry_times}/${max_retry_times}"
+            echo "uv venv ${py_env[i]} retrying ${retry_times}/${max_retry_times}"
             ${install_command} 2>&1 >/dev/null
             status=$?
         done
         if [[ ${status} -ne 0 ]]; then
-            echo "conda install ${py_env[i]} failed after retrying ${max_retry_times} times.\
+            echo "uv venv ${py_env[i]} failed after retrying ${max_retry_times} times.\
             You can retry to execute the script again."
             exit 1
         fi
+
+        $CURRENT_DIR/.uv/envs/${py_env[i]}/bin/pip install -q uv==${UV_VERSION}
         print_function "STEP" "install python${py_env[i]}... [SUCCESS]"
     done
 }
@@ -276,38 +256,35 @@ function install_py_env() {
 # Install tox.
 # In some situations,you need to run the script with "sudo". e.g. sudo ./lint-python.sh
 function install_tox() {
-    source $CONDA_HOME/bin/activate
+    source $ENV_HOME/bin/activate
     if [ -f "$TOX_PATH" ]; then
-        $PIP_PATH uninstall tox -y -q 2>&1 >/dev/null
+        $UV_PATH pip uninstall tox -q 2>&1 >/dev/null
         if [ $? -ne 0 ]; then
-            echo "pip uninstall tox failed \
+            echo "uv pip uninstall tox failed \
             please try to exec the script again.\
             if failed many times, you can try to exec in the form of sudo ./lint-python.sh -f"
             exit 1
         fi
     fi
 
-    # tox 3.14.0 depends on both 0.19 and 0.23 of importlib_metadata at the same time and
-    # conda will try to install both these two versions and it will cause problems occasionally.
-    # Using pip as the package manager could avoid this problem.
-    $CURRENT_DIR/install_command.sh -q virtualenv==20.10.0 tox==3.14.0 2>&1 >/dev/null
+    $CURRENT_DIR/install_command.sh -q tox==3.14.0 2>&1 >/dev/null
     if [ $? -ne 0 ]; then
-        echo "pip install tox failed \
+        echo "uv pip install tox failed \
         please try to exec the script again.\
         if failed many times, you can try to exec in the form of sudo ./lint-python.sh -f"
         exit 1
     fi
-    conda deactivate
+    deactivate
 }
 
 # Install flake8.
 # In some situations,you need to run the script with "sudo". e.g. sudo ./lint-python.sh
 function install_flake8() {
-    source $CONDA_HOME/bin/activate
+    source $UV_HOME/bin/activate
     if [ -f "$FLAKE8_PATH" ]; then
-        $PIP_PATH uninstall flake8 -y -q 2>&1 >/dev/null
+        $UV_PATH pip uninstall flake8 -q 2>&1 >/dev/null
         if [ $? -ne 0 ]; then
-            echo "pip uninstall flake8 failed \
+            echo "uv pip uninstall flake8 failed \
             please try to exec the script again.\
             if failed many times, you can try to exec in the form of sudo ./lint-python.sh -f"
             exit 1
@@ -316,22 +293,22 @@ function install_flake8() {
 
     $CURRENT_DIR/install_command.sh -q flake8==4.0.1 2>&1 >/dev/null
     if [ $? -ne 0 ]; then
-        echo "pip install flake8 failed \
+        echo "uv pip install flake8 failed \
         please try to exec the script again.\
         if failed many times, you can try to exec in the form of sudo ./lint-python.sh -f"
         exit 1
     fi
-    conda deactivate
+    deactivate
 }
 
 # Install sphinx.
 # In some situations,you need to run the script with "sudo". e.g. sudo ./lint-python.sh
 function install_sphinx() {
-    source $CONDA_HOME/bin/activate
+    source $UV_HOME/bin/activate
     if [ -f "$SPHINX_PATH" ]; then
-        $PIP_PATH uninstall Sphinx -y -q 2>&1 >/dev/null
+        $UV_PATH pip uninstall Sphinx -q 2>&1 >/dev/null
         if [ $? -ne 0 ]; then
-            echo "pip uninstall sphinx failed \
+            echo "uv pip uninstall sphinx failed \
             please try to exec the script again.\
             if failed many times, you can try to exec in the form of sudo ./lint-python.sh -f"
             exit 1
@@ -340,36 +317,36 @@ function install_sphinx() {
 
     $CURRENT_DIR/install_command.sh -q Sphinx==4.5.0 importlib-metadata==4.4.0 Docutils==0.17.1 pydata_sphinx_theme==0.11.0 sphinx_mdinclude==0.5.3 "Jinja2<3.1.0" "sphinxcontrib-applehelp<1.0.8" "sphinxcontrib.devhelp<1.0.6" "sphinxcontrib.htmlhelp<2.0.5" "sphinxcontrib-serializinghtml<1.1.10" "sphinxcontrib-qthelp<1.0.7" 2>&1 >/dev/null
     if [ $? -ne 0 ]; then
-        echo "pip install sphinx failed \
+        echo "uv pip install sphinx failed \
         please try to exec the script again.\
         if failed many times, you can try to exec in the form of sudo ./lint-python.sh -f"
         exit 1
     fi
-    conda deactivate
+    deactivate
 }
 
 
 # Install mypy.
 # In some situations, you need to run the script with "sudo". e.g. sudo ./lint-python.sh
 function install_mypy() {
-    source ${CONDA_HOME}/bin/activate
+    source ${UV_HOME}/bin/activate
     if [[ -f "$MYPY_PATH" ]]; then
-        ${PIP_PATH} uninstall mypy -y -q 2>&1 >/dev/null
+        ${UV_PATH} pip uninstall mypy -q 2>&1 >/dev/null
         if [[ $? -ne 0 ]]; then
-            echo "pip uninstall mypy failed \
+            echo "uv pip uninstall mypy failed \
             please try to exec the script again.\
             if failed many times, you can try to exec in the form of sudo ./lint-python.sh -f"
             exit 1
         fi
     fi
-    ${CURRENT_DIR}/install_command.sh -q mypy==1.5.1 2>&1 >/dev/null
+    ${CURRENT_DIR}/install_command.sh -q mypy==1.5.1 types-pytz types-python-dateutil 2>&1 >/dev/null
     if [[ $? -ne 0 ]]; then
-        echo "pip install mypy failed \
+        echo "uv pip install mypy failed \
         please try to exec the script again.\
         if failed many times, you can try to exec in the form of sudo ./lint-python.sh -f"
         exit 1
     fi
-    conda deactivate
+    deactivate
 }
 
 function need_install_component() {
@@ -390,69 +367,58 @@ function install_environment() {
     get_os_index $sys_os
     local os_index=$?
 
-    # step-1 install wget
-    # the file size of the miniconda.sh is too big to use "wget" tool to download instead
-    # of the "curl" in the weak network environment.
+    # step-1 install uv
     if [ $STEP -lt 1 ]; then
-        print_function "STEP" "installing wget..."
-        install_wget $os_index
+        print_function "STEP" "installing uv..."
+        create_dir $CURRENT_DIR/download
+        install_uv
         STEP=1
         checkpoint_stage $STAGE $STEP
-        print_function "STEP" "install wget... [SUCCESS]"
+        print_function "STEP" "install uv... [SUCCESS]"
     fi
 
-    # step-2 install miniconda
-    if [ $STEP -lt 2 ]; then
-        print_function "STEP" "installing miniconda..."
-        create_dir $CURRENT_DIR/download
-        install_miniconda $os_index
-        STEP=2
-        checkpoint_stage $STAGE $STEP
-        print_function "STEP" "install miniconda... [SUCCESS]"
-    fi
-
-    # step-3 install python environment which includes
+    # step-2 install python environment which includes
     # 3.8 3.9 3.10 3.11
-    if [ $STEP -lt 3 ] && [ `need_install_component "py_env"` = true ]; then
+    if [ $STEP -lt 2 ] && [ `need_install_component "py_env"` = true ]; then
         print_function "STEP" "installing python environment..."
         install_py_env
-        STEP=3
+        STEP=2
         checkpoint_stage $STAGE $STEP
         print_function "STEP" "install python environment... [SUCCESS]"
     fi
 
-    # step-4 install tox
-    if [ $STEP -lt 4 ] && [ `need_install_component "tox"` = true ]; then
+    # step-3 install tox
+    if [ $STEP -lt 3 ] && [ `need_install_component "tox"` = true ]; then
         print_function "STEP" "installing tox..."
         install_tox
-        STEP=4
+        STEP=3
         checkpoint_stage $STAGE $STEP
         print_function "STEP" "install tox... [SUCCESS]"
     fi
 
-    # step-5 install  flake8
-    if [ $STEP -lt 5 ] && [ `need_install_component "flake8"` = true ]; then
+    # step-4 install  flake8
+    if [ $STEP -lt 4 ] && [ `need_install_component "flake8"` = true ]; then
         print_function "STEP" "installing flake8..."
         install_flake8
-        STEP=5
+        STEP=4
         checkpoint_stage $STAGE $STEP
         print_function "STEP" "install flake8... [SUCCESS]"
     fi
 
-    # step-6 install sphinx
-    if [ $STEP -lt 6 ] && [ `need_install_component "sphinx"` = true ]; then
+    # step-5 install sphinx
+    if [ $STEP -lt 5 ] && [ `need_install_component "sphinx"` = true ]; then
         print_function "STEP" "installing sphinx..."
         install_sphinx
-        STEP=6
+        STEP=5
         checkpoint_stage $STAGE $STEP
         print_function "STEP" "install sphinx... [SUCCESS]"
     fi
 
-    # step-7 install mypy
-    if [[ ${STEP} -lt 7 ]] && [[ `need_install_component "mypy"` = true ]]; then
+    # step-5 install mypy
+    if [[ ${STEP} -lt 6 ]] && [[ `need_install_component "mypy"` = true ]]; then
         print_function "STEP" "installing mypy..."
         install_mypy
-        STEP=7
+        STEP=6
         checkpoint_stage ${STAGE} ${STEP}
         print_function "STEP" "install mypy... [SUCCESS]"
     fi
@@ -474,13 +440,13 @@ function create_dir() {
 
 # Set created py-env in $PATH for tox's creating virtual env
 function activate () {
-    if [ ! -d $CURRENT_DIR/.conda/envs ]; then
-        echo "For some unknown reasons, missing the directory $CURRENT_DIR/.conda/envs,\
+    if [ ! -d $CURRENT_DIR/.uv/envs ]; then
+        echo "For some unknown reasons, missing the directory $CURRENT_DIR/.uv/envs,\
         you should exec the script with the option: -f"
         exit 1
     fi
 
-    for py_dir in $CURRENT_DIR/.conda/envs/*
+    for py_dir in $CURRENT_DIR/.uv/envs/*
     do
         PATH=$py_dir/bin:$PATH
     done
@@ -625,6 +591,7 @@ function tox_check() {
     fi
     # Reset the $PATH
     deactivate
+
     # If check failed, stop the running script.
     if [ $TOX_RESULT -eq '0' ]; then
         exit 1
@@ -710,17 +677,17 @@ CURRENT_DIR="$(cd "$( dirname "$0" )" && pwd)"
 # FLINK_PYTHON_DIR is "flink/flink-python"
 FLINK_PYTHON_DIR=$(dirname "$CURRENT_DIR")
 
-# conda home path
-if [ -z "${FLINK_CONDA_HOME+x}" ]; then
-    CONDA_HOME="$CURRENT_DIR/.conda"
-    ENV_HOME="$CONDA_HOME"
+# uv home path
+if [ -z "${FLINK_UV_HOME+x}" ]; then
+    UV_HOME="$CURRENT_DIR/.uv"
+    ENV_HOME="$UV_HOME"
 else
-    CONDA_HOME=$FLINK_CONDA_HOME
-    ENV_HOME="${CONDA_PREFIX-$CONDA_HOME}"
+    UV_HOME=$FLINK_UV_HOME
+    ENV_HOME="${UV_PREFIX-$UV_HOME}"
 fi
 
-# conda path
-CONDA_PATH=$CONDA_HOME/bin/conda
+# uv path
+UV_PATH=$UV_HOME/bin/uv
 
 # pip path
 PIP_PATH=$ENV_HOME/bin/pip
@@ -745,7 +712,7 @@ SUPPORT_OS=("Darwin" "Linux")
 STAGE_FILE=$CURRENT_DIR/.stage.txt
 
 # the dir includes all kinds of py env installed.
-VIRTUAL_ENV=$CONDA_HOME/envs
+VIRTUAL_ENV=$UV_HOME/envs
 
 LOG_DIR=$CURRENT_DIR/log
 
@@ -763,11 +730,14 @@ create_dir $LOG_DIR
 # clean LOG_FILE content
 echo >$LOG_FILE
 
-# miniconda script
-CONDA_INSTALL_SH=$CURRENT_DIR/download/miniconda.sh
+# static version of uv that we use across all envs
+UV_VERSION=0.5.23
+
+# location of uv installation script
+UV_INSTALL_SH=$CURRENT_DIR/download/uv.sh
 
 # stage "install" includes the num of steps.
-STAGE_INSTALL_STEPS=7
+STAGE_INSTALL_STEPS=6
 
 # whether force to restart the script.
 FORCE_START=0
@@ -808,7 +778,6 @@ usage: $0 [options]
 -l          list all checks supported.
 Examples:
   ./lint-python.sh -s basic        =>  install environment with basic components.
-  ./lint-python.sh -s py_env       =>  install environment with python env(3.8,3.9,3.10, 3.11).
   ./lint-python.sh -s all          =>  install environment with all components such as python env,tox,flake8,sphinx,mypy etc.
   ./lint-python.sh -s tox,flake8   =>  install environment with tox,flake8.
   ./lint-python.sh -s tox -f       =>  reinstall environment with tox.
@@ -860,7 +829,7 @@ skip_checks=0
 
 if [[ ${CLEAN_UP_FLAG} -eq 1 ]]; then
     printf "clean up python environment"
-    rm -rf ${CONDA_HOME}
+    rm -rf ${UV_HOME}
     rm -rf ${STAGE_FILE}
     rm -rf ${FLINK_PYTHON_DIR}/.tox
     skip_checks=1

--- a/flink-python/pyproject.toml
+++ b/flink-python/pyproject.toml
@@ -19,7 +19,7 @@
 # Minimum requirements for the build system to execute.
 requires = [
     "packaging>=20.5; platform_machine=='arm64'",  # macos M1
-    "setuptools>=18.0",
+    "setuptools>=75.8",
     "wheel",
     "apache-beam>=2.54.0,<=2.61.0",
     "cython>=0.29.24",

--- a/tools/azure-pipelines/build-python-wheels.yml
+++ b/tools/azure-pipelines/build-python-wheels.yml
@@ -18,6 +18,9 @@ jobs:
     pool:
       vmImage: 'ubuntu-22.04'
     steps:
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: '3.11'
       - script: |
           cd flink-python
           bash dev/build-wheels.sh

--- a/tools/azure-pipelines/e2e-template.yml
+++ b/tools/azure-pipelines/e2e-template.yml
@@ -48,6 +48,9 @@ jobs:
     - script: ./tools/azure-pipelines/free_disk_space.sh
       target: host
       displayName: Free up disk space
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '3.11'
     # the cache task does not create directories on a cache miss, and can later fail when trying to tar the directory if the test haven't created it
     # this may for example happen if a given directory is only used by a subset of tests, which are run in a different 'group'
     - bash: |

--- a/tools/releasing/create_binary_release.sh
+++ b/tools/releasing/create_binary_release.sh
@@ -87,15 +87,15 @@ make_python_release() {
   cd flink-python/
   # use lint-python.sh script to create a python environment.
   dev/lint-python.sh -s basic
-  source dev/.conda/bin/activate
-  pip install -r dev/dev-requirements.txt
+  source dev/.uv/bin/activate
+  uv pip install -r dev/dev-requirements.txt
 
   # build apache-flink-libraries sdist
   pushd apache-flink-libraries
   python setup.py sdist
   pushd dist/
   apache_flink_libraries_actual_name=`echo *.tar.gz`
-  apache_flink_libraries_release_name="apache-flink-libraries-${PYFLINK_VERSION}.tar.gz"
+  apache_flink_libraries_release_name="apache_flink_libraries-${PYFLINK_VERSION}.tar.gz"
 
   if [[ "$apache_flink_libraries_actual_name" != "$apache_flink_libraries_release_name" ]] ; then
     echo -e "\033[31;1mThe file name of the python package: ${apache_flink_libraries_actual_name} is not consistent with given release version: ${PYFLINK_VERSION}!\033[0m"
@@ -109,10 +109,10 @@ make_python_release() {
   popd
 
   python setup.py sdist
-  conda deactivate
+  deactivate
   cd dist/
   pyflink_actual_name=`echo *.tar.gz`
-  pyflink_release_name="apache-flink-${PYFLINK_VERSION}.tar.gz"
+  pyflink_release_name="apache_flink-${PYFLINK_VERSION}.tar.gz"
 
   if [[ "$pyflink_actual_name" != "$pyflink_release_name" ]] ; then
     echo -e "\033[31;1mThe file name of the python package: ${pyflink_actual_name} is not consistent with given release version: ${PYFLINK_VERSION}!\033[0m"


### PR DESCRIPTION
## What is the purpose of the change

Given the issues raised in https://issues.apache.org/jira/browse/LEGAL-688, we've decided to move away from using conda. `conda` is being used in Flink in the following ways:

- Setting up PyFlink developer environments.
- Setting up a range of environments with different Python versions (3.8, 3.9, 3.10, 3.11) to both validate the Flink apis over those versions, and to build Python wheels for those versions.
- Setting up a Python environment for use in building the binary releases.
- Setting up a Python environment or the PyFlink, PyFlink Yarn and PyFlink Kubernetes end-to-end tests.

To summarise, conda is largely being used for the creation of Python virtual environments for both developers and CI. This PR replaces conda with [uv](https://docs.astral.sh/uv/), a fast Python package and virtual environment manager. In the cases where conda was being used to manage non-python packages (for example, installing the `zip` binary in the PyFlink yarn tests) this has instead been changed to use the package manager native to the environment (`apt`, in this particular case).

## Brief change log

- Replaced `conda` with `uv` for managing the creation of Python environments and installing Python packages for PyFlink in both testing, wheel building and developer contexts.
- Changed the minimum bound for `setuptools` to `>=75.3` to ensure that package names are normalized (underscores instead of hyphens in this case) in accordance with [PEP 625](https://peps.python.org/pep-0625/) (PyPi will begin enforcing this at some point soon).


## Verifying this change

This change is already covered by existing tests, such as:

- PyFlink end-to-end tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
