### PR TITLE
[BP-2.0][FLINK-37387][build] Enable license check for jdk17 and jdk21

### DIFF
--- a/flink-filesystems/flink-oss-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-oss-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -7,9 +7,9 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.aliyun.oss:aliyun-sdk-oss:3.17.4
-- com.aliyun:aliyun-java-sdk-core:4.7.3
-- com.aliyun:aliyun-java-sdk-kms:2.16.6
-- com.aliyun:aliyun-java-sdk-ram:3.3.2
+- com.aliyun:aliyun-java-sdk-core:4.5.10
+- com.aliyun:aliyun-java-sdk-kms:2.11.0
+- com.aliyun:aliyun-java-sdk-ram:3.1.0
 - com.google.code.gson:gson:2.8.6
 - commons-codec:commons-codec:1.15
 - commons-logging:commons-logging:1.1.3
@@ -19,9 +19,8 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.hadoop:hadoop-aliyun:3.3.4
 - org.apache.httpcomponents:httpclient:4.5.13
 - org.apache.httpcomponents:httpcore:4.4.14
-- org.codehaus.jettison:jettison:1.1
+- org.codehaus.jettison:jettison:1.5.4
 - org.ini4j:ini4j:0.5.4
-- stax:stax-api:1.0.1
 
 The binary distribution of this product bundles these dependencies under the Eclipse Public License - v 2.0 (https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt)
 - org.jacoco:org.jacoco.agent:runtime:0.8.5
@@ -29,4 +28,4 @@ The binary distribution of this product bundles these dependencies under the Ecl
 This project bundles the following dependencies under the JDOM license.
 See bundled license files for details.
 
-- org.jdom:jdom2:2.0.6
+- org.jdom:jdom2:2.0.6.1

--- a/tools/ci/compile.sh
+++ b/tools/ci/compile.sh
@@ -114,10 +114,7 @@ EXIT_CODE=$(($EXIT_CODE+$?))
 echo "============ Run license check ============"
 
 find $MVN_VALIDATION_DIR
-# We use a different Scala version with Java 17 and 21
-if [[ ${PROFILE} != *"jdk17"* ]] && [[ ${PROFILE} != *"jdk21"* ]]; then
-  MVN=$MVN ${CI_DIR}/license_check.sh $MVN_CLEAN_COMPILE_OUT $MVN_VALIDATION_DIR || exit $?
-fi
+MVN=$MVN ${CI_DIR}/license_check.sh $MVN_CLEAN_COMPILE_OUT $MVN_VALIDATION_DIR || exit $?
 
 exit $EXIT_CODE
 


### PR DESCRIPTION
[BP-2.0][FLINK-37387][build] Enable license check for jdk17 and jdk21
[BP-2.0][hotfix] fix NOTICE file in order to fix java 11 license check