### PR TITLE
[FLINK-37327] [Formats (JSON, Avro, Parquet, ORC, SequenceFile)] Debezium Avro Format: Add FormatOption to Optionally Skip emitting UPDATE_BEFORE Rows

### DIFF
--- a/docs/content.zh/docs/connectors/table/formats/debezium.md
+++ b/docs/content.zh/docs/connectors/table/formats/debezium.md
@@ -325,7 +325,7 @@ Flink 提供了 `debezium-avro-confluent` 和 `debezium-json` 两种 format 来�
             <td>optional</td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
-            <td>In upsert mode the format will not produce UPDATE_BEFORE Rows from Debezium op='u' change events when deserializing.</td>
+            <td>In upsert mode the format will not produce UPDATE_BEFORE rows from Debezium op='u' change events when deserializing.</td>
         </tr>
         <tr>
             <td><h5>debezium-avro-confluent.properties</h5></td>

--- a/docs/content.zh/docs/connectors/table/formats/debezium.md
+++ b/docs/content.zh/docs/connectors/table/formats/debezium.md
@@ -321,7 +321,7 @@ Flink 提供了 `debezium-avro-confluent` 和 `debezium-json` 两种 format 来�
             <td>Bearer auth token for Schema Registry</td>
         </tr>
         <tr>
-            <td><h5>debezium-avro-confluent.enable-upsert-mode</h5></td>
+            <td><h5>debezium-avro-confluent.upsert-mode</h5></td>
             <td>optional</td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/docs/content.zh/docs/connectors/table/formats/debezium.md
+++ b/docs/content.zh/docs/connectors/table/formats/debezium.md
@@ -321,6 +321,13 @@ Flink 提供了 `debezium-avro-confluent` 和 `debezium-json` 两种 format 来�
             <td>Bearer auth token for Schema Registry</td>
         </tr>
         <tr>
+            <td><h5>debezium-avro-confluent.enable-upsert-mode</h5></td>
+            <td>optional</td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>In upsert mode the format will not produce UPDATE_BEFORE Rows from Debezium op='u' change events when deserializing.</td>
+        </tr>
+        <tr>
             <td><h5>debezium-avro-confluent.properties</h5></td>
             <td>optional</td>
             <td style="word-wrap: break-word;">(none)</td>

--- a/docs/content/docs/connectors/table/formats/debezium.md
+++ b/docs/content/docs/connectors/table/formats/debezium.md
@@ -311,7 +311,7 @@ Use format `debezium-avro-confluent` to interpret Debezium Avro messages and for
             <td>Bearer auth token for Schema Registry</td>
         </tr>
         <tr>
-            <td><h5>debezium-avro-confluent.enable-upsert-mode</h5></td>
+            <td><h5>debezium-avro-confluent.upsert-mode</h5></td>
             <td>optional</td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/docs/content/docs/connectors/table/formats/debezium.md
+++ b/docs/content/docs/connectors/table/formats/debezium.md
@@ -311,6 +311,13 @@ Use format `debezium-avro-confluent` to interpret Debezium Avro messages and for
             <td>Bearer auth token for Schema Registry</td>
         </tr>
         <tr>
+            <td><h5>debezium-avro-confluent.enable-upsert-mode</h5></td>
+            <td>optional</td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>In upsert mode the format will not produce UPDATE_BEFORE Rows from Debezium op='u' change events when deserializing.</td>
+        </tr>
+        <tr>
             <td><h5>debezium-avro-confluent.properties</h5></td>
             <td>optional</td>
             <td style="word-wrap: break-word;">(none)</td>

--- a/docs/content/docs/connectors/table/formats/debezium.md
+++ b/docs/content/docs/connectors/table/formats/debezium.md
@@ -315,7 +315,7 @@ Use format `debezium-avro-confluent` to interpret Debezium Avro messages and for
             <td>optional</td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
