### PR TITLE
[BP-2.0][FLINK-37222] Do not reuse views across TableEnvironments in SQL client

### DIFF
--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/SqlClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/SqlClientTest.java
@@ -215,6 +215,14 @@ class SqlClientTest extends SqlClientTestBase {
     }
 
     @Test
+    void testExecuteNexmark() throws Exception {
+        final URL sqlFile = getClass().getClassLoader().getResource("nexmark.sql");
+        String[] args = new String[] {"-f", sqlFile.getPath()};
+        String output = runSqlClient(args);
+        assertThat(output).doesNotContain("java.lang.AssertionError");
+    }
+
+    @Test
     void testDisplayMultiLineSqlInInteractiveMode() throws Exception {
         List<String> statements =
                 Arrays.asList(

--- a/flink-table/flink-sql-client/src/test/resources/nexmark.sql
+++ b/flink-table/flink-sql-client/src/test/resources/nexmark.sql
@@ -1,0 +1,116 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+CREATE TABLE datagen
+(
+    event_type   int,
+    person       ROW<
+        id  BIGINT,
+        name         VARCHAR,
+        emailAddress VARCHAR,
+        creditCard   VARCHAR,
+        city         VARCHAR,
+        state        VARCHAR,
+        `dateTime`   TIMESTAMP(3),
+        extra        VARCHAR>,
+    auction      ROW<
+        id  BIGINT,
+        itemName     VARCHAR,
+        description  VARCHAR,
+        initialBid   BIGINT,
+        reserve      BIGINT,
+        `dateTime`   TIMESTAMP(3),
+        expires      TIMESTAMP(3),
+        seller       BIGINT,
+        category     BIGINT,
+        extra        VARCHAR>,
+    bid          ROW<
+        auction  BIGINT,
+        bidder       BIGINT,
+        price        BIGINT,
+        channel      VARCHAR,
+        url          VARCHAR,
+        `dateTime`   TIMESTAMP(3),
+        extra        VARCHAR>,
+    `dateTime` AS
+        CASE
+            WHEN event_type = 0 THEN person.`dateTime`
+            WHEN event_type = 1 THEN auction.`dateTime`
+            ELSE bid.`dateTime`
+        END,
+    WATERMARK FOR `dateTime` AS `dateTime` - INTERVAL '4' SECOND
+) WITH (
+      'connector' = 'datagen',
+      'number-of-rows' = '10'
+);
+CREATE VIEW person AS
+SELECT person.id,
+       person.name,
+       person.emailAddress,
+       person.creditCard,
+       person.city,
+       person.state,
+       `dateTime`,
+       person.extra
+FROM datagen
+WHERE event_type = 0;
+
+CREATE VIEW auction AS
+SELECT auction.id,
+       auction.itemName,
+       auction.description,
+       auction.initialBid,
+       auction.reserve,
+       `dateTime`,
+       auction.expires,
+       auction.seller,
+       auction.category,
+       auction.extra
+FROM datagen
+WHERE event_type = 1;
+
+CREATE VIEW bid AS
+SELECT bid.auction,
+       bid.bidder,
+       bid.price,
+       bid.channel,
+       bid.url,
+       `dateTime`,
+       bid.extra
+FROM datagen
+WHERE event_type = 2;
+
+
+CREATE TABLE nexmark_q7
+(
+    auction    BIGINT,
+    bidder     BIGINT,
+    price      BIGINT,
+    `dateTime` TIMESTAMP(3),
+    extra      VARCHAR
+) WITH (
+      'connector' = 'blackhole'
+);
+
+INSERT INTO nexmark_q7
+SELECT B.auction, B.price, B.bidder, B.`dateTime`, B.extra
+from bid B
+         JOIN (SELECT MAX(price) AS maxprice, window_end as `dateTime`
+               FROM TABLE(
+                       TUMBLE(TABLE bid, DESCRIPTOR(`dateTime`), INTERVAL '10' SECOND))
+               GROUP BY window_start, window_end) B1
+              ON B.price = B1.maxprice
+WHERE B.`dateTime` BETWEEN B1.`dateTime` - INTERVAL '10' SECOND AND B1.`dateTime`;

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/context/EnvironmentReusableInMemoryCatalog.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/context/EnvironmentReusableInMemoryCatalog.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.service.context;
+
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.catalog.CatalogBaseTable;
+import org.apache.flink.table.catalog.CatalogView;
+import org.apache.flink.table.catalog.GenericInMemoryCatalog;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.QueryOperationCatalogView;
+import org.apache.flink.table.catalog.ResolvedCatalogView;
+import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
+import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
+
+import java.util.Optional;
+
+/**
+ * An in-memory catalog that can be reused across different {@link TableEnvironment}. The SQL client
+ * works against {@link TableEnvironment} design and reuses some of the components (e.g.
+ * CatalogManager), but not all (e.g. Planner) which causes e.g. views registered in an in-memory
+ * catalog to fail. This class is a workaround not to keep Planner bound parts of a view reused
+ * across different {@link TableEnvironment}.
+ */
+public class EnvironmentReusableInMemoryCatalog extends GenericInMemoryCatalog {
+    public EnvironmentReusableInMemoryCatalog(String name, String defaultDatabase) {
+        super(name, defaultDatabase);
+    }
+
+    @Override
+    public void createTable(ObjectPath tablePath, CatalogBaseTable table, boolean ignoreIfExists)
+            throws TableAlreadyExistException, DatabaseNotExistException {
+        CatalogBaseTable tableToRegister =
+                extractView(table)
+                        .flatMap(QueryOperationCatalogView::getOriginalView)
+                        .map(v -> (CatalogBaseTable) v)
+                        .orElse(table);
+        super.createTable(tablePath, tableToRegister, ignoreIfExists);
+    }
+
+    private Optional<QueryOperationCatalogView> extractView(CatalogBaseTable table) {
+        if (table instanceof ResolvedCatalogView) {
+            final CatalogView origin = ((ResolvedCatalogView) table).getOrigin();
+            if (origin instanceof QueryOperationCatalogView) {
+                return Optional.of((QueryOperationCatalogView) origin);
+            }
+            return Optional.empty();
+        } else if (table instanceof QueryOperationCatalogView) {
+            return Optional.of((QueryOperationCatalogView) table);
+        }
+        return Optional.empty();
+    }
+}

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/context/SessionContext.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/context/SessionContext.java
@@ -30,7 +30,6 @@ import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.CatalogManager;
 import org.apache.flink.table.catalog.CatalogStoreHolder;
 import org.apache.flink.table.catalog.FunctionCatalog;
-import org.apache.flink.table.catalog.GenericInMemoryCatalog;
 import org.apache.flink.table.factories.CatalogStoreFactory;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.factories.TableFactoryUtil;
@@ -446,7 +445,7 @@ public class SessionContext {
                                                     catalogStore.config(),
                                                     catalogStore.classLoader()))
                             .orElse(
-                                    new GenericInMemoryCatalog(
+                                    new EnvironmentReusableInMemoryCatalog(
                                             defaultCatalogName, settings.getBuiltInDatabaseName()));
         }
         defaultCatalog.open();

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/QueryOperationCatalogView.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/QueryOperationCatalogView.java
@@ -110,4 +110,9 @@ public final class QueryOperationCatalogView implements CatalogView {
     public boolean supportsShowCreateView() {
         return originalView != null;
     }
+
+    @Internal
+    public Optional<CatalogView> getOriginalView() {
+        return Optional.ofNullable(originalView);
+    }
 }


### PR DESCRIPTION
## What is the purpose of the change

After FLINK-37098, there is a bug when submitting jobs via sql client. This PR fixes this.

## Brief change log

 - A test verifying the sql client with complex sql job.
 - A fix that not reuse views across TableEnvironments in SQL client

## Verifying this change

This change has added test named `testExecuteNexmark`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
