### PR TITLE
[FLINK-37267][table] Add support for UNNEST WITH ORDINALITY

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -477,6 +477,17 @@ public final class BuiltInFunctionDefinitions {
                     .internal()
                     .build();
 
+    public static final BuiltInFunctionDefinition INTERNAL_UNNEST_ROWS_WITH_ORDINALITY =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("$UNNEST_ROWS_WITH_ORDINALITY$1")
+                    .kind(TABLE)
+                    .inputTypeStrategy(sequence(ANY))
+                    .outputTypeStrategy(SpecificTypeStrategies.UNUSED)
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.table.UnnestRowsWithOrdinalityFunction")
+                    .internal()
+                    .build();
+
     public static final BuiltInFunctionDefinition INTERNAL_HASHCODE =
             BuiltInFunctionDefinition.newBuilder()
                     .name("$HASHCODE$1")

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/LogicalUnnestRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/LogicalUnnestRule.java
@@ -72,21 +72,13 @@ public class LogicalUnnestRule extends RelRule<LogicalUnnestRule.LogicalUnnestRu
             } else if (relNode instanceof LogicalProject) {
                 LogicalProject logicalProject = (LogicalProject) relNode;
                 relNode = getRel(logicalProject.getInput());
-                if (relNode instanceof Uncollect) {
-                    return true;
-                }
-                return false;
+                return relNode instanceof Uncollect;
             }
         } else if (right instanceof LogicalProject) {
             LogicalProject logicalProject = (LogicalProject) right;
             RelNode relNode = getRel(logicalProject.getInput());
-            if (relNode instanceof Uncollect) {
-                return true;
-            }
-            return false;
-        } else if (right instanceof Uncollect) {
-            return true;
-        }
+            return relNode instanceof Uncollect;
+        } else return right instanceof Uncollect;
         return false;
     }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/LogicalUnnestRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/LogicalUnnestRule.java
@@ -78,7 +78,9 @@ public class LogicalUnnestRule extends RelRule<LogicalUnnestRule.LogicalUnnestRu
             LogicalProject logicalProject = (LogicalProject) right;
             RelNode relNode = getRel(logicalProject.getInput());
             return relNode instanceof Uncollect;
-        } else return right instanceof Uncollect;
+        } else {
+            return right instanceof Uncollect;
+        }
         return false;
     }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/LogicalUnnestRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/LogicalUnnestRule.java
@@ -22,7 +22,7 @@ import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.planner.functions.bridging.BridgingSqlFunction;
 import org.apache.flink.table.planner.utils.ShortcutUtils;
-import org.apache.flink.table.runtime.functions.table.UnnestRowsFunction;
+import org.apache.flink.table.runtime.functions.table.UnnestRowsFunctionBase;
 import org.apache.flink.table.types.logical.LogicalType;
 
 import org.apache.flink.shaded.guava32.com.google.common.collect.ImmutableList;
@@ -68,12 +68,12 @@ public class LogicalUnnestRule extends RelRule<LogicalUnnestRule.LogicalUnnestRu
             LogicalFilter logicalFilter = (LogicalFilter) right;
             RelNode relNode = getRel(logicalFilter.getInput());
             if (relNode instanceof Uncollect) {
-                return !((Uncollect) relNode).withOrdinality;
+                return true;
             } else if (relNode instanceof LogicalProject) {
                 LogicalProject logicalProject = (LogicalProject) relNode;
                 relNode = getRel(logicalProject.getInput());
                 if (relNode instanceof Uncollect) {
-                    return !((Uncollect) relNode).withOrdinality;
+                    return true;
                 }
                 return false;
             }
@@ -81,13 +81,11 @@ public class LogicalUnnestRule extends RelRule<LogicalUnnestRule.LogicalUnnestRu
             LogicalProject logicalProject = (LogicalProject) right;
             RelNode relNode = getRel(logicalProject.getInput());
             if (relNode instanceof Uncollect) {
-                Uncollect uncollect = (Uncollect) relNode;
-                return !uncollect.withOrdinality;
+                return true;
             }
             return false;
         } else if (right instanceof Uncollect) {
-            Uncollect uncollect = (Uncollect) right;
-            return !uncollect.withOrdinality;
+            return true;
         }
         return false;
     }
@@ -131,16 +129,22 @@ public class LogicalUnnestRule extends RelRule<LogicalUnnestRule.LogicalUnnestRu
                             ((Map.Entry) uncollect.getInput().getRowType().getFieldList().get(0))
                                     .getValue();
             LogicalType logicalType = FlinkTypeFactory.toLogicalType(relDataType);
+
             BridgingSqlFunction sqlFunction =
                     BridgingSqlFunction.of(
-                            cluster, BuiltInFunctionDefinitions.INTERNAL_UNNEST_ROWS);
+                            cluster,
+                            uncollect.withOrdinality
+                                    ? BuiltInFunctionDefinitions
+                                            .INTERNAL_UNNEST_ROWS_WITH_ORDINALITY
+                                    : BuiltInFunctionDefinitions.INTERNAL_UNNEST_ROWS);
             RexNode rexCall =
                     cluster.getRexBuilder()
                             .makeCall(
                                     typeFactory.createFieldTypeFromLogicalType(
                                             toRowType(
-                                                    UnnestRowsFunction.getUnnestedType(
-                                                            logicalType))),
+                                                    UnnestRowsFunctionBase.getUnnestedType(
+                                                            logicalType,
+                                                            uncollect.withOrdinality))),
                                     sqlFunction,
                                     ((LogicalProject) getRel(uncollect.getInput())).getProjects());
             return new LogicalTableFunctionScan(

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/UnnestTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/UnnestTest.xml
@@ -355,4 +355,202 @@ Calc(select=[a, _1 AS b1, _2 AS b2])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testUnnestWithOrdinalityAndValues">
+    <Resource name="sql">
+      <![CDATA[SELECT val, pos FROM UNNEST(ARRAY[1,2,3]) WITH ORDINALITY AS t(val, pos)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(val=[$0], pos=[$1])
++- LogicalProject(val=[$0], pos=[$1])
+   +- Uncollect(withOrdinality=[true])
+      +- LogicalProject(EXPR$0=[ARRAY(1, 2, 3)])
+         +- LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1(ARRAY(1, 2, 3))], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1(ARRAY(1, 2, 3)))], select=[f0,ordinality], rowType=[RecordType:peek_no_expand(INTEGER f0, INTEGER ordinality)], joinType=[INNER])
++- Values(tuples=[[{  }]], values=[])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUnnestWithOrdinalityArray">
+    <Resource name="sql">
+      <![CDATA[SELECT a, number, ordinality FROM MyTable CROSS JOIN UNNEST(b) WITH ORDINALITY AS t(number, ordinality)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], number=[$2], ordinality=[$3])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalProject(number=[$0], ordinality=[$1])
+      +- Uncollect(withOrdinality=[true])
+         +- LogicalProject(b=[$cor0.b])
+            +- LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, f0 AS number, ordinality])
++- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b))], select=[a,b,f0,ordinality], rowType=[RecordType(INTEGER a, INTEGER ARRAY b, INTEGER f0, INTEGER ordinality)], joinType=[INNER])
+   +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUnnestWithOrdinalityArrayOfArray">
+    <Resource name="sql">
+      <![CDATA[
+SELECT id, array_val, array_pos, elem, element_pos
+FROM MyTable
+CROSS JOIN UNNEST(nested_array) WITH ORDINALITY AS A(array_val, array_pos)
+CROSS JOIN UNNEST(array_val) WITH ORDINALITY AS B(elem, element_pos)
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], array_val=[$2], array_pos=[$3], elem=[$4], element_pos=[$5])
++- LogicalCorrelate(correlation=[$cor1], joinType=[inner], requiredColumns=[{2}])
+   :- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+   :  :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   :  +- LogicalProject(array_val=[$0], array_pos=[$1])
+   :     +- Uncollect(withOrdinality=[true])
+   :        +- LogicalProject(nested_array=[$cor0.nested_array])
+   :           +- LogicalValues(tuples=[[{ 0 }]])
+   +- LogicalProject(elem=[$0], element_pos=[$1])
+      +- Uncollect(withOrdinality=[true])
+         +- LogicalProject(array_val=[$cor1.array_val])
+            +- LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[id, f0 AS array_val, ordinality AS array_pos, f00 AS elem, ordinality0 AS element_pos])
++- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor1.array_val)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor1.array_val))], select=[id,nested_array,f0,ordinality,f00,ordinality0], rowType=[RecordType(INTEGER id, INTEGER ARRAY ARRAY nested_array, INTEGER ARRAY f0, INTEGER ordinality, INTEGER f00, INTEGER ordinality0)], joinType=[INNER])
+   +- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.nested_array)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.nested_array))], select=[id,nested_array,f0,ordinality], rowType=[RecordType(INTEGER id, INTEGER ARRAY ARRAY nested_array, INTEGER ARRAY f0, INTEGER ordinality)], joinType=[INNER])
+      +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[id, nested_array])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUnnestWithOrdinalityMap">
+    <Resource name="sql">
+      <![CDATA[SELECT id, k, v, pos FROM MyTable CROSS JOIN UNNEST(map_data) WITH ORDINALITY AS f(k, v, pos)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], k=[$2], v=[$3], pos=[$4])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalProject(k=[$0], v=[$1], pos=[$2])
+      +- Uncollect(withOrdinality=[true])
+         +- LogicalProject(map_data=[$cor0.map_data])
+            +- LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[id, f0 AS k, f1 AS v, ordinality AS pos])
++- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.map_data)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.map_data))], select=[id,map_data,f0,f1,ordinality], rowType=[RecordType(INTEGER id, (VARCHAR(2147483647), VARCHAR(2147483647)) MAP map_data, VARCHAR(2147483647) f0, VARCHAR(2147483647) f1, INTEGER ordinality)], joinType=[INNER])
+   +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[id, map_data])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUnnestWithOrdinalityMultiset">
+    <Resource name="sql">
+      <![CDATA[
+WITH T AS (SELECT a, COLLECT(c) as words FROM MyTable GROUP BY a)
+SELECT a, word, pos
+FROM T CROSS JOIN UNNEST(words) WITH ORDINALITY AS A(word, pos)
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], word=[$2], pos=[$3])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+   :- LogicalAggregate(group=[{0}], words=[COLLECT($1)])
+   :  +- LogicalProject(a=[$0], c=[$2])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalProject(word=[$0], pos=[$1])
+      +- Uncollect(withOrdinality=[true])
+         +- LogicalProject(words=[$cor0.words])
+            +- LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, f0 AS word, ordinality AS pos])
++- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.words)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.words))], select=[a,words,f0,ordinality], rowType=[RecordType(INTEGER a, VARCHAR(2147483647) MULTISET words, VARCHAR(2147483647) f0, INTEGER ordinality)], joinType=[INNER])
+   +- SortAggregate(isMerge=[true], groupBy=[a], select=[a, Final_COLLECT(words) AS words])
+      +- Exchange(distribution=[forward])
+         +- Sort(orderBy=[a ASC])
+            +- Exchange(distribution=[hash[a]])
+               +- LocalSortAggregate(groupBy=[a], select=[a, Partial_COLLECT(c) AS words])
+                  +- Exchange(distribution=[forward])
+                     +- Sort(orderBy=[a ASC])
+                        +- Calc(select=[a, c])
+                           +- BoundedStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUnnestWithOrdinalityWithFilter">
+    <Resource name="sql">
+      <![CDATA[
+SELECT a, number, ordinality 
+FROM MyTable 
+CROSS JOIN UNNEST(b) WITH ORDINALITY AS t(number, ordinality)
+WHERE number > 10 AND ordinality < 3
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], number=[$2], ordinality=[$3])
++- LogicalFilter(condition=[AND(>($2, 10), <($3, 3))])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+      :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+      +- LogicalProject(number=[$0], ordinality=[$1])
+         +- Uncollect(withOrdinality=[true])
+            +- LogicalProject(b=[$cor0.b])
+               +- LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, f0 AS number, ordinality])
++- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b))], select=[a,b,f0,ordinality], rowType=[RecordType(INTEGER a, INTEGER ARRAY b, INTEGER f0, INTEGER ordinality)], joinType=[INNER], condition=[AND(>($0, 10), <($1, 3))])
+   +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUnnestWithOrdinalityInSubquery">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM (
+  SELECT a, number, ordinality 
+  FROM MyTable 
+  CROSS JOIN UNNEST(b) WITH ORDINALITY AS t(number, ordinality)
+) subquery 
+WHERE ordinality = 1
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], number=[$1], ordinality=[$2])
++- LogicalFilter(condition=[=($2, 1)])
+   +- LogicalProject(a=[$0], number=[$2], ordinality=[$3])
+      +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+         :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+         +- LogicalProject(number=[$0], ordinality=[$1])
+            +- Uncollect(withOrdinality=[true])
+               +- LogicalProject(b=[$cor0.b])
+                  +- LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, number, ordinality])
++- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b))], select=[a,b,number,ordinality], rowType=[RecordType(INTEGER a, INTEGER ARRAY b, INTEGER number, INTEGER ordinality)], joinType=[INNER], condition=[=($1, 1)])
+   +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
 </Root>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/UnnestTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/UnnestTest.xml
