### PR TITLE
[FLINK-37400] Remove redundant serializer duplication during value serialization of ForSt states

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/AbstractKeyedState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/AbstractKeyedState.java
@@ -45,6 +45,8 @@ public abstract class AbstractKeyedState<K, N, V> implements InternalKeyedState<
 
     private final StateDescriptor<V> stateDescriptor;
 
+    private final ThreadLocal<TypeSerializer<V>> valueSerializer;
+
     /**
      * Creates a new AbstractKeyedState with the given asyncExecutionController and stateDescriptor.
      */
@@ -52,6 +54,7 @@ public abstract class AbstractKeyedState<K, N, V> implements InternalKeyedState<
             StateRequestHandler stateRequestHandler, StateDescriptor<V> stateDescriptor) {
         this.stateRequestHandler = stateRequestHandler;
         this.stateDescriptor = stateDescriptor;
+        this.valueSerializer = ThreadLocal.withInitial(stateDescriptor::getSerializer);
     }
 
     /**
@@ -91,7 +94,7 @@ public abstract class AbstractKeyedState<K, N, V> implements InternalKeyedState<
 
     /** Return related value serializer. */
     public TypeSerializer<V> getValueSerializer() {
-        return stateDescriptor.getSerializer();
+        return valueSerializer.get();
     }
 
     public StateRequestHandler getStateRequestHandler() {


### PR DESCRIPTION
## What is the purpose of the change

When serializing values in ForSt states, the serializer is duplicated every time, which introduces unnecessary overhead. This PR optimize it out.

## Brief change log

 - Introduce a threadlocal in `AbstractKeyedState` to store value serializer and reuse within one thread.


## Verifying this change


This change is a trivial rework that is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): **yes**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
