### PR TITLE
[FLINK-37339][doc] Update java_compatibility doc

### DIFF
--- a/docs/content.zh/docs/deployment/java_compatibility.md
+++ b/docs/content.zh/docs/deployment/java_compatibility.md
@@ -28,9 +28,7 @@ This page lists which Java versions Flink supports and what limitations apply (i
 
 ## Java 11
 
-Support for Java 11 was added in 1.10.0 and is the recommended Java version to run Flink on.
-
-This is the default version for docker images.
+Support for Java 11 was added in 1.10.0.
 
 ### Untested Flink features
 
@@ -45,11 +43,23 @@ The following Flink features have not been tested with Java 11:
 
 ## Java 17
 
-Experimental support for Java 17 was added in 1.18.0. ([FLINK-15736](https://issues.apache.org/jira/browse/FLINK-15736))
+We use Java 17 by default in Flink 2.0.0 and is the recommended Java version to run Flink on.
+This is the default version for docker images.
 
 ### Untested Flink features
 
 These Flink features have not been tested with Java 17:
+
+* Hive connector
+* Hbase 1.x connector
+
+## Java 21
+
+Experimental support for Java 21 was added in 2.0.0. ([FLINK-33163](https://issues.apache.org/jira/browse/FLINK-33163))
+
+### Untested Flink features
+
+These Flink features have not been tested with Java 21:
 
 * Hive connector
 * Hbase 1.x connector
@@ -68,5 +78,5 @@ The list of configured arguments must not be shortened, but only extended.
 
 ### Known issues
 
-* Java records are not supported. See [FLINK-32380](https://issues.apache.org/jira/browse/FLINK-32380) for updates.
+* Mandatory Kryo dependency upgrade, [FLIP-371](https://cwiki.apache.org/confluence/display/FLINK/FLIP-317%3A+Upgrade+Kryo+from+2.24.0+to+5.5.0).
 * SIGSEGV in C2 Compiler thread: Early Java 17 builds are affected by a bug where the JVM can fail abruptly. Update your Java 17 installation to resolve the issue. See [JDK-8277529](https://bugs.openjdk.org/browse/JDK-8277529) for details.

--- a/docs/content/docs/deployment/java_compatibility.md
+++ b/docs/content/docs/deployment/java_compatibility.md
@@ -28,9 +28,7 @@ This page lists which Java versions Flink supports and what limitations apply (i
 
 ## Java 11
 
-Support for Java 11 was added in 1.10.0 and is the recommended Java version to run Flink on.
-
-This is the default version for docker images.
+Support for Java 11 was added in 1.10.0.
 
 ### Untested Flink features
 
@@ -45,12 +43,23 @@ The following Flink features have not been tested with Java 11:
 
 ## Java 17
 
-Experimental support for Java 17 was added in 1.18. ([FLINK-15736](https://issues.apache.org/jira/browse/FLINK-15736))
-In Flink 1.19, we added support for Java Records. ([FLINK-32380](https://issues.apache.org/jira/browse/FLINK-32380))
+We use Java 17 by default in Flink 2.0.0 and is the recommended Java version to run Flink on.
+This is the default version for docker images.
 
 ### Untested Flink features
 
 These Flink features have not been tested with Java 17:
+
+* Hive connector
+* Hbase 1.x connector
+
+## Java 21
+
+Experimental support for Java 21 was added in 2.0.0. ([FLINK-33163](https://issues.apache.org/jira/browse/FLINK-33163))
+
+### Untested Flink features
+
+These Flink features have not been tested with Java 21:
 
 * Hive connector
 * Hbase 1.x connector


### PR DESCRIPTION
## What is the purpose of the change

*Update java_compatibility doc*


## Brief change log

  - *Update java_compatibility doc for jdk17 & jdk21*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
