### PR TITLE
[FLINK-37109][State Processor API] Improve state processor API performance when reading keyed rocksdb state by allowing duplicates

### DIFF
--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/SavepointReader.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/SavepointReader.java
@@ -385,6 +385,7 @@ public class SavepointReader {
      * @param keyTypeInfo The type information of the key in state.
      * @param outTypeInfo The type information of the output of the transform reader function.
      * @param <K> The type of the key in state.
+     * @param skipDeduplication skipDeduplication to improve read performance, but will return deuplicate keys in DataStream
      * @param <OUT> The output type of the transform function.
      * @return A {@code DataStream} of objects read from keyed state.
      * @throws IOException If the savepoint does not contain operator state with the given uid.
@@ -393,7 +394,8 @@ public class SavepointReader {
             OperatorIdentifier identifier,
             KeyedStateReaderFunction<K, OUT> function,
             TypeInformation<K> keyTypeInfo,
-            TypeInformation<OUT> outTypeInfo)
+            TypeInformation<OUT> outTypeInfo,
+            Boolean skipDeduplication)
             throws IOException {
 
         OperatorState operatorState = metadata.getOperatorState(identifier);
@@ -403,7 +405,8 @@ public class SavepointReader {
                         stateBackend,
                         MutableConfig.of(env.getConfiguration()),
                         new KeyedStateReaderOperator<>(function, keyTypeInfo),
-                        env.getConfig());
+                        env.getConfig(),
+                        skipDeduplication);
 
         return SourceBuilder.fromFormat(env, inputFormat, outTypeInfo);
     }


### PR DESCRIPTION
## What is the purpose of the change

Improve state processor API performance when reading keyed rocksdb state by allowing duplicates

## Brief change log

- Add parameter to KeyedStateInputFormat.java - to allow optionally skipping of deduplication (i.e. removing of keys from flink sttate when reading). I chose to add an extra constructor, so current usages are backwards compatible 
- Wiring parameter to SavepointReader.java - that can be optionally specified 

## Verifying this change

// TODO add tests
Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes 
  - The serializers: no 
  - The runtime per-record code paths (performance sensitive): no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no 
  - The S3 file system connector: no 

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented (but happy to add where necessary) 