### PR TITLE
[FLINK-35687] JSON_QUERY should return a well formatted nested objects/arrays for ARRAY<STRING> (#24976)

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
@@ -447,6 +447,33 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                                 "JSON_QUERY(f0, '$.a' RETURNING ARRAY<STRING> WITHOUT WRAPPER EMPTY ARRAY ON ERROR)",
                                 new String[] {},
                                 DataTypes.ARRAY(DataTypes.STRING())),
+
+                // stringifying RETURNING<ARRAY>
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.JSON_QUERY)
+                        .onFieldsWithData(
+                                "{\"items\": [{\"itemId\":1234, \"count\":10}, null, {\"itemId\":4567, \"count\":11}]}",
+                                "{\"items\": [[1234, 2345], null, [\"itemId\", \"count\"]]}",
+                                "{\"arr\": [\"abc\", null, \"def\"]}")
+                        .andDataTypes(STRING(), STRING(), STRING())
+                        .testResult(
+                                $("f0").jsonQuery("$.items", ARRAY(STRING())),
+                                "JSON_QUERY(f0, '$.items' RETURNING ARRAY<STRING>)",
+                                new String[] {
+                                    "{\"itemId\":1234,\"count\":10}",
+                                    null,
+                                    "{\"itemId\":4567,\"count\":11}"
+                                },
+                                ARRAY(STRING()))
+                        .testResult(
+                                $("f1").jsonQuery("$.items", ARRAY(STRING())),
+                                "JSON_QUERY(f1, '$.items' RETURNING ARRAY<STRING>)",
+                                new String[] {"[1234,2345]", null, "[\"itemId\",\"count\"]"},
+                                ARRAY(STRING()))
+                        .testResult(
+                                $("f2").jsonQuery("$.arr", ARRAY(STRING())),
+                                "JSON_QUERY(f2, '$.arr' RETURNING ARRAY<STRING>)",
+                                new String[] {"abc", null, "def"},
+                                ARRAY(STRING())),
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.JSON_QUERY)
                         .onFieldsWithData(jsonValue)
                         .andDataTypes(STRING())

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlJsonUtils.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlJsonUtils.java
@@ -265,7 +265,13 @@ public class SqlJsonUtils {
                             for (int i = 0; i < list.size(); i++) {
                                 final Object el = list.get(i);
                                 if (el != null) {
-                                    arr[i] = StringData.fromString(el.toString());
+                                    final String stringifiedEl;
+                                    if (isScalarObject(el)) {
+                                        stringifiedEl = String.valueOf(el);
+                                    } else {
+                                        stringifiedEl = jsonize(el);
+                                    }
+                                    arr[i] = StringData.fromString(stringifiedEl);
                                 }
                             }
 


### PR DESCRIPTION
backport of https://github.com/apache/flink/commit/90508a00bb310d26f9be245098cda9192647ab14