### PR TITLE
[FLINK-37336][python] Introduce TablePipeline descriptor to Python Table API

### DIFF
--- a/flink-python/docs/reference/pyflink.table/catalog.rst
+++ b/flink-python/docs/reference/pyflink.table/catalog.rst
@@ -255,15 +255,18 @@ A CatalogDescriptor is a template for creating a catalog instance. It closely re
 ObjectIdentifier
 ----------------
 
-Identifies an object in a catalog. It allows to identify objects such as tables, views,
-function, or types in a catalog. An identifier must be fully qualified. It is the
-responsibility of the catalog manager to resolve an identifier to an object.
+Identifies an object in a catalog, including tables, views, function, or types.
+An :class:`ObjectIdentifier` must be fully qualified. It is the responsibility of the catalog
+manager to resolve an :class:`ObjectIdentifier` to an object.
 
 While Path :class:`ObjectPath` is used within the same catalog, instances of this class can be
-used across catalogs.
+used across catalogs. An :class:`ObjectPath` only describes the name and database of an
+object and so is scoped over a particular catalog, but an :class:`ObjectIdentifier` is fully
+qualified and describes the name, database and catalog of the object.
 
-Two objects are considered equal if they share the same object identifier in a stable session
-context.
+Two objects are considered equal if they share the same :class:`ObjectIdentifier` in a session
+context, such as a :class:`~pyflink.table.TableEnvironment`, where catalogs (or objects in a
+catalog) have not been added, deleted or modified.
 
 .. currentmodule:: pyflink.table.catalog
 

--- a/flink-python/docs/reference/pyflink.table/catalog.rst
+++ b/flink-python/docs/reference/pyflink.table/catalog.rst
@@ -250,3 +250,31 @@ A CatalogDescriptor is a template for creating a catalog instance. It closely re
     :toctree: api/
 
     CatalogDescriptor.of
+
+
+ObjectIdentifier
+----------------
+
+Identifies an object in a catalog. It allows to identify objects such as tables, views,
+function, or types in a catalog. An identifier must be fully qualified. It is the
+responsibility of the catalog manager to resolve an identifier to an object.
+
+While Path :class:`ObjectPath` is used within the same catalog, instances of this class can be
+used across catalogs.
+
+Two objects are considered equal if they share the same object identifier in a stable session
+context.
+
+.. currentmodule:: pyflink.table.catalog
+
+.. autosummary::
+    :toctree: api/
+
+    ObjectIdentifier.of
+    ObjectIdentifier.get_catalog_name
+    ObjectIdentifier.get_database_name
+    ObjectIdentifier.get_object_name
+    ObjectIdentifier.to_object_path
+    ObjectIdentifier.to_list
+    ObjectIdentifier.as_serializable_string
+    ObjectIdentifier.as_summary_string

--- a/flink-python/docs/reference/pyflink.table/descriptors.rst
+++ b/flink-python/docs/reference/pyflink.table/descriptors.rst
@@ -140,3 +140,18 @@ The set of changes contained in a changelog.
     ChangelogMode.insert_only
     ChangelogMode.upsert
     ChangelogMode.all
+
+
+TablePipeline
+-------------
+
+Describes a complete pipeline from one or more source tables to a sink table.
+
+.. currentmodule:: pyflink.table.table_pipeline
+
+.. autosummary::
+    :toctree: api/
+
+    TablePipeline.execute
+    TablePipeline.explain
+    TablePipeline.get_sink_identifier

