### PR TITLE
[FLINK-37344][doc] setup_hugo.sh now installs the binary only

### DIFF
--- a/docs/setup_hugo.sh
+++ b/docs/setup_hugo.sh
@@ -35,4 +35,8 @@ if ! curl --fail -OL $HUGO_REPO ; then
 	echo "Failed to download Hugo binary"
 	exit 1
 fi
-tar -zxvf $HUGO_ARTIFACT -C /usr/local/bin
+if [ "$OS" = "Mac" ]; then
+    tar -zxvf $HUGO_ARTIFACT -C /usr/local/bin --include='hugo'
+else
+    tar -zxvf $HUGO_ARTIFACT -C /usr/local/bin --wildcards --no-anchored 'hugo'
+fi


### PR DESCRIPTION
## What is the purpose of the change

This is a tiny change. `setup_hugo.sh` now installs everything inside the `tar.gz` file into `/usr/local/bin`, but hugo executable is enough. In this PR I've added that filter.

## Brief change log

Added a filter to install only hugo executable.

## Verifying this change

Manually on MacOS and Linux.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