-            <td>In upsert mode the format will not produce UPDATE_BEFORE Rows from Debezium op='u' change events when deserializing.</td>
+            <td>In upsert mode the format will not produce UPDATE_BEFORE rows from Debezium op='u' change events when deserializing.</td>
         </tr>
         <tr>
             <td><h5>debezium-avro-confluent.properties</h5></td>

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroDeserializationSchema.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroDeserializationSchema.java
@@ -122,13 +122,6 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
     @VisibleForTesting
     DebeziumAvroDeserializationSchema(
             TypeInformation<RowData> producedTypeInfo,
-            AvroRowDataDeserializationSchema avroDeserializer) {
-        this(producedTypeInfo, avroDeserializer, false);
-    }
-
-    @VisibleForTesting
-    DebeziumAvroDeserializationSchema(
-            TypeInformation<RowData> producedTypeInfo,
             AvroRowDataDeserializationSchema avroDeserializer,
             boolean enableUpsertMode) {
         this.producedTypeInfo = producedTypeInfo;

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroDeserializationSchema.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroDeserializationSchema.java
@@ -83,7 +83,7 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
     /** TypeInformation of the produced {@link RowData}. */
     private final TypeInformation<RowData> producedTypeInfo;
 
-    private final boolean enableUpsertMode;
+    private final boolean upsertMode;
 
     public DebeziumAvroDeserializationSchema(
             RowType rowType,
@@ -100,9 +100,9 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
             String schemaRegistryUrl,
             @Nullable String schemaString,
             @Nullable Map<String, ?> registryConfigs,
-            boolean enableUpsertMode) {
+            boolean upsertMode) {
         this.producedTypeInfo = producedTypeInfo;
-        this.enableUpsertMode = enableUpsertMode;
+        this.upsertMode = upsertMode;
         RowType debeziumAvroRowType = createDebeziumAvroRowType(fromLogicalToDataType(rowType));
 
         validateSchemaString(schemaString, debeziumAvroRowType);
@@ -123,10 +123,10 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
     DebeziumAvroDeserializationSchema(
             TypeInformation<RowData> producedTypeInfo,
             AvroRowDataDeserializationSchema avroDeserializer,
-            boolean enableUpsertMode) {
+            boolean upsertMode) {
         this.producedTypeInfo = producedTypeInfo;
         this.avroDeserializer = avroDeserializer;
-        this.enableUpsertMode = enableUpsertMode;
+        this.upsertMode = upsertMode;
     }
 
     @Override
@@ -161,7 +161,7 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
                             String.format(REPLICA_IDENTITY_EXCEPTION, "UPDATE"));
                 }
                 after.setRowKind(RowKind.UPDATE_AFTER);
-                if (!enableUpsertMode) {
+                if (!upsertMode) {
                     before.setRowKind(RowKind.UPDATE_BEFORE);
                     out.collect(before);
                 }
@@ -206,12 +206,12 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
         DebeziumAvroDeserializationSchema that = (DebeziumAvroDeserializationSchema) o;
         return Objects.equals(avroDeserializer, that.avroDeserializer)
                 && Objects.equals(producedTypeInfo, that.producedTypeInfo)
-                && enableUpsertMode == that.enableUpsertMode;
+                && upsertMode == that.upsertMode;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(avroDeserializer, producedTypeInfo, enableUpsertMode);
+        return Objects.hash(avroDeserializer, producedTypeInfo, upsertMode);
     }
 
     public static RowType createDebeziumAvroRowType(DataType databaseSchema) {

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroFormatFactory.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroFormatFactory.java
@@ -195,6 +195,7 @@ public class DebeziumAvroFormatFactory
         options.add(BASIC_AUTH_USER_INFO);
         options.add(BEARER_AUTH_CREDENTIALS_SOURCE);
         options.add(BEARER_AUTH_TOKEN);
+        options.add(ENABLE_UPSERT_MODE);
         return options;
     }
 

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroFormatFactory.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroFormatFactory.java
@@ -139,6 +139,7 @@ public class DebeziumAvroFormatFactory
         String schemaRegistryURL = formatOptions.get(URL);
         Optional<String> subject = formatOptions.getOptional(SUBJECT);
         String schema = formatOptions.getOptional(SCHEMA).orElse(null);