@@ -450,7 +450,7 @@ LogicalProject(a=[$0], b=[$1], s=[$2], t=[$3], o=[$4])
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b))], select=[a,b,f0,f1,ordinality], rowType=[RecordType(INTEGER a, RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2) ARRAY b, INTEGER f0, VARCHAR(2147483647) f1, INTEGER ordinality)], joinType=[INNER], condition=[>($0, 13)])
+Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b))], select=[a,b,_1,_2,ordinality], rowType=[RecordType(INTEGER a, RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2) ARRAY b, INTEGER _1, VARCHAR(2147483647) _2, INTEGER ordinality)], joinType=[INNER], condition=[>($0, 13)])
 +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b])
 ]]>
     </Resource>
@@ -472,7 +472,7 @@ LogicalProject(a=[$0], b=[$1], _1=[$2], _2=[$3], ORDINALITY=[$4])
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b))], select=[a,b,f0,f1,ordinality], rowType=[RecordType(INTEGER a, RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2) ARRAY b, INTEGER f0, VARCHAR(2147483647) f1, INTEGER ordinality)], joinType=[INNER], condition=[>($0, 1)])
+Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b))], select=[a,b,_1,_2,ordinality], rowType=[RecordType(INTEGER a, RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2) ARRAY b, INTEGER _1, VARCHAR(2147483647) _2, INTEGER ordinality)], joinType=[INNER], condition=[>($0, 1)])
 +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b])
 ]]>
     </Resource>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/UnnestTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/UnnestTest.xml
@@ -370,7 +370,7 @@ LogicalProject(val=[$0], pos=[$1])
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1(ARRAY(1, 2, 3))], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1(ARRAY(1, 2, 3)))], select=[f0,ordinality], rowType=[RecordType:peek_no_expand(INTEGER f0, INTEGER ordinality)], joinType=[INNER])
+Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1(ARRAY(1, 2, 3))], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1(ARRAY(1, 2, 3)))], select=[EXPR$0,ORDINALITY], rowType=[RecordType:peek_no_expand(INTEGER EXPR$0, INTEGER ORDINALITY)], joinType=[INNER])
 +- Values(tuples=[[{  }]], values=[])
 ]]>
     </Resource>
@@ -392,8 +392,8 @@ LogicalProject(a=[$0], number=[$2], ordinality=[$3])
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, f0 AS number, ordinality])
-+- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b))], select=[a,b,f0,ordinality], rowType=[RecordType(INTEGER a, INTEGER ARRAY b, INTEGER f0, INTEGER ordinality)], joinType=[INNER])
+Calc(select=[a, EXPR$0 AS number, ORDINALITY AS ordinality])
++- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b))], select=[a,b,EXPR$0,ORDINALITY], rowType=[RecordType(INTEGER a, INTEGER ARRAY b, INTEGER EXPR$0, INTEGER ORDINALITY)], joinType=[INNER])
    +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b])
 ]]>
     </Resource>
@@ -425,9 +425,9 @@ LogicalProject(id=[$0], array_val=[$2], array_pos=[$3], elem=[$4], element_pos=[
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[id, f0 AS array_val, ordinality AS array_pos, f00 AS elem, ordinality0 AS element_pos])
-+- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor1.array_val)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor1.array_val))], select=[id,nested_array,f0,ordinality,f00,ordinality0], rowType=[RecordType(INTEGER id, INTEGER ARRAY ARRAY nested_array, INTEGER ARRAY f0, INTEGER ordinality, INTEGER f00, INTEGER ordinality0)], joinType=[INNER])
-   +- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.nested_array)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.nested_array))], select=[id,nested_array,f0,ordinality], rowType=[RecordType(INTEGER id, INTEGER ARRAY ARRAY nested_array, INTEGER ARRAY f0, INTEGER ordinality)], joinType=[INNER])
+Calc(select=[id, EXPR$0 AS array_val, ORDINALITY AS array_pos, EXPR$00 AS elem, ORDINALITY0 AS element_pos])
++- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor1.array_val)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor1.array_val))], select=[id,nested_array,EXPR$0,ORDINALITY,EXPR$00,ORDINALITY0], rowType=[RecordType(INTEGER id, INTEGER ARRAY ARRAY nested_array, INTEGER ARRAY EXPR$0, INTEGER ORDINALITY, INTEGER EXPR$00, INTEGER ORDINALITY0)], joinType=[INNER])
+   +- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.nested_array)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.nested_array))], select=[id,nested_array,EXPR$0,ORDINALITY], rowType=[RecordType(INTEGER id, INTEGER ARRAY ARRAY nested_array, INTEGER ARRAY EXPR$0, INTEGER ORDINALITY)], joinType=[INNER])
       +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[id, nested_array])
 ]]>
     </Resource>
@@ -450,7 +450,7 @@ LogicalProject(a=[$0], b=[$1], s=[$2], t=[$3], o=[$4])
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b))], select=[a,b,_1,_2,ordinality], rowType=[RecordType(INTEGER a, RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2) ARRAY b, INTEGER _1, VARCHAR(2147483647) _2, INTEGER ordinality)], joinType=[INNER], condition=[>($0, 13)])
+Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b))], select=[a,b,_1,_2,ORDINALITY], rowType=[RecordType(INTEGER a, RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2) ARRAY b, INTEGER _1, VARCHAR(2147483647) _2, INTEGER ORDINALITY)], joinType=[INNER], condition=[>($0, 13)])
 +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b])
 ]]>
     </Resource>
@@ -472,7 +472,7 @@ LogicalProject(a=[$0], b=[$1], _1=[$2], _2=[$3], ORDINALITY=[$4])
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b))], select=[a,b,_1,_2,ordinality], rowType=[RecordType(INTEGER a, RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2) ARRAY b, INTEGER _1, VARCHAR(2147483647) _2, INTEGER ordinality)], joinType=[INNER], condition=[>($0, 1)])
+Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b))], select=[a,b,_1,_2,ORDINALITY], rowType=[RecordType(INTEGER a, RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2) ARRAY b, INTEGER _1, VARCHAR(2147483647) _2, INTEGER ORDINALITY)], joinType=[INNER], condition=[>($0, 1)])
 +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b])
 ]]>
     </Resource>
