### PR TITLE
[FLINK-37214][runtime] Refactors test to use proper Executor service for the main thread

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableImplTest.java
@@ -30,12 +30,14 @@ import org.apache.flink.runtime.taskexecutor.SlotStatus;
 import org.apache.flink.runtime.taskexecutor.exceptions.SlotAllocationException;
 import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.testutils.executor.TestExecutorExtension;
+import org.apache.flink.util.concurrent.FutureUtils;
+import org.apache.flink.util.function.SupplierWithException;
+import org.apache.flink.util.function.ThrowingConsumer;
 import org.apache.flink.util.function.TriFunctionWithException;
 
 import org.apache.flink.shaded.guava32.com.google.common.collect.Sets;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.time.Duration;
@@ -46,6 +48,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Function;
 
 import static org.apache.flink.core.testutils.FlinkAssertions.assertThatFuture;
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createExecutionAttemptId;
@@ -60,63 +63,66 @@ class TaskSlotTableImplTest {
     private static final TestExecutorExtension<ScheduledExecutorService> EXECUTOR_EXTENSION =
             TestingUtils.defaultExecutorExtension();
 
+    @RegisterExtension
+    private static final TestExecutorExtension<ScheduledExecutorService>
+            MAIN_THREAD_EXECUTOR_EXTENSION = TestingUtils.defaultExecutorExtension();
+
     private static final Duration SLOT_TIMEOUT = Duration.ofSeconds(100L);
 
     /** Tests that one can mark allocated slots as active. */
     @Test
     void testTryMarkSlotActive() throws Exception {
-        final TaskSlotTableImpl<?> taskSlotTable = createTaskSlotTableAndStart(3);
+        runInMainThread(
+                3,
+                taskSlotTable -> {
+                    final JobID jobId1 = new JobID();
+                    final AllocationID allocationId1 = new AllocationID();
+                    taskSlotTable.allocateSlot(0, jobId1, allocationId1, SLOT_TIMEOUT);
+                    final AllocationID allocationId2 = new AllocationID();
+                    taskSlotTable.allocateSlot(1, jobId1, allocationId2, SLOT_TIMEOUT);
+                    final AllocationID allocationId3 = new AllocationID();
+                    final JobID jobId2 = new JobID();
+                    taskSlotTable.allocateSlot(2, jobId2, allocationId3, SLOT_TIMEOUT);
 
-        try {
-            final JobID jobId1 = new JobID();
-            final AllocationID allocationId1 = new AllocationID();
-            taskSlotTable.allocateSlot(0, jobId1, allocationId1, SLOT_TIMEOUT);
-            final AllocationID allocationId2 = new AllocationID();
-            taskSlotTable.allocateSlot(1, jobId1, allocationId2, SLOT_TIMEOUT);
-            final AllocationID allocationId3 = new AllocationID();
-            final JobID jobId2 = new JobID();
-            taskSlotTable.allocateSlot(2, jobId2, allocationId3, SLOT_TIMEOUT);
+                    taskSlotTable.markSlotActive(allocationId1);
 
-            taskSlotTable.markSlotActive(allocationId1);
+                    assertThat(taskSlotTable.isAllocated(0, jobId1, allocationId1)).isTrue();
+                    assertThat(taskSlotTable.isAllocated(1, jobId1, allocationId2)).isTrue();
+                    assertThat(taskSlotTable.isAllocated(2, jobId2, allocationId3)).isTrue();
 
-            assertThat(taskSlotTable.isAllocated(0, jobId1, allocationId1)).isTrue();
-            assertThat(taskSlotTable.isAllocated(1, jobId1, allocationId2)).isTrue();
-            assertThat(taskSlotTable.isAllocated(2, jobId2, allocationId3)).isTrue();
+                    assertThat(taskSlotTable.getActiveTaskSlotAllocationIdsPerJob(jobId1))
+                            .isEqualTo(Sets.newHashSet(allocationId1));
 
-            assertThat(taskSlotTable.getActiveTaskSlotAllocationIdsPerJob(jobId1))
-                    .isEqualTo(Sets.newHashSet(allocationId1));
+                    assertThat(taskSlotTable.tryMarkSlotActive(jobId1, allocationId1)).isTrue();
+                    assertThat(taskSlotTable.tryMarkSlotActive(jobId1, allocationId2)).isTrue();
+                    assertThat(taskSlotTable.tryMarkSlotActive(jobId1, allocationId3)).isFalse();
 
-            assertThat(taskSlotTable.tryMarkSlotActive(jobId1, allocationId1)).isTrue();
-            assertThat(taskSlotTable.tryMarkSlotActive(jobId1, allocationId2)).isTrue();
-            assertThat(taskSlotTable.tryMarkSlotActive(jobId1, allocationId3)).isFalse();
-
-            assertThat(taskSlotTable.getActiveTaskSlotAllocationIdsPerJob(jobId1))
-                    .isEqualTo(new HashSet<>(Arrays.asList(allocationId2, allocationId1)));
-        } finally {
-            taskSlotTable.close();
-            assertThat(taskSlotTable.isClosed()).isTrue();
-        }
+                    assertThat(taskSlotTable.getActiveTaskSlotAllocationIdsPerJob(jobId1))
+                            .isEqualTo(new HashSet<>(Arrays.asList(allocationId2, allocationId1)));
+                });
     }
 
     /** Tests {@link TaskSlotTableImpl#getActiveTaskSlotAllocationIds()}. */
     @Test
     void testRetrievingAllActiveSlots() throws Exception {
-        try (final TaskSlotTableImpl<?> taskSlotTable = createTaskSlotTableAndStart(3)) {
-            final JobID jobId1 = new JobID();
-            final AllocationID allocationId1 = new AllocationID();
-            taskSlotTable.allocateSlot(0, jobId1, allocationId1, SLOT_TIMEOUT);
-            final AllocationID allocationId2 = new AllocationID();
-            taskSlotTable.allocateSlot(1, jobId1, allocationId2, SLOT_TIMEOUT);
-            final AllocationID allocationId3 = new AllocationID();
-            final JobID jobId2 = new JobID();
-            taskSlotTable.allocateSlot(2, jobId2, allocationId3, SLOT_TIMEOUT);
+        runInMainThread(
+                3,
+                taskSlotTable -> {
+                    final JobID jobId1 = new JobID();
+                    final AllocationID allocationId1 = new AllocationID();
+                    taskSlotTable.allocateSlot(0, jobId1, allocationId1, SLOT_TIMEOUT);
+                    final AllocationID allocationId2 = new AllocationID();
+                    taskSlotTable.allocateSlot(1, jobId1, allocationId2, SLOT_TIMEOUT);
+                    final AllocationID allocationId3 = new AllocationID();
+                    final JobID jobId2 = new JobID();
+                    taskSlotTable.allocateSlot(2, jobId2, allocationId3, SLOT_TIMEOUT);
 
-            taskSlotTable.markSlotActive(allocationId1);
-            taskSlotTable.markSlotActive(allocationId3);
+                    taskSlotTable.markSlotActive(allocationId1);
+                    taskSlotTable.markSlotActive(allocationId3);
 
-            assertThat(taskSlotTable.getActiveTaskSlotAllocationIds())
-                    .isEqualTo(Sets.newHashSet(allocationId1, allocationId3));
-        }
+                    assertThat(taskSlotTable.getActiveTaskSlotAllocationIds())
+                            .isEqualTo(Sets.newHashSet(allocationId1, allocationId3));
+                });
     }
 
     /**
@@ -125,31 +131,37 @@ class TaskSlotTableImplTest {
      */
     @Test
     void testInconsistentStaticSlotAllocation() throws Exception {
-        try (final TaskSlotTable<TaskSlotPayload> taskSlotTable = createTaskSlotTableAndStart(2)) {
-            final JobID jobId = new JobID();
-            final AllocationID allocationId1 = new AllocationID();
-            final AllocationID allocationId2 = new AllocationID();
+        runInMainThread(
+                2,
+                taskSlotTable -> {
+                    final JobID jobId = new JobID();
+                    final AllocationID allocationId1 = new AllocationID();
+                    final AllocationID allocationId2 = new AllocationID();
 
-            assertThatNoException()
-                    .isThrownBy(
-                            () ->
-                                    taskSlotTable.allocateSlot(
-                                            0, jobId, allocationId1, SLOT_TIMEOUT));
-            assertThatThrownBy(
-                            () -> taskSlotTable.allocateSlot(1, jobId, allocationId1, SLOT_TIMEOUT))
-                    .isInstanceOf(SlotAllocationException.class);
-            assertThatThrownBy(
-                            () -> taskSlotTable.allocateSlot(0, jobId, allocationId2, SLOT_TIMEOUT))
-                    .isInstanceOf(SlotAllocationException.class);
+                    assertThatNoException()
+                            .isThrownBy(
+                                    () ->
+                                            taskSlotTable.allocateSlot(
+                                                    0, jobId, allocationId1, SLOT_TIMEOUT));
+                    assertThatThrownBy(
+                                    () ->
+                                            taskSlotTable.allocateSlot(
+                                                    1, jobId, allocationId1, SLOT_TIMEOUT))
+                            .isInstanceOf(SlotAllocationException.class);
+                    assertThatThrownBy(
+                                    () ->
+                                            taskSlotTable.allocateSlot(
+                                                    0, jobId, allocationId2, SLOT_TIMEOUT))
+                            .isInstanceOf(SlotAllocationException.class);
 
-            assertThat(taskSlotTable.isAllocated(0, jobId, allocationId1)).isTrue();
-            assertThat(taskSlotTable.isSlotFree(1)).isTrue();
+                    assertThat(taskSlotTable.isAllocated(0, jobId, allocationId1)).isTrue();
+                    assertThat(taskSlotTable.isSlotFree(1)).isTrue();
 
-            Iterator<TaskSlot<TaskSlotPayload>> allocatedSlots =
-                    taskSlotTable.getAllocatedSlots(jobId);
-            assertThat(allocatedSlots.next().getIndex()).isZero();
-            assertThat(allocatedSlots.hasNext()).isFalse();
-        }
+                    Iterator<TaskSlot<TaskSlotPayload>> allocatedSlots =
+                            taskSlotTable.getAllocatedSlots(jobId);
+                    assertThat(allocatedSlots.next().getIndex()).isZero();
+                    assertThat(allocatedSlots.hasNext()).isFalse();
+                });
     }
 
     /**
@@ -158,307 +170,329 @@ class TaskSlotTableImplTest {
      */
     @Test
     void testInconsistentDynamicSlotAllocation() throws Exception {
-        try (final TaskSlotTable<TaskSlotPayload> taskSlotTable = createTaskSlotTableAndStart(1)) {
-            final JobID jobId1 = new JobID();
-            final JobID jobId2 = new JobID();
-            final AllocationID allocationId = new AllocationID();
+        runInMainThread(
+                1,
+                taskSlotTable -> {
+                    final JobID jobId1 = new JobID();
+                    final JobID jobId2 = new JobID();
+                    final AllocationID allocationId = new AllocationID();
 
-            assertThatNoException()
-                    .isThrownBy(
-                            () ->
-                                    taskSlotTable.allocateSlot(
-                                            -1, jobId1, allocationId, SLOT_TIMEOUT));
-            assertThatThrownBy(
-                            () ->
-                                    taskSlotTable.allocateSlot(
-                                            -1, jobId2, allocationId, SLOT_TIMEOUT))
-                    .isInstanceOf(SlotAllocationException.class);
+                    assertThatNoException()
+                            .isThrownBy(
+                                    () ->
+                                            taskSlotTable.allocateSlot(
+                                                    -1, jobId1, allocationId, SLOT_TIMEOUT));
+                    assertThatThrownBy(
+                                    () ->
+                                            taskSlotTable.allocateSlot(
+                                                    -1, jobId2, allocationId, SLOT_TIMEOUT))
+                            .isInstanceOf(SlotAllocationException.class);
 
-            assertThat(taskSlotTable.isAllocated(1, jobId1, allocationId)).isTrue();
+                    assertThat(taskSlotTable.isAllocated(1, jobId1, allocationId)).isTrue();
 
-            Iterator<TaskSlot<TaskSlotPayload>> allocatedSlots =
-                    taskSlotTable.getAllocatedSlots(jobId1);
-            assertThat(allocatedSlots.next().getAllocationId()).isEqualTo(allocationId);
-            assertThat(allocatedSlots.hasNext()).isFalse();
-        }
+                    Iterator<TaskSlot<TaskSlotPayload>> allocatedSlots =
+                            taskSlotTable.getAllocatedSlots(jobId1);
+                    assertThat(allocatedSlots.next().getAllocationId()).isEqualTo(allocationId);
+                    assertThat(allocatedSlots.hasNext()).isFalse();
+                });
     }
 
     @Test
     void testDuplicateStaticSlotAllocation() throws Exception {
-        try (final TaskSlotTable<TaskSlotPayload> taskSlotTable = createTaskSlotTableAndStart(2)) {
-            final JobID jobId = new JobID();
-            final AllocationID allocationId = new AllocationID();
+        runInMainThread(
+                2,
+                taskSlotTable -> {
+                    final JobID jobId = new JobID();
+                    final AllocationID allocationId = new AllocationID();
 
-            assertThatNoException()
-                    .isThrownBy(
-                            () ->
-                                    taskSlotTable.allocateSlot(
-                                            0,
-                                            jobId,
-                                            allocationId,
-                                            ResourceProfile.UNKNOWN,
-                                            SLOT_TIMEOUT));
-            assertThatNoException()
-                    .isThrownBy(
-                            () ->
-                                    taskSlotTable.allocateSlot(
-                                            0,
-                                            jobId,
-                                            allocationId,
-                                            ResourceProfile.UNKNOWN,
-                                            SLOT_TIMEOUT));
+                    assertThatNoException()
+                            .isThrownBy(
+                                    () ->
+                                            taskSlotTable.allocateSlot(
+                                                    0,
+                                                    jobId,
+                                                    allocationId,
+                                                    ResourceProfile.UNKNOWN,
+                                                    SLOT_TIMEOUT));
+                    assertThatNoException()
+                            .isThrownBy(
+                                    () ->
+                                            taskSlotTable.allocateSlot(
+                                                    0,
+                                                    jobId,
+                                                    allocationId,
+                                                    ResourceProfile.UNKNOWN,
+                                                    SLOT_TIMEOUT));
 
-            assertThat(taskSlotTable.isAllocated(0, jobId, allocationId)).isTrue();
-            assertThat(taskSlotTable.isSlotFree(1)).isTrue();
+                    assertThat(taskSlotTable.isAllocated(0, jobId, allocationId)).isTrue();
+                    assertThat(taskSlotTable.isSlotFree(1)).isTrue();
 
-            Iterator<TaskSlot<TaskSlotPayload>> allocatedSlots =
-                    taskSlotTable.getAllocatedSlots(jobId);
-            assertThat(allocatedSlots.next().getIndex()).isZero();
-            assertThat(allocatedSlots.hasNext()).isFalse();
-        }
+                    Iterator<TaskSlot<TaskSlotPayload>> allocatedSlots =
+                            taskSlotTable.getAllocatedSlots(jobId);
+                    assertThat(allocatedSlots.next().getIndex()).isZero();
+                    assertThat(allocatedSlots.hasNext()).isFalse();
+                });
     }
 
     @Test
     void testDuplicateDynamicSlotAllocation() throws Exception {
-        try (final TaskSlotTable<TaskSlotPayload> taskSlotTable = createTaskSlotTableAndStart(1)) {
-            final JobID jobId = new JobID();
-            final AllocationID allocationId = new AllocationID();
+        runInMainThread(
+                1,
+                taskSlotTable -> {
+                    final JobID jobId = new JobID();
+                    final AllocationID allocationId = new AllocationID();
 
-            assertThatNoException()
-                    .isThrownBy(
-                            () ->
-                                    taskSlotTable.allocateSlot(
-                                            -1, jobId, allocationId, SLOT_TIMEOUT));
-            Iterator<TaskSlot<TaskSlotPayload>> allocatedSlots =
-                    taskSlotTable.getAllocatedSlots(jobId);
-            TaskSlot<TaskSlotPayload> taskSlot1 = allocatedSlots.next();
+                    assertThatNoException()
+                            .isThrownBy(
+                                    () ->
+                                            taskSlotTable.allocateSlot(
+                                                    -1, jobId, allocationId, SLOT_TIMEOUT));
+                    Iterator<TaskSlot<TaskSlotPayload>> allocatedSlots =
+                            taskSlotTable.getAllocatedSlots(jobId);
+                    TaskSlot<TaskSlotPayload> taskSlot1 = allocatedSlots.next();
 
-            assertThatNoException()
-                    .isThrownBy(
-                            () ->
-                                    taskSlotTable.allocateSlot(
-                                            -1, jobId, allocationId, SLOT_TIMEOUT));
-            allocatedSlots = taskSlotTable.getAllocatedSlots(jobId);
-            TaskSlot<TaskSlotPayload> taskSlot2 = allocatedSlots.next();
+                    assertThatNoException()
+                            .isThrownBy(
+                                    () ->
+                                            taskSlotTable.allocateSlot(
+                                                    -1, jobId, allocationId, SLOT_TIMEOUT));
+                    allocatedSlots = taskSlotTable.getAllocatedSlots(jobId);
+                    TaskSlot<TaskSlotPayload> taskSlot2 = allocatedSlots.next();
 
-            assertThat(taskSlotTable.isAllocated(1, jobId, allocationId)).isTrue();
-            assertThat(taskSlot2).isEqualTo(taskSlot1);
-            assertThat(allocatedSlots.hasNext()).isFalse();
-        }
+                    assertThat(taskSlotTable.isAllocated(1, jobId, allocationId)).isTrue();
+                    assertThat(taskSlot2).isEqualTo(taskSlot1);
+                    assertThat(allocatedSlots.hasNext()).isFalse();
+                });
     }
 
     @Test
     void testFreeSlot() throws Exception {
-        try (final TaskSlotTable<TaskSlotPayload> taskSlotTable = createTaskSlotTableAndStart(2)) {
-            final JobID jobId = new JobID();
-            final AllocationID allocationId1 = new AllocationID();
-            final AllocationID allocationId2 = new AllocationID();
+        runInMainThread(
+                2,
+                taskSlotTable -> {
+                    final JobID jobId = new JobID();
+                    final AllocationID allocationId1 = new AllocationID();
+                    final AllocationID allocationId2 = new AllocationID();
 
-            assertThatNoException()
-                    .isThrownBy(
-                            () ->
-                                    taskSlotTable.allocateSlot(
-                                            0, jobId, allocationId1, SLOT_TIMEOUT));
-            assertThatNoException()
-                    .isThrownBy(
-                            () ->
-                                    taskSlotTable.allocateSlot(
-                                            1, jobId, allocationId2, SLOT_TIMEOUT));
+                    assertThatNoException()
+                            .isThrownBy(
+                                    () ->
+                                            taskSlotTable.allocateSlot(
+                                                    0, jobId, allocationId1, SLOT_TIMEOUT));
+                    assertThatNoException()
+                            .isThrownBy(
+                                    () ->
+                                            taskSlotTable.allocateSlot(
+                                                    1, jobId, allocationId2, SLOT_TIMEOUT));
 
-            assertThat(taskSlotTable.freeSlot(allocationId2)).isOne();
+                    assertThat(taskSlotTable.freeSlot(allocationId2)).isOne();
 
-            Iterator<TaskSlot<TaskSlotPayload>> allocatedSlots =
-                    taskSlotTable.getAllocatedSlots(jobId);
-            assertThat(allocatedSlots.next().getIndex()).isZero();
-            assertThat(allocatedSlots.hasNext()).isFalse();
-            assertThat(taskSlotTable.isAllocated(1, jobId, allocationId1)).isFalse();
-            assertThat(taskSlotTable.isAllocated(1, jobId, allocationId2)).isFalse();
-            assertThat(taskSlotTable.isSlotFree(1)).isTrue();
-        }
+                    Iterator<TaskSlot<TaskSlotPayload>> allocatedSlots =
+                            taskSlotTable.getAllocatedSlots(jobId);
+                    assertThat(allocatedSlots.next().getIndex()).isZero();
+                    assertThat(allocatedSlots.hasNext()).isFalse();
+                    assertThat(taskSlotTable.isAllocated(1, jobId, allocationId1)).isFalse();
+                    assertThat(taskSlotTable.isAllocated(1, jobId, allocationId2)).isFalse();
+                    assertThat(taskSlotTable.isSlotFree(1)).isTrue();
+                });
     }
 
     @Test
     void testSlotAllocationWithDynamicSlotId() throws Exception {
-        try (final TaskSlotTable<TaskSlotPayload> taskSlotTable = createTaskSlotTableAndStart(2)) {
-            final JobID jobId = new JobID();
-            final AllocationID allocationId = new AllocationID();
+        runInMainThread(
+                2,
+                taskSlotTable -> {
+                    final JobID jobId = new JobID();
+                    final AllocationID allocationId = new AllocationID();
 
-            assertThatNoException()
-                    .isThrownBy(
-                            () ->
-                                    taskSlotTable.allocateSlot(
-                                            -1, jobId, allocationId, SLOT_TIMEOUT));
+                    assertThatNoException()
+                            .isThrownBy(
+                                    () ->
+                                            taskSlotTable.allocateSlot(
+                                                    -1, jobId, allocationId, SLOT_TIMEOUT));
 
-            Iterator<TaskSlot<TaskSlotPayload>> allocatedSlots =
-                    taskSlotTable.getAllocatedSlots(jobId);
-            assertThat(allocatedSlots.next().getIndex()).isEqualTo(2);
-            assertThat(allocatedSlots.hasNext()).isFalse();
-            assertThat(taskSlotTable.isAllocated(2, jobId, allocationId)).isTrue();
-        }
+                    Iterator<TaskSlot<TaskSlotPayload>> allocatedSlots =
+                            taskSlotTable.getAllocatedSlots(jobId);
+                    assertThat(allocatedSlots.next().getIndex()).isEqualTo(2);
+                    assertThat(allocatedSlots.hasNext()).isFalse();
+                    assertThat(taskSlotTable.isAllocated(2, jobId, allocationId)).isTrue();
+                });
     }
 
     @Test
     void testSlotAllocationWithConcreteResourceProfile() throws Exception {
-        try (final TaskSlotTable<TaskSlotPayload> taskSlotTable = createTaskSlotTableAndStart(2)) {
-            final JobID jobId = new JobID();
-            final AllocationID allocationId = new AllocationID();
-            final ResourceProfile resourceProfile =
-                    TaskSlotUtils.DEFAULT_RESOURCE_PROFILE.merge(
-                            ResourceProfile.newBuilder().setCpuCores(0.1).build());
+        runInMainThread(
+                2,
+                taskSlotTable -> {
+                    final JobID jobId = new JobID();
+                    final AllocationID allocationId = new AllocationID();
+                    final ResourceProfile resourceProfile =
+                            TaskSlotUtils.DEFAULT_RESOURCE_PROFILE.merge(
+                                    ResourceProfile.newBuilder().setCpuCores(0.1).build());
 
-            assertThatNoException()
-                    .isThrownBy(
-                            () ->
-                                    taskSlotTable.allocateSlot(
-                                            -1,
-                                            jobId,
-                                            allocationId,
-                                            resourceProfile,
-                                            SLOT_TIMEOUT));
+                    assertThatNoException()
+                            .isThrownBy(
+                                    () ->
+                                            taskSlotTable.allocateSlot(
+                                                    -1,
+                                                    jobId,
+                                                    allocationId,
+                                                    resourceProfile,
+                                                    SLOT_TIMEOUT));
 
-            Iterator<TaskSlot<TaskSlotPayload>> allocatedSlots =
-                    taskSlotTable.getAllocatedSlots(jobId);
-            TaskSlot<TaskSlotPayload> allocatedSlot = allocatedSlots.next();
-            assertThat(allocatedSlot.getIndex()).isEqualTo(2);
-            assertThat(allocatedSlot.getResourceProfile()).isEqualTo(resourceProfile);
-            assertThat(allocatedSlots.hasNext()).isFalse();
-        }
+                    Iterator<TaskSlot<TaskSlotPayload>> allocatedSlots =
+                            taskSlotTable.getAllocatedSlots(jobId);
+                    TaskSlot<TaskSlotPayload> allocatedSlot = allocatedSlots.next();
+                    assertThat(allocatedSlot.getIndex()).isEqualTo(2);
+                    assertThat(allocatedSlot.getResourceProfile()).isEqualTo(resourceProfile);
+                    assertThat(allocatedSlots.hasNext()).isFalse();
+                });
     }
 
     @Test
     void testSlotAllocationWithUnknownResourceProfile() throws Exception {
-        try (final TaskSlotTableImpl<TaskSlotPayload> taskSlotTable =
-                createTaskSlotTableAndStart(2)) {
-            final JobID jobId = new JobID();
-            final AllocationID allocationId = new AllocationID();
+        runInMainThread(
+                2,
+                taskSlotTable -> {
+                    final JobID jobId = new JobID();
+                    final AllocationID allocationId = new AllocationID();
 
-            assertThatNoException()
-                    .isThrownBy(
-                            () ->
-                                    taskSlotTable.allocateSlot(
-                                            -1,
-                                            jobId,
-                                            allocationId,
-                                            ResourceProfile.UNKNOWN,
-                                            SLOT_TIMEOUT));
+                    assertThatNoException()
+                            .isThrownBy(
+                                    () ->
+                                            taskSlotTable.allocateSlot(
+                                                    -1,
+                                                    jobId,
+                                                    allocationId,
+                                                    ResourceProfile.UNKNOWN,
+                                                    SLOT_TIMEOUT));
 
-            Iterator<TaskSlot<TaskSlotPayload>> allocatedSlots =
-                    taskSlotTable.getAllocatedSlots(jobId);
-            TaskSlot<TaskSlotPayload> allocatedSlot = allocatedSlots.next();
-            assertThat(allocatedSlot.getIndex()).isEqualTo(2);
-            assertThat(allocatedSlot.getResourceProfile())
-                    .isEqualTo(TaskSlotUtils.DEFAULT_RESOURCE_PROFILE);
-            assertThat(allocatedSlots.hasNext()).isFalse();
-        }
+                    Iterator<TaskSlot<TaskSlotPayload>> allocatedSlots =
+                            taskSlotTable.getAllocatedSlots(jobId);
+                    TaskSlot<TaskSlotPayload> allocatedSlot = allocatedSlots.next();
+                    assertThat(allocatedSlot.getIndex()).isEqualTo(2);
+                    assertThat(allocatedSlot.getResourceProfile())
+                            .isEqualTo(TaskSlotUtils.DEFAULT_RESOURCE_PROFILE);
+                    assertThat(allocatedSlots.hasNext()).isFalse();
+                });
     }
 
     @Test
     void testSlotAllocationWithResourceProfileFailure() throws Exception {
-        try (final TaskSlotTable<TaskSlotPayload> taskSlotTable = createTaskSlotTableAndStart(2)) {
-            final JobID jobId = new JobID();
-            final AllocationID allocationId = new AllocationID();
-            ResourceProfile resourceProfile = TaskSlotUtils.DEFAULT_RESOURCE_PROFILE;
-            resourceProfile = resourceProfile.merge(resourceProfile).merge(resourceProfile);
+        runInMainThread(
+                2,
+                taskSlotTable -> {
+                    final JobID jobId = new JobID();
+                    final AllocationID allocationId = new AllocationID();
+                    ResourceProfile resourceProfile = TaskSlotUtils.DEFAULT_RESOURCE_PROFILE;
+                    resourceProfile = resourceProfile.merge(resourceProfile).merge(resourceProfile);
 
-            final ResourceProfile mergedResourceProfile = resourceProfile;
+                    final ResourceProfile mergedResourceProfile = resourceProfile;
 
-            assertThatThrownBy(
-                            () ->
-                                    taskSlotTable.allocateSlot(
-                                            -1,
-                                            jobId,
-                                            allocationId,
-                                            mergedResourceProfile,
-                                            SLOT_TIMEOUT))
-                    .isInstanceOf(SlotAllocationException.class);
+                    assertThatThrownBy(
+                                    () ->
+                                            taskSlotTable.allocateSlot(
+                                                    -1,
+                                                    jobId,
+                                                    allocationId,
+                                                    mergedResourceProfile,
+                                                    SLOT_TIMEOUT))
+                            .isInstanceOf(SlotAllocationException.class);
 
-            Iterator<TaskSlot<TaskSlotPayload>> allocatedSlots =
-                    taskSlotTable.getAllocatedSlots(jobId);
-            assertThat(allocatedSlots.hasNext()).isFalse();
-        }
+                    Iterator<TaskSlot<TaskSlotPayload>> allocatedSlots =
+                            taskSlotTable.getAllocatedSlots(jobId);
+                    assertThat(allocatedSlots.hasNext()).isFalse();
+                });
     }
 
     @Test
     void testGenerateSlotReport() throws Exception {
-        try (final TaskSlotTable<TaskSlotPayload> taskSlotTable = createTaskSlotTableAndStart(3)) {
-            final JobID jobId = new JobID();
-            final AllocationID allocationId1 = new AllocationID();
-            final AllocationID allocationId2 = new AllocationID();
-            final AllocationID allocationId3 = new AllocationID();
+        runInMainThread(
+                3,
+                taskSlotTable -> {
+                    final JobID jobId = new JobID();
+                    final AllocationID allocationId1 = new AllocationID();
+                    final AllocationID allocationId2 = new AllocationID();
+                    final AllocationID allocationId3 = new AllocationID();
 
-            assertThatNoException()
-                    .as(
-                            "Slot with allocation ID %s should have been allocated successfully.",
-                            allocationId1)
-                    .isThrownBy(
-                            () ->
-                                    taskSlotTable.allocateSlot(
-                                            0, jobId, allocationId1, SLOT_TIMEOUT));
-            assertThatNoException()
-                    .as(
-                            "Slot with allocation ID %s should have been allocated successfully.",
-                            allocationId2)
-                    .isThrownBy(
-                            () ->
-                                    taskSlotTable.allocateSlot(
-                                            -1, jobId, allocationId2, SLOT_TIMEOUT)); // index 3
-            assertThatNoException()
-                    .as(
-                            "Slot with allocation ID %s should have been allocated successfully.",
-                            allocationId3)
-                    .isThrownBy(
-                            () ->
-                                    taskSlotTable.allocateSlot(
-                                            -1, jobId, allocationId3, SLOT_TIMEOUT));
+                    assertThatNoException()
+                            .as(
+                                    "Slot with allocation ID %s should have been allocated successfully.",
+                                    allocationId1)
+                            .isThrownBy(
+                                    () ->
+                                            taskSlotTable.allocateSlot(
+                                                    0, jobId, allocationId1, SLOT_TIMEOUT));
+                    assertThatNoException()
+                            .as(
+                                    "Slot with allocation ID %s should have been allocated successfully.",
+                                    allocationId2)
+                            .isThrownBy(
+                                    () ->
+                                            taskSlotTable.allocateSlot(
+                                                    -1,
+                                                    jobId,
+                                                    allocationId2,
+                                                    SLOT_TIMEOUT)); // index 3
+                    assertThatNoException()
+                            .as(
+                                    "Slot with allocation ID %s should have been allocated successfully.",
+                                    allocationId3)
+                            .isThrownBy(
+                                    () ->
+                                            taskSlotTable.allocateSlot(
+                                                    -1, jobId, allocationId3, SLOT_TIMEOUT));
 
-            assertThat(taskSlotTable.freeSlot(allocationId2)).isEqualTo(3);
+                    assertThat(taskSlotTable.freeSlot(allocationId2)).isEqualTo(3);
 
-            ResourceID resourceId = ResourceID.generate();
-            SlotReport slotReport = taskSlotTable.createSlotReport(resourceId);
-            List<SlotStatus> slotStatuses = new ArrayList<>();
-            slotReport.iterator().forEachRemaining(slotStatuses::add);
+                    ResourceID resourceId = ResourceID.generate();
+                    SlotReport slotReport = taskSlotTable.createSlotReport(resourceId);
+                    List<SlotStatus> slotStatuses = new ArrayList<>();
+                    slotReport.iterator().forEachRemaining(slotStatuses::add);
 
-            assertThat(slotStatuses).hasSize(4);
-            assertThat(slotStatuses)
-                    .containsExactlyInAnyOrder(
-                            new SlotStatus(
-                                    new SlotID(resourceId, 0),
-                                    TaskSlotUtils.DEFAULT_RESOURCE_PROFILE,
-                                    jobId,
-                                    allocationId1),
-                            new SlotStatus(
-                                    new SlotID(resourceId, 1),
-                                    TaskSlotUtils.DEFAULT_RESOURCE_PROFILE,
-                                    null,
-                                    null),
-                            new SlotStatus(
-                                    new SlotID(resourceId, 2),
-                                    TaskSlotUtils.DEFAULT_RESOURCE_PROFILE,
-                                    null,
-                                    null),
-                            new SlotStatus(
-                                    new SlotID(resourceId, 4),
-                                    TaskSlotUtils.DEFAULT_RESOURCE_PROFILE,
-                                    jobId,
-                                    allocationId3));
-        }
+                    assertThat(slotStatuses).hasSize(4);
+                    assertThat(slotStatuses)
+                            .containsExactlyInAnyOrder(
+                                    new SlotStatus(
+                                            new SlotID(resourceId, 0),
+                                            TaskSlotUtils.DEFAULT_RESOURCE_PROFILE,
+                                            jobId,
+                                            allocationId1),
+                                    new SlotStatus(
+                                            new SlotID(resourceId, 1),
+                                            TaskSlotUtils.DEFAULT_RESOURCE_PROFILE,
+                                            null,
+                                            null),
+                                    new SlotStatus(
+                                            new SlotID(resourceId, 2),
+                                            TaskSlotUtils.DEFAULT_RESOURCE_PROFILE,
+                                            null,
+                                            null),
+                                    new SlotStatus(
+                                            new SlotID(resourceId, 4),
+                                            TaskSlotUtils.DEFAULT_RESOURCE_PROFILE,
+                                            jobId,
+                                            allocationId3));
+                });
     }
 
     @Test
     void testAllocateSlot() throws Exception {
         final JobID jobId = new JobID();
         final AllocationID allocationId = new AllocationID();
-        try (final TaskSlotTable<TaskSlotPayload> taskSlotTable =
-                createTaskSlotTableWithAllocatedSlot(
-                        jobId, allocationId, new TestingSlotActionsBuilder().build())) {
-            Iterator<TaskSlot<TaskSlotPayload>> allocatedSlots =
-                    taskSlotTable.getAllocatedSlots(jobId);
-            TaskSlot<TaskSlotPayload> nextSlot = allocatedSlots.next();
-            assertThat(nextSlot.getIndex()).isZero();
-            assertThat(nextSlot.getAllocationId()).isEqualTo(allocationId);
-            assertThat(nextSlot.getJobId()).isEqualTo(jobId);
-            assertThat(allocatedSlots.hasNext()).isFalse();
-        }
+        runInMainThread(
+                () ->
+                        createTaskSlotTableWithAllocatedSlot(
+                                jobId, allocationId, new TestingSlotActionsBuilder().build()),
+                taskSlotTable -> {
+                    Iterator<TaskSlot<TaskSlotPayload>> allocatedSlots =
+                            taskSlotTable.getAllocatedSlots(jobId);
+                    TaskSlot<TaskSlotPayload> nextSlot = allocatedSlots.next();
+                    assertThat(nextSlot.getIndex()).isZero();
+                    assertThat(nextSlot.getAllocationId()).isEqualTo(allocationId);
+                    assertThat(nextSlot.getJobId()).isEqualTo(jobId);
+                    assertThat(allocatedSlots.hasNext()).isFalse();
+                });
     }
 
     @Test
@@ -468,18 +502,19 @@ class TaskSlotTableImplTest {
         final AllocationID allocationId = new AllocationID();
         TaskSlotPayload task =
                 new TestingTaskSlotPayload(jobId, executionAttemptId, allocationId).terminate();
-        try (final TaskSlotTable<TaskSlotPayload> taskSlotTable =
-                createTaskSlotTableWithStartedTask(task)) {
-            Iterator<TaskSlotPayload> tasks = taskSlotTable.getTasks(jobId);
-            TaskSlotPayload nextTask = tasks.next();
-            assertThat(nextTask.getExecutionId()).isEqualTo(executionAttemptId);
-            assertThat(nextTask.getAllocationId()).isEqualTo(allocationId);
-            assertThat(tasks.hasNext()).isFalse();
-        }
+
+        runInMainThread(
+                () -> createTaskSlotTableWithStartedTask(task),
+                taskSlotTable -> {
+                    Iterator<TaskSlotPayload> tasks = taskSlotTable.getTasks(jobId);
+                    TaskSlotPayload nextTask = tasks.next();
+                    assertThat(nextTask.getExecutionId()).isEqualTo(executionAttemptId);
+                    assertThat(nextTask.getAllocationId()).isEqualTo(allocationId);
+                    assertThat(tasks.hasNext()).isFalse();
+                });
     }
 
     @Test
-    @Timeout(10)
     void testRemoveTaskCallsFreeSlotAction() throws Exception {
         final JobID jobId = new JobID();
         final ExecutionAttemptID executionAttemptId = createExecutionAttemptId();
@@ -489,39 +524,41 @@ class TaskSlotTableImplTest {
                 new TestingSlotActions(freeSlotFuture::complete, (aid, uid) -> {});
         TaskSlotPayload task =
                 new TestingTaskSlotPayload(jobId, executionAttemptId, allocationId).terminate();
-        try (final TaskSlotTable<TaskSlotPayload> taskSlotTable =
-                createTaskSlotTableWithStartedTask(task, slotActions)) {
-            // we have to initiate closing of the slot externally
-            // to enable that the last remaining finished task does the final slot freeing
-            taskSlotTable.freeSlot(allocationId);
-            taskSlotTable.removeTask(executionAttemptId);
-            assertThatFuture(freeSlotFuture).eventuallySucceeds().isEqualTo(allocationId);
-        }
+
+        runInMainThread(
+                () -> createTaskSlotTableWithStartedTask(task, slotActions),
+                taskSlotTable -> {
+                    // we have to initiate closing of the slot externally to enable that the last
+                    // remaining finished task does the final slot freeing
+                    taskSlotTable.freeSlot(allocationId);
+                    taskSlotTable.removeTask(executionAttemptId);
+                    assertThatFuture(freeSlotFuture).eventuallySucceeds().isEqualTo(allocationId);
+                });
     }
 
     @Test
-    @Timeout(10)
     void testFreeSlotInterruptsSubmittedTask() throws Exception {
         TestingTaskSlotPayload task = new TestingTaskSlotPayload();
-        try (final TaskSlotTable<TaskSlotPayload> taskSlotTable =
-                createTaskSlotTableWithStartedTask(task)) {
-            assertThat(taskSlotTable.freeSlot(task.getAllocationId())).isEqualTo(-1);
-            task.waitForFailure();
-            task.terminate();
-        }
+        runInMainThread(
+                () -> createTaskSlotTableWithStartedTask(task),
+                taskSlotTable -> {
+                    assertThat(taskSlotTable.freeSlot(task.getAllocationId())).isEqualTo(-1);
+                    task.waitForFailure();
+                    task.terminate();
+                });
     }
 
     @Test
-    @Timeout(10)
     void testTableIsClosedOnlyWhenAllTasksTerminated() throws Exception {
         TestingTaskSlotPayload task = new TestingTaskSlotPayload();
-        final TaskSlotTable<TaskSlotPayload> taskSlotTable =
-                createTaskSlotTableWithStartedTask(task);
-        assertThat(taskSlotTable.freeSlot(task.getAllocationId())).isEqualTo(-1);
-        CompletableFuture<Void> closingFuture = taskSlotTable.closeAsync();
-        assertThat(closingFuture).isNotDone();
-        task.terminate();
-        closingFuture.get();
+        runInMainThread(
+                () -> createTaskSlotTableWithStartedTask(task),
+                taskSlotTable -> {
+                    assertThat(taskSlotTable.freeSlot(task.getAllocationId())).isEqualTo(-1);
+                    CompletableFuture<Void> closingFuture = taskSlotTable.closeAsync();
+                    assertThat(closingFuture).isNotDone();
+                    task.terminate();
+                });
     }
 
     @Test
@@ -532,17 +569,20 @@ class TaskSlotTableImplTest {
                         .setTimeoutSlotConsumer(
                                 (allocationID, uuid) -> timeoutFuture.complete(allocationID))
                         .build();
-
-        try (final TaskSlotTableImpl<TaskSlotPayload> taskSlotTable =
-                createTaskSlotTableAndStart(1, testingSlotActions)) {
-            final AllocationID allocationId = new AllocationID();
-            assertThatNoException()
-                    .isThrownBy(
-                            () ->
-                                    taskSlotTable.allocateSlot(
-                                            0, new JobID(), allocationId, Duration.ofMillis(1L)));
-            assertThatFuture(timeoutFuture).eventuallySucceeds().isEqualTo(allocationId);
-        }
+        runInMainThread(
+                () -> createTaskSlotTableAndStart(1, testingSlotActions),
+                taskSlotTable -> {
+                    final AllocationID allocationId = new AllocationID();
+                    assertThatNoException()
+                            .isThrownBy(
+                                    () ->
+                                            taskSlotTable.allocateSlot(
+                                                    0,
+                                                    new JobID(),
+                                                    allocationId,
+                                                    Duration.ofMillis(1L)));
+                    assertThatFuture(timeoutFuture).eventuallySucceeds().isEqualTo(allocationId);
+                });
     }
 
     @Test
@@ -572,31 +612,36 @@ class TaskSlotTableImplTest {
                         .setUnregisterTimeoutConsumer(timeoutCancellationFuture::complete)
                         .createTestingTimerService();
 
-        try (final TaskSlotTableImpl<TaskSlotPayload> taskSlotTable =
-                createTaskSlotTableAndStart(1, testingTimerService)) {
-            final AllocationID allocationId = new AllocationID();
-            final long timeout = 50L;
-            final JobID jobId = new JobID();
-            assertThatNoException()
-                    .isThrownBy(
-                            () ->
-                                    taskSlotTable.allocateSlot(
-                                            0, jobId, allocationId, Duration.ofMillis(timeout)));
-            assertThat(taskSlotTableAction.apply(taskSlotTable, jobId, allocationId)).isTrue();
+        runInMainThread(
+                () -> createTaskSlotTableAndStart(1, testingTimerService),
+                taskSlotTable -> {
+                    final AllocationID allocationId = new AllocationID();
+                    final long timeout = 50L;
+                    final JobID jobId = new JobID();
+                    assertThatNoException()
+                            .isThrownBy(
+                                    () ->
+                                            taskSlotTable.allocateSlot(
+                                                    0,
+                                                    jobId,
+                                                    allocationId,
+                                                    Duration.ofMillis(timeout)));
+                    assertThat(taskSlotTableAction.apply(taskSlotTable, jobId, allocationId))
+                            .isTrue();
 
-            timeoutCancellationFuture.get();
-        }
+                    timeoutCancellationFuture.get();
+                });
     }
 
-    private static TaskSlotTable<TaskSlotPayload> createTaskSlotTableWithStartedTask(
+    private static TaskSlotTableImpl<TaskSlotPayload> createTaskSlotTableWithStartedTask(
             final TaskSlotPayload task) throws SlotNotFoundException, SlotNotActiveException {
         return createTaskSlotTableWithStartedTask(task, new TestingSlotActionsBuilder().build());
     }
 
-    private static TaskSlotTable<TaskSlotPayload> createTaskSlotTableWithStartedTask(
+    private static TaskSlotTableImpl<TaskSlotPayload> createTaskSlotTableWithStartedTask(
             final TaskSlotPayload task, final SlotActions slotActions)
             throws SlotNotFoundException, SlotNotActiveException {
-        final TaskSlotTable<TaskSlotPayload> taskSlotTable =
+        final TaskSlotTableImpl<TaskSlotPayload> taskSlotTable =
                 createTaskSlotTableWithAllocatedSlot(
                         task.getJobID(), task.getAllocationId(), slotActions);
         taskSlotTable.markSlotActive(task.getAllocationId());
@@ -604,9 +649,9 @@ class TaskSlotTableImplTest {
         return taskSlotTable;
     }
 
-    private static TaskSlotTable<TaskSlotPayload> createTaskSlotTableWithAllocatedSlot(
+    private static TaskSlotTableImpl<TaskSlotPayload> createTaskSlotTableWithAllocatedSlot(
             final JobID jobId, final AllocationID allocationId, final SlotActions slotActions) {
-        final TaskSlotTable<TaskSlotPayload> taskSlotTable =
+        final TaskSlotTableImpl<TaskSlotPayload> taskSlotTable =
                 createTaskSlotTableAndStart(1, slotActions);
         assertThatNoException()
                 .isThrownBy(() -> taskSlotTable.allocateSlot(0, jobId, allocationId, SLOT_TIMEOUT));
@@ -622,7 +667,10 @@ class TaskSlotTableImplTest {
             final int numberOfSlots, final SlotActions slotActions) {
         final TaskSlotTableImpl<TaskSlotPayload> taskSlotTable =
                 TaskSlotUtils.createTaskSlotTable(numberOfSlots, EXECUTOR_EXTENSION.getExecutor());
-        taskSlotTable.start(slotActions, ComponentMainThreadExecutorServiceAdapter.forMainThread());
+        taskSlotTable.start(
+                slotActions,
+                ComponentMainThreadExecutorServiceAdapter.forSingleThreadExecutor(
+                        MAIN_THREAD_EXECUTOR_EXTENSION.getExecutor()));
         return taskSlotTable;
     }
 
@@ -633,7 +681,31 @@ class TaskSlotTableImplTest {
                         numberOfSlots, timerService, EXECUTOR_EXTENSION.getExecutor());
         taskSlotTable.start(
                 new TestingSlotActionsBuilder().build(),
-                ComponentMainThreadExecutorServiceAdapter.forMainThread());
+                ComponentMainThreadExecutorServiceAdapter.forSingleThreadExecutor(
+                        MAIN_THREAD_EXECUTOR_EXTENSION.getExecutor()));
         return taskSlotTable;
+    }
+
+    private static void runInMainThread(
+            SupplierWithException<TaskSlotTableImpl<TaskSlotPayload>, Exception>
+                    taskSlotTableFactory,
+            ThrowingConsumer<TaskSlotTableImpl<TaskSlotPayload>, ? extends Exception> callback)
+            throws Exception {
+        final TaskSlotTableImpl<TaskSlotPayload> taskSlotTable = taskSlotTableFactory.get();
+
+        FutureUtils.runAsync(
+                        () -> callback.accept(taskSlotTable),
+                        MAIN_THREAD_EXECUTOR_EXTENSION.getExecutor())
+                .thenApply(ignored -> taskSlotTable.closeAsync())
+                .thenCompose(Function.identity())
+                .thenRun(() -> assertThat(taskSlotTable.isClosed()).isTrue())
+                .join();
+    }
+
+    private static void runInMainThread(
+            int slotCount,
+            ThrowingConsumer<TaskSlotTableImpl<TaskSlotPayload>, ? extends Exception> callback)
+            throws Exception {
+        runInMainThread(() -> createTaskSlotTableAndStart(slotCount), callback);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Refactors test to use proper Executor (rather than `directExecutor`). This allows for callbacks to be scheduled on the main thread in production code.

## Brief change log

* Introduces single-thread executor as the main thread

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable