### PR TITLE
[FLINK-37336][python] Introduce TablePipeline descriptor to Python Table API

### DIFF
--- a/flink-python/docs/reference/pyflink.table/catalog.rst
+++ b/flink-python/docs/reference/pyflink.table/catalog.rst
@@ -250,3 +250,31 @@ A CatalogDescriptor is a template for creating a catalog instance. It closely re
     :toctree: api/
 
     CatalogDescriptor.of
+
+
+ObjectIdentifier
+----------------
+
+Identifies an object in a catalog. It allows to identify objects such as tables, views,
+function, or types in a catalog. An identifier must be fully qualified. It is the
+responsibility of the catalog manager to resolve an identifier to an object.
+
+While Path :class:`ObjectPath` is used within the same catalog, instances of this class can be
+used across catalogs.
+
+Two objects are considered equal if they share the same object identifier in a stable session
+context.
+
+.. currentmodule:: pyflink.table.catalog
+
+.. autosummary::
+    :toctree: api/
+
+    ObjectIdentifier.of
+    ObjectIdentifier.get_catalog_name
+    ObjectIdentifier.get_database_name
+    ObjectIdentifier.get_object_name
+    ObjectIdentifier.to_object_path
+    ObjectIdentifier.to_list
+    ObjectIdentifier.as_serializable_string
+    ObjectIdentifier.as_summary_string

--- a/flink-python/docs/reference/pyflink.table/descriptors.rst
+++ b/flink-python/docs/reference/pyflink.table/descriptors.rst
@@ -140,3 +140,18 @@ The set of changes contained in a changelog.
     ChangelogMode.insert_only
     ChangelogMode.upsert
     ChangelogMode.all
+
+
+TablePipeline
+-------------
+
+Describes a complete pipeline from one or more source tables to a sink table.
+
+.. currentmodule:: pyflink.table.table_pipeline
+
+.. autosummary::
+    :toctree: api/
+
+    TablePipeline.execute
+    TablePipeline.explain
+    TablePipeline.get_sink_identifier

--- a/flink-python/pyflink/table/statement_set.py
+++ b/flink-python/pyflink/table/statement_set.py
@@ -20,6 +20,7 @@ from typing import Union
 from pyflink.java_gateway import get_gateway
 from pyflink.table import ExplainDetail
 from pyflink.table.table_descriptor import TableDescriptor
+from pyflink.table.table_pipeline import TablePipeline
 from pyflink.table.table_result import TableResult
 from pyflink.util.java_utils import to_j_explain_detail_arr
 
@@ -39,6 +40,18 @@ class StatementSet(object):
     def __init__(self, _j_statement_set, t_env):
         self._j_statement_set = _j_statement_set
         self._t_env = t_env
+
+    def add(self, table_pipeline: TablePipeline) -> 'StatementSet':
+        """
+        Adds a :class:`~pyflink.table.TablePipeline`.
+
+        :param table_pipeline: The TablePipeline to be added.
+        :return: current StatementSet instance.
+
+        .. versionadded:: 2.1.0
+        """
+        self._j_statement_set.add(table_pipeline._j_table_pipeline)
+        return self
 
     def add_insert_sql(self, stmt: str) -> 'StatementSet':
         """

--- a/flink-python/pyflink/table/table_pipeline.py
+++ b/flink-python/pyflink/table/table_pipeline.py
@@ -1,0 +1,78 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+from typing import Optional
+from pyflink.java_gateway import get_gateway
+from pyflink.table import ExplainDetail
+from pyflink.table.catalog import ObjectIdentifier
+from pyflink.table.table_result import TableResult
+from pyflink.util.java_utils import to_j_explain_detail_arr
+
+__all__ = ["TablePipeline"]
+
+
+class TablePipeline(object):
+    """
+    Describes a complete pipeline from one or more source tables to a sink table.
+    """
+
+    def __init__(self, j_table_pipeline, t_env):
+        self._j_table_pipeline = j_table_pipeline
+        self._t_env = t_env
+
+    def __str__(self) -> str:
+        return self._j_table_pipeline.toString()
+
+    def execute(self) -> TableResult:
+        """
+        Executes the table pipeline.
+
+        .. versionadded:: 2.1.0
+        """
+        self._t_env._before_execute()
+        return TableResult(self._j_table_pipeline.execute())
+
+    def explain(self, *extra_details: ExplainDetail) -> str:
+        """
+        Returns the AST and the execution plan of the table pipeline.
+
+        :param extra_details: The extra explain details which the explain result should include,
+                              e.g. estimated cost, changelog mode for streaming
+        :return: AST and execution plans
+
+        .. versionadded:: 2.1.0
+        """
+        gateway = get_gateway()
+        j_extra_details = to_j_explain_detail_arr(extra_details)
+        return self._j_table_pipeline.explain(
+            gateway.jvm.org.apache.flink.table.api.ExplainFormat.TEXT, j_extra_details
+        )
+
+    def get_sink_identifier(self) -> Optional[ObjectIdentifier]:
+        """
+        Returns the sink table's :class:`~pyflink.table.catalog.ObjectIdentifier`, if any.
+        The result is empty for anonymous sink tables that haven't been registered before.
+
+        .. versionadded:: 2.1.0
+        """
+        optional_result = self._j_table_pipeline.getSinkIdentifier()
+        return (
+            ObjectIdentifier(j_object_identifier=optional_result.get())
+            if optional_result.isPresent()
+            else None
+        )

--- a/flink-python/pyflink/table/tests/test_catalog_completeness.py
+++ b/flink-python/pyflink/table/tests/test_catalog_completeness.py
@@ -18,7 +18,7 @@
 
 from pyflink.testing.test_case_utils import PythonAPICompletenessTestCase, PyFlinkTestCase
 from pyflink.table.catalog import Catalog, CatalogDatabase, CatalogBaseTable, CatalogPartition, \
-    CatalogFunction, CatalogColumnStatistics, CatalogPartitionSpec, ObjectPath
+    CatalogFunction, CatalogColumnStatistics, CatalogPartitionSpec, ObjectPath, ObjectIdentifier
 
 
 class CatalogAPICompletenessTests(PythonAPICompletenessTestCase, PyFlinkTestCase):
@@ -158,6 +158,21 @@ class CatalogColumnStatisticsAPICompletenessTests(PythonAPICompletenessTestCase,
     @classmethod
     def java_class(cls):
         return "org.apache.flink.table.catalog.stats.CatalogColumnStatistics"
+
+
+class ObjectIdentifierAPICompletenessTests(PythonAPICompletenessTestCase, PyFlinkTestCase):
+    """
+    Tests whether the Python :class:`ObjectIdentifier` is consistent with
+    Java `org.apache.flink.table.catalog.ObjectIdentifier`.
+    """
+
+    @classmethod
+    def python_class(cls):
+        return ObjectIdentifier
+
+    @classmethod
+    def java_class(cls):
+        return "org.apache.flink.table.catalog.ObjectIdentifier"
 
 
 if __name__ == '__main__':

--- a/flink-python/pyflink/table/tests/test_table_completeness.py
+++ b/flink-python/pyflink/table/tests/test_table_completeness.py
@@ -41,7 +41,7 @@ class TableAPICompletenessTests(PythonAPICompletenessTestCase, PyFlinkTestCase):
         # FLINK-12408 is merged. So we exclude this method for the time being.
         # Also FLINK-25986 are excluded.
         return {'createTemporalTableFunction', 'getQueryOperation', 'getResolvedSchema',
-                'insertInto', 'printExplain'}
+                'printExplain'}
 
     @classmethod
     def java_method_name(cls, python_method_name):


### PR DESCRIPTION
## What is the purpose of the change

Currently, the TablePipeline descriptor is not supported in the Pyflink Table API, so API methods such as `insert_into` on a table environment are subsequently not supported. This PR introduces the `TablePipeline` descriptor so that users can setup a table pipeline, explain it, execute it, etc. (Please ignore the branch name, I got my JIRA Ids mixed up 😅)

## Brief change log

- Introduced `TablePipeline` descriptor.
- Introduced the `ObjectIdentifier` catalog entity.
- Adds `StatementSet.add` to add a `TablePipeline` to the `StatementSet`.
- Adds `Table.insert_into` to declare a `TablePipeline` with a given table path or table descriptor.

## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*:
- Catalog and Table API completeness tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes, functions added to `Table` and `StatementSet`)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
