### PR TITLE
[FLINK-35622][runtime] Filter out noisy 'Coordinator of operator xxx does not exist' exceptions in CollectResultFetcher

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/CoordinatorNotExistException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/CoordinatorNotExistException.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+/** Indicates coordinator of the operator does not exist. */
+public class CoordinatorNotExistException extends RestHandlerException {
+    private static final long serialVersionUID = 1L;
+
+    public CoordinatorNotExistException(
+            OperatorID operator, String otherPossibleCause, boolean logException) {
+        super(
+                "Coordinator of operator "
+                        + operator
+                        + " does not exist"
+                        + (otherPossibleCause == null ? "." : " or " + otherPossibleCause),
+                HttpResponseStatus.NOT_FOUND,
+                logException ? LoggingBehavior.LOG : LoggingBehavior.IGNORE);
+    }
+
+    public CoordinatorNotExistException(OperatorID operator) {
+        this(operator, null, true);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultOperatorCoordinatorHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultOperatorCoordinatorHandler.java
@@ -135,10 +135,8 @@ public class DefaultOperatorCoordinatorHandler implements OperatorCoordinatorHan
 
         final OperatorCoordinatorHolder coordinatorHolder = coordinatorMap.get(operator);
         if (coordinatorHolder == null) {
-            throw new FlinkException(
-                    "Coordinator of operator "
-                            + operator
-                            + " does not exist or the job vertex this operator belongs to is not initialized.");
+            throw new CoordinatorNotExistException(
+                    operator, "the job vertex this operator belongs to is not initialized.", false);
         }
 
         final OperatorCoordinator coordinator = coordinatorHolder.coordinator();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
@@ -95,6 +95,7 @@ import org.apache.flink.runtime.operators.coordination.TaskNotRunningException;
 import org.apache.flink.runtime.query.KvStateLocation;
 import org.apache.flink.runtime.query.UnknownKvStateLocation;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.scheduler.CoordinatorNotExistException;
 import org.apache.flink.runtime.scheduler.DefaultVertexParallelismInfo;
 import org.apache.flink.runtime.scheduler.DefaultVertexParallelismStore;
 import org.apache.flink.runtime.scheduler.ExecutionGraphFactory;
@@ -1055,10 +1056,7 @@ public class AdaptiveScheduler
                 .orElseGet(
                         () ->
                                 FutureUtils.completedExceptionally(
-                                        new FlinkException(
-                                                "Coordinator of operator "
-                                                        + operator
-                                                        + " does not exist")));
+                                        new CoordinatorNotExistException(operator)));
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectResultFetcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectResultFetcher.java
@@ -27,6 +27,7 @@ import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.runtime.dispatcher.UnavailableDispatcherOperationException;
 import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
 import org.apache.flink.runtime.operators.coordination.CoordinationRequestGateway;
+import org.apache.flink.runtime.scheduler.CoordinatorNotExistException;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.Preconditions;
 
@@ -139,6 +140,10 @@ public class CollectResultFetcher<T> {
                         LOG.debug(
                                 "The job cannot be found. It is very likely that the job is not in a RUNNING state.",
                                 e);
+                    } else if (ExceptionUtils.findThrowableWithMessage(
+                                    e, CoordinatorNotExistException.class.getName())
+                            .isPresent()) {
+                        LOG.debug("The coordinator does not exist.", e);
                     } else {
                         LOG.warn("An exception occurred when fetching query results", e);
                     }


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

When running large-scale flink batch jobs with the collect sink(e.g. running tpc-ds tests), the Flink JobManager frequently logs "Coordinator of operator xxxx does not exist or the job vertex this operator belongs to is not initialized." exceptions when using the collect() method.

This exception is caused by the collect sink attempting to fetch data from the corresponding operator coordinator on the JM based on the operator ID. However, batch jobs do not initialize all job vertices at the beginning, and instead, initialize them in a sequential manner. As a result, when a job vertex has not been initialized yet, the corresponding coordinator cannot be found, leading to the printing of this message.


## Brief change log

  - Add `CoordinatorNotExistException` that extends `FlinkException`
  - Use `CoordinatorNotExistException` to improve relevant exception
  - Filter out `CoordinatorNotExistException` in `CollectResultFetcher` 


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
