### PR TITLE
[FLINK-37365][pyflink] Add API stability decorators for PyFlink APIs

### DIFF
--- a/flink-python/pyflink/table/catalog.py
+++ b/flink-python/pyflink/table/catalog.py
@@ -28,6 +28,7 @@ from pyflink.table.types import DataType, _to_java_data_type, _from_java_data_ty
 from pyflink.util.java_utils import to_jarray
 from typing import Dict, List, Optional, Union
 from abc import ABCMeta, abstractmethod
+from pyflink.util.api_stability_decorators import PublicEvolving
 
 __all__ = ['Catalog', 'CatalogDatabase', 'CatalogBaseTable', 'CatalogPartition', 'CatalogFunction',
            'Procedure', 'ObjectPath', 'CatalogPartitionSpec', 'CatalogTableStatistics',
@@ -36,6 +37,7 @@ __all__ = ['Catalog', 'CatalogDatabase', 'CatalogBaseTable', 'CatalogPartition',
            'Constraint', 'UniqueConstraint', 'ResolvedSchema']
 
 
+@PublicEvolving()
 class Catalog(object):
     """
     Catalog is responsible for reading and writing metadata such as database/table/views/UDFs
@@ -733,6 +735,7 @@ class Catalog(object):
             ignore_if_not_exists)
 
 
+@PublicEvolving()
 class CatalogDatabase(object):
     """
     Represents a database object in a catalog.
@@ -809,6 +812,7 @@ class CatalogDatabase(object):
             return None
 
 
+@PublicEvolving()
 class CatalogBaseTable(object):
     """
     CatalogBaseTable is the common parent of table and view. It has a map of
@@ -943,6 +947,7 @@ class CatalogBaseTable(object):
             return None
 
 
+@PublicEvolving()
 class CatalogPartition(object):
     """
     Represents a partition object in catalog.
@@ -1022,6 +1027,7 @@ class CatalogPartition(object):
         return self._j_catalog_partition.getComment()
 
 
+@PublicEvolving()
 class CatalogFunction(object):
     """
     Interface for a function in a catalog.
@@ -1113,6 +1119,7 @@ class CatalogFunction(object):
         return self._j_catalog_function.getFunctionLanguage()
 
 
+@PublicEvolving()
 class CatalogModel(object):
     """
     Interface for a model in a catalog.
@@ -1176,6 +1183,7 @@ class CatalogModel(object):
         return dict(self._j_catalog_model.getOptions())
 
 
+@PublicEvolving()
 class Procedure(object):
     """
     Interface for a procedure in a catalog.
@@ -1189,6 +1197,7 @@ class Procedure(object):
         return Procedure(j_procedure)
 
 
+@PublicEvolving()
 class ObjectPath(object):
     """
     A database name and object (table/view/function) name combo in a catalog.
@@ -1226,6 +1235,7 @@ class ObjectPath(object):
         return ObjectPath(j_object_path=gateway.jvm.ObjectPath.fromString(full_name))
 
 
+@PublicEvolving()
 class CatalogPartitionSpec(object):
     """
     Represents a partition spec object in catalog.
@@ -1259,6 +1269,7 @@ class CatalogPartitionSpec(object):
         return dict(self._j_catalog_partition_spec.getPartitionSpec())
 
 
+@PublicEvolving()
 class CatalogTableStatistics(object):
     """
     Statistics for a non-partitioned table or a partition of a partitioned table.
@@ -1313,6 +1324,7 @@ class CatalogTableStatistics(object):
             j_catalog_table_statistics=self._j_catalog_table_statistics.copy())
 
 
+@PublicEvolving()
 class CatalogColumnStatistics(object):
     """
     Column statistics of a table or partition.
@@ -1379,6 +1391,7 @@ class JdbcCatalog(Catalog):
         super(JdbcCatalog, self).__init__(j_jdbc_catalog)
 
 
+@PublicEvolving()
 class CatalogDescriptor:
     """
     Describes a catalog with the catalog name and configuration.
@@ -1483,6 +1496,7 @@ class ObjectIdentifier(object):
         return self._j_object_identifier.asSummaryString()
 
 
+@PublicEvolving()
 class Column(metaclass=ABCMeta):
     """
     Representation of a column in a :class:`ResolvedSchema`.
@@ -1642,6 +1656,7 @@ class Column(metaclass=ABCMeta):
         pass
 
 
+@PublicEvolving()
 class PhysicalColumn(Column):
     """
     Representation of a physical column.
@@ -1670,6 +1685,7 @@ class PhysicalColumn(Column):
         return self._j_physical_column.rename(new_name)
 
 
+@PublicEvolving()
 class ComputedColumn(Column):
     """
     Representation of a computed column.
@@ -1710,6 +1726,7 @@ class ComputedColumn(Column):
         return self._j_computed_column.rename(new_name)
 
 
+@PublicEvolving()
 class MetadataColumn(Column):
     """
     Representation of a metadata column.
@@ -1754,6 +1771,7 @@ class MetadataColumn(Column):
         return self._j_metadata_column.rename(new_name)
 
 
+@PublicEvolving()
 class WatermarkSpec:
     """
     Representation of a watermark specification in :class:`ResolvedSchema`.
@@ -1811,6 +1829,7 @@ class WatermarkSpec:
         return self._j_watermark_spec.asSummaryString()
 
 
+@PublicEvolving()
 class Constraint(metaclass=ABCMeta):
     """
     Integrity constraints, generally referred to simply as constraints, define the valid states of