@@ -494,8 +494,8 @@ LogicalProject(id=[$0], k=[$2], v=[$3], pos=[$4])
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[id, f0 AS k, f1 AS v, ordinality AS pos])
-+- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.map_data)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.map_data))], select=[id,map_data,f0,f1,ordinality], rowType=[RecordType(INTEGER id, (VARCHAR(2147483647), VARCHAR(2147483647)) MAP map_data, VARCHAR(2147483647) f0, VARCHAR(2147483647) f1, INTEGER ordinality)], joinType=[INNER])
+Calc(select=[id, f0 AS k, f1 AS v, ORDINALITY AS pos])
++- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.map_data)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.map_data))], select=[id,map_data,f0,f1,ORDINALITY], rowType=[RecordType(INTEGER id, (VARCHAR(2147483647), VARCHAR(2147483647)) MAP map_data, VARCHAR(2147483647) f0, VARCHAR(2147483647) f1, INTEGER ORDINALITY)], joinType=[INNER])
    +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[id, map_data])
 ]]>
     </Resource>
@@ -523,8 +523,8 @@ LogicalProject(a=[$0], word=[$2], pos=[$3])
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, f0 AS word, ordinality AS pos])
-+- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.words)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.words))], select=[a,words,f0,ordinality], rowType=[RecordType(INTEGER a, VARCHAR(2147483647) MULTISET words, VARCHAR(2147483647) f0, INTEGER ordinality)], joinType=[INNER])
+Calc(select=[a, EXPR$0 AS word, ORDINALITY AS pos])
++- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.words)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.words))], select=[a,words,EXPR$0,ORDINALITY], rowType=[RecordType(INTEGER a, VARCHAR(2147483647) MULTISET words, VARCHAR(2147483647) EXPR$0, INTEGER ORDINALITY)], joinType=[INNER])
    +- SortAggregate(isMerge=[true], groupBy=[a], select=[a, Final_COLLECT(words) AS words])
       +- Exchange(distribution=[forward])
          +- Sort(orderBy=[a ASC])
@@ -560,8 +560,8 @@ LogicalProject(a=[$0], number=[$2], ordinality=[$3])
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, f0 AS number, ordinality])
-+- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b))], select=[a,b,f0,ordinality], rowType=[RecordType(INTEGER a, INTEGER ARRAY b, INTEGER f0, INTEGER ordinality)], joinType=[INNER], condition=[AND(>($0, 10), <($1, 3))])
+Calc(select=[a, EXPR$0 AS number, ORDINALITY AS ordinality])
++- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b))], select=[a,b,EXPR$0,ORDINALITY], rowType=[RecordType(INTEGER a, INTEGER ARRAY b, INTEGER EXPR$0, INTEGER ORDINALITY)], joinType=[INNER], condition=[AND(>($0, 10), <($1, 3))])
    +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b])
 ]]>
     </Resource>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/UnnestTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/UnnestTest.xml
@@ -432,6 +432,51 @@ Calc(select=[id, f0 AS array_val, ordinality AS array_pos, f00 AS elem, ordinali
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testUnnestWithOrdinalityArrayOfRowsFromTableWithFilter">
+    <Resource name="sql">
+      <![CDATA[SELECT a, b, s, t, o FROM MyTable, UNNEST(MyTable.b) WITH ORDINALITY AS A (s, t, o) WHERE s > 13]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], s=[$2], t=[$3], o=[$4])
++- LogicalFilter(condition=[>($2, 13)])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+      :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+      +- LogicalProject(s=[$0], t=[$1], o=[$2])
+         +- Uncollect(withOrdinality=[true])
+            +- LogicalProject(b=[$cor0.b])
+               +- LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b))], select=[a,b,f0,f1,ordinality], rowType=[RecordType(INTEGER a, RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2) ARRAY b, INTEGER f0, VARCHAR(2147483647) f1, INTEGER ordinality)], joinType=[INNER], condition=[>($0, 13)])
++- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUnnestWithOrdinalityArrayOfRowsWithoutAlias">
+    <Resource name="sql">
+      <![CDATA[SELECT a, b, A._1, A._2, A.`ORDINALITY` FROM MyTable, UNNEST(MyTable.b) WITH ORDINALITY AS A where A._1 > 1]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], _1=[$2], _2=[$3], ORDINALITY=[$4])
++- LogicalFilter(condition=[>($2, 1)])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+      :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+      +- Uncollect(withOrdinality=[true])
+         +- LogicalProject(b=[$cor0.b])
+            +- LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b))], select=[a,b,f0,f1,ordinality], rowType=[RecordType(INTEGER a, RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2) ARRAY b, INTEGER f0, VARCHAR(2147483647) f1, INTEGER ordinality)], joinType=[INNER], condition=[>($0, 1)])
++- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testUnnestWithOrdinalityMap">
     <Resource name="sql">
       <![CDATA[SELECT id, k, v, pos FROM MyTable CROSS JOIN UNNEST(map_data) WITH ORDINALITY AS f(k, v, pos)]]>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/LogicalUnnestRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/LogicalUnnestRuleTest.xml
@@ -374,4 +374,216 @@ LogicalProject(a=[$0], b1=[$1], b2=[$2])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testUnnestWithOrdinalityAndValues">
+    <Resource name="sql">
+      <![CDATA[SELECT val, pos FROM UNNEST(ARRAY[1,2,3]) WITH ORDINALITY AS t(val, pos)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(val=[$0], pos=[$1])
++- LogicalProject(val=[$0], pos=[$1])
+   +- Uncollect(withOrdinality=[true])
+      +- LogicalProject(EXPR$0=[ARRAY(1, 2, 3)])
+         +- LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(val=[$0], pos=[$1])
++- LogicalProject(val=[$0], pos=[$1])
+   +- Uncollect(withOrdinality=[true])
+      +- LogicalProject(EXPR$0=[ARRAY(1, 2, 3)])
+         +- LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUnnestWithOrdinalityArray">
+    <Resource name="sql">
+      <![CDATA[SELECT a, number, ordinality FROM MyTable CROSS JOIN UNNEST(b) WITH ORDINALITY AS t(number, ordinality)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], number=[$2], ordinality=[$3])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalProject(number=[$0], ordinality=[$1])
+      +- Uncollect(withOrdinality=[true])
+         +- LogicalProject(b=[$cor0.b])
+            +- LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(a=[$0], number=[$2], ordinality=[$3])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalProject(number=[$0], ordinality=[$1])
+      +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], rowType=[RecordType:peek_no_expand(INTEGER f0, INTEGER ordinality)])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUnnestWithOrdinalityArrayOfArray">
+    <Resource name="sql">
+      <![CDATA[
+SELECT id, array_val, array_pos, elem, element_pos
+FROM MyTable
+CROSS JOIN UNNEST(nested_array) WITH ORDINALITY AS A(array_val, array_pos)
+CROSS JOIN UNNEST(array_val) WITH ORDINALITY AS B(elem, element_pos)
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], array_val=[$2], array_pos=[$3], elem=[$4], element_pos=[$5])
++- LogicalCorrelate(correlation=[$cor1], joinType=[inner], requiredColumns=[{2}])
+   :- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+   :  :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   :  +- LogicalProject(array_val=[$0], array_pos=[$1])
+   :     +- Uncollect(withOrdinality=[true])
+   :        +- LogicalProject(nested_array=[$cor0.nested_array])
+   :           +- LogicalValues(tuples=[[{ 0 }]])
+   +- LogicalProject(elem=[$0], element_pos=[$1])
+      +- Uncollect(withOrdinality=[true])
+         +- LogicalProject(array_val=[$cor1.array_val])
+            +- LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(id=[$0], array_val=[$2], array_pos=[$3], elem=[$4], element_pos=[$5])
++- LogicalCorrelate(correlation=[$cor1], joinType=[inner], requiredColumns=[{2}])
+   :- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+   :  :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   :  +- LogicalProject(array_val=[$0], array_pos=[$1])
+   :     +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.nested_array)], rowType=[RecordType:peek_no_expand(INTEGER ARRAY f0, INTEGER ordinality)])
+   +- LogicalProject(elem=[$0], element_pos=[$1])
+      +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor1.array_val)], rowType=[RecordType:peek_no_expand(INTEGER f0, INTEGER ordinality)])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUnnestWithOrdinalityMap">
+    <Resource name="sql">
+      <![CDATA[SELECT id, k, v, pos FROM MyTable CROSS JOIN UNNEST(map_data) WITH ORDINALITY AS f(k, v, pos)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], k=[$2], v=[$3], pos=[$4])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalProject(k=[$0], v=[$1], pos=[$2])
+      +- Uncollect(withOrdinality=[true])
+         +- LogicalProject(map_data=[$cor0.map_data])
+            +- LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(id=[$0], k=[$2], v=[$3], pos=[$4])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalProject(k=[$0], v=[$1], pos=[$2])
+      +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.map_data)], rowType=[RecordType:peek_no_expand(VARCHAR(2147483647) f0, VARCHAR(2147483647) f1, INTEGER ordinality)])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUnnestWithOrdinalityMultiset">
+    <Resource name="sql">
+      <![CDATA[
+WITH T AS (SELECT a, COLLECT(c) as words FROM MyTable GROUP BY a)
+SELECT a, word, pos
+FROM T CROSS JOIN UNNEST(words) WITH ORDINALITY AS A(word, pos)
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], word=[$2], pos=[$3])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+   :- LogicalAggregate(group=[{0}], words=[COLLECT($1)])
+   :  +- LogicalProject(a=[$0], c=[$2])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalProject(word=[$0], pos=[$1])
+      +- Uncollect(withOrdinality=[true])
+         +- LogicalProject(words=[$cor0.words])
+            +- LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(a=[$0], word=[$2], pos=[$3])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+   :- LogicalAggregate(group=[{0}], words=[COLLECT($1)])
+   :  +- LogicalProject(a=[$0], c=[$2])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalProject(word=[$0], pos=[$1])
+      +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.words)], rowType=[RecordType:peek_no_expand(VARCHAR(2147483647) f0, INTEGER ordinality)])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUnnestWithOrdinalityWithFilter">
+    <Resource name="sql">
+      <![CDATA[
+SELECT a, number, ordinality 
+FROM MyTable 
+CROSS JOIN UNNEST(b) WITH ORDINALITY AS t(number, ordinality)
+WHERE number > 10 AND ordinality < 3
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], number=[$2], ordinality=[$3])
++- LogicalFilter(condition=[AND(>($2, 10), <($3, 3))])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+      :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+      +- LogicalProject(number=[$0], ordinality=[$1])
+         +- Uncollect(withOrdinality=[true])
+            +- LogicalProject(b=[$cor0.b])
+               +- LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(a=[$0], number=[$2], ordinality=[$3])
++- LogicalFilter(condition=[AND(>($2, 10), <($3, 3))])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+      :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+      +- LogicalProject(number=[$0], ordinality=[$1])
+         +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], rowType=[RecordType:peek_no_expand(INTEGER f0, INTEGER ordinality)])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUnnestWithOrdinalityInSubquery">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM (
+  SELECT a, number, ordinality 
+  FROM MyTable 
+  CROSS JOIN UNNEST(b) WITH ORDINALITY AS t(number, ordinality)
+) subquery 
+WHERE ordinality = 1
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], number=[$1], ordinality=[$2])
++- LogicalFilter(condition=[=($2, 1)])
+   +- LogicalProject(a=[$0], number=[$2], ordinality=[$3])
+      +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+         :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+         +- LogicalProject(number=[$0], ordinality=[$1])
+            +- Uncollect(withOrdinality=[true])
+               +- LogicalProject(b=[$cor0.b])
+                  +- LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(a=[$0], number=[$1], ordinality=[$2])
++- LogicalFilter(condition=[=($2, 1)])
+   +- LogicalProject(a=[$0], number=[$2], ordinality=[$3])
+      +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+         :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+         +- LogicalProject(number=[$0], ordinality=[$1])
+            +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], rowType=[RecordType:peek_no_expand(INTEGER f0, INTEGER ordinality)])
+]]>
+    </Resource>
+  </TestCase>
 </Root>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/LogicalUnnestRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/LogicalUnnestRuleTest.xml
