### PR TITLE
[FLINK-37021][state/forst] Support reusing files in LEGACY recovery mode

### DIFF
--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/datatransfer/DataTransferStrategyBuilder.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/datatransfer/DataTransferStrategyBuilder.java
@@ -125,7 +125,7 @@ public class DataTransferStrategyBuilder {
         if (forStFlinkFileSystem == null
                 || cpSharedFs == null
                 || !forStFlinkFileSystem.getUri().equals(cpSharedFs.getUri())
-                || recoveryClaimMode != RecoveryClaimMode.CLAIM) {
+                || recoveryClaimMode == RecoveryClaimMode.NO_CLAIM) {
             strategy =
                     forStFlinkFileSystem == null
                             ? new CopyDataTransferStrategy()

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/datatransfer/DataTransferStrategyTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/datatransfer/DataTransferStrategyTest.java
@@ -109,8 +109,6 @@ public class DataTransferStrategyTest {
 
         Map<String, Path> dbFilePaths = new HashMap<>();
 
-        FileOwnershipDecider fileOwnershipDecider;
-
         DBFilesContainer(Path dbLocalBase, Path dbRemoteBase) throws IOException {
             realFileSystem = LocalFileSystem.getLocalFileSystem();
 
@@ -133,8 +131,6 @@ public class DataTransferStrategyTest {
                             4096);
             tmpResourcesRegistry = new CloseableRegistry();
             closeableRegistry = new CloseableRegistry();
-
-            this.fileOwnershipDecider = fileOwnershipDecider;
         }
 
         private void createDbFiles(List<String> fileNames) throws IOException {
@@ -479,6 +475,9 @@ public class DataTransferStrategyTest {
 
         testRestoreStrategyAsExpected(
                 forStFlinkFileSystem, RecoveryClaimMode.NO_CLAIM, CopyDataTransferStrategy.class);
+
+        testRestoreStrategyAsExpected(
+                forStFlinkFileSystem, RecoveryClaimMode.LEGACY, ReusableDataTransferStrategy.class);
 
         testRestoreStrategyAsExpected(
                 null, RecoveryClaimMode.CLAIM, CopyDataTransferStrategy.class);


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

To support ForStDB reusing files when restoring in LEGACY mode.


## Brief change log

- Make ```DataTransferStrategyBuilder``` create ```ReusableDataTransferStrategy``` when ```recoveryClaimMode == RecoveryClaimMode.LEGACY```


## Verifying this change


This change is already covered by existing tests, such as ```DataTransferStrategyTest#testBuildingStrategyAsExpected```.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
