### PR TITLE
[FLINK-37312][doc] Add missing closing tab in state_v2.md

### DIFF
--- a/docs/content.zh/docs/dev/datastream/fault-tolerance/state_v2.md
+++ b/docs/content.zh/docs/dev/datastream/fault-tolerance/state_v2.md
@@ -74,6 +74,7 @@ DataStream<WordCount> words = // [...]
 KeyedStream<WordCount> keyed = words
   .keyBy(WordCount::getWord).enableAsyncState();
 ```
+{{< /tab >}}
 {{< /tabs >}}
 
 {{< top >}}

--- a/docs/content/docs/dev/datastream/fault-tolerance/state_v2.md
+++ b/docs/content/docs/dev/datastream/fault-tolerance/state_v2.md
@@ -74,6 +74,7 @@ DataStream<WordCount> words = // [...]
 KeyedStream<WordCount> keyed = words
   .keyBy(WordCount::getWord).enableAsyncState();
 ```
+{{< /tab >}}
 {{< /tabs >}}
 
 {{< top >}}


### PR DESCRIPTION
## What is the purpose of the change

Documentation build fails with the following error:
```
Error: error building site: process: readAndProcessContent: "/Users/gaborsomogyi/flink/docs/content.zh/docs/dev/datastream/fault-tolerance/state_v2.md:63:1": failed to extract shortcode: shortcode "tabs" must be closed or self-closed
```

## Brief change log

Added missing tab closing.

## Verifying this change

`./build_docs.sh`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