@@ -1849,6 +1868,7 @@ class Constraint(metaclass=ABCMeta):
         """
         return self._j_constraint.asSummaryString()
 
+    @PublicEvolving()
     class ConstraintType(Enum):
         """
         Type of the constraint.
@@ -1866,6 +1886,7 @@ class Constraint(metaclass=ABCMeta):
         UNIQUE_KEY = 1
 
 
+@PublicEvolving()
 class UniqueConstraint(Constraint):
     """
     A unique key constraint. It can be declared also as a PRIMARY KEY.
@@ -1899,6 +1920,7 @@ class UniqueConstraint(Constraint):
         return self._j_unique_constraint.getTypeString()
 
 
+@PublicEvolving()
 class ResolvedSchema(object):
     """
     Schema of a table or view consisting of columns, constraints, and watermark specifications.

--- a/flink-python/pyflink/table/changelog_mode.py
+++ b/flink-python/pyflink/table/changelog_mode.py
@@ -16,10 +16,12 @@
 # limitations under the License.
 ################################################################################
 from pyflink.java_gateway import get_gateway
+from pyflink.util.api_stability_decorators import PublicEvolving
 
 __all__ = ['ChangelogMode']
 
 
+@PublicEvolving()
 class ChangelogMode(object):
     """
     The set of changes contained in a changelog.
@@ -30,18 +32,28 @@ class ChangelogMode(object):
 
     @staticmethod
     def insert_only():
+        """
+        Shortcut for a simple :attr:`~pyflink.common.RowKind.INSERT`-only changelog.
+        """
         gateway = get_gateway()
         return ChangelogMode(
             gateway.jvm.org.apache.flink.table.connector.ChangelogMode.insertOnly())
 
     @staticmethod
     def upsert():
+        """
+        Shortcut for an upsert changelog that describes idempotent updates on a key and thus does
+        does not contain :attr:`~pyflink.common.RowKind.UPDATE_BEFORE` rows.
+        """
         gateway = get_gateway()
         return ChangelogMode(
             gateway.jvm.org.apache.flink.table.connector.ChangelogMode.upsert())
 
     @staticmethod
     def all():
+        """
+        Shortcut for a changelog that can contain all :class:`~pyflink.common.RowKind`.
+        """
         gateway = get_gateway()
         return ChangelogMode(
             gateway.jvm.org.apache.flink.table.connector.ChangelogMode.all())

--- a/flink-python/pyflink/table/data_view.py
+++ b/flink-python/pyflink/table/data_view.py
@@ -18,6 +18,8 @@
 from abc import ABC, abstractmethod
 from typing import TypeVar, Generic, Iterable, List, Any, Iterator, Dict, Tuple
 
+from pyflink.util.api_stability_decorators import PublicEvolving
+
 T = TypeVar('T')
 K = TypeVar('K')
 V = TypeVar('V')
@@ -25,6 +27,7 @@ V = TypeVar('V')
 __all__ = ['DataView', 'ListView', 'MapView']
 
 
+@PublicEvolving()
 class DataView(ABC):
     """
     A DataView is a collection type that can be used in the accumulator of an user defined
@@ -40,6 +43,7 @@ class DataView(ABC):
         pass
 
 
+@PublicEvolving()
 class ListView(DataView, Generic[T]):
     """
     A :class:`DataView` that provides list-like functionality in the accumulator of an
@@ -102,6 +106,7 @@ class ListView(DataView, Generic[T]):
         return iter(self.get())
 
 
+@PublicEvolving()
 class MapView(Generic[K, V]):
     """
     A :class:`DataView` that provides dict-like functionality in the accumulator of an

--- a/flink-python/pyflink/table/environment_settings.py
+++ b/flink-python/pyflink/table/environment_settings.py
@@ -17,6 +17,7 @@
 ################################################################################
 
 from pyflink.java_gateway import get_gateway
+from pyflink.util.api_stability_decorators import PublicEvolving
 from pyflink.util.java_utils import create_url_class_loader
 
 from pyflink.common import Configuration
@@ -24,6 +25,7 @@ from pyflink.common import Configuration
 __all__ = ['EnvironmentSettings']
 
 
+@PublicEvolving()
 class EnvironmentSettings(object):
     """
     Defines all parameters that initialize a table environment. Those parameters are used only

--- a/flink-python/pyflink/table/explain_detail.py
+++ b/flink-python/pyflink/table/explain_detail.py
@@ -18,7 +18,10 @@
 
 __all__ = ['ExplainDetail']
 
+from pyflink.util.api_stability_decorators import PublicEvolving
 
+
+@PublicEvolving()
 class ExplainDetail(object):
     """
     ExplainDetail defines the types of details for explain result.

--- a/flink-python/pyflink/table/module.py
+++ b/flink-python/pyflink/table/module.py
@@ -19,7 +19,10 @@ from pyflink.java_gateway import get_gateway
 
 __all__ = ['HiveModule', 'Module', 'ModuleEntry']
 
+from pyflink.util.api_stability_decorators import PublicEvolving
 
+
+@PublicEvolving()
 class Module(object):
     """
     Modules define a set of metadata, including functions, user defined types, operators, rules,
@@ -34,6 +37,7 @@ class Module(object):
         self._j_module = j_module
 
 
+@PublicEvolving()
 class HiveModule(Module):
     """
     Module to provide Hive built-in metadata.
@@ -51,6 +55,7 @@ class HiveModule(Module):
         super(HiveModule, self).__init__(j_hive_module)
 
 
