### PR TITLE
[FLINK-37321][table] Make window functions with wrong descriptors fail during planning rather than runtime 

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowAggregateBase.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowAggregateBase.java
@@ -156,13 +156,6 @@ public abstract class StreamExecWindowAggregateBase extends StreamExecAggregateB
         } else if (windowSpec instanceof CumulativeWindowSpec) {
             Duration maxSize = ((CumulativeWindowSpec) windowSpec).getMaxSize();
             Duration step = ((CumulativeWindowSpec) windowSpec).getStep();
-            if (maxSize.toMillis() % step.toMillis() != 0) {
-                throw new TableException(
-                        String.format(
-                                "CUMULATE table function based aggregate requires maxSize must be an "
-                                        + "integral multiple of step, but got maxSize %s ms and step %s ms",
-                                maxSize.toMillis(), step.toMillis()));
-            }
             SliceAssigners.CumulativeSliceAssigner assigner =
                     SliceAssigners.cumulative(timeAttributeIndex, shiftTimeZone, maxSize, step);
             Duration offset = ((CumulativeWindowSpec) windowSpec).getOffset();

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/WindowUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/WindowUtil.scala
@@ -219,7 +219,8 @@ object WindowUtil {
         val interval = getOperandAsLong(windowCall.operands(2))
         if (interval <= 0) {
           throw new TableException(
-            "Only positive interval constant for TUMBLE window descriptors is supported.")
+            s"TUMBLE table function based aggregate requires size being positive," +
+              s" but got $interval ms.")
         }
         new TumblingWindowSpec(Duration.ofMillis(interval), offset)
 
@@ -233,7 +234,8 @@ object WindowUtil {
         val size = getOperandAsLong(windowCall.operands(3))
         if (slide <= 0 || size <= 0) {
           throw new TableException(
-            "Only positive slide and size constant for HOP window descriptors are supported.")
+            s"HOP table function based aggregate requires slide and size being positive," +
+              s" but got slide $slide ms and size $size ms.")
         }
         new HoppingWindowSpec(Duration.ofMillis(size), Duration.ofMillis(slide), offset)
 
@@ -247,11 +249,12 @@ object WindowUtil {
         val maxSize = getOperandAsLong(windowCall.operands(3))
         if (step <= 0 || maxSize <= 0) {
           throw new TableException(
-            "Only positive step and size constant for CUMULATE window descriptors are supported.")
+            s"CUMULATE table function based aggregate requires maxSize and step being positive," +
+              s" but got maxSize $maxSize ms and step $step ms.")
         }
         if (maxSize % step != 0) {
-          throw new TableException(
-            "CUMULATE window requires size being an integral multiple of step.")
+          throw new TableException("CUMULATE table function based aggregate requires maxSize " +
+            s"must be an integral multiple of step, but got maxSize $maxSize ms and step $step ms.")
         }
         new CumulativeWindowSpec(Duration.ofMillis(maxSize), Duration.ofMillis(step), offset)
       case FlinkSqlOperatorTable.SESSION =>
@@ -262,7 +265,8 @@ object WindowUtil {
         val gap = getOperandAsLong(windowCall.operands(2))
         if (gap <= 0) {
           throw new TableException(
-            "Only positive gap constant for SESSION window descriptors is supported.")
+            s"SESSION table function based aggregate requires gap being positive," +
+              s" but got gap $gap ms.")
         }
         new SessionWindowSpec(Duration.ofMillis(gap), tableArgCall.getPartitionKeys)
     }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/WindowUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/WindowUtil.scala
@@ -217,6 +217,10 @@ object WindowUtil {
           null
         }
         val interval = getOperandAsLong(windowCall.operands(2))
+        if (interval <= 0) {
+          throw new TableException(
+            "Only positive interval constant for TUMBLE window descriptors is supported.")
+        }
         new TumblingWindowSpec(Duration.ofMillis(interval), offset)
 
       case FlinkSqlOperatorTable.HOP =>
@@ -227,6 +231,10 @@ object WindowUtil {
         }
         val slide = getOperandAsLong(windowCall.operands(2))
         val size = getOperandAsLong(windowCall.operands(3))
+        if (slide <= 0 || size <= 0) {
+          throw new TableException(
+            "Only positive slide and size constant for HOP window descriptors are supported.")
+        }
         new HoppingWindowSpec(Duration.ofMillis(size), Duration.ofMillis(slide), offset)
 
       case FlinkSqlOperatorTable.CUMULATE =>