@@ -418,7 +418,7 @@ LogicalProject(a=[$0], number=[$2], ordinality=[$3])
 +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
    :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
    +- LogicalProject(number=[$0], ordinality=[$1])
-      +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], rowType=[RecordType:peek_no_expand(INTEGER f0, INTEGER ordinality)])
+      +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], rowType=[RecordType:peek_no_expand(INTEGER EXPR$0, INTEGER ORDINALITY)])
 ]]>
     </Resource>
   </TestCase>
@@ -454,9 +454,9 @@ LogicalProject(id=[$0], array_val=[$2], array_pos=[$3], elem=[$4], element_pos=[
    :- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
    :  :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
    :  +- LogicalProject(array_val=[$0], array_pos=[$1])
-   :     +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.nested_array)], rowType=[RecordType:peek_no_expand(INTEGER ARRAY f0, INTEGER ordinality)])
+   :     +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.nested_array)], rowType=[RecordType:peek_no_expand(INTEGER ARRAY EXPR$0, INTEGER ORDINALITY)])
    +- LogicalProject(elem=[$0], element_pos=[$1])
-      +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor1.array_val)], rowType=[RecordType:peek_no_expand(INTEGER f0, INTEGER ordinality)])
+      +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor1.array_val)], rowType=[RecordType:peek_no_expand(INTEGER EXPR$0, INTEGER ORDINALITY)])
 ]]>
     </Resource>
   </TestCase>
@@ -483,7 +483,7 @@ LogicalProject(a=[$0], b=[$1], s=[$2], t=[$3], o=[$4])
    +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
       :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
       +- LogicalProject(s=[$0], t=[$1], o=[$2])
-         +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], rowType=[RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2, INTEGER ordinality)])
+         +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], rowType=[RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2, INTEGER ORDINALITY)])
 ]]>
     </Resource>
   </TestCase>
@@ -508,7 +508,7 @@ LogicalProject(a=[$0], b=[$1], _1=[$2], _2=[$3], ORDINALITY=[$4])
 +- LogicalFilter(condition=[>($2, 1)])
    +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
       :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-      +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], rowType=[RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2, INTEGER ordinality)])
+      +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], rowType=[RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2, INTEGER ORDINALITY)])
 ]]>
     </Resource>
   </TestCase>
@@ -533,7 +533,7 @@ LogicalProject(id=[$0], k=[$2], v=[$3], pos=[$4])
 +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
    :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
    +- LogicalProject(k=[$0], v=[$1], pos=[$2])
-      +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.map_data)], rowType=[RecordType:peek_no_expand(VARCHAR(2147483647) f0, VARCHAR(2147483647) f1, INTEGER ordinality)])
+      +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.map_data)], rowType=[RecordType:peek_no_expand(VARCHAR(2147483647) f0, VARCHAR(2147483647) f1, INTEGER ORDINALITY)])
 ]]>
     </Resource>
   </TestCase>
@@ -566,7 +566,7 @@ LogicalProject(a=[$0], word=[$2], pos=[$3])
    :  +- LogicalProject(a=[$0], c=[$2])
    :     +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
    +- LogicalProject(word=[$0], pos=[$1])
-      +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.words)], rowType=[RecordType:peek_no_expand(VARCHAR(2147483647) f0, INTEGER ordinality)])
+      +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.words)], rowType=[RecordType:peek_no_expand(VARCHAR(2147483647) EXPR$0, INTEGER ORDINALITY)])
 ]]>
     </Resource>
   </TestCase>
@@ -598,7 +598,7 @@ LogicalProject(a=[$0], number=[$2], ordinality=[$3])
    +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
       :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
       +- LogicalProject(number=[$0], ordinality=[$1])
-         +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], rowType=[RecordType:peek_no_expand(INTEGER f0, INTEGER ordinality)])
+         +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], rowType=[RecordType:peek_no_expand(INTEGER EXPR$0, INTEGER ORDINALITY)])
 ]]>
     </Resource>
   </TestCase>
@@ -634,7 +634,7 @@ LogicalProject(a=[$0], number=[$1], ordinality=[$2])
       +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
          :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
          +- LogicalProject(number=[$0], ordinality=[$1])
-            +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], rowType=[RecordType:peek_no_expand(INTEGER f0, INTEGER ordinality)])
+            +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], rowType=[RecordType:peek_no_expand(INTEGER EXPR$0, INTEGER ORDINALITY)])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/LogicalUnnestRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/LogicalUnnestRuleTest.xml
@@ -460,6 +460,58 @@ LogicalProject(id=[$0], array_val=[$2], array_pos=[$3], elem=[$4], element_pos=[
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testUnnestWithOrdinalityArrayOfRowsFromTableWithFilter">
+    <Resource name="sql">
+      <![CDATA[SELECT a, b, s, t, o FROM MyTable, UNNEST(MyTable.b) WITH ORDINALITY AS A (s, t, o) WHERE s > 13]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], s=[$2], t=[$3], o=[$4])
++- LogicalFilter(condition=[>($2, 13)])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+      :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+      +- LogicalProject(s=[$0], t=[$1], o=[$2])
+         +- Uncollect(withOrdinality=[true])
+            +- LogicalProject(b=[$cor0.b])
+               +- LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], s=[$2], t=[$3], o=[$4])
++- LogicalFilter(condition=[>($2, 13)])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+      :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+      +- LogicalProject(s=[$0], t=[$1], o=[$2])
+         +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], rowType=[RecordType:peek_no_expand(INTEGER f0, VARCHAR(2147483647) f1, INTEGER ordinality)])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUnnestWithOrdinalityArrayOfRowsWithoutAlias">
+    <Resource name="sql">
+      <![CDATA[SELECT a, b, A._1, A._2, A.`ORDINALITY` FROM MyTable, UNNEST(MyTable.b) WITH ORDINALITY AS A where A._1 > 1]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], _1=[$2], _2=[$3], ORDINALITY=[$4])
++- LogicalFilter(condition=[>($2, 1)])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+      :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+      +- Uncollect(withOrdinality=[true])
+         +- LogicalProject(b=[$cor0.b])
+            +- LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], _1=[$2], _2=[$3], ORDINALITY=[$4])
++- LogicalFilter(condition=[>($2, 1)])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+      :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+      +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], rowType=[RecordType:peek_no_expand(INTEGER f0, VARCHAR(2147483647) f1, INTEGER ordinality)])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testUnnestWithOrdinalityMap">
     <Resource name="sql">
       <![CDATA[SELECT id, k, v, pos FROM MyTable CROSS JOIN UNNEST(map_data) WITH ORDINALITY AS f(k, v, pos)]]>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/LogicalUnnestRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/LogicalUnnestRuleTest.xml
@@ -483,7 +483,7 @@ LogicalProject(a=[$0], b=[$1], s=[$2], t=[$3], o=[$4])
    +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
       :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
       +- LogicalProject(s=[$0], t=[$1], o=[$2])
-         +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], rowType=[RecordType:peek_no_expand(INTEGER f0, VARCHAR(2147483647) f1, INTEGER ordinality)])
+         +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], rowType=[RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2, INTEGER ordinality)])
 ]]>
     </Resource>
   </TestCase>
@@ -508,7 +508,7 @@ LogicalProject(a=[$0], b=[$1], _1=[$2], _2=[$3], ORDINALITY=[$4])
 +- LogicalFilter(condition=[>($2, 1)])
    +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
       :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-      +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], rowType=[RecordType:peek_no_expand(INTEGER f0, VARCHAR(2147483647) f1, INTEGER ordinality)])