+@PublicEvolving()
 class ModuleEntry(object):
     """
     A POJO to represent a module's name and use status.

--- a/flink-python/pyflink/table/resolved_expression.py
+++ b/flink-python/pyflink/table/resolved_expression.py
@@ -19,10 +19,12 @@ from typing import List
 
 from pyflink.table import Expression
 from pyflink.table.types import DataType, _from_java_data_type
+from pyflink.util.api_stability_decorators import PublicEvolving
 
 __all__ = ["ResolvedExpression"]
 
 
+@PublicEvolving()
 class ResolvedExpression(Expression):
     """
     Expression that has been fully resolved and validated.

--- a/flink-python/pyflink/table/result_kind.py
+++ b/flink-python/pyflink/table/result_kind.py
@@ -19,7 +19,10 @@ from pyflink.java_gateway import get_gateway
 
 __all__ = ['ResultKind']
 
+from pyflink.util.api_stability_decorators import PublicEvolving
 
+
+@PublicEvolving()
 class ResultKind(object):
     """
     ResultKind defines the types of the result.

--- a/flink-python/pyflink/table/schema.py
+++ b/flink-python/pyflink/table/schema.py
@@ -21,6 +21,7 @@ from pyflink.java_gateway import get_gateway
 from pyflink.table import Expression
 from pyflink.table.expression import _get_java_expression
 from pyflink.table.types import DataType, _to_java_data_type
+from pyflink.util.api_stability_decorators import PublicEvolving
 from pyflink.util.java_utils import to_jarray
 
 if TYPE_CHECKING:
@@ -31,6 +32,7 @@ if TYPE_CHECKING:
 __all__ = ['Schema']
 
 
+@PublicEvolving()
 class Schema(object):
     """
     Schema of a table or view.
@@ -67,6 +69,7 @@ class Schema(object):
     def __hash__(self):
         return self._j_schema.hashCode()
 
+    @PublicEvolving()
     class Builder(object):
         """
         A builder for constructing an immutable but still unresolved Schema.

--- a/flink-python/pyflink/table/sql_dialect.py
+++ b/flink-python/pyflink/table/sql_dialect.py
@@ -16,10 +16,12 @@
 # limitations under the License.
 ################################################################################
 from pyflink.java_gateway import get_gateway
+from pyflink.util.api_stability_decorators import PublicEvolving
 
 __all__ = ['SqlDialect']
 
 
+@PublicEvolving()
 class SqlDialect(object):
     """
     Enumeration of valid SQL compatibility modes.

--- a/flink-python/pyflink/table/statement_set.py
+++ b/flink-python/pyflink/table/statement_set.py
@@ -22,11 +22,13 @@ from pyflink.table import ExplainDetail
 from pyflink.table.table_descriptor import TableDescriptor
 from pyflink.table.table_pipeline import TablePipeline
 from pyflink.table.table_result import TableResult
+from pyflink.util.api_stability_decorators import PublicEvolving
 from pyflink.util.java_utils import to_j_explain_detail_arr
 
 __all__ = ['StatementSet']
 
 
+@PublicEvolving()
 class StatementSet(object):
     """
     A :class:`~StatementSet` accepts pipelines defined by DML statements or :class:`~Table` objects.

--- a/flink-python/pyflink/table/table.py
+++ b/flink-python/pyflink/table/table.py
@@ -35,12 +35,15 @@ from pyflink.table.udf import UserDefinedScalarFunctionWrapper, \
 from pyflink.table.utils import tz_convert_from_internal, to_expression_jarray
 from pyflink.table.window import OverWindow, GroupWindow
 
+from pyflink.util.api_stability_decorators import Deprecated, PublicEvolving
+
 from pyflink.util.java_utils import to_jarray
 from pyflink.util.java_utils import to_j_explain_detail_arr
 
 __all__ = ['Table', 'GroupedTable', 'GroupWindowedTable', 'OverWindowedTable', 'WindowGroupedTable']
 
 
+@PublicEvolving()
 class Table(object):
     """
     A :class:`~pyflink.table.Table` object is the core abstraction of the Table API.
@@ -959,14 +962,12 @@ class Table(object):
             import pandas as pd
             return pd.DataFrame.from_records([], columns=self.get_schema().get_field_names())
 
+    @Deprecated(since="2.1.0", detail=":func:`Table.get_resolved_schema` instead.")
     def get_schema(self) -> TableSchema:
         """
         Returns the :class:`~pyflink.table.TableSchema` of this table.
 
         :return: The schema of this table.
-
-        .. deprecated:: 2.1.0
-           Use :func:`Table.get_resolved_schema` instead.
         """
         return TableSchema(j_table_schema=self._j_table.getSchema())
 
@@ -1175,6 +1176,7 @@ class Table(object):
             )
 
 
+@PublicEvolving()
 class GroupedTable(object):
     """
     A table that has been grouped on a set of grouping keys.
@@ -1299,6 +1301,7 @@ class GroupedTable(object):
             return FlatAggregateTable(self._j_table.flatAggregate(func._j_expr), self._t_env)
 
 
+@PublicEvolving()
 class GroupWindowedTable(object):
     """
     A table that has been windowed for :class:`~pyflink.table.GroupWindow`.
@@ -1338,6 +1341,7 @@ class GroupWindowedTable(object):
             self._j_table.groupBy(to_expression_jarray(fields)), self._t_env)
 
 
+@PublicEvolving()
 class WindowGroupedTable(object):
     """
     A table that has been windowed and grouped for :class:`~pyflink.table.window.GroupWindow`.
@@ -1423,6 +1427,7 @@ class WindowGroupedTable(object):
         return func_expression
 
 
+@PublicEvolving()
 class OverWindowedTable(object):
     """
     A table that has been windowed for :class:`~pyflink.table.window.OverWindow`.
