### PR TITLE
[FLINK-37219][table] Support value state in PTFs

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/annotation/StateHint.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/annotation/StateHint.java
@@ -40,12 +40,12 @@ import java.lang.annotation.Target;
  * support a single state entry at the beginning of an accumulate()/retract() method (i.e. the
  * accumulator).
  *
- * <p>For example, {@code @StateHint(name = "count", type = @DataTypeHint("BIGINT"))} is a state
- * entry with the data type BIGINT named "count".
+ * <p>Because state needs to be mutable for read and write access, only row or structured types
+ * qualify as a data type for state entries. For example, {@code @StateHint(name = "count", type
+ * = @DataTypeHint("ROW<count BIGINT>"))} is a state entry with the data type BIGINT named "count".
  *
- * <p>Note: Usually, a state entry is partitioned by a key and can not be accessed globally. The
- * partitioning (or whether it is only a single partition) is defined by the corresponding function
- * call.
+ * <p>Note: A state entry is partitioned by a key and can not be accessed globally. The partitioning
+ * (or a single partition in case of no partitioning) is defined by the corresponding function call.
  *
  * @see FunctionHint
  */
@@ -70,4 +70,25 @@ public @interface StateHint {
      * or provide hints for the reflection-based extraction of the data type.
      */
     DataTypeHint type() default @DataTypeHint();
+
+    /**
+     * The time-to-live (TTL) duration that automatically cleans up the state entry.
+     *
+     * <p>It specifies a minimum time interval for how long idle state (i.e., state which was not
+     * updated by a create or write operation) will be retained. State will never be cleared until
+     * it was idle for less than the minimum time, and will be cleared at some time after it was
+     * idle.
+     *
+     * <p>Use this for being able to efficiently manage an ever-growing state size or for complying
+     * with data protection requirements.
+     *
+     * <p>The cleanup is based on processing time, which effectively corresponds to the wall clock
+     * time as defined by {@link System#currentTimeMillis()}).
+     *
+     * <p>The provided string must use Flink's duration syntax (e.g., "3 days", "45 min", "3 hours",
+     * "60 s"). If no unit is specified, the value is interpreted as milliseconds. The TTL setting
+     * on a state entry has higher precedence than the global state TTL configuration for the entire
+     * pipeline.
+     */
+    String ttl() default "";
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/annotation/StateHint.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/annotation/StateHint.java
@@ -89,6 +89,8 @@ public @interface StateHint {
      * "60 s"). If no unit is specified, the value is interpreted as milliseconds. The TTL setting
      * on a state entry has higher precedence than the global state TTL configuration for the entire
      * pipeline.
+     *
+     * @see org.apache.flink.util.TimeUtils#parseDuration(String)
      */
     String ttl() default "";
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/UserDefinedFunctionHelper.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/UserDefinedFunctionHelper.java
@@ -95,6 +95,8 @@ public final class UserDefinedFunctionHelper {
 
     public static final String PROCESS_TABLE_EVAL = "eval";
 
+    public static final String DEFAULT_ACCUMULATOR_NAME = "acc";
+
     /**
      * Tries to infer the TypeInformation of an AggregateFunction's accumulator type.
      *

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/DefaultStateTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/DefaultStateTypeStrategy.java
@@ -22,6 +22,9 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.util.Preconditions;
 
+import javax.annotation.Nullable;
+
+import java.time.Duration;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -30,10 +33,12 @@ import java.util.Optional;
 class DefaultStateTypeStrategy implements StateTypeStrategy {
 
     private final TypeStrategy typeStrategy;
+    private final @Nullable Duration timeToLive;
 
-    DefaultStateTypeStrategy(TypeStrategy typeStrategy) {
+    DefaultStateTypeStrategy(TypeStrategy typeStrategy, @Nullable Duration timeToLive) {
         this.typeStrategy =
                 Preconditions.checkNotNull(typeStrategy, "Type strategy must not be null.");
+        this.timeToLive = timeToLive;
     }
 
     @Override
@@ -42,21 +47,25 @@ class DefaultStateTypeStrategy implements StateTypeStrategy {
     }
 
     @Override
+    public Optional<Duration> getTimeToLive(CallContext callContext) {
+        return Optional.ofNullable(timeToLive);
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
         }
-        if (o instanceof DefaultStateTypeStrategy) {
-            return Objects.equals(typeStrategy, ((DefaultStateTypeStrategy) o).typeStrategy);
+        if (o == null || getClass() != o.getClass()) {
+            return false;
         }
-        if (o instanceof TypeStrategy) {
-            return Objects.equals(typeStrategy, o);
-        }
-        return false;
+        final DefaultStateTypeStrategy that = (DefaultStateTypeStrategy) o;
+        return Objects.equals(typeStrategy, that.typeStrategy)
+                && Objects.equals(timeToLive, that.timeToLive);
     }
 
     @Override
     public int hashCode() {
-        return typeStrategy.hashCode();
+        return Objects.hash(typeStrategy, timeToLive);
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/StateTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/StateTypeStrategy.java
@@ -20,13 +20,29 @@ package org.apache.flink.table.types.inference;
 
 import org.apache.flink.annotation.PublicEvolving;
 
+import javax.annotation.Nullable;
+
+import java.time.Duration;
+import java.util.Optional;
+
 /** Strategy for inferring a function call's intermediate result data type (i.e. state entry). */
 @PublicEvolving
 public interface StateTypeStrategy extends TypeStrategy {
 
     static StateTypeStrategy of(TypeStrategy typeStrategy) {
-        return new DefaultStateTypeStrategy(typeStrategy);
+        return new DefaultStateTypeStrategy(typeStrategy, null);
     }
 
-    // marker interface which will be filled with additional contracts in the future
+    static StateTypeStrategy of(TypeStrategy typeStrategy, @Nullable Duration timeToLive) {
+        return new DefaultStateTypeStrategy(typeStrategy, timeToLive);
+    }
+
+    /**
+     * The time-to-live (TTL) duration that automatically cleans up the state entry.
+     *
+     * <p>Returning {@code Optional.empty()} will fall back to default behavior. Returning a value
+     * equal or greater than 0 means setting a custom TTL for this state entry and ignoring the
+     * global defaults.
+     */
+    Optional<Duration> getTimeToLive(CallContext callContext);
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeInference.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeInference.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.types.inference;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.functions.UserDefinedFunctionHelper;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.util.Preconditions;
 
@@ -233,7 +234,9 @@ public final class TypeInference {
         public Builder accumulatorTypeStrategy(TypeStrategy accumulatorTypeStrategy) {
             Preconditions.checkNotNull(
                     accumulatorTypeStrategy, "Accumulator type strategy must not be null.");
-            this.stateTypeStrategies.put("acc", StateTypeStrategy.of(accumulatorTypeStrategy));
+            this.stateTypeStrategies.put(
+                    UserDefinedFunctionHelper.DEFAULT_ACCUMULATOR_NAME,
+                    StateTypeStrategy.of(accumulatorTypeStrategy));
             return this;
         }
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeInferenceUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeInferenceUtil.java
@@ -370,6 +370,7 @@ public final class TypeInferenceUtil {
     }
 
     /** Result of running {@link StateTypeStrategy}. */
+    @Internal
     public static final class StateInfo {
 
         private final DataType dataType;

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/TypeInferenceExtractorTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/TypeInferenceExtractorTest.java
@@ -55,6 +55,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import javax.annotation.Nullable;
 
 import java.math.BigDecimal;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
@@ -626,8 +627,12 @@ class TypeInferenceExtractorTest {
                 // ---
                 TestSpec.forProcessTableFunction(MultiStateProcessTableFunction.class)
                         .expectStaticArgument(StaticArgument.scalar("i", DataTypes.INT(), false))
-                        .expectState("s1", TypeStrategies.explicit(MyFirstState.TYPE))
-                        .expectState("s2", TypeStrategies.explicit(MySecondState.TYPE))
+                        .expectState(
+                                "s1",
+                                TypeStrategies.explicit(MyFirstState.TYPE),
+                                Duration.ofDays(2))
+                        .expectState(
+                                "s2", TypeStrategies.explicit(MySecondState.TYPE), Duration.ZERO)
                         .expectOutput(TypeStrategies.explicit(DataTypes.INT())),
                 // ---
                 TestSpec.forProcessTableFunction(UntypedTableArgProcessTableFunction.class)
@@ -711,8 +716,20 @@ class TypeInferenceExtractorTest {
                                 "Could not extract a data type from 'class java.lang.Object' in parameter 0 of method 'eval'"),
                 // ---
                 TestSpec.forProcessTableFunction(EnrichedExtractionStateProcessTableFunction.class)
-                        .expectState("d", TypeStrategies.explicit(DataTypes.DECIMAL(3, 2)))
+                        .expectState(
+                                "u",
+                                TypeStrategies.explicit(
+                                        EnrichedExtractionStateProcessTableFunction.User.TYPE))
                         .expectOutput(TypeStrategies.explicit(DataTypes.INT())),
+                // ---
+                TestSpec.forProcessTableFunction(
+                                MissingDefaultConstructorStateProcessTableFunction.class)
+                        .expectErrorMessage(
+                                "State entries must provide an argument-less constructor so that all fields are mutable."),
+                // ---
+                TestSpec.forProcessTableFunction(NonCompositeStateProcessTableFunction.class)
+                        .expectErrorMessage(
+                                "State entries must use a mutable, composite data type. But was: INT"),
                 // ---
                 TestSpec.forProcessTableFunction(WrongTypedTableProcessTableFunction.class)
                         .expectErrorMessage(
@@ -1251,22 +1268,16 @@ class TypeInferenceExtractorTest {
         }
 
         TestSpec expectAccumulator(TypeStrategy typeStrategy) {
-            this.expectedStateStrategies.put("acc", StateTypeStrategy.of(typeStrategy));
-            return this;
-        }
-
-        TestSpec expectState(String name, StateTypeStrategy stateTypeStrategy) {
-            this.expectedStateStrategies.put(name, stateTypeStrategy);
+            expectState("acc", typeStrategy);
             return this;
         }
 
         TestSpec expectState(String name, TypeStrategy typeStrategy) {
-            this.expectedStateStrategies.put(name, StateTypeStrategy.of(typeStrategy));
-            return this;
+            return expectState(name, typeStrategy, null);
         }
 
-        TestSpec expectState(LinkedHashMap<String, StateTypeStrategy> stateTypeStrategy) {
-            this.expectedStateStrategies.putAll(stateTypeStrategy);
+        TestSpec expectState(String name, TypeStrategy typeStrategy, @Nullable Duration ttl) {
+            this.expectedStateStrategies.put(name, StateTypeStrategy.of(typeStrategy, ttl));
             return this;
         }
 
@@ -2277,7 +2288,10 @@ class TypeInferenceExtractorTest {
     }
 
     private static class MultiStateProcessTableFunction extends ProcessTableFunction<Integer> {
-        public void eval(@StateHint MyFirstState s1, @StateHint MySecondState s2, Integer i) {}
+        public void eval(
+                @StateHint(ttl = "2 days") MyFirstState s1,
+                @StateHint(ttl = "0") MySecondState s2,
+                Integer i) {}
     }
 
     private static class UntypedTableArgProcessTableFunction extends ProcessTableFunction<Integer> {
@@ -2365,13 +2379,21 @@ class TypeInferenceExtractorTest {
     private static class EnrichedExtractionStateProcessTableFunction
             extends ProcessTableFunction<Integer> {
 
+        public static class User {
+            static final DataType TYPE =
+                    DataTypes.STRUCTURED(
+                            EnrichedExtractionStateProcessTableFunction.User.class,
+                            DataTypes.FIELD("score", DataTypes.DECIMAL(3, 2)));
+            public BigDecimal score;
+        }
+
         public void eval(
                 @StateHint(
                                 type =
                                         @DataTypeHint(
                                                 defaultDecimalPrecision = 3,
                                                 defaultDecimalScale = 2))
-                        BigDecimal d) {}
+                        User u) {}
     }
 
     private static class WrongTypedTableProcessTableFunction extends ProcessTableFunction<Integer> {
@@ -2405,6 +2427,31 @@ class TypeInferenceExtractorTest {
         public void eval(int i) {}
 
         public void eval(String i) {}
+    }
+
+    private static class MissingDefaultConstructorStateProcessTableFunction
+            extends ProcessTableFunction<Integer> {
+
+        public static class Score {
+
+            public final int value;
+
+            public Score(int value) {
+                this.value = value;
+            }
+        }
+
+        public int eval(@StateHint Score s, @ArgumentHint(ArgumentTrait.TABLE_AS_ROW) Row t) {
+            return 0;
+        }
+    }
+
+    private static class NonCompositeStateProcessTableFunction
+            extends ProcessTableFunction<Integer> {
+
+        public int eval(@StateHint Integer i, @ArgumentHint(ArgumentTrait.TABLE_AS_ROW) Row t) {
+            return 0;
+        }
     }
 
     private static class TableArgScalarFunction extends ScalarFunction {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecProcessTableFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecProcessTableFunction.java
@@ -30,6 +30,8 @@ import org.apache.flink.table.functions.ProcessTableFunction;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.planner.calcite.RexTableArgCall;
 import org.apache.flink.table.planner.codegen.CodeGeneratorContext;
+import org.apache.flink.table.planner.codegen.EqualiserCodeGenerator;
+import org.apache.flink.table.planner.codegen.HashCodeGenerator;
 import org.apache.flink.table.planner.codegen.ProcessTableRunnerGenerator;
 import org.apache.flink.table.planner.delegation.PlannerBase;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
@@ -42,14 +44,18 @@ import org.apache.flink.table.planner.plan.nodes.exec.utils.ExecNodeUtil;
 import org.apache.flink.table.planner.plan.nodes.exec.utils.TransformationMetadata;
 import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalProcessTableFunction;
 import org.apache.flink.table.planner.plan.utils.KeySelectorUtil;
+import org.apache.flink.table.runtime.generated.GeneratedHashFunction;
 import org.apache.flink.table.runtime.generated.GeneratedProcessTableRunner;
+import org.apache.flink.table.runtime.generated.GeneratedRecordEqualiser;
 import org.apache.flink.table.runtime.keyselector.RowDataKeySelector;
 import org.apache.flink.table.runtime.operators.process.ProcessTableOperatorFactory;
+import org.apache.flink.table.runtime.operators.process.RuntimeStateInfo;
 import org.apache.flink.table.runtime.operators.process.RuntimeTableSemantics;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.inference.StaticArgument;
 import org.apache.flink.table.types.inference.StaticArgumentTrait;
+import org.apache.flink.table.types.inference.TypeInferenceUtil.StateInfo;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.RowKind;
 
@@ -61,9 +67,14 @@ import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import java.time.Duration;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+
+import static org.apache.flink.table.planner.codegen.ProcessTableRunnerGenerator.GeneratedRunnerResult;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getFieldCount;
 
 /**
  * {@link StreamExecNode} for {@link ProcessTableFunction}.
@@ -156,33 +167,64 @@ public class StreamExecProcessTableFunction extends ExecNodeBase<RowData>
         final List<Ord<StaticArgument>> providedInputArgs =
                 StreamPhysicalProcessTableFunction.getProvidedInputArgs(invocation);
         final List<RexNode> operands = invocation.getOperands();
-        final List<RuntimeTableSemantics> tableSemantics =
+        final List<RuntimeTableSemantics> runtimeTableSemantics =
                 providedInputArgs.stream()
                         .map(
                                 providedInputArg -> {
                                     final RexTableArgCall tableArgCall =
                                             (RexTableArgCall) operands.get(providedInputArg.i);
                                     final StaticArgument tabledArg = providedInputArg.e;
-                                    return createTableSemantics(tabledArg, tableArgCall);
+                                    return createRuntimeTableSemantics(tabledArg, tableArgCall);
                                 })
                         .collect(Collectors.toList());
 
         final CodeGeneratorContext ctx =
                 new CodeGeneratorContext(config, planner.getFlinkContext().getClassLoader());
 
-        final GeneratedProcessTableRunner generatedRunner =
+        final GeneratedRunnerResult generated =
                 ProcessTableRunnerGenerator.generate(ctx, invocation, inputChangelogModes);
+        final GeneratedProcessTableRunner generatedRunner = generated.runner();
+        final LinkedHashMap<String, StateInfo> stateInfos = generated.stateInfos();
+
+        final List<RuntimeStateInfo> runtimeStateInfos =
+                stateInfos.entrySet().stream()
+                        .map(
+                                stateInfo ->
+                                        createRuntimeStateInfo(
+                                                stateInfo.getKey(), stateInfo.getValue(), config))
+                        .collect(Collectors.toList());
+        final GeneratedHashFunction[] stateHashCode =
+                runtimeStateInfos.stream()
+                        .map(RuntimeStateInfo::getType)
+                        .map(
+                                t ->
+                                        HashCodeGenerator.generateRowHash(
+                                                ctx,
+                                                t,
+                                                "StateHashCode",
+                                                IntStream.range(0, getFieldCount(t)).toArray()))
+                        .toArray(GeneratedHashFunction[]::new);
+        final GeneratedRecordEqualiser[] stateEquals =
+                runtimeStateInfos.stream()
+                        .map(RuntimeStateInfo::getType)
+                        .map(t -> EqualiserCodeGenerator.generateRowEquals(ctx, t, "StateEquals"))
+                        .toArray(GeneratedRecordEqualiser[]::new);
 
         final RuntimeTableSemantics singleTableSemantics;
-        if (tableSemantics.isEmpty()) {
+        if (runtimeTableSemantics.isEmpty()) {
             // For constant function calls
             singleTableSemantics = null;
         } else {
-            singleTableSemantics = tableSemantics.get(0);
+            singleTableSemantics = runtimeTableSemantics.get(0);
         }
 
         final ProcessTableOperatorFactory operatorFactory =
-                new ProcessTableOperatorFactory(singleTableSemantics, generatedRunner);
+                new ProcessTableOperatorFactory(
+                        singleTableSemantics,
+                        runtimeStateInfos,
+                        generatedRunner,
+                        stateHashCode,
+                        stateEquals);
 
         final String effectiveUid =
                 uid != null ? uid : createTransformationUid(PROCESS_TRANSFORMATION, config);
@@ -221,7 +263,7 @@ public class StreamExecProcessTableFunction extends ExecNodeBase<RowData>
         return transform;
     }
 
-    private RuntimeTableSemantics createTableSemantics(
+    private RuntimeTableSemantics createRuntimeTableSemantics(
             StaticArgument tableArg, RexTableArgCall tableArgCall) {
         final RowKind[] kinds =
                 inputChangelogModes
@@ -244,5 +286,31 @@ public class StreamExecProcessTableFunction extends ExecNodeBase<RowData>
                 expectedChanges,
                 tableArg.is(StaticArgumentTrait.PASS_COLUMNS_THROUGH),
                 tableArg.is(StaticArgumentTrait.TABLE_AS_SET));
+    }
+
+    private static RuntimeStateInfo createRuntimeStateInfo(
+            String name, StateInfo stateInfo, ExecNodeConfig config) {
+        return new RuntimeStateInfo(
+                name,
+                stateInfo.getDataType().getLogicalType(),
+                deriveStateTimeToLive(
+                        stateInfo.getTimeToLive().orElse(null), config.getStateRetentionTime()));
+    }
+
+    private static long deriveStateTimeToLive(
+            @Nullable Duration declaration, long globalRetentionTime) {
+        // User declaration take precedence. Including a potential 0.
+        if (declaration != null) {
+            return declaration.toMillis();
+        }
+        // This prepares the state layout of every PTF. It makes enabling state TTL at a later
+        // point in time possible. The past has shown that users often don't consider ever-growing
+        // state initially and would like to enable it later - without breaking the savepoint.
+        // Setting it to Long.MAX_VALUE is a better default than 0. It comes with overhead which is
+        // why a 0 declaration can override this for efficiency.
+        if (globalRetentionTime == 0) {
+            return Long.MAX_VALUE;
+        }
+        return globalRetentionTime;
     }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/EqualiserCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/EqualiserCodeGenerator.scala
@@ -24,7 +24,7 @@ import org.apache.flink.table.planner.codegen.Indenter.toISC
 import org.apache.flink.table.planner.codegen.calls.ScalarOperatorGens.generateEquals
 import org.apache.flink.table.runtime.generated.{GeneratedRecordEqualiser, RecordEqualiser}
 import org.apache.flink.table.runtime.types.PlannerTypeUtils
-import org.apache.flink.table.types.logical.{BooleanType, DistinctType, LogicalType, RowType}
+import org.apache.flink.table.types.logical.{BooleanType, DistinctType, LogicalType}
 import org.apache.flink.table.types.logical.LogicalTypeRoot._
 import org.apache.flink.table.types.logical.utils.LogicalTypeChecks.{getFieldTypes, isCompositeType}
 
@@ -40,12 +40,12 @@ class EqualiserCodeGenerator(
   private val LEFT_INPUT = "left"
   private val RIGHT_INPUT = "right"
 
-  def this(rowType: RowType, classLoader: ClassLoader) = {
-    this(rowType.getChildren.asScala.toArray, rowType.getChildren.asScala.toArray, classLoader)
-  }
-
   def this(fieldTypes: Array[LogicalType], classLoader: ClassLoader) = {
     this(fieldTypes, fieldTypes, classLoader)
+  }
+
+  def this(compositeType: LogicalType, classLoader: ClassLoader) = {
+    this(getFieldTypes(compositeType).asScala.toArray, classLoader)
   }
 
   def generateRecordEqualiser(name: String): GeneratedRecordEqualiser = {
@@ -188,6 +188,14 @@ class EqualiserCodeGenerator(
 }
 
 object EqualiserCodeGenerator {
+
+  def generateRowEquals(
+      ctx: CodeGeneratorContext,
+      compositeType: LogicalType,
+      name: String): GeneratedRecordEqualiser = {
+    val equaliserGenerator = new EqualiserCodeGenerator(compositeType, ctx.classLoader)
+    equaliserGenerator.generateRecordEqualiser(name)
+  }
 
   def generateRecordEqualiserCode(
       ctx: CodeGeneratorContext,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ProcessTableRunnerGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ProcessTableRunnerGenerator.scala
@@ -18,13 +18,15 @@
 package org.apache.flink.table.planner.codegen
 
 import org.apache.flink.api.common.functions.OpenContext
-import org.apache.flink.table.api.{TableException, ValidationException}
+import org.apache.flink.table.api.ValidationException
 import org.apache.flink.table.connector.ChangelogMode
+import org.apache.flink.table.data.RowData
+import org.apache.flink.table.data.conversion.RowRowConverter
 import org.apache.flink.table.functions.{FunctionDefinition, ProcessTableFunction, UserDefinedFunction, UserDefinedFunctionHelper}
 import org.apache.flink.table.functions.UserDefinedFunctionHelper.{validateClassForRuntime, PROCESS_TABLE_EVAL}
 import org.apache.flink.table.planner.calcite.{FlinkTypeFactory, RexTableArgCall}
-import org.apache.flink.table.planner.codegen.CodeGenUtils.{className, newName, ROW_DATA}
-import org.apache.flink.table.planner.codegen.GeneratedExpression.NO_CODE
+import org.apache.flink.table.planner.codegen.CodeGenUtils._
+import org.apache.flink.table.planner.codegen.GeneratedExpression.{NEVER_NULL, NO_CODE}
 import org.apache.flink.table.planner.codegen.Indenter.toISC
 import org.apache.flink.table.planner.codegen.calls.BridgingFunctionGenUtil
 import org.apache.flink.table.planner.codegen.calls.BridgingFunctionGenUtil.{verifyFunctionAwareOutputType, DefaultExpressionEvaluatorFactory}
@@ -34,7 +36,11 @@ import org.apache.flink.table.planner.functions.inference.OperatorBindingCallCon
 import org.apache.flink.table.planner.utils.JavaScalaConversionUtil.toScala
 import org.apache.flink.table.runtime.generated.{GeneratedProcessTableRunner, ProcessTableRunner}
 import org.apache.flink.table.types.DataType
+import org.apache.flink.table.types.extraction.ExtractionUtils
 import org.apache.flink.table.types.inference.{StaticArgument, StaticArgumentTrait, SystemTypeInference, TypeInferenceUtil}
+import org.apache.flink.table.types.inference.TypeInferenceUtil.StateInfo
+import org.apache.flink.table.types.logical.utils.LogicalTypeChecks
+import org.apache.flink.types.Row
 
 import org.apache.calcite.rex.{RexCall, RexCallBinding, RexNode}
 
@@ -46,10 +52,14 @@ import scala.collection.JavaConverters._
 /** Code generator for [[ProcessTableRunner]]. */
 object ProcessTableRunnerGenerator {
 
+  case class GeneratedRunnerResult(
+      runner: GeneratedProcessTableRunner,
+      stateInfos: util.LinkedHashMap[String, StateInfo])
+
   def generate(
       ctx: CodeGeneratorContext,
       invocation: RexCall,
-      inputChangelogModes: java.util.List[ChangelogMode]): GeneratedProcessTableRunner = {
+      inputChangelogModes: java.util.List[ChangelogMode]): GeneratedRunnerResult = {
     val function: BridgingSqlFunction = invocation.getOperator.asInstanceOf[BridgingSqlFunction]
     val definition: FunctionDefinition = function.getDefinition
     val dataTypeFactory = function.getDataTypeFactory
@@ -88,21 +98,40 @@ object ProcessTableRunnerGenerator {
     val adaptedCallContext = TypeInferenceUtil.adaptArguments(inference, callContext, null)
     val enrichedArgumentDataTypes = toScala(adaptedCallContext.getArgumentDataTypes)
 
-    // Derive state type with conversion class
-    val stateStrategies = inference.getStateTypeStrategies
-    if (!stateStrategies.isEmpty) {
-      throw new TableException("State is not supported for PTFs yet.")
-    }
-
     // Enrich output types with conversion class
     val enrichedOutputDataType =
       TypeInferenceUtil.inferOutputType(adaptedCallContext, inference.getOutputTypeStrategy)
     verifyFunctionAwareOutputType(returnType, enrichedOutputDataType, udf)
 
-    // Find and verify suitable runtime method
-    val withContext = verifyEvalImplementation(enrichedArgumentDataTypes, udf, functionName)
+    // Derive state type with conversion class.
+    // This happens after specialization such that the state entries can be highly
+    // specialized to the call.
+    val stateInfos =
+      TypeInferenceUtil.inferStateInfos(adaptedCallContext, inference.getStateTypeStrategies)
+    val stateDataTypes = stateInfos.asScala.values.map(_.getDataType).toSeq
+    stateDataTypes.foreach(ExtractionUtils.checkStateDataType)
 
+    // Generate operands (state + args)
+    val stateToFunctionTerm = "stateToFunction"
+    val stateClearedTerm = "stateCleared"
+    val stateFromFunctionTerm = "stateFromFunction"
+    val externalStateOperands = generateStateToFunction(ctx, stateDataTypes, stateToFunctionTerm)
+    val stateFromFunctionCode = generateStateFromFunction(
+      ctx,
+      stateDataTypes,
+      externalStateOperands,
+      stateClearedTerm,
+      stateFromFunctionTerm)
     val tablesTerm = "tables"
+    val callOperands = generateCallOperands(ctx, call, tablesTerm)
+    val externalCallOperands =
+      BridgingFunctionGenUtil.prepareExternalOperands(ctx, callOperands, enrichedArgumentDataTypes)
+    val allExternalOperands = externalStateOperands ++ externalCallOperands
+    val allDataTypes = stateDataTypes ++ enrichedArgumentDataTypes
+
+    // Find and verify suitable runtime method
+
+    val withContext = verifyEvalImplementation(allDataTypes, udf, functionName)
     val contextTerm = if (withContext) {
       Some("runnerContext")
     } else {
@@ -110,14 +139,13 @@ object ProcessTableRunnerGenerator {
     }
 
     // Generate function call with operands (table/scalar arguments and state)
-    val operands = generateOperands(ctx, call, tablesTerm)
-    val functionCall = BridgingFunctionGenUtil.generateFunctionAwareCall(
+    val functionTerm = ctx.addReusableFunction(udf)
+    val functionCall = BridgingFunctionGenUtil.generateTableFunctionCall(
       ctx,
-      operands,
-      enrichedArgumentDataTypes,
+      functionTerm,
+      allExternalOperands,
       enrichedOutputDataType,
       returnType,
-      udf,
       skipIfArgsNull = false,
       contextTerm)
 
@@ -134,7 +162,7 @@ object ProcessTableRunnerGenerator {
     val code =
       j"""
       public final class $name
-          extends ${classOf[ProcessTableRunner].getCanonicalName} {
+          extends ${className[ProcessTableRunner]} {
 
         private transient $ROW_DATA[] $tablesTerm;
 
@@ -145,19 +173,25 @@ object ProcessTableRunnerGenerator {
         }
 
         @Override
-        public void open(${classOf[OpenContext].getCanonicalName} openContext) throws Exception {
+        public void open(${className[OpenContext]} openContext) throws Exception {
           ${ctx.reuseOpenCode()}
           $tablesTerm = new $ROW_DATA[${inputChangelogModes.size()}];
         }
 
         @Override
-        public void processElement(int inputIndex, $ROW_DATA row) throws Exception {
+        public void processElement(
+            $ROW_DATA[] $stateToFunctionTerm,
+            boolean[] $stateClearedTerm,
+            $ROW_DATA[] $stateFromFunctionTerm,
+            int inputIndex,
+            $ROW_DATA row) throws Exception {
           ${className[util.Arrays]}.fill($tablesTerm, null);
           $tablesTerm[inputIndex] = row;
           ${ctx.reusePerRecordCode()}
           ${ctx.reuseLocalVariableCode()}
           ${ctx.reuseInputUnboxingCode()}
           ${functionCall.code}
+          ${stateFromFunctionCode.mkString("\n")}
         }
 
         @Override
@@ -169,7 +203,10 @@ object ProcessTableRunnerGenerator {
       }
     """.stripMargin
 
-    new GeneratedProcessTableRunner(name, code, ctx.references.toArray, ctx.tableConfig)
+    val generatedRunner =
+      new GeneratedProcessTableRunner(name, code, ctx.references.toArray, ctx.tableConfig)
+
+    GeneratedRunnerResult(generatedRunner, stateInfos)
   }
 
   private def removeSystemTypeInference(
@@ -195,7 +232,67 @@ object ProcessTableRunnerGenerator {
     invocation.clone(newReturnType, newOperands.asJava)
   }
 
-  private def generateOperands(
+  private def generateStateToFunction(
+      ctx: CodeGeneratorContext,
+      stateDataTypes: Seq[DataType],
+      stateToFunctionTerm: String): Seq[GeneratedExpression] = {
+    stateDataTypes.zipWithIndex
+      .map {
+        case (stateDataType, pos) =>
+          val stateEntryTerm = s"$stateToFunctionTerm[$pos]"
+          val externalStateTypeTerm = typeTerm(stateDataType.getConversionClass)
+          val externalStateTerm = newName(ctx, "externalState")
+
+          val converterCode = genToExternalConverter(ctx, stateDataType, stateEntryTerm)
+
+          val constructorCode = stateDataType.getConversionClass match {
+            case rowType if rowType == classOf[Row] =>
+              // This allows us to retrieve the converter term that has been generated
+              // in genToExternalConverter(). The converter is able to created named positions
+              // for row fields.
+              val converterTerm = ctx.addReusableConverter(stateDataType)
+              s"((${className[RowRowConverter]}) $converterTerm).createEmptyRow()"
+            case rowType if rowType == classOf[RowData] =>
+              val fieldCount = LogicalTypeChecks.getFieldCount(stateDataType.getLogicalType)
+              s"new $GENERIC_ROW($fieldCount)"
+            case structuredType @ _ => s"new ${className(structuredType)}()"
+          }
+
+          val externalStateCode =
+            s"""
+               |final $externalStateTypeTerm $externalStateTerm;
+               |if ($stateEntryTerm == null) {
+               |  $externalStateTerm = $constructorCode;
+               |} else {
+               |  $externalStateTerm = $converterCode;
+               |}
+               |""".stripMargin
+
+          GeneratedExpression(
+            s"$externalStateTerm",
+            NEVER_NULL,
+            externalStateCode,
+            stateDataType.getLogicalType)
+      }
+  }
+
+  private def generateStateFromFunction(
+      ctx: CodeGeneratorContext,
+      stateDataTypes: Seq[DataType],
+      externalStateOperands: Seq[GeneratedExpression],
+      stateClearedTerm: String,
+      stateFromFunctionTerm: String): Seq[String] = {
+    stateDataTypes.zipWithIndex
+      .map {
+        case (stateDataType, pos) =>
+          val stateEntryTerm = s"$stateFromFunctionTerm[$pos]"
+          val externalStateOperandTerm = externalStateOperands(pos).resultTerm
+          s"$stateEntryTerm = $stateClearedTerm[$pos] ? null : " +
+            s"${genToInternalConverter(ctx, stateDataType)(externalStateOperandTerm)};"
+      }
+  }
+
+  private def generateCallOperands(
       ctx: CodeGeneratorContext,
       call: RexCall,
       tablesTerm: String): Seq[GeneratedExpression] = {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/BridgingFunctionGenUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/BridgingFunctionGenUtil.scala
@@ -126,7 +126,7 @@ object BridgingFunctionGenUtil {
     (call, enrichedOutputDataType)
   }
 
-  def generateFunctionAwareCall(
+  private def generateFunctionAwareCall(
       ctx: CodeGeneratorContext,
       operands: Seq[GeneratedExpression],
       argumentDataTypes: Seq[DataType],
@@ -165,7 +165,7 @@ object BridgingFunctionGenUtil {
     }
   }
 
-  private def generateTableFunctionCall(
+  def generateTableFunctionCall(
       ctx: CodeGeneratorContext,
       functionTerm: String,
       externalOperands: Seq[GeneratedExpression],

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionSemanticTests.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionSemanticTests.java
@@ -41,6 +41,11 @@ public class ProcessTableFunctionSemanticTests extends SemanticTestBase {
                 ProcessTableFunctionTestPrograms.PROCESS_UPDATING_INPUT,
                 ProcessTableFunctionTestPrograms.PROCESS_OPTIONAL_PARTITION_BY,
                 ProcessTableFunctionTestPrograms.PROCESS_ATOMIC_WRAPPING,
-                ProcessTableFunctionTestPrograms.PROCESS_CONTEXT);
+                ProcessTableFunctionTestPrograms.PROCESS_CONTEXT,
+                ProcessTableFunctionTestPrograms.PROCESS_POJO_STATE,
+                ProcessTableFunctionTestPrograms.PROCESS_DEFAULT_POJO_STATE,
+                ProcessTableFunctionTestPrograms.PROCESS_MULTI_STATE,
+                ProcessTableFunctionTestPrograms.PROCESS_CLEARING_STATE,
+                ProcessTableFunctionTestPrograms.PROCESS_STATE_TTL);
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/conversion/RowRowConverter.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/conversion/RowRowConverter.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.Row;
+import org.apache.flink.types.RowKind;
 import org.apache.flink.types.RowUtils;
 
 import java.util.LinkedHashMap;
@@ -104,6 +105,13 @@ public class RowRowConverter implements DataStructureConverter<RowData, Row> {
         }
         return RowUtils.createRowWithNamedPositions(
                 internal.getRowKind(), fieldByPosition, positionByName);
+    }
+
+    /** Used in code generation e.g. for generating empty {@link Row} state with named positions. */
+    public Row createEmptyRow() {
+        final Object[] fieldByPosition = new Object[fieldConverters.length];
+        return RowUtils.createRowWithNamedPositions(
+                RowKind.INSERT, fieldByPosition, positionByName);
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/generated/ProcessTableRunner.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/generated/ProcessTableRunner.java
@@ -33,5 +33,21 @@ public abstract class ProcessTableRunner extends AbstractRichFunction {
     public Collector<RowData> runnerCollector;
     public ProcessTableFunction.Context runnerContext;
 
-    public abstract void processElement(int inputIndex, RowData row) throws Exception;
+    /**
+     * @param stateToFunction state entries to be converted into external data structure; null if
+     *     state is empty
+     * @param stateCleared reference to whether the state has been cleared within the function; if
+     *     yes, a conversion from external to internal data structure is not necessary anymore
+     * @param stateFromFunction state ready for persistence; null if {@param stateCleared} was true
+     *     during conversion
+     * @param inputIndex index of the currently processed input table
+     * @param row data of the currently processed input table
+     */
+    public abstract void processElement(
+            RowData[] stateToFunction,
+            boolean[] stateCleared,
+            RowData[] stateFromFunction,
+            int inputIndex,
+            RowData row)
+            throws Exception;
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/process/ProcessTableOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/process/ProcessTableOperator.java
@@ -18,8 +18,14 @@
 
 package org.apache.flink.table.runtime.operators.process;
 
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.functions.DefaultOpenContext;
 import org.apache.flink.api.common.functions.util.FunctionUtils;
+import org.apache.flink.api.common.state.KeyedStateStore;
+import org.apache.flink.api.common.state.StateTtlConfig;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
@@ -28,10 +34,20 @@ import org.apache.flink.table.api.TableRuntimeException;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.functions.ProcessTableFunction;
 import org.apache.flink.table.functions.TableSemantics;
+import org.apache.flink.table.runtime.generated.HashFunction;
 import org.apache.flink.table.runtime.generated.ProcessTableRunner;
+import org.apache.flink.table.runtime.generated.RecordEqualiser;
+import org.apache.flink.table.runtime.typeutils.InternalSerializers;
+import org.apache.flink.table.runtime.util.StateConfigUtil;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.types.RowKind;
 
 import javax.annotation.Nullable;
 
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -40,30 +56,72 @@ public class ProcessTableOperator extends AbstractStreamOperator<RowData>
         implements OneInputStreamOperator<RowData, RowData> {
 
     private final @Nullable RuntimeTableSemantics tableSemantics;
+    private final List<RuntimeStateInfo> stateInfos;
     private final ProcessTableRunner processTableRunner;
+    private final HashFunction[] stateHashCode;
+    private final RecordEqualiser[] stateEquals;
 
     private transient PassThroughCollectorBase collector;
+    private transient ValueStateDescriptor<RowData>[] stateDescriptors;
+    private transient ValueState<RowData>[] stateHandles;
+    private transient RowData[] stateToFunction;
+    private transient boolean[] stateCleared;
+    private transient RowData[] stateFromFunction;
 
     public ProcessTableOperator(
             StreamOperatorParameters<RowData> parameters,
             @Nullable RuntimeTableSemantics tableSemantics,
-            ProcessTableRunner processTableRunner) {
+            List<RuntimeStateInfo> stateInfos,
+            ProcessTableRunner processTableRunner,
+            HashFunction[] stateHashCode,
+            RecordEqualiser[] stateEquals) {
         super(parameters);
         this.tableSemantics = tableSemantics;
+        this.stateInfos = stateInfos;
         this.processTableRunner = processTableRunner;
+        this.stateHashCode = stateHashCode;
+        this.stateEquals = stateEquals;
     }
 
     @Override
+    @SuppressWarnings({"rawtypes", "unchecked"})
     public void open() throws Exception {
         super.open();
+
+        // Pass through columns
         if (tableSemantics == null || tableSemantics.passColumnsThrough()) {
             collector = new PassAllCollector(output);
         } else {
             collector = new PassPartitionKeysCollector(output, tableSemantics.partitionByColumns());
         }
         processTableRunner.runnerCollector = this.collector;
-        processTableRunner.runnerContext = new ProcessFunctionContext(tableSemantics);
 
+        // State
+        final KeyedStateStore keyedStateStore = getKeyedStateStore();
+        stateDescriptors = new ValueStateDescriptor[stateInfos.size()];
+        stateHandles = new ValueState[stateInfos.size()];
+        stateToFunction = new RowData[stateInfos.size()];
+        stateCleared = new boolean[stateInfos.size()];
+        stateFromFunction = new RowData[stateInfos.size()];
+        for (int i = 0; i < stateInfos.size(); i++) {
+            final RuntimeStateInfo stateInfo = stateInfos.get(i);
+            final LogicalType type = stateInfo.getType();
+            final ValueStateDescriptor<RowData> descriptor =
+                    new ValueStateDescriptor(
+                            stateInfo.getStateName(), InternalSerializers.create(type));
+            final StateTtlConfig ttlConfig =
+                    StateConfigUtil.createTtlConfig(stateInfo.getTimeToLive());
+            if (ttlConfig.isEnabled()) {
+                descriptor.enableTimeToLive(ttlConfig);
+            }
+            stateDescriptors[i] = descriptor;
+            stateHandles[i] = keyedStateStore.getState(descriptor);
+        }
+
+        // Context
+        processTableRunner.runnerContext = new ProcessFunctionContext();
+
+        // Prepare runner
         FunctionUtils.setFunctionRuntimeContext(processTableRunner, getRuntimeContext());
         FunctionUtils.openFunction(processTableRunner, DefaultOpenContext.INSTANCE);
     }
@@ -72,18 +130,71 @@ public class ProcessTableOperator extends AbstractStreamOperator<RowData>
     public void processElement(StreamRecord<RowData> element) throws Exception {
         collector.setInput(element.getValue());
 
-        processTableRunner.processElement(0, element.getValue());
+        // For each function call:
+        // - the state is read from Flink
+        // - converted into external data structure
+        // - evaluated
+        // - converted into internal data structure (if not cleared)
+        // - the state is written into Flink
+
+        moveStateToFunction();
+        processTableRunner.processElement(
+                stateToFunction, stateCleared, stateFromFunction, 0, element.getValue());
+        moveStateFromFunction();
     }
 
-    private static class ProcessFunctionContext implements ProcessTableFunction.Context {
+    private void moveStateToFunction() throws IOException {
+        Arrays.fill(stateCleared, false);
+        for (int i = 0; i < stateHandles.length; i++) {
+            final RowData value = stateHandles[i].value();
+            stateToFunction[i] = value;
+        }
+    }
+
+    private void moveStateFromFunction() throws IOException {
+        for (int i = 0; i < stateHandles.length; i++) {
+            final RowData fromFunction = stateFromFunction[i];
+            if (fromFunction == null || isEmpty(fromFunction)) {
+                // Reduce state size
+                stateHandles[i].clear();
+            } else {
+                final HashFunction hashCode = this.stateHashCode[i];
+                final RecordEqualiser equals = this.stateEquals[i];
+                final RowData toFunction = stateToFunction[i];
+                // Reduce state updates by checking if something has changed
+                if (toFunction == null
+                        || hashCode.hashCode(toFunction) != hashCode.hashCode(fromFunction)
+                        || !equals.equals(toFunction, fromFunction)) {
+                    stateHandles[i].update(fromFunction);
+                }
+            }
+        }
+    }
+
+    private static boolean isEmpty(RowData row) {
+        for (int i = 0; i < row.getArity(); i++) {
+            if (!row.isNullAt(i)) {
+                return false;
+            }
+        }
+        return row.getRowKind() == RowKind.INSERT;
+    }
+
+    @Internal
+    public class ProcessFunctionContext implements ProcessTableFunction.Context {
 
         private final Map<String, RuntimeTableSemantics> tableSemanticsMap;
+        private final Map<String, Integer> stateNameToPosMap;
 
-        ProcessFunctionContext(@Nullable RuntimeTableSemantics tableSemantics) {
+        ProcessFunctionContext() {
             this.tableSemanticsMap =
                     Optional.ofNullable(tableSemantics)
                             .map(s -> Map.of(tableSemantics.getArgName(), tableSemantics))
                             .orElse(Map.of());
+            this.stateNameToPosMap = new HashMap<>();
+            for (int i = 0; i < stateInfos.size(); i++) {
+                this.stateNameToPosMap.put(stateInfos.get(i).getStateName(), i);
+            }
         }
 
         @Override
@@ -93,6 +204,29 @@ public class ProcessTableOperator extends AbstractStreamOperator<RowData>
                 throw new TableRuntimeException("Unknown table argument: " + argName);
             }
             return tableSemantics;
+        }
+
+        @Override
+        public void clearState(String stateName) {
+            final Integer statePos = stateNameToPosMap.get(stateName);
+            if (statePos == null) {
+                throw new TableRuntimeException("Unknown state entry: " + stateName);
+            }
+            stateCleared[statePos] = true;
+        }
+
+        @Override
+        public void clearAllState() {
+            Arrays.fill(stateCleared, true);
+        }
+
+        @VisibleForTesting
+        public ValueStateDescriptor<RowData> getValueStateDescriptor(String stateName) {
+            final Integer statePos = stateNameToPosMap.get(stateName);
+            if (statePos == null) {
+                throw new TableRuntimeException("Unknown state entry: " + stateName);
+            }
+            return stateDescriptors[statePos];
         }
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/process/RuntimeStateInfo.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/process/RuntimeStateInfo.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.process;
+
+import org.apache.flink.table.types.inference.TypeInferenceUtil.StateInfo;
+import org.apache.flink.table.types.logical.LogicalType;
+
+import java.io.Serializable;
+
+/**
+ * Serializable representation of {@link StateInfo} that will translate into state descriptors and
+ * state access.
+ */
+public class RuntimeStateInfo implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String stateName;
+    private final LogicalType type;
+    private final long timeToLive;
+
+    public RuntimeStateInfo(String stateName, LogicalType type, long timeToLive) {
+        this.stateName = stateName;
+        this.type = type;
+        this.timeToLive = timeToLive;
+    }
+
+    public String getStateName() {
+        return stateName;
+    }
+
+    public LogicalType getType() {
+        return type;
+    }
+
+    public long getTimeToLive() {
+        return timeToLive;
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This adds support for value state and thus enables stateful PTFs.

For each function call:
 - the state is read from Flink
 - converted into external data structure
 - evaluated
 - converted into internal data structure (if not cleared)
 - the state is written into Flink

State TTL is considered per-state or globally.

## Brief change log

- `TypeInferenceUtil` refactored to fully support state entries
- `ProcessTableOperator` (including code generation) updated

## Verifying this change

This change added tests and can be verified as follows: `ProcessTableFunctionSemanticTests`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