+      +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], rowType=[RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2, INTEGER ordinality)])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/UnnestTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/UnnestTest.xml
@@ -367,4 +367,197 @@ Calc(select=[a, _1 AS b1, _2 AS b2])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testUnnestWithOrdinalityAndValues">
+    <Resource name="sql">
+      <![CDATA[SELECT val, pos FROM UNNEST(ARRAY[1,2,3]) WITH ORDINALITY AS t(val, pos)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(val=[$0], pos=[$1])
++- LogicalProject(val=[$0], pos=[$1])
+   +- Uncollect(withOrdinality=[true])
+      +- LogicalProject(EXPR$0=[ARRAY(1, 2, 3)])
+         +- LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1(ARRAY(1, 2, 3))], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1(ARRAY(1, 2, 3)))], select=[f0,ordinality], rowType=[RecordType:peek_no_expand(INTEGER f0, INTEGER ordinality)], joinType=[INNER])
++- Values(tuples=[[{  }]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUnnestWithOrdinalityArray">
+    <Resource name="sql">
+      <![CDATA[SELECT a, number, ordinality FROM MyTable CROSS JOIN UNNEST(b) WITH ORDINALITY AS t(number, ordinality)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], number=[$2], ordinality=[$3])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalProject(number=[$0], ordinality=[$1])
+      +- Uncollect(withOrdinality=[true])
+         +- LogicalProject(b=[$cor0.b])
+            +- LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, f0 AS number, ordinality])
++- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b))], select=[a,b,f0,ordinality], rowType=[RecordType(INTEGER a, INTEGER ARRAY b, INTEGER f0, INTEGER ordinality)], joinType=[INNER])
+   +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUnnestWithOrdinalityArrayOfArray">
+    <Resource name="sql">
+      <![CDATA[
+SELECT id, array_val, array_pos, elem, element_pos
+FROM MyTable
+CROSS JOIN UNNEST(nested_array) WITH ORDINALITY AS A(array_val, array_pos)
+CROSS JOIN UNNEST(array_val) WITH ORDINALITY AS B(elem, element_pos)
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], array_val=[$2], array_pos=[$3], elem=[$4], element_pos=[$5])
++- LogicalCorrelate(correlation=[$cor1], joinType=[inner], requiredColumns=[{2}])
+   :- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+   :  :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   :  +- LogicalProject(array_val=[$0], array_pos=[$1])
+   :     +- Uncollect(withOrdinality=[true])
+   :        +- LogicalProject(nested_array=[$cor0.nested_array])
+   :           +- LogicalValues(tuples=[[{ 0 }]])
+   +- LogicalProject(elem=[$0], element_pos=[$1])
+      +- Uncollect(withOrdinality=[true])
+         +- LogicalProject(array_val=[$cor1.array_val])
+            +- LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[id, f0 AS array_val, ordinality AS array_pos, f00 AS elem, ordinality0 AS element_pos])
++- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor1.array_val)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor1.array_val))], select=[id,nested_array,f0,ordinality,f00,ordinality0], rowType=[RecordType(INTEGER id, INTEGER ARRAY ARRAY nested_array, INTEGER ARRAY f0, INTEGER ordinality, INTEGER f00, INTEGER ordinality0)], joinType=[INNER])
+   +- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.nested_array)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.nested_array))], select=[id,nested_array,f0,ordinality], rowType=[RecordType(INTEGER id, INTEGER ARRAY ARRAY nested_array, INTEGER ARRAY f0, INTEGER ordinality)], joinType=[INNER])
+      +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[id, nested_array])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUnnestWithOrdinalityMap">
+    <Resource name="sql">
+      <![CDATA[SELECT id, k, v, pos FROM MyTable CROSS JOIN UNNEST(map_data) WITH ORDINALITY AS f(k, v, pos)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], k=[$2], v=[$3], pos=[$4])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalProject(k=[$0], v=[$1], pos=[$2])
+      +- Uncollect(withOrdinality=[true])
+         +- LogicalProject(map_data=[$cor0.map_data])
+            +- LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[id, f0 AS k, f1 AS v, ordinality AS pos])
++- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.map_data)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.map_data))], select=[id,map_data,f0,f1,ordinality], rowType=[RecordType(INTEGER id, (VARCHAR(2147483647), VARCHAR(2147483647)) MAP map_data, VARCHAR(2147483647) f0, VARCHAR(2147483647) f1, INTEGER ordinality)], joinType=[INNER])
+   +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[id, map_data])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUnnestWithOrdinalityMultiset">
+    <Resource name="sql">
+      <![CDATA[
+WITH T AS (SELECT a, COLLECT(c) as words FROM MyTable GROUP BY a)
+SELECT a, word, pos
+FROM T CROSS JOIN UNNEST(words) WITH ORDINALITY AS A(word, pos)
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], word=[$2], pos=[$3])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+   :- LogicalAggregate(group=[{0}], words=[COLLECT($1)])
+   :  +- LogicalProject(a=[$0], c=[$2])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalProject(word=[$0], pos=[$1])
+      +- Uncollect(withOrdinality=[true])
+         +- LogicalProject(words=[$cor0.words])
+            +- LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, f0 AS word, ordinality AS pos])
++- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.words)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.words))], select=[a,words,f0,ordinality], rowType=[RecordType(INTEGER a, VARCHAR(2147483647) MULTISET words, VARCHAR(2147483647) f0, INTEGER ordinality)], joinType=[INNER])
+   +- GroupAggregate(groupBy=[a], select=[a, COLLECT(c) AS words])
+      +- Exchange(distribution=[hash[a]])
+         +- Calc(select=[a, c])
+            +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUnnestWithOrdinalityWithFilter">
+    <Resource name="sql">
+      <![CDATA[
+SELECT a, number, ordinality 
+FROM MyTable 
+CROSS JOIN UNNEST(b) WITH ORDINALITY AS t(number, ordinality)
+WHERE number > 10 AND ordinality < 3
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], number=[$2], ordinality=[$3])
++- LogicalFilter(condition=[AND(>($2, 10), <($3, 3))])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+      :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+      +- LogicalProject(number=[$0], ordinality=[$1])
+         +- Uncollect(withOrdinality=[true])
+            +- LogicalProject(b=[$cor0.b])
+               +- LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, f0 AS number, ordinality])
++- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b))], select=[a,b,f0,ordinality], rowType=[RecordType(INTEGER a, INTEGER ARRAY b, INTEGER f0, INTEGER ordinality)], joinType=[INNER], condition=[AND(>($0, 10), <($1, 3))])
+   +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUnnestWithOrdinalityInSubquery">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM (
+  SELECT a, number, ordinality 
+  FROM MyTable 
+  CROSS JOIN UNNEST(b) WITH ORDINALITY AS t(number, ordinality)
+) subquery 
+WHERE ordinality = 1
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], number=[$1], ordinality=[$2])
++- LogicalFilter(condition=[=($2, 1)])
+   +- LogicalProject(a=[$0], number=[$2], ordinality=[$3])
+      +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+         :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+         +- LogicalProject(number=[$0], ordinality=[$1])
+            +- Uncollect(withOrdinality=[true])
+               +- LogicalProject(b=[$cor0.b])
+                  +- LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, number, ordinality])
++- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b))], select=[a,b,number,ordinality], rowType=[RecordType(INTEGER a, INTEGER ARRAY b, INTEGER number, INTEGER ordinality)], joinType=[INNER], condition=[=($1, 1)])
+   +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
 </Root>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/UnnestTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/UnnestTest.xml
@@ -462,7 +462,7 @@ LogicalProject(a=[$0], b=[$1], s=[$2], t=[$3], o=[$4])
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b))], select=[a,b,f0,f1,ordinality], rowType=[RecordType(INTEGER a, RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2) ARRAY b, INTEGER f0, VARCHAR(2147483647) f1, INTEGER ordinality)], joinType=[INNER], condition=[>($0, 13)])
+Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b))], select=[a,b,_1,_2,ordinality], rowType=[RecordType(INTEGER a, RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2) ARRAY b, INTEGER _1, VARCHAR(2147483647) _2, INTEGER ordinality)], joinType=[INNER], condition=[>($0, 13)])
 +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b])
 ]]>
     </Resource>
@@ -484,7 +484,7 @@ LogicalProject(a=[$0], b=[$1], _1=[$2], _2=[$3], ORDINALITY=[$4])
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b))], select=[a,b,f0,f1,ordinality], rowType=[RecordType(INTEGER a, RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2) ARRAY b, INTEGER f0, VARCHAR(2147483647) f1, INTEGER ordinality)], joinType=[INNER], condition=[>($0, 1)])
+Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b))], select=[a,b,_1,_2,ordinality], rowType=[RecordType(INTEGER a, RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2) ARRAY b, INTEGER _1, VARCHAR(2147483647) _2, INTEGER ordinality)], joinType=[INNER], condition=[>($0, 1)])
 +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b])
 ]]>
     </Resource>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/UnnestTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/UnnestTest.xml
@@ -444,6 +444,51 @@ Calc(select=[id, f0 AS array_val, ordinality AS array_pos, f00 AS elem, ordinali
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testUnnestWithOrdinalityArrayOfRowsFromTableWithFilter">
+    <Resource name="sql">
+      <![CDATA[SELECT a, b, s, t, o FROM MyTable, UNNEST(MyTable.b) WITH ORDINALITY AS A (s, t, o) WHERE s > 13]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], s=[$2], t=[$3], o=[$4])
++- LogicalFilter(condition=[>($2, 13)])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+      :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+      +- LogicalProject(s=[$0], t=[$1], o=[$2])
+         +- Uncollect(withOrdinality=[true])
+            +- LogicalProject(b=[$cor0.b])
+               +- LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b))], select=[a,b,f0,f1,ordinality], rowType=[RecordType(INTEGER a, RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2) ARRAY b, INTEGER f0, VARCHAR(2147483647) f1, INTEGER ordinality)], joinType=[INNER], condition=[>($0, 13)])
++- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUnnestWithOrdinalityArrayOfRowsWithoutAlias">
+    <Resource name="sql">
+      <![CDATA[SELECT a, b, A._1, A._2, A.`ORDINALITY` FROM MyTable, UNNEST(MyTable.b) WITH ORDINALITY AS A where A._1 > 1]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], _1=[$2], _2=[$3], ORDINALITY=[$4])
++- LogicalFilter(condition=[>($2, 1)])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+      :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+      +- Uncollect(withOrdinality=[true])
+         +- LogicalProject(b=[$cor0.b])
+            +- LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b))], select=[a,b,f0,f1,ordinality], rowType=[RecordType(INTEGER a, RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2) ARRAY b, INTEGER f0, VARCHAR(2147483647) f1, INTEGER ordinality)], joinType=[INNER], condition=[>($0, 1)])
++- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testUnnestWithOrdinalityMap">
     <Resource name="sql">
       <![CDATA[SELECT id, k, v, pos FROM MyTable CROSS JOIN UNNEST(map_data) WITH ORDINALITY AS f(k, v, pos)]]>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/UnnestTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/UnnestTest.xml
