### PR TITLE
[FLINK-37328][FileSystems] Upgrade GCS connector to 2.2.26.

### DIFF
--- a/docs/content.zh/docs/deployment/filesystems/gcs.md
+++ b/docs/content.zh/docs/deployment/filesystems/gcs.md
@@ -58,7 +58,7 @@ Note that these examples are *not* exhaustive and you can use GCS in other place
 Flink provides the `flink-gs-fs-hadoop` file system to write to GCS.
 This implementation is self-contained with no dependency footprint, so there is no need to add Hadoop to the classpath to use it.
 
-`flink-gs-fs-hadoop` registers a `FileSystem` wrapper for URIs with the *gs://* scheme. It uses Google's [gcs-connector](https://mvnrepository.com/artifact/com.google.cloud.bigdataoss/gcs-connector/hadoop3-2.2.18) Hadoop library to access GCS. It also uses Google's [google-cloud-storage](https://mvnrepository.com/artifact/com.google.cloud/google-cloud-storage/2.29.1) library to provide `RecoverableWriter` support.
+`flink-gs-fs-hadoop` registers a `FileSystem` wrapper for URIs with the *gs://* scheme. It uses Google's [gcs-connector](https://mvnrepository.com/artifact/com.google.cloud.bigdataoss/gcs-connector/hadoop3-2.2.26) Hadoop library to access GCS. It also uses Google's [google-cloud-storage](https://mvnrepository.com/artifact/com.google.cloud/google-cloud-storage/2.44.1) library to provide `RecoverableWriter` support.
 
 This file system can be used with the [FileSystem connector]({{< ref "docs/connectors/datastream/filesystem.md" >}}).
 
@@ -71,7 +71,7 @@ cp ./opt/flink-gs-fs-hadoop-{{< version >}}.jar ./plugins/gs-fs-hadoop/
 
 ### Configuration
 
