### PR TITLE
[FLINK-35810][test] increase unittest Xmx to debug FLINK-35810

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@ under the License.
 		<!-- XmxMax / forkCountITCase -->
 		<flink.XmxITCase>1536m</flink.XmxITCase>
 		<!-- XmxMax / forkCountUnitTest -->
-		<flink.XmxUnitTest>768m</flink.XmxUnitTest>
+		<flink.XmxUnitTest>1024m</flink.XmxUnitTest>
 		<!-- Need to use a user property here because the surefire
 			 forkCount is not exposed as a property. With this we can set
 			 it on the "mvn" commandline in travis. -->


### PR DESCRIPTION
I download the heap dump file in failed build. But don't find any suspicious leak objects.

Slightly increase the memory limit to help troubleshoot this problem.