@@ -1455,6 +1460,7 @@ class OverWindowedTable(object):
         return Table(self._j_table.select(to_expression_jarray(fields)), self._t_env)
 
 
+@PublicEvolving()
 class AggregatedTable(object):
     """
     A table that has been performed on the aggregate function.
@@ -1493,6 +1499,7 @@ class AggregatedTable(object):
         return Table(self._j_table.select(to_expression_jarray(fields)), self._t_env)
 
 
+@PublicEvolving()
 class FlatAggregateTable(object):
     """
     A table that performs flatAggregate on a :class:`~pyflink.table.Table`, a

--- a/flink-python/pyflink/table/table_config.py
+++ b/flink-python/pyflink/table/table_config.py
@@ -22,12 +22,14 @@ from py4j.compat import long
 from pyflink.common.configuration import Configuration
 from pyflink.java_gateway import get_gateway
 from pyflink.table.sql_dialect import SqlDialect
+from pyflink.util.api_stability_decorators import PublicEvolving, Internal
 
 __all__ = ['TableConfig']
 
 from pyflink.util.java_utils import add_jars_to_context_class_loader
 
 
+@PublicEvolving()
 class TableConfig(object):
     """
     Configuration for the current :class:`TableEnvironment` session to adjust Table & SQL API
@@ -207,6 +209,7 @@ class TableConfig(object):
         """
         self._j_table_config.addConfiguration(configuration._j_configuration)
 
+    @Internal()
     def to_map(self) -> dict:
         """
         Calls the toMap method of the underlying Java TableConfig to get the configuration map.

--- a/flink-python/pyflink/table/table_descriptor.py
+++ b/flink-python/pyflink/table/table_descriptor.py
@@ -20,11 +20,13 @@ from typing import Dict, Union, List, Optional
 from pyflink.common.config_options import ConfigOption
 from pyflink.java_gateway import get_gateway
 from pyflink.table.schema import Schema
+from pyflink.util.api_stability_decorators import PublicEvolving
 from pyflink.util.java_utils import to_jarray
 
 __all__ = ['TableDescriptor', 'FormatDescriptor']
 
 
+@PublicEvolving()
 class TableDescriptor(object):
     """
     Describes a CatalogTable representing a source or sink.
@@ -83,6 +85,7 @@ class TableDescriptor(object):
     def __hash__(self):
         return self._j_table_descriptor.hashCode()
 
+    @PublicEvolving()
     class Builder(object):
         """
         Builder for TableDescriptor.

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -45,6 +45,7 @@ from pyflink.table.types import _create_type_verifier, RowType, DataType, \
 from pyflink.table.udf import UserDefinedFunctionWrapper, AggregateFunction, udaf, \
     udtaf, TableAggregateFunction
 from pyflink.table.utils import to_expression_jarray
+from pyflink.util.api_stability_decorators import PublicEvolving, Deprecated
 from pyflink.util.java_utils import get_j_env_configuration, is_local_deployment, load_java_class, \
     to_j_explain_detail_arr, to_jarray, get_field
 
@@ -54,6 +55,7 @@ __all__ = [
 ]
 
 
+@PublicEvolving()
 class TableEnvironment(object):
     """
     A table environment is the base class, entry point, and central context for creating Table
@@ -128,6 +130,11 @@ class TableEnvironment(object):
         """
         self._j_tenv.createCatalog(catalog_name, catalog_descriptor._j_catalog_descriptor)
 
+    @Deprecated(since="2.1.0", detail="""
+    Use :func:`create_catalog` instead. The new method uses a
+    :class:`~pyflink.table.catalog.CatalogDescriptor` to initialize the catalog instance and store
+    the `~pyflink.table.catalog.CatalogDescriptor` in the catalog store.
+    """)
     def register_catalog(self, catalog_name: str, catalog: Catalog):
         """
         Registers a :class:`~pyflink.table.catalog.Catalog` under a unique name.

--- a/flink-python/pyflink/table/table_pipeline.py
+++ b/flink-python/pyflink/table/table_pipeline.py
@@ -21,11 +21,13 @@ from pyflink.java_gateway import get_gateway
 from pyflink.table import ExplainDetail
 from pyflink.table.catalog import ObjectIdentifier
 from pyflink.table.table_result import TableResult
+from pyflink.util.api_stability_decorators import PublicEvolving
 from pyflink.util.java_utils import to_j_explain_detail_arr
 
 __all__ = ["TablePipeline"]
 
 
+@PublicEvolving()
 class TablePipeline(object):
     """
     Describes a complete pipeline from one or more source tables to a sink table.

--- a/flink-python/pyflink/table/table_result.py
+++ b/flink-python/pyflink/table/table_result.py
@@ -28,10 +28,12 @@ from pyflink.table.result_kind import ResultKind
 from pyflink.table.table_schema import TableSchema
 from pyflink.table.types import _from_java_data_type
 from pyflink.table.utils import pickled_bytes_to_python_converter
+from pyflink.util.api_stability_decorators import PublicEvolving, Deprecated
 
 __all__ = ['TableResult', 'CloseableIterator']
 
 
+@PublicEvolving()
 class TableResult(object):
     """
     A :class:`~pyflink.table.TableResult` is the representation of the statement execution result.
@@ -76,6 +78,14 @@ class TableResult(object):
         else:
             get_method(self._j_table_result, "await")()
 
