### PR TITLE
[FLINK-31275] extend lineage listener with QueryOperationEvent

### DIFF
--- a/docs/content/docs/deployment/advanced/job_status_listener.md
+++ b/docs/content/docs/deployment/advanced/job_status_listener.md
@@ -27,6 +27,7 @@ Flink provides a pluggable interface for users to register their custom logic fo
 This enables users to implement their own flink lineage reporter to send lineage info to third party data lineage systems for example Datahub and Openlineage.
 
 The job status changed listeners are triggered every time status change happened for the application. The data lineage info is included in the JobCreatedEvent.
+QueryOperationEvent can be used together with JobCreatedEvent to provide column level lineage for Flink SQL and Table API jobs.
 
 ### Implement a plugin for your custom enricher
 

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/operation/OperationExecutor.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/operation/OperationExecutor.java
@@ -28,6 +28,8 @@ import org.apache.flink.client.deployment.DefaultClusterClientServiceLoader;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.execution.JobStatusChangedListener;
+import org.apache.flink.core.execution.JobStatusChangedListenerUtils;
 import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -464,6 +466,10 @@ public class OperationExecutor {
                         catalogManager,
                         functionCatalog);
 
+        final List<JobStatusChangedListener> jobStatusChangedListeners =
+                JobStatusChangedListenerUtils.createJobStatusChangedListeners(
+                        settings.getConfiguration());
+
         return new StreamTableEnvironmentImpl(
                 catalogManager,
                 moduleManager,
@@ -473,7 +479,8 @@ public class OperationExecutor {
                 env,
                 planner,
                 executor,
-                settings.isStreamingMode());
+                settings.isStreamingMode(),
+                jobStatusChangedListeners);
     }
 
     private ResultFetcher executeOperationInStatementSetState(

--- a/flink-table/flink-table-api-bridge-base/src/main/java/org/apache/flink/table/api/bridge/internal/AbstractStreamTableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-bridge-base/src/main/java/org/apache/flink/table/api/bridge/internal/AbstractStreamTableEnvironmentImpl.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.TupleTypeInfo;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.core.execution.JobStatusChangedListener;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.Schema;
@@ -84,7 +85,8 @@ public abstract class AbstractStreamTableEnvironmentImpl extends TableEnvironmen
             FunctionCatalog functionCatalog,
             Planner planner,
             boolean isStreamingMode,
-            StreamExecutionEnvironment executionEnvironment) {
+            StreamExecutionEnvironment executionEnvironment,
+            List<JobStatusChangedListener> jobStatusChangedListeners) {
         super(
                 catalogManager,
                 moduleManager,
@@ -93,7 +95,8 @@ public abstract class AbstractStreamTableEnvironmentImpl extends TableEnvironmen
                 executor,
                 functionCatalog,
                 planner,
-                isStreamingMode);
+                isStreamingMode,
+                jobStatusChangedListeners);
         this.executionEnvironment = executionEnvironment;
     }
 

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/internal/StreamTableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/internal/StreamTableEnvironmentImpl.java
@@ -22,6 +22,9 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.execution.JobStatusChangedListener;
+import org.apache.flink.core.execution.JobStatusChangedListenerUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.DataTypes;
@@ -62,6 +65,7 @@ import org.apache.flink.util.Preconditions;
 
 import java.net.URL;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -83,7 +87,8 @@ public final class StreamTableEnvironmentImpl extends AbstractStreamTableEnviron
             StreamExecutionEnvironment executionEnvironment,
             Planner planner,
             Executor executor,
-            boolean isStreamingMode) {
+            boolean isStreamingMode,
+            List<JobStatusChangedListener> jobStatusChangedListeners) {
         super(
                 catalogManager,
                 moduleManager,
@@ -93,7 +98,8 @@ public final class StreamTableEnvironmentImpl extends AbstractStreamTableEnviron
                 functionCatalog,
                 planner,
                 isStreamingMode,
-                executionEnvironment);
+                executionEnvironment,
+                jobStatusChangedListeners);
     }
 
     public static StreamTableEnvironment create(
@@ -157,6 +163,10 @@ public final class StreamTableEnvironmentImpl extends AbstractStreamTableEnviron
                         catalogManager,
                         functionCatalog);
 
+        final List<JobStatusChangedListener> jobStatusChangedListeners =
+                JobStatusChangedListenerUtils.createJobStatusChangedListeners(
+                        (Configuration) tableConfig.getRootConfiguration());
+
         return new StreamTableEnvironmentImpl(
                 catalogManager,
                 moduleManager,
@@ -166,7 +176,8 @@ public final class StreamTableEnvironmentImpl extends AbstractStreamTableEnviron
                 executionEnvironment,
                 planner,
                 executor,
-                settings.isStreamingMode());
+                settings.isStreamingMode(),
+                jobStatusChangedListeners);
     }
 
     @Override

