### PR TITLE
[FLINK-37109][state] Improve state processor API key iteration speed

### DIFF
--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/KeyedStateInputFormat.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/KeyedStateInputFormat.java
@@ -226,8 +226,6 @@ public class KeyedStateInputFormat<K, N, OUT>
                     "User defined function KeyedStateReaderFunction#readKey threw an exception", e);
         }
 
-        keysAndNamespaces.remove();
-
         return out.next();
     }
 

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/MultiStateKeyIterator.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/MultiStateKeyIterator.java
@@ -19,12 +19,10 @@
 package org.apache.flink.state.api.input;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.runtime.state.KeyedStateBackend;
 import org.apache.flink.runtime.state.VoidNamespace;
-import org.apache.flink.runtime.state.VoidNamespaceSerializer;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.Preconditions;
 
@@ -32,13 +30,11 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
  * An iterator for reading all keys in a state backend across multiple partitioned states.
- *
- * <p>To read unique keys across all partitioned states callers must invoke {@link
- * MultiStateKeyIterator#remove}.
  *
  * @param <K> Type of the key by which state is keyed.
  */
@@ -46,78 +42,41 @@ import java.util.stream.Stream;
 public final class MultiStateKeyIterator<K> implements CloseableIterator<K> {
     private final List<? extends StateDescriptor<?, ?>> descriptors;
 
-    private final KeyedStateBackend<K> backend;
-
-    /** Avoids using Stream#flatMap due to a known flaw, see FLINK-26585 for more details. */
-    private final Iterator<? extends StateDescriptor<?, ?>> outerIter;
-
-    private Iterator<K> innerIter;
+    private final Iterator<K> iterator;
 
     private final CloseableRegistry registry;
-
-    private K currentKey;
 
     public MultiStateKeyIterator(
             List<? extends StateDescriptor<?, ?>> descriptors, KeyedStateBackend<K> backend) {
 
         this.descriptors = Preconditions.checkNotNull(descriptors);
-        this.backend = Preconditions.checkNotNull(backend);
-
-        outerIter = this.descriptors.iterator();
-        innerIter = null;
-
-        this.registry = new CloseableRegistry();
+        Preconditions.checkNotNull(backend);
+        registry = new CloseableRegistry();
+        Stream<K> stream =
+                backend.getKeys(
+                        this.descriptors.stream()
+                                .map(StateDescriptor::getName)
+                                .collect(Collectors.toList()),
+                        VoidNamespace.INSTANCE);
+        try {
+            registry.registerCloseable(stream::close);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to read keys from configured StateBackend", e);
+        }
+        iterator = stream.iterator();
     }
 
     @Override
     public boolean hasNext() {
-        while (innerIter == null || !innerIter.hasNext()) {
-            if (!outerIter.hasNext()) {
-                return false;
-            }
-
-            StateDescriptor<?, ?> descriptor = outerIter.next();
-            Stream<K> stream = backend.getKeys(descriptor.getName(), VoidNamespace.INSTANCE);
-            innerIter = stream.iterator();
-            try {
-                registry.registerCloseable(stream::close);
-            } catch (IOException e) {
-                throw new RuntimeException("Failed to read keys from configured StateBackend", e);
-            }
-        }
-        return true;
+        return iterator.hasNext();
     }
 
     @Override
     public K next() {
-        if (!this.hasNext()) {
+        if (!hasNext()) {
             throw new NoSuchElementException();
         } else {
-            currentKey = this.innerIter.next();
-            return currentKey;
-        }
-    }
-
-    /** Removes the current key from <b>ALL</b> known states in the state backend. */
-    @Override
-    public void remove() {
-        if (currentKey == null) {
-            return;
-        }
-
-        for (StateDescriptor<?, ?> descriptor : descriptors) {
-            try {
-                State state =
-                        backend.getPartitionedState(
-                                VoidNamespace.INSTANCE,
-                                VoidNamespaceSerializer.INSTANCE,
-                                descriptor);
-
-                state.clear();
-            } catch (Exception e) {
-                throw new RuntimeException(
-                        "Failed to drop partitioned state from state backend", e);
-            }
+            return iterator.next();
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateBackend.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.util.Disposable;
 
+import java.util.List;
 import java.util.stream.Stream;
 
 /**
@@ -69,11 +70,19 @@ public interface KeyedStateBackend<K>
 
     /**
      * @return A stream of all keys for the given state and namespace. Modifications to the state
-     *     during iterating over it keys are not supported.
+     *     during iterating over its keys are not supported.
      * @param state State variable for which existing keys will be returned.
      * @param namespace Namespace for which existing keys will be returned.
      */
     <N> Stream<K> getKeys(String state, N namespace);
+
+    /**
+     * @return A stream of all keys for the multiple states and a given namespace. Modifications to
+     *     the states during iterating over its keys are not supported.
+     * @param states State variables for which existing keys will be returned.
+     * @param namespace Namespace for which existing keys will be returned.
+     */
+    <N> Stream<K> getKeys(List<String> states, N namespace);
 
     /**
      * @return A stream of all keys for the given state and namespace. Modifications to the state

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestUtils.java
@@ -34,6 +34,7 @@ import javax.annotation.Nonnull;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.List;
 import java.util.concurrent.RunnableFuture;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -214,6 +215,11 @@ public class StateBackendTestUtils {
                 @Override
                 public <N> Stream<K> getKeys(String state, N namespace) {
                     return delegatedKeyedStateBackend.getKeys(state, namespace);
+                }
+
+                @Override
+                public <N> Stream<K> getKeys(List<String> states, N namespace) {
+                    return delegatedKeyedStateBackend.getKeys(states, namespace);
                 }
 
                 @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackend.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackend.java
@@ -207,6 +207,19 @@ public class MockKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
     }
 
     @Override
+    public <N> Stream<K> getKeys(List<String> states, N namespace) {
+        return stateValues.entrySet().stream()
+                .filter(e -> states.contains(e.getKey()))
+                .flatMap(
+                        e1 ->
+                                e1.getValue().entrySet().stream()
+                                        .filter(e2 -> e2.getValue().containsKey(namespace))
+                                        .map(Map.Entry::getKey))
+                .collect(Collectors.toSet())
+                .stream();
+    }
+
+    @Override
     @SuppressWarnings("unchecked")
     public <N> Stream<Tuple2<K, N>> getKeysAndNamespaces(String state) {
         return stateValues.get(state).entrySet().stream()

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
@@ -309,6 +309,11 @@ public class ChangelogKeyedStateBackend<K>
     }
 
     @Override
+    public <N> Stream<K> getKeys(List<String> states, N namespace) {
+        return keyedStateBackend.getKeys(states, namespace);
+    }
+
+    @Override
     public <N> Stream<Tuple2<K, N>> getKeysAndNamespaces(String state) {
         return keyedStateBackend.getKeysAndNamespaces(state);
     }

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/restore/ChangelogMigrationRestoreTarget.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/restore/ChangelogMigrationRestoreTarget.java
@@ -48,6 +48,7 @@ import javax.annotation.Nonnull;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.RunnableFuture;
 import java.util.stream.Stream;
 
@@ -220,6 +221,11 @@ public class ChangelogMigrationRestoreTarget<K> implements ChangelogRestoreTarge
             @Override
             public <N> Stream<K> getKeys(String state, N namespace) {
                 return keyedStateBackend.getKeys(state, namespace);
+            }
+
+            @Override
+            public <N> Stream<K> getKeys(List<String> states, N namespace) {
+                return keyedStateBackend.getKeys(states, namespace);
             }
 
             @Override

--- a/flink-state-backends/flink-statebackend-common/src/test/java/org/apache/flink/state/common/PeriodicMaterializationManagerTest.java
+++ b/flink-state-backends/flink-statebackend-common/src/test/java/org/apache/flink/state/common/PeriodicMaterializationManagerTest.java
@@ -22,8 +22,6 @@ import org.apache.flink.runtime.mailbox.SyncMailboxExecutor;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.state.common.PeriodicMaterializationManager.MaterializationTarget;
 
-import org.junit.jupiter.api.Test;
-
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.flink.shaded.guava31.com.google.common.collect.Iterators.getOnlyElement;
 import static org.apache.flink.util.concurrent.Executors.newDirectExecutorService;
@@ -32,7 +30,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 /** {@link PeriodicMaterializationManager} test. */
 class PeriodicMaterializationManagerTest {
 
-    @Test
     void testInitialDelay() {
         ManuallyTriggeredScheduledExecutorService scheduledExecutorService =
                 new ManuallyTriggeredScheduledExecutorService();

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/iterator/AbstractRocksStateKeysIterator.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/iterator/AbstractRocksStateKeysIterator.java
@@ -72,4 +72,17 @@ public abstract class AbstractRocksStateKeysIterator<K> implements AutoCloseable
     public void close() {
         iterator.close();
     }
+
+    public static boolean isMatchingNameSpace(
+            @Nonnull byte[] key, int namespaceBytesStartPos, @Nonnull byte[] namespaceBytes) {
+        if (key.length >= namespaceBytesStartPos + namespaceBytes.length) {
+            for (int i = 0; i < namespaceBytes.length; ++i) {
+                if (key[namespaceBytesStartPos + i] != namespaceBytes[i]) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return false;
+    }
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/iterator/RocksMultiStateKeysIterator.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/iterator/RocksMultiStateKeysIterator.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state.iterator;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.contrib.streaming.state.RocksIteratorWrapper;
+import org.apache.flink.core.memory.DataInputDeserializer;
+import org.apache.flink.runtime.state.CompositeKeySerializationUtils;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+
+import static org.apache.flink.contrib.streaming.state.iterator.AbstractRocksStateKeysIterator.isMatchingNameSpace;
+
+/**
+ * Adapter class to bridge between {@link RocksIteratorWrapper} and {@link Iterator} to iterate over
+ * the keys. This class is not thread safe.
+ *
+ * @param <K> the type of the iterated objects, which are keys in RocksDB.
+ */
+public class RocksMultiStateKeysIterator<K> implements AutoCloseable, Iterator<K> {
+
+    private final List<RocksIteratorWrapper> iterators;
+    private final List<String> states;
+    private final TypeSerializer<K> keySerializer;
+    private final List<Boolean> ambiguousKeyPossibles;
+    private final int keyGroupPrefixBytes;
+    private final byte[] namespaceBytes;
+    private final DataInputDeserializer byteArrayDataInputView;
+
+    private final byte[][] iteratorKeys;
+    private final int[] iteratorKeysToRemove;
+    private K previousKey;
+    private K nextKey;
+
+    public RocksMultiStateKeysIterator(
+            List<RocksIteratorWrapper> iterators,
+            List<String> states,
+            @Nonnull TypeSerializer<K> keySerializer,
+            int keyGroupPrefixBytes,
+            List<Boolean> ambiguousKeyPossibles,
+            @Nonnull byte[] namespaceBytes) {
+        this.iterators = iterators;
+        this.states = states;
+        this.keySerializer = keySerializer;
+        this.ambiguousKeyPossibles = ambiguousKeyPossibles;
+        this.keyGroupPrefixBytes = keyGroupPrefixBytes;
+        this.namespaceBytes = namespaceBytes;
+        this.byteArrayDataInputView = new DataInputDeserializer();
+        this.iteratorKeys = new byte[iterators.size()][];
+        Arrays.fill(iteratorKeys, null);
+        this.iteratorKeysToRemove = new int[iterators.size()];
+        Arrays.fill(iteratorKeysToRemove, -1);
+        this.previousKey = null;
+        this.nextKey = null;
+    }
+
+    @Override
+    public boolean hasNext() {
+        try {
+            while (nextKey == null && hasDataToProcess()) {
+                pullKeysFromIterators();
+                K smallestIteratorKey = calculateSmallestKeyFromLocalData();
+                if (smallestIteratorKey != null) {
+                    previousKey = smallestIteratorKey;
+                    nextKey = smallestIteratorKey;
+                }
+            }
+        } catch (Exception e) {
+            throw new FlinkRuntimeException(
+                    "Failed to access states [" + String.join(",", states) + "]", e);
+        }
+        return nextKey != null;
+    }
+
+    private boolean hasDataToProcess() {
+        boolean result = iterators.stream().anyMatch(RocksIteratorWrapper::isValid);
+        if (!result) {
+            for (int i = 0; i < iterators.size(); ++i) {
+                if (iteratorKeys[i] != null) {
+                    result = true;
+                    break;
+                }
+            }
+        }
+        return result;
+    }
+
+    private void pullKeysFromIterators() {
+        for (int i = 0; i < iterators.size(); ++i) {
+            RocksIteratorWrapper iterator = iterators.get(i);
+            if (iteratorKeys[i] == null && iterator.isValid()) {
+                iteratorKeys[i] = iterator.key();
+                iterator.next();
+            }
+        }
+    }
+
+    @Nullable
+    private K calculateSmallestKeyFromLocalData() throws IOException {
+        int smallestIteratorKeyIndex = -1;
+        byte[] smallestIteratorKey = null;
+        int iteratorKeysToRemoveIndex = 0;
+        for (int i = 0; i < iteratorKeys.length; ++i) {
+            byte[] iteratorKey = iteratorKeys[i];
+            if (iteratorKey != null) {
+                boolean update = smallestIteratorKey == null;
+                if (!update) {
+                    int cmp = arraysCompare(iteratorKey, smallestIteratorKey);
+                    if (cmp < 0) {
+                        update = true;
+                    } else if (cmp == 0) {
+                        iteratorKeysToRemove[iteratorKeysToRemoveIndex++] = i;
+                    }
+                }
+
+                if (update) {
+                    smallestIteratorKeyIndex = i;
+                    smallestIteratorKey = iteratorKey;
+                    Arrays.fill(iteratorKeysToRemove, -1);
+                    iteratorKeysToRemoveIndex = 0;
+                    iteratorKeysToRemove[iteratorKeysToRemoveIndex++] = i;
+                }
+            }
+        }
+
+        if (smallestIteratorKey != null) {
+            for (int i = 0; i < iteratorKeysToRemoveIndex; ++i) {
+                iteratorKeys[iteratorKeysToRemove[i]] = null;
+            }
+            byteArrayDataInputView.setBuffer(
+                    smallestIteratorKey,
+                    keyGroupPrefixBytes,
+                    smallestIteratorKey.length - keyGroupPrefixBytes);
+            final K smallestIteratorKeyValue =
+                    CompositeKeySerializationUtils.readKey(
+                            keySerializer,
+                            byteArrayDataInputView,
+                            ambiguousKeyPossibles.get(smallestIteratorKeyIndex));
+            if (isMatchingNameSpace(
+                            smallestIteratorKey,
+                            byteArrayDataInputView.getPosition(),
+                            namespaceBytes)
+                    && !Objects.equals(previousKey, smallestIteratorKeyValue)) {
+                return smallestIteratorKeyValue;
+            }
+        }
+
+        return null;
+    }
+
+    private static int arraysCompare(byte[] a, byte[] b) {
+        int minLength = Math.min(a.length, b.length);
+        for (int i = 0; i < minLength; ++i) {
+            int cmp = Byte.compare(a[i], b[i]);
+            if (cmp != 0) {
+                return cmp;
+            }
+        }
+        return a.length - b.length;
+    }
+
+    @Override
+    public K next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException(
+                    "Failed to access states [" + String.join(",", states) + "]");
+        }
+
+        K tmpKey = nextKey;
+        nextKey = null;
+        return tmpKey;
+    }
+
+    @Override
+    public void close() {
+        for (RocksIteratorWrapper iterator : iterators) {
+            iterator.close();
+        }
+    }
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/iterator/RocksStateKeysIterator.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/iterator/RocksStateKeysIterator.java
@@ -62,9 +62,9 @@ public class RocksStateKeysIterator<K> extends AbstractRocksStateKeysIterator<K>
 
                 final byte[] keyBytes = iterator.key();
                 final K currentKey = deserializeKey(keyBytes, byteArrayDataInputView);
-                final int namespaceByteStartPos = byteArrayDataInputView.getPosition();
 
-                if (isMatchingNameSpace(keyBytes, namespaceByteStartPos)
+                if (isMatchingNameSpace(
+                                keyBytes, byteArrayDataInputView.getPosition(), namespaceBytes)
                         && !Objects.equals(previousKey, currentKey)) {
                     previousKey = currentKey;
                     nextKey = currentKey;
@@ -86,19 +86,5 @@ public class RocksStateKeysIterator<K> extends AbstractRocksStateKeysIterator<K>
         K tmpKey = nextKey;
         nextKey = null;
         return tmpKey;
-    }
-
-    private boolean isMatchingNameSpace(@Nonnull byte[] key, int beginPos) {
-        final int namespaceBytesLength = namespaceBytes.length;
-        final int basicLength = namespaceBytesLength + beginPos;
-        if (key.length >= basicLength) {
-            for (int i = 0; i < namespaceBytesLength; ++i) {
-                if (key[beginPos + i] != namespaceBytes[i]) {
-                    return false;
-                }
-            }
-            return true;
-        }
-        return false;
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionKeyedStateBackend.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionKeyedStateBackend.java
@@ -152,6 +152,15 @@ public class BatchExecutionKeyedStateBackend<K> implements CheckpointableKeyedSt
     }
 
     @Override
+    public <N> Stream<K> getKeys(List<String> states, N namespace) {
+        LOG.debug("Returning an empty stream in BATCH execution mode in getKeys().");
+        // We return an empty Stream here. This is correct because the BATCH broadcast operators
+        // process the broadcast side first, meaning we know that the keyed side will always be
+        // empty when this is called
+        return Stream.empty();
+    }
+
+    @Override
     public <N> Stream<Tuple2<K, N>> getKeysAndNamespaces(String state) {
         LOG.debug("Returning an empty stream in BATCH execution mode in getKeysAndNamespaces().");
         // We return an empty Stream here. This is correct because the BATCH broadcast operators

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestStateBackend.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestStateBackend.java
@@ -55,6 +55,7 @@ import javax.annotation.Nonnull;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.RunnableFuture;
 import java.util.stream.Stream;
@@ -158,6 +159,11 @@ public class TestStateBackend extends AbstractStateBackend {
 
         @Override
         public <N> Stream<K> getKeys(String state, N namespace) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <N> Stream<K> getKeys(List<String> states, N namespace) {
             throw new UnsupportedOperationException();
         }
 


### PR DESCRIPTION
## What is the purpose of the change

This is backport of https://github.com/apache/flink/pull/26134.

State processor API with RocksDB is extremely slow because it does the following for key deduplication:
* Get keys from `columnFamility1`
* Get keys from `columnFamility2`
* Iterate over the keys
* Calls `KeyedStateReaderFunction.readKey`
* Removes the key from both column families

Since key removal is slow compared to other operations the overall performance is unacceptable.
Instead of the mentioned method we've migrated to the following:
* Get keys from `columnFamility1`
* Get keys from `columnFamility2`
* Added `RocksMultiStateKeysIterator` which iterates on all column families at the same time in an ordered way

As a result key deduplication happens on iteration time in a streaming manner.
Important note that this change effects only state processor API, existing checkpointing save/restore code paths are untouched.

## Brief change log

Changed state processor API key iteration deduplication algorithm.

## Verifying this change

Existing unit tests + performance/correctness tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