--- a/flink-python/pyflink/table/catalog.py
+++ b/flink-python/pyflink/table/catalog.py
@@ -1395,15 +1395,18 @@ class CatalogDescriptor:
 
 class ObjectIdentifier(object):
     """
-    Identifies an object in a catalog. It allows to identify objects such as tables, views,
-    function, or types in a catalog. An identifier must be fully qualified. It is the
-    responsibility of the catalog manager to resolve an identifier to an object.
+    Identifies an object in a catalog, including tables, views, function, or types.
+    An :class:`ObjectIdentifier` must be fully qualified. It is the responsibility of the catalog
+    manager to resolve an :class:`ObjectIdentifier` to an object.
 
     While Path :class:`ObjectPath` is used within the same catalog, instances of this class can be
-    used across catalogs.
+    used across catalogs. An :class:`ObjectPath` only describes the name and database of an
+    object and so is scoped over a particular catalog, but an :class:`ObjectIdentifier` is fully
+    qualified and describes the name, database and catalog of the object.
 
-    Two objects are considered equal if they share the same object identifier in a stable session
-    context.
+    Two objects are considered equal if they share the same :class:`ObjectIdentifier` in a session
+    context, such as a :class:`~pyflink.table.TableEnvironment`, where catalogs (or objects in a
+    catalog) have not been added, deleted or modified.
     """
 
     _UNKNOWN = "<UNKNOWN>"

--- a/flink-python/pyflink/table/catalog.py
+++ b/flink-python/pyflink/table/catalog.py
@@ -1409,8 +1409,6 @@ class ObjectIdentifier(object):
     catalog) have not been added, deleted or modified.
     """
 
-    _UNKNOWN = "<UNKNOWN>"
-
     def __init__(self, j_object_identifier):
         self._j_object_identifier = j_object_identifier
 
@@ -1431,14 +1429,11 @@ class ObjectIdentifier(object):
         assert database_name is not None, "Database name must not be null."
         assert object_name is not None, "Object name must not be null."
 
-        if catalog_name == ObjectIdentifier._UNKNOWN or database_name == ObjectIdentifier._UNKNOWN:
-            raise ValueError(f"Catalog or database cannot be named {ObjectIdentifier._UNKNOWN}")
-        else:
-            gateway = get_gateway()
-            j_object_identifier = gateway.jvm.org.apache.flink.table.catalog.ObjectIdentifier.of(
-                catalog_name, database_name, object_name
-            )
-            return ObjectIdentifier(j_object_identifier=j_object_identifier)
+        gateway = get_gateway()
+        j_object_identifier = gateway.jvm.org.apache.flink.table.catalog.ObjectIdentifier.of(
+            catalog_name, database_name, object_name
+        )
+        return ObjectIdentifier(j_object_identifier=j_object_identifier)
 
     def get_catalog_name(self) -> str:
         return self._j_object_identifier.getCatalogName()

--- a/flink-python/pyflink/table/statement_set.py
+++ b/flink-python/pyflink/table/statement_set.py
@@ -20,6 +20,7 @@ from typing import Union
 from pyflink.java_gateway import get_gateway
 from pyflink.table import ExplainDetail
 from pyflink.table.table_descriptor import TableDescriptor
+from pyflink.table.table_pipeline import TablePipeline
 from pyflink.table.table_result import TableResult
 from pyflink.util.java_utils import to_j_explain_detail_arr
 
@@ -39,6 +40,18 @@ class StatementSet(object):
     def __init__(self, _j_statement_set, t_env):
         self._j_statement_set = _j_statement_set
         self._t_env = t_env
+
+    def add(self, table_pipeline: TablePipeline) -> 'StatementSet':
+        """
+        Adds a :class:`~pyflink.table.TablePipeline`.
+
+        :param table_pipeline: The TablePipeline to be added.
+        :return: current StatementSet instance.
+
+        .. versionadded:: 2.1.0
+        """
+        self._j_statement_set.add(table_pipeline._j_table_pipeline)
+        return self
 
     def add_insert_sql(self, stmt: str) -> 'StatementSet':
         """

