### PR TITLE
[FLINK-37387][build] Enable license check for jdk17 and jdk21

### DIFF
--- a/tools/ci/compile.sh
+++ b/tools/ci/compile.sh
@@ -114,10 +114,7 @@ EXIT_CODE=$(($EXIT_CODE+$?))
 echo "============ Run license check ============"
 
 find $MVN_VALIDATION_DIR
-# We use a different Scala version with Java 17 and 21
-if [[ ${PROFILE} != *"jdk17"* ]] && [[ ${PROFILE} != *"jdk21"* ]]; then
-  MVN=$MVN ${CI_DIR}/license_check.sh $MVN_CLEAN_COMPILE_OUT $MVN_VALIDATION_DIR || exit $?
-fi
+MVN=$MVN ${CI_DIR}/license_check.sh $MVN_CLEAN_COMPILE_OUT $MVN_VALIDATION_DIR || exit $?
 
 exit $EXIT_CODE
 


### PR DESCRIPTION
## What is the purpose of the change

As it was highlighted at https://github.com/apache/flink/pull/26217 and https://github.com/apache/flink/pull/26214 the issue is present for jdk17 and jdk21

The PR enables back license check for jdk17 and jdk21 since now for all java versions (11, 17, 21) the same scala is used

this seems to be a missing step after bumping scala version

## Brief change log
license_check.sh


## Verifying this change


This change is already covered by existing tests, such as *(please describe tests)*.
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
