### PR TITLE
[FLINK-37276] Add missing state v2 access interfaces in `RuntimeContext`

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/RuntimeContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/RuntimeContext.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.common.functions;
 
+import org.apache.flink.annotation.Experimental;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.JobInfo;
@@ -409,6 +410,95 @@ public interface RuntimeContext {
      */
     @PublicEvolving
     <UK, UV> MapState<UK, UV> getMapState(MapStateDescriptor<UK, UV> stateProperties);
+
+    // ------------------------------------------------------------------------
+    //  Methods for accessing state V2
+    // ------------------------------------------------------------------------
+
+    /**
+     * Gets a handle to the system's key/value state. The key/value state is only accessible if the
+     * function is executed on a KeyedStream. On each access, the state exposes the value for the
+     * key of the element currently processed by the function. Each function may have multiple
+     * partitioned states, addressed with different names.
+     *
+     * <p>Because the scope of each value is the key of the currently processed element, and the
+     * elements are distributed by the Flink runtime, the system can transparently scale out and
+     * redistribute the state and KeyedStream.
+     *
+     * @param stateProperties The descriptor defining the properties of the stats.
+     * @param <T> The type of value stored in the state.
+     * @return The partitioned state object.
+     * @throws UnsupportedOperationException Thrown, if no partitioned state is available for the
+     *     function (function is not part of a KeyedStream).
+     */
+    @Experimental
+    <T> org.apache.flink.api.common.state.v2.ValueState<T> getState(
+            org.apache.flink.api.common.state.v2.ValueStateDescriptor<T> stateProperties);
+
+    /**
+     * Gets a handle to the system's key/value list state. This state is similar to the state
+     * accessed via {@link #getState(ValueStateDescriptor)}, but is optimized for state that holds
+     * lists. One can add elements to the list, or retrieve the list as a whole.
+     *
+     * @param stateProperties The descriptor defining the properties of the stats.
+     * @param <T> The type of value stored in the state.
+     * @return The partitioned state object.
+     * @throws UnsupportedOperationException Thrown, if no partitioned state is available for the
+     *     function (function is not part os a KeyedStream).
+     */
+    @Experimental
+    <T> org.apache.flink.api.common.state.v2.ListState<T> getListState(
+            org.apache.flink.api.common.state.v2.ListStateDescriptor<T> stateProperties);
+
+    /**
+     * Gets a handle to the system's key/value reducing state. This state is similar to the state
+     * accessed via {@link #getState(ValueStateDescriptor)}, but is optimized for state that
+     * aggregates values.
+     *
+     * @param stateProperties The descriptor defining the properties of the stats.
+     * @param <T> The type of value stored in the state.
+     * @return The partitioned state object.
+     * @throws UnsupportedOperationException Thrown, if no partitioned state is available for the
+     *     function (function is not part of a KeyedStream).
+     */
+    @Experimental
+    <T> org.apache.flink.api.common.state.v2.ReducingState<T> getReducingState(
+            org.apache.flink.api.common.state.v2.ReducingStateDescriptor<T> stateProperties);
+
+    /**
+     * Gets a handle to the system's key/value aggregating state. This state is similar to the state
+     * accessed via {@link #getState(ValueStateDescriptor)}, but is optimized for state that
+     * aggregates values with different types.
+     *
+     * @param stateProperties The descriptor defining the properties of the stats.
+     * @param <IN> The type of the values that are added to the state.
+     * @param <ACC> The type of the accumulator (intermediate aggregation state).
+     * @param <OUT> The type of the values that are returned from the state.
+     * @return The partitioned state object.
+     * @throws UnsupportedOperationException Thrown, if no partitioned state is available for the
+     *     function (function is not part of a KeyedStream).
+     */
+    @Experimental
+    <IN, ACC, OUT>
+            org.apache.flink.api.common.state.v2.AggregatingState<IN, OUT> getAggregatingState(
+                    org.apache.flink.api.common.state.v2.AggregatingStateDescriptor<IN, ACC, OUT>
+                            stateProperties);
+
+    /**
+     * Gets a handle to the system's key/value map state. This state is similar to the state
+     * accessed via {@link #getState(ValueStateDescriptor)}, but is optimized for state that is
+     * composed of user-defined key-value pairs
+     *
+     * @param stateProperties The descriptor defining the properties of the stats.
+     * @param <UK> The type of the user keys stored in the state.
+     * @param <UV> The type of the user values stored in the state.
+     * @return The partitioned state object.
+     * @throws UnsupportedOperationException Thrown, if no partitioned state is available for the
+     *     function (function is not part of a KeyedStream).
+     */
+    @Experimental
+    <UK, UV> org.apache.flink.api.common.state.v2.MapState<UK, UV> getMapState(
+            org.apache.flink.api.common.state.v2.MapStateDescriptor<UK, UV> stateProperties);
 
     /**
      * Get the meta information of current job.

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/util/AbstractRuntimeUDFContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/util/AbstractRuntimeUDFContext.java
@@ -232,6 +232,43 @@ public abstract class AbstractRuntimeUDFContext implements RuntimeContext {
                 "This state is only accessible by functions executed on a KeyedStream");
     }
 
+    @Override
+    public <T> org.apache.flink.api.common.state.v2.ValueState<T> getState(
+            org.apache.flink.api.common.state.v2.ValueStateDescriptor<T> stateProperties) {
+        throw new UnsupportedOperationException(
+                "This state is only accessible by functions executed on a KeyedStream");
+    }
+
+    @Override
+    public <T> org.apache.flink.api.common.state.v2.ListState<T> getListState(
+            org.apache.flink.api.common.state.v2.ListStateDescriptor<T> stateProperties) {
+        throw new UnsupportedOperationException(
+                "This state is only accessible by functions executed on a KeyedStream");
+    }
+
+    @Override
+    public <T> org.apache.flink.api.common.state.v2.ReducingState<T> getReducingState(
+            org.apache.flink.api.common.state.v2.ReducingStateDescriptor<T> stateProperties) {
+        throw new UnsupportedOperationException(
+                "This state is only accessible by functions executed on a KeyedStream");
+    }
+
+    @Override
+    public <IN, ACC, OUT>
+            org.apache.flink.api.common.state.v2.AggregatingState<IN, OUT> getAggregatingState(
+                    org.apache.flink.api.common.state.v2.AggregatingStateDescriptor<IN, ACC, OUT>
+                            stateProperties) {
+        throw new UnsupportedOperationException(
+                "This state is only accessible by functions executed on a KeyedStream");
+    }
+
+    @Override
+    public <UK, UV> org.apache.flink.api.common.state.v2.MapState<UK, UV> getMapState(
+            org.apache.flink.api.common.state.v2.MapStateDescriptor<UK, UV> stateProperties) {
+        throw new UnsupportedOperationException(
+                "This state is only accessible by functions executed on a KeyedStream");
+    }
+
     @Internal
     @VisibleForTesting
     public String getAllocationIDAsString() {

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/v2/AggregatingStateDescriptor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/v2/AggregatingStateDescriptor.java
@@ -43,7 +43,7 @@ public class AggregatingStateDescriptor<IN, ACC, OUT> extends StateDescriptor<AC
     private final AggregateFunction<IN, ACC, OUT> aggregateFunction;
 
     /**
-     * Create a new state descriptor with the given name, function, and type.
+     * Create a new {@code AggregatingStateDescriptor} with the given name, function, and type.
      *
      * @param stateId The (unique) name for the state.
      * @param aggregateFunction The {@code AggregateFunction} used to aggregate the state.
@@ -58,7 +58,7 @@ public class AggregatingStateDescriptor<IN, ACC, OUT> extends StateDescriptor<AC
     }
 
     /**
-     * Create a new {@code ReducingStateDescriptor} with the given stateId and the given type
+     * Create a new {@code AggregatingStateDescriptor} with the given stateId and the given type
      * serializer.
      *
      * @param stateId The (unique) stateId for the state.
@@ -70,6 +70,23 @@ public class AggregatingStateDescriptor<IN, ACC, OUT> extends StateDescriptor<AC
             @Nonnull TypeSerializer<ACC> serializer) {
         super(stateId, serializer);
         this.aggregateFunction = checkNotNull(aggregateFunction);
+    }
+
+    /**
+     * Creates a new {@code AggregatingStateDescriptor} with the given name, function, and type.
+     *
+     * <p>If this constructor fails (because it is not possible to describe the type via a class),
+     * consider using the {@link #AggregatingStateDescriptor(String, AggregateFunction,
+     * TypeInformation)} constructor.
+     *
+     * @param name The (unique) name for the state.
+     * @param aggFunction The {@code AggregateFunction} used to aggregate the state.
+     * @param stateType The type of the accumulator. The accumulator is stored in the state.
+     */
+    public AggregatingStateDescriptor(
+            String name, AggregateFunction<IN, ACC, OUT> aggFunction, Class<ACC> stateType) {
+        super(name, stateType);
+        this.aggregateFunction = checkNotNull(aggFunction);
     }
 
     /** Returns the Aggregate function for this state. */

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/v2/ListStateDescriptor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/v2/ListStateDescriptor.java
@@ -54,6 +54,19 @@ public class ListStateDescriptor<T> extends StateDescriptor<T> {
         super(stateId, serializer);
     }
 
+    /**
+     * Creates a new {@code ListStateDescriptor} with the given name and list element type.
+     *
+     * <p>If this constructor fails (because it is not possible to describe the type via a class),
+     * consider using the {@link #ListStateDescriptor(String, TypeInformation)} constructor.
+     *
+     * @param name The (unique) name for the state.
+     * @param elementTypeClass The type of the elements in the state.
+     */
+    public ListStateDescriptor(String name, Class<T> elementTypeClass) {
+        super(name, elementTypeClass);
+    }
+
     @Override
     public Type getType() {
         return Type.LIST;

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/v2/MapStateDescriptor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/v2/MapStateDescriptor.java
@@ -71,6 +71,22 @@ public class MapStateDescriptor<UK, UV> extends StateDescriptor<UV> {
         this.userKeySerializer = new StateSerializerReference<>(userKeySerializer);
     }
 
+    /**
+     * Create a new {@code MapStateDescriptor} with the given name and the given type information.
+     *
+     * <p>If this constructor fails (because it is not possible to describe the type via a class),
+     * consider using the {@link #MapStateDescriptor(String, TypeInformation, TypeInformation)}
+     * constructor.
+     *
+     * @param name The name of the {@code MapStateDescriptor}.
+     * @param keyClass The class of the type of keys in the state.
+     * @param valueClass The class of the type of values in the state.
+     */
+    public MapStateDescriptor(String name, Class<UK> keyClass, Class<UV> valueClass) {
+        super(name, valueClass);
+        this.userKeySerializer = new StateSerializerReference<>(keyClass);
+    }
+
     @Nonnull
     public TypeSerializer<UK> getUserKeySerializer() {
         TypeSerializer<UK> serializer = userKeySerializer.get();

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/v2/ReducingStateDescriptor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/v2/ReducingStateDescriptor.java
@@ -67,6 +67,23 @@ public class ReducingStateDescriptor<T> extends StateDescriptor<T> {
         this.reduceFunction = checkNotNull(reduceFunction);
     }
 
+    /**
+     * Creates a new {@code ReducingStateDescriptor} with the given name, type, and default value.
+     *
+     * <p>If this constructor fails (because it is not possible to describe the type via a class),
+     * consider using the {@link #ReducingStateDescriptor(String, ReduceFunction, TypeInformation)}
+     * constructor.
+     *
+     * @param name The (unique) name for the state.
+     * @param reduceFunction The {@code ReduceFunction} used to aggregate the state.
+     * @param typeClass The type of the values in the state.
+     */
+    public ReducingStateDescriptor(
+            String name, ReduceFunction<T> reduceFunction, Class<T> typeClass) {
+        super(name, typeClass);
+        this.reduceFunction = checkNotNull(reduceFunction);
+    }
+
     /** Returns the reduce function to be used for the reducing state. */
     public ReduceFunction<T> getReduceFunction() {
         return reduceFunction;

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/v2/StateDescriptor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/v2/StateDescriptor.java
@@ -87,6 +87,21 @@ public abstract class StateDescriptor<T> implements Serializable {
         this.typeSerializer = new StateSerializerReference<>(serializer);
     }
 
+    /**
+     * Create a new {@code StateDescriptor} with the given name and the given type information.
+     *
+     * <p>If this constructor fails (because it is not possible to describe the type via a class),
+     * consider using the {@link #StateDescriptor(String, TypeInformation)} constructor.
+     *
+     * @param name The name of the {@code StateDescriptor}.
+     * @param type The class of the type of values in the state.
+     */
+    protected StateDescriptor(String name, Class<T> type) {
+        this.stateId = checkNotNull(name, "name must not be null");
+        checkNotNull(type, "type class must not be null");
+        this.typeSerializer = new StateSerializerReference<>(type);
+    }
+
     // ------------------------------------------------------------------------
 
     /**

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/v2/ValueStateDescriptor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/v2/ValueStateDescriptor.java
@@ -54,6 +54,19 @@ public class ValueStateDescriptor<T> extends StateDescriptor<T> {
         super(stateId, serializer);
     }
 
+    /**
+     * Creates a new {@code ValueStateDescriptor} with the given name and type
+     *
+     * <p>If this constructor fails (because it is not possible to describe the type via a class),
+     * consider using the {@link #ValueStateDescriptor(String, TypeInformation)} constructor.
+     *
+     * @param stateId The (unique) name for the state.
+     * @param typeClass The type of the values in the state.
+     */
+    public ValueStateDescriptor(@Nonnull String stateId, @Nonnull Class<T> typeClass) {
+        super(stateId, typeClass);
+    }
+
     @Override
     public Type getType() {
         return Type.VALUE;

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CepRuntimeContext.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CepRuntimeContext.java
@@ -194,4 +194,36 @@ class CepRuntimeContext implements RuntimeContext {
     public <UK, UV> MapState<UK, UV> getMapState(final MapStateDescriptor<UK, UV> stateProperties) {
         throw new UnsupportedOperationException("State is not supported.");
     }
+
+    @Override
+    public <T> org.apache.flink.api.common.state.v2.ValueState<T> getState(
+            org.apache.flink.api.common.state.v2.ValueStateDescriptor<T> stateProperties) {
+        throw new UnsupportedOperationException("State is not supported.");
+    }
+
+    @Override
+    public <T> org.apache.flink.api.common.state.v2.ListState<T> getListState(
+            org.apache.flink.api.common.state.v2.ListStateDescriptor<T> stateProperties) {
+        throw new UnsupportedOperationException("State is not supported.");
+    }
+
+    @Override
+    public <T> org.apache.flink.api.common.state.v2.ReducingState<T> getReducingState(
+            org.apache.flink.api.common.state.v2.ReducingStateDescriptor<T> stateProperties) {
+        throw new UnsupportedOperationException("State is not supported.");
+    }
+
+    @Override
+    public <IN, ACC, OUT>
+            org.apache.flink.api.common.state.v2.AggregatingState<IN, OUT> getAggregatingState(
+                    org.apache.flink.api.common.state.v2.AggregatingStateDescriptor<IN, ACC, OUT>
+                            stateProperties) {
+        throw new UnsupportedOperationException("State is not supported.");
+    }
+
+    @Override
+    public <UK, UV> org.apache.flink.api.common.state.v2.MapState<UK, UV> getMapState(
+            org.apache.flink.api.common.state.v2.MapStateDescriptor<UK, UV> stateProperties) {
+        throw new UnsupportedOperationException("State is not supported.");
+    }
 }

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CepRuntimeContextTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CepRuntimeContextTest.java
@@ -192,6 +192,51 @@ public class CepRuntimeContextTest extends TestLogger {
         }
 
         try {
+            runtimeContext.getState(
+                    new org.apache.flink.api.common.state.v2.ValueStateDescriptor<>(
+                            "foobar", Integer.class));
+            fail("Expected getState to fail with unsupported operation exception.");
+        } catch (UnsupportedOperationException e) {
+            // expected
+        }
+
+        try {
+            runtimeContext.getListState(
+                    new org.apache.flink.api.common.state.v2.ListStateDescriptor<>(
+                            "foobar", Integer.class));
+            fail("Expected getListState to fail with unsupported operation exception.");
+        } catch (UnsupportedOperationException e) {
+            // expected
+        }
+
+        try {
+            runtimeContext.getReducingState(
+                    new org.apache.flink.api.common.state.v2.ReducingStateDescriptor<>(
+                            "foobar", mock(ReduceFunction.class), Integer.class));
+            fail("Expected getReducingState to fail with unsupported operation exception.");
+        } catch (UnsupportedOperationException e) {
+            // expected
+        }
+
+        try {
+            runtimeContext.getAggregatingState(
+                    new org.apache.flink.api.common.state.v2.AggregatingStateDescriptor<>(
+                            "foobar", mock(AggregateFunction.class), Integer.class));
+            fail("Expected getAggregatingState to fail with unsupported operation exception.");
+        } catch (UnsupportedOperationException e) {
+            // expected
+        }
+
+        try {
+            runtimeContext.getMapState(
+                    new org.apache.flink.api.common.state.v2.MapStateDescriptor<>(
+                            "foobar", Integer.class, String.class));
+            fail("Expected getMapState to fail with unsupported operation exception.");
+        } catch (UnsupportedOperationException e) {
+            // expected
+        }
+
+        try {
             runtimeContext.addAccumulator("foobar", mock(Accumulator.class));
             fail("Expected addAccumulator to fail with unsupported operation exception.");
         } catch (UnsupportedOperationException e) {

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointRuntimeContext.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointRuntimeContext.java
@@ -232,6 +232,38 @@ public final class SavepointRuntimeContext implements RuntimeContext {
         return keyedStateStore.getMapState(stateProperties);
     }
 
+    @Override
+    public <T> org.apache.flink.api.common.state.v2.ValueState<T> getState(
+            org.apache.flink.api.common.state.v2.ValueStateDescriptor<T> stateProperties) {
+        throw new UnsupportedOperationException("State processor api does not support state v2.");
+    }
+
+    @Override
+    public <T> org.apache.flink.api.common.state.v2.ListState<T> getListState(
+            org.apache.flink.api.common.state.v2.ListStateDescriptor<T> stateProperties) {
+        throw new UnsupportedOperationException("State processor api does not support state v2.");
+    }
+
+    @Override
+    public <T> org.apache.flink.api.common.state.v2.ReducingState<T> getReducingState(
+            org.apache.flink.api.common.state.v2.ReducingStateDescriptor<T> stateProperties) {
+        throw new UnsupportedOperationException("State processor api does not support state v2.");
+    }
+
+    @Override
+    public <IN, ACC, OUT>
+            org.apache.flink.api.common.state.v2.AggregatingState<IN, OUT> getAggregatingState(
+                    org.apache.flink.api.common.state.v2.AggregatingStateDescriptor<IN, ACC, OUT>
+                            stateProperties) {
+        throw new UnsupportedOperationException("State processor api does not support state v2.");
+    }
+
+    @Override
+    public <UK, UV> org.apache.flink.api.common.state.v2.MapState<UK, UV> getMapState(
+            org.apache.flink.api.common.state.v2.MapStateDescriptor<UK, UV> stateProperties) {
+        throw new UnsupportedOperationException("State processor api does not support state v2.");
+    }
+
     public List<StateDescriptor<?, ?>> getStateDescriptors() {
         if (registeredDescriptors.isEmpty()) {
             return Collections.emptyList();

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContext.java
@@ -247,6 +247,12 @@ public class StreamingRuntimeContext extends AbstractRuntimeUDFContext {
         return keyedStateStore;
     }
 
+    @Override
+    public <T> org.apache.flink.api.common.state.v2.ValueState<T> getState(
+            org.apache.flink.api.common.state.v2.ValueStateDescriptor<T> stateProperties) {
+        return getValueState(stateProperties);
+    }
+
     // TODO: Reconstruct this after StateManager is ready in FLIP-410.
     public <T> org.apache.flink.api.common.state.v2.ValueState<T> getValueState(
             org.apache.flink.api.common.state.v2.ValueStateDescriptor<T> stateProperties) {
@@ -255,6 +261,7 @@ public class StreamingRuntimeContext extends AbstractRuntimeUDFContext {
         return keyedStateStore.getValueState(stateProperties);
     }
 
+    @Override
     public <T> org.apache.flink.api.common.state.v2.ListState<T> getListState(
             org.apache.flink.api.common.state.v2.ListStateDescriptor<T> stateProperties) {
         KeyedStateStore keyedStateStore = checkPreconditionsAndGetKeyedStateStore(stateProperties);
@@ -262,6 +269,7 @@ public class StreamingRuntimeContext extends AbstractRuntimeUDFContext {
         return keyedStateStore.getListState(stateProperties);
     }
 
+    @Override
     public <UK, UV> org.apache.flink.api.common.state.v2.MapState<UK, UV> getMapState(
             org.apache.flink.api.common.state.v2.MapStateDescriptor<UK, UV> stateProperties) {
         KeyedStateStore keyedStateStore = checkPreconditionsAndGetKeyedStateStore(stateProperties);
@@ -269,6 +277,7 @@ public class StreamingRuntimeContext extends AbstractRuntimeUDFContext {
         return keyedStateStore.getMapState(stateProperties);
     }
 
+    @Override
     public <T> org.apache.flink.api.common.state.v2.ReducingState<T> getReducingState(
             org.apache.flink.api.common.state.v2.ReducingStateDescriptor<T> stateProperties) {
         KeyedStateStore keyedStateStore = checkPreconditionsAndGetKeyedStateStore(stateProperties);
@@ -276,6 +285,7 @@ public class StreamingRuntimeContext extends AbstractRuntimeUDFContext {
         return keyedStateStore.getReducingState(stateProperties);
     }
 
+    @Override
     public <IN, ACC, OUT>
             org.apache.flink.api.common.state.v2.AggregatingState<IN, OUT> getAggregatingState(
                     org.apache.flink.api.common.state.v2.AggregatingStateDescriptor<IN, ACC, OUT>

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/RichAsyncFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/RichAsyncFunction.java
@@ -187,6 +187,44 @@ public abstract class RichAsyncFunction<IN, OUT> extends AbstractRichFunction
         }
 
         @Override
+        public <T> org.apache.flink.api.common.state.v2.ValueState<T> getState(
+                org.apache.flink.api.common.state.v2.ValueStateDescriptor<T> stateProperties) {
+            throw new UnsupportedOperationException(
+                    "State is not supported in rich async functions.");
+        }
+
+        @Override
+        public <T> org.apache.flink.api.common.state.v2.ListState<T> getListState(
+                org.apache.flink.api.common.state.v2.ListStateDescriptor<T> stateProperties) {
+            throw new UnsupportedOperationException(
+                    "State is not supported in rich async functions.");
+        }
+
+        @Override
+        public <T> org.apache.flink.api.common.state.v2.ReducingState<T> getReducingState(
+                org.apache.flink.api.common.state.v2.ReducingStateDescriptor<T> stateProperties) {
+            throw new UnsupportedOperationException(
+                    "State is not supported in rich async functions.");
+        }
+
+        @Override
+        public <IN, ACC, OUT>
+                org.apache.flink.api.common.state.v2.AggregatingState<IN, OUT> getAggregatingState(
+                        org.apache.flink.api.common.state.v2.AggregatingStateDescriptor<
+                                        IN, ACC, OUT>
+                                stateProperties) {
+            throw new UnsupportedOperationException(
+                    "State is not supported in rich async functions.");
+        }
+
+        @Override
+        public <UK, UV> org.apache.flink.api.common.state.v2.MapState<UK, UV> getMapState(
+                org.apache.flink.api.common.state.v2.MapStateDescriptor<UK, UV> stateProperties) {
+            throw new UnsupportedOperationException(
+                    "State is not supported in rich async functions.");
+        }
+
+        @Override
         public <V, A extends Serializable> void addAccumulator(
                 String name, Accumulator<V, A> accumulator) {
             throw new UnsupportedOperationException(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/async/RichAsyncFunctionTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/async/RichAsyncFunctionTest.java
@@ -207,6 +207,79 @@ class RichAsyncFunctionTest {
 
         assertThatThrownBy(
                         () ->
+                                runtimeContext.getState(
+                                        new org.apache.flink.api.common.state.v2
+                                                .ValueStateDescriptor<>("foobar", Integer.class)))
+                .isInstanceOf(UnsupportedOperationException.class);
+
+        assertThatThrownBy(
+                        () ->
+                                runtimeContext.getListState(
+                                        new org.apache.flink.api.common.state.v2
+                                                .ListStateDescriptor<>("foobar", Integer.class)))
+                .isInstanceOf(UnsupportedOperationException.class);
+
+        assertThatThrownBy(
+                        () ->
+                                runtimeContext.getReducingState(
+                                        new org.apache.flink.api.common.state.v2
+                                                .ReducingStateDescriptor<>(
+                                                "foobar",
+                                                new ReduceFunction<Integer>() {
+                                                    private static final long serialVersionUID =
+                                                            2136425961884441050L;
+
+                                                    @Override
+                                                    public Integer reduce(
+                                                            Integer value1, Integer value2) {
+                                                        return value1;
+                                                    }
+                                                },
+                                                Integer.class)))
+                .isInstanceOf(UnsupportedOperationException.class);
+
+        assertThatThrownBy(
+                        () ->
+                                runtimeContext.getAggregatingState(
+                                        new org.apache.flink.api.common.state.v2
+                                                .AggregatingStateDescriptor<>(
+                                                "foobar",
+                                                new AggregateFunction<Integer, Integer, Integer>() {
+
+                                                    @Override
+                                                    public Integer createAccumulator() {
+                                                        return null;
+                                                    }
+
+                                                    @Override
+                                                    public Integer add(
+                                                            Integer value, Integer accumulator) {
+                                                        return null;
+                                                    }
+
+                                                    @Override
+                                                    public Integer getResult(Integer accumulator) {
+                                                        return null;
+                                                    }
+
+                                                    @Override
+                                                    public Integer merge(Integer a, Integer b) {
+                                                        return null;
+                                                    }
+                                                },
+                                                Integer.class)))
+                .isInstanceOf(UnsupportedOperationException.class);
+
+        assertThatThrownBy(
+                        () ->
+                                runtimeContext.getMapState(
+                                        new org.apache.flink.api.common.state.v2
+                                                .MapStateDescriptor<>(
+                                                "foobar", Integer.class, String.class)))
+                .isInstanceOf(UnsupportedOperationException.class);
+
+        assertThatThrownBy(
+                        () ->
                                 runtimeContext.addAccumulator(
                                         "foobar",
                                         new Accumulator<Integer, Integer>() {

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/aggregate/async/AsyncStateGroupAggFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/aggregate/async/AsyncStateGroupAggFunction.java
@@ -21,7 +21,6 @@ package org.apache.flink.table.runtime.operators.aggregate.async;
 import org.apache.flink.api.common.functions.OpenContext;
 import org.apache.flink.api.common.state.v2.ValueState;
 import org.apache.flink.api.common.state.v2.ValueStateDescriptor;
-import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.generated.GeneratedAggsHandleFunction;
 import org.apache.flink.table.runtime.generated.GeneratedRecordEqualiser;
@@ -86,7 +85,7 @@ public class AsyncStateGroupAggFunction extends GroupAggFunctionBase {
             accDesc.enableTimeToLive(ttlConfig);
         }
 
-        accState = ((StreamingRuntimeContext) getRuntimeContext()).getValueState(accDesc);
+        accState = getRuntimeContext().getState(accDesc);
         aggHelper = new AsyncStateGroupAggHelper();
     }
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/asyncprocessing/AsyncStateDeduplicateFunctionBase.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/asyncprocessing/AsyncStateDeduplicateFunctionBase.java
@@ -24,7 +24,6 @@ import org.apache.flink.api.common.state.v2.ValueState;
 import org.apache.flink.api.common.state.v2.ValueStateDescriptor;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
 import org.apache.flink.table.runtime.operators.deduplicate.DeduplicateFunctionBase;
 
 import org.slf4j.Logger;
@@ -68,6 +67,6 @@ abstract class AsyncStateDeduplicateFunctionBase<T, K, IN, OUT>
         if (ttlConfig.isEnabled()) {
             stateDesc.enableTimeToLive(ttlConfig);
         }
-        state = ((StreamingRuntimeContext) getRuntimeContext()).getValueState(stateDesc);
+        state = getRuntimeContext().getState(stateDesc);
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/async/AbstractAsyncStateTopNFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/async/AbstractAsyncStateTopNFunction.java
@@ -25,7 +25,6 @@ import org.apache.flink.api.common.state.v2.ValueState;
 import org.apache.flink.api.common.state.v2.ValueStateDescriptor;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.core.state.StateFutureUtils;
-import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.generated.GeneratedRecordComparator;
 import org.apache.flink.table.runtime.keyselector.RowDataKeySelector;
@@ -78,8 +77,7 @@ public abstract class AbstractAsyncStateTopNFunction extends AbstractTopNFunctio
             if (ttlConfig.isEnabled()) {
                 rankStateDesc.enableTimeToLive(ttlConfig);
             }
-            rankEndState =
-                    ((StreamingRuntimeContext) getRuntimeContext()).getValueState(rankStateDesc);
+            rankEndState = getRuntimeContext().getState(rankStateDesc);
         }
     }
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/async/AsyncStateAppendOnlyTopNFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/async/AsyncStateAppendOnlyTopNFunction.java
@@ -27,7 +27,6 @@ import org.apache.flink.api.common.state.v2.StateFuture;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.typeutils.ListTypeInfo;
 import org.apache.flink.core.state.StateFutureUtils;
-import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.generated.GeneratedRecordComparator;
 import org.apache.flink.table.runtime.keyselector.RowDataKeySelector;
@@ -97,7 +96,7 @@ public class AsyncStateAppendOnlyTopNFunction extends AbstractAsyncStateTopNFunc
         if (ttlConfig.isEnabled()) {
             mapStateDescriptor.enableTimeToLive(ttlConfig);
         }
-        dataState = ((StreamingRuntimeContext) getRuntimeContext()).getMapState(mapStateDescriptor);
+        dataState = getRuntimeContext().getMapState(mapStateDescriptor);
 
         helper = new AsyncStateAppendOnlyTopNHelper();
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/async/AsyncStateFastTop1Function.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/async/AsyncStateFastTop1Function.java
@@ -30,7 +30,6 @@ import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
-import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
 import org.apache.flink.streaming.runtime.operators.asyncprocessing.AsyncStateProcessingOperator;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.generated.GeneratedRecordComparator;
@@ -98,8 +97,7 @@ public class AsyncStateFastTop1Function extends AbstractAsyncStateTopNFunction
         if (ttlConfig.isEnabled()) {
             valueStateDescriptor.enableTimeToLive(ttlConfig);
         }
-        dataState =
-                ((StreamingRuntimeContext) getRuntimeContext()).getValueState(valueStateDescriptor);
+        dataState = getRuntimeContext().getState(valueStateDescriptor);
 
         helper = new AsyncStateFastTop1Helper();
 


### PR DESCRIPTION
## What is the purpose of the change

We have introduced the state v2 creating methods in `StreamingRuntimeContext`, but these methods have not exposed to `RuntimeContext`. Thus user may not be able to access the state via `getRuntimeContext().getState`. 

## Brief change log

- Add Add constructors for state v2 descriptors that accept type class
- Add state access interfaces in `RuntimeContext`

## Verifying this change

This change is a trivial work without any test coverage.
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
