### PR TITLE
[hotfix] Fix post-release japicmp update script for macOS

### DIFF
--- a/tools/releasing/update_japicmp_configuration.sh
+++ b/tools/releasing/update_japicmp_configuration.sh
@@ -64,7 +64,8 @@ function clear_exclusions() {
   exclusion_end=$(($(sed -n '/<!-- MARKER: end exclusions/=' ${POM}) - 1))
 
   if [[ $exclusion_start -lt $exclusion_end ]]; then
-    sed -i "${exclusion_start},${exclusion_end}d" ${POM}
+    sed -i.bak "${exclusion_start},${exclusion_end}d" ${POM}
+    rm ${POM}.bak
   fi
 }
 


### PR DESCRIPTION
Mac uses BSD sed that requires an explicit extension for `-i` option. This works universally for both GNU and BSD sed. 
I believe it previously caused issues with `@PublicEvolving` javacmp exclusions not being correctly removed after the release which led to incompatible changes being merged. Without the fix, the pom file gets modified incompletely, with an error message that is easy to miss
`sed: 1: "../pom.xml": invalid command code . `

Note: to reproduce current erroneous behavior, put a couple of lines between the `MARKER:` comments in pom.xml
