### PR TITLE
[hotfix] Rename SparkJoinReorderRule to FlinkJoinReorderRule

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkJoinReorderRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkJoinReorderRule.java
@@ -54,7 +54,7 @@ public class FlinkJoinReorderRule extends RelRule<FlinkJoinReorderRule.Config>
     private static final FlinkBushyJoinReorderRule BUSHY_JOIN_REORDER =
             FlinkBushyJoinReorderRule.Config.DEFAULT.toRule();
 
-    /** Creates an FlinkJoinReorderRule. */
+    /** Creates a FlinkJoinReorderRule. */
     protected FlinkJoinReorderRule(FlinkJoinReorderRule.Config config) {
         super(config);
     }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkJoinReorderRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkJoinReorderRule.java
@@ -54,7 +54,7 @@ public class FlinkJoinReorderRule extends RelRule<FlinkJoinReorderRule.Config>
     private static final FlinkBushyJoinReorderRule BUSHY_JOIN_REORDER =
             FlinkBushyJoinReorderRule.Config.DEFAULT.toRule();
 
-    /** Creates an SparkJoinReorderRule. */
+    /** Creates an FlinkJoinReorderRule. */
     protected FlinkJoinReorderRule(FlinkJoinReorderRule.Config config) {
         super(config);
     }


### PR DESCRIPTION
Creates a FlinkJoinReorderRule and not SparkJoinReorderRule