+    @Deprecated(since="2.1.0", detail="""
+    This function has been deprecated as part of FLIP-164.
+    :class:`~pyflink.table.table_schema.TableSchema` has been replaced by two more
+    dedicated classes :class:`~pyflink.table.Schema` and
+    :class:`~pyflink.table.catalog.ResolvedSchema`. Use :class:`~pyflink.table.Schema` for
+    declaration in APIs. :class:`~pyflink.table.catalog.ResolvedSchema` is offered by the
+    framework after resolution and validation.
+    """)
     def get_table_schema(self) -> TableSchema:
         """
         Returns the schema of the result.
@@ -84,13 +94,6 @@ class TableResult(object):
         :rtype: pyflink.table.TableSchema
 
         .. versionadded:: 1.11.0
-        .. deprecated:: 2.1.0
-           This function has been deprecated as part of FLIP-164.
-           :class:`~pyflink.table.table_schema.TableSchema` has been replaced by two more
-           dedicated classes :class:`~pyflink.table.Schema` and
-           :class:`~pyflink.table.catalog.ResolvedSchema`. Use :class:`~pyflink.table.Schema` for
-           declaration in APIs. :class:`~pyflink.table.catalog.ResolvedSchema` is offered by the
-           framework after resolution and validation.
         """
         return TableSchema(j_table_schema=self._get_java_table_schema())
 

--- a/flink-python/pyflink/table/table_schema.py
+++ b/flink-python/pyflink/table/table_schema.py
@@ -19,16 +19,23 @@ from typing import List, Optional, Union
 
 from pyflink.java_gateway import get_gateway
 from pyflink.table.types import DataType, RowType, _to_java_data_type, _from_java_data_type
+from pyflink.util.api_stability_decorators import Deprecated
 from pyflink.util.java_utils import to_jarray
 
 __all__ = ['TableSchema']
 
 
+@Deprecated(since="2.1.0", detail="""
+This class has been deprecated as part of FLIP-164. It has been replaced by two more dedicated
+classes :class:`~pyflink.table.Schema` and :class:`~pyflink.table.catalog.ResolvedSchema`.
+Use :class:`~pyflink.table.Schema` for declaration in APIs.
+:class:`~pyflink.table.catalog.ResolvedSchema` is offered by the framework after resolution and
+validation.
+""")
 class TableSchema(object):
     """
     A table schema that represents a table's structure with field names and data types.
     """
-
     def __init__(self, field_names: List[str] = None, data_types: List[DataType] = None,
                  j_table_schema=None):
         if j_table_schema is None:

--- a/flink-python/pyflink/table/types.py
+++ b/flink-python/pyflink/table/types.py
@@ -32,6 +32,7 @@ from py4j.java_gateway import get_java_class
 from typing import List, Union
 
 from pyflink.common.types import _create_row
+from pyflink.util.api_stability_decorators import PublicEvolving
 from pyflink.util.java_utils import to_jarray, is_instance_of
 from pyflink.java_gateway import get_gateway
 from pyflink.common import Row, RowKind
@@ -39,6 +40,7 @@ from pyflink.common import Row, RowKind
 __all__ = ['DataTypes', 'UserDefinedType', 'Row', 'RowKind']
 
 
+@PublicEvolving()
 class DataType(object):
     """
     Describes the data type of a value in the table ecosystem. Instances of this class can be used

--- a/flink-python/pyflink/table/udf.py
+++ b/flink-python/pyflink/table/udf.py
@@ -25,11 +25,13 @@ from pyflink.metrics import MetricGroup
 from pyflink.table import Expression
 from pyflink.table.types import DataType, _to_java_data_type
 from pyflink.util import java_utils
+from pyflink.util.api_stability_decorators import PublicEvolving, Internal
 
 __all__ = ['FunctionContext', 'AggregateFunction', 'ScalarFunction', 'TableFunction',
            'TableAggregateFunction', 'udf', 'udtf', 'udaf', 'udtaf']
 
 
+@PublicEvolving()
 class FunctionContext(object):
     """
     Used to obtain global runtime information about the context in which the
@@ -65,6 +67,7 @@ class FunctionContext(object):
         return self._job_parameters[key] if key in self._job_parameters else default_value
 
 
+@PublicEvolving()
 class UserDefinedFunction(abc.ABC):
     """
     Base interface for user-defined function.
@@ -102,6 +105,7 @@ class UserDefinedFunction(abc.ABC):
         return True
 
 
+@PublicEvolving()
 class ScalarFunction(UserDefinedFunction):
     """
     Base interface for user-defined scalar function. A user-defined scalar functions maps zero, one,
@@ -118,6 +122,7 @@ class ScalarFunction(UserDefinedFunction):
         pass
 
 
+@PublicEvolving()
 class TableFunction(UserDefinedFunction):
     """
     Base interface for user-defined table function. A user-defined table function creates zero, one,
@@ -138,6 +143,7 @@ T = TypeVar('T')
 ACC = TypeVar('ACC')
 
 
+@PublicEvolving()
 class ImperativeAggregateFunction(UserDefinedFunction, Generic[T, ACC]):
     """
     Base interface for user-defined aggregate function and table aggregate function.
@@ -211,6 +217,7 @@ class ImperativeAggregateFunction(UserDefinedFunction, Generic[T, ACC]):
         raise RuntimeError("Method get_accumulator_type is not implemented")
 
 
+@PublicEvolving()
 class AggregateFunction(ImperativeAggregateFunction):
     """
     Base interface for user-defined aggregate function. A user-defined aggregate function maps
@@ -232,6 +239,7 @@ class AggregateFunction(ImperativeAggregateFunction):
         pass
 
 
+@PublicEvolving()
 class TableAggregateFunction(ImperativeAggregateFunction):
     """
     Base class for a user-defined table aggregate function. A user-defined table aggregate function