@@ -237,6 +245,10 @@ object WindowUtil {
         }
         val step = getOperandAsLong(windowCall.operands(2))
         val maxSize = getOperandAsLong(windowCall.operands(3))
+        if (step <= 0 || maxSize <= 0) {
+          throw new TableException(
+            "Only positive step and size constant for CUMULATE window descriptors are supported.")
+        }
         new CumulativeWindowSpec(Duration.ofMillis(maxSize), Duration.ofMillis(step), offset)
       case FlinkSqlOperatorTable.SESSION =>
         val tableArgCall = windowCall.operands(0).asInstanceOf[RexTableArgCall]
@@ -244,6 +256,10 @@ object WindowUtil {
           throw new ValidationException("Session window TVF doesn't support order by clause.")
         }
         val gap = getOperandAsLong(windowCall.operands(2))
+        if (gap <= 0) {
+          throw new TableException(
+            "Only positive gap constant for SESSION window descriptors is supported.")
+        }
         new SessionWindowSpec(Duration.ofMillis(gap), tableArgCall.getPartitionKeys)
     }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/WindowUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/WindowUtil.scala
@@ -219,7 +219,7 @@ object WindowUtil {
         val interval = getOperandAsLong(windowCall.operands(2))
         if (interval <= 0) {
           throw new TableException(
-            s"TUMBLE table function based aggregate requires size being positive," +
+            s"TUMBLE table function based aggregate requires size to be positive," +
               s" but got $interval ms.")
         }
         new TumblingWindowSpec(Duration.ofMillis(interval), offset)
@@ -234,7 +234,7 @@ object WindowUtil {
         val size = getOperandAsLong(windowCall.operands(3))
         if (slide <= 0 || size <= 0) {
           throw new TableException(
-            s"HOP table function based aggregate requires slide and size being positive," +
+            s"HOP table function based aggregate requires slide and size to be positive," +
               s" but got slide $slide ms and size $size ms.")
         }
         new HoppingWindowSpec(Duration.ofMillis(size), Duration.ofMillis(slide), offset)
@@ -249,7 +249,7 @@ object WindowUtil {
         val maxSize = getOperandAsLong(windowCall.operands(3))
         if (step <= 0 || maxSize <= 0) {
           throw new TableException(
-            s"CUMULATE table function based aggregate requires maxSize and step being positive," +
+            s"CUMULATE table function based aggregate requires maxSize and step to be positive," +
               s" but got maxSize $maxSize ms and step $step ms.")
         }
         if (maxSize % step != 0) {
@@ -265,7 +265,7 @@ object WindowUtil {
         val gap = getOperandAsLong(windowCall.operands(2))
         if (gap <= 0) {
           throw new TableException(
-            s"SESSION table function based aggregate requires gap being positive," +
+            s"SESSION table function based aggregate requires gap to be positive," +
               s" but got gap $gap ms.")
         }
         new SessionWindowSpec(Duration.ofMillis(gap), tableArgCall.getPartitionKeys)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/WindowUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/WindowUtil.scala
@@ -249,6 +249,10 @@ object WindowUtil {
           throw new TableException(
             "Only positive step and size constant for CUMULATE window descriptors are supported.")
         }
+        if (maxSize % step != 0) {
+          throw new TableException(
+            "CUMULATE window requires size being an integral multiple of step.")
+        }
         new CumulativeWindowSpec(Duration.ofMillis(maxSize), Duration.ofMillis(step), offset)
       case FlinkSqlOperatorTable.SESSION =>
         val tableArgCall = windowCall.operands(0).asInstanceOf[RexTableArgCall]

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/WindowUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/WindowUtil.scala
@@ -218,9 +218,14 @@ object WindowUtil {
         }
         val interval = getOperandAsLong(windowCall.operands(2))
         if (interval <= 0) {
-          throw new TableException(
+          throw new ValidationException(
             s"TUMBLE table function based aggregate requires size to be positive," +
               s" but got $interval ms.")
+        }
+        if (offset != null && Math.abs(offset.toMillis) >= interval) {
+          throw new ValidationException(
+            s"TUMBLE table function parameters must satisfy abs(offset) < size, " +
+              s"but got size $interval ms and offset ${offset.toMillis} ms.")
         }
         new TumblingWindowSpec(Duration.ofMillis(interval), offset)
 
@@ -233,7 +238,7 @@ object WindowUtil {
         val slide = getOperandAsLong(windowCall.operands(2))
         val size = getOperandAsLong(windowCall.operands(3))
         if (slide <= 0 || size <= 0) {
-          throw new TableException(
+          throw new ValidationException(
             s"HOP table function based aggregate requires slide and size to be positive," +
               s" but got slide $slide ms and size $size ms.")
         }
@@ -248,12 +253,12 @@ object WindowUtil {
         val step = getOperandAsLong(windowCall.operands(2))
         val maxSize = getOperandAsLong(windowCall.operands(3))
         if (step <= 0 || maxSize <= 0) {
-          throw new TableException(
+          throw new ValidationException(
             s"CUMULATE table function based aggregate requires maxSize and step to be positive," +
               s" but got maxSize $maxSize ms and step $step ms.")
         }
         if (maxSize % step != 0) {
-          throw new TableException("CUMULATE table function based aggregate requires maxSize " +
+          throw new ValidationException("CUMULATE table function based aggregate requires maxSize " +
             s"must be an integral multiple of step, but got maxSize $maxSize ms and step $step ms.")
         }
         new CumulativeWindowSpec(Duration.ofMillis(maxSize), Duration.ofMillis(step), offset)
@@ -264,7 +269,7 @@ object WindowUtil {
         }
         val gap = getOperandAsLong(windowCall.operands(2))
         if (gap <= 0) {
-          throw new TableException(
+          throw new ValidationException(
             s"SESSION table function based aggregate requires gap to be positive," +
               s" but got gap $gap ms.")
         }

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/WindowAggregateTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/WindowAggregateTest.xml
@@ -668,7 +668,7 @@ SELECT
    b,
    count(distinct c) AS uv
 FROM TABLE(
-   CUMULATE(TABLE MyTable, DESCRIPTOR(rowtime), INTERVAL '25' MINUTE, INTERVAL '1' HOUR))
+   CUMULATE(TABLE MyTable, DESCRIPTOR(rowtime), INTERVAL '20' MINUTE, INTERVAL '1' HOUR))
 GROUP BY GROUPING SETS ((a), (b)), window_start, window_end
       ]]>
     </Resource>
@@ -677,7 +677,7 @@ GROUP BY GROUPING SETS ((a), (b)), window_start, window_end
 LogicalProject(a=[$0], b=[$1], uv=[$4])
 +- LogicalAggregate(group=[{0, 1, 2, 3}], groups=[[{0, 2, 3}, {1, 2, 3}]], uv=[COUNT(DISTINCT $4)])
    +- LogicalProject(a=[$0], b=[$1], window_start=[$7], window_end=[$8], c=[$2])
-      +- LogicalTableFunctionScan(invocation=[CUMULATE(TABLE(#0), DESCRIPTOR($5), 1500000:INTERVAL MINUTE, 3600000:INTERVAL HOUR)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP(3) *ROWTIME* window_time)])
+      +- LogicalTableFunctionScan(invocation=[CUMULATE(TABLE(#0), DESCRIPTOR($5), 1200000:INTERVAL MINUTE, 3600000:INTERVAL HOUR)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP(3) *ROWTIME* window_time)])
          +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6])
             +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($5, 1000:INTERVAL SECOND)])
                +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[PROCTIME()])
@@ -687,7 +687,7 @@ LogicalProject(a=[$0], b=[$1], uv=[$4])
     <Resource name="optimized rel plan">
       <![CDATA[
 Calc(select=[a, b, uv])
-+- WindowAggregate(groupBy=[a, b, $e], window=[CUMULATE(time_col=[rowtime], max_size=[1 h], step=[25 min])], select=[a, b, $e, COUNT(DISTINCT c) AS uv, start('w$) AS window_start, end('w$) AS window_end])
++- WindowAggregate(groupBy=[a, b, $e], window=[CUMULATE(time_col=[rowtime], max_size=[1 h], step=[20 min])], select=[a, b, $e, COUNT(DISTINCT c) AS uv, start('w$) AS window_start, end('w$) AS window_end])
    +- Exchange(distribution=[hash[a, b, $e]])
       +- Expand(projects=[{a, null AS b, c, 4 AS $e, rowtime}, {null AS a, b, c, 8 AS $e, rowtime}])
          +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
@@ -703,7 +703,7 @@ SELECT
    b,
    count(distinct c) AS uv
 FROM TABLE(
-   CUMULATE(TABLE MyTable, DESCRIPTOR(rowtime), INTERVAL '25' MINUTE, INTERVAL '1' HOUR))
+   CUMULATE(TABLE MyTable, DESCRIPTOR(rowtime), INTERVAL '20' MINUTE, INTERVAL '1' HOUR))
 GROUP BY GROUPING SETS ((a), (b)), window_start, window_end
       ]]>
     </Resource>
@@ -712,7 +712,7 @@ GROUP BY GROUPING SETS ((a), (b)), window_start, window_end
 LogicalProject(a=[$0], b=[$1], uv=[$4])
 +- LogicalAggregate(group=[{0, 1, 2, 3}], groups=[[{0, 2, 3}, {1, 2, 3}]], uv=[COUNT(DISTINCT $4)])
    +- LogicalProject(a=[$0], b=[$1], window_start=[$7], window_end=[$8], c=[$2])
-      +- LogicalTableFunctionScan(invocation=[CUMULATE(TABLE(#0), DESCRIPTOR($5), 1500000:INTERVAL MINUTE, 3600000:INTERVAL HOUR)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP(3) *ROWTIME* window_time)])
+      +- LogicalTableFunctionScan(invocation=[CUMULATE(TABLE(#0), DESCRIPTOR($5), 1200000:INTERVAL MINUTE, 3600000:INTERVAL HOUR)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP(3) *ROWTIME* window_time)])
          +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6])
             +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($5, 1000:INTERVAL SECOND)])
                +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[PROCTIME()])
@@ -722,9 +722,9 @@ LogicalProject(a=[$0], b=[$1], uv=[$4])
     <Resource name="optimized rel plan">
       <![CDATA[
 Calc(select=[a, b, uv])
-+- GlobalWindowAggregate(groupBy=[a, b, $e], window=[CUMULATE(slice_end=[$slice_end], max_size=[1 h], step=[25 min])], select=[a, b, $e, COUNT(distinct$0 count$0) AS uv, start('w$) AS window_start, end('w$) AS window_end])
++- GlobalWindowAggregate(groupBy=[a, b, $e], window=[CUMULATE(slice_end=[$slice_end], max_size=[1 h], step=[20 min])], select=[a, b, $e, COUNT(distinct$0 count$0) AS uv, start('w$) AS window_start, end('w$) AS window_end])
    +- Exchange(distribution=[hash[a, b, $e]])
-      +- LocalWindowAggregate(groupBy=[a, b, $e], window=[CUMULATE(time_col=[rowtime], max_size=[1 h], step=[25 min])], select=[a, b, $e, COUNT(distinct$0 c) AS count$0, DISTINCT(c) AS distinct$0, slice_end('w$) AS $slice_end])
+      +- LocalWindowAggregate(groupBy=[a, b, $e], window=[CUMULATE(time_col=[rowtime], max_size=[1 h], step=[20 min])], select=[a, b, $e, COUNT(distinct$0 c) AS count$0, DISTINCT(c) AS distinct$0, slice_end('w$) AS $slice_end])
          +- Expand(projects=[{a, null AS b, c, 4 AS $e, rowtime}, {null AS a, b, c, 8 AS $e, rowtime}])
             +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
                +- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, b, c, rowtime], metadata=[]]], fields=[a, b, c, rowtime])

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/WindowTableFunctionTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/WindowTableFunctionTest.scala
@@ -351,7 +351,7 @@ class WindowTableFunctionTest extends TableTestBase {
 
   @ParameterizedTest(name = "{index}: {0}")
   @ValueSource(ints = Array[Int](-1, 0))
-  def testTumbleWindowWithWrongInterval(interval: Int): Unit = {
+  def testTumbleWindowWithNonPositiveInterval(interval: Int): Unit = {
     val sql =
       s"""
          |SELECT *
@@ -366,7 +366,7 @@ class WindowTableFunctionTest extends TableTestBase {
 
   @ParameterizedTest(name = "{index}: {0}, {1}")
   @CsvSource(Array[String]("-1, 1", "0, 2", "3, 0", "4, -3"))
-  def testCumulateWindowWithWrongStepAndSize(step: Int, size: Int): Unit = {
+  def testCumulateWindowWithNonPositiveStepAndSize(step: Int, size: Int): Unit = {
     val sql =
       s"""
          |SELECT *
@@ -381,8 +381,23 @@ class WindowTableFunctionTest extends TableTestBase {
   }
 
   @ParameterizedTest(name = "{index}: {0}, {1}")
+  @CsvSource(Array[String]("2, 3", "4, 7"))
+  def testCumulateWindowWithWrongStepAndSize(step: Int, size: Int): Unit = {
+    val sql =
+      s"""
+         |SELECT *
+         |FROM TABLE(
+         | CUMULATE(TABLE MyTable, DESCRIPTOR(rowtime), INTERVAL '$step' SECOND, INTERVAL '$size' SECOND))
+         |""".stripMargin
+
+    assertThatThrownBy(() => util.verifyRelPlan(sql))
+      .hasCause(
+        new TableException("CUMULATE window requires size being an integral multiple of step."))
+  }
+
+  @ParameterizedTest(name = "{index}: {0}, {1}")
   @CsvSource(Array[String]("-1, 1", "0, 2", "3, 0", "4, -3"))
-  def testHopWindowWithWrongSlideAndSize(slide: Int, size: Int): Unit = {
+  def testHopWindowWithNonPositiveSlideAndSize(slide: Int, size: Int): Unit = {
     val sql =
       s"""
          |SELECT *
@@ -398,7 +413,7 @@ class WindowTableFunctionTest extends TableTestBase {
 
   @ParameterizedTest(name = "{index}: {0}")
   @ValueSource(ints = Array[Int](-1, 0))
-  def testSessionWindowWithWrongGap(gap: Int): Unit = {
+  def testSessionWindowWithNonPositiveGap(gap: Int): Unit = {
     val sql =
       s"""
          |SELECT *

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/WindowTableFunctionTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/WindowTableFunctionTest.scala
@@ -24,7 +24,7 @@ import org.apache.flink.table.planner.utils.TableTestBase
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.{CsvSource, ValueSource, ValueSources}
+import org.junit.jupiter.params.provider.{CsvSource, ValueSource}
 
 import java.time.Duration
 
@@ -361,7 +361,8 @@ class WindowTableFunctionTest extends TableTestBase {
     assertThatThrownBy(() => util.verifyRelPlan(sql))
       .hasCause(
         new TableException(
-          "Only positive interval constant for TUMBLE window descriptors is supported."))
+          s"TUMBLE table function based aggregate requires size being positive," +
+            s" but got ${interval * 1000 * 60} ms."))
   }
 
   @ParameterizedTest(name = "{index}: {0}, {1}")
@@ -377,7 +378,8 @@ class WindowTableFunctionTest extends TableTestBase {
     assertThatThrownBy(() => util.verifyRelPlan(sql))
       .hasCause(
         new TableException(
-          "Only positive step and size constant for CUMULATE window descriptors are supported."))
+          "CUMULATE table function based aggregate requires maxSize and step being positive," +
+            s" but got maxSize ${size * 1000 * 60 * 60} ms and step ${step * 1000 * 60} ms."))
   }
 
   @ParameterizedTest(name = "{index}: {0}, {1}")
@@ -391,8 +393,8 @@ class WindowTableFunctionTest extends TableTestBase {
          |""".stripMargin
 
     assertThatThrownBy(() => util.verifyRelPlan(sql))
-      .hasCause(
-        new TableException("CUMULATE window requires size being an integral multiple of step."))
+      .hasCause(new TableException("CUMULATE table function based aggregate requires maxSize must " +
+        s"be an integral multiple of step, but got maxSize ${size * 1000} ms and step ${step * 1000} ms."))
   }
 
   @ParameterizedTest(name = "{index}: {0}, {1}")
@@ -408,7 +410,8 @@ class WindowTableFunctionTest extends TableTestBase {
     assertThatThrownBy(() => util.verifyRelPlan(sql))
       .hasCause(
         new TableException(
-          "Only positive slide and size constant for HOP window descriptors are supported."))
+          "HOP table function based aggregate requires slide and size being positive," +
+            s" but got slide ${slide * 1000 * 60} ms and size ${size * 1000 * 60} ms."))
   }
 
   @ParameterizedTest(name = "{index}: {0}")
@@ -423,7 +426,8 @@ class WindowTableFunctionTest extends TableTestBase {
     assertThatThrownBy(() => util.verifyRelPlan(sql))
       .hasCause(
         new TableException(
-          "Only positive gap constant for SESSION window descriptors is supported."))
+          s"SESSION table function based aggregate requires gap being positive," +
+            s" but got gap ${gap * 1000 * 60} ms."))
   }
 
   private def enableMiniBatch(): Unit = {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/WindowTableFunctionTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/WindowTableFunctionTest.scala
@@ -361,7 +361,7 @@ class WindowTableFunctionTest extends TableTestBase {
     assertThatThrownBy(() => util.verifyRelPlan(sql))
       .hasCause(
         new TableException(
-          s"TUMBLE table function based aggregate requires size being positive," +
+          s"TUMBLE table function based aggregate requires size to be positive," +
             s" but got ${interval * 1000 * 60} ms."))
   }
 
@@ -378,7 +378,7 @@ class WindowTableFunctionTest extends TableTestBase {
     assertThatThrownBy(() => util.verifyRelPlan(sql))
       .hasCause(
         new TableException(
-          "CUMULATE table function based aggregate requires maxSize and step being positive," +
+          "CUMULATE table function based aggregate requires maxSize and step to be positive," +
             s" but got maxSize ${size * 1000 * 60 * 60} ms and step ${step * 1000 * 60} ms."))
   }
 
@@ -410,7 +410,7 @@ class WindowTableFunctionTest extends TableTestBase {
     assertThatThrownBy(() => util.verifyRelPlan(sql))
       .hasCause(
         new TableException(
-          "HOP table function based aggregate requires slide and size being positive," +
+          "HOP table function based aggregate requires slide and size to be positive," +
             s" but got slide ${slide * 1000 * 60} ms and size ${size * 1000 * 60} ms."))
   }
 
@@ -426,7 +426,7 @@ class WindowTableFunctionTest extends TableTestBase {
     assertThatThrownBy(() => util.verifyRelPlan(sql))
       .hasCause(
         new TableException(
-          s"SESSION table function based aggregate requires gap being positive," +
+          s"SESSION table function based aggregate requires gap to be positive," +
             s" but got gap ${gap * 1000 * 60} ms."))
   }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/agg/WindowAggregateTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/agg/WindowAggregateTest.scala
@@ -1120,7 +1120,7 @@ class WindowAggregateTest(aggPhaseEnforcer: AggregatePhaseStrategy) extends Tabl
         |   b,
         |   count(distinct c) AS uv
         |FROM TABLE(
-        |   CUMULATE(TABLE MyTable, DESCRIPTOR(rowtime), INTERVAL '25' MINUTE, INTERVAL '1' HOUR))
+        |   CUMULATE(TABLE MyTable, DESCRIPTOR(rowtime), INTERVAL '20' MINUTE, INTERVAL '1' HOUR))
         |GROUP BY GROUPING SETS ((a), (b)), window_start, window_end
       """.stripMargin
     util.verifyRelPlan(sql)

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/window/tvf/slicing/SliceAssigners.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/window/tvf/slicing/SliceAssigners.java
@@ -161,7 +161,7 @@ public final class SliceAssigners {
             checkArgument(
                     Math.abs(offset) < size,
                     String.format(
-                            "Tumbling Window parameters must satisfy abs(offset) < size, bot got size %dms and offset %dms.",
+                            "Tumbling Window parameters must satisfy abs(offset) < size, but got size %dms and offset %dms.",
                             size, offset));
             this.size = size;
             this.offset = offset;

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/tvf/slicing/TumblingSliceAssignerTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/tvf/slicing/TumblingSliceAssignerTest.java
@@ -142,7 +142,7 @@ class TumblingSliceAssignerTest extends SliceAssignerTestBase {
                 () ->
                         SliceAssigners.tumbling(0, zoneId, Duration.ofSeconds(10))
                                 .withOffset(Duration.ofSeconds(20)),
-                "Tumbling Window parameters must satisfy abs(offset) < size, bot got size 10000ms and offset 20000ms.");
+                "Tumbling Window parameters must satisfy abs(offset) < size, but got size 10000ms and offset 20000ms.");
 
         // should pass
         SliceAssigners.tumbling(0, zoneId, Duration.ofSeconds(10))


### PR DESCRIPTION

## What is the purpose of the change
Queries with wrongly defined descriptors should fail during planning, like
```sql


SELECT *
FROM TABLE(
 CUMULATE(TABLE MyTable, DESCRIPTOR(rowtime), INTERVAL '0' MINUTE, INTERVAL '0' HOUR));

SELECT *
FROM TABLE(
 HOP(TABLE MyTable, DESCRIPTOR(rowtime), INTERVAL '0' MINUTE, INTERVAL '0' MINUTE));

SELECT *
FROM TABLE(TUMBLE(TABLE MyTable, DESCRIPTOR(rowtime), INTERVAL '0' MINUTE));

SELECT *
FROM TABLE(SESSION(TABLE MyTable, DESCRIPTOR(rowtime), INTERVAL '0' MINUTE));


```

## Brief change log

`WindowUtil`

## Verifying this change
`WindowTableFunctionTest.scala`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
