### PR TITLE
[FLINK-36998][table-planner] Keep same behavior about the RowKind of data in globalUpsertResult for KeyedUpsertingSinkFunction while being inserted or being restore

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesRuntimeFunctions.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesRuntimeFunctions.java
@@ -518,13 +518,17 @@ final class TestValuesRuntimeFunctions {
                         .flatMap(List::stream)
                         .forEach(
                                 row -> {
-                                    boolean isDelete = row.getKind() == RowKind.DELETE;
+                                    boolean isDelete =
+                                            row.getKind() == RowKind.DELETE
+                                                    || row.getKind() == RowKind.UPDATE_BEFORE;
                                     Row key = Row.project(row, keyIndices);
                                     key.setKind(RowKind.INSERT);
                                     if (isDelete) {
                                         localUpsertResult.remove(key);
                                     } else {
-                                        localUpsertResult.put(key, row);
+                                        final Row upsertRow = Row.copy(row);
+                                        upsertRow.setKind(RowKind.INSERT);
+                                        localUpsertResult.put(key, upsertRow);
                                     }
                                 });
             }


### PR DESCRIPTION
## What is the purpose of the change

BP https://github.com/apache/flink/pull/25892 to release-2.0.

*Set +I to data when restoring in values KeyedUpsertingSinkFunction*


## Brief change log

  - *Set +I to data when restoring in values KeyedUpsertingSinkFunction*
  - *Add tests*

## Verifying this change

This change has added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? 
