### PR TITLE
[hotfix][table-planner] Use equals instead of '==' to compare digests in FlinkCalcMergeRule

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkCalcMergeRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkCalcMergeRule.java
@@ -77,7 +77,7 @@ public class FlinkCalcMergeRule extends RelRule<FlinkCalcMergeRule.FlinkCalcMerg
         Calc bottomCalc = call.rel(1);
 
         Calc newCalc = FlinkRelUtil.merge(topCalc, bottomCalc);
-        if (newCalc.getDigest() == bottomCalc.getDigest()) {
+        if (newCalc.getDigest().equals(bottomCalc.getDigest())) {
             // newCalc is equivalent to bottomCalc,
             // which means that topCalc
             // must be trivial. Take it out of the game.


### PR DESCRIPTION
This is a backport pr of #26108 to 2.0 branch 
