### PR TITLE
[hotfix] Enable @PublicEvolving japicmp checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@ under the License.
 		<minikdc.version>3.2.4</minikdc.version>
 		<hive.version>2.3.10</hive.version>
 		<orc.version>1.5.6</orc.version>
-		<japicmp.referenceVersion>1.19.0</japicmp.referenceVersion>
+		<japicmp.referenceVersion>1.20.0</japicmp.referenceVersion>
 		<japicmp.outputDir>tools/japicmp-output</japicmp.outputDir>
 		<checkstyle.version>9.3</checkstyle.version>
 		<!-- can be removed with maven-spotless-plugin:2.38+ -->
@@ -2356,11 +2356,10 @@ under the License.
 								<include>@org.apache.flink.annotation.Public</include>
 								<!-- The following line is un-commented by tools/releasing/update_japicmp_configuration.sh
 								 	as part of the release process -->
-								<!--<include>@org.apache.flink.annotation.PublicEvolving</include>-->
+								<include>@org.apache.flink.annotation.PublicEvolving</include>
 							</includes>
 							<excludes>
 								<exclude>@org.apache.flink.annotation.Experimental</exclude>
-								<exclude>@org.apache.flink.annotation.PublicEvolving</exclude>
 								<exclude>@org.apache.flink.annotation.Internal</exclude>
 								<!-- MARKER: start exclusions; these will be wiped by tools/releasing/update_japicmp_configuration.sh -->
 								<!-- New method has been added to the interface, with a default implementation. This shouldn't break binary compatibility. -->

--- a/pom.xml
+++ b/pom.xml
@@ -2363,6 +2363,10 @@ under the License.
 								<exclude>@org.apache.flink.annotation.PublicEvolving</exclude>
 								<exclude>@org.apache.flink.annotation.Internal</exclude>
 								<!-- MARKER: start exclusions; these will be wiped by tools/releasing/update_japicmp_configuration.sh -->
+								<!-- New method has been added to the interface, with a default implementation. This shouldn't break binary compatibility. -->
+								<exclude>org.apache.flink.api.common.eventtime.WatermarkGeneratorSupplier$Context</exclude>
+								<!-- Base interface has been extracted from the existing Clock class. This interface shouldn't affect user code. -->
+								<exclude>org.apache.flink.util.clock.Clock</exclude>
 								<exclude>org.apache.flink.api.common.state.AggregatingState</exclude>
 								<exclude>org.apache.flink.api.common.state.AppendingState</exclude>
 								<exclude>org.apache.flink.api.common.state.BroadcastState</exclude>


### PR DESCRIPTION
`@PublicEvolving` checks are supposed to be kept enabled on release-x.y branches. The fact that it was disabled on `release-1.20` led to PRs CI skipping the check and two commits that break binary compatibility being merged:

https://issues.apache.org/jira/browse/FLINK-37098?focusedCommentId=17921143&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17921143

https://issues.apache.org/jira/browse/FLINK-35886?focusedCommentId=17916974&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17916974

The japicmp reference version has also not been properly updated after the 1.20.0 release.