### PR TITLE
[FLINK-37196][docs] Use cp to sync local docs

### DIFF
--- a/docs/setup_docs.sh
+++ b/docs/setup_docs.sh
@@ -32,7 +32,7 @@ function integrate_connector_docs {
   theme_dir="../themes/connectors"
   mkdir -p "${theme_dir}"
 
-  rsync -a flink-connector-${connector}/docs/* "${theme_dir}/"
+  cp -r flink-connector-${connector}/docs/* "${theme_dir}/"
 }
 
 


### PR DESCRIPTION
## What is the purpose of the change

*Fix the build documentation pipeline issue*

Use `cp` to replace `rsync` for local docs coping. 

If we persist in using rsync, should update the https://github.com/zentol/flink-ci-docker repo to install rsync. But I think there's nothing wrong with cp for this scenario. Feel free to revert this If you updated the `flink-ci-docker` image.


## Brief change log

  - * Use cp to sync local docs*

## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
