### PR TITLE
[hotfix][table-planner] Use equals instead of '==' to compare digests in FlinkCalcMergeRule

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkCalcMergeRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkCalcMergeRule.java
@@ -77,7 +77,7 @@ public class FlinkCalcMergeRule extends RelRule<FlinkCalcMergeRule.FlinkCalcMerg
         Calc bottomCalc = call.rel(1);
 
         Calc newCalc = FlinkRelUtil.merge(topCalc, bottomCalc);
-        if (newCalc.getDigest() == bottomCalc.getDigest()) {
+        if (newCalc.getDigest().equals(bottomCalc.getDigest())) {
             // newCalc is equivalent to bottomCalc,
             // which means that topCalc
             // must be trivial. Take it out of the game.


### PR DESCRIPTION
## What is the purpose of the change
This is a trivial fix for string comparison in `FlinkCalcMergeRule`.  
However it doesn't actually affect the optimization results, so no new cases were added to the fix.
But we can verify this detail by debugging `FlinkCalcMergeRule`'s optimization process with the following case(add to `FlinkCalcMergeRuleTest`):
```scala
@Test
def testCalcMergeWithTrivialCalc(): Unit = {
  val testTable = "MyTable"
  val relBuilder = util.getPlanner.plannerContext.createRelBuilder()
  val flinkLogicalTraits = relBuilder.getCluster.traitSetOf(FlinkConventions.LOGICAL)
  val table = relBuilder.getRelOptSchema
    .asInstanceOf[CalciteCatalogReader]
    .getTable(ImmutableList.of(testTable))
    .asInstanceOf[FlinkPreparingTableBase]
  val flinkLogicalTableScan = new FlinkLogicalDataStreamTableScan(
    relBuilder.getCluster,
    flinkLogicalTraits,
    Collections.emptyList[RelHint](),
    table)

  relBuilder.scan(testTable)
  val logicScan = relBuilder.peek(0)
  val rowType = logicScan.getRowType
  val projects = (0 until (rowType.getFieldCount)).map(f => relBuilder.field(f)).toList
  val program = RexProgram.create(
    rowType,
    projects,
    null,
    rowType,
    relBuilder.getRexBuilder
  )

  val bottomCalc = FlinkLogicalCalc.create(flinkLogicalTableScan, program)
  // create a trivial calc
  val topCalc = FlinkLogicalCalc.create(bottomCalc, program)

  val optimizedRels = util.getPlanner.optimize(Array(topCalc))
  print(bottomCalc.getRelDigest, optimizedRels.get(0).getRelDigest)
  assertThat(bottomCalc.getRelDigest).isEqualTo(optimizedRels.get(0).getRelDigest)
  //    util.assertPlanEquals(Array(topCalc), Array.empty[ExplainDetail], withRowType = false, Array(PlanKind.OPT_REL), () => Unit)
}
```

## Brief change log
fix string comparison

## Verifying this change
existing tests

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (no)