### PR TITLE
[FLINK-37301][state/forst] Fix wrong flag returned by `ForStStateBackend#supportsSavepointFormat`

### DIFF
--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStStateBackend.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStStateBackend.java
@@ -29,6 +29,7 @@ import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.configuration.description.InlineElement;
 import org.apache.flink.core.execution.RecoveryClaimMode;
+import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.execution.Environment;
@@ -636,9 +637,16 @@ public class ForStStateBackend extends AbstractManagedMemoryStateBackend
         return optionsFactory;
     }
 
-    /** Both ForStSyncKeyedStateBackend and ForStKeyedStateBackend support no claim mode. */
+    @Override
     public boolean supportsNoClaimRestoreMode() {
+        // Both ForStSyncKeyedStateBackend and ForStKeyedStateBackend support no claim mode.
         return true;
+    }
+
+    @Override
+    public boolean supportsSavepointFormat(SavepointFormatType formatType) {
+        // We only support native format for now.
+        return formatType == SavepointFormatType.NATIVE;
     }
 
     // ------------------------------------------------------------------------

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStStateBackendConfigTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStStateBackendConfigTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
@@ -769,6 +770,13 @@ public class ForStStateBackendConfigTest {
                 keyedBackend.close();
             }
         }
+    }
+
+    @Test
+    public void testSupportSavepoint() {
+        ForStStateBackend forStStateBackend = new ForStStateBackend();
+        assertFalse(forStStateBackend.supportsSavepointFormat(SavepointFormatType.CANONICAL));
+        assertTrue(forStStateBackend.supportsSavepointFormat(SavepointFormatType.NATIVE));
     }
 
     private void verifySetParameter(Runnable setter) {


### PR DESCRIPTION
## What is the purpose of the change

The `ForStStateBackend` did not override the `supportsSavepointFormat`, which means it gives the wrong flag. We should fix this.


## Brief change log

 - Return true in `supportsSavepointFormat` when it is `NATIVE` format


## Verifying this change


This change is a trivial rework, a simple test is added.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
