### PR TITLE
[FLINK-37196][docs] Use JDK17 to run documentation build

### DIFF
--- a/.github/workflows/docs.sh
+++ b/.github/workflows/docs.sh
@@ -18,10 +18,10 @@
 ################################################################################
 set -e
 
-# override env to use Java 11 to for build instead default Java 8
+# override env to use Java 17 to for build instead default Java 8
 # path to JDK is taken from https://github.com/apache/flink-connector-shared-utils/blob/ci_utils/docker/base/Dockerfile#L37-L40
-export JAVA_HOME=$JAVA_HOME_11_X64
-export PATH=$JAVA_HOME_11_X64/bin:$PATH
+export JAVA_HOME=$JAVA_HOME_17_X64
+export PATH=$JAVA_HOME_17_X64/bin:$PATH
 
 mvn --version
 java -version


### PR DESCRIPTION
Fix the build issue: https://github.com/apache/flink/actions/runs/12942648074/job/36100724287#step:5:3199

Should also updated for `release-2.0` branch.