-The underlying Hadoop file system can be configured using the [Hadoop configuration keys](https://github.com/GoogleCloudDataproc/hadoop-connectors/blob/v2.2.18/gcs/CONFIGURATION.md) for `gcs-connector` by adding the configurations to your [Flink configuration file]({{< ref "docs/deployment/config#flink-配置文件" >}}).
+The underlying Hadoop file system can be configured using the [Hadoop configuration keys](https://github.com/GoogleCloudDataproc/hadoop-connectors/blob/v2.2.26/gcs/CONFIGURATION.md) for `gcs-connector` by adding the configurations to your [Flink configuration file]({{< ref "docs/deployment/config#flink-配置文件" >}}).
 
 For example, `gcs-connector` has a `fs.gs.http.connect-timeout` configuration key. If you want to change it, you need to set `gs.http.connect-timeout: xyz` in [Flink configuration file]({{< ref "docs/deployment/config#flink-配置文件" >}}). Flink will internally translate this back to `fs.gs.http.connect-timeout`.
 

--- a/docs/content/docs/deployment/filesystems/gcs.md
+++ b/docs/content/docs/deployment/filesystems/gcs.md
@@ -58,7 +58,7 @@ Note that these examples are *not* exhaustive and you can use GCS in other place
 Flink provides the `flink-gs-fs-hadoop` file system to write to GCS.
 This implementation is self-contained with no dependency footprint, so there is no need to add Hadoop to the classpath to use it.
 
-`flink-gs-fs-hadoop` registers a `FileSystem` wrapper for URIs with the *gs://* scheme. It uses Google's [gcs-connector](https://mvnrepository.com/artifact/com.google.cloud.bigdataoss/gcs-connector/hadoop3-2.2.18) Hadoop library to access GCS. It also uses Google's [google-cloud-storage](https://mvnrepository.com/artifact/com.google.cloud/google-cloud-storage/2.29.1) library to provide `RecoverableWriter` support.
+`flink-gs-fs-hadoop` registers a `FileSystem` wrapper for URIs with the *gs://* scheme. It uses Google's [gcs-connector](https://mvnrepository.com/artifact/com.google.cloud.bigdataoss/gcs-connector/hadoop3-2.2.26) Hadoop library to access GCS. It also uses Google's [google-cloud-storage](https://mvnrepository.com/artifact/com.google.cloud/google-cloud-storage/2.44.1) library to provide `RecoverableWriter` support.
 
 This file system can be used with the [FileSystem connector]({{< ref "docs/connectors/datastream/filesystem.md" >}}).
 
@@ -71,7 +71,7 @@ cp ./opt/flink-gs-fs-hadoop-{{< version >}}.jar ./plugins/gs-fs-hadoop/
 
 ### Configuration
 
-The underlying Hadoop file system can be configured using the [Hadoop configuration keys](https://github.com/GoogleCloudDataproc/hadoop-connectors/blob/v2.2.18/gcs/CONFIGURATION.md) for `gcs-connector` by adding the configurations to your [Flink configuration file]({{< ref "docs/deployment/config#flink-configuration-file" >}}).
+The underlying Hadoop file system can be configured using the [Hadoop configuration keys](https://github.com/GoogleCloudDataproc/hadoop-connectors/blob/v2.2.26/gcs/CONFIGURATION.md) for `gcs-connector` by adding the configurations to your [Flink configuration file]({{< ref "docs/deployment/config#flink-configuration-file" >}}).
 
 For example, `gcs-connector` has a `fs.gs.http.connect-timeout` configuration key. If you want to change it, you need to set `gs.http.connect-timeout: xyz` in [Flink configuration file]({{< ref "docs/deployment/config#flink-configuration-file" >}}). Flink will internally translate this back to `fs.gs.http.connect-timeout`. 
 

--- a/flink-filesystems/flink-gs-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-gs-fs-hadoop/pom.xml
@@ -34,10 +34,10 @@ under the License.
 	<properties>
 		<!-- If updating these dependency versions, please also update the corresponding links -->
 		<!-- in the GCS file system documentation. -->
-		<fs.gs.sdk.version>2.29.1</fs.gs.sdk.version>
-		<fs.gs.connector.version>hadoop3-2.2.18</fs.gs.connector.version>
+		<fs.gs.sdk.version>2.44.1</fs.gs.sdk.version>
+		<fs.gs.connector.version>hadoop3-2.2.26</fs.gs.connector.version>
 		<!-- Set this to the highest version of grpc artifacts from gcs-connector and google-cloud-storage -->
-		<fs.gs.grpc.version>1.59.1</fs.gs.grpc.version>
+		<fs.gs.grpc.version>1.70.0</fs.gs.grpc.version>
 	</properties>
 
 	<dependencies>

--- a/flink-filesystems/flink-gs-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-gs-fs-hadoop
-Copyright 2014-2024 The Apache Software Foundation
+Copyright 2014-2025 The Apache Software Foundation
 
 This project includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -9,55 +9,55 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-core:2.18.2
 - com.google.android:annotations:4.1.1.4
 - com.google.api-client:google-api-client-jackson2:2.0.1
-- com.google.api-client:google-api-client:2.2.0
-- com.google.api.grpc:gapic-google-cloud-storage-v2:2.29.1-alpha
-- com.google.api.grpc:grpc-google-cloud-storage-v2:2.29.1-alpha
-- com.google.api.grpc:proto-google-cloud-monitoring-v3:1.64.0
-- com.google.api.grpc:proto-google-cloud-storage-v2:2.29.1-alpha
-- com.google.api.grpc:proto-google-common-protos:2.28.0
-- com.google.api.grpc:proto-google-iam-v1:1.23.0
+- com.google.api-client:google-api-client:2.7.0
+- com.google.api.grpc:gapic-google-cloud-storage-v2:2.44.1-beta
+- com.google.api.grpc:grpc-google-cloud-storage-v2:2.44.1-beta
+- com.google.api.grpc:proto-google-cloud-monitoring-v3:3.31.0
+- com.google.api.grpc:proto-google-cloud-storage-v2:2.44.1-beta
+- com.google.api.grpc:proto-google-common-protos:2.48.0
+- com.google.api.grpc:proto-google-iam-v1:1.43.0
 - com.google.apis:google-api-services-iamcredentials:v1-rev20211203-2.0.0
-- com.google.apis:google-api-services-storage:v1-rev20231028-2.0.0
-- com.google.auto.value:auto-value-annotations:1.10.4
-- com.google.cloud.bigdataoss:gcs-connector:hadoop3-2.2.18
-- com.google.cloud.bigdataoss:gcsio:2.2.18
-- com.google.cloud.bigdataoss:util-hadoop:hadoop3-2.2.18
-- com.google.cloud.bigdataoss:util:2.2.18
-- com.google.cloud:google-cloud-core-grpc:2.27.0
-- com.google.cloud:google-cloud-core-http:2.27.0
-- com.google.cloud:google-cloud-core:2.27.0
-- com.google.cloud:google-cloud-monitoring:1.82.0
-- com.google.cloud:google-cloud-storage:2.29.1
-- com.google.code.gson:gson:2.10.1
+- com.google.apis:google-api-services-storage:v1-rev20241008-2.0.0
+- com.google.auto.value:auto-value-annotations:1.11.0
+- com.google.cloud.bigdataoss:gcs-connector:hadoop3-2.2.26
+- com.google.cloud.bigdataoss:gcsio:2.2.26
+- com.google.cloud.bigdataoss:util-hadoop:hadoop3-2.2.26
+- com.google.cloud.bigdataoss:util:2.2.26
+- com.google.cloud:google-cloud-core-grpc:2.47.0
+- com.google.cloud:google-cloud-core-http:2.47.0
+- com.google.cloud:google-cloud-core:2.47.0
+- com.google.cloud:google-cloud-monitoring:3.31.0
+- com.google.cloud:google-cloud-storage:2.44.1
+- com.google.code.gson:gson:2.11.0
 - com.google.flogger:flogger-system-backend:0.7.1
 - com.google.flogger:flogger:0.7.1
 - com.google.flogger:google-extensions:0.7.1
 - com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
-- com.google.http-client:google-http-client-apache-v2:1.43.3
-- com.google.http-client:google-http-client-appengine:1.43.3
-- com.google.http-client:google-http-client-gson:1.43.3
-- com.google.http-client:google-http-client-jackson2:1.43.3
-- com.google.http-client:google-http-client:1.43.3
-- com.google.oauth-client:google-oauth-client:1.34.1
+- com.google.http-client:google-http-client-apache-v2:1.45.0
+- com.google.http-client:google-http-client-appengine:1.45.0
+- com.google.http-client:google-http-client-gson:1.45.0
+- com.google.http-client:google-http-client-jackson2:1.45.0
+- com.google.http-client:google-http-client:1.45.0
+- com.google.oauth-client:google-oauth-client:1.36.0
 - com.lmax:disruptor:3.4.2
 - commons-codec:commons-codec:1.15
-- io.grpc:grpc-alts:1.59.1
-- io.grpc:grpc-api:1.59.1
-- io.grpc:grpc-auth:1.59.1
-- io.grpc:grpc-census:1.59.1
-- io.grpc:grpc-context:1.59.1
-- io.grpc:grpc-core:1.59.1
-- io.grpc:grpc-googleapis:1.59.1
-- io.grpc:grpc-grpclb:1.59.1
-- io.grpc:grpc-inprocess:1.59.1
-- io.grpc:grpc-netty-shaded:1.59.1
-- io.grpc:grpc-protobuf-lite:1.59.1
-- io.grpc:grpc-protobuf:1.59.1
-- io.grpc:grpc-rls:1.59.1
-- io.grpc:grpc-services:1.59.1
-- io.grpc:grpc-stub:1.59.1
-- io.grpc:grpc-util:1.59.1
-- io.grpc:grpc-xds:1.59.1
+- io.grpc:grpc-alts:1.70.0
+- io.grpc:grpc-api:1.70.0
+- io.grpc:grpc-auth:1.70.0
+- io.grpc:grpc-census:1.70.0
+- io.grpc:grpc-context:1.70.0
+- io.grpc:grpc-core:1.70.0
+- io.grpc:grpc-googleapis:1.70.0
+- io.grpc:grpc-grpclb:1.70.0
+- io.grpc:grpc-inprocess:1.70.0
+- io.grpc:grpc-netty-shaded:1.70.0
+- io.grpc:grpc-protobuf-lite:1.70.0
+- io.grpc:grpc-protobuf:1.70.0
+- io.grpc:grpc-rls:1.70.0
+- io.grpc:grpc-services:1.70.0
+- io.grpc:grpc-stub:1.70.0
+- io.grpc:grpc-util:1.70.0
+- io.grpc:grpc-xds:1.70.0
 - io.opencensus:opencensus-api:0.31.1
 - io.opencensus:opencensus-contrib-exemplar-util:0.31.0
 - io.opencensus:opencensus-contrib-grpc-metrics:0.31.0
@@ -68,7 +68,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - io.opencensus:opencensus-impl:0.31.0
 - io.opencensus:opencensus-impl-core:0.31.0
 - io.opencensus:opencensus-proto:0.2.0
-- io.perfmark:perfmark-api:0.26.0
+- io.perfmark:perfmark-api:0.27.0
 - org.apache.httpcomponents:httpclient:4.5.13
 - org.apache.httpcomponents:httpcore:4.4.14
 - org.conscrypt:conscrypt-openjdk-uber:2.5.2
@@ -76,15 +76,15 @@ This project bundles the following dependencies under the Apache Software Licens
 This project bundles the following dependencies under BSD-3 License (https://opensource.org/licenses/BSD-3-Clause).
 See bundled license files for details.
 
-- com.google.api:api-common:2.20.0
-- com.google.api:gax-grpc:2.37.0
-- com.google.api:gax-httpjson:2.37.0
-- com.google.api:gax:2.37.0
-- com.google.auth:google-auth-library-credentials:1.20.0
-- com.google.auth:google-auth-library-oauth2-http:1.20.0
-- com.google.protobuf:protobuf-java-util:3.24.4
-- com.google.protobuf:protobuf-java:3.24.4
-- org.threeten:threetenbp:1.6.8
+- com.google.api:api-common:2.40.0
+- com.google.api:gax-grpc:2.57.0
+- com.google.api:gax-httpjson:2.57.0
+- com.google.api:gax:2.57.0
+- com.google.auth:google-auth-library-credentials:1.29.0
+- com.google.auth:google-auth-library-oauth2-http:1.29.0
+- com.google.protobuf:protobuf-java-util:3.25.5
+- com.google.protobuf:protobuf-java:3.25.5
+- org.threeten:threetenbp:1.7.0
 
 This project bundles the following dependencies under the Go License (https://golang.org/LICENSE).
 See bundled license files for details.
@@ -93,4 +93,4 @@ See bundled license files for details.
 This project bundles the following dependencies under the MIT License.
 See bundled license files for details.
 
-- org.codehaus.mojo:animal-sniffer-annotations:1.23
+- org.codehaus.mojo:animal-sniffer-annotations:1.24


### PR DESCRIPTION
## What is the purpose of the change

Upgrade GCS connector to 2.2.26.

## Brief change log

Upgrade the [GCS Connector](https://github.com/GoogleCloudDataproc/hadoop-connectors/tree/v2.2.26/gcs) bundled in the Flink distro from version 2.2.18 to 2.2.26.

[Release Notes](https://github.com/GoogleCloudDataproc/hadoop-connectors/blob/v2.2.26/gcs/CHANGES.md)

## Verifying this change

This change is already covered by existing tests. I also have the new integration tests from #26102 patched in locally. (I would prefer for that test PR to be merged first, so that we have more testing confidence on these upgrades in the future.)

```
mvn -Pfast -pl flink-filesystems/flink-gs-fs-hadoop clean verify
```

For testing the documentation changes, I attempted to build locally, but I encountered an unrelated error that I haven't investigated yet.

```
cd docs
./build_docs.sh -p
...
ERROR render of "section" failed: "/usr/local/google/home/cnauroth/git/apache/flink/docs/layouts/_default/baseof.html:24:5": execute of template failed: template: _default/list.html:24:5: executing "_default/list.html" at <partial "docs/html-head" .>: error calling partial: execute of template failed: html/template:partials/docs/html-head.html:33:13: no such template "_internal/google_analytics_async.html"
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no (but yes to the GCS connector)

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
