### PR TITLE
[FLINK-37333][runtime] Use ForwardForUnspecifiedPartitioner when adaptive broadcast join takes effect.

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/adaptive/AdaptiveJoinOperatorGenerator.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/adaptive/AdaptiveJoinOperatorGenerator.java
@@ -27,6 +27,9 @@ import org.apache.flink.table.runtime.operators.join.FlinkJoinType;
 import org.apache.flink.table.runtime.operators.join.adaptive.AdaptiveJoin;
 import org.apache.flink.table.types.logical.RowType;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import static org.apache.flink.util.Preconditions.checkState;
 
 /**
@@ -34,7 +37,7 @@ import static org.apache.flink.util.Preconditions.checkState;
  * shuffle hash join or shuffle merge join operator based on actual conditions.
  */
 public class AdaptiveJoinOperatorGenerator implements AdaptiveJoin {
-
+    private static final Logger LOG = LoggerFactory.getLogger(AdaptiveJoinOperatorGenerator.class);
     private final int[] leftKeys;
 
     private final int[] rightKeys;
@@ -64,6 +67,8 @@ public class AdaptiveJoinOperatorGenerator implements AdaptiveJoin {
     private final OperatorType originalJoin;
 
     private boolean leftIsBuild;
+
+    private boolean originalLeftIsBuild;
 
     private boolean isBroadcastJoin;
 
@@ -105,6 +110,7 @@ public class AdaptiveJoinOperatorGenerator implements AdaptiveJoin {
                                 + "SortMergeJoin, not including %s.",
                         originalJoin.toString()));
         this.leftIsBuild = leftIsBuild;
+        this.originalLeftIsBuild = leftIsBuild;
         this.originalJoin = originalJoin;
     }
 
@@ -164,6 +170,12 @@ public class AdaptiveJoinOperatorGenerator implements AdaptiveJoin {
             return false;
         }
 
+        if (leftIsBuild != originalLeftIsBuild) {
+            LOG.info(
+                    "The build side of the adaptive join has been updated. Compile phase build side: {}, Runtime build side: {}.",
+                    originalLeftIsBuild ? "left" : "right",
+                    leftIsBuild ? "left" : "right");
+        }
         return !leftIsBuild;
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/strategy/AdaptiveBroadcastJoinOptimizationStrategy.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/strategy/AdaptiveBroadcastJoinOptimizationStrategy.java
@@ -162,7 +162,22 @@ public class AdaptiveBroadcastJoinOptimizationStrategy
                             broadcastThreshold,
                             leftInputSize,
                             rightInputSize);
+                } else {
+                    LOG.info(
+                            "Modification to stream edges for the join node [{}] failed. Keep the join node as is.",
+                            adaptiveJoinNode.getId());
                 }
+            } else {
+                LOG.debug(
+                        "The size of the specified side of the input data for the join node [{}] "
+                                + "is too large to be converted into a broadcast hash join. "
+                                + "The Join type: {}, Broadcast threshold: {} bytes, Left input size: "
+                                + "{} bytes, Right input size: {} bytes.",
+                        adaptiveJoinNode.getId(),
+                        joinType,
+                        broadcastThreshold,
+                        leftInputSize,
+                        rightInputSize);
             }
             adaptiveJoin.markAsBroadcastJoin(
                     isBroadcast, isBroadcast ? leftIsBuild : leftSmallerThanRight);
@@ -208,7 +223,8 @@ public class AdaptiveBroadcastJoinOptimizationStrategy
                         filterEdges(inEdges, leftIsBuild ? 1 : 2), new BroadcastPartitioner<>());
         List<StreamEdgeUpdateRequestInfo> modifiedProbeSideEdges =
                 generateStreamEdgeUpdateRequestInfos(
-                        filterEdges(inEdges, leftIsBuild ? 2 : 1), new ForwardForUnspecifiedPartitioner<>());
+                        filterEdges(inEdges, leftIsBuild ? 2 : 1),
+                        new ForwardForUnspecifiedPartitioner<>());
         modifiedBuildSideEdges.addAll(modifiedProbeSideEdges);
 
         return context.modifyStreamEdge(modifiedBuildSideEdges);

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/strategy/AdaptiveBroadcastJoinOptimizationStrategy.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/strategy/AdaptiveBroadcastJoinOptimizationStrategy.java
@@ -27,7 +27,7 @@ import org.apache.flink.streaming.api.graph.util.ImmutableStreamEdge;
 import org.apache.flink.streaming.api.graph.util.ImmutableStreamNode;
 import org.apache.flink.streaming.api.graph.util.StreamEdgeUpdateRequestInfo;
 import org.apache.flink.streaming.runtime.partitioner.BroadcastPartitioner;
-import org.apache.flink.streaming.runtime.partitioner.ForwardPartitioner;
+import org.apache.flink.streaming.runtime.partitioner.ForwardForUnspecifiedPartitioner;
 import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
 import org.apache.flink.table.api.config.OptimizerConfigOptions;
 import org.apache.flink.table.runtime.operators.join.FlinkJoinType;
@@ -208,7 +208,7 @@ public class AdaptiveBroadcastJoinOptimizationStrategy
                         filterEdges(inEdges, leftIsBuild ? 1 : 2), new BroadcastPartitioner<>());
         List<StreamEdgeUpdateRequestInfo> modifiedProbeSideEdges =
                 generateStreamEdgeUpdateRequestInfos(
-                        filterEdges(inEdges, leftIsBuild ? 2 : 1), new ForwardPartitioner<>());
+                        filterEdges(inEdges, leftIsBuild ? 2 : 1), new ForwardForUnspecifiedPartitioner<>());
         modifiedBuildSideEdges.addAll(modifiedProbeSideEdges);
 
         return context.modifyStreamEdge(modifiedBuildSideEdges);

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/strategy/PostProcessAdaptiveJoinStrategy.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/strategy/PostProcessAdaptiveJoinStrategy.java
@@ -29,6 +29,9 @@ import org.apache.flink.streaming.api.graph.util.StreamNodeUpdateRequestInfo;
 import org.apache.flink.table.runtime.operators.join.adaptive.AdaptiveJoin;
 import org.apache.flink.util.Preconditions;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -39,6 +42,9 @@ import java.util.List;
  * right sides.
  */
 public class PostProcessAdaptiveJoinStrategy extends BaseAdaptiveJoinOperatorOptimizationStrategy {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(PostProcessAdaptiveJoinStrategy.class);
 
     @Override
     public boolean onOperatorsFinished(
@@ -68,6 +74,10 @@ public class PostProcessAdaptiveJoinStrategy extends BaseAdaptiveJoinOperatorOpt
                             "Unexpected error occurs while reordering the inputs "
                                     + "of the adaptive join node, potentially leading to data inaccuracies. "
                                     + "Exceptions will be thrown.");
+                } else {
+                    LOG.info(
+                            "Reordered the inputs of the adaptive join node {}.",
+                            adaptiveJoinNode.getId());
                 }
             }
 


### PR DESCRIPTION
## What is the purpose of the change

According to the design, we need to change the original forward partitioner to a rescale partitioner after the adaptive broadcast join takes effect. Accordingly, we need to use ForwardForUnspecifiedPartitioner to achieve this purpose.


## Brief change log

  - *Use ForwardForUnspecifiedPartitioner when adaptive broadcast join takes effect*


## Verifying this change
This change is already covered by existing tests, such as DefaultStreamGraphContextTest#testModifyStreamEdge.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (no)
