### PR TITLE
[hotfix] fix NOTICE file in order to fix java 11 license check

### DIFF
--- a/flink-filesystems/flink-oss-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-oss-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -7,9 +7,9 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.aliyun.oss:aliyun-sdk-oss:3.17.4
-- com.aliyun:aliyun-java-sdk-core:4.7.3
-- com.aliyun:aliyun-java-sdk-kms:2.16.6
-- com.aliyun:aliyun-java-sdk-ram:3.3.2
+- com.aliyun:aliyun-java-sdk-core:4.5.10
+- com.aliyun:aliyun-java-sdk-kms:2.11.0
+- com.aliyun:aliyun-java-sdk-ram:3.1.0
 - com.google.code.gson:gson:2.8.6
 - commons-codec:commons-codec:1.15
 - commons-logging:commons-logging:1.1.3
@@ -19,9 +19,8 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.hadoop:hadoop-aliyun:3.3.4
 - org.apache.httpcomponents:httpclient:4.5.13
 - org.apache.httpcomponents:httpcore:4.4.14
-- org.codehaus.jettison:jettison:1.1
+- org.codehaus.jettison:jettison:1.5.4
 - org.ini4j:ini4j:0.5.4
-- stax:stax-api:1.0.1
 
 The binary distribution of this product bundles these dependencies under the Eclipse Public License - v 2.0 (https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt)
 - org.jacoco:org.jacoco.agent:runtime:0.8.5
@@ -29,4 +28,4 @@ The binary distribution of this product bundles these dependencies under the Ecl
 This project bundles the following dependencies under the JDOM license.
 See bundled license files for details.
 
-- org.jdom:jdom2:2.0.6
+- org.jdom:jdom2:2.0.6.1


### PR DESCRIPTION
## What is the purpose of the change

The PR is to fix licensecheck in jdk11
I also created a follow up task to make the behavior across different jdk's same [FLINK-37387](https://issues.apache.org/jira/browse/FLINK-37387)

an example of a failed build https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=66304&view=logs&j=946871de-358d-5815-3994-8175615bc253&t=e0240c62-4570-5d1c-51af-dd63d2093da1&l=41059

## Brief change log

NOTICE

## Verifying this change


This change is already covered by existing tests, such as *(please describe tests)*.

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