@@ -255,6 +263,7 @@ class TableAggregateFunction(ImperativeAggregateFunction):
         pass
 
 
+@Internal()
 class DelegatingScalarFunction(ScalarFunction):
     """
     Helper scalar function implementation for lambda expression and python function. It's for
@@ -268,6 +277,7 @@ class DelegatingScalarFunction(ScalarFunction):
         return self.func(*args)
 
 
+@Internal()
 class DelegationTableFunction(TableFunction):
     """
     Helper table function implementation for lambda expression and python function. It's for
@@ -281,6 +291,7 @@ class DelegationTableFunction(TableFunction):
         return self.func(*args)
 
 
+@Internal()
 class DelegatingPandasAggregateFunction(AggregateFunction):
     """
     Helper pandas aggregate function implementation for lambda expression and python function.
@@ -319,6 +330,7 @@ class PandasAggregateFunctionWrapper(object):
         self.func.close()
 
 
+@Internal()
 class UserDefinedFunctionWrapper(object):
     """
     Base Wrapper for Python user-defined function. It handles things like converting lambda

--- a/flink-python/pyflink/table/window.py
+++ b/flink-python/pyflink/table/window.py
@@ -20,6 +20,7 @@ from py4j.java_gateway import get_method
 from pyflink.java_gateway import get_gateway
 from pyflink.table import Expression
 from pyflink.table.expression import _get_java_expression
+from pyflink.util.api_stability_decorators import PublicEvolving
 
 __all__ = [
     'Tumble',
@@ -33,6 +34,7 @@ __all__ = [
 from pyflink.table.utils import to_expression_jarray
 
 
+@PublicEvolving()
 class GroupWindow(object):
     """
     A group window specification.
@@ -51,6 +53,7 @@ class GroupWindow(object):
         self._java_window = java_window
 
 
+@PublicEvolving()
 class Tumble(object):
     """
     Helper class for creating a tumbling window. Tumbling windows are consecutive, non-overlapping
@@ -79,6 +82,7 @@ class Tumble(object):
         return TumbleWithSize(get_gateway().jvm.Tumble.over(_get_java_expression(size)))
 
 
+@PublicEvolving()
 class TumbleWithSize(object):
     """
     Tumbling window.
@@ -106,6 +110,7 @@ class TumbleWithSize(object):
         return TumbleWithSizeOnTime(self._java_window.on(_get_java_expression(time_field)))
 
 
+@PublicEvolving()
 class TumbleWithSizeOnTime(object):
     """
     Tumbling window on time. You need to assign an alias for the window.
@@ -128,6 +133,7 @@ class TumbleWithSizeOnTime(object):
         return GroupWindow(get_method(self._java_window, "as")(alias))
 
 
+@PublicEvolving()
 class Session(object):
     """
     Helper class for creating a session window. The boundary of session windows are defined by
@@ -157,6 +163,7 @@ class Session(object):
         return SessionWithGap(get_gateway().jvm.Session.withGap(_get_java_expression(gap)))
 
 
+@PublicEvolving()
 class SessionWithGap(object):
     """
     Session window.
@@ -184,6 +191,7 @@ class SessionWithGap(object):
         return SessionWithGapOnTime(self._java_window.on(_get_java_expression(time_field)))
 
 
+@PublicEvolving()
 class SessionWithGapOnTime(object):
     """
     Session window on time. You need to assign an alias for the window.
@@ -206,6 +214,7 @@ class SessionWithGapOnTime(object):
         return GroupWindow(get_method(self._java_window, "as")(alias))
 
 
+@PublicEvolving()
 class Slide(object):
     """
     Helper class for creating a sliding window. Sliding windows have a fixed size and slide by
@@ -243,6 +252,7 @@ class Slide(object):
         return SlideWithSize(get_gateway().jvm.Slide.over(_get_java_expression(size)))
 
 
+@PublicEvolving()
 class SlideWithSize(object):
     """
     Partially specified sliding window. The size of the window either as time or row-count
@@ -269,6 +279,7 @@ class SlideWithSize(object):
         return SlideWithSizeAndSlide(self._java_window.every(_get_java_expression(slide)))
 
 
+@PublicEvolving()
 class SlideWithSizeAndSlide(object):
     """
     Sliding window. The size of the window either as time or row-count interval.
@@ -293,6 +304,7 @@ class SlideWithSizeAndSlide(object):
         return SlideWithSizeAndSlideOnTime(self._java_window.on(_get_java_expression(time_field)))
 
 
+@PublicEvolving()
 class SlideWithSizeAndSlideOnTime(object):
     """
     Sliding window on time. You need to assign an alias for the window.
@@ -315,6 +327,7 @@ class SlideWithSizeAndSlideOnTime(object):
         return GroupWindow(get_method(self._java_window, "as")(alias))
 
 
+@PublicEvolving()
 class Over(object):
     """
     Helper class for creating an over window. Similar to SQL, over window aggregates compute an
@@ -361,6 +374,7 @@ class Over(object):
             to_expression_jarray(partition_by)))
 
 
+@PublicEvolving()
 class OverWindowPartitionedOrdered(object):
     """
     Partially defined over window with (optional) partitioning and order.
@@ -389,6 +403,7 @@ class OverWindowPartitionedOrdered(object):
             self._java_over_window.preceding(_get_java_expression(preceding)))
 
 
+@PublicEvolving()
 class OverWindowPartitionedOrderedPreceding(object):
     """
     Partially defined over window with (optional) partitioning, order, and preceding.
