### PR TITLE
[hotfix] Do not use `org.jetbrains.annotations.Nullable`

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestTaskStateManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestTaskStateManager.java
@@ -252,7 +252,7 @@ public class TestTaskStateManager implements TaskStateManager {
         return stateChangelogStorage;
     }
 
-    @org.jetbrains.annotations.Nullable
+    @Nullable
     @Override
     public StateChangelogStorageView<?> getStateChangelogStorageView(
             Configuration configuration, ChangelogStateHandle changelogStateHandle) {

--- a/tools/maven/checkstyle.xml
+++ b/tools/maven/checkstyle.xml
@@ -246,6 +246,16 @@ This file is based on the checkstyle file of Apache Beam.
 			<property name="message" value="Use import javax.annotation.Nonnull"/>
 		</module>
 
+		<module name="RegexpSinglelineJava">
+			<property name="format" value="^\s*@org.jetbrains.annotations.Nullable\s*$"/>
+			<property name="message" value="Use import javax.annotation.Nullable"/>
+		</module>
+
+		<module name="RegexpSinglelineJava">
+			<property name="format" value="^\s*@org.jetbrains.annotations.Nonnull\s*$"/>
+			<property name="message" value="Use import javax.annotation.Nonnull"/>
+		</module>
+
 		<!--
 
 		JAVADOC CHECKS


### PR DESCRIPTION
## What is the purpose of the change

Add this to checkstyle conf 
it was tere before, however for some reason absolute names appeared in code (not in imports)
## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
