### PR TITLE
[FLINK-37289][table] Resolve JVM bytecode size limit exceeded in <init> method due to excessive field initializations in SQL job

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/TableConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/TableConfigOptions.java
@@ -233,6 +233,19 @@ public class TableConfigOptions {
                     .withDescription(
                             "Specifies a threshold where class members of generated code will be grouped into arrays by types.");
 
+    @Documentation.ExcludeFromDocumentation(
+            "This option is rarely used. The default value is good enough for almost all cases.")
+    public static final ConfigOption<Integer> FIELDS_PER_INIT_METHOD =
+            key("table.generated-code.fields-per-init-method")
+                    .intType()
+                    .defaultValue(1000)
+                    .withDescription(
+                            "Specifies the maximum number of fields to initialize within a single initialization method. "
+                                    + "This option is used to split the initialization of class members in generated code "
+                                    + "into multiple methods with an 'init$' prefix. By doing so, it helps reduce the size "
+                                    + "of the class <init> method and avoids the 64KB method size limit in Java. "
+                                    + "This is achieved by replacing multiple 'putfield' instructions with fewer 'invokespecial' calls.");
+
     // ------------------------------------------------------------------------------------------
     // Enum option types
     // ------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-code-splitter/src/test/java/org/apache/flink/table/codesplit/MemberFieldRewriterTest.java
+++ b/flink-table/flink-table-code-splitter/src/test/java/org/apache/flink/table/codesplit/MemberFieldRewriterTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 class MemberFieldRewriterTest extends CodeRewriterTestBase<MemberFieldRewriter> {
 
     public MemberFieldRewriterTest() {
-        super("member", code -> new MemberFieldRewriter(code, 3));
+        super("member", code -> new MemberFieldRewriter(code, 3, 1));
     }
 
     @Test

--- a/flink-table/flink-table-code-splitter/src/test/resources/member/expected/TestNotRewriteFunctionParameter.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/member/expected/TestNotRewriteFunctionParameter.java
@@ -2,8 +2,12 @@ public class TestNotRewriteFunctionParameter {
 int[] rewrite$0 = new int[3];
 
 {
-rewrite$0[0] = 1;
+    init$0();
 }
+void init$0() {
+    rewrite$0[0] = 1;
+}
+
 
     
     

--- a/flink-table/flink-table-code-splitter/src/test/resources/member/expected/TestNotRewriteLocalVariable.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/member/expected/TestNotRewriteLocalVariable.java
@@ -2,10 +2,22 @@ public class TestNotRewriteLocalVariable {
 int[] rewrite$0 = new int[3];
 
 {
-rewrite$0[0] = 1;
-rewrite$0[1] = 2;
-rewrite$0[2] = 3;
+    init$0();
+    init$1();
+    init$2();
 }
+void init$0() {
+    rewrite$0[0] = 1;
+}
+
+void init$1() {
+    rewrite$0[1] = 2;
+}
+
+void init$2() {
+    rewrite$0[2] = 3;
+}
+
 
     
     

--- a/flink-table/flink-table-code-splitter/src/test/resources/member/expected/TestNotRewriteMember.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/member/expected/TestNotRewriteMember.java
@@ -2,8 +2,12 @@ public class TestNotRewriteMember {
 int[] rewrite$0 = new int[3];
 
 {
-rewrite$0[1] = 1;
+    init$0();
 }
+void init$0() {
+    rewrite$0[1] = 1;
+}
+
 
     
     private static int b;

--- a/flink-table/flink-table-code-splitter/src/test/resources/member/expected/TestRewriteGenericType.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/member/expected/TestRewriteGenericType.java
@@ -3,10 +3,22 @@ java.util.List<Integer>[] rewrite$0 = new java.util.List[1];
 java.util.List<String>[] rewrite$1 = new java.util.List[2];
 
 {
-rewrite$1[0] = new java.util.ArrayList<>();
-rewrite$0[0] = new java.util.ArrayList<>();
-rewrite$1[1] = new java.util.ArrayList<>();
+    init$0();
+    init$1();
+    init$2();
 }
+void init$0() {
+    rewrite$1[0] = new java.util.ArrayList<>();
+}
+
+void init$1() {
+    rewrite$0[0] = new java.util.ArrayList<>();
+}
+
+void init$2() {
+    rewrite$1[1] = new java.util.ArrayList<>();
+}
+
 
     
     

--- a/flink-table/flink-table-code-splitter/src/test/resources/member/expected/TestRewriteInnerClass.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/member/expected/TestRewriteInnerClass.java
@@ -2,8 +2,12 @@ public class TestRewriteInnerClass {
 int[] rewrite$0 = new int[3];
 
 {
-rewrite$0[1] = 1;
+    init$0();
 }
+void init$0() {
+    rewrite$0[1] = 1;
+}
+
 
     
     

--- a/flink-table/flink-table-code-splitter/src/test/resources/member/expected/TestRewriteMemberField.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/member/expected/TestRewriteMemberField.java
@@ -4,9 +4,17 @@ int[] rewrite$1 = new int[3];
 long[] rewrite$2 = new long[2];
 
 {
-rewrite$1[1] = 1;
-rewrite$0[1] = "GGGGG";
+    init$0();
+    init$1();
 }
+void init$0() {
+    rewrite$1[1] = 1;
+}
+
+void init$1() {
+    rewrite$0[1] = "GGGGG";
+}
+
 
     
     

--- a/flink-table/flink-table-code-splitter/src/test/resources/splitter/expected/TestSplitJavaCode.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/splitter/expected/TestSplitJavaCode.java
@@ -4,8 +4,12 @@ int[][] rewrite$27 = new int[1][];
 int[] rewrite$28 = new int[16];
 
 {
-rewrite$28[15] = 1;
+    init$0();
 }
+void init$0() {
+    rewrite$28[15] = 1;
+}
+
 
 
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/codegen/CodeSplitTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/codegen/CodeSplitTest.java
@@ -237,11 +237,13 @@ class CodeSplitTest {
         Configuration splitTableConfig = new Configuration();
         splitTableConfig.set(TableConfigOptions.MAX_LENGTH_GENERATED_CODE, 4000);
         splitTableConfig.set(TableConfigOptions.MAX_MEMBERS_GENERATED_CODE, 10000);
+        splitTableConfig.set(TableConfigOptions.FIELDS_PER_INIT_METHOD, 1000);
         consumer.accept(splitTableConfig);
 
         Configuration noSplitTableConfig = new Configuration();
         noSplitTableConfig.set(TableConfigOptions.MAX_LENGTH_GENERATED_CODE, Integer.MAX_VALUE);
         noSplitTableConfig.set(TableConfigOptions.MAX_MEMBERS_GENERATED_CODE, Integer.MAX_VALUE);
+        noSplitTableConfig.set(TableConfigOptions.FIELDS_PER_INIT_METHOD, Integer.MAX_VALUE);
         PrintStream originalStdOut = System.out;
         try {
             // redirect stdout to a null output stream to silence compile error in CompileUtils

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CodeSplitITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CodeSplitITCase.scala
@@ -201,6 +201,7 @@ class CodeSplitITCase extends BatchTestBase {
   private[flink] def runTest(sql: String, results: Seq[Row]): Unit = {
     tEnv.getConfig.set(TableConfigOptions.MAX_LENGTH_GENERATED_CODE, Int.box(4000))
     tEnv.getConfig.set(TableConfigOptions.MAX_MEMBERS_GENERATED_CODE, Int.box(10000))
+    tEnv.getConfig.set(TableConfigOptions.FIELDS_PER_INIT_METHOD, Int.box(1000));
     checkResult(sql.mkString, results)
   }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/generated/GeneratedClass.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/generated/GeneratedClass.java
@@ -58,7 +58,8 @@ public abstract class GeneratedClass<T> implements Serializable {
                         : JavaCodeSplitter.split(
                                 code,
                                 config.get(TableConfigOptions.MAX_LENGTH_GENERATED_CODE),
-                                config.get(TableConfigOptions.MAX_MEMBERS_GENERATED_CODE));
+                                config.get(TableConfigOptions.MAX_MEMBERS_GENERATED_CODE),
+                                config.get(TableConfigOptions.FIELDS_PER_INIT_METHOD));
         this.references = references;
     }
 


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The SQL job encounters issues due to having too many fields in the DML operations, such as a job which has over 2,000 fields. This results in the code generation process creating an initialization block that needs to initialize these fields and some auxiliary intermediate variables, totaling over 20,000 members. Consequently, the bytecode for the `<init>` method exceeds the JVM's single method limit of 64KB.

The initial logic in the initialization block, when translated into bytecode, is executed via `putfield` instructions. The solution is to segment the numerous `putfield` instructions into smaller blocks. For example, group every 1,000 initialization statements into a private method, then call these private methods within the initialization block. This transforms the initialization block into a series of `invokespecial` instructions, which are fewer in number.

For a detailed explanation, refer to the demonstration at https://godbolt.org/z/q9d1ncTrE.


## Brief change log

- In the `MemberFieldRewriter` class, move the logic for initializing members into methods with an `init$` suffix followed by a number, and then call these `init$` suffixed methods within the initialization block.


## Verifying this change

This change is already covered by existing tests, such as `MemberFieldRewriterTest` and `JavaCodeSplitterTest`.



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