@@ -418,6 +433,7 @@ class OverWindowPartitionedOrderedPreceding(object):
             self._java_over_window.following(_get_java_expression(following)))
 
 
+@PublicEvolving()
 class OverWindowPartitioned(object):
     """
     Partially defined over window with partitioning.
@@ -442,6 +458,7 @@ class OverWindowPartitioned(object):
             _get_java_expression(order_by)))
 
 
+@PublicEvolving()
 class OverWindow(object):
     """
     An over window specification.

--- a/flink-python/pyflink/util/api_stability_decorators.py
+++ b/flink-python/pyflink/util/api_stability_decorators.py
@@ -1,0 +1,215 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+from inspect import getmembers, isfunction, isclass
+from typing import TypeVar, Callable, Any, Union, Type, Optional
+from abc import ABCMeta, abstractmethod
+import warnings
+from typing_extensions import override
+from textwrap import dedent, indent
+
+__all__ = ["Deprecated", "Experimental", "Internal", "PublicEvolving"]
+
+# TypeVar for anything callable (function or class)
+T = TypeVar("T", bound=Union[Callable[..., Any], Type[Any]])
+
+
+class BaseAPIStabilityDecorator(metaclass=ABCMeta):
+    """
+    Base class for implementing API stability decorators.
+
+    This abstract base class provides the foundation for creating decorators that
+    mark API elements (functions or classes) with stability indicators. It handles
+    the mechanics of applying documentation directives to both standalone functions
+    and entire classes, including their public methods.
+    """
+
+    @abstractmethod
+    def get_directive(self, func_or_cls: T) -> str:
+        """
+        Returns the Sphinx directive that should be appended to the docs of the function/class
+        for the given decorator.
+        """
+        pass
+
+    @staticmethod
+    def _get_element_type_name(func_or_cls: T) -> str:
+        """
+        Returns a string representation of the API element's type.
+        """
+        if isfunction(func_or_cls):
+            return "function"
+        elif isclass(func_or_cls):
+            return "class"
+        else:
+            return "API"
+
+    def __call__(self, func_or_cls: T) -> T:
+        """
+        Appends a directive to the docstring of the given function or class.
+        If a class, it also appends the directive to the docstrings of the public functions
+        of that class.
+        """
+        directive = dedent(self.get_directive(func_or_cls))
+
+        docstring = func_or_cls.__doc__ or ""
+
+        # Class/Function docstrings can be at an arbitrary level of indentation depending on the
+        # depth. We should dedent the docstring here so that we can insert the directive at the
+        # correct indentation.
+        docstring = dedent(docstring)
+
+        # Avoid duplicating directives if already present in the docstring.
+        if directive not in docstring:
+            func_or_cls.__doc__ = f"{docstring}\n{directive}"
+
+        if isclass(func_or_cls):
+            for name, method in getmembers(func_or_cls, isfunction):
+                if not name.startswith("_"):
+                    method_docstring = method.__doc__ or ""
+                    method_docstring = dedent(method_docstring)
+
+                    if directive not in method_docstring:
+                        method.__doc__ = f"{method_docstring}\n{directive}"
+
+        return func_or_cls
+
+
+class Deprecated(BaseAPIStabilityDecorator):
+    """
+    Decorator to mark classes and functions as deprecated since a certain version, with an
+    optional extra-details parameter.
+
+    Example:
+
+    .. code-block:: python
+
+        @Deprecated(since="1.2.3", detail="Use :class:`MyNewClass` instead)
+        class MyClass:
+
+            @Deprecated(since="1.0.0")
+            def func(self):
+                pass
+
+    :param str since: The version that this class/function was deprecated in.
+    :param str detail: Optional explanatory detail for the deprecation.
+    """
+
+    def __init__(self, since: str, detail: Optional[str] = None):
+        self.since = since
+        self.detail = detail
+
+    def get_directive(self, func_or_cls: T) -> str:
+        return f".. deprecated:: {self.since}\n{indent(dedent(self.detail), '   ')}"
+
+    @override
+    def __call__(self, func_or_cls: T) -> T:
+        """
+        Emit a warning on the deprecation of the given function/class. Then call the base class
+        for docstring modification.
+        """
+        msg = f"{func_or_cls.__qualname__} has been deprecated since version {self.since}."
+        if self.detail is not None:
+            msg = f"{msg} {self.detail}"
+
+        warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
+        return super().__call__(func_or_cls)
+
+
+class Experimental(BaseAPIStabilityDecorator):
+    """
+    Decorator to mark classes for experimental use.
+
+    Classes with this annotation are neither battle-tested nor stable, and may be changed or
+    removed in future versions.
+
+    Example:
+
+    .. code-block:: python
+
+        @Experimental()
+        class MyClass:
+
+            @Experimental()
+            def func(self):
+                pass
+
+    """
+
+    def get_directive(self, func_or_cls: T) -> str:
+        return f"""
+.. warning:: This *{self._get_element_type_name(func_or_cls)}* is marked as **experimental**. It
+             is neither battle-tested nor stable, and may be changed or removed in future
+             versions.
+        """
+
+
+class Internal(BaseAPIStabilityDecorator):
+    """
+    Decorator to mark functions within stable, public APIs as an internal developer API.
+
+    Developer APIs are stable but internal to Flink and might change across releases.
+
+    Example:
+
+    .. code-block:: python
+
+        @Internal()
+        class MyClass:
+
+            @Internal()
+            def func(self):
+                pass
+
+    """
+
+    def get_directive(self, func_or_cls: T) -> str:
+        return f"""
+.. caution:: This *{self._get_element_type_name(func_or_cls)}* is marked as **internal**.
+             It as an internal developer API, which are stable but internal to Flink and
+             might change across versions.
+        """
+
+
+class PublicEvolving(BaseAPIStabilityDecorator):
+    """
+    Decorator to mark classes and functions for public use, but with evolving interfaces.
+
+    Classes and functions with this decorator are intended for public use and have stable behaviour.
+    However, their interfaces and signatures are not considered to be stable and might be changed
+    across versions.
+
+    Example:
+
+    .. code-block:: python
+
+        @PublicEvolving()
+        class MyClass:
+
+            @PublicEvolving()
+            def func(self):
+                pass
+
+    """
+
+    def get_directive(self, func_or_cls: T) -> str:
+        return f"""
+.. note:: This *{self._get_element_type_name(func_or_cls)}* is marked as **evolving**. It is
+          intended for public use and has stable behaviour. However, its interface/signature is
+          not considered to be stable and might be changed across versions.
+        """


