### PR TITLE
[FLINK-35810][BP-2.0] Fix AsyncWaitOperatorTest missing endInput bug

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
@@ -907,6 +907,7 @@ class AsyncWaitOperatorTest {
             harness.processAll();
             assertThat(harness.getOutput()).containsOnly(new StreamRecord<>(1));
             assertThat(TimeoutAfterCompletionTestFunction.TIMED_OUT).isFalse();
+            harness.waitForTaskCompletion();
         }
     }
 
@@ -1246,6 +1247,7 @@ class AsyncWaitOperatorTest {
                         testHarness.getOutput(),
                         new StreamRecordComparator());
             }
+            testHarness.waitForTaskCompletion();
         }
     }
 
@@ -1318,6 +1320,7 @@ class AsyncWaitOperatorTest {
             // case when test machine under high load)
             assertThat(asyncFunction.getTryCount(1)).isLessThanOrEqualTo(2);
             assertThat(asyncFunction.getTryCount(2)).isLessThanOrEqualTo(2);
+            testHarness.waitForTaskCompletion();
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the bug that AsyncWaitOperator might be triggering mailboxExecutor.execute() after the mailbox has been quiesced in AsyncWaitOperatorTest.testProcessingTimeRepeatedCompleteUnorderedWithRetry().

The cause of this bug is that AsyncWaitOperatorTest forgot to invoke AsyncWaitOperator#endInput before closing the wrapping testHarness, causing the scheduled processing time timers in AsyncWaitOperator not being cancelled.

FLINK-35810 mentioned that there is always an OOM before this test failure, but these two errors should be independent from each other. In the following CIs, OOM still exists while AsyncWaitOperatorTest has passed.

* https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=66387&view=logs&j=77a9d8e1-d610-59b3-fc2a-4766541e0e33&t=125e07e7-8de0-5c6c-a541-a567415af3ef
* https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=66389&view=logs&j=77a9d8e1-d610-59b3-fc2a-4766541e0e33&t=125e07e7-8de0-5c6c-a541-a567415af3ef

## Brief change log

  - Trigger AsyncWaitOperator#endInput by calling testHarness.waitForTaskCompletion() at the end of AsyncWaitOperatorTest.testProcessingTimeRepeatedCompleteUnorderedWithRetry() and other test cases with similar testHarness invoking patterns.

## Verifying this change

The bug can first be reproduced locally with the following steps:
1. In IllWrittenOddInputEmptyResultAsyncFunction, change sleep(3) into sleep(100L * input). This will increase the race condition and the unorderness between the async executions that triggers this bug.
2. In testProcessingTimeWithRetry, change `testHarness.getOutput().size() < expectedOutput.size()` into `testHarness.getOutput().size() < 2`, and remove the following TestHarnessUtil.assertOutputEqualsSorted() invocation. This helps the test case reaches the testHarness.close() earlier and increase the possibility of the bug.
3. Repeatedly run testProcessingTimeRepeatedCompleteUnorderedWithRetry(). Now there should be a 40% possibility to reproduce the failure described in FLINK-35810.

Now add back the bugfix codes in this PR, and the test failure won't be reproduced anymore.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
