### PR TITLE
[FLINK-30719] Update frontend-maven-plugin from 1.12.1 to 1.15.1

### DIFF
--- a/flink-runtime-web/pom.xml
+++ b/flink-runtime-web/pom.xml
@@ -255,7 +255,7 @@ under the License.
 			<plugin>
 				<groupId>com.github.eirslett</groupId>
 				<artifactId>frontend-maven-plugin</artifactId>
-				<version>1.12.1</version>
+				<version>1.15.1</version>
 				<executions>
 					<execution>
 						<id>install node and npm</id>


### PR DESCRIPTION
## What is the purpose of the change

There was a fix on frontend-maven-plugin https://github.com/eirslett/frontend-maven-plugin/commit/e2d0445fd3dd055bc576e37d89a907efa5435cb9
which should help with corrupted file issue FLINK-30719

## Brief change log

pom.xml


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes )
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
