### PR TITLE
[FLINK-37215][runtime] Moves SlotAllocationException into TaskSlotTableImpl

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -1288,15 +1288,12 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
             SlotID slotId, JobID jobId, AllocationID allocationId, ResourceProfile resourceProfile)
             throws SlotAllocationException {
         if (taskSlotTable.isSlotFree(slotId.getSlotNumber())) {
-            if (!taskSlotTable.allocateSlot(
+            taskSlotTable.allocateSlot(
                     slotId.getSlotNumber(),
                     jobId,
                     allocationId,
                     resourceProfile,
-                    taskManagerConfiguration.getSlotTimeout())) {
-                log.info("Could not allocate slot for {}.", allocationId);
-                throw new SlotAllocationException("Could not allocate slot.");
-            }
+                    taskManagerConfiguration.getSlotTimeout());
         } else if (!taskSlotTable.isAllocated(slotId.getSlotNumber(), jobId, allocationId)) {
             final String message =
                     "The slot " + slotId + " has already been allocated for a different job.";

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTable.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
+import org.apache.flink.runtime.taskexecutor.exceptions.SlotAllocationException;
 import org.apache.flink.util.AutoCloseableAsync;
 
 import javax.annotation.Nullable;
@@ -93,10 +94,11 @@ public interface TaskSlotTable<T extends TaskSlotPayload>
      * @param jobId to allocate the task slot for
      * @param allocationId identifying the allocation
      * @param slotTimeout until the slot times out
-     * @return True if the task slot could be allocated; otherwise false
+     * @throws SlotAllocationException if allocating the slot failed.
      */
     @VisibleForTesting
-    boolean allocateSlot(int index, JobID jobId, AllocationID allocationId, Duration slotTimeout);
+    void allocateSlot(int index, JobID jobId, AllocationID allocationId, Duration slotTimeout)
+            throws SlotAllocationException;
 
     /**
      * Allocate the slot with the given index for the given job and allocation id. If negative index
@@ -109,14 +111,15 @@ public interface TaskSlotTable<T extends TaskSlotPayload>
      * @param resourceProfile of the requested slot, used only for dynamic slot allocation and will
      *     be ignored otherwise
      * @param slotTimeout until the slot times out
-     * @return True if the task slot could be allocated; otherwise false
+     * @throws SlotAllocationException if allocating the slot failed.
      */
-    boolean allocateSlot(
+    void allocateSlot(
             int index,
             JobID jobId,
             AllocationID allocationId,
             ResourceProfile resourceProfile,
-            Duration slotTimeout);
+            Duration slotTimeout)
+            throws SlotAllocationException;
 
     /**
      * Marks the slot under the given allocation id as active. If the slot could not be found, then

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -86,6 +86,7 @@ import org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager;
 import org.apache.flink.runtime.state.TaskExecutorStateChangelogStoragesManager;
 import org.apache.flink.runtime.taskexecutor.TaskSubmissionTestEnvironment.Builder;
 import org.apache.flink.runtime.taskexecutor.exceptions.RegistrationTimeoutException;
+import org.apache.flink.runtime.taskexecutor.exceptions.SlotAllocationException;
 import org.apache.flink.runtime.taskexecutor.exceptions.TaskManagerException;
 import org.apache.flink.runtime.taskexecutor.exceptions.TaskSubmissionException;
 import org.apache.flink.runtime.taskexecutor.partition.ClusterPartitionReport;
@@ -2939,26 +2940,29 @@ class TaskExecutorTest {
         }
 
         @Override
-        public boolean allocateSlot(
-                int index, JobID jobId, AllocationID allocationId, Duration slotTimeout) {
-            final boolean result = super.allocateSlot(index, jobId, allocationId, slotTimeout);
-            allocateSlotLatch.trigger();
-
-            return result;
+        public void allocateSlot(
+                int index, JobID jobId, AllocationID allocationId, Duration slotTimeout)
+                throws SlotAllocationException {
+            try {
+                super.allocateSlot(index, jobId, allocationId, slotTimeout);
+            } finally {
+                allocateSlotLatch.trigger();
+            }
         }
 
         @Override
-        public boolean allocateSlot(
+        public void allocateSlot(
                 int index,
                 JobID jobId,
                 AllocationID allocationId,
                 ResourceProfile resourceProfile,
-                Duration slotTimeout) {
-            final boolean result =
-                    super.allocateSlot(index, jobId, allocationId, resourceProfile, slotTimeout);
-            allocateSlotLatch.trigger();
-
-            return result;
+                Duration slotTimeout)
+                throws SlotAllocationException {
+            try {
+                super.allocateSlot(index, jobId, allocationId, resourceProfile, slotTimeout);
+            } finally {
+                allocateSlotLatch.trigger();
+            }
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableImplTest.java
@@ -62,7 +62,7 @@ class TaskSlotTableImplTest {
 
     private static final Duration SLOT_TIMEOUT = Duration.ofSeconds(100L);
 
-    /** Tests that one can can mark allocated slots as active. */
+    /** Tests that one can mark allocated slots as active. */
     @Test
     void testTryMarkSlotActive() throws Exception {
         final TaskSlotTableImpl<?> taskSlotTable = createTaskSlotTableAndStart(3);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableImplTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAda
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
 import org.apache.flink.runtime.taskexecutor.SlotStatus;
+import org.apache.flink.runtime.taskexecutor.exceptions.SlotAllocationException;
 import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.testutils.executor.TestExecutorExtension;
 import org.apache.flink.util.function.TriFunctionWithException;
@@ -49,6 +50,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import static org.apache.flink.core.testutils.FlinkAssertions.assertThatFuture;
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createExecutionAttemptId;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for the {@link TaskSlotTable}. */
 class TaskSlotTableImplTest {
@@ -127,9 +130,17 @@ class TaskSlotTableImplTest {
             final AllocationID allocationId1 = new AllocationID();
             final AllocationID allocationId2 = new AllocationID();
 
-            assertThat(taskSlotTable.allocateSlot(0, jobId, allocationId1, SLOT_TIMEOUT)).isTrue();
-            assertThat(taskSlotTable.allocateSlot(1, jobId, allocationId1, SLOT_TIMEOUT)).isFalse();
-            assertThat(taskSlotTable.allocateSlot(0, jobId, allocationId2, SLOT_TIMEOUT)).isFalse();
+            assertThatNoException()
+                    .isThrownBy(
+                            () ->
+                                    taskSlotTable.allocateSlot(
+                                            0, jobId, allocationId1, SLOT_TIMEOUT));
+            assertThatThrownBy(
+                            () -> taskSlotTable.allocateSlot(1, jobId, allocationId1, SLOT_TIMEOUT))
+                    .isInstanceOf(SlotAllocationException.class);
+            assertThatThrownBy(
+                            () -> taskSlotTable.allocateSlot(0, jobId, allocationId2, SLOT_TIMEOUT))
+                    .isInstanceOf(SlotAllocationException.class);
 
             assertThat(taskSlotTable.isAllocated(0, jobId, allocationId1)).isTrue();
             assertThat(taskSlotTable.isSlotFree(1)).isTrue();
@@ -152,9 +163,16 @@ class TaskSlotTableImplTest {
             final JobID jobId2 = new JobID();
             final AllocationID allocationId = new AllocationID();
 
-            assertThat(taskSlotTable.allocateSlot(-1, jobId1, allocationId, SLOT_TIMEOUT)).isTrue();
-            assertThat(taskSlotTable.allocateSlot(-1, jobId2, allocationId, SLOT_TIMEOUT))
-                    .isFalse();
+            assertThatNoException()
+                    .isThrownBy(
+                            () ->
+                                    taskSlotTable.allocateSlot(
+                                            -1, jobId1, allocationId, SLOT_TIMEOUT));
+            assertThatThrownBy(
+                            () ->
+                                    taskSlotTable.allocateSlot(
+                                            -1, jobId2, allocationId, SLOT_TIMEOUT))
+                    .isInstanceOf(SlotAllocationException.class);
 
             assertThat(taskSlotTable.isAllocated(1, jobId1, allocationId)).isTrue();
 
@@ -171,14 +189,24 @@ class TaskSlotTableImplTest {
             final JobID jobId = new JobID();
             final AllocationID allocationId = new AllocationID();
 
-            assertThat(
-                            taskSlotTable.allocateSlot(
-                                    0, jobId, allocationId, ResourceProfile.UNKNOWN, SLOT_TIMEOUT))
-                    .isTrue();
-            assertThat(
-                            taskSlotTable.allocateSlot(
-                                    0, jobId, allocationId, ResourceProfile.UNKNOWN, SLOT_TIMEOUT))
-                    .isTrue();
+            assertThatNoException()
+                    .isThrownBy(
+                            () ->
+                                    taskSlotTable.allocateSlot(
+                                            0,
+                                            jobId,
+                                            allocationId,
+                                            ResourceProfile.UNKNOWN,
+                                            SLOT_TIMEOUT));
+            assertThatNoException()
+                    .isThrownBy(
+                            () ->
+                                    taskSlotTable.allocateSlot(
+                                            0,
+                                            jobId,
+                                            allocationId,
+                                            ResourceProfile.UNKNOWN,
+                                            SLOT_TIMEOUT));
 
             assertThat(taskSlotTable.isAllocated(0, jobId, allocationId)).isTrue();
             assertThat(taskSlotTable.isSlotFree(1)).isTrue();
@@ -196,12 +224,20 @@ class TaskSlotTableImplTest {
             final JobID jobId = new JobID();
             final AllocationID allocationId = new AllocationID();
 
-            assertThat(taskSlotTable.allocateSlot(-1, jobId, allocationId, SLOT_TIMEOUT)).isTrue();
+            assertThatNoException()
+                    .isThrownBy(
+                            () ->
+                                    taskSlotTable.allocateSlot(
+                                            -1, jobId, allocationId, SLOT_TIMEOUT));
             Iterator<TaskSlot<TaskSlotPayload>> allocatedSlots =
                     taskSlotTable.getAllocatedSlots(jobId);
             TaskSlot<TaskSlotPayload> taskSlot1 = allocatedSlots.next();
 
-            assertThat(taskSlotTable.allocateSlot(-1, jobId, allocationId, SLOT_TIMEOUT)).isTrue();
+            assertThatNoException()
+                    .isThrownBy(
+                            () ->
+                                    taskSlotTable.allocateSlot(
+                                            -1, jobId, allocationId, SLOT_TIMEOUT));
             allocatedSlots = taskSlotTable.getAllocatedSlots(jobId);
             TaskSlot<TaskSlotPayload> taskSlot2 = allocatedSlots.next();
 
@@ -218,8 +254,16 @@ class TaskSlotTableImplTest {
             final AllocationID allocationId1 = new AllocationID();
             final AllocationID allocationId2 = new AllocationID();
 
-            assertThat(taskSlotTable.allocateSlot(0, jobId, allocationId1, SLOT_TIMEOUT)).isTrue();
-            assertThat(taskSlotTable.allocateSlot(1, jobId, allocationId2, SLOT_TIMEOUT)).isTrue();
+            assertThatNoException()
+                    .isThrownBy(
+                            () ->
+                                    taskSlotTable.allocateSlot(
+                                            0, jobId, allocationId1, SLOT_TIMEOUT));
+            assertThatNoException()
+                    .isThrownBy(
+                            () ->
+                                    taskSlotTable.allocateSlot(
+                                            1, jobId, allocationId2, SLOT_TIMEOUT));
 
             assertThat(taskSlotTable.freeSlot(allocationId2)).isOne();
 
@@ -239,7 +283,11 @@ class TaskSlotTableImplTest {
             final JobID jobId = new JobID();
             final AllocationID allocationId = new AllocationID();
 
-            assertThat(taskSlotTable.allocateSlot(-1, jobId, allocationId, SLOT_TIMEOUT)).isTrue();
+            assertThatNoException()
+                    .isThrownBy(
+                            () ->
+                                    taskSlotTable.allocateSlot(
+                                            -1, jobId, allocationId, SLOT_TIMEOUT));
 
             Iterator<TaskSlot<TaskSlotPayload>> allocatedSlots =
                     taskSlotTable.getAllocatedSlots(jobId);
@@ -258,10 +306,15 @@ class TaskSlotTableImplTest {
                     TaskSlotUtils.DEFAULT_RESOURCE_PROFILE.merge(
                             ResourceProfile.newBuilder().setCpuCores(0.1).build());
 
-            assertThat(
-                            taskSlotTable.allocateSlot(
-                                    -1, jobId, allocationId, resourceProfile, SLOT_TIMEOUT))
-                    .isTrue();
+            assertThatNoException()
+                    .isThrownBy(
+                            () ->
+                                    taskSlotTable.allocateSlot(
+                                            -1,
+                                            jobId,
+                                            allocationId,
+                                            resourceProfile,
+                                            SLOT_TIMEOUT));
 
             Iterator<TaskSlot<TaskSlotPayload>> allocatedSlots =
                     taskSlotTable.getAllocatedSlots(jobId);
@@ -279,10 +332,15 @@ class TaskSlotTableImplTest {
             final JobID jobId = new JobID();
             final AllocationID allocationId = new AllocationID();
 
-            assertThat(
-                            taskSlotTable.allocateSlot(
-                                    -1, jobId, allocationId, ResourceProfile.UNKNOWN, SLOT_TIMEOUT))
-                    .isTrue();
+            assertThatNoException()
+                    .isThrownBy(
+                            () ->
+                                    taskSlotTable.allocateSlot(
+                                            -1,
+                                            jobId,
+                                            allocationId,
+                                            ResourceProfile.UNKNOWN,
+                                            SLOT_TIMEOUT));
 
             Iterator<TaskSlot<TaskSlotPayload>> allocatedSlots =
                     taskSlotTable.getAllocatedSlots(jobId);
@@ -302,10 +360,17 @@ class TaskSlotTableImplTest {
             ResourceProfile resourceProfile = TaskSlotUtils.DEFAULT_RESOURCE_PROFILE;
             resourceProfile = resourceProfile.merge(resourceProfile).merge(resourceProfile);
 
-            assertThat(
-                            taskSlotTable.allocateSlot(
-                                    -1, jobId, allocationId, resourceProfile, SLOT_TIMEOUT))
-                    .isFalse();
+            final ResourceProfile mergedResourceProfile = resourceProfile;
+
+            assertThatThrownBy(
+                            () ->
+                                    taskSlotTable.allocateSlot(
+                                            -1,
+                                            jobId,
+                                            allocationId,
+                                            mergedResourceProfile,
+                                            SLOT_TIMEOUT))
+                    .isInstanceOf(SlotAllocationException.class);
 
             Iterator<TaskSlot<TaskSlotPayload>> allocatedSlots =
                     taskSlotTable.getAllocatedSlots(jobId);
@@ -321,12 +386,30 @@ class TaskSlotTableImplTest {
             final AllocationID allocationId2 = new AllocationID();
             final AllocationID allocationId3 = new AllocationID();
 
-            assertThat(taskSlotTable.allocateSlot(0, jobId, allocationId1, SLOT_TIMEOUT))
-                    .isTrue(); // index 0
-            assertThat(taskSlotTable.allocateSlot(-1, jobId, allocationId2, SLOT_TIMEOUT))
-                    .isTrue(); // index 3
-            assertThat(taskSlotTable.allocateSlot(-1, jobId, allocationId3, SLOT_TIMEOUT))
-                    .isTrue(); // index 4
+            assertThatNoException()
+                    .as(
+                            "Slot with allocation ID %s should have been allocated successfully.",
+                            allocationId1)
+                    .isThrownBy(
+                            () ->
+                                    taskSlotTable.allocateSlot(
+                                            0, jobId, allocationId1, SLOT_TIMEOUT));
+            assertThatNoException()
+                    .as(
+                            "Slot with allocation ID %s should have been allocated successfully.",
+                            allocationId2)
+                    .isThrownBy(
+                            () ->
+                                    taskSlotTable.allocateSlot(
+                                            -1, jobId, allocationId2, SLOT_TIMEOUT)); // index 3
+            assertThatNoException()
+                    .as(
+                            "Slot with allocation ID %s should have been allocated successfully.",
+                            allocationId3)
+                    .isThrownBy(
+                            () ->
+                                    taskSlotTable.allocateSlot(
+                                            -1, jobId, allocationId3, SLOT_TIMEOUT));
 
             assertThat(taskSlotTable.freeSlot(allocationId2)).isEqualTo(3);
 
@@ -453,10 +536,11 @@ class TaskSlotTableImplTest {
         try (final TaskSlotTableImpl<TaskSlotPayload> taskSlotTable =
                 createTaskSlotTableAndStart(1, testingSlotActions)) {
             final AllocationID allocationId = new AllocationID();
-            assertThat(
-                            taskSlotTable.allocateSlot(
-                                    0, new JobID(), allocationId, Duration.ofMillis(1L)))
-                    .isTrue();
+            assertThatNoException()
+                    .isThrownBy(
+                            () ->
+                                    taskSlotTable.allocateSlot(
+                                            0, new JobID(), allocationId, Duration.ofMillis(1L)));
             assertThatFuture(timeoutFuture).eventuallySucceeds().isEqualTo(allocationId);
         }
     }
@@ -493,10 +577,11 @@ class TaskSlotTableImplTest {
             final AllocationID allocationId = new AllocationID();
             final long timeout = 50L;
             final JobID jobId = new JobID();
-            assertThat(
-                            taskSlotTable.allocateSlot(
-                                    0, jobId, allocationId, Duration.ofMillis(timeout)))
-                    .isTrue();
+            assertThatNoException()
+                    .isThrownBy(
+                            () ->
+                                    taskSlotTable.allocateSlot(
+                                            0, jobId, allocationId, Duration.ofMillis(timeout)));
             assertThat(taskSlotTableAction.apply(taskSlotTable, jobId, allocationId)).isTrue();
 
             timeoutCancellationFuture.get();
@@ -523,7 +608,8 @@ class TaskSlotTableImplTest {
             final JobID jobId, final AllocationID allocationId, final SlotActions slotActions) {
         final TaskSlotTable<TaskSlotPayload> taskSlotTable =
                 createTaskSlotTableAndStart(1, slotActions);
-        assertThat(taskSlotTable.allocateSlot(0, jobId, allocationId, SLOT_TIMEOUT)).isTrue();
+        assertThatNoException()
+                .isThrownBy(() -> taskSlotTable.allocateSlot(0, jobId, allocationId, SLOT_TIMEOUT));
         return taskSlotTable;
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Minor refactoring to connect the reason of the `SlotAllocationException` with the exception itself (rather than having a generic error message and the actual reason somewhere else in the logs).

## Brief change log

* Moves `SlotAllocationException` throwing into `TaskSlotTableImpl#allocateSlot`

## Verifying this change

* Adjusted available tests accordingly

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable