### PR TITLE
[FLINK-36324] Harden runtime error cases for table builtin functions

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/BuiltInAggregateFunctionTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/BuiltInAggregateFunctionTestBase.java
@@ -18,9 +18,11 @@
 
 package org.apache.flink.table.planner.functions;
 
+import org.apache.flink.client.program.MiniClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.StateBackendOptions;
 import org.apache.flink.legacy.table.connector.source.SourceFunctionProvider;
+import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.streaming.api.functions.source.legacy.SourceFunction;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.Schema;
@@ -38,27 +40,30 @@ import org.apache.flink.table.functions.BuiltInFunctionDefinition;
 import org.apache.flink.table.operations.AggregateQueryOperation;
 import org.apache.flink.table.operations.ProjectQueryOperation;
 import org.apache.flink.table.planner.factories.TableFactoryHarness;
+import org.apache.flink.table.planner.functions.BuiltInFunctionTestBase.TestCase;
+import org.apache.flink.table.planner.functions.BuiltInFunctionTestBase.TestCaseWithClusterClient;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.test.junit5.InjectMiniCluster;
 import org.apache.flink.test.junit5.MiniClusterExtension;
 import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.SerializedThrowable;
 
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -86,14 +91,15 @@ abstract class BuiltInAggregateFunctionTestBase {
 
     abstract Stream<TestSpec> getTestCaseSpecs();
 
-    final Stream<BuiltInFunctionTestBase.TestCase> getTestCases() {
+    final Stream<TestCase> getTestCases() {
         return this.getTestCaseSpecs().flatMap(TestSpec::getTestCases);
     }
 
     @ParameterizedTest
     @MethodSource("getTestCases")
-    final void test(BuiltInFunctionTestBase.TestCase testCase) throws Throwable {
-        testCase.execute();
+    final void test(TestCase testCase, @InjectMiniCluster MiniCluster miniCluster)
+            throws Throwable {
+        testCase.execute(new MiniClusterClient(miniCluster.getConfiguration(), miniCluster));
     }
 
     protected static Table asTable(TableEnvironment tEnv, DataType sourceRowType, List<Row> rows) {
@@ -308,8 +314,9 @@ abstract class BuiltInAggregateFunctionTestBase {
             return this;
         }
 
-        private Executable createTestItemExecutable(TestItem testItem, String stateBackend) {
-            return () -> {
+        private TestCaseWithClusterClient createTestItemExecutable(
+                TestItem testItem, String stateBackend) {
+            return (clusterClient) -> {
                 Configuration conf = new Configuration();
                 conf.set(StateBackendOptions.STATE_BACKEND, stateBackend);
                 final TableEnvironment tEnv =
@@ -320,23 +327,23 @@ abstract class BuiltInAggregateFunctionTestBase {
                                         .build());
                 final Table sourceTable = asTable(tEnv, sourceRowType, sourceRows);
 
-                testItem.execute(tEnv, sourceTable);
+                testItem.execute(tEnv, sourceTable, clusterClient);
             };
         }
 
-        Stream<BuiltInFunctionTestBase.TestCase> getTestCases() {
+        Stream<TestCase> getTestCases() {
             return Stream.concat(
                     testItems.stream()
                             .map(
                                     testItem ->
-                                            new BuiltInFunctionTestBase.TestCase(
+                                            new TestCase(
                                                     testItem.toString(),
                                                     createTestItemExecutable(
                                                             testItem, HASHMAP_STATE_BACKEND_NAME))),
                     testItems.stream()
                             .map(
                                     testItem ->
-                                            new BuiltInFunctionTestBase.TestCase(
+                                            new TestCase(
                                                     testItem.toString(),
                                                     createTestItemExecutable(
                                                             testItem,
@@ -362,7 +369,7 @@ abstract class BuiltInAggregateFunctionTestBase {
     // ---------------------------------------------------------------------------------------------
 
     private interface TestItem {
-        void execute(TableEnvironment tEnv, Table sourceTable);
+        void execute(TableEnvironment tEnv, Table sourceTable, MiniClusterClient clusterClient);
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -377,7 +384,8 @@ abstract class BuiltInAggregateFunctionTestBase {
         }
 
         @Override
-        public void execute(TableEnvironment tEnv, Table sourceTable) {
+        public void execute(
+                TableEnvironment tEnv, Table sourceTable, MiniClusterClient clusterClient) {
             final TableResult tableResult = getResult(tEnv, sourceTable);
 
             if (expectedRowType != null) {
@@ -495,7 +503,6 @@ abstract class BuiltInAggregateFunctionTestBase {
             return tEnv.sqlQuery(stringBuilder.toString()).execute();
         }
 
-        @Nonnull
         private static List<ResolvedExpression> recreateSelectList(
                 AggregateQueryOperation aggQueryOperation,
                 ProjectQueryOperation projectQueryOperation) {
@@ -579,7 +586,8 @@ abstract class BuiltInAggregateFunctionTestBase {
         }
 
         @Override
-        public void execute(TableEnvironment tEnv, Table sourceTable) {
+        public void execute(
+                TableEnvironment tEnv, Table sourceTable, MiniClusterClient clusterClient) {
             AtomicReference<TableResult> tableResult = new AtomicReference<>();
 
             Throwable t =
@@ -604,9 +612,25 @@ abstract class BuiltInAggregateFunctionTestBase {
                         .containsExactlyElementsOf(getFieldDataTypes(expectedRowType));
             }
 
-            assertThatThrownBy(() -> tableResult.get().await())
+            assertThatThrownBy(() -> runAndWaitForFailure(clusterClient, tableResult))
                     .isNotNull()
                     .satisfies(this.errorMatcher());
+        }
+
+        private void runAndWaitForFailure(
+                final MiniClusterClient clusterClient,
+                final AtomicReference<TableResult> tableResult)
+                throws Throwable {
+            final TableResult result = tableResult.get();
+            result.await();
+            final Optional<SerializedThrowable> serializedThrowable =
+                    clusterClient
+                            .requestJobResult(result.getJobClient().get().getJobID())
+                            .get()
+                            .getSerializedThrowable();
+            if (serializedThrowable.isPresent()) {
+                throw serializedThrowable.get().deserializeError(getClass().getClassLoader());
+            }
         }
 
         protected abstract Table query(TableEnvironment tEnv, @Nullable Table inputTable);

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/BuiltInFunctionTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/BuiltInFunctionTestBase.java
@@ -18,7 +18,9 @@
 
 package org.apache.flink.table.planner.functions;
 
+import org.apache.flink.client.program.MiniClusterClient;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.Table;
@@ -34,14 +36,15 @@ import org.apache.flink.table.functions.UserDefinedFunction;
 import org.apache.flink.table.operations.ProjectQueryOperation;
 import org.apache.flink.table.types.AbstractDataType;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.test.junit5.InjectMiniCluster;
 import org.apache.flink.test.junit5.MiniClusterExtension;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.SerializedThrowable;
 
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -51,6 +54,7 @@ import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -95,28 +99,32 @@ abstract class BuiltInFunctionTestBase {
 
     @ParameterizedTest
     @MethodSource("getTestCases")
-    final void test(TestCase testCase) throws Throwable {
-        testCase.execute();
+    final void test(TestCase testCase, @InjectMiniCluster MiniCluster miniCluster)
+            throws Throwable {
+        testCase.execute(new MiniClusterClient(miniCluster.getConfiguration(), miniCluster));
     }
 
     // --------------------------------------------------------------------------------------------
     // Test model
     // --------------------------------------------------------------------------------------------
 
+    interface TestCaseWithClusterClient {
+        void execute(MiniClusterClient clusterClient) throws Throwable;
+    }
+
     /** Single test case. */
-    static class TestCase implements Executable {
+    static class TestCase implements TestCaseWithClusterClient {
 
         private final String name;
-        private final Executable executable;
+        private final TestCaseWithClusterClient executable;
 
-        TestCase(String name, Executable executable) {
+        TestCase(String name, TestCaseWithClusterClient executable) {
             this.name = name;
             this.executable = executable;
         }
 
-        @Override
-        public void execute() throws Throwable {
-            this.executable.execute();
+        public void execute(MiniClusterClient clusterClient) throws Throwable {
+            this.executable.execute(clusterClient);
         }
 
         @Override
@@ -324,7 +332,7 @@ abstract class BuiltInFunctionTestBase {
         private TestCase getTestCase(Configuration configuration, TestItem testItem) {
             return new TestCase(
                     testItem.toString(),
-                    () -> {
+                    (clusterClient) -> {
                         final TableEnvironmentInternal env =
                                 (TableEnvironmentInternal)
                                         TableEnvironment.create(
@@ -353,7 +361,7 @@ abstract class BuiltInFunctionTestBase {
                             inputTable = env.fromValues(DataTypes.ROW(fields), Row.of(fieldData));
                         }
 
-                        testItem.test(env, inputTable);
+                        testItem.test(env, inputTable, clusterClient);
                     });
         }
 
@@ -370,7 +378,11 @@ abstract class BuiltInFunctionTestBase {
          * @param inputTable The input table of this test that contains input data and data type. If
          *     it is null, the test is not dependent on the input data.
          */
-        void test(TableEnvironmentInternal env, @Nullable Table inputTable) throws Exception;
+        void test(
+                TableEnvironmentInternal env,
+                @Nullable Table inputTable,
+                MiniClusterClient clusterClient)
+                throws Exception;
     }
 
     private abstract static class ResultTestItem<T> implements TestItem {
@@ -387,7 +399,10 @@ abstract class BuiltInFunctionTestBase {
         abstract Table query(TableEnvironment env, @Nullable Table inputTable);
 
         @Override
-        public void test(TableEnvironmentInternal env, @Nullable Table inputTable)
+        public void test(
+                TableEnvironmentInternal env,
+                @Nullable Table inputTable,
+                MiniClusterClient clusterClient)
                 throws Exception {
             final Table resultTable = this.query(env, inputTable);
 
@@ -459,7 +474,10 @@ abstract class BuiltInFunctionTestBase {
         }
 
         @Override
-        public void test(TableEnvironmentInternal env, @Nullable Table inputTable) {
+        public void test(
+                TableEnvironmentInternal env,
+                @Nullable Table inputTable,
+                MiniClusterClient clusterClient) {
             AtomicReference<TableResult> tableResult = new AtomicReference<>();
 
             Throwable t =
@@ -475,7 +493,22 @@ abstract class BuiltInFunctionTestBase {
                 assertThat(t).as("Error while validating the query").isNull();
             }
 
-            assertThatThrownBy(() -> tableResult.get().await())
+            assertThatThrownBy(
+                            () -> {
+                                final TableResult result = tableResult.get();
+                                result.await();
+                                final Optional<SerializedThrowable> serializedThrowable =
+                                        clusterClient
+                                                .requestJobResult(
+                                                        result.getJobClient().get().getJobID())
+                                                .get()
+                                                .getSerializedThrowable();
+                                if (serializedThrowable.isPresent()) {
+                                    throw serializedThrowable
+                                            .get()
+                                            .deserializeError(getClass().getClassLoader());
+                                }
+                            })
                     .isNotNull()
                     .satisfies(this.errorMatcher());
         }


### PR DESCRIPTION

## What is the purpose of the change

To stabilize tests checking for runtime exceptions for SQL builtin functions.

It seems, depending on timing `tableResult.await()` does not always return a runtime exception. The safest way is to request the runtime exception directly from the cluster.

## Verifying this change

The tests should pass

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