### PR DESCRIPTION
## What is the purpose of the change

Currently, the Java APIs use annotations like `@PublicEvolving` and `@Experimental` to clearly indicate the stability status of API components. This is super helpful for understanding which parts of the API are stable for production use and which might change in future releases.

The Python APIs lack this kind of explicit stability indication. This PR adds a set of decorators, corresponding to the annotations used in the Java APIs, that allow us to decorate classes/functions depending on their stability. These decorators also modify the underlying docstrings of the classes/functions that they decorate, so that the API stability is also reflected in the Sphinx documentation. Additionally, classes/functions that are deprecated output a warning at runtime on their invocation. 

The decorators function at both the class and function level. At the function level, they enrich the docstring of the function with an rst block that is rendered as a directive in the Sphinx documentation for that function. At the class level, they enrich the docstring of the class *and* also the docstrings of the classes public functions, so that, for example, the function documentation for a class annotated as `PublicEvolving()` also contains a directive block informing the user that the *class* the function is part of is marked as public evolving. The following decorators, and their resulting documentation changes:

### Decorators

#### `Deprecated` 

`Deprecated` is distinct from the other decorators in that it takes a set of arguments, a mandatory `since` argument and an optional `detail` argument. These are output as a [Sphinx deprecated directive](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-deprecated), hence the mandatory `since` argument.

Without `detail`:
```python

@Deprecated(since="1.2.3")
def MyClass:
    pass
```

Output in the Sphinx documentation:
<img width="672" alt="Screenshot 2025-03-04 at 18 06 59" src="https://github.com/user-attachments/assets/1bda13e1-f22c-4180-b925-ba42ac8cdfbc" />


With `detail`:
```python

@Deprecated(since="1.2.3", detail="Lorem ipsum dolor sit amet.")
def MyClass:
    pass
```

Output in the Sphinx documentation:
<img width="672" alt="Screenshot 2025-03-04 at 18 08 02" src="https://github.com/user-attachments/assets/c47ca62e-0681-4a5b-8373-42aff2f0f84f" />

#### `Experimental`

```python

@Experimental()
def MyClass:
    pass
```

Output in the Sphinx documentation:
<img width="672" alt="Screenshot 2025-03-04 at 18 06 50" src="https://github.com/user-attachments/assets/80ebb7dc-8bcc-47e1-8048-3e340b93a2d7" />

#### `Internal`

```python

@Internal()
def MyClass:
    pass
```

Output in the Sphinx documentation:
<img width="672" alt="Screenshot 2025-03-04 at 18 06 39" src="https://github.com/user-attachments/assets/c1ee65f2-452a-4e3f-b774-ab58398bac8a" />

#### `PublicEvolving`

```python

@PublicEvolving()
def MyClass:
    pass
```

Output in the Sphinx documentation:
<img width="672" alt="Screenshot 2025-03-04 at 18 06 33" src="https://github.com/user-attachments/assets/a92cecd6-6006-41cb-a9e0-8f8156cf4952" />

### Combining Decorators

The decorators can also be combined. Multiple decorators can be applied to a class/function, and this will output the directives of all the decorators in the documentation for that class/function. Decorators on classes and then on functions in those classes will also combine, so that the decoration from the class is propagated down to the function and combined with the annotations on that function. So, for example, the following code:

```python

@PublicEvolving()
class ResolvedSchema(object):
    """
    Schema of a table or view consisting of columns, constraints, and watermark specifications.

    This class is the result of resolving a :class:`~pyflink.table.Schema` into a final validated
    representation.

    - Data types and functions have been expanded to fully qualified identifiers.
    - Time attributes are represented in the column's data type.
    - :class:`pyflink.table.Expression` have been translated to
      :class:`pyflink.table.ResolvedExpression`

    This class should not be passed into a connector. It is therefore also not serializable.
    Instead, the :func:`to_physical_row_data_type` can be passed around where necessary.
    """

    @Experimental()
    @Deprecated(since="1.2.3", detail="Use :func:`better_get_columns`")
    def get_columns(self) -> List[Column]:
        pass
```

Will produce the following on the documentation for the function `ResolvedSchema.get_columns`:
<img width="709" alt="Screenshot 2025-03-04 at 17 56 30" src="https://github.com/user-attachments/assets/a35bf02e-5cc9-42c0-8de1-f162752fd768" />
 


## Brief change log

  - Added `PublicEvolving/Deprecated/Internal/Experimental` decorators for Pyflink APIs.
  - Aligned Python Table API object's API annotations with those on the Java side.

## Verifying this change

This change added tests and can be verified as follows:

- Building the documentation and observing the output on class/function autosummary docs.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