--- a/flink-python/pyflink/table/table.py
+++ b/flink-python/pyflink/table/table.py
@@ -1084,9 +1084,8 @@ class Table(object):
         """
         When ``target_path_or_descriptor`` is a table path:
 
-            Declares that the pipeline defined by the given :class:`Table` (backed by a
-            DynamicTableSink) should be written to a table that was registered under the specified
-            path.
+            Declares that the pipeline defined by the given :class:`Table` should be written to a
+            table (backed by a DynamicTableSink) that was registered under the specified path.
 
             See the documentation of
             :func:`pyflink.table.table_environment.TableEnvironment.use_database` or

--- a/flink-python/pyflink/table/table.py
+++ b/flink-python/pyflink/table/table.py
@@ -1096,8 +1096,8 @@ class Table(object):
             Example:
             ::
 
-                >>> table = table_env.sql_query("SELECTFROM MyTable")
-                >>> table_pipeline = table.insert_into_table_path("MySinkTable", True)
+                >>> table = table_env.sql_query("SELECT * FROM MyTable")
+                >>> table_pipeline = table.insert_into("MySinkTable", True)
                 >>> table_result = table_pipeline.execute().wait()
 
         When ``target_path_or_descriptor`` is a  :class:`~pyflink.table.TableDescriptor` :
@@ -1110,8 +1110,8 @@ class Table(object):
             in the operation tree. Note that calling this method multiple times, even with the same
             descriptor, results in multiple sink tables instances.
 
-            This method allows to declare a :class:`~pyflink.table.Schema` for the sink descriptor.
-            The declaration is similar to a ``CREATE TABLE`` DDL in SQL and allows to:
+            A :class:`~pyflink.table.Schema` can be associated with the sink descriptor, which
+            asserts a structure on the described table, and can be used to:
 
             - overwrite automatically derived columns with a custom
               :class:`~pyflink.table.types.DataType`

--- a/flink-python/pyflink/table/table.py
+++ b/flink-python/pyflink/table/table.py
@@ -1100,7 +1100,7 @@ class Table(object):
                 >>> table_pipeline = table.insert_into_table_path("MySinkTable", True)
                 >>> table_result = table_pipeline.execute().wait()
 
-        When ``target_path_or_descriptor`` is a  :ref:`refname`
+        When ``target_path_or_descriptor`` is a  :class:`~pyflink.table.TableDescriptor` :
 
             Declares that the pipeline defined by the given :class:`Table` object should be written
             to a table (backed by a DynamicTableSink) expressed via the given
@@ -1142,7 +1142,9 @@ class Table(object):
         execution, use a :class:`~pyflink.table.StatementSet` (see
         :func:`~pyflink.table.TableEnvironment.create_statement_set()`).
 
-        :param tablePath: The path of the registered table.
+        :param table_path_or_descriptor: The path of the registered
+            :class:`~pyflink.table.TableSink` or the descriptor describing the sink table into which
+            data should be inserted.
         :param overwrite: Indicates whether existing data should be overwritten.
         :return: The complete pipeline from one or more source tables to a sink table.
 

--- a/flink-python/pyflink/table/table_pipeline.py
+++ b/flink-python/pyflink/table/table_pipeline.py
@@ -67,6 +67,9 @@ class TablePipeline(object):
         """
         Returns the sink table's :class:`~pyflink.table.catalog.ObjectIdentifier`, if any.
         The result is empty for anonymous sink tables that haven't been registered before.
