### PR TITLE
[FLINK-37385][table] Add support for smile format

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/CompiledPlan.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/CompiledPlan.java
@@ -65,6 +65,9 @@ public interface CompiledPlan extends Explainable<CompiledPlan>, Executable {
     /** Convert the plan to a JSON string representation. */
     String asJsonString();
 
+    /** Convert the plan to a Smile binary representation. */
+    byte[] asSmileBytes();
+
     /**
      * @see #writeToFile(File)
      */

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/PlanReference.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/PlanReference.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.api;
 
 import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.PublicEvolving;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -68,13 +69,13 @@ public abstract class PlanReference {
     /** Create a reference starting from a JSON string. */
     public static PlanReference fromJsonString(String jsonString) {
         Objects.requireNonNull(jsonString, "Json string cannot be null");
-        return new ContentPlanReference(jsonString);
+        return new JsonContentPlanReference(jsonString);
     }
 
     /** Create a reference starting from a Smile binary representation. */
     public static PlanReference fromSmileBytes(byte[] smileBytes) {
         Objects.requireNonNull(smileBytes, "Smile bytes cannot be null");
-        return new ByteContentPlanReference(smileBytes);
+        return new BytesContentPlanReference(smileBytes);
     }
 
     /**
@@ -131,12 +132,12 @@ public abstract class PlanReference {
     }
 
     /** Plan reference to a string containing the serialized persisted plan in JSON. */
-    @Experimental
-    public static class ContentPlanReference extends PlanReference {
+    @PublicEvolving
+    public static class JsonContentPlanReference extends PlanReference {
 
         private final String content;
 
-        private ContentPlanReference(String content) {
+        private JsonContentPlanReference(String content) {
             this.content = content;
         }
 
@@ -152,7 +153,7 @@ public abstract class PlanReference {
             if (o == null || getClass() != o.getClass()) {
                 return false;
             }
-            ContentPlanReference that = (ContentPlanReference) o;
+            JsonContentPlanReference that = (JsonContentPlanReference) o;
             return Objects.equals(content, that.content);
         }
 
@@ -168,12 +169,12 @@ public abstract class PlanReference {
     }
 
     /** Plan reference to a string containing the serialized persisted plan in Smile. */
-    @Experimental
-    public static class ByteContentPlanReference extends PlanReference {
+    @PublicEvolving
+    public static class BytesContentPlanReference extends PlanReference {
 
         private final byte[] content;
 
-        private ByteContentPlanReference(byte[] content) {
+        private BytesContentPlanReference(byte[] content) {
             this.content = content;
         }
 
@@ -189,7 +190,7 @@ public abstract class PlanReference {
             if (o == null || getClass() != o.getClass()) {
                 return false;
             }
-            ByteContentPlanReference that = (ByteContentPlanReference) o;
+            BytesContentPlanReference that = (BytesContentPlanReference) o;
             return Arrays.equals(content, that.content);
         }
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/PlanReference.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/PlanReference.java
@@ -23,6 +23,7 @@ import org.apache.flink.annotation.Experimental;
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Objects;
 
 /**
@@ -68,6 +69,12 @@ public abstract class PlanReference {
     public static PlanReference fromJsonString(String jsonString) {
         Objects.requireNonNull(jsonString, "Json string cannot be null");
         return new ContentPlanReference(jsonString);
+    }
+
+    /** Create a reference starting from a Smile binary representation. */
+    public static PlanReference fromSmileBytes(byte[] smileBytes) {
+        Objects.requireNonNull(smileBytes, "Smile bytes cannot be null");
+        return new ByteContentPlanReference(smileBytes);
     }
 
     /**
@@ -157,6 +164,43 @@ public abstract class PlanReference {
         @Override
         public String toString() {
             return "Plan:\n" + content;
+        }
+    }
+
+    /** Plan reference to a string containing the serialized persisted plan in Smile. */
+    @Experimental
+    public static class ByteContentPlanReference extends PlanReference {
+
+        private final byte[] content;
+
+        private ByteContentPlanReference(byte[] content) {
+            this.content = content;
+        }
+
+        public byte[] getContent() {
+            return content;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            ByteContentPlanReference that = (ByteContentPlanReference) o;
+            return Arrays.equals(content, that.content);
+        }
+
+        @Override
+        public int hashCode() {
+            return Arrays.hashCode(content);
+        }
+
+        @Override
+        public String toString() {
+            return "Plan:\n" + Arrays.toString(content);
         }
     }
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/CompiledPlanImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/CompiledPlanImpl.java
@@ -51,6 +51,11 @@ class CompiledPlanImpl implements CompiledPlan {
     }
 
     @Override
+    public byte[] asSmileBytes() {
+        return internalPlan.asSmileBytes();
+    }
+
+    @Override
     public void writeToFile(File file, boolean ignoreIfExists) {
         internalPlan.writeToFile(
                 file,

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/InternalPlan.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/InternalPlan.java
@@ -40,6 +40,11 @@ public interface InternalPlan {
     String asJsonString();
 
     /**
+     * @see CompiledPlan#asSmileBytes()
+     */
+    byte[] asSmileBytes();
+
+    /**
      * Note that {@code ignoreIfExists} has precedence over {@code failIfExists}.
      *
      * @see CompiledPlan#writeToFile(File, boolean)

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/ExecNodeGraphInternalPlan.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/ExecNodeGraphInternalPlan.java
@@ -42,13 +42,18 @@ import java.util.stream.Collectors;
 public class ExecNodeGraphInternalPlan implements InternalPlan {
 
     private final Supplier<String> serializedPlanSupplier;
+    private final Supplier<byte[]> smileSerializedPlanSupplier;
     private final ExecNodeGraph execNodeGraph;
 
-    private String serializedPlan;
+    private String jsonSerializedPlan;
+    private byte[] smileSerializedPlan;
 
     public ExecNodeGraphInternalPlan(
-            Supplier<String> serializedPlanSupplier, ExecNodeGraph execNodeGraph) {
-        this.serializedPlanSupplier = serializedPlanSupplier;
+            Supplier<String> jsonSerializedPlanSupplier,
+            Supplier<byte[]> smileSerializedPlanSupplier,
+            ExecNodeGraph execNodeGraph) {
+        this.serializedPlanSupplier = jsonSerializedPlanSupplier;
+        this.smileSerializedPlanSupplier = smileSerializedPlanSupplier;
         this.execNodeGraph = execNodeGraph;
     }
 
@@ -58,10 +63,18 @@ public class ExecNodeGraphInternalPlan implements InternalPlan {
 
     @Override
     public String asJsonString() {
-        if (serializedPlan == null) {
-            serializedPlan = serializedPlanSupplier.get();
+        if (jsonSerializedPlan == null) {
+            jsonSerializedPlan = serializedPlanSupplier.get();
         }
-        return serializedPlan;
+        return jsonSerializedPlan;
+    }
+
+    @Override
+    public byte[] asSmileBytes() {
+        if (smileSerializedPlan == null) {
+            smileSerializedPlan = smileSerializedPlanSupplier.get();
+        }
+        return smileSerializedPlan;
     }
 
     @Override

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ColumnJsonDeserializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ColumnJsonDeserializer.java
@@ -45,8 +45,8 @@ import static org.apache.flink.table.planner.plan.nodes.exec.serde.ColumnJsonSer
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.ColumnJsonSerializer.KIND_PHYSICAL;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.ColumnJsonSerializer.METADATA_KEY;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.ColumnJsonSerializer.NAME;
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil.deserializeOptionalField;
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil.traverse;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.CompiledPlanSerdeUtil.deserializeOptionalField;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.CompiledPlanSerdeUtil.traverse;
 
 /**
  * JSON deserializer for {@link Column}.

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ColumnJsonDeserializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ColumnJsonDeserializer.java
@@ -45,8 +45,8 @@ import static org.apache.flink.table.planner.plan.nodes.exec.serde.ColumnJsonSer
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.ColumnJsonSerializer.KIND_PHYSICAL;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.ColumnJsonSerializer.METADATA_KEY;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.ColumnJsonSerializer.NAME;
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeUtil.deserializeOptionalField;
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeUtil.traverse;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil.deserializeOptionalField;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil.traverse;
 
 /**
  * JSON deserializer for {@link Column}.

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ColumnJsonSerializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ColumnJsonSerializer.java
@@ -27,7 +27,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ser.std.S
 
 import java.io.IOException;
 
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeUtil.serializeOptionalField;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil.serializeOptionalField;
 
 /**
  * JSON serializer for {@link Column}.

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ColumnJsonSerializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ColumnJsonSerializer.java
@@ -27,7 +27,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ser.std.S
 
 import java.io.IOException;
 
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil.serializeOptionalField;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.CompiledPlanSerdeUtil.serializeOptionalField;
 
 /**
  * JSON serializer for {@link Column}.

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/CompiledPlanSerdeUtil.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/CompiledPlanSerdeUtil.java
@@ -91,21 +91,26 @@ public class CompiledPlanSerdeUtil {
 
     static {
         JSON_OBJECT_MAPPER_INSTANCE = JacksonMapperFactory.createObjectMapper();
+        JSON_OBJECT_MAPPER_INSTANCE
+                .setTypeFactory(
+                        // Make sure to register the classloader of the planner
+                        JSON_OBJECT_MAPPER_INSTANCE
+                                .getTypeFactory()
+                                .withClassLoader(CompiledPlanSerdeUtil.class.getClassLoader()))
+                .disable(MapperFeature.USE_GETTERS_AS_SETTERS)
+                .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
+                .registerModule(createFlinkTableJacksonModule());
 
-        JSON_OBJECT_MAPPER_INSTANCE.setTypeFactory(
-                // Make sure to register the classloader of the planner
-                JSON_OBJECT_MAPPER_INSTANCE
-                        .getTypeFactory()
-                        .withClassLoader(CompiledPlanSerdeUtil.class.getClassLoader()));
-        JSON_OBJECT_MAPPER_INSTANCE.disable(MapperFeature.USE_GETTERS_AS_SETTERS);
-        JSON_OBJECT_MAPPER_INSTANCE.enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS);
-        JSON_OBJECT_MAPPER_INSTANCE.registerModule(createFlinkTableJacksonModule());
-
-        SMILE_OBJECT_MAPPER_INSTANCE =
-                JacksonMapperFactory.createObjectMapper(new SmileFactory())
-                        .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
-                        .disable(MapperFeature.USE_GETTERS_AS_SETTERS)
-                        .registerModule(createFlinkTableJacksonModule());
+        SMILE_OBJECT_MAPPER_INSTANCE = JacksonMapperFactory.createObjectMapper(new SmileFactory());
+        SMILE_OBJECT_MAPPER_INSTANCE
+                .setTypeFactory(
+                        // Make sure to register the classloader of the planner
+                        SMILE_OBJECT_MAPPER_INSTANCE
+                                .getTypeFactory()
+                                .withClassLoader(CompiledPlanSerdeUtil.class.getClassLoader()))
+                .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+                .disable(MapperFeature.USE_GETTERS_AS_SETTERS)
+                .registerModule(createFlinkTableJacksonModule());
     }
 
     public static ObjectReader createJsonObjectReader(SerdeContext serdeContext) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/CompiledPlanSerdeUtil.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/CompiledPlanSerdeUtil.java
@@ -75,7 +75,7 @@ import java.util.Optional;
 
 /** A utility class that provide abilities for JSON and Smile serialization and deserialization. */
 @Internal
-public class JsonSmileSerdeUtil {
+public class CompiledPlanSerdeUtil {
 
     /**
      * Object mapper shared instance to serialize and deserialize the plan. Note that creating and
@@ -96,7 +96,7 @@ public class JsonSmileSerdeUtil {
                 // Make sure to register the classloader of the planner
                 JSON_OBJECT_MAPPER_INSTANCE
                         .getTypeFactory()
-                        .withClassLoader(JsonSmileSerdeUtil.class.getClassLoader()));
+                        .withClassLoader(CompiledPlanSerdeUtil.class.getClassLoader()));
         JSON_OBJECT_MAPPER_INSTANCE.disable(MapperFeature.USE_GETTERS_AS_SETTERS);
         JSON_OBJECT_MAPPER_INSTANCE.enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS);
         JSON_OBJECT_MAPPER_INSTANCE.registerModule(createFlinkTableJacksonModule());
@@ -269,5 +269,5 @@ public class JsonSmileSerdeUtil {
         }
     }
 
-    private JsonSmileSerdeUtil() {}
+    private CompiledPlanSerdeUtil() {}
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ContextResolvedTableJsonDeserializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ContextResolvedTableJsonDeserializer.java
@@ -73,7 +73,7 @@ final class ContextResolvedTableJsonDeserializer extends StdDeserializer<Context
 
         // Deserialize the two fields, if available
         final ObjectIdentifier identifier =
-                JsonSmileSerdeUtil.deserializeOptionalField(
+                CompiledPlanSerdeUtil.deserializeOptionalField(
                                 objectNode,
                                 FIELD_NAME_IDENTIFIER,
                                 ObjectIdentifier.class,
@@ -81,7 +81,7 @@ final class ContextResolvedTableJsonDeserializer extends StdDeserializer<Context
                                 ctx)
                         .orElse(null);
         final ResolvedCatalogTable resolvedCatalogTable =
-                JsonSmileSerdeUtil.deserializeOptionalField(
+                CompiledPlanSerdeUtil.deserializeOptionalField(
                                 objectNode,
                                 FIELD_NAME_CATALOG_TABLE,
                                 ResolvedCatalogTable.class,

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ContextResolvedTableJsonDeserializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ContextResolvedTableJsonDeserializer.java
@@ -73,7 +73,7 @@ final class ContextResolvedTableJsonDeserializer extends StdDeserializer<Context
 
         // Deserialize the two fields, if available
         final ObjectIdentifier identifier =
-                JsonSerdeUtil.deserializeOptionalField(
+                JsonSmileSerdeUtil.deserializeOptionalField(
                                 objectNode,
                                 FIELD_NAME_IDENTIFIER,
                                 ObjectIdentifier.class,
@@ -81,7 +81,7 @@ final class ContextResolvedTableJsonDeserializer extends StdDeserializer<Context
                                 ctx)
                         .orElse(null);
         final ResolvedCatalogTable resolvedCatalogTable =
-                JsonSerdeUtil.deserializeOptionalField(
+                JsonSmileSerdeUtil.deserializeOptionalField(
                                 objectNode,
                                 FIELD_NAME_CATALOG_TABLE,
                                 ResolvedCatalogTable.class,

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DataTypeJsonDeserializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DataTypeJsonDeserializer.java
@@ -51,7 +51,7 @@ import static org.apache.flink.table.planner.plan.nodes.exec.serde.DataTypeJsonS
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.DataTypeJsonSerializer.FIELD_NAME_KEY_CLASS;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.DataTypeJsonSerializer.FIELD_NAME_TYPE;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.DataTypeJsonSerializer.FIELD_NAME_VALUE_CLASS;
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeUtil.loadClass;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil.loadClass;
 
 /**
  * JSON deserializer for {@link DataType}.

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DataTypeJsonDeserializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DataTypeJsonDeserializer.java
@@ -44,6 +44,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.CompiledPlanSerdeUtil.loadClass;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.DataTypeJsonSerializer.FIELD_NAME_CONVERSION_CLASS;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.DataTypeJsonSerializer.FIELD_NAME_ELEMENT_CLASS;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.DataTypeJsonSerializer.FIELD_NAME_FIELDS;
@@ -51,7 +52,6 @@ import static org.apache.flink.table.planner.plan.nodes.exec.serde.DataTypeJsonS
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.DataTypeJsonSerializer.FIELD_NAME_KEY_CLASS;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.DataTypeJsonSerializer.FIELD_NAME_TYPE;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.DataTypeJsonSerializer.FIELD_NAME_VALUE_CLASS;
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil.loadClass;
 
 /**
  * JSON deserializer for {@link DataType}.

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/JsonSmileSerdeUtil.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/JsonSmileSerdeUtil.java
@@ -61,6 +61,8 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.deser.std
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.jsontype.NamedType;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.module.SimpleModule;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.dataformat.smile.SmileFactory;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.dataformat.smile.SmileGenerator;
 
 import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.type.RelDataType;
@@ -71,51 +73,71 @@ import org.apache.calcite.rex.RexWindowBound;
 import java.io.IOException;
 import java.util.Optional;
 
-/** A utility class that provide abilities for JSON serialization and deserialization. */
+/** A utility class that provide abilities for JSON and Smile serialization and deserialization. */
 @Internal
-public class JsonSerdeUtil {
+public class JsonSmileSerdeUtil {
 
     /**
      * Object mapper shared instance to serialize and deserialize the plan. Note that creating and
      * copying of object mappers is expensive and should be avoided.
      *
      * <p>This is not exposed to avoid bad usages, like adding new modules. If you need to read and
-     * write json persisted plans, use {@link #createObjectWriter(SerdeContext)} and {@link
-     * #createObjectReader(SerdeContext)}.
+     * write json or smile persisted plans, use {@link #createJsonObjectWriter(SerdeContext)} and
+     * {@link #createJsonObjectReader(SerdeContext)}.
      */
-    private static final ObjectMapper OBJECT_MAPPER_INSTANCE;
+    private static final ObjectMapper JSON_OBJECT_MAPPER_INSTANCE;
+
+    private static final ObjectMapper SMILE_OBJECT_MAPPER_INSTANCE =
+            JacksonMapperFactory.createObjectMapper(new SmileFactory())
+                    .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+                    .registerModule(createFlinkTableJacksonModule());
 
     static {
-        OBJECT_MAPPER_INSTANCE = JacksonMapperFactory.createObjectMapper();
+        JSON_OBJECT_MAPPER_INSTANCE = JacksonMapperFactory.createObjectMapper();
 
-        OBJECT_MAPPER_INSTANCE.setTypeFactory(
+        JSON_OBJECT_MAPPER_INSTANCE.setTypeFactory(
                 // Make sure to register the classloader of the planner
-                OBJECT_MAPPER_INSTANCE
+                JSON_OBJECT_MAPPER_INSTANCE
                         .getTypeFactory()
-                        .withClassLoader(JsonSerdeUtil.class.getClassLoader()));
-        OBJECT_MAPPER_INSTANCE.configure(MapperFeature.USE_GETTERS_AS_SETTERS, false);
-        OBJECT_MAPPER_INSTANCE.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
-        OBJECT_MAPPER_INSTANCE.registerModule(createFlinkTableJacksonModule());
+                        .withClassLoader(JsonSmileSerdeUtil.class.getClassLoader()));
+        JSON_OBJECT_MAPPER_INSTANCE.configure(MapperFeature.USE_GETTERS_AS_SETTERS, false);
+        JSON_OBJECT_MAPPER_INSTANCE.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
+        JSON_OBJECT_MAPPER_INSTANCE.registerModule(createFlinkTableJacksonModule());
     }
 
-    public static ObjectReader createObjectReader(SerdeContext serdeContext) {
-        return OBJECT_MAPPER_INSTANCE
+    public static ObjectReader createJsonObjectReader(SerdeContext serdeContext) {
+        return JSON_OBJECT_MAPPER_INSTANCE
                 .reader()
                 .withAttribute(SerdeContext.SERDE_CONTEXT_KEY, serdeContext)
                 .with(defaultInjectedValues());
     }
 
-    public static ObjectWriter createObjectWriter(SerdeContext serdeContext) {
-        return OBJECT_MAPPER_INSTANCE
+    public static ObjectWriter createJsonObjectWriter(SerdeContext serdeContext) {
+        return JSON_OBJECT_MAPPER_INSTANCE
                 .writer()
                 .withAttribute(SerdeContext.SERDE_CONTEXT_KEY, serdeContext);
+    }
+
+    public static ObjectWriter createSmileObjectWriter(SerdeContext serdeContext) {
+        return SMILE_OBJECT_MAPPER_INSTANCE
+                .writer()
+                .withAttribute(SerdeContext.SERDE_CONTEXT_KEY, serdeContext)
+                .with(SmileGenerator.Feature.CHECK_SHARED_STRING_VALUES);
+    }
+
+    public static ObjectReader createSmileObjectReader(SerdeContext serdeContext) {
+        return SMILE_OBJECT_MAPPER_INSTANCE
+                .reader()
+                .withAttribute(SerdeContext.SERDE_CONTEXT_KEY, serdeContext)
+                .with(SmileGenerator.Feature.CHECK_SHARED_STRING_VALUES)
+                .with(defaultInjectedValues());
     }
 
     private static InjectableValues defaultInjectedValues() {
         return new InjectableValues.Std().addValue("isDeserialize", true);
     }
 
-    private static Module createFlinkTableJacksonModule() {
+    static Module createFlinkTableJacksonModule() {
         final SimpleModule module = new SimpleModule("Flink table module");
         ExecNodeMetadataUtil.execNodes()
                 .forEach(c -> module.registerSubtypes(new NamedType(c, c.getName())));
@@ -244,5 +266,5 @@ public class JsonSerdeUtil {
         }
     }
 
-    private JsonSerdeUtil() {}
+    private JsonSmileSerdeUtil() {}
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalTypeJsonDeserializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalTypeJsonDeserializer.java
@@ -61,7 +61,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeUtil.loadClass;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil.loadClass;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_ATTRIBUTES;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_ATTRIBUTE_DESCRIPTION;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_ATTRIBUTE_NAME;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalTypeJsonDeserializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalTypeJsonDeserializer.java
@@ -61,7 +61,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil.loadClass;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.CompiledPlanSerdeUtil.loadClass;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_ATTRIBUTES;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_ATTRIBUTE_DESCRIPTION;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_ATTRIBUTE_NAME;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalWindowJsonDeserializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalWindowJsonDeserializer.java
@@ -38,7 +38,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.deser.std
 import java.io.IOException;
 import java.time.Duration;
 
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeUtil.traverse;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil.traverse;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalWindowJsonSerializer.FIELD_NAME_ALIAS;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalWindowJsonSerializer.FIELD_NAME_FIELD_INDEX;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalWindowJsonSerializer.FIELD_NAME_FIELD_NAME;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalWindowJsonDeserializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalWindowJsonDeserializer.java
@@ -38,7 +38,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.deser.std
 import java.io.IOException;
 import java.time.Duration;
 
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil.traverse;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.CompiledPlanSerdeUtil.traverse;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalWindowJsonSerializer.FIELD_NAME_ALIAS;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalWindowJsonSerializer.FIELD_NAME_FIELD_INDEX;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalWindowJsonSerializer.FIELD_NAME_FIELD_NAME;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ResolvedCatalogTableJsonDeserializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ResolvedCatalogTableJsonDeserializer.java
@@ -36,8 +36,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeUtil.deserializeOptionalField;
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeUtil.traverse;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil.deserializeOptionalField;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil.traverse;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.ResolvedCatalogTableJsonSerializer.COMMENT;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.ResolvedCatalogTableJsonSerializer.DISTRIBUTION;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.ResolvedCatalogTableJsonSerializer.OPTIONS;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ResolvedCatalogTableJsonDeserializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ResolvedCatalogTableJsonDeserializer.java
@@ -36,8 +36,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil.deserializeOptionalField;
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil.traverse;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.CompiledPlanSerdeUtil.deserializeOptionalField;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.CompiledPlanSerdeUtil.traverse;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.ResolvedCatalogTableJsonSerializer.COMMENT;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.ResolvedCatalogTableJsonSerializer.DISTRIBUTION;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.ResolvedCatalogTableJsonSerializer.OPTIONS;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ResolvedSchemaJsonDeserializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ResolvedSchemaJsonDeserializer.java
@@ -32,8 +32,8 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.Obje
 import java.io.IOException;
 import java.util.List;
 
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil.deserializeOptionalField;
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil.traverse;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.CompiledPlanSerdeUtil.deserializeOptionalField;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.CompiledPlanSerdeUtil.traverse;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.ResolvedSchemaJsonSerializer.COLUMNS;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.ResolvedSchemaJsonSerializer.PRIMARY_KEY;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.ResolvedSchemaJsonSerializer.WATERMARK_SPECS;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ResolvedSchemaJsonDeserializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ResolvedSchemaJsonDeserializer.java
@@ -32,8 +32,8 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.Obje
 import java.io.IOException;
 import java.util.List;
 
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeUtil.deserializeOptionalField;
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeUtil.traverse;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil.deserializeOptionalField;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil.traverse;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.ResolvedSchemaJsonSerializer.COLUMNS;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.ResolvedSchemaJsonSerializer.PRIMARY_KEY;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.ResolvedSchemaJsonSerializer.WATERMARK_SPECS;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ResolvedSchemaJsonSerializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ResolvedSchemaJsonSerializer.java
@@ -27,7 +27,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ser.std.S
 
 import java.io.IOException;
 
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil.serializeOptionalField;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.CompiledPlanSerdeUtil.serializeOptionalField;
 
 /**
  * JSON serializer for {@link ResolvedSchema}.

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ResolvedSchemaJsonSerializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ResolvedSchemaJsonSerializer.java
@@ -27,7 +27,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ser.std.S
 
 import java.io.IOException;
 
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeUtil.serializeOptionalField;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil.serializeOptionalField;
 
 /**
  * JSON serializer for {@link ResolvedSchema}.

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonDeserializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonDeserializer.java
@@ -78,7 +78,7 @@ import static com.google.common.collect.Range.lessThan;
 import static org.apache.flink.table.api.config.TableConfigOptions.CatalogPlanRestore.IDENTIFIER;
 import static org.apache.flink.table.api.config.TableConfigOptions.PLAN_COMPILE_CATALOG_OBJECTS;
 import static org.apache.flink.table.api.config.TableConfigOptions.PLAN_RESTORE_CATALOG_OBJECTS;
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeUtil.loadClass;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil.loadClass;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.FIELD_NAME_ALPHA;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.FIELD_NAME_BOUND_LOWER;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.FIELD_NAME_BOUND_TYPE;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonDeserializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonDeserializer.java
@@ -78,7 +78,7 @@ import static com.google.common.collect.Range.lessThan;
 import static org.apache.flink.table.api.config.TableConfigOptions.CatalogPlanRestore.IDENTIFIER;
 import static org.apache.flink.table.api.config.TableConfigOptions.PLAN_COMPILE_CATALOG_OBJECTS;
 import static org.apache.flink.table.api.config.TableConfigOptions.PLAN_RESTORE_CATALOG_OBJECTS;
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil.loadClass;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.CompiledPlanSerdeUtil.loadClass;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.FIELD_NAME_ALPHA;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.FIELD_NAME_BOUND_LOWER;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.FIELD_NAME_BOUND_TYPE;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/TableDistributionJsonDeserializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/TableDistributionJsonDeserializer.java
@@ -31,8 +31,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeUtil.deserializeOptionalField;
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeUtil.traverse;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil.deserializeOptionalField;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil.traverse;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.TableDistributionJsonSerializer.BUCKET_COUNT;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.TableDistributionJsonSerializer.BUCKET_KEYS;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.TableDistributionJsonSerializer.KIND;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/TableDistributionJsonDeserializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/TableDistributionJsonDeserializer.java
@@ -31,8 +31,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil.deserializeOptionalField;
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil.traverse;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.CompiledPlanSerdeUtil.deserializeOptionalField;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.CompiledPlanSerdeUtil.traverse;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.TableDistributionJsonSerializer.BUCKET_COUNT;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.TableDistributionJsonSerializer.BUCKET_KEYS;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.TableDistributionJsonSerializer.KIND;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/TableDistributionJsonSerializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/TableDistributionJsonSerializer.java
@@ -27,7 +27,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ser.std.S
 
 import java.io.IOException;
 
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil.serializeOptionalField;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.CompiledPlanSerdeUtil.serializeOptionalField;
 
 /**
  * JSON serializer for {@link TableDistribution}.

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/TableDistributionJsonSerializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/TableDistributionJsonSerializer.java
@@ -27,7 +27,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ser.std.S
 
 import java.io.IOException;
 
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeUtil.serializeOptionalField;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil.serializeOptionalField;
 
 /**
  * JSON serializer for {@link TableDistribution}.

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/StreamPlanner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/StreamPlanner.scala
@@ -23,7 +23,7 @@ import org.apache.flink.configuration.ExecutionOptions
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectReader
 import org.apache.flink.streaming.api.graph.StreamGraph
 import org.apache.flink.table.api._
-import org.apache.flink.table.api.PlanReference.{ContentPlanReference, FilePlanReference, ResourcePlanReference}
+import org.apache.flink.table.api.PlanReference.{FilePlanReference, JsonContentPlanReference, ResourcePlanReference}
 import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog}
 import org.apache.flink.table.delegation.{Executor, InternalPlan}
 import org.apache.flink.table.module.ModuleManager
@@ -32,7 +32,7 @@ import org.apache.flink.table.planner.plan.`trait`._
 import org.apache.flink.table.planner.plan.ExecNodeGraphInternalPlan
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeGraph
 import org.apache.flink.table.planner.plan.nodes.exec.processor.ExecNodeGraphProcessor
-import org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil
+import org.apache.flink.table.planner.plan.nodes.exec.serde.CompiledPlanSerdeUtil
 import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecNode
 import org.apache.flink.table.planner.plan.nodes.exec.utils.ExecNodePlanDumper
 import org.apache.flink.table.planner.plan.optimize.{Optimizer, StreamCommonSubGraphBasedOptimizer}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/StreamPlanner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/StreamPlanner.scala
@@ -32,7 +32,7 @@ import org.apache.flink.table.planner.plan.`trait`._
 import org.apache.flink.table.planner.plan.ExecNodeGraphInternalPlan
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeGraph
 import org.apache.flink.table.planner.plan.nodes.exec.processor.ExecNodeGraphProcessor
-import org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeUtil
+import org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil
 import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecNode
 import org.apache.flink.table.planner.plan.nodes.exec.utils.ExecNodePlanDumper
 import org.apache.flink.table.planner.plan.optimize.{Optimizer, StreamCommonSubGraphBasedOptimizer}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ContextResolvedTableSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ContextResolvedTableSerdeTest.java
@@ -55,8 +55,8 @@ import static org.apache.flink.table.planner.plan.nodes.exec.serde.ContextResolv
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.ContextResolvedTableJsonSerializer.FIELD_NAME_IDENTIFIER;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeTestUtil.assertThatJsonContains;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeTestUtil.assertThatJsonDoesNotContain;
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeUtil.createObjectReader;
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeUtil.createObjectWriter;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil.createJsonObjectReader;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil.createJsonObjectWriter;
 import static org.apache.flink.table.utils.CatalogManagerMocks.DEFAULT_CATALOG;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -226,11 +226,11 @@ public class ContextResolvedTableSerdeTest {
                                         .options(PLAN_OPTIONS)
                                         .build(),
                                 CATALOG_TABLE_RESOLVED_SCHEMA));
-        final byte[] actualSerialized = createObjectWriter(ctx).writeValueAsBytes(spec);
+        final byte[] actualSerialized = createJsonObjectWriter(ctx).writeValueAsBytes(spec);
 
         assertThatThrownBy(
                         () ->
-                                createObjectReader(ctx)
+                                createJsonObjectReader(ctx)
                                         .readValue(actualSerialized, ContextResolvedTable.class))
                 .satisfies(
                         anyCauseMatches(
@@ -302,11 +302,11 @@ public class ContextResolvedTableSerdeTest {
                                         CATALOG_TABLE_RESOLVED_SCHEMA));
 
                 final byte[] actualSerialized =
-                        createObjectWriter(serdeCtx).writeValueAsBytes(spec);
+                        createJsonObjectWriter(serdeCtx).writeValueAsBytes(spec);
 
                 assertThatThrownBy(
                                 () ->
-                                        createObjectReader(serdeCtx)
+                                        createJsonObjectReader(serdeCtx)
                                                 .readValue(
                                                         actualSerialized,
                                                         ContextResolvedTable.class))
@@ -331,12 +331,12 @@ public class ContextResolvedTableSerdeTest {
             @Test
             void deserializationFail() throws Exception {
                 final byte[] actualSerialized =
-                        createObjectWriter(ctx)
+                        createJsonObjectWriter(ctx)
                                 .writeValueAsBytes(PERMANENT_PLAN_CONTEXT_RESOLVED_TABLE);
 
                 assertThatThrownBy(
                                 () ->
-                                        createObjectReader(ctx)
+                                        createJsonObjectReader(ctx)
                                                 .readValue(
                                                         actualSerialized,
                                                         ContextResolvedTable.class))
@@ -427,11 +427,11 @@ public class ContextResolvedTableSerdeTest {
                                                 .build(),
                                         resolvedSchema));
 
-                final byte[] actualSerialized = createObjectWriter(ctx).writeValueAsBytes(spec);
+                final byte[] actualSerialized = createJsonObjectWriter(ctx).writeValueAsBytes(spec);
 
                 assertThatThrownBy(
                                 () ->
-                                        createObjectReader(ctx)
+                                        createJsonObjectReader(ctx)
                                                 .readValue(
                                                         actualSerialized,
                                                         ContextResolvedTable.class))
@@ -498,12 +498,12 @@ public class ContextResolvedTableSerdeTest {
             @Test
             void withPermanentTable() throws Exception {
                 final byte[] actualSerialized =
-                        createObjectWriter(ctx)
+                        createJsonObjectWriter(ctx)
                                 .writeValueAsBytes(PERMANENT_PLAN_CONTEXT_RESOLVED_TABLE);
 
                 assertThatThrownBy(
                                 () ->
-                                        createObjectReader(ctx)
+                                        createJsonObjectReader(ctx)
                                                 .readValue(
                                                         actualSerialized,
                                                         ContextResolvedTable.class))
@@ -657,9 +657,9 @@ public class ContextResolvedTableSerdeTest {
     private Tuple2<JsonNode, ContextResolvedTable> serDe(
             SerdeContext serdeCtx, ContextResolvedTable contextResolvedTable) throws Exception {
         final byte[] actualSerialized =
-                createObjectWriter(serdeCtx).writeValueAsBytes(contextResolvedTable);
+                createJsonObjectWriter(serdeCtx).writeValueAsBytes(contextResolvedTable);
 
-        final ObjectReader objectReader = createObjectReader(serdeCtx);
+        final ObjectReader objectReader = createJsonObjectReader(serdeCtx);
         final JsonNode middleDeserialized = objectReader.readTree(actualSerialized);
         final ContextResolvedTable actualDeserialized =
                 objectReader.readValue(actualSerialized, ContextResolvedTable.class);

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ContextResolvedTableSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ContextResolvedTableSerdeTest.java
@@ -51,12 +51,12 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.flink.core.testutils.FlinkAssertions.anyCauseMatches;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.CompiledPlanSerdeUtil.createJsonObjectReader;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.CompiledPlanSerdeUtil.createJsonObjectWriter;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.ContextResolvedTableJsonSerializer.FIELD_NAME_CATALOG_TABLE;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.ContextResolvedTableJsonSerializer.FIELD_NAME_IDENTIFIER;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeTestUtil.assertThatJsonContains;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeTestUtil.assertThatJsonDoesNotContain;
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil.createJsonObjectReader;
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil.createJsonObjectWriter;
 import static org.apache.flink.table.utils.CatalogManagerMocks.DEFAULT_CATALOG;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ExecNodeGraphJsonSerializerTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ExecNodeGraphJsonSerializerTest.java
@@ -43,7 +43,8 @@ class ExecNodeGraphJsonSerializerTest {
     @Test
     void testSerializingUnsupportedNode() {
         final ObjectWriter objectWriter =
-                JsonSerdeUtil.createObjectWriter(JsonSerdeTestUtil.configuredSerdeContext());
+                JsonSmileSerdeUtil.createJsonObjectWriter(
+                        JsonSerdeTestUtil.configuredSerdeContext());
         assertThatThrownBy(
                         () ->
                                 objectWriter.writeValueAsString(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ExecNodeGraphJsonSerializerTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ExecNodeGraphJsonSerializerTest.java
@@ -43,7 +43,7 @@ class ExecNodeGraphJsonSerializerTest {
     @Test
     void testSerializingUnsupportedNode() {
         final ObjectWriter objectWriter =
-                JsonSmileSerdeUtil.createJsonObjectWriter(
+                CompiledPlanSerdeUtil.createJsonObjectWriter(
                         JsonSerdeTestUtil.configuredSerdeContext());
         assertThatThrownBy(
                         () ->

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/FlinkVersionJsonSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/FlinkVersionJsonSerdeTest.java
@@ -51,7 +51,7 @@ final class FlinkVersionJsonSerdeTest {
 
         assertThat(toJson(ctx, FlinkVersion.v1_15))
                 .isEqualTo(
-                        JsonSmileSerdeUtil.createJsonObjectWriter(ctx)
+                        CompiledPlanSerdeUtil.createJsonObjectWriter(ctx)
                                 .writeValueAsString(flinkVersion));
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/FlinkVersionJsonSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/FlinkVersionJsonSerdeTest.java
@@ -50,6 +50,8 @@ final class FlinkVersionJsonSerdeTest {
         final String flinkVersion = "1.15";
 
         assertThat(toJson(ctx, FlinkVersion.v1_15))
-                .isEqualTo(JsonSerdeUtil.createObjectWriter(ctx).writeValueAsString(flinkVersion));
+                .isEqualTo(
+                        JsonSmileSerdeUtil.createJsonObjectWriter(ctx)
+                                .writeValueAsString(flinkVersion));
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/JsonSerdeTestUtil.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/JsonSerdeTestUtil.java
@@ -82,13 +82,13 @@ class JsonSerdeTestUtil {
     }
 
     static String toJson(SerdeContext serdeContext, Object object) throws IOException {
-        final ObjectWriter objectWriter = JsonSerdeUtil.createObjectWriter(serdeContext);
+        final ObjectWriter objectWriter = JsonSmileSerdeUtil.createJsonObjectWriter(serdeContext);
         return objectWriter.writeValueAsString(object);
     }
 
     static <T> T toObject(SerdeContext serdeContext, String json, Class<T> clazz)
             throws IOException {
-        final ObjectReader objectReader = JsonSerdeUtil.createObjectReader(serdeContext);
+        final ObjectReader objectReader = JsonSmileSerdeUtil.createJsonObjectReader(serdeContext);
         return objectReader.readValue(json, clazz);
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/JsonSerdeTestUtil.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/JsonSerdeTestUtil.java
@@ -82,13 +82,15 @@ class JsonSerdeTestUtil {
     }
 
     static String toJson(SerdeContext serdeContext, Object object) throws IOException {
-        final ObjectWriter objectWriter = JsonSmileSerdeUtil.createJsonObjectWriter(serdeContext);
+        final ObjectWriter objectWriter =
+                CompiledPlanSerdeUtil.createJsonObjectWriter(serdeContext);
         return objectWriter.writeValueAsString(object);
     }
 
     static <T> T toObject(SerdeContext serdeContext, String json, Class<T> clazz)
             throws IOException {
-        final ObjectReader objectReader = JsonSmileSerdeUtil.createJsonObjectReader(serdeContext);
+        final ObjectReader objectReader =
+                CompiledPlanSerdeUtil.createJsonObjectReader(serdeContext);
         return objectReader.readValue(json, clazz);
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LookupKeySerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LookupKeySerdeTest.java
@@ -37,8 +37,8 @@ class LookupKeySerdeTest {
     @Test
     void testLookupKey() throws IOException {
         SerdeContext serdeCtx = JsonSerdeTestUtil.configuredSerdeContext();
-        ObjectReader objectReader = JsonSerdeUtil.createObjectReader(serdeCtx);
-        ObjectWriter objectWriter = JsonSerdeUtil.createObjectWriter(serdeCtx);
+        ObjectReader objectReader = JsonSmileSerdeUtil.createJsonObjectReader(serdeCtx);
+        ObjectWriter objectWriter = JsonSmileSerdeUtil.createJsonObjectWriter(serdeCtx);
 
         LookupJoinUtil.LookupKey[] lookupKeys =
                 new LookupJoinUtil.LookupKey[] {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LookupKeySerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LookupKeySerdeTest.java
@@ -37,8 +37,8 @@ class LookupKeySerdeTest {
     @Test
     void testLookupKey() throws IOException {
         SerdeContext serdeCtx = JsonSerdeTestUtil.configuredSerdeContext();
-        ObjectReader objectReader = JsonSmileSerdeUtil.createJsonObjectReader(serdeCtx);
-        ObjectWriter objectWriter = JsonSmileSerdeUtil.createJsonObjectWriter(serdeCtx);
+        ObjectReader objectReader = CompiledPlanSerdeUtil.createJsonObjectReader(serdeCtx);
+        ObjectWriter objectWriter = CompiledPlanSerdeUtil.createJsonObjectWriter(serdeCtx);
 
         LookupJoinUtil.LookupKey[] lookupKeys =
                 new LookupJoinUtil.LookupKey[] {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ResolvedCatalogTableSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ResolvedCatalogTableSerdeTest.java
@@ -57,7 +57,7 @@ import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeTest
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeTestUtil.assertThatJsonDoesNotContain;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeTestUtil.configuredSerdeContext;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeTestUtil.testJsonRoundTrip;
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeUtil.createObjectReader;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil.createJsonObjectReader;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
@@ -151,11 +151,11 @@ class ResolvedCatalogTableSerdeTest {
         SerdeContext serdeCtx = configuredSerdeContext();
 
         byte[] actualSerialized =
-                JsonSerdeUtil.createObjectWriter(serdeCtx)
+                JsonSmileSerdeUtil.createJsonObjectWriter(serdeCtx)
                         .withAttribute(ResolvedCatalogTableJsonSerializer.SERIALIZE_OPTIONS, false)
                         .writeValueAsBytes(FULL_RESOLVED_CATALOG_TABLE);
 
-        final ObjectReader objectReader = createObjectReader(serdeCtx);
+        final ObjectReader objectReader = createJsonObjectReader(serdeCtx);
         JsonNode actualJson = objectReader.readTree(actualSerialized);
         assertThatJsonContains(actualJson, ResolvedCatalogTableJsonSerializer.RESOLVED_SCHEMA);
         assertThatJsonContains(actualJson, ResolvedCatalogTableJsonSerializer.PARTITION_KEYS);
@@ -187,7 +187,7 @@ class ResolvedCatalogTableSerdeTest {
     @Test
     void testDontSerializeExternalInlineTable() {
         SerdeContext serdeCtx = configuredSerdeContext();
-        ObjectWriter objectWriter = JsonSerdeUtil.createObjectWriter(serdeCtx);
+        ObjectWriter objectWriter = JsonSmileSerdeUtil.createJsonObjectWriter(serdeCtx);
 
         assertThatThrownBy(
                         () ->

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ResolvedCatalogTableSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ResolvedCatalogTableSerdeTest.java
@@ -53,11 +53,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.CompiledPlanSerdeUtil.createJsonObjectReader;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeTestUtil.assertThatJsonContains;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeTestUtil.assertThatJsonDoesNotContain;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeTestUtil.configuredSerdeContext;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeTestUtil.testJsonRoundTrip;
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil.createJsonObjectReader;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
@@ -151,7 +151,7 @@ class ResolvedCatalogTableSerdeTest {
         SerdeContext serdeCtx = configuredSerdeContext();
 
         byte[] actualSerialized =
-                JsonSmileSerdeUtil.createJsonObjectWriter(serdeCtx)
+                CompiledPlanSerdeUtil.createJsonObjectWriter(serdeCtx)
                         .withAttribute(ResolvedCatalogTableJsonSerializer.SERIALIZE_OPTIONS, false)
                         .writeValueAsBytes(FULL_RESOLVED_CATALOG_TABLE);
 
@@ -187,7 +187,7 @@ class ResolvedCatalogTableSerdeTest {
     @Test
     void testDontSerializeExternalInlineTable() {
         SerdeContext serdeCtx = configuredSerdeContext();
-        ObjectWriter objectWriter = JsonSmileSerdeUtil.createJsonObjectWriter(serdeCtx);
+        ObjectWriter objectWriter = CompiledPlanSerdeUtil.createJsonObjectWriter(serdeCtx);
 
         assertThatThrownBy(
                         () ->

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonSerdeTest.java
@@ -88,8 +88,8 @@ import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeTest
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeTestUtil.assertThatJsonDoesNotContain;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeTestUtil.testJsonRoundTrip;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeTestUtil.toJson;
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeUtil.createObjectReader;
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeUtil.createObjectWriter;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil.createJsonObjectReader;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil.createJsonObjectWriter;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.FIELD_NAME_CLASS;
 import static org.apache.flink.table.utils.CatalogManagerMocks.DEFAULT_CATALOG;
 import static org.apache.flink.table.utils.CatalogManagerMocks.DEFAULT_DATABASE;
@@ -778,15 +778,15 @@ public class RexNodeJsonSerdeTest {
 
     private JsonNode serializePermanentFunction(SerdeContext serdeContext) throws Exception {
         final byte[] actualSerialized =
-                createObjectWriter(serdeContext)
+                createJsonObjectWriter(serdeContext)
                         .writeValueAsBytes(createFunctionCall(serdeContext, PERMANENT_FUNCTION));
-        return createObjectReader(serdeContext).readTree(actualSerialized);
+        return createJsonObjectReader(serdeContext).readTree(actualSerialized);
     }
 
     private ContextResolvedFunction deserialize(SerdeContext serdeContext, JsonNode node)
             throws IOException {
         final RexNode actualDeserialized =
-                createObjectReader(serdeContext).readValue(node, RexNode.class);
+                createJsonObjectReader(serdeContext).readValue(node, RexNode.class);
         return ((BridgingSqlFunction) ((RexCall) actualDeserialized).getOperator())
                 .getResolvedFunction();
     }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonSerdeTest.java
@@ -84,12 +84,12 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.apache.flink.core.testutils.FlinkAssertions.anyCauseMatches;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.CompiledPlanSerdeUtil.createJsonObjectReader;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.CompiledPlanSerdeUtil.createJsonObjectWriter;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeTestUtil.assertThatJsonContains;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeTestUtil.assertThatJsonDoesNotContain;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeTestUtil.testJsonRoundTrip;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeTestUtil.toJson;
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil.createJsonObjectReader;
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSmileSerdeUtil.createJsonObjectWriter;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.FIELD_NAME_CLASS;
 import static org.apache.flink.table.utils.CatalogManagerMocks.DEFAULT_CATALOG;
 import static org.apache.flink.table.utils.CatalogManagerMocks.DEFAULT_DATABASE;

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexWindowBoundSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexWindowBoundSerdeTest.java
@@ -36,8 +36,8 @@ class RexWindowBoundSerdeTest {
     @Test
     void testSerde() throws IOException {
         SerdeContext serdeCtx = JsonSerdeTestUtil.configuredSerdeContext();
-        ObjectReader objectReader = JsonSerdeUtil.createObjectReader(serdeCtx);
-        ObjectWriter objectWriter = JsonSerdeUtil.createObjectWriter(serdeCtx);
+        ObjectReader objectReader = JsonSmileSerdeUtil.createJsonObjectReader(serdeCtx);
+        ObjectWriter objectWriter = JsonSmileSerdeUtil.createJsonObjectWriter(serdeCtx);
 
         assertThat(
                         objectReader.readValue(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexWindowBoundSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexWindowBoundSerdeTest.java
@@ -36,8 +36,8 @@ class RexWindowBoundSerdeTest {
     @Test
     void testSerde() throws IOException {
         SerdeContext serdeCtx = JsonSerdeTestUtil.configuredSerdeContext();
-        ObjectReader objectReader = JsonSmileSerdeUtil.createJsonObjectReader(serdeCtx);
-        ObjectWriter objectWriter = JsonSmileSerdeUtil.createJsonObjectWriter(serdeCtx);
+        ObjectReader objectReader = CompiledPlanSerdeUtil.createJsonObjectReader(serdeCtx);
+        ObjectWriter objectWriter = CompiledPlanSerdeUtil.createJsonObjectWriter(serdeCtx);
 
         assertThat(
                         objectReader.readValue(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/testutils/RestoreTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/testutils/RestoreTestBase.java
@@ -363,7 +363,10 @@ public abstract class RestoreTestBase implements TableTestProgramRunner {
         program.getSetupFunctionTestSteps().forEach(s -> s.apply(tEnv));
         program.getSetupTemporalFunctionTestSteps().forEach(s -> s.apply(tEnv));
 
-        final CompiledPlan compiledPlan = tEnv.loadPlan(PlanReference.fromFile(planPath));
+        final byte[] compiledPlanAsSmileBytes =
+                tEnv.loadPlan(PlanReference.fromFile(planPath)).asSmileBytes();
+        final CompiledPlan compiledPlan =
+                tEnv.loadPlan(PlanReference.fromSmileBytes(compiledPlanAsSmileBytes));
 
         if (afterRestoreSource == AfterRestoreSource.INFINITE) {
             final TableResult tableResult = compiledPlan.execute();


### PR DESCRIPTION
## What is the purpose of the change

Implementation of FLIP-508: add support for Smile format

## Verifying this change

During restore tests we extract compiled plans as Smile, load from it again and continue

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( yes)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? (yes )
  - If yes, how is the feature documented? (JavaDocs )