--- a/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/api/bridge/java/internal/StreamTableEnvironmentImplTest.java
+++ b/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/api/bridge/java/internal/StreamTableEnvironmentImplTest.java
@@ -19,6 +19,8 @@
 package org.apache.flink.table.api.bridge.java.internal;
 
 import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.core.execution.JobStatusChangedListener;
+import org.apache.flink.core.execution.JobStatusChangedListenerUtils;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.Table;
@@ -84,6 +86,9 @@ class StreamTableEnvironmentImplTest {
                         new URL[0],
                         Thread.currentThread().getContextClassLoader(),
                         tableConfig.getConfiguration());
+        final List<JobStatusChangedListener> jobStatusChangedListeners =
+                JobStatusChangedListenerUtils.createJobStatusChangedListeners(
+                        tableConfig.getConfiguration());
 
         return new StreamTableEnvironmentImpl(
                 catalogManager,
@@ -94,7 +99,8 @@ class StreamTableEnvironmentImplTest {
                 env,
                 new TestPlanner(elements.getTransformation()),
                 new ExecutorMock(),
-                true);
+                true,
+                jobStatusChangedListeners);
     }
 
     private static class TestPlanner extends PlannerMock {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/runtime/execution/DefaultQueryOperationEvent.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/runtime/execution/DefaultQueryOperationEvent.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.execution;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.table.operations.QueryOperation;
+
+import java.util.List;
+
+/** Default implementation of {@link QueryOperationEvent}. */
+public class DefaultQueryOperationEvent implements QueryOperationEvent {
+    private final JobID jobId;
+    private final List<QueryOperation> queryOperation;
+
+    public DefaultQueryOperationEvent(JobID jobId, List<QueryOperation> queryOperation) {
+        this.jobId = jobId;
+        this.queryOperation = queryOperation;
+    }
+
+    @Override
+    public List<QueryOperation> queryOperation() {
+        return queryOperation;
+    }
+
+    @Override
+    public JobID jobId() {
+        return jobId;
+    }
+
+    @Override
+    public String jobName() {
+        return null;
+    }
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/runtime/execution/QueryOperationEvent.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/runtime/execution/QueryOperationEvent.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.execution;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.core.execution.JobStatusChangedEvent;
+import org.apache.flink.table.operations.QueryOperation;
+
+import java.util.List;
+
+/** Basic query operation event. */
+@PublicEvolving
+public interface QueryOperationEvent extends JobStatusChangedEvent {
+
+    /* Table query operation. */
+    List<QueryOperation> queryOperation();
+}

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/TableEnvironmentMock.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/TableEnvironmentMock.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.module.ModuleManager;
 import org.apache.flink.table.resource.ResourceManager;
 
 import java.net.URL;
+import java.util.Collections;
 
 /** Mocking {@link TableEnvironment} for tests. */
 public class TableEnvironmentMock extends TableEnvironmentImpl {
@@ -57,7 +58,8 @@ public class TableEnvironmentMock extends TableEnvironmentImpl {
                 executor,
                 functionCatalog,
                 planner,
-                isStreamingMode);
+                isStreamingMode,
+                Collections.emptyList());
         this.catalogManager = catalogManager;
         this.executor = executor;
         this.functionCatalog = functionCatalog;

--- a/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/internal/StreamTableEnvironmentImpl.scala
+++ b/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/internal/StreamTableEnvironmentImpl.scala
@@ -41,6 +41,7 @@ import org.apache.flink.types.Row
 import org.apache.flink.util.{FlinkUserCodeClassLoaders, MutableURLClassLoader, Preconditions}
 
 import java.net.URL
+import java.util.Collections
 import java.util.Optional
 
 import scala.collection.JavaConverters._
@@ -69,7 +70,8 @@ class StreamTableEnvironmentImpl(
     functionCatalog,
     planner,
     isStreaming,
-    executionEnvironment)
+    executionEnvironment,
+    Collections.emptyList())
   with StreamTableEnvironment {
 
   override def fromDataStream[T](dataStream: DataStream[T]): Table = {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
@@ -1648,7 +1648,8 @@ class TestingTableEnvironment private (
     executor,
     functionCatalog,
     planner,
-    isStreamingMode) {
+    isStreamingMode,
+    Collections.emptyList()) {
 
   def getResourceManager: ResourceManager = resourceManager
 


### PR DESCRIPTION
## What is the purpose of the change

This change should enable extracting column level lineage for Flink SQL jobs. 
This can be achieved by `JobStatusChangedListener` if Flink exposes `QueryOperation`. 
More details on the approach can be found in docs:  https://docs.google.com/document/d/1XmbHy6XqBrMoH9rkSyOG0wbwQZgf0epz-07lr_NfikI/edit?usp=sharing

## Brief change log

  - *Introduce new `QueryOperationEvent` which implements `QueryOperationEvent` *
  - notify query operations from *TableEnvironmentImpl*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? Added extra info on job listeners' page.