+        Registering sink tables can be done via
+        :func:`~pyflink.table.TableEnvironment.create_temporary_table` using a
+        :class:`~pyflink.table.TableDescriptor`.
 
         .. versionadded:: 2.1.0
         """

--- a/flink-python/pyflink/table/table_pipeline.py
+++ b/flink-python/pyflink/table/table_pipeline.py
@@ -1,0 +1,78 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+from typing import Optional
+from pyflink.java_gateway import get_gateway
+from pyflink.table import ExplainDetail
+from pyflink.table.catalog import ObjectIdentifier
+from pyflink.table.table_result import TableResult
+from pyflink.util.java_utils import to_j_explain_detail_arr
+
+__all__ = ["TablePipeline"]
+
+
+class TablePipeline(object):
+    """
+    Describes a complete pipeline from one or more source tables to a sink table.
+    """
+
+    def __init__(self, j_table_pipeline, t_env):
+        self._j_table_pipeline = j_table_pipeline
+        self._t_env = t_env
+
+    def __str__(self) -> str:
+        return self._j_table_pipeline.toString()
+
+    def execute(self) -> TableResult:
+        """
+        Executes the table pipeline.
+
+        .. versionadded:: 2.1.0
+        """
+        self._t_env._before_execute()
+        return TableResult(self._j_table_pipeline.execute())
+
+    def explain(self, *extra_details: ExplainDetail) -> str:
+        """
+        Returns the AST and the execution plan of the table pipeline.
+
+        :param extra_details: The extra explain details which the explain result should include,
+                              e.g. estimated cost, changelog mode for streaming
+        :return: AST and execution plans
+
+        .. versionadded:: 2.1.0
+        """
+        gateway = get_gateway()
+        j_extra_details = to_j_explain_detail_arr(extra_details)
+        return self._j_table_pipeline.explain(
+            gateway.jvm.org.apache.flink.table.api.ExplainFormat.TEXT, j_extra_details
+        )
+
+    def get_sink_identifier(self) -> Optional[ObjectIdentifier]:
+        """
+        Returns the sink table's :class:`~pyflink.table.catalog.ObjectIdentifier`, if any.
+        The result is empty for anonymous sink tables that haven't been registered before.
+
+        .. versionadded:: 2.1.0
+        """
+        optional_result = self._j_table_pipeline.getSinkIdentifier()
+        return (
+            ObjectIdentifier(j_object_identifier=optional_result.get())
+            if optional_result.isPresent()
+            else None
+        )

--- a/flink-python/pyflink/table/tests/test_catalog_completeness.py
+++ b/flink-python/pyflink/table/tests/test_catalog_completeness.py
@@ -18,7 +18,7 @@
 
 from pyflink.testing.test_case_utils import PythonAPICompletenessTestCase, PyFlinkTestCase
 from pyflink.table.catalog import Catalog, CatalogDatabase, CatalogBaseTable, CatalogPartition, \
-    CatalogFunction, CatalogColumnStatistics, CatalogPartitionSpec, ObjectPath
+    CatalogFunction, CatalogColumnStatistics, CatalogPartitionSpec, ObjectPath, ObjectIdentifier
 
 
 class CatalogAPICompletenessTests(PythonAPICompletenessTestCase, PyFlinkTestCase):
@@ -158,6 +158,21 @@ class CatalogColumnStatisticsAPICompletenessTests(PythonAPICompletenessTestCase,
     @classmethod
     def java_class(cls):
         return "org.apache.flink.table.catalog.stats.CatalogColumnStatistics"
+
+
+class ObjectIdentifierAPICompletenessTests(PythonAPICompletenessTestCase, PyFlinkTestCase):
+    """
+    Tests whether the Python :class:`ObjectIdentifier` is consistent with
+    Java `org.apache.flink.table.catalog.ObjectIdentifier`.
+    """
+
+    @classmethod
+    def python_class(cls):
+        return ObjectIdentifier
+
+    @classmethod
+    def java_class(cls):
+        return "org.apache.flink.table.catalog.ObjectIdentifier"
 
 
 if __name__ == '__main__':

--- a/flink-python/pyflink/table/tests/test_table_completeness.py
+++ b/flink-python/pyflink/table/tests/test_table_completeness.py
@@ -41,7 +41,7 @@ class TableAPICompletenessTests(PythonAPICompletenessTestCase, PyFlinkTestCase):
         # FLINK-12408 is merged. So we exclude this method for the time being.
         # Also FLINK-25986 are excluded.
         return {'createTemporalTableFunction', 'getQueryOperation', 'getResolvedSchema',
-                'insertInto', 'printExplain'}
+                'printExplain'}
 
     @classmethod
     def java_method_name(cls, python_method_name):

--- a/flink-python/pyflink/table/tests/test_table_pipeline.py
+++ b/flink-python/pyflink/table/tests/test_table_pipeline.py
@@ -1,0 +1,95 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+from pyflink.table import DataTypes, ResultKind
+from pyflink.table.schema import Schema
+from pyflink.table.table_descriptor import TableDescriptor
+from pyflink.testing.test_case_utils import PyFlinkStreamTableTestCase
+
+
+class TablePipelineTest(PyFlinkStreamTableTestCase):
+
+    def test_table_pipeline_with_anonymous_sink(self):
+        schema = Schema.new_builder().column("f0", DataTypes.STRING()).build()
+        table = self.t_env.from_descriptor(
+            TableDescriptor.for_connector("datagen")
+            .option("number-of-rows", "10")
+            .schema(schema)
+            .build()
+        )
+        table_pipeline = table.insert_into(
+            TableDescriptor.for_connector("blackhole").schema(schema).build()
+        )
+        self.assertEqual(table_pipeline.get_sink_identifier(), None)
+
+    def test_table_pipeline_with_registered_sink(self):
+        schema = Schema.new_builder().column("f0", DataTypes.STRING()).build()
+        table = self.t_env.from_descriptor(
+            TableDescriptor.for_connector("datagen")
+            .option("number-of-rows", "10")
+            .schema(schema)
+            .build()
+        )
+        self.t_env.create_temporary_table(
+            "RegisteredSink",
+            TableDescriptor.for_connector("blackhole").schema(schema).build(),
+        )
+        table_pipeline = table.insert_into("RegisteredSink")
+        object_identifier = table_pipeline.get_sink_identifier()
+
+        self.assertEqual(object_identifier.get_catalog_name(), "default_catalog")
+        self.assertEqual(object_identifier.get_database_name(), "default_database")
+        self.assertEqual(object_identifier.get_object_name(), "RegisteredSink")
+        self.assertEqual(
+            object_identifier.as_summary_string(),
+            "default_catalog.default_database.RegisteredSink",
+        )
+
+    def test_table_pipeline_execute(self):
+        schema = Schema.new_builder().column("f0", DataTypes.STRING()).build()
+        table = self.t_env.from_descriptor(
+            TableDescriptor.for_connector("datagen")
+            .option("number-of-rows", "10")
+            .schema(schema)
+            .build()
+        )
+        self.t_env.create_temporary_table(
+            "RegisteredSinkForExecute",
+            TableDescriptor.for_connector("blackhole").schema(schema).build(),
+        )
+        table_pipeline = table.insert_into("RegisteredSinkForExecute")
+
+        table_result = table_pipeline.execute()
+        self.assertEqual(
+            table_result.get_result_kind(), ResultKind.SUCCESS_WITH_CONTENT
+        )
+        self.assertEqual(
+            table_result.get_table_schema().get_field_names()[0],
+            "default_catalog.default_database.RegisteredSinkForExecute",
+        )
+
+
+if __name__ == "__main__":
+    import unittest
+
+    try:
+        import xmlrunner
+
+        testRunner = xmlrunner.XMLTestRunner(output="target/test-reports")
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/flink-python/pyflink/table/tests/test_table_pipeline_completeness.py
+++ b/flink-python/pyflink/table/tests/test_table_pipeline_completeness.py
@@ -1,0 +1,50 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+from pyflink.testing.test_case_utils import PythonAPICompletenessTestCase, PyFlinkTestCase
+from pyflink.table.table_pipeline import TablePipeline
+
+
+class TablePipelineAPICompletenessTests(PythonAPICompletenessTestCase, PyFlinkTestCase):
+    """
+    Tests whether the Python :class:`TablePipeline` is consistent with
+    Java `org.apache.flink.table.api.TablePipeline`.
+    """
+
+    @classmethod
+    def python_class(cls):
+        return TablePipeline
+
+    @classmethod
+    def java_class(cls):
+        return "org.apache.flink.table.api.TablePipeline"
+
+    @classmethod
+    def excluded_methods(cls):
+        return {'printExplain', 'compilePlan'}
+
+
+if __name__ == '__main__':
+    import unittest
+
+    try:
+        import xmlrunner
+        testRunner = xmlrunner.XMLTestRunner(output='target/test-reports')
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)


### PR DESCRIPTION
## What is the purpose of the change

Currently, the TablePipeline descriptor is not supported in the Pyflink Table API, so API methods such as `insert_into` on a table environment are subsequently not supported. This PR introduces the `TablePipeline` descriptor so that users can setup a table pipeline, explain it, execute it, etc.

## Brief change log

- Introduced `TablePipeline` descriptor.
- Introduced the `ObjectIdentifier` catalog entity.
- Adds `StatementSet.add` to add a `TablePipeline` to the `StatementSet`.
- Adds `Table.insert_into` to declare a `TablePipeline` with a given table path or table descriptor.

## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*:
- Catalog and Table API completeness tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes, functions added to `Table` and `StatementSet`)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
