### PR TITLE
[FLINK-37243] Adds main thread callback to AsyncWaitOperator

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/CollectionSupplier.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/CollectionSupplier.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.functions.async;
+
+import java.util.Collection;
+
+/**
+ * Supplies a collection of output. Used in {@link ResultFuture} to provide a supplier for results.
+ *
+ * @param <OUT> The type of the output.
+ */
+public interface CollectionSupplier<OUT> {
+    /**
+     * Returns the collection of results.
+     *
+     * @throws Exception
+     */
+    Collection<OUT> get() throws Exception;
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/CollectionSupplier.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/CollectionSupplier.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.streaming.api.functions.async;
 
+import org.apache.flink.annotation.PublicEvolving;
+
 import java.util.Collection;
 
 /**
@@ -25,6 +27,7 @@ import java.util.Collection;
  *
  * @param <OUT> The type of the output.
  */
+@PublicEvolving
 public interface CollectionSupplier<OUT> {
     /**
      * Returns the collection of results.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/ResultFuture.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/ResultFuture.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.api.functions.async;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.util.function.SupplierWithException;
 
 import java.util.Collection;
 
@@ -47,4 +48,13 @@ public interface ResultFuture<OUT> {
      * @param error A Throwable object.
      */
     void completeExceptionally(Throwable error);
+
+    /**
+     * The same as complete, but will execute the supplier on the Mailbox thread which initiated the
+     * asynchronous process.
+     *
+     * <p>Note that if an exception is thrown while executing the supplier, the result should be the
+     * same as calling {@link ResultFuture#completeExceptionally(Throwable)}.
+     */
+    void complete(SupplierWithException<Collection<OUT>, Exception> supplier);
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/ResultFuture.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/ResultFuture.java
@@ -19,7 +19,6 @@
 package org.apache.flink.streaming.api.functions.async;
 
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.util.function.SupplierWithException;
 
 import java.util.Collection;
 
@@ -56,5 +55,5 @@ public interface ResultFuture<OUT> {
      * <p>Note that if an exception is thrown while executing the supplier, the result should be the
      * same as calling {@link ResultFuture#completeExceptionally(Throwable)}.
      */
-    void complete(SupplierWithException<Collection<OUT>, Exception> supplier);
+    void complete(CollectionSupplier<OUT> supplier);
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/queue/StreamElementQueueEntry.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/queue/StreamElementQueueEntry.java
@@ -22,8 +22,11 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.streaming.api.functions.async.ResultFuture;
 import org.apache.flink.streaming.api.operators.TimestampedCollector;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
+import org.apache.flink.util.function.SupplierWithException;
 
 import javax.annotation.Nonnull;
+
+import java.util.Collection;
 
 /**
  * An entry for the {@link StreamElementQueue}. The stream element queue entry stores the {@link
@@ -61,5 +64,9 @@ interface StreamElementQueueEntry<OUT> extends ResultFuture<OUT> {
     default void completeExceptionally(Throwable error) {
         throw new UnsupportedOperationException(
                 "This result future should only be used to set completed results.");
+    }
+
+    default void complete(SupplierWithException<Collection<OUT>, Exception> supplier) {
+        throw new UnsupportedOperationException();
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/queue/StreamElementQueueEntry.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/queue/StreamElementQueueEntry.java
@@ -19,14 +19,12 @@
 package org.apache.flink.streaming.api.operators.async.queue;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.streaming.api.functions.async.CollectionSupplier;
 import org.apache.flink.streaming.api.functions.async.ResultFuture;
 import org.apache.flink.streaming.api.operators.TimestampedCollector;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
-import org.apache.flink.util.function.SupplierWithException;
 
 import javax.annotation.Nonnull;
-
-import java.util.Collection;
 
 /**
  * An entry for the {@link StreamElementQueue}. The stream element queue entry stores the {@link
@@ -66,7 +64,7 @@ interface StreamElementQueueEntry<OUT> extends ResultFuture<OUT> {
                 "This result future should only be used to set completed results.");
     }
 
-    default void complete(SupplierWithException<Collection<OUT>, Exception> supplier) {
+    default void complete(CollectionSupplier<OUT> supplier) {
         throw new UnsupportedOperationException();
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
@@ -1359,7 +1359,7 @@ class AsyncWaitOperatorTest {
         testProcessingTimeWithMailboxThreadError(exceptionRetryStrategy);
     }
 
-    public void testProcessingTimeWithMailboxThreadError(
+    private void testProcessingTimeWithMailboxThreadError(
             @Nullable AsyncRetryStrategy<Integer> asyncRetryStrategy) throws Exception {
         StreamTaskMailboxTestHarnessBuilder<Integer> builder =
                 new StreamTaskMailboxTestHarnessBuilder<>(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
@@ -96,8 +96,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.apache.flink.streaming.util.retryable.AsyncRetryStrategies.NO_RETRY_STRATEGY;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 /**

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
@@ -1329,37 +1329,39 @@ class AsyncWaitOperatorTest {
 
     @Test
     public void testProcessingTimeWithMailboxThreadOrdered() throws Exception {
-        testProcessingTimeWithCallThread(AsyncDataStream.OutputMode.ORDERED, NO_RETRY_STRATEGY);
+        testProcessingTimeWithCollectFromMailboxThread(
+                AsyncDataStream.OutputMode.ORDERED, NO_RETRY_STRATEGY);
     }
 
     @Test
     public void testProcessingTimeWithMailboxThreadUnordered() throws Exception {
-        testProcessingTimeWithCallThread(AsyncDataStream.OutputMode.UNORDERED, NO_RETRY_STRATEGY);
+        testProcessingTimeWithCollectFromMailboxThread(
+                AsyncDataStream.OutputMode.UNORDERED, NO_RETRY_STRATEGY);
     }
 
     @Test
     public void testProcessingTimeWithMailboxThreadOrderedWithRetry() throws Exception {
-        testProcessingTimeWithCallThread(
+        testProcessingTimeWithCollectFromMailboxThread(
                 AsyncDataStream.OutputMode.ORDERED, exceptionRetryStrategy);
     }
 
     @Test
     public void testProcessingTimeWithMailboxThreadUnorderedWithRetry() throws Exception {
-        testProcessingTimeWithCallThread(
+        testProcessingTimeWithCollectFromMailboxThread(
                 AsyncDataStream.OutputMode.UNORDERED, exceptionRetryStrategy);
     }
 
     @Test
-    public void testProcessingTimeWithMailboxThreadError() throws Exception {
-        testProcessingTimeWithMailboxThreadError(NO_RETRY_STRATEGY);
+    public void testProcessingTimeWithErrorFromMailboxThread() throws Exception {
+        testProcessingTimeWithErrorFromMailboxThread(NO_RETRY_STRATEGY);
     }
 
     @Test
     public void testProcessingTimeWithMailboxThreadErrorWithRetry() throws Exception {
-        testProcessingTimeWithMailboxThreadError(exceptionRetryStrategy);
+        testProcessingTimeWithErrorFromMailboxThread(exceptionRetryStrategy);
     }
 
-    private void testProcessingTimeWithMailboxThreadError(
+    private void testProcessingTimeWithErrorFromMailboxThread(
             @Nullable AsyncRetryStrategy<Integer> asyncRetryStrategy) throws Exception {
         StreamTaskMailboxTestHarnessBuilder<Integer> builder =
                 new StreamTaskMailboxTestHarnessBuilder<>(
@@ -1396,7 +1398,7 @@ class AsyncWaitOperatorTest {
         }
     }
 
-    private void testProcessingTimeWithCallThread(
+    private void testProcessingTimeWithCollectFromMailboxThread(
             AsyncDataStream.OutputMode mode,
             @Nullable AsyncRetryStrategy<Integer> asyncRetryStrategy)
             throws Exception {
@@ -1575,10 +1577,12 @@ class AsyncWaitOperatorTest {
         @Override
         public void asyncInvoke(final Integer input, final ResultFuture<Integer> resultFuture)
                 throws Exception {
+            Thread callThread = Thread.currentThread();
             executorService.submit(
                     () ->
                             resultFuture.complete(
                                     () -> {
+                                        assertEquals(callThread, Thread.currentThread());
                                         throw new ExpectedTestException();
                                     }));
         }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarness.java
@@ -195,4 +195,8 @@ public class StreamTaskMailboxTestHarness<OUT> implements AutoCloseable {
     public TestCheckpointResponder getCheckpointResponder() {
         return (TestCheckpointResponder) taskStateManager.getCheckpointResponder();
     }
+
+    public StreamMockEnvironment getStreamMockEnvironment() {
+        return streamMockEnvironment;
+    }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/codegen/AsyncCodeGeneratorTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/codegen/AsyncCodeGeneratorTest.java
@@ -34,6 +34,7 @@ import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.util.function.SupplierWithException;
 
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
@@ -197,6 +198,15 @@ public class AsyncCodeGeneratorTest {
 
         public CompletableFuture<Collection<RowData>> getResult() {
             return data;
+        }
+
+        @Override
+        public void complete(SupplierWithException<Collection<RowData>, Exception> supplier) {
+            try {
+                data.complete(supplier.get());
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
         }
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/codegen/AsyncCodeGeneratorTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/codegen/AsyncCodeGeneratorTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.codegen;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.functions.async.AsyncFunction;
+import org.apache.flink.streaming.api.functions.async.CollectionSupplier;
 import org.apache.flink.streaming.api.functions.async.ResultFuture;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
@@ -34,7 +35,6 @@ import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
-import org.apache.flink.util.function.SupplierWithException;
 
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
@@ -201,7 +201,7 @@ public class AsyncCodeGeneratorTest {
         }
 
         @Override
-        public void complete(SupplierWithException<Collection<RowData>, Exception> supplier) {
+        public void complete(CollectionSupplier<RowData> supplier) {
             try {
                 data.complete(supplier.get());
             } catch (Exception e) {

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/collector/TableFunctionResultFuture.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/collector/TableFunctionResultFuture.java
@@ -20,6 +20,9 @@ package org.apache.flink.table.runtime.collector;
 
 import org.apache.flink.api.common.functions.AbstractRichFunction;
 import org.apache.flink.streaming.api.functions.async.ResultFuture;
+import org.apache.flink.util.function.SupplierWithException;
+
+import java.util.Collection;
 
 /** The basic implementation of collector for {@link ResultFuture} in table joining. */
 public abstract class TableFunctionResultFuture<T> extends AbstractRichFunction
@@ -59,5 +62,10 @@ public abstract class TableFunctionResultFuture<T> extends AbstractRichFunction
     @Override
     public void completeExceptionally(Throwable error) {
         this.resultFuture.completeExceptionally(error);
+    }
+
+    @Override
+    public void complete(SupplierWithException<Collection<T>, Exception> supplier) {
+        throw new UnsupportedOperationException();
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/collector/TableFunctionResultFuture.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/collector/TableFunctionResultFuture.java
@@ -19,10 +19,8 @@
 package org.apache.flink.table.runtime.collector;
 
 import org.apache.flink.api.common.functions.AbstractRichFunction;
+import org.apache.flink.streaming.api.functions.async.CollectionSupplier;
 import org.apache.flink.streaming.api.functions.async.ResultFuture;
-import org.apache.flink.util.function.SupplierWithException;
-
-import java.util.Collection;
 
 /** The basic implementation of collector for {@link ResultFuture} in table joining. */
 public abstract class TableFunctionResultFuture<T> extends AbstractRichFunction
@@ -64,8 +62,12 @@ public abstract class TableFunctionResultFuture<T> extends AbstractRichFunction
         this.resultFuture.completeExceptionally(error);
     }
 
+    /**
+     * Unsupported, because the containing classes are AsyncFunctions which don't have access to the
+     * mailbox to invoke from the caller thread.
+     */
     @Override
-    public void complete(SupplierWithException<Collection<T>, Exception> supplier) {
+    public void complete(CollectionSupplier<T> supplier) {
         throw new UnsupportedOperationException();
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/lookup/AsyncLookupJoinRunner.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/lookup/AsyncLookupJoinRunner.java
@@ -35,6 +35,7 @@ import org.apache.flink.table.runtime.generated.FilterCondition;
 import org.apache.flink.table.runtime.generated.GeneratedFunction;
 import org.apache.flink.table.runtime.generated.GeneratedResultFuture;
 import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
+import org.apache.flink.util.function.SupplierWithException;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -274,6 +275,11 @@ public class AsyncLookupJoinRunner extends RichAsyncFunction<RowData, RowData> {
             realOutput.completeExceptionally(error);
         }
 
+        @Override
+        public void complete(SupplierWithException<Collection<Object>, Exception> supplier) {
+            throw new UnsupportedOperationException();
+        }
+
         public void close() throws Exception {
             joinConditionResultFuture.close();
         }
@@ -294,6 +300,11 @@ public class AsyncLookupJoinRunner extends RichAsyncFunction<RowData, RowData> {
             @Override
             public void completeExceptionally(Throwable error) {
                 JoinedRowResultFuture.this.completeExceptionally(error);
+            }
+
+            @Override
+            public void complete(SupplierWithException<Collection<RowData>, Exception> supplier) {
+                throw new UnsupportedOperationException();
             }
         }
     }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/lookup/AsyncLookupJoinRunner.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/lookup/AsyncLookupJoinRunner.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.functions.OpenContext;
 import org.apache.flink.api.common.functions.util.FunctionUtils;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.functions.async.AsyncFunction;
+import org.apache.flink.streaming.api.functions.async.CollectionSupplier;
 import org.apache.flink.streaming.api.functions.async.ResultFuture;
 import org.apache.flink.streaming.api.functions.async.RichAsyncFunction;
 import org.apache.flink.table.data.GenericRowData;
@@ -35,7 +36,6 @@ import org.apache.flink.table.runtime.generated.FilterCondition;
 import org.apache.flink.table.runtime.generated.GeneratedFunction;
 import org.apache.flink.table.runtime.generated.GeneratedResultFuture;
 import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
-import org.apache.flink.util.function.SupplierWithException;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -275,8 +275,12 @@ public class AsyncLookupJoinRunner extends RichAsyncFunction<RowData, RowData> {
             realOutput.completeExceptionally(error);
         }
 
+        /**
+         * Unsupported, because the containing classes are AsyncFunctions which don't have access to
+         * the mailbox to invoke from the caller thread.
+         */
         @Override
-        public void complete(SupplierWithException<Collection<Object>, Exception> supplier) {
+        public void complete(CollectionSupplier<Object> supplier) {
             throw new UnsupportedOperationException();
         }
 
@@ -302,8 +306,12 @@ public class AsyncLookupJoinRunner extends RichAsyncFunction<RowData, RowData> {
                 JoinedRowResultFuture.this.completeExceptionally(error);
             }
 
+            /**
+             * Unsupported, because the containing classes are AsyncFunctions which don't have
+             * access to the mailbox to invoke from the caller thread.
+             */
             @Override
-            public void complete(SupplierWithException<Collection<RowData>, Exception> supplier) {
+            public void complete(CollectionSupplier<RowData> supplier) {
                 throw new UnsupportedOperationException();
             }
         }


### PR DESCRIPTION
Fixes [a bug](https://issues.apache.org/jira/browse/FLINK-37243) where the data converter was being invoked from a user callback thread. With this change, you can callback into AsyncWaitOperator and have it invoke a callback from the Mailbox thread.

Specifically, this is done by exposing on `ResultFuture` a variation of `callback`:
```
void complete(SupplierWithException<Collection<OUT>, Exception> supplier);
```
Rather than requiring the client to return the result directly, it can give a supplier which will be executed on the mailbox thread for consistency (i.e. in our case use of the converter).