@@ -382,7 +382,7 @@ LogicalProject(val=[$0], pos=[$1])
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1(ARRAY(1, 2, 3))], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1(ARRAY(1, 2, 3)))], select=[f0,ordinality], rowType=[RecordType:peek_no_expand(INTEGER f0, INTEGER ordinality)], joinType=[INNER])
+Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1(ARRAY(1, 2, 3))], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1(ARRAY(1, 2, 3)))], select=[EXPR$0,ORDINALITY], rowType=[RecordType:peek_no_expand(INTEGER EXPR$0, INTEGER ORDINALITY)], joinType=[INNER])
 +- Values(tuples=[[{  }]])
 ]]>
     </Resource>
@@ -404,8 +404,8 @@ LogicalProject(a=[$0], number=[$2], ordinality=[$3])
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, f0 AS number, ordinality])
-+- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b))], select=[a,b,f0,ordinality], rowType=[RecordType(INTEGER a, INTEGER ARRAY b, INTEGER f0, INTEGER ordinality)], joinType=[INNER])
+Calc(select=[a, EXPR$0 AS number, ORDINALITY AS ordinality])
++- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b))], select=[a,b,EXPR$0,ORDINALITY], rowType=[RecordType(INTEGER a, INTEGER ARRAY b, INTEGER EXPR$0, INTEGER ORDINALITY)], joinType=[INNER])
    +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b])
 ]]>
     </Resource>
@@ -437,9 +437,9 @@ LogicalProject(id=[$0], array_val=[$2], array_pos=[$3], elem=[$4], element_pos=[
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[id, f0 AS array_val, ordinality AS array_pos, f00 AS elem, ordinality0 AS element_pos])
-+- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor1.array_val)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor1.array_val))], select=[id,nested_array,f0,ordinality,f00,ordinality0], rowType=[RecordType(INTEGER id, INTEGER ARRAY ARRAY nested_array, INTEGER ARRAY f0, INTEGER ordinality, INTEGER f00, INTEGER ordinality0)], joinType=[INNER])
-   +- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.nested_array)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.nested_array))], select=[id,nested_array,f0,ordinality], rowType=[RecordType(INTEGER id, INTEGER ARRAY ARRAY nested_array, INTEGER ARRAY f0, INTEGER ordinality)], joinType=[INNER])
+Calc(select=[id, EXPR$0 AS array_val, ORDINALITY AS array_pos, EXPR$00 AS elem, ORDINALITY0 AS element_pos])
++- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor1.array_val)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor1.array_val))], select=[id,nested_array,EXPR$0,ORDINALITY,EXPR$00,ORDINALITY0], rowType=[RecordType(INTEGER id, INTEGER ARRAY ARRAY nested_array, INTEGER ARRAY EXPR$0, INTEGER ORDINALITY, INTEGER EXPR$00, INTEGER ORDINALITY0)], joinType=[INNER])
+   +- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.nested_array)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.nested_array))], select=[id,nested_array,EXPR$0,ORDINALITY], rowType=[RecordType(INTEGER id, INTEGER ARRAY ARRAY nested_array, INTEGER ARRAY EXPR$0, INTEGER ORDINALITY)], joinType=[INNER])
       +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[id, nested_array])
 ]]>
     </Resource>
@@ -462,7 +462,7 @@ LogicalProject(a=[$0], b=[$1], s=[$2], t=[$3], o=[$4])
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b))], select=[a,b,_1,_2,ordinality], rowType=[RecordType(INTEGER a, RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2) ARRAY b, INTEGER _1, VARCHAR(2147483647) _2, INTEGER ordinality)], joinType=[INNER], condition=[>($0, 13)])
+Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b))], select=[a,b,_1,_2,ORDINALITY], rowType=[RecordType(INTEGER a, RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2) ARRAY b, INTEGER _1, VARCHAR(2147483647) _2, INTEGER ORDINALITY)], joinType=[INNER], condition=[>($0, 13)])
 +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b])
 ]]>
     </Resource>
@@ -484,7 +484,7 @@ LogicalProject(a=[$0], b=[$1], _1=[$2], _2=[$3], ORDINALITY=[$4])
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b))], select=[a,b,_1,_2,ordinality], rowType=[RecordType(INTEGER a, RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2) ARRAY b, INTEGER _1, VARCHAR(2147483647) _2, INTEGER ordinality)], joinType=[INNER], condition=[>($0, 1)])
+Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b))], select=[a,b,_1,_2,ORDINALITY], rowType=[RecordType(INTEGER a, RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2) ARRAY b, INTEGER _1, VARCHAR(2147483647) _2, INTEGER ORDINALITY)], joinType=[INNER], condition=[>($0, 1)])
 +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b])
 ]]>
     </Resource>
@@ -506,8 +506,8 @@ LogicalProject(id=[$0], k=[$2], v=[$3], pos=[$4])
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[id, f0 AS k, f1 AS v, ordinality AS pos])
-+- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.map_data)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.map_data))], select=[id,map_data,f0,f1,ordinality], rowType=[RecordType(INTEGER id, (VARCHAR(2147483647), VARCHAR(2147483647)) MAP map_data, VARCHAR(2147483647) f0, VARCHAR(2147483647) f1, INTEGER ordinality)], joinType=[INNER])
+Calc(select=[id, f0 AS k, f1 AS v, ORDINALITY AS pos])
++- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.map_data)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.map_data))], select=[id,map_data,f0,f1,ORDINALITY], rowType=[RecordType(INTEGER id, (VARCHAR(2147483647), VARCHAR(2147483647)) MAP map_data, VARCHAR(2147483647) f0, VARCHAR(2147483647) f1, INTEGER ORDINALITY)], joinType=[INNER])
    +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[id, map_data])
 ]]>
     </Resource>
@@ -535,8 +535,8 @@ LogicalProject(a=[$0], word=[$2], pos=[$3])
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, f0 AS word, ordinality AS pos])
-+- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.words)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.words))], select=[a,words,f0,ordinality], rowType=[RecordType(INTEGER a, VARCHAR(2147483647) MULTISET words, VARCHAR(2147483647) f0, INTEGER ordinality)], joinType=[INNER])
+Calc(select=[a, EXPR$0 AS word, ORDINALITY AS pos])
++- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.words)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.words))], select=[a,words,EXPR$0,ORDINALITY], rowType=[RecordType(INTEGER a, VARCHAR(2147483647) MULTISET words, VARCHAR(2147483647) EXPR$0, INTEGER ORDINALITY)], joinType=[INNER])
    +- GroupAggregate(groupBy=[a], select=[a, COLLECT(c) AS words])
       +- Exchange(distribution=[hash[a]])
          +- Calc(select=[a, c])
@@ -567,8 +567,8 @@ LogicalProject(a=[$0], number=[$2], ordinality=[$3])
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, f0 AS number, ordinality])
-+- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b))], select=[a,b,f0,ordinality], rowType=[RecordType(INTEGER a, INTEGER ARRAY b, INTEGER f0, INTEGER ordinality)], joinType=[INNER], condition=[AND(>($0, 10), <($1, 3))])
+Calc(select=[a, EXPR$0 AS number, ORDINALITY AS ordinality])
++- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b))], select=[a,b,EXPR$0,ORDINALITY], rowType=[RecordType(INTEGER a, INTEGER ARRAY b, INTEGER EXPR$0, INTEGER ORDINALITY)], joinType=[INNER], condition=[AND(>($0, 10), <($1, 3))])
    +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b])
 ]]>
     </Resource>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/common/UnnestTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/common/UnnestTestBase.scala
@@ -146,6 +146,11 @@ abstract class UnnestTestBase(withExecPlan: Boolean) extends TableTestBase {
   }
 
   @Test
