### PR TITLE
[FLINK-37148][docs] Update DataStream V2 documents for StateManager#getState and StateManager#getStateOptional methods

### DIFF
--- a/docs/content.zh/docs/dev/datastream-v2/context_and_state_processing.md
+++ b/docs/content.zh/docs/dev/datastream-v2/context_and_state_processing.md
@@ -102,9 +102,8 @@ private static class StatefulFunction implements OneInputStreamProcessFunction<L
     public void processRecord(Long record, Collector<Long> output, RuntimeContext ctx)
             throws Exception {
         // Step3: Getting and updating state via `StateManager`.
-        Optional<ListState<Long>> stateOptional =
+        ListState<Long> state =
                 ctx.getStateManager().getState(LIST_STATE_DECLARATION);
-        ListState<Long> state = stateOptional.get();
         // do something with this state. For example, update the state by this record.
         state.update(Collections.singletonList(record));
     }
@@ -207,20 +206,48 @@ public interface StateManager {
     <K> K getCurrentKey() throws UnsupportedOperationException;
 
     /**
+     * Get the optional of the specific list state.
+     *
+     * @param stateDeclaration of this state.
+     * @return the list state corresponds to the state declaration, this may be empty.
+     */
+    <T> Optional<ListState<T>> getStateOptional(ListStateDeclaration<T> stateDeclaration)
+            throws Exception;
+
+    /**
      * Get the specific list state.
      *
      * @param stateDeclaration of this state.
-     * @return the list state corresponds to the state declaration.
+     * @return the list state corresponds to the state declaration
+     * @throws RuntimeException if the state is not available.
      */
-    <T> Optional<ListState<T>> getState(ListStateDeclaration<T> stateDeclaration) throws Exception;
+    <T> ListState<T> getState(ListStateDeclaration<T> stateDeclaration) throws Exception;
+
+    /**
+     * Get the optional of the specific value state.
+     *
+     * @param stateDeclaration of this state.
+     * @return the value state corresponds to the state declaration, this may be empty.
+     */
+    <T> Optional<ValueState<T>> getStateOptional(ValueStateDeclaration<T> stateDeclaration)
+            throws Exception;
 
     /**
      * Get the specific value state.
      *
      * @param stateDeclaration of this state.
      * @return the value state corresponds to the state declaration.
+     * @throws RuntimeException if the state is not available.
      */
-    <T> Optional<ValueState<T>> getState(ValueStateDeclaration<T> stateDeclaration)
+    <T> ValueState<T> getState(ValueStateDeclaration<T> stateDeclaration) throws Exception;
+
+    /**
+     * Get the optional of the specific map state.
+     *
+     * @param stateDeclaration of this state.
+     * @return the map state corresponds to the state declaration, this may be empty.
+     */
+    <K, V> Optional<MapState<K, V>> getStateOptional(MapStateDeclaration<K, V> stateDeclaration)
             throws Exception;
 
     /**
@@ -228,8 +255,17 @@ public interface StateManager {
      *
      * @param stateDeclaration of this state.
      * @return the map state corresponds to the state declaration.
+     * @throws RuntimeException if the state is not available.
      */
-    <K, V> Optional<MapState<K, V>> getState(MapStateDeclaration<K, V> stateDeclaration)
+    <K, V> MapState<K, V> getState(MapStateDeclaration<K, V> stateDeclaration) throws Exception;
+
+    /**
+     * Get the optional of the specific reducing state.
+     *
+     * @param stateDeclaration of this state.
+     * @return the reducing state corresponds to the state declaration, this may be empty.
+     */
+    <T> Optional<ReducingState<T>> getStateOptional(ReducingStateDeclaration<T> stateDeclaration)
             throws Exception;
 
     /**
@@ -237,32 +273,52 @@ public interface StateManager {
      *
      * @param stateDeclaration of this state.
      * @return the reducing state corresponds to the state declaration.
+     * @throws RuntimeException if the state is not available.
      */
-    <T> Optional<ReducingState<T>> getState(ReducingStateDeclaration<T> stateDeclaration)
-            throws Exception;
+    <T> ReducingState<T> getState(ReducingStateDeclaration<T> stateDeclaration) throws Exception;
+
+    /**
+     * Get the optional of the specific aggregating state.
+     *
+     * @param stateDeclaration of this state.
+     * @return the aggregating state corresponds to the state declaration, this may be empty.
+     */
+    <IN, ACC, OUT> Optional<AggregatingState<IN, OUT>> getStateOptional(
+            AggregatingStateDeclaration<IN, ACC, OUT> stateDeclaration) throws Exception;
 
     /**
      * Get the specific aggregating state.
      *
      * @param stateDeclaration of this state.
      * @return the aggregating state corresponds to the state declaration.
+     * @throws RuntimeException if the state is not available.
      */
-    <IN, ACC, OUT> Optional<AggregatingState<IN, OUT>> getState(
+    <IN, ACC, OUT> AggregatingState<IN, OUT> getState(
             AggregatingStateDeclaration<IN, ACC, OUT> stateDeclaration) throws Exception;
+
+    /**
+     * Get the optional of the specific broadcast state.
+     *
+     * @param stateDeclaration of this state.
+     * @return the broadcast state corresponds to the state declaration, this may be empty.
+     */
+    <K, V> Optional<BroadcastState<K, V>> getStateOptional(
+            BroadcastStateDeclaration<K, V> stateDeclaration) throws Exception;
 
     /**
      * Get the specific broadcast state.
      *
      * @param stateDeclaration of this state.
      * @return the broadcast state corresponds to the state declaration.
+     * @throws RuntimeException if the state is not available.
      */
-    <K, V> Optional<BroadcastState<K, V>> getState(BroadcastStateDeclaration<K, V> stateDeclaration)
+    <K, V> BroadcastState<K, V> getState(BroadcastStateDeclaration<K, V> stateDeclaration)
             throws Exception;
 }
 ```
 
 You can get the `StateManager` from anywhere you have access to the `PartitionedContext` using `context#getStateManager()`. 
-Next, using the `getState` method to obtain the state you declared, and then read and updated it.
+Next, using the `getState` or `getStateOptional` method to obtain the state you declared, and then read and updated it.
 
 
 ### The Legitimacy of State Declaration and Access

--- a/docs/content/docs/dev/datastream-v2/context_and_state_processing.md
+++ b/docs/content/docs/dev/datastream-v2/context_and_state_processing.md
@@ -102,9 +102,8 @@ private static class StatefulFunction implements OneInputStreamProcessFunction<L
     public void processRecord(Long record, Collector<Long> output, RuntimeContext ctx)
             throws Exception {
         // Step3: Getting and updating state via `StateManager`.
-        Optional<ListState<Long>> stateOptional =
+        ListState<Long> state =
                 ctx.getStateManager().getState(LIST_STATE_DECLARATION);
-        ListState<Long> state = stateOptional.get();
         // do something with this state. For example, update the state by this record.
         state.update(Collections.singletonList(record));
     }
@@ -207,20 +206,48 @@ public interface StateManager {
     <K> K getCurrentKey() throws UnsupportedOperationException;
 
     /**
+     * Get the optional of the specific list state.
+     *
+     * @param stateDeclaration of this state.
+     * @return the list state corresponds to the state declaration, this may be empty.
+     */
+    <T> Optional<ListState<T>> getStateOptional(ListStateDeclaration<T> stateDeclaration)
+            throws Exception;
+
+    /**
      * Get the specific list state.
      *
      * @param stateDeclaration of this state.
-     * @return the list state corresponds to the state declaration.
+     * @return the list state corresponds to the state declaration
+     * @throws RuntimeException if the state is not available.
      */
-    <T> Optional<ListState<T>> getState(ListStateDeclaration<T> stateDeclaration) throws Exception;
+    <T> ListState<T> getState(ListStateDeclaration<T> stateDeclaration) throws Exception;
+
+    /**
+     * Get the optional of the specific value state.
+     *
+     * @param stateDeclaration of this state.
+     * @return the value state corresponds to the state declaration, this may be empty.
+     */
+    <T> Optional<ValueState<T>> getStateOptional(ValueStateDeclaration<T> stateDeclaration)
+            throws Exception;
 
     /**
      * Get the specific value state.
      *
      * @param stateDeclaration of this state.
      * @return the value state corresponds to the state declaration.
+     * @throws RuntimeException if the state is not available.
      */
-    <T> Optional<ValueState<T>> getState(ValueStateDeclaration<T> stateDeclaration)
+    <T> ValueState<T> getState(ValueStateDeclaration<T> stateDeclaration) throws Exception;
+
+    /**
+     * Get the optional of the specific map state.
+     *
+     * @param stateDeclaration of this state.
+     * @return the map state corresponds to the state declaration, this may be empty.
+     */
+    <K, V> Optional<MapState<K, V>> getStateOptional(MapStateDeclaration<K, V> stateDeclaration)
             throws Exception;
 
     /**
@@ -228,8 +255,17 @@ public interface StateManager {
      *
      * @param stateDeclaration of this state.
      * @return the map state corresponds to the state declaration.
+     * @throws RuntimeException if the state is not available.
      */
-    <K, V> Optional<MapState<K, V>> getState(MapStateDeclaration<K, V> stateDeclaration)
+    <K, V> MapState<K, V> getState(MapStateDeclaration<K, V> stateDeclaration) throws Exception;
+
+    /**
+     * Get the optional of the specific reducing state.
+     *
+     * @param stateDeclaration of this state.
+     * @return the reducing state corresponds to the state declaration, this may be empty.
+     */
+    <T> Optional<ReducingState<T>> getStateOptional(ReducingStateDeclaration<T> stateDeclaration)
             throws Exception;
 
     /**
@@ -237,32 +273,52 @@ public interface StateManager {
      *
      * @param stateDeclaration of this state.
      * @return the reducing state corresponds to the state declaration.
+     * @throws RuntimeException if the state is not available.
      */
-    <T> Optional<ReducingState<T>> getState(ReducingStateDeclaration<T> stateDeclaration)
-            throws Exception;
+    <T> ReducingState<T> getState(ReducingStateDeclaration<T> stateDeclaration) throws Exception;
+
+    /**
+     * Get the optional of the specific aggregating state.
+     *
+     * @param stateDeclaration of this state.
+     * @return the aggregating state corresponds to the state declaration, this may be empty.
+     */
+    <IN, ACC, OUT> Optional<AggregatingState<IN, OUT>> getStateOptional(
+            AggregatingStateDeclaration<IN, ACC, OUT> stateDeclaration) throws Exception;
 
     /**
      * Get the specific aggregating state.
      *
      * @param stateDeclaration of this state.
      * @return the aggregating state corresponds to the state declaration.
+     * @throws RuntimeException if the state is not available.
      */
-    <IN, ACC, OUT> Optional<AggregatingState<IN, OUT>> getState(
+    <IN, ACC, OUT> AggregatingState<IN, OUT> getState(
             AggregatingStateDeclaration<IN, ACC, OUT> stateDeclaration) throws Exception;
+
+    /**
+     * Get the optional of the specific broadcast state.
+     *
+     * @param stateDeclaration of this state.
+     * @return the broadcast state corresponds to the state declaration, this may be empty.
+     */
+    <K, V> Optional<BroadcastState<K, V>> getStateOptional(
+            BroadcastStateDeclaration<K, V> stateDeclaration) throws Exception;
 
     /**
      * Get the specific broadcast state.
      *
      * @param stateDeclaration of this state.
      * @return the broadcast state corresponds to the state declaration.
+     * @throws RuntimeException if the state is not available.
      */
-    <K, V> Optional<BroadcastState<K, V>> getState(BroadcastStateDeclaration<K, V> stateDeclaration)
+    <K, V> BroadcastState<K, V> getState(BroadcastStateDeclaration<K, V> stateDeclaration)
             throws Exception;
 }
 ```
 
 You can get the `StateManager` from anywhere you have access to the `PartitionedContext` using `context#getStateManager()`. 
-Next, using the `getState` method to obtain the state you declared, and then read and updated it.
+Next, using the `getState` or `getStateOptional` method to obtain the state you declared, and then read and updated it.
 
 
 ### The Legitimacy of State Declaration and Access


### PR DESCRIPTION
## What is the purpose of the change

The PR [#26057](https://github.com/apache/flink/pull/26057) adds documentation for DataStream V2. 

While writing DataStream V2 examples, we found that the StateManager#getState method was inconvenient for users. To address this, we distinguished between the StateManager#getState and StateManager#getStateOptional methods in [#26118](https://github.com/apache/flink/pull/26118).

The documentation also needs to be updated to reflect these changes.

## Brief change log

- Update DataStream V2 documents for StateManager#getState and StateManager#getStateOptional methods

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
