### PR TITLE
[FLINK-37382][runtime] Early optimization for adaptive join when either input is below broadcast threshold.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/DefaultStreamGraphContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/DefaultStreamGraphContext.java
@@ -194,14 +194,16 @@ public class DefaultStreamGraphContext implements StreamGraphContext {
     }
 
     @Override
-    public boolean areAllUpstreamNodesFinished(ImmutableStreamNode streamNode) {
-        for (ImmutableStreamEdge streamEdge : streamNode.getInEdges()) {
-            if (!finishedStreamNodeIds.contains(streamEdge.getSourceId())) {
-                return false;
-            }
-        }
-
-        return true;
+    public boolean checkUpstreamNodesFinished(ImmutableStreamNode streamNode, Integer typeNumber) {
+        List<ImmutableStreamEdge> inEdgesWithTypeNumber =
+                streamNode.getInEdges().stream()
+                        .filter(edge -> typeNumber == null || edge.getTypeNumber() == typeNumber)
+                        .collect(Collectors.toList());
+        checkState(
+                !inEdgesWithTypeNumber.isEmpty(),
+                String.format("The stream edge with typeNumber %s does not exist.", typeNumber));
+        return inEdgesWithTypeNumber.stream()
+                .allMatch(edge -> finishedStreamNodeIds.contains(edge.getSourceId()));
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphContext.java
@@ -76,12 +76,14 @@ public interface StreamGraphContext {
     boolean modifyStreamNode(List<StreamNodeUpdateRequestInfo> requestInfos);
 
     /**
-     * Check whether all upstream nodes of the stream node have finished executing.
+     * Check if the upstream nodes of the stream node with the specified type number have finished.
+     * If the type number is null, evaluate the completion of all upstream processes.
      *
      * @param streamNode the stream node that needs to be determined.
      * @return true if all upstream nodes are finished, false otherwise.
      */
-    boolean areAllUpstreamNodesFinished(ImmutableStreamNode streamNode);
+    boolean checkUpstreamNodesFinished(
+            ImmutableStreamNode streamNode, @Nullable Integer typeNumber);
 
     /**
      * Retrieves the IntermediateDataSetID consumed by the specified edge.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/StreamGraphOptimizerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/StreamGraphOptimizerTest.java
@@ -89,7 +89,8 @@ class StreamGraphOptimizerTest {
                     }
 
                     @Override
-                    public boolean areAllUpstreamNodesFinished(ImmutableStreamNode streamNode) {
+                    public boolean checkUpstreamNodesFinished(
+                            ImmutableStreamNode streamNode, Integer typeNumber) {
                         return false;
                     }
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/strategy/AdaptiveBroadcastJoinOptimizationStrategy.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/strategy/AdaptiveBroadcastJoinOptimizationStrategy.java
@@ -38,8 +38,10 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.apache.flink.table.runtime.strategy.AdaptiveJoinOptimizationUtils.filterEdges;
 import static org.apache.flink.table.runtime.strategy.AdaptiveJoinOptimizationUtils.isBroadcastJoin;
@@ -55,6 +57,7 @@ public class AdaptiveBroadcastJoinOptimizationStrategy
     private Long broadcastThreshold;
 
     private Map<Integer, Map<Integer, Long>> aggregatedInputBytesByTypeNumberAndNodeId;
+    private Set<Integer> optimizedAdaptiveJoinNodes;
 
     @Override
     public void initialize(StreamGraphContext context) {
@@ -62,6 +65,7 @@ public class AdaptiveBroadcastJoinOptimizationStrategy
         broadcastThreshold =
                 config.get(OptimizerConfigOptions.TABLE_OPTIMIZER_BROADCAST_JOIN_THRESHOLD);
         aggregatedInputBytesByTypeNumberAndNodeId = new HashMap<>();
+        optimizedAdaptiveJoinNodes = new HashSet<>();
     }
 
     @Override
@@ -79,7 +83,8 @@ public class AdaptiveBroadcastJoinOptimizationStrategy
             ImmutableStreamNode adaptiveJoinNode,
             List<ImmutableStreamEdge> upstreamStreamEdges,
             AdaptiveJoin adaptiveJoin) {
-        if (!canPerformOptimization(adaptiveJoinNode, context)) {
+        if (!canPerformOptimization(adaptiveJoinNode, context)
+                || optimizedAdaptiveJoinNodes.contains(adaptiveJoinNode.getId())) {
             return;
         }
         for (ImmutableStreamEdge upstreamEdge : upstreamStreamEdges) {
@@ -97,92 +102,115 @@ public class AdaptiveBroadcastJoinOptimizationStrategy
                     adaptiveJoinNode, upstreamEdge.getTypeNumber(), producedBytes);
         }
 
-        // If all upstream nodes have finished, we attempt to optimize the AdaptiveJoin node.
-        if (context.areAllUpstreamNodesFinished(adaptiveJoinNode)) {
-            Long leftInputSize =
-                    aggregatedInputBytesByTypeNumberAndNodeId.get(adaptiveJoinNode.getId()).get(1);
+        FlinkJoinType joinType = adaptiveJoin.getJoinType();
+        Long leftInputSize = null;
+        Long rightInputSize = null;
+
+        // When either input side of the adaptive join meets broadcast requirements, the broadcast
+        // optimization can be immediately applied. This allows the opposite side to produce data
+        // in a pointwise manner if it has not yet started scheduling, thereby reducing the costs
+        // associated with shuffle writes and network overhead. Furthermore, in the future,
+        // when multi-input support is available in the runtime, it could enable chaining large
+        // input nodes with adaptive join nodes, further minimizing overall overhead.
+        if (context.checkUpstreamNodesFinished(adaptiveJoinNode, LEFT_INPUT_TYPE_NUMBER)) {
+            leftInputSize =
+                    aggregatedInputBytesByTypeNumberAndNodeId
+                            .get(adaptiveJoinNode.getId())
+                            .get(LEFT_INPUT_TYPE_NUMBER);
             checkState(
                     leftInputSize != null,
                     "Left input bytes of adaptive join [%s] is unknown, which is unexpected.",
                     adaptiveJoinNode.getId());
-            Long rightInputSize =
-                    aggregatedInputBytesByTypeNumberAndNodeId.get(adaptiveJoinNode.getId()).get(2);
+            boolean leftIsBuild = true;
+            if (checkInputSideCanBeBroadcast(joinType, leftIsBuild, leftInputSize)
+                    && tryBroadcastOptimization(
+                            adaptiveJoinNode, context, adaptiveJoin, leftIsBuild, leftInputSize)) {
+                return;
+            }
+        }
+        if (context.checkUpstreamNodesFinished(adaptiveJoinNode, RIGHT_INPUT_TYPE_NUMBER)) {
+            rightInputSize =
+                    aggregatedInputBytesByTypeNumberAndNodeId
+                            .get(adaptiveJoinNode.getId())
+                            .get(RIGHT_INPUT_TYPE_NUMBER);
             checkState(
                     rightInputSize != null,
                     "Right input bytes of adaptive join [%s] is unknown, which is unexpected.",
                     adaptiveJoinNode.getId());
+            boolean leftIsBuild = false;
+            if (checkInputSideCanBeBroadcast(joinType, leftIsBuild, rightInputSize)
+                    && tryBroadcastOptimization(
+                            adaptiveJoinNode, context, adaptiveJoin, leftIsBuild, rightInputSize)) {
+                return;
+            }
+        }
 
-            boolean leftSizeSmallerThanThreshold = leftInputSize <= broadcastThreshold;
-            boolean rightSizeSmallerThanThreshold = rightInputSize <= broadcastThreshold;
+        // When neither input meets broadcast thresholds, recompute the smaller side to provide
+        // better performance for the shuffle join.
+        if (leftInputSize != null && rightInputSize != null) {
+            LOG.debug(
+                    "The size of the specified side of the input data for the join node [{}] "
+                            + "is too large to be converted into a broadcast hash join. "
+                            + "The Join type: {}, Broadcast threshold: {} bytes, Left input size: "
+                            + "{} bytes, Right input size: {} bytes.",
+                    adaptiveJoinNode.getId(),
+                    joinType,
+                    broadcastThreshold,
+                    leftInputSize,
+                    rightInputSize);
             boolean leftSmallerThanRight = leftInputSize < rightInputSize;
-            FlinkJoinType joinType = adaptiveJoin.getJoinType();
-            boolean canBeBroadcast;
-            boolean leftIsBuild;
+            adaptiveJoin.markAsBroadcastJoin(false, leftSmallerThanRight);
+            optimizedAdaptiveJoinNodes.add(adaptiveJoinNode.getId());
+            aggregatedInputBytesByTypeNumberAndNodeId.remove(adaptiveJoinNode.getId());
+        }
+    }
+
+    private boolean tryBroadcastOptimization(
+            ImmutableStreamNode adaptiveJoinNode,
+            StreamGraphContext context,
+            AdaptiveJoin adaptiveJoin,
+            boolean leftIsBuild,
+            long inputBytes) {
+        if (tryModifyStreamEdgesForBroadcastJoin(
+                adaptiveJoinNode.getInEdges(), context, leftIsBuild)) {
+            LOG.info(
+                    "The {} input data size of the join node [{}] is small enough, "
+                            + "adaptively convert it to a broadcast hash join. Broadcast "
+                            + "threshold bytes: {}, actual input bytes: {}.",
+                    leftIsBuild ? "left" : "right",
+                    adaptiveJoinNode.getId(),
+                    broadcastThreshold,
+                    inputBytes);
+            adaptiveJoin.markAsBroadcastJoin(true, leftIsBuild);
+            optimizedAdaptiveJoinNodes.add(adaptiveJoinNode.getId());
+            aggregatedInputBytesByTypeNumberAndNodeId.remove(adaptiveJoinNode.getId());
+            return true;
+        } else {
+            LOG.info(
+                    "Modification to stream edges for the join node [{}] failed. Keep the join node as is.",
+                    adaptiveJoinNode.getId());
+            return false;
+        }
+    }
+
+    private Boolean checkInputSideCanBeBroadcast(
+            FlinkJoinType joinType, boolean isLeftBuild, long producedBytes) {
+        if (producedBytes < broadcastThreshold) {
             switch (joinType) {
                 case RIGHT:
-                    // For a right outer join, if the left side can be broadcast, then the left side
-                    // is
-                    // always the build side; otherwise, the smaller side is the build side.
-                    canBeBroadcast = leftSizeSmallerThanThreshold;
-                    leftIsBuild = true;
-                    break;
+                    return isLeftBuild;
                 case INNER:
-                    canBeBroadcast = leftSizeSmallerThanThreshold || rightSizeSmallerThanThreshold;
-                    leftIsBuild = leftSmallerThanRight;
-                    break;
+                    return true;
                 case LEFT:
                 case SEMI:
                 case ANTI:
-                    // For left outer / semi / anti join, if the right side can be broadcast, then
-                    // the
-                    // right side is always the build side; otherwise, the smaller side is the build
-                    // side.
-                    canBeBroadcast = rightSizeSmallerThanThreshold;
-                    leftIsBuild = false;
-                    break;
+                    return !isLeftBuild;
                 case FULL:
                 default:
                     throw new RuntimeException(String.format("Unexpected join type %s.", joinType));
             }
-
-            boolean isBroadcast = false;
-            if (canBeBroadcast) {
-                isBroadcast =
-                        tryModifyStreamEdgesForBroadcastJoin(
-                                adaptiveJoinNode.getInEdges(), context, leftIsBuild);
-
-                if (isBroadcast) {
-                    LOG.info(
-                            "The {} input data size of the join node [{}] is small enough, "
-                                    + "adaptively convert it to a broadcast hash join. Broadcast "
-                                    + "threshold bytes: {}, left input bytes: {}, right input bytes: {}.",
-                            leftIsBuild ? "left" : "right",
-                            adaptiveJoinNode.getId(),
-                            broadcastThreshold,
-                            leftInputSize,
-                            rightInputSize);
-                } else {
-                    LOG.info(
-                            "Modification to stream edges for the join node [{}] failed. Keep the join node as is.",
-                            adaptiveJoinNode.getId());
-                }
-            } else {
-                LOG.debug(
-                        "The size of the specified side of the input data for the join node [{}] "
-                                + "is too large to be converted into a broadcast hash join. "
-                                + "The Join type: {}, Broadcast threshold: {} bytes, Left input size: "
-                                + "{} bytes, Right input size: {} bytes.",
-                        adaptiveJoinNode.getId(),
-                        joinType,
-                        broadcastThreshold,
-                        leftInputSize,
-                        rightInputSize);
-            }
-            adaptiveJoin.markAsBroadcastJoin(
-                    isBroadcast, isBroadcast ? leftIsBuild : leftSmallerThanRight);
-
-            aggregatedInputBytesByTypeNumberAndNodeId.remove(adaptiveJoinNode.getId());
         }
+        return false;
     }
 
     private boolean canPerformOptimization(
@@ -223,10 +251,15 @@ public class AdaptiveBroadcastJoinOptimizationStrategy
             List<ImmutableStreamEdge> inEdges, StreamGraphContext context, boolean leftIsBuild) {
         List<StreamEdgeUpdateRequestInfo> modifiedBuildSideEdges =
                 generateStreamEdgeUpdateRequestInfos(
-                        filterEdges(inEdges, leftIsBuild ? 1 : 2), new BroadcastPartitioner<>());
+                        filterEdges(
+                                inEdges,
+                                leftIsBuild ? LEFT_INPUT_TYPE_NUMBER : RIGHT_INPUT_TYPE_NUMBER),
+                        new BroadcastPartitioner<>());
         List<StreamEdgeUpdateRequestInfo> modifiedProbeSideEdges =
                 generateStreamEdgeUpdateRequestInfos(
-                        filterEdges(inEdges, leftIsBuild ? 2 : 1),
+                        filterEdges(
+                                inEdges,
+                                leftIsBuild ? RIGHT_INPUT_TYPE_NUMBER : LEFT_INPUT_TYPE_NUMBER),
                         new ForwardForUnspecifiedPartitioner<>());
         modifiedBuildSideEdges.addAll(modifiedProbeSideEdges);
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/strategy/AdaptiveSkewedJoinOptimizationStrategy.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/strategy/AdaptiveSkewedJoinOptimizationStrategy.java
@@ -54,9 +54,6 @@ public class AdaptiveSkewedJoinOptimizationStrategy
     private static final Logger LOG =
             LoggerFactory.getLogger(AdaptiveSkewedJoinOptimizationStrategy.class);
 
-    private static final int LEFT_INPUT_TYPE_NUMBER = 1;
-    private static final int RIGHT_INPUT_TYPE_NUMBER = 2;
-
     private Map<Integer, Map<Integer, long[]>> aggregatedProducedBytesByTypeNumberAndNodeId;
 
     private OptimizerConfigOptions.AdaptiveSkewedJoinOptimizationStrategy
@@ -110,7 +107,7 @@ public class AdaptiveSkewedJoinOptimizationStrategy
                     edge.getTypeNumber(),
                     ((AllToAllBlockingResultInfo) resultInfo).getAggregatedSubpartitionBytes());
         }
-        if (context.areAllUpstreamNodesFinished(adaptiveJoinNode)) {
+        if (context.checkUpstreamNodesFinished(adaptiveJoinNode, null)) {
             applyAdaptiveSkewedJoinOptimization(
                     context, adaptiveJoinNode, adaptiveJoin.getJoinType());
             freeNodeStatistic(adaptiveJoinNode.getId());

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/strategy/BaseAdaptiveJoinOperatorOptimizationStrategy.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/strategy/BaseAdaptiveJoinOperatorOptimizationStrategy.java
@@ -47,6 +47,9 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public abstract class BaseAdaptiveJoinOperatorOptimizationStrategy
         implements StreamGraphOptimizationStrategy {
 
+    protected static final int LEFT_INPUT_TYPE_NUMBER = 1;
+    protected static final int RIGHT_INPUT_TYPE_NUMBER = 2;
+
     /** Set of partitioners that can automatically correct key group. */
     private static final Set<Class<?>> PARTITIONERS_CAN_CORRECT_KEY_GROUP_AUTOMATIC =
             Set.of(

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/strategy/PostProcessAdaptiveJoinStrategy.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/strategy/PostProcessAdaptiveJoinStrategy.java
@@ -61,7 +61,7 @@ public class PostProcessAdaptiveJoinStrategy extends BaseAdaptiveJoinOperatorOpt
             ImmutableStreamNode adaptiveJoinNode,
             List<ImmutableStreamEdge> upstreamStreamEdges,
             AdaptiveJoin adaptiveJoin) {
-        if (context.areAllUpstreamNodesFinished(adaptiveJoinNode)) {
+        if (context.checkUpstreamNodesFinished(adaptiveJoinNode, null)) {
             // For hash join, reorder the join node inputs so the build side is read first.
             if (adaptiveJoin.shouldReorderInputs()) {
                 if (!context.modifyStreamEdge(


### PR DESCRIPTION
## What is the purpose of the change

When the large table side has not yet initialized, if the small table side finishes early and the output data volume is smaller than the broadcast threshold, the adaptive join operator can be optimized to a broadcast hash join in advance. This can help reduce network shuffle overhead.

## Brief change log

  - *The adaptive broadcast join optimization is triggered in advance when any input of the join node meets the broadcast condition.*


## Verifying this change
This change is already covered by existing tests, such as *(please describe tests)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (no)
