### PR TITLE
[hotfix][tests] Use Junit5 import in FileSinkTest.

### DIFF
--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/FileSinkTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/FileSinkTest.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link FileSink}. */
-public class FileSinkTest {
+class FileSinkTest {
 
     @Test
     public void testCreateFileWriterWithTimerRegistered() throws IOException {

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/FileSinkTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/FileSinkTest.java
@@ -23,7 +23,7 @@ import org.apache.flink.connector.file.sink.utils.IntegerFileSinkTestDataUtils;
 import org.apache.flink.connector.file.sink.utils.PartSizeAndCheckpointRollingPolicy;
 import org.apache.flink.core.fs.Path;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/FileSinkTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/FileSinkTest.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class FileSinkTest {
 
     @Test
-    public void testCreateFileWriterWithTimerRegistered() throws IOException {
+    void testCreateFileWriterWithTimerRegistered() throws IOException {
         TestSinkInitContext ctx = new TestSinkInitContext();
         FileSink<Integer> sink =
                 FileSink.forRowFormat(

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/FileSinkTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/FileSinkTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link FileSink}. */
 public class FileSinkTest {
@@ -41,6 +41,6 @@ public class FileSinkTest {
                         .withRollingPolicy(new PartSizeAndCheckpointRollingPolicy<>(1024, true))
                         .build();
         sink.createWriter(ctx);
-        assertEquals(ctx.getTestProcessingTimeService().getNumActiveTimers(), 1);
+        assertThat(ctx.getTestProcessingTimeService().getNumActiveTimers()).isEqualTo(1);
     }
 }

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/FileSinkTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/FileSinkTest.java
@@ -41,6 +41,6 @@ public class FileSinkTest {
                         .withRollingPolicy(new PartSizeAndCheckpointRollingPolicy<>(1024, true))
                         .build();
         sink.createWriter(ctx);
-        assertThat(ctx.getTestProcessingTimeService().getNumActiveTimers()).isEqualTo(1);
+        assertThat(ctx.getTestProcessingTimeService().getNumActiveTimers()).isOne();
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

There is a minor issue where all tests in the module containing FileSinkTest are written using JUnit 5 syntax, but FileSinkTest uses JUnit 4 imports. In this PR, we will complete the upgrade of FileSinkTest to JUnit 5.

## Brief change log

In this PR, we have improved the following:

1. The class descriptor, as JUnit 5 no longer requires classes/methods to be public.
2. Replaced the original assertEquals with AssertJ syntax.

This change is very minor, and I don't plan to create a Jira for it.

## Verifying this change

Junit Test & CI

## Does this pull request potentially affect one of the following parts:

no.

## Documentation

no.
