### PR TITLE
[hotfix] Update failureaccess in order to fix java 11 license check

### DIFF
--- a/flink-table/flink-table-planner/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-table-planner/src/main/resources/META-INF/NOTICE
@@ -7,7 +7,7 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.google.guava:guava:33.4.0-jre
-- com.google.guava:failureaccess:1.0.1
+- com.google.guava:failureaccess:1.0.2
 - org.apache.calcite:calcite-core:1.34.0
 - org.apache.calcite:calcite-linq4j:1.34.0
 - org.apache.calcite.avatica:avatica-core:1.23.0


### PR DESCRIPTION
## What is the purpose of the change

The PR is to fix licensecheck in jdk11
I also created a follow up task to make the behavior across different jdk's same FLINK-37387

an example of a failed build https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=66272&view=logs&j=946871de-358d-5815-3994-8175615bc253&t=e0240c62-4570-5d1c-51af-dd63d2093da1&l=41112

## Brief change log
NOTICE

## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: (yes)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