+  def testUnnestWithOrdinalityAndValues(): Unit = {
+    verifyPlan("SELECT val, pos FROM UNNEST(ARRAY[1,2,3]) WITH ORDINALITY AS t(val, pos)")
+  }
+
+  @Test
   def testUnnestWithOrdinalityArray(): Unit = {
     util.addTableSource[(Int, Array[Int])]("MyTable", 'a, 'b)
     verifyPlan(
@@ -153,8 +158,17 @@ abstract class UnnestTestBase(withExecPlan: Boolean) extends TableTestBase {
   }
 
   @Test
-  def testUnnestWithOrdinalityAndValues(): Unit = {
-    verifyPlan("SELECT val, pos FROM UNNEST(ARRAY[1,2,3]) WITH ORDINALITY AS t(val, pos)")
+  def testUnnestWithOrdinalityArrayOfRowsWithoutAlias(): Unit = {
+    util.addTableSource[(Int, Array[(Int, String)])]("MyTable", 'a, 'b)
+    verifyPlan(
+      "SELECT a, b, A._1, A._2, A.`ORDINALITY` FROM MyTable, UNNEST(MyTable.b) WITH ORDINALITY AS A where A._1 > 1")
+  }
+
+  @Test
+  def testUnnestWithOrdinalityArrayOfRowsFromTableWithFilter(): Unit = {
+    util.addTableSource[(Int, Array[(Int, String)])]("MyTable", 'a, 'b)
+    verifyPlan(
+      "SELECT a, b, s, t, o FROM MyTable, UNNEST(MyTable.b) WITH ORDINALITY AS A (s, t, o) WHERE s > 13")
   }
 
   @Test

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/common/UnnestTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/common/UnnestTestBase.scala
@@ -145,6 +145,79 @@ abstract class UnnestTestBase(withExecPlan: Boolean) extends TableTestBase {
     verifyPlan(sqlQuery)
   }
 
+  @Test
+  def testUnnestWithOrdinalityArray(): Unit = {
+    util.addTableSource[(Int, Array[Int])]("MyTable", 'a, 'b)
+    verifyPlan(
+      "SELECT a, number, ordinality FROM MyTable CROSS JOIN UNNEST(b) WITH ORDINALITY AS t(number, ordinality)")
+  }
+
+  @Test
+  def testUnnestWithOrdinalityAndValues(): Unit = {
+    verifyPlan("SELECT val, pos FROM UNNEST(ARRAY[1,2,3]) WITH ORDINALITY AS t(val, pos)")
+  }
+
+  @Test
+  def testUnnestWithOrdinalityArrayOfArray(): Unit = {
+    util.addTableSource[(Int, Array[Array[Int]])]("MyTable", 'id, 'nested_array)
+    val sqlQuery =
+      """
+        |SELECT id, array_val, array_pos, elem, element_pos
+        |FROM MyTable
+        |CROSS JOIN UNNEST(nested_array) WITH ORDINALITY AS A(array_val, array_pos)
+        |CROSS JOIN UNNEST(array_val) WITH ORDINALITY AS B(elem, element_pos)
+        |""".stripMargin
+    verifyPlan(sqlQuery)
+  }
+
+  @Test
+  def testUnnestWithOrdinalityMultiset(): Unit = {
+    util.addDataStream[(Int, String, String)]("MyTable", 'a, 'b, 'c)
+    val sqlQuery =
+      """
+        |WITH T AS (SELECT a, COLLECT(c) as words FROM MyTable GROUP BY a)
+        |SELECT a, word, pos
+        |FROM T CROSS JOIN UNNEST(words) WITH ORDINALITY AS A(word, pos)
+        |""".stripMargin
+    verifyPlan(sqlQuery)
+  }
+
+  @Test
+  def testUnnestWithOrdinalityMap(): Unit = {
+    util.addTableSource(
+      "MyTable",
+      Array[AbstractDataType[_]](
+        DataTypes.INT(),
+        DataTypes.MAP(DataTypes.STRING(), DataTypes.STRING())),
+      Array("id", "map_data"))
+    verifyPlan(
+      "SELECT id, k, v, pos FROM MyTable CROSS JOIN UNNEST(map_data) WITH ORDINALITY AS f(k, v, pos)")
+  }
+
+  @Test
+  def testUnnestWithOrdinalityWithFilter(): Unit = {
+    util.addTableSource[(Int, Array[Int])]("MyTable", 'a, 'b)
+    verifyPlan("""
+                 |SELECT a, number, ordinality 
+                 |FROM MyTable 
+                 |CROSS JOIN UNNEST(b) WITH ORDINALITY AS t(number, ordinality)
+                 |WHERE number > 10 AND ordinality < 3
+                 |""".stripMargin)
+  }
+
+  @Test
+  def testUnnestWithOrdinalityInSubquery(): Unit = {
+    util.addTableSource[(Int, Array[Int])]("MyTable", 'a, 'b)
+    verifyPlan("""
+                 |SELECT * FROM (
+                 |  SELECT a, number, ordinality 
+                 |  FROM MyTable 
+                 |  CROSS JOIN UNNEST(b) WITH ORDINALITY AS t(number, ordinality)
+                 |) subquery 
+                 |WHERE ordinality = 1
+                 |""".stripMargin)
+  }
+
   def verifyPlan(sql: String): Unit = {
     if (withExecPlan) {
       util.verifyExecPlan(sql)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/UnnestITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/UnnestITCase.scala
@@ -448,25 +448,22 @@ class UnnestITCase extends BatchTestBase {
   def testUnnestForMapOfRowsWithOrdinality(): Unit = {
     val data = List(
       row(
-        1, {
-          val map = new java.util.HashMap[Row, Row]()
-          map.put(Row.of("a", "a"), Row.of(10: Integer))
-          map.put(Row.of("b", "b"), Row.of(11: Integer))
-          map
-        }),
+        1,
+        Map(
+          Row.of("a", "a") -> Row.of(10: Integer),
+          Row.of("b", "b") -> Row.of(11: Integer)
+        ).asJava),
       row(
-        2, {
-          val map = new java.util.HashMap[Row, Row]()
-          map.put(Row.of("c", "c"), Row.of(20: Integer))
-          map
-        }),
+        2,
+        Map(
+          Row.of("c", "c") -> Row.of(20: Integer)
+        ).asJava),
       row(
-        3, {
-          val map = new java.util.HashMap[Row, Row]()
-          map.put(Row.of("d", "d"), Row.of(30: Integer))
-          map.put(Row.of("e", "e"), Row.of(31: Integer))
-          map
-        })
+        3,
+        Map(
+          Row.of("d", "d") -> Row.of(30: Integer),
+          Row.of("e", "e") -> Row.of(31: Integer)
+        ).asJava)
     )
 
     registerCollection(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/UnnestITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/UnnestITCase.scala
@@ -23,12 +23,13 @@ import org.apache.flink.table.api._
 import org.apache.flink.table.api.bridge.scala._
 import org.apache.flink.table.expressions.Expression
 import org.apache.flink.table.legacy.api.Types
+import org.apache.flink.table.planner.runtime.utils._
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.StateBackendMode
 import org.apache.flink.table.planner.runtime.utils.TimeTestUtil.TimestampAndWatermarkWithOffset
-import org.apache.flink.table.planner.runtime.utils._
 import org.apache.flink.table.utils.LegacyRowExtension
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension
 import org.apache.flink.types.Row
+
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.TestTemplate
 import org.junit.jupiter.api.extension.{ExtendWith, RegisterExtension}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/table/UnnestRowsFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/table/UnnestRowsFunction.java
@@ -34,7 +34,7 @@ import org.apache.flink.table.types.logical.RowType;
 public class UnnestRowsFunction extends UnnestRowsFunctionBase {
 
     public UnnestRowsFunction() {
-        super();
+        super(false);
     }
 
     @Override
@@ -65,7 +65,7 @@ public class UnnestRowsFunction extends UnnestRowsFunctionBase {
                 SpecializedContext context,
                 LogicalType elementType,
                 ArrayData.ElementGetter elementGetter) {
-            super(context, elementType);
+            super(context, elementType, false);
             this.elementGetter = elementGetter;
         }
 
@@ -91,7 +91,7 @@ public class UnnestRowsFunction extends UnnestRowsFunctionBase {
                 LogicalType keyValTypes,
                 ArrayData.ElementGetter keyGetter,
                 ArrayData.ElementGetter valueGetter) {
-            super(context, keyValTypes);
+            super(context, keyValTypes, false);
             this.keyGetter = keyGetter;
             this.valueGetter = valueGetter;
         }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/table/UnnestRowsFunctionBase.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/table/UnnestRowsFunctionBase.java
@@ -159,11 +159,11 @@ public abstract class UnnestRowsFunctionBase extends BuiltInSpecializedFunction 
             final int size = mapData.size();
             final ArrayData keyArray = mapData.keyArray();
             final ArrayData valueArray = mapData.valueArray();
-            for (int i = 0; i < size; i++) {
+            for (int pos = 0; pos < size; pos++) {
                 collector.collect(
-                        keyGetter.getElementOrNull(keyArray, i),
-                        valueGetter.getElementOrNull(valueArray, i),
-                        i + 1);
+                        keyGetter.getElementOrNull(keyArray, pos),
+                        valueGetter.getElementOrNull(valueArray, pos),
+                        pos + 1);
             }
         }
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/table/UnnestRowsFunctionBase.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/table/UnnestRowsFunctionBase.java
@@ -119,7 +119,7 @@ public abstract class UnnestRowsFunctionBase extends BuiltInSpecializedFunction 
                                     rowType.getFields().stream(),
                                     Stream.of(
                                             new RowType.RowField(
-                                                    "ordinality",
+                                                    "ORDINALITY",
                                                     DataTypes.INT().notNull().getLogicalType())))
                             .collect(Collectors.toList()));
         } else {
@@ -127,7 +127,7 @@ public abstract class UnnestRowsFunctionBase extends BuiltInSpecializedFunction 
             return RowType.of(
                     false,
                     new LogicalType[] {baseType, DataTypes.INT().notNull().getLogicalType()},
-                    new String[] {"f0", "ordinality"});
+                    new String[] {"EXPR$0", "ORDINALITY"});
         }
     }
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/table/UnnestRowsFunctionBase.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/table/UnnestRowsFunctionBase.java
@@ -36,8 +36,11 @@ import org.apache.flink.table.types.logical.RowType;
 @Internal
 public abstract class UnnestRowsFunctionBase extends BuiltInSpecializedFunction {
 
-    public UnnestRowsFunctionBase() {
-        super(BuiltInFunctionDefinitions.INTERNAL_UNNEST_ROWS);
+    public UnnestRowsFunctionBase(boolean withOrdinality) {
+        super(
+                withOrdinality
+                        ? BuiltInFunctionDefinitions.INTERNAL_UNNEST_ROWS_WITH_ORDINALITY
+                        : BuiltInFunctionDefinitions.INTERNAL_UNNEST_ROWS);
     }
 
     @Override
@@ -136,8 +139,13 @@ public abstract class UnnestRowsFunctionBase extends BuiltInSpecializedFunction 
     protected abstract static class UnnestTableFunctionBase extends BuiltInTableFunction<Object> {
         private final transient DataType outputDataType;
 
-        UnnestTableFunctionBase(SpecializedContext context, LogicalType elementType) {
-            super(BuiltInFunctionDefinitions.INTERNAL_UNNEST_ROWS, context);
+        UnnestTableFunctionBase(
+                SpecializedContext context, LogicalType elementType, boolean withOrdinality) {
+            super(
+                    withOrdinality
+                            ? BuiltInFunctionDefinitions.INTERNAL_UNNEST_ROWS_WITH_ORDINALITY
+                            : BuiltInFunctionDefinitions.INTERNAL_UNNEST_ROWS,
+                    context);
             outputDataType = DataTypes.of(elementType).toInternal();
         }
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/table/UnnestRowsFunctionBase.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/table/UnnestRowsFunctionBase.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.table;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.MapData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.UserDefinedFunction;
+import org.apache.flink.table.runtime.functions.BuiltInSpecializedFunction;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.MultisetType;
+import org.apache.flink.table.types.logical.RowType;
+
+/** Base class for flattening ARRAY, MAP, and MULTISET using a table function. */
+@Internal
+public abstract class UnnestRowsFunctionBase extends BuiltInSpecializedFunction {
+
+    public UnnestRowsFunctionBase() {
+        super(BuiltInFunctionDefinitions.INTERNAL_UNNEST_ROWS);
+    }
+
+    @Override
+    public UserDefinedFunction specialize(SpecializedContext context) {
+        final LogicalType argType =
+                context.getCallContext().getArgumentDataTypes().get(0).getLogicalType();
+        switch (argType.getTypeRoot()) {
+            case ARRAY:
+                final ArrayType arrayType = (ArrayType) argType;
+                return createCollectionUnnestFunction(
+                        context,
+                        arrayType.getElementType(),
+                        ArrayData.createElementGetter(arrayType.getElementType()));
+            case MULTISET:
+                final MultisetType multisetType = (MultisetType) argType;
+                return createCollectionUnnestFunction(
+                        context,
+                        multisetType.getElementType(),
+                        ArrayData.createElementGetter(multisetType.getElementType()));
+            case MAP:
+                final MapType mapType = (MapType) argType;
+                return createMapUnnestFunction(
+                        context,
+                        RowType.of(false, mapType.getKeyType(), mapType.getValueType()),
+                        ArrayData.createElementGetter(mapType.getKeyType()),
+                        ArrayData.createElementGetter(mapType.getValueType()));
+            default:
+                throw new UnsupportedOperationException("Unsupported type for UNNEST: " + argType);
+        }
+    }
+
+    protected abstract UserDefinedFunction createCollectionUnnestFunction(
+            SpecializedContext context,
+            LogicalType elementType,
+            ArrayData.ElementGetter elementGetter);
+
+    protected abstract UserDefinedFunction createMapUnnestFunction(
+            SpecializedContext context,
+            RowType keyValTypes,
+            ArrayData.ElementGetter keyGetter,
+            ArrayData.ElementGetter valueGetter);
+
+    public static LogicalType getUnnestedType(LogicalType logicalType, boolean withOrdinality) {
+        LogicalType baseType;
+        switch (logicalType.getTypeRoot()) {
+            case ARRAY:
+                baseType = ((ArrayType) logicalType).getElementType();
+                break;
+            case MULTISET:
+                baseType = ((MultisetType) logicalType).getElementType();
+                break;
+            case MAP:
+                MapType mapType = (MapType) logicalType;
+                if (withOrdinality) {
+                    return RowType.of(
+                            false,
+                            new LogicalType[] {
+                                mapType.getKeyType(),
+                                mapType.getValueType(),
+                                DataTypes.INT().notNull().getLogicalType()
+                            },
+                            new String[] {"f0", "f1", "ordinality"});
+                }
+                return RowType.of(false, mapType.getKeyType(), mapType.getValueType());
+            default:
+                throw new UnsupportedOperationException("Unsupported UNNEST type: " + logicalType);
+        }
+
+        if (withOrdinality) {
+            return RowType.of(
+                    false,
+                    new LogicalType[] {baseType, DataTypes.INT().notNull().getLogicalType()},
+                    new String[] {"f0", "ordinality"});
+        }
+        return baseType;
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Runtime Implementation Base Classes
+    // --------------------------------------------------------------------------------------------
+
+    /** Base class for table functions that unwrap collections and maps. */
+    protected abstract static class UnnestTableFunctionBase extends BuiltInTableFunction<Object> {
+        private final transient DataType outputDataType;
+
+        UnnestTableFunctionBase(SpecializedContext context, LogicalType elementType) {
+            super(BuiltInFunctionDefinitions.INTERNAL_UNNEST_ROWS, context);
+            outputDataType = DataTypes.of(elementType).toInternal();
+        }
+
+        // The output type in the context is already wrapped, however, the result of the function
+        // is not. Therefore, we this function has to be implemented with the custom output type.
+        @Override
+        public DataType getOutputDataType() {
+            return outputDataType;
+        }
+
+        protected void evalArrayData(
+                ArrayData arrayData,
+                ArrayData.ElementGetter elementGetter,
+                UnnestCollector collector) {
+            if (arrayData == null) {
+                return;
+            }
+            final int size = arrayData.size();
+            for (int pos = 0; pos < size; pos++) {
+                collector.collect(elementGetter.getElementOrNull(arrayData, pos), pos + 1);
+            }
+        }
+
+        protected void evalMapData(
+                MapData mapData,
+                ArrayData.ElementGetter keyGetter,
+                ArrayData.ElementGetter valueGetter,
+                MapUnnestCollector collector) {
+            if (mapData == null) {
+                return;
+            }
+            final int size = mapData.size();
+            final ArrayData keyArray = mapData.keyArray();
+            final ArrayData valueArray = mapData.valueArray();
+            for (int i = 0; i < size; i++) {
+                collector.collect(
+                        keyGetter.getElementOrNull(keyArray, i),
+                        valueGetter.getElementOrNull(valueArray, i),
+                        i + 1);
+            }
+        }
+
+        protected void evalMultisetData(
+                MapData mapData, ArrayData.ElementGetter elementGetter, UnnestCollector collector) {
+            if (mapData == null) {
+                return;
+            }
+            final int size = mapData.size();
+            final ArrayData keys = mapData.keyArray();
+            final ArrayData values = mapData.valueArray();
+            int ordinal = 1;
+            for (int pos = 0; pos < size; pos++) {
+                final int multiplier = values.getInt(pos);
+                final Object key = elementGetter.getElementOrNull(keys, pos);
+                for (int i = 0; i < multiplier; i++) {
+                    collector.collect(key, ordinal++);
+                }
+            }
+        }
+
+        @FunctionalInterface
+        protected interface UnnestCollector {
+            void collect(Object element, int position);
+        }
+
+        @FunctionalInterface
+        protected interface MapUnnestCollector {
+            void collect(Object key, Object value, int position);
+        }
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/table/UnnestRowsWithOrdinalityFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/table/UnnestRowsWithOrdinalityFunction.java
@@ -36,7 +36,7 @@ import org.apache.flink.table.types.logical.RowType;
 public class UnnestRowsWithOrdinalityFunction extends UnnestRowsFunctionBase {
 
     public UnnestRowsWithOrdinalityFunction() {
-        super();
+        super(true);
     }
 
     @Override
@@ -72,7 +72,7 @@ public class UnnestRowsWithOrdinalityFunction extends UnnestRowsFunctionBase {
                 SpecializedContext context,
                 LogicalType elementType,
                 ArrayData.ElementGetter elementGetter) {
-            super(context, elementType);
+            super(context, elementType, true);
             this.elementGetter = elementGetter;
 
             if (elementType instanceof RowType) {
@@ -133,7 +133,7 @@ public class UnnestRowsWithOrdinalityFunction extends UnnestRowsFunctionBase {
                 LogicalType keyValTypes,
                 ArrayData.ElementGetter keyGetter,
                 ArrayData.ElementGetter valueGetter) {
-            super(context, keyValTypes);
+            super(context, keyValTypes, true);
             this.keyGetter = keyGetter;
             this.valueGetter = valueGetter;
         }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/table/UnnestRowsWithOrdinalityFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/table/UnnestRowsWithOrdinalityFunction.java
@@ -80,6 +80,10 @@ public class UnnestRowsWithOrdinalityFunction extends UnnestRowsFunctionBase {
             this.elementGetter = elementGetter;
 
             if (elementType instanceof RowType) {
+                /* When unnesting a collection, according to Calcite's implementation,
+                row(a,b) unnests to a row(a, b, ordinality) and not to (row(a,b), ordinality).
+                That means, if we are unnesting a row, we need field getters
+                to be able to extract all field values */
                 RowType rowType = (RowType) elementType;
                 this.fieldGetters = createFieldGetters(rowType);
                 this.outputDataType = createRowTypeOutputDataType(rowType);


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The SQL standard specifies a WITH ORDINALITY clause that can be appended to any UNNEST function call, which returns a new row for each element and its position in the data structure being unnested.

Examples:

```sql
– Returns a new row for each element in a constant array and its position in the array
SELECT *
FROM (VALUES('order_1'))
CROSS JOIN UNNEST(ARRAY["shirt", "pants", "hat"])
WITH ORDINALITY AS t(product_name, index)

id       product_name  index
=======  ============  =====
order_1  shirt             1
order_1  pants             2
order_1  hat               3

– Returns a new row for each element and its position in the array assuming a Orders table with an array column `product_names`
SELECT order_id, product_name, product_index
FROM Orders
CROSS JOIN UNNEST(product_names)
WITH ORDINALITY AS t(product_name, product_index)
```

A unnest with ordinality will return each element and the position of the element in the data structure, 1-indexed. The order of the elements for arrays is guaranteed. Since maps and multisets are unordered, the order of the elements is not guaranteed.

## Brief change log

  - Created UnnestRowsWithOrdinalityFunction
  - Refactored code so we have one UnnestRowsFunctionBase for both with and without ordinality
  - Refactored to remove duplicated code: eval and type logic in UnnestRowsFunctionBase. We just `.collect` with or without the index (ordinality) as an extra column depending if with or without ordinality.
 - Call UnnestRowsFunction or UnnestRowsWithOrdinalityFunction in LogicalUnnestRule.java when rewriting tree.
 - For arrays and multisets of rows, we extract the fields and emit one single row with one extra column, following Calcite's implementation.
  - Revamped outdated unnest documentation

## Verifying this change

This change added tests and can be verified as follows:

  -  Added several stream tests, batch tests and plan tests    
   - I'm still testing/checking if we need to add other relevant tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
