### PR TITLE
[FLINK-36585][connector/common] SplitFetcherManager.close() should not chain runnables to the element queue future in a tight loop

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherManager.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherManager.java
@@ -38,6 +38,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -60,6 +61,7 @@ import static org.apache.flink.configuration.PipelineOptions.ALLOW_UNALIGNED_SOU
 @PublicEvolving
 public abstract class SplitFetcherManager<E, SplitT extends SourceSplit> {
     private static final Logger LOG = LoggerFactory.getLogger(SplitFetcherManager.class);
+    static final String THREAD_NAME_PREFIX = "Source Data Fetcher for ";
 
     private final Consumer<Throwable> errorHandler;
 
@@ -153,7 +155,7 @@ public abstract class SplitFetcherManager<E, SplitT extends SourceSplit> {
         final String taskThreadName = Thread.currentThread().getName();
         this.executors =
                 Executors.newCachedThreadPool(
-                        r -> new Thread(r, "Source Data Fetcher for " + taskThreadName));
+                        r -> new Thread(r, THREAD_NAME_PREFIX + taskThreadName));
         this.closed = false;
     }
 
@@ -269,19 +271,32 @@ public abstract class SplitFetcherManager<E, SplitT extends SourceSplit> {
         // fetcher threads blocking on putting batches into the element queue.
         executors.submit(
                 () -> {
-                    while (fetchersToShutDown.get() > 0
-                            && System.currentTimeMillis() - startTime < timeoutMs) {
-                        elementsQueue
-                                .getAvailabilityFuture()
-                                .thenRun(() -> elementsQueue.poll().recycle());
+                    long timeElapsed = System.currentTimeMillis() - startTime;
+                    while (fetchersToShutDown.get() > 0 && timeElapsed < timeoutMs) {
+                        try {
+                            elementsQueue
+                                    .getAvailabilityFuture()
+                                    .thenRun(() -> elementsQueue.poll().recycle())
+                                    .get(timeoutMs - timeElapsed, TimeUnit.MILLISECONDS);
+                        } catch (ExecutionException ee) {
+                            // Ignore the exception and continue.
+                        } catch (Exception e) {
+                            LOG.warn(
+                                    "Received exception when waiting for the fetchers to "
+                                            + "shutdown.",
+                                    e);
+                            break;
+                        }
+                        timeElapsed = System.currentTimeMillis() - startTime;
                     }
                 });
         executors.shutdown();
-        if (!executors.awaitTermination(timeoutMs, TimeUnit.MILLISECONDS)) {
+        long timeElapsed = System.currentTimeMillis() - startTime;
+        if (!executors.awaitTermination(timeoutMs - timeElapsed, TimeUnit.MILLISECONDS)) {
             LOG.warn(
                     "Failed to close the split fetchers in {} ms. There are still {} split fetchers running",
                     timeoutMs,
-                    fetchersToShutDown);
+                    fetchersToShutDown.get());
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change
This is a re-commit of the patch ( #25569 ) after fixing the accidentally changed timeout unit of the SplitFetcherManager close timeout.

## Brief change log

Changes in the Original Fix:

This patch fixes an issue introduced in https://github.com/apache/flink/pull/25130. In SplitFetcherManager.close(), the element queue draining thread was chaining the runnables to the element queue availability future in a tight loop. This causes problem (e.g. OOM, high CPU util) when the fetcher threads do not shutdown quickly.

This patch changes the tight async loop to a blocking loop.

Changes in the followup patch fixes the accidentally changed timeout unit of the SplitFetcherManager close timeout.

## Verifying this change
Unit tests have been added.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (No)
  - If yes, how is the feature documented? (No)
