### PR TITLE
[FLINK-37384][runtime] Optimize the parallelism decide logic for pointwise

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchScheduler.java
@@ -900,8 +900,18 @@ public class AdaptiveBatchScheduler extends DefaultScheduler implements JobGraph
     }
 
     private boolean canInitialize(final ExecutionJobVertex jobVertex) {
-        if (jobVertex.isInitialized() || !jobVertex.isParallelismDecided()) {
+        if (jobVertex.isInitialized()
+                || (!jobVertex.isParallelismDecided()
+                        && adaptiveExecutionHandler.getInitialParallelism(
+                                        jobVertex.getJobVertexId())
+                                == ExecutionConfig.PARALLELISM_DEFAULT)) {
             return false;
+        }
+
+        if (!jobVertex.isParallelismDecided()) {
+            changeJobVertexParallelism(
+                    jobVertex,
+                    adaptiveExecutionHandler.getInitialParallelism(jobVertex.getJobVertexId()));
         }
 
         // all the upstream job vertices need to have been initialized

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/util/PointwiseVertexInputInfoComputer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/util/PointwiseVertexInputInfoComputer.java
@@ -32,10 +32,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.runtime.scheduler.adaptivebatch.util.SubpartitionSlice.createSubpartitionSlice;
-import static org.apache.flink.runtime.scheduler.adaptivebatch.util.VertexParallelismAndInputInfosDeciderUtils.calculateDataVolumePerTaskForInput;
-import static org.apache.flink.runtime.scheduler.adaptivebatch.util.VertexParallelismAndInputInfosDeciderUtils.createdJobVertexInputInfoForNonBroadcast;
+import static org.apache.flink.runtime.scheduler.adaptivebatch.util.VertexParallelismAndInputInfosDeciderUtils.checkAndGetPartitionNum;
+import static org.apache.flink.runtime.scheduler.adaptivebatch.util.VertexParallelismAndInputInfosDeciderUtils.checkAndGetSubpartitionNum;
+import static org.apache.flink.runtime.scheduler.adaptivebatch.util.VertexParallelismAndInputInfosDeciderUtils.createJobVertexInputInfos;
+import static org.apache.flink.runtime.scheduler.adaptivebatch.util.VertexParallelismAndInputInfosDeciderUtils.getInputsWithIntraCorrelation;
+import static org.apache.flink.runtime.scheduler.adaptivebatch.util.VertexParallelismAndInputInfosDeciderUtils.getMinSubpartitionCount;
 import static org.apache.flink.runtime.scheduler.adaptivebatch.util.VertexParallelismAndInputInfosDeciderUtils.isLegalParallelism;
 import static org.apache.flink.runtime.scheduler.adaptivebatch.util.VertexParallelismAndInputInfosDeciderUtils.tryComputeSubpartitionSliceRange;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -44,44 +48,6 @@ import static org.apache.flink.util.Preconditions.checkState;
 public class PointwiseVertexInputInfoComputer {
     private static final Logger LOG =
             LoggerFactory.getLogger(PointwiseVertexInputInfoComputer.class);
-
-    /**
-     * Computes the input information for a job vertex based on the provided blocking input
-     * information and parallelism.
-     *
-     * @param inputInfos List of blocking input information for the job vertex.
-     * @param parallelism Parallelism of the job vertex.
-     * @param dataVolumePerTask Proposed data volume per task for this set of inputInfo.
-     * @return A map of intermediate data set IDs to their corresponding job vertex input
-     *     information.
-     */
-    public Map<IntermediateDataSetID, JobVertexInputInfo> compute(
-            List<BlockingInputInfo> inputInfos, int parallelism, long dataVolumePerTask) {
-        long totalDataBytes =
-                inputInfos.stream().mapToLong(BlockingInputInfo::getNumBytesProduced).sum();
-        Map<IntermediateDataSetID, JobVertexInputInfo> vertexInputInfos = new HashMap<>();
-        for (BlockingInputInfo inputInfo : inputInfos) {
-            // Currently, we consider all inputs in this method must don't have inter-inputs key
-            // correlation. If other possibilities are introduced in the future, please add new
-            // branches to this method.
-            checkState(!inputInfo.areInterInputsKeysCorrelated());
-            if (inputInfo.isIntraInputKeyCorrelated()) {
-                // In this case, we won't split subpartitions within the same partition, so need
-                // to ensure NumPartitions >= parallelism.
-                checkState(parallelism <= inputInfo.getNumPartitions());
-            }
-            vertexInputInfos.put(
-                    inputInfo.getResultId(),
-                    computeVertexInputInfo(
-                            inputInfo,
-                            parallelism,
-                            calculateDataVolumePerTaskForInput(
-                                    dataVolumePerTask,
-                                    inputInfo.getNumBytesProduced(),
-                                    totalDataBytes)));
-        }
-        return vertexInputInfos;
-    }
 
     /**
      * Decide parallelism and input infos, which will make the data be evenly distributed to
@@ -100,57 +66,91 @@ public class PointwiseVertexInputInfoComputer {
      * The final result is the `SubpartitionGroup` that each of the three parallel tasks need to
      * subscribe.
      *
-     * @param inputInfo The information of consumed blocking results
-     * @param parallelism The parallelism of the job vertex. Since pointwise inputs always compute
-     *     vertex input info one-by-one, we need a determined parallelism to ensure the final
-     *     decided parallelism for all inputs is consistent.
-     * @return the vertex input info
+     * @param inputInfos The information of consumed blocking results
+     * @param parallelism The parallelism of the job vertex
+     * @param minParallelism the min parallelism
+     * @param maxParallelism the max parallelism
+     * @param dataVolumePerTask proposed data volume per task for this set of inputInfo
+     * @return the parallelism and vertex input infos
      */
-    private static JobVertexInputInfo computeVertexInputInfo(
-            BlockingInputInfo inputInfo, int parallelism, long dataVolumePerTask) {
-        List<SubpartitionSlice> subpartitionSlices = createSubpartitionSlices(inputInfo);
+    public Map<IntermediateDataSetID, JobVertexInputInfo> compute(
+            List<BlockingInputInfo> inputInfos,
+            int parallelism,
+            int minParallelism,
+            int maxParallelism,
+            long dataVolumePerTask) {
+        Map<Integer, List<SubpartitionSlice>> subpartitionSlicesByInputIndex =
+                createSubpartitionSlicesByInputIndex(inputInfos);
 
-        // Node: SubpartitionSliceRanges does not represent the real index of the subpartitions, but
+        // Note: SubpartitionSliceRanges does not represent the real index of the subpartitions, but
         // the location of that subpartition in all subpartitions, as we aggregate all subpartitions
         // into a one-digit array to calculate.
         Optional<List<IndexRange>> optionalSubpartitionSliceRanges =
                 tryComputeSubpartitionSliceRange(
-                        parallelism,
-                        parallelism,
+                        minParallelism,
+                        maxParallelism,
                         dataVolumePerTask,
-                        Map.of(inputInfo.getInputTypeNumber(), subpartitionSlices));
+                        subpartitionSlicesByInputIndex);
 
         if (optionalSubpartitionSliceRanges.isEmpty()) {
             LOG.info(
-                    "Cannot find a legal parallelism to evenly distribute data amount for input {}, "
+                    "Cannot find a legal parallelism to evenly distribute data amount for inputs {}, "
                             + "fallback to compute a parallelism that can evenly distribute num subpartitions.",
-                    inputInfo.getResultId());
+                    inputInfos.stream()
+                            .map(BlockingInputInfo::getResultId)
+                            .collect(Collectors.toList()));
             // This computer is only used in the adaptive batch scenario, where isDynamicGraph
             // should always be true.
-            return VertexInputInfoComputationUtils.computeVertexInputInfoForPointwise(
-                    inputInfo.getNumPartitions(),
-                    parallelism,
-                    inputInfo::getNumSubpartitions,
-                    true);
+            return VertexInputInfoComputationUtils.computeVertexInputInfos(
+                    parallelism, inputInfos, true);
         }
 
         List<IndexRange> subpartitionSliceRanges = optionalSubpartitionSliceRanges.get();
 
-        checkState(isLegalParallelism(subpartitionSliceRanges.size(), parallelism, parallelism));
+        checkState(
+                isLegalParallelism(subpartitionSliceRanges.size(), minParallelism, maxParallelism));
 
-        // Create vertex input info based on the subpartition slice and ranges.
-        return createJobVertexInputInfo(inputInfo, subpartitionSliceRanges, subpartitionSlices);
+        // Create vertex input infos based on the subpartition slice and ranges.
+        return createJobVertexInputInfos(
+                inputInfos,
+                subpartitionSlicesByInputIndex,
+                subpartitionSliceRanges,
+                index -> index);
     }
 
-    private static List<SubpartitionSlice> createSubpartitionSlices(BlockingInputInfo inputInfo) {
+    private static Map<Integer, List<SubpartitionSlice>> createSubpartitionSlicesByInputIndex(
+            List<BlockingInputInfo> inputInfos) {
+        int numSubpartitionSlices;
+        List<BlockingInputInfo> inputsWithIntraCorrelation =
+                getInputsWithIntraCorrelation(inputInfos);
+        if (!inputsWithIntraCorrelation.isEmpty()) {
+            // Ensure that when creating subpartition slices, data with intra-correlation will
+            // not be split.
+            numSubpartitionSlices = checkAndGetPartitionNum(inputsWithIntraCorrelation);
+        } else {
+            numSubpartitionSlices = getMinSubpartitionCount(inputInfos);
+        }
+
+        Map<Integer, List<SubpartitionSlice>> subpartitionSlices = new HashMap<>();
+        for (int i = 0; i < inputInfos.size(); ++i) {
+            BlockingInputInfo inputInfo = inputInfos.get(i);
+            subpartitionSlices.put(i, createSubpartitionSlices(inputInfo, numSubpartitionSlices));
+        }
+
+        return subpartitionSlices;
+    }
+
+    private static List<SubpartitionSlice> createSubpartitionSlices(
+            BlockingInputInfo inputInfo, int total) {
         List<SubpartitionSlice> subpartitionSlices = new ArrayList<>();
-        if (inputInfo.isIntraInputKeyCorrelated()) {
-            // If the input has intra-input correlation, we need to ensure all subpartitions
-            // in the same partition index are assigned to the same downstream concurrent task.
-            for (int i = 0; i < inputInfo.getNumPartitions(); ++i) {
-                IndexRange partitionRange = new IndexRange(i, i);
-                IndexRange subpartitionRange =
-                        new IndexRange(0, inputInfo.getNumSubpartitions(i) - 1);
+        int numPartitions = inputInfo.getNumPartitions();
+        int numSubpartitions = checkAndGetSubpartitionNum(List.of(inputInfo));
+        if (numPartitions >= total) {
+            for (int i = 0; i < total; ++i) {
+                int start = i * numPartitions / total;
+                int nextStart = (i + 1) * numPartitions / total;
+                IndexRange partitionRange = new IndexRange(start, nextStart - 1);
+                IndexRange subpartitionRange = new IndexRange(0, numSubpartitions - 1);
                 subpartitionSlices.add(
                         createSubpartitionSlice(
                                 partitionRange,
@@ -158,10 +158,14 @@ public class PointwiseVertexInputInfoComputer {
                                 inputInfo.getNumBytesProduced(partitionRange, subpartitionRange)));
             }
         } else {
-            for (int i = 0; i < inputInfo.getNumPartitions(); ++i) {
+            for (int i = 0; i < numPartitions; i++) {
+                int count = (i + 1) * total / numPartitions - i * total / numPartitions;
+                checkState(count > 0 && count <= numSubpartitions);
                 IndexRange partitionRange = new IndexRange(i, i);
-                for (int j = 0; j < inputInfo.getNumSubpartitions(i); ++j) {
-                    IndexRange subpartitionRange = new IndexRange(j, j);
+                for (int j = 0; j < count; ++j) {
+                    int start = j * numSubpartitions / count;
+                    int nextStart = (j + 1) * numSubpartitions / count;
+                    IndexRange subpartitionRange = new IndexRange(start, nextStart - 1);
                     subpartitionSlices.add(
                             createSubpartitionSlice(
                                     partitionRange,
@@ -172,14 +176,5 @@ public class PointwiseVertexInputInfoComputer {
             }
         }
         return subpartitionSlices;
-    }
-
-    private static JobVertexInputInfo createJobVertexInputInfo(
-            BlockingInputInfo inputInfo,
-            List<IndexRange> subpartitionSliceRanges,
-            List<SubpartitionSlice> subpartitionSlices) {
-        checkState(!inputInfo.isBroadcast());
-        return createdJobVertexInputInfoForNonBroadcast(
-                inputInfo, subpartitionSliceRanges, subpartitionSlices);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchSchedulerTest.java
@@ -193,7 +193,7 @@ class AdaptiveBatchSchedulerTest {
         // trigger source finished.
         transitionExecutionsState(scheduler, ExecutionState.FINISHED, source);
         assertThat(mapExecutionJobVertex.getParallelism()).isEqualTo(5);
-        assertThat(sinkExecutionJobVertex.getParallelism()).isEqualTo(-1);
+        assertThat(sinkExecutionJobVertex.getParallelism()).isEqualTo(5);
 
         // trigger map finished.
         transitionExecutionsState(scheduler, ExecutionState.FINISHED, map);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/DefaultVertexParallelismAndInputInfosDeciderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/DefaultVertexParallelismAndInputInfosDeciderTest.java
@@ -300,32 +300,6 @@ class DefaultVertexParallelismAndInputInfosDeciderTest {
     }
 
     @Test
-    void testParallelismAlreadyDecided() {
-        final DefaultVertexParallelismAndInputInfosDecider decider =
-                createDecider(MIN_PARALLELISM, MAX_PARALLELISM, DATA_VOLUME_PER_TASK);
-
-        AllToAllBlockingResultInfo allToAllBlockingResultInfo =
-                createAllToAllBlockingResultInfo(
-                        new long[] {10L, 15L, 13L, 12L, 1L, 10L, 8L, 20L, 12L, 17L});
-        ParallelismAndInputInfos parallelismAndInputInfos =
-                decider.decideParallelismAndInputInfosForVertex(
-                        new JobVertexID(),
-                        Collections.singletonList(
-                                toBlockingInputInfoView(allToAllBlockingResultInfo)),
-                        3,
-                        MIN_PARALLELISM,
-                        MAX_PARALLELISM);
-
-        assertThat(parallelismAndInputInfos.getParallelism()).isEqualTo(3);
-        assertThat(parallelismAndInputInfos.getJobVertexInputInfos()).hasSize(1);
-
-        checkAllToAllJobVertexInputInfo(
-                Iterables.getOnlyElement(
-                        parallelismAndInputInfos.getJobVertexInputInfos().values()),
-                Arrays.asList(new IndexRange(0, 2), new IndexRange(3, 6), new IndexRange(7, 9)));
-    }
-
-    @Test
     void testSourceJobVertex() {
         ParallelismAndInputInfos parallelismAndInputInfos =
                 createDeciderAndDecideParallelismAndInputInfos(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/DefaultVertexParallelismAndInputInfosDeciderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/DefaultVertexParallelismAndInputInfosDeciderTest.java
@@ -300,6 +300,45 @@ class DefaultVertexParallelismAndInputInfosDeciderTest {
     }
 
     @Test
+    void testHavePointwiseAndBroadcastEdge() {
+        AllToAllBlockingResultInfo resultInfo1 =
+                createAllToAllBlockingResultInfo(
+                        new long[] {10L, 15L, 13L, 12L, 1L, 10L, 8L, 20L, 12L, 17L}, true, false);
+        PointwiseBlockingResultInfo resultInfo2 =
+                createPointwiseBlockingResultInfo(
+                        new long[] {8L, 12L, 21L, 9L, 13L}, new long[] {7L, 19L, 13L, 14L, 5L});
+        ParallelismAndInputInfos parallelismAndInputInfos =
+                createDeciderAndDecideParallelismAndInputInfos(
+                        1, 10, 60L, Arrays.asList(resultInfo1, resultInfo2));
+
+        assertThat(parallelismAndInputInfos.getParallelism()).isEqualTo(6);
+        assertThat(parallelismAndInputInfos.getJobVertexInputInfos()).hasSize(2);
+
+        checkAllToAllJobVertexInputInfo(
+                parallelismAndInputInfos.getJobVertexInputInfos().get(resultInfo1.getResultId()),
+                Arrays.asList(
+                        new IndexRange(0, 9),
+                        new IndexRange(0, 9),
+                        new IndexRange(0, 9),
+                        new IndexRange(0, 9),
+                        new IndexRange(0, 9),
+                        new IndexRange(0, 9)));
+        checkJobVertexInputInfo(
+                parallelismAndInputInfos.getJobVertexInputInfos().get(resultInfo2.getResultId()),
+                Arrays.asList(
+                        Map.of(new IndexRange(0, 0), new IndexRange(0, 1)),
+                        Map.of(new IndexRange(0, 0), new IndexRange(2, 3)),
+                        Map.of(
+                                new IndexRange(0, 0),
+                                new IndexRange(4, 4),
+                                new IndexRange(1, 1),
+                                new IndexRange(0, 0)),
+                        Map.of(new IndexRange(1, 1), new IndexRange(1, 1)),
+                        Map.of(new IndexRange(1, 1), new IndexRange(2, 3)),
+                        Map.of(new IndexRange(1, 1), new IndexRange(4, 4))));
+    }
+
+    @Test
     void testSourceJobVertex() {
         ParallelismAndInputInfos parallelismAndInputInfos =
                 createDeciderAndDecideParallelismAndInputInfos(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/util/PointwiseVertexInputInfoComputerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/util/PointwiseVertexInputInfoComputerTest.java
@@ -42,13 +42,13 @@ class PointwiseVertexInputInfoComputerTest {
         PointwiseVertexInputInfoComputer computer = createPointwiseVertexInputInfoComputer();
         List<BlockingInputInfo> inputInfos = createBlockingInputInfos(2, List.of(), false);
         Map<IntermediateDataSetID, JobVertexInputInfo> vertexInputs =
-                computer.compute(inputInfos, 2, 10);
+                computer.compute(inputInfos, 2, 2, 2, 10);
         checkCorrectnessForNonCorrelatedInput(vertexInputs, inputInfos.get(0), 2);
         checkConsumedDataVolumePerSubtask(new long[] {3L, 3L}, inputInfos, vertexInputs);
 
         // with different parallelism
         Map<IntermediateDataSetID, JobVertexInputInfo> vertexInputs2 =
-                computer.compute(inputInfos, 3, 10);
+                computer.compute(inputInfos, 3, 3, 3, 10);
         checkCorrectnessForNonCorrelatedInput(vertexInputs2, inputInfos.get(0), 3);
         checkConsumedDataVolumePerSubtask(new long[] {2L, 2L, 2L}, inputInfos, vertexInputs2);
     }
@@ -62,14 +62,17 @@ class PointwiseVertexInputInfoComputerTest {
         inputInfosWithDifferentSkewedPartitions.add(inputInfo1);
         inputInfosWithDifferentSkewedPartitions.add(inputInfo2);
         Map<IntermediateDataSetID, JobVertexInputInfo> vertexInputs =
-                computer.compute(inputInfosWithDifferentSkewedPartitions, 3, 10);
+                computer.compute(inputInfosWithDifferentSkewedPartitions, 3, 3, 3, 10);
         checkCorrectnessForNonCorrelatedInput(vertexInputs, inputInfo1, 3);
         checkConsumedDataVolumePerSubtask(
-                new long[] {10L, 10L, 16L}, List.of(inputInfo1), vertexInputs);
+                new long[] {20L, 11L, 5L}, List.of(inputInfo1), vertexInputs);
 
         checkCorrectnessForNonCorrelatedInput(vertexInputs, inputInfo2, 3);
         checkConsumedDataVolumePerSubtask(
-                new long[] {13L, 10L, 13L}, List.of(inputInfo2), vertexInputs);
+                new long[] {2L, 11L, 23L}, List.of(inputInfo2), vertexInputs);
+
+        checkConsumedDataVolumePerSubtask(
+                new long[] {22L, 22L, 28L}, List.of(inputInfo1, inputInfo2), vertexInputs);
     }
 
     @Test
@@ -81,14 +84,17 @@ class PointwiseVertexInputInfoComputerTest {
         inputInfosWithDifferentNumPartitions.add(inputInfo1);
         inputInfosWithDifferentNumPartitions.add(inputInfo2);
         Map<IntermediateDataSetID, JobVertexInputInfo> vertexInputs =
-                computer.compute(inputInfosWithDifferentNumPartitions, 3, 10);
+                computer.compute(inputInfosWithDifferentNumPartitions, 3, 3, 3, 10);
         checkCorrectnessForNonCorrelatedInput(vertexInputs, inputInfo1, 3);
         checkConsumedDataVolumePerSubtask(
-                new long[] {13L, 10L, 13L}, List.of(inputInfo1), vertexInputs);
+                new long[] {13L, 20L, 3L}, List.of(inputInfo1), vertexInputs);
 
         checkCorrectnessForNonCorrelatedInput(vertexInputs, inputInfo2, 3);
         checkConsumedDataVolumePerSubtask(
-                new long[] {13L, 10L, 10L}, List.of(inputInfo2), vertexInputs);
+                new long[] {3L, 10L, 20L}, List.of(inputInfo2), vertexInputs);
+
+        checkConsumedDataVolumePerSubtask(
+                new long[] {16L, 30L, 23L}, List.of(inputInfo1, inputInfo2), vertexInputs);
     }
 
     @Test
@@ -100,14 +106,17 @@ class PointwiseVertexInputInfoComputerTest {
         inputInfosWithDifferentNumSubpartitions.add(inputInfo1);
         inputInfosWithDifferentNumSubpartitions.add(inputInfo2);
         Map<IntermediateDataSetID, JobVertexInputInfo> vertexInputs =
-                computer.compute(inputInfosWithDifferentNumSubpartitions, 3, 10);
+                computer.compute(inputInfosWithDifferentNumSubpartitions, 3, 3, 3, 10);
         checkCorrectnessForNonCorrelatedInput(vertexInputs, inputInfo1, 3);
         checkConsumedDataVolumePerSubtask(
                 new long[] {13L, 10L, 13L}, List.of(inputInfo1), vertexInputs);
 
         checkCorrectnessForNonCorrelatedInput(vertexInputs, inputInfo2, 3);
         checkConsumedDataVolumePerSubtask(
-                new long[] {25L, 20L, 15L}, List.of(inputInfo2), vertexInputs);
+                new long[] {15L, 20L, 25L}, List.of(inputInfo2), vertexInputs);
+
+        checkConsumedDataVolumePerSubtask(
+                new long[] {28L, 30L, 38L}, List.of(inputInfo1, inputInfo2), vertexInputs);
     }
 
     @Test
@@ -115,7 +124,7 @@ class PointwiseVertexInputInfoComputerTest {
         PointwiseVertexInputInfoComputer computer = createPointwiseVertexInputInfoComputer();
         List<BlockingInputInfo> inputInfos = createBlockingInputInfos(3, List.of(), true);
         Map<IntermediateDataSetID, JobVertexInputInfo> vertexInputs =
-                computer.compute(inputInfos, 3, 10);
+                computer.compute(inputInfos, 3, 3, 3, 10);
         checkCorrectnessForNonCorrelatedInput(vertexInputs, inputInfos.get(0), 3);
         checkConsumedSubpartitionGroups(
                 List.of(
@@ -127,7 +136,7 @@ class PointwiseVertexInputInfoComputerTest {
 
         // with different parallelism
         Map<IntermediateDataSetID, JobVertexInputInfo> vertexInputs2 =
-                computer.compute(inputInfos, 2, 10);
+                computer.compute(inputInfos, 2, 2, 2, 10);
         checkCorrectnessForNonCorrelatedInput(vertexInputs2, inputInfos.get(0), 2);
         checkConsumedSubpartitionGroups(
                 List.of(


### PR DESCRIPTION
## What is the purpose of the change
When a Flink job contains a Rescale edge converted from Hash, the pre-determined parallelism limits the flexibility of parallelism derivation for Pointwise-type inputs. This consequently leads to a high likelihood of needing to use the adjustToClosestLegalParallelism method in this scenario to adjust the parallelism to meet expectations. This adjustment incurs a significant time complexity (O(log n * n * n), specific to this scenario), so we need to optimize the parallelism decision logic for Pointwise to enhance performance in this case.

## Brief change log

Optimize the parallelism decide logic for pointwise.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