+        Boolean enableUpsertMode = formatOptions.get(ENABLE_UPSERT_MODE);
         Map<String, ?> optionalPropertiesMap = buildOptionalPropertiesMap(formatOptions);
 
         if (!subject.isPresent()) {
@@ -151,6 +152,13 @@ public class DebeziumAvroFormatFactory
         return new EncodingFormat<SerializationSchema<RowData>>() {
             @Override
             public ChangelogMode getChangelogMode() {
+                if (enableUpsertMode) {
+                    return ChangelogMode.newBuilder()
+                            .addContainedKind(RowKind.INSERT)
+                            .addContainedKind(RowKind.UPDATE_AFTER)
+                            .addContainedKind(RowKind.DELETE)
+                            .build();
+                }
                 return ChangelogMode.newBuilder()
                         .addContainedKind(RowKind.INSERT)
                         .addContainedKind(RowKind.UPDATE_BEFORE)

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroFormatFactory.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroFormatFactory.java
@@ -76,8 +76,8 @@ public class DebeziumAvroFormatFactory
 
     public static final String IDENTIFIER = "debezium-avro-confluent";
 
-    public static final ConfigOption<Boolean> ENABLE_UPSERT_MODE =
-            ConfigOptions.key("enable-upsert-mode")
+    public static final ConfigOption<Boolean> UPSERT_MODE =
+            ConfigOptions.key("upsert-mode")
                     .booleanType()
                     .defaultValue(false)
                     .withDescription(
@@ -90,7 +90,7 @@ public class DebeziumAvroFormatFactory
         FactoryUtil.validateFactoryOptions(this, formatOptions);
         String schemaRegistryURL = formatOptions.get(URL);
         String schema = formatOptions.getOptional(SCHEMA).orElse(null);
-        Boolean enableUpsertMode = formatOptions.get(ENABLE_UPSERT_MODE);
+        Boolean upsertMode = formatOptions.get(UPSERT_MODE);
         Map<String, ?> optionalPropertiesMap = buildOptionalPropertiesMap(formatOptions);
 
         return new ProjectableDecodingFormat<DeserializationSchema<RowData>>() {
@@ -109,12 +109,12 @@ public class DebeziumAvroFormatFactory
                         schemaRegistryURL,
                         schema,
                         optionalPropertiesMap,
-                        enableUpsertMode);
+                        upsertMode);
             }
 
             @Override
             public ChangelogMode getChangelogMode() {
-                if (enableUpsertMode) {
+                if (upsertMode) {
                     return ChangelogMode.newBuilder()
                             .addContainedKind(RowKind.INSERT)
                             .addContainedKind(RowKind.UPDATE_AFTER)
@@ -139,7 +139,7 @@ public class DebeziumAvroFormatFactory
         String schemaRegistryURL = formatOptions.get(URL);
         Optional<String> subject = formatOptions.getOptional(SUBJECT);
         String schema = formatOptions.getOptional(SCHEMA).orElse(null);
-        Boolean enableUpsertMode = formatOptions.get(ENABLE_UPSERT_MODE);
+        Boolean upsertMode = formatOptions.get(UPSERT_MODE);
         Map<String, ?> optionalPropertiesMap = buildOptionalPropertiesMap(formatOptions);
 
         if (!subject.isPresent()) {
@@ -152,7 +152,7 @@ public class DebeziumAvroFormatFactory
         return new EncodingFormat<SerializationSchema<RowData>>() {
             @Override
             public ChangelogMode getChangelogMode() {
-                if (enableUpsertMode) {
+                if (upsertMode) {
                     return ChangelogMode.newBuilder()
                             .addContainedKind(RowKind.INSERT)
                             .addContainedKind(RowKind.UPDATE_AFTER)
@@ -203,7 +203,7 @@ public class DebeziumAvroFormatFactory
         options.add(BASIC_AUTH_USER_INFO);
         options.add(BEARER_AUTH_CREDENTIALS_SOURCE);
         options.add(BEARER_AUTH_TOKEN);
-        options.add(ENABLE_UPSERT_MODE);
+        options.add(UPSERT_MODE);
         return options;
     }
 

--- a/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroFormatFactoryTest.java
+++ b/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroFormatFactoryTest.java
@@ -149,7 +149,7 @@ class DebeziumAvroFormatFactoryTest {
     @Test
     void testSeDeSchemaWithUpsertMode() {
         final Map<String, String> options = getAllOptions();
-        options.put("debezium-avro-confluent.enable-upsert-mode", "true");
+        options.put("debezium-avro-confluent.upsert-mode", "true");
         final Map<String, String> registryConfigs = getRegistryConfigs();
 
         DebeziumAvroDeserializationSchema expectedDeser =
@@ -197,7 +197,7 @@ class DebeziumAvroFormatFactoryTest {
     @Test
     void testChangelogModeWithoutUpsertMode() {
         final Map<String, String> options = getAllOptions();
-        options.put("debezium-avro-confluent.enable-upsert-mode", "false");
+        options.put("debezium-avro-confluent.upsert-mode", "false");
 
         // Test that the changelog mode is correct for non-upsert mode
         final DynamicTableSource actualSource = createTableSource(SCHEMA, options);

--- a/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroFormatFactoryTest.java
+++ b/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroFormatFactoryTest.java
@@ -177,6 +177,21 @@ class DebeziumAvroFormatFactoryTest {
                             assertThat(changelogMode.contains(RowKind.DELETE)).isTrue();
                             assertThat(changelogMode.contains(RowKind.UPDATE_BEFORE)).isFalse();
                         });
+
+        // Test that the encoder's changelog mode is correct for upsert mode
+        final DynamicTableSink actualSink = createTableSink(SCHEMA, options);
+        assertThat(actualSink).isInstanceOf(TestDynamicTableFactory.DynamicTableSinkMock.class);
+        TestDynamicTableFactory.DynamicTableSinkMock sinkMock =
+                (TestDynamicTableFactory.DynamicTableSinkMock) actualSink;
+
+        assertThat(sinkMock.valueFormat.getChangelogMode())
+                .satisfies(
+                        changelogMode -> {
+                            assertThat(changelogMode.contains(RowKind.INSERT)).isTrue();
+                            assertThat(changelogMode.contains(RowKind.UPDATE_AFTER)).isTrue();
+                            assertThat(changelogMode.contains(RowKind.DELETE)).isTrue();
+                            assertThat(changelogMode.contains(RowKind.UPDATE_BEFORE)).isFalse();
+                        });
     }
 
     @Test
@@ -191,6 +206,21 @@ class DebeziumAvroFormatFactoryTest {
                 (TestDynamicTableFactory.DynamicTableSourceMock) actualSource;
 
         assertThat(scanSourceMock.valueFormat.getChangelogMode())
+                .satisfies(
+                        changelogMode -> {
+                            assertThat(changelogMode.contains(RowKind.INSERT)).isTrue();
+                            assertThat(changelogMode.contains(RowKind.UPDATE_AFTER)).isTrue();
+                            assertThat(changelogMode.contains(RowKind.UPDATE_BEFORE)).isTrue();
+                            assertThat(changelogMode.contains(RowKind.DELETE)).isTrue();
+                        });
+
+        // Test that the encoder's changelog mode is correct for non-upsert mode
+        final DynamicTableSink actualSink = createTableSink(SCHEMA, options);
+        assertThat(actualSink).isInstanceOf(TestDynamicTableFactory.DynamicTableSinkMock.class);
+        TestDynamicTableFactory.DynamicTableSinkMock sinkMock =
+                (TestDynamicTableFactory.DynamicTableSinkMock) actualSink;
+
+        assertThat(sinkMock.valueFormat.getChangelogMode())
                 .satisfies(
                         changelogMode -> {
                             assertThat(changelogMode.contains(RowKind.INSERT)).isTrue();

--- a/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroSerDeSchemaTest.java
+++ b/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroSerDeSchemaTest.java
@@ -127,11 +127,21 @@ class DebeziumAvroSerDeSchemaTest {
 
     @Test
     void testUpdateDataDeserialization() throws Exception {
-        List<String> actual = testDeserialization("debezium-avro-update.avro");
+        List<String> actual = testDeserialization("debezium-avro-update.avro", false);
 
         List<String> expected =
                 Arrays.asList(
                         "-U(1,lisi,test debezium avro data,21.799999237060547)",
+                        "+U(1,zhangsan,test debezium avro data,21.799999237060547)");
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void testUpdateDataDeserializationWithUpsertMode() throws Exception {
+        List<String> actual = testDeserialization("debezium-avro-update.avro", true);
+
+        List<String> expected =
+                Collections.singletonList(
                         "+U(1,zhangsan,test debezium avro data,21.799999237060547)");
         assertThat(actual).isEqualTo(expected);
     }
@@ -147,6 +157,10 @@ class DebeziumAvroSerDeSchemaTest {
     }
 
     public List<String> testDeserialization(String dataPath) throws Exception {
+        return testDeserialization(dataPath, false);
+    }
+
+    public List<String> testDeserialization(String dataPath, boolean enableUpsertMode) throws Exception {
         RowType rowTypeDe =
                 DebeziumAvroDeserializationSchema.createDebeziumAvroRowType(
                         fromLogicalToDataType(rowType));
@@ -155,7 +169,9 @@ class DebeziumAvroSerDeSchemaTest {
 
         DebeziumAvroDeserializationSchema dbzDeserializer =
                 new DebeziumAvroDeserializationSchema(
-                        InternalTypeInfo.of(rowType), getDeserializationSchema(rowTypeDe));
+                        InternalTypeInfo.of(rowType),
+                        getDeserializationSchema(rowTypeDe),
+                        enableUpsertMode);
         dbzDeserializer.open(new MockInitializationContext());
 
         SimpleCollector collector = new SimpleCollector();

--- a/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroSerDeSchemaTest.java
+++ b/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroSerDeSchemaTest.java
@@ -102,7 +102,7 @@ class DebeziumAvroSerDeSchemaTest {
         client.register(SUBJECT, DEBEZIUM_SCHEMA_COMPATIBLE_TEST);
         DebeziumAvroDeserializationSchema dbzDeserializer =
                 new DebeziumAvroDeserializationSchema(
-                        InternalTypeInfo.of(rowType), getDeserializationSchema(rowTypeDe));
+                        InternalTypeInfo.of(rowType), getDeserializationSchema(rowTypeDe), false);
         dbzDeserializer.open(new MockInitializationContext());
 
         SimpleCollector collector = new SimpleCollector();

--- a/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroSerDeSchemaTest.java
+++ b/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroSerDeSchemaTest.java
@@ -160,7 +160,8 @@ class DebeziumAvroSerDeSchemaTest {
         return testDeserialization(dataPath, false);
     }
 
-    public List<String> testDeserialization(String dataPath, boolean enableUpsertMode) throws Exception {
+    public List<String> testDeserialization(String dataPath, boolean enableUpsertMode)
+            throws Exception {
         RowType rowTypeDe =
                 DebeziumAvroDeserializationSchema.createDebeziumAvroRowType(
                         fromLogicalToDataType(rowType));


### PR DESCRIPTION
<!--  
  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
Add a Format Option to the Debezium Format to optionally skip emitting the UPDATE_BEFORE Rows when deserializing a Debezium message with op='u'.

This is helpful for Flink SQL applications that want to operate in UPSERT (ChangelogMode=[I,UA,D]) mode and save on processing the UPDATE_BEFORE Rows since the downstream sinks can handle it. 

Note no changes are required for the encoder since Flink [encodes UPDATE_BEFORE and UPDATE_AFTER as DELETE and INSERT Debezium messages.](https://nightlies.apache.org/flink/flink-docs-release-1.20/docs/connectors/table/formats/debezium/)

## Brief change log
- Add `ENABLE_UPSERT_MODE` ConfigOption to `DebeziumAvroFormatFactory`
- Update `DebeziumAvroDeserializationSchema` to handle the new option properly and skip emitting UPDATE_BEFORE when the option is enabled 
- Add test coverage to `DebeziumAvroSerDeSchemaTest`

## Verifying this change

This change added tests and can be verified as follows:

  - Added `testUpdateDataDeserializationWithUpsertMode` that deserializes an update and checks no -U is emitted when upsert mode is enabled.
  - Added `testSeDeSchemaWithUpsertMode` to test the format factory flag functionality, and changelog mode is correctly set. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): /no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
