### PR TITLE
[FLINK-37419] Align the map value serialization in ForSt sync and async states

### DIFF
--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStDBMapEntryIterRequest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStDBMapEntryIterRequest.java
@@ -59,10 +59,12 @@ public class ForStDBMapEntryIterRequest<K, N, UK, UV>
             List<RawEntry> entries, int userKeyOffset) throws IOException {
         Collection<Map.Entry<UK, UV>> deserializedEntries = new ArrayList<>(entries.size());
         for (RawEntry en : entries) {
-            deserializedEntries.add(
-                    new MapEntry<>(
-                            deserializeUserKey(en.rawKeyBytes, userKeyOffset),
-                            deserializeUserValue(en.rawValueBytes)));
+            // Since be written in Sync mode, the user value can be null.
+            UV userValue = deserializeUserValue(en.rawValueBytes);
+            if (userValue != null) {
+                UK userKey = deserializeUserKey(en.rawKeyBytes, userKeyOffset);
+                deserializedEntries.add(new MapEntry<>(userKey, userValue));
+            }
         }
         return deserializedEntries;
     }

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStDBMapKeyIterRequest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStDBMapKeyIterRequest.java
@@ -57,6 +57,7 @@ public class ForStDBMapKeyIterRequest<K, N, UK, UV> extends ForStDBIterRequest<K
             throws IOException {
         Collection<UK> deserializedEntries = new ArrayList<>(entries.size());
         for (RawEntry en : entries) {
+            // TODO: In Sync mode the user value can be null, so we need to skip null user value.
             deserializedEntries.add(deserializeUserKey(en.rawKeyBytes, userKeyOffset));
         }
         return deserializedEntries;

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStDBMapValueIterRequest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStDBMapValueIterRequest.java
@@ -56,7 +56,10 @@ public class ForStDBMapValueIterRequest<K, N, UK, UV> extends ForStDBIterRequest
             throws IOException {
         Collection<UV> deserializedEntries = new ArrayList<>(entries.size());
         for (RawEntry en : entries) {
-            deserializedEntries.add(deserializeUserValue(en.rawValueBytes));
+            UV userValue = deserializeUserValue(en.rawValueBytes);
+            if (userValue != null) {
+                deserializedEntries.add(userValue);
+            }
         }
         return deserializedEntries;
     }

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStMapState.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStMapState.java
@@ -140,8 +140,8 @@ public class ForStMapState<K, N, UK, UV> extends AbstractMapState<K, N, UK, UV>
     public UV deserializeValue(byte[] valueBytes) throws IOException {
         DataInputDeserializer inputView = valueDeserializerView.get();
         inputView.setBuffer(valueBytes);
-        inputView.readBoolean();
-        return userValueSerializer.deserialize(inputView);
+        boolean isNull = inputView.readBoolean();
+        return isNull ? null : userValueSerializer.deserialize(inputView);
     }
 
     public UK deserializeUserKey(byte[] userKeyBytes, int userKeyOffset) throws IOException {

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStMapState.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStMapState.java
@@ -131,6 +131,7 @@ public class ForStMapState<K, N, UK, UV> extends AbstractMapState<K, N, UK, UV>
     public byte[] serializeValue(UV value) throws IOException {
         DataOutputSerializer outputView = valueSerializerView.get();
         outputView.clear();
+        outputView.writeBoolean(false);
         userValueSerializer.serialize(value, outputView);
         return outputView.getCopyOfBuffer();
     }
@@ -139,6 +140,7 @@ public class ForStMapState<K, N, UK, UV> extends AbstractMapState<K, N, UK, UV>
     public UV deserializeValue(byte[] valueBytes) throws IOException {
         DataInputDeserializer inputView = valueDeserializerView.get();
         inputView.setBuffer(valueBytes);
+        inputView.readBoolean();
         return userValueSerializer.deserialize(inputView);
     }
 


### PR DESCRIPTION
## What is the purpose of the change

There is a difference in value serialization between the sync and async state of ForSt. This PR aligns that.


## Brief change log

 - Add a flag in value (de-)serialization of ForStMapState.


## Verifying this change

This change is already covered by existing tests for R/W test for `ForStMapState`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
