### PR TITLE
[FLINK-37302][table] Support PTFs with time and timer services

### DIFF
--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/test/program/TableTestProgram.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/test/program/TableTestProgram.java
@@ -329,8 +329,11 @@ public class TableTestProgram {
          * Run step for executing SQL that will fail eventually with a {@link
          * TableRuntimeException}.
          */
-        public Builder runFailingSql(String sql, String expectedErrorMessage) {
-            this.runSteps.add(new FailingSqlTestStep(sql, expectedErrorMessage));
+        public Builder runFailingSql(
+                String sql,
+                Class<? extends Exception> expectedException,
+                String expectedErrorMessage) {
+            this.runSteps.add(new FailingSqlTestStep(sql, expectedException, expectedErrorMessage));
             return this;
         }
 

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/test/program/TableTestProgram.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/test/program/TableTestProgram.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.test.program;
 
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.TableRuntimeException;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.functions.UserDefinedFunction;
 import org.apache.flink.table.test.program.FunctionTestStep.FunctionBehavior;
@@ -321,6 +322,15 @@ public class TableTestProgram {
         /** Run step for executing SQL. */
         public Builder runSql(String sql) {
             this.runSteps.add(new SqlTestStep(sql));
+            return this;
+        }
+
+        /**
+         * Run step for executing SQL that will fail eventually with a {@link
+         * TableRuntimeException}.
+         */
+        public Builder runFailingSql(String sql, String expectedErrorMessage) {
+            this.runSteps.add(new FailingSqlTestStep(sql, expectedErrorMessage));
             return this;
         }
 

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/test/program/TestStep.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/test/program/TestStep.java
@@ -50,6 +50,7 @@ public interface TestStep {
         SINK_WITHOUT_DATA,
         SINK_WITH_DATA,
         SINK_WITH_RESTORE_DATA,
+        FAILING_SQL
     }
 
     TestKind getKind();

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/ProcessTableFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/ProcessTableFunction.java
@@ -349,6 +349,7 @@ import java.time.LocalDateTime;
  *     collect("Timeout for: " + memory.seen)
  *   }
  * }
+ * </pre>
  *
  * <h2>Efficiency and Design Principles</h2>
  *

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/ProcessTableFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/ProcessTableFunction.java
@@ -578,6 +578,7 @@ public abstract class ProcessTableFunction<T> extends UserDefinedFunction {
     }
 
     /** Special {@link Context} that is available when the {@code onTimer()} method is called. */
+    @PublicEvolving
     public interface OnTimerContext extends Context {
 
         /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/ProcessTableFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/ProcessTableFunction.java
@@ -295,10 +295,10 @@ import java.time.LocalDateTime;
  *
  * <h2>Time</h2>
  *
- * <p>Every PTF takes an optional {@code on_time} argument. The {@code on_time} argument in the function call declares the time attribute column for which
- * a watermark has been declared. When processing a table's row, this timestamp can be accessed via
- * {@link TimeContext#time()} and the watermark via {@link TimeContext#currentWatermark()}
- * respectively.
+ * <p>Every PTF takes an optional {@code on_time} argument. The {@code on_time} argument in the
+ * function call declares the time attribute column for which a watermark has been declared. When
+ * processing a table's row, this timestamp can be accessed via {@link TimeContext#time()} and the
+ * watermark via {@link TimeContext#currentWatermark()} respectively.
  *
  * <p>Specifying an {@code on_time} argument in the function call instructs the framework to return
  * a {@code rowtime} column in the function's output for subsequent time-based operations.
@@ -309,16 +309,17 @@ import java.time.LocalDateTime;
  * <h2>Timers</h2>
  *
  * <p>A PTF that takes set semantic tables can support timers. Timers allow for continuing the
- * processing at a later point in time. This makes waiting, synchronization, or timeouts possible. A timer
- * fires for the registered time when the watermark progresses the logical clock.
+ * processing at a later point in time. This makes waiting, synchronization, or timeouts possible. A
+ * timer fires for the registered time when the watermark progresses the logical clock.
  *
  * <p>Timers can be named ({@link TimeContext#registerOnTime(String, Object)}) or unnamed ({@link
  * TimeContext#registerOnTime(Object)}). The name of a timer can be useful for replacing or deleting
- * an existing timer, or for identifying multiple timers via {@link OnTimerContext#currentTimer()} when they fire.
+ * an existing timer, or for identifying multiple timers via {@link OnTimerContext#currentTimer()}
+ * when they fire.
  *
  * <p>An {@code onTimer()} method must be declared next to the eval() method for reacting to timer
- * events. The signature of the onTimer() method must contain an optional {@link OnTimerContext} followed by all
- * state entries (as declared in the eval() method).
+ * events. The signature of the onTimer() method must contain an optional {@link OnTimerContext}
+ * followed by all state entries (as declared in the eval() method).
  *
  * <p>Flink takes care of storing and restoring timers during failures or restarts. Thus, timers are
  * a special kind of state. Similarly, timers are scoped to a virtual processor defined by the
@@ -349,7 +350,7 @@ import java.time.LocalDateTime;
  *     collect("Timeout for: " + memory.seen)
  *   }
  * }
- * </pre>
+ * }</pre>
  *
  * <h2>Efficiency and Design Principles</h2>
  *

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/ProcessTableFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/ProcessTableFunction.java
@@ -332,10 +332,7 @@ import java.time.LocalDateTime;
  *     public String seen = null;
  *   }
  *
- *   public void eval(
- *       Context ctx,
- *       @StateHint SeenState memory,
- *       @ArgumentHint( { TABLE_AS_SET, REQUIRE_ON_TIME } ) Row input) {
+ *   public void eval(Context ctx, @StateHint SeenState memory, @ArgumentHint( { TABLE_AS_SET, REQUIRE_ON_TIME } ) Row input) {
  *     TimeContext<Instant> timeCtx = ctx.timeContext(Instant.class);
  *     if (memory.seen == null) {
  *       memory.seen = input.getField(0).toString();

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/UserDefinedFunctionHelper.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/UserDefinedFunctionHelper.java
@@ -95,6 +95,8 @@ public final class UserDefinedFunctionHelper {
 
     public static final String PROCESS_TABLE_EVAL = "eval";
 
+    public static final String PROCESS_TABLE_ON_TIMER = "onTimer";
+
     public static final String DEFAULT_ACCUMULATOR_NAME = "acc";
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/StaticArgumentTrait.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/StaticArgumentTrait.java
@@ -32,13 +32,19 @@ import java.util.stream.Collectors;
  */
 @PublicEvolving
 public enum StaticArgumentTrait {
+    // Roots
     SCALAR(),
     TABLE(),
     MODEL(),
+
+    // For TABLE
     TABLE_AS_ROW(TABLE),
     TABLE_AS_SET(TABLE),
     PASS_COLUMNS_THROUGH(TABLE),
     SUPPORT_UPDATES(TABLE),
+    REQUIRE_ON_TIME(TABLE),
+
+    // For TABLE_AS_SET
     OPTIONAL_PARTITION_BY(TABLE_AS_SET);
 
     private final Set<StaticArgumentTrait> requirements;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/SystemTypeInference.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/SystemTypeInference.java
@@ -28,13 +28,24 @@ import org.apache.flink.table.functions.FunctionKind;
 import org.apache.flink.table.functions.ProcessTableFunction;
 import org.apache.flink.table.functions.TableSemantics;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.RowType.RowField;
+import org.apache.flink.table.types.logical.TimestampKind;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
+import org.apache.flink.table.types.logical.utils.LogicalTypeMerging;
+import org.apache.flink.types.ColumnList;
 
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -57,7 +68,11 @@ import java.util.stream.Stream;
 public class SystemTypeInference {
 
     public static final List<StaticArgument> PROCESS_TABLE_FUNCTION_SYSTEM_ARGS =
-            List.of(StaticArgument.scalar("uid", DataTypes.STRING(), true));
+            List.of(
+                    StaticArgument.scalar("on_time", DataTypes.DESCRIPTOR(), true),
+                    StaticArgument.scalar("uid", DataTypes.STRING(), true));
+
+    public static final String PROCESS_TABLE_FUNCTION_RESULT_ROWTIME = "rowtime";
 
     /**
      * Format of unique identifiers for {@link ProcessTableFunction}.
@@ -129,10 +144,10 @@ public class SystemTypeInference {
     private static void checkReservedArgs(List<StaticArgument> staticArgs) {
         final Set<String> declaredArgs =
                 staticArgs.stream().map(StaticArgument::getName).collect(Collectors.toSet());
-        final Set<String> reservedArgs =
+        final List<String> reservedArgs =
                 PROCESS_TABLE_FUNCTION_SYSTEM_ARGS.stream()
                         .map(StaticArgument::getName)
-                        .collect(Collectors.toSet());
+                        .collect(Collectors.toList());
         if (reservedArgs.stream().anyMatch(declaredArgs::contains)) {
             throw new ValidationException(
                     "Function signature must not declare system arguments. "
@@ -177,15 +192,18 @@ public class SystemTypeInference {
         if (functionKind != FunctionKind.TABLE && functionKind != FunctionKind.PROCESS_TABLE) {
             return outputStrategy;
         }
-        return new SystemOutputStrategy(staticArgs, outputStrategy);
+        return new SystemOutputStrategy(functionKind, staticArgs, outputStrategy);
     }
 
     private static class SystemOutputStrategy implements TypeStrategy {
 
+        private final FunctionKind functionKind;
         private final List<StaticArgument> staticArgs;
         private final TypeStrategy origin;
 
-        private SystemOutputStrategy(List<StaticArgument> staticArgs, TypeStrategy origin) {
+        private SystemOutputStrategy(
+                FunctionKind functionKind, List<StaticArgument> staticArgs, TypeStrategy origin) {
+            this.functionKind = functionKind;
             this.staticArgs = staticArgs;
             this.origin = origin;
         }
@@ -208,6 +226,7 @@ public class SystemTypeInference {
                                 // this whole topic is kind of vendor specific already
                                 fields.addAll(derivePassThroughFields(callContext));
                                 fields.addAll(deriveFunctionOutputFields(functionDataType));
+                                fields.addAll(deriveRowtimeField(callContext));
 
                                 final List<Field> uniqueFields = makeFieldNamesUnique(fields);
 
@@ -233,7 +252,7 @@ public class SystemTypeInference {
         }
 
         private List<Field> derivePassThroughFields(CallContext callContext) {
-            if (staticArgs == null) {
+            if (functionKind != FunctionKind.PROCESS_TABLE) {
                 return List.of();
             }
             final List<DataType> argDataTypes = callContext.getArgumentDataTypes();
@@ -275,6 +294,149 @@ public class SystemTypeInference {
                     .mapToObj(pos -> DataTypes.FIELD(fieldNames.get(pos), fieldTypes.get(pos)))
                     .collect(Collectors.toList());
         }
+
+        private List<Field> deriveRowtimeField(CallContext callContext) {
+            if (this.functionKind != FunctionKind.PROCESS_TABLE) {
+                return List.of();
+            }
+            final List<DataType> args = callContext.getArgumentDataTypes();
+
+            // Check if on_time is defined and non-empty
+            final int onTimePos = args.size() - 2;
+            final Set<String> onTimeFields =
+                    callContext
+                            .getArgumentValue(onTimePos, ColumnList.class)
+                            .map(ColumnList::getNames)
+                            .map(Set::copyOf)
+                            .orElse(Set.of());
+
+            final Set<String> usedOnTimeFields = new HashSet<>();
+
+            final List<LogicalType> onTimeColumns =
+                    IntStream.range(0, staticArgs.size())
+                            .mapToObj(
+                                    pos -> {
+                                        final StaticArgument staticArg = staticArgs.get(pos);
+                                        if (!staticArg.is(StaticArgumentTrait.TABLE)) {
+                                            return null;
+                                        }
+                                        final RowType rowType =
+                                                (RowType) args.get(pos).getLogicalType();
+                                        final int onTimeColumn =
+                                                findUniqueOnTimeColumn(
+                                                        staticArg.getName(), rowType, onTimeFields);
+                                        if (onTimeColumn >= 0) {
+                                            usedOnTimeFields.add(
+                                                    rowType.getFieldNames().get(onTimeColumn));
+                                            return rowType.getTypeAt(onTimeColumn);
+                                        }
+                                        if (staticArg.is(StaticArgumentTrait.REQUIRE_ON_TIME)) {
+                                            throw new ValidationException(
+                                                    String.format(
+                                                            "Table argument '%s' requires a time attribute. "
+                                                                    + "Please provide one using the implicit `on_time` argument. "
+                                                                    + "For example: myFunction(..., on_time => DESCRIPTOR(`my_timestamp`)",
+                                                            staticArg.getName()));
+                                        }
+                                        return null;
+                                    })
+                            .filter(Objects::nonNull)
+                            .collect(Collectors.toList());
+
+            final Set<String> unusedOnTimeFields = new HashSet<>(onTimeFields);
+            unusedOnTimeFields.removeAll(usedOnTimeFields);
+            if (!unusedOnTimeFields.isEmpty()) {
+                throw new ValidationException(
+                        "Invalid time attribute declaration. "
+                                + "Each column in the `on_time` argument must reference at least one "
+                                + "column in one of the table arguments. Unknown references: "
+                                + unusedOnTimeFields);
+            }
+
+            if (onTimeColumns.isEmpty()) {
+                return List.of();
+            }
+
+            // Don't allow mixtures of time attribute roots
+            if (onTimeColumns.stream().map(LogicalType::getTypeRoot).distinct().count() > 1) {
+                throw new ValidationException(
+                        "Invalid time attribute declaration. "
+                                + "All columns in the `on_time` argument must reference the same data type kind.");
+            }
+
+            final LogicalType commonOnTimeType =
+                    LogicalTypeMerging.findCommonType(onTimeColumns)
+                            .orElseThrow(
+                                    () ->
+                                            new IllegalStateException(
+                                                    "Unable to derive data type for PTF result time attribute."));
+
+            final LogicalType resultTimestamp =
+                    forwardTimeAttribute(commonOnTimeType, onTimeColumns);
+
+            return List.of(
+                    DataTypes.FIELD(
+                            PROCESS_TABLE_FUNCTION_RESULT_ROWTIME, DataTypes.of(resultTimestamp)));
+        }
+
+        private static int findUniqueOnTimeColumn(
+                String tableArgName, RowType rowType, Set<String> onTimeFields) {
+            final List<RowField> fields = rowType.getFields();
+            int found = -1;
+            for (int pos = 0; pos < fields.size(); pos++) {
+                final RowField field = fields.get(pos);
+                if (!onTimeFields.contains(field.getName())) {
+                    continue;
+                }
+                if (found != -1) {
+                    throw new ValidationException(
+                            String.format(
+                                    "Ambiguous time attribute found. "
+                                            + "The `on_time` argument must reference at most one column in a table argument. "
+                                            + "Currently, the columns in `on_time` point to both '%s' and '%s' in table argument '%s'.",
+                                    fields.get(found).getName(), field.getName(), tableArgName));
+                }
+                found = pos;
+                if (isUnsupportedOnTimeColumn(field.getType())) {
+                    throw new ValidationException(
+                            String.format(
+                                    "Unsupported data type for time attribute. "
+                                            + "The `on_time` argument must reference a TIMESTAMP or TIMESTAMP_LTZ column (up to precision 3). "
+                                            + "However, column '%s' in table argument '%s' has data type '%s'.",
+                                    field.getName(),
+                                    tableArgName,
+                                    field.getType().asSummaryString()));
+                }
+            }
+            return found;
+        }
+
+        private static LogicalType forwardTimeAttribute(
+                LogicalType timestampType, List<LogicalType> onTimeColumns) {
+            if (onTimeColumns.stream().noneMatch(LogicalTypeChecks::isTimeAttribute)) {
+                return timestampType.copy(false);
+            }
+            switch (timestampType.getTypeRoot()) {
+                case TIMESTAMP_WITHOUT_TIME_ZONE:
+                    return new TimestampType(
+                            false,
+                            TimestampKind.ROWTIME,
+                            LogicalTypeChecks.getPrecision(timestampType));
+                case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                    return new LocalZonedTimestampType(
+                            false,
+                            TimestampKind.ROWTIME,
+                            LogicalTypeChecks.getPrecision(timestampType));
+                default:
+                    throw new IllegalStateException(
+                            "Timestamp type expected for PTF result time attribute.");
+            }
+        }
+
+        private static boolean isUnsupportedOnTimeColumn(LogicalType type) {
+            return !LogicalTypeChecks.canBeTimeAttributeType(type)
+                    || LogicalTypeChecks.getPrecision(type) > 3;
+        }
     }
 
     private static class SystemInputStrategy implements InputTypeStrategy {
@@ -312,8 +474,8 @@ public class SystemTypeInference {
                                 + "that is not overloaded and doesn't contain varargs.");
             }
 
-            checkUidArg(callContext);
             checkTableArgTraits(staticArgs, callContext);
+            checkUidArg(callContext);
 
             return Optional.of(inferredDataTypes);
         }
@@ -329,7 +491,7 @@ public class SystemTypeInference {
             final List<DataType> args = callContext.getArgumentDataTypes();
 
             // Verify the uid format if provided
-            int uidPos = args.size() - 1;
+            final int uidPos = args.size() - 1;
             if (!callContext.isArgumentNull(uidPos)) {
                 final String uid = callContext.getArgumentValue(uidPos, String.class).orElse("");
                 if (isInvalidUidForProcessTableFunction(uid)) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/SystemTypeInference.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/SystemTypeInference.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.functions.TableSemantics;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.RowType.RowField;
 import org.apache.flink.table.types.logical.TimestampKind;
@@ -358,10 +359,16 @@ public class SystemTypeInference {
             }
 
             // Don't allow mixtures of time attribute roots
-            if (onTimeColumns.stream().map(LogicalType::getTypeRoot).distinct().count() > 1) {
+            final Set<LogicalTypeRoot> onTimeRoots =
+                    onTimeColumns.stream()
+                            .map(LogicalType::getTypeRoot)
+                            .collect(Collectors.toSet());
+            if (onTimeRoots.size() > 1) {
                 throw new ValidationException(
                         "Invalid time attribute declaration. "
-                                + "All columns in the `on_time` argument must reference the same data type kind.");
+                                + "All columns in the `on_time` argument must reference the same data type kind. "
+                                + "But found: "
+                                + onTimeRoots);
             }
 
             final LogicalType commonOnTimeType =

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionSemanticTests.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionSemanticTests.java
@@ -47,6 +47,19 @@ public class ProcessTableFunctionSemanticTests extends SemanticTestBase {
                 ProcessTableFunctionTestPrograms.PROCESS_MULTI_STATE,
                 ProcessTableFunctionTestPrograms.PROCESS_CLEARING_STATE,
                 ProcessTableFunctionTestPrograms.PROCESS_STATE_TTL,
-                ProcessTableFunctionTestPrograms.PROCESS_DESCRIPTOR);
+                ProcessTableFunctionTestPrograms.PROCESS_DESCRIPTOR,
+                ProcessTableFunctionTestPrograms.PROCESS_TIME_CONVERSIONS,
+                ProcessTableFunctionTestPrograms.PROCESS_REGULAR_TIMESTAMP,
+                ProcessTableFunctionTestPrograms.PROCESS_NAMED_TIMERS,
+                ProcessTableFunctionTestPrograms.PROCESS_UNNAMED_TIMERS,
+                ProcessTableFunctionTestPrograms.PROCESS_LATE_EVENTS,
+                ProcessTableFunctionTestPrograms.PROCESS_SCALAR_ARGS_TIME,
+                ProcessTableFunctionTestPrograms.PROCESS_OPTIONAL_PARTITION_BY_TIME,
+                ProcessTableFunctionTestPrograms.PROCESS_OPTIONAL_ON_TIME,
+                ProcessTableFunctionTestPrograms.PROCESS_POJO_STATE_TIME,
+                ProcessTableFunctionTestPrograms.PROCESS_CHAINED_TIME,
+                ProcessTableFunctionTestPrograms.PROCESS_INVALID_TABLE_AS_ROW_TIMERS,
+                ProcessTableFunctionTestPrograms.PROCESS_INVALID_PASS_THROUGH_TIMERS,
+                ProcessTableFunctionTestPrograms.PROCESS_INVALID_UPDATING_TIMERS);
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionTestPrograms.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionTestPrograms.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.plan.nodes.exec.stream;
 
+import org.apache.flink.table.api.TableRuntimeException;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.AtomicTypeWrappingFunction;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.ChainedReceivingFunction;
@@ -718,6 +719,7 @@ public class ProcessTableFunctionTestPrograms {
                     .setupSql(BASIC_VALUES)
                     .runFailingSql(
                             "SELECT * FROM f(r => TABLE t)",
+                            TableRuntimeException.class,
                             "Timers are not supported in the current PTF declaration.")
                     .build();
 
@@ -729,6 +731,7 @@ public class ProcessTableFunctionTestPrograms {
                     .setupTableSource(TIMED_SOURCE)
                     .runFailingSql(
                             "SELECT * FROM f(r => TABLE t PARTITION BY name, on_time => DESCRIPTOR(ts))",
+                            TableRuntimeException.class,
                             "Timers are not supported in the current PTF declaration.")
                     .build();
 
@@ -740,6 +743,7 @@ public class ProcessTableFunctionTestPrograms {
                     .setupSql(UPDATING_VALUES)
                     .runFailingSql(
                             "SELECT * FROM f(r => TABLE t PARTITION BY name)",
+                            TableRuntimeException.class,
                             "Timers are not supported in the current PTF declaration.")
                     .build();
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionTestUtils.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionTestUtils.java
@@ -29,13 +29,18 @@ import org.apache.flink.table.runtime.operators.process.ProcessTableOperator;
 import org.apache.flink.types.ColumnList;
 import org.apache.flink.types.Row;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+
 import static org.apache.flink.table.annotation.ArgumentTrait.OPTIONAL_PARTITION_BY;
 import static org.apache.flink.table.annotation.ArgumentTrait.PASS_COLUMNS_THROUGH;
+import static org.apache.flink.table.annotation.ArgumentTrait.REQUIRE_ON_TIME;
 import static org.apache.flink.table.annotation.ArgumentTrait.SUPPORT_UPDATES;
 import static org.apache.flink.table.annotation.ArgumentTrait.TABLE_AS_ROW;
 import static org.apache.flink.table.annotation.ArgumentTrait.TABLE_AS_SET;
 
 /** Testing functions for {@link ProcessTableFunction}. */
+@SuppressWarnings("unused")
 public class ProcessTableFunctionTestUtils {
 
     /** Testing function. */
@@ -47,12 +52,67 @@ public class ProcessTableFunctionTestUtils {
 
     @DataTypeHint("ROW<`out` STRING>")
     public abstract static class TestProcessTableFunctionBase extends ProcessTableFunction<Row> {
-        public void collectObjects(Object... objects) {
+        protected void collectObjects(Object... objects) {
             // Row.toString is useful because it can handle all common objects,
             // but we use '{}' to indicate that this is a custom string output.
             final String asString = Row.of(objects).toString();
             final String objectsAsString = asString.substring(3, asString.length() - 1);
             collect(Row.of("{" + objectsAsString + "}"));
+        }
+
+        protected void collectEvalEvent(TimeContext<Long> timeCtx, Row r) {
+            collectObjects(
+                    String.format(
+                            "Processing input row %s at time %s watermark %s",
+                            r, timeCtx.time(), timeCtx.currentWatermark()));
+        }
+
+        protected void collectOnTimerEvent(OnTimerContext ctx) {
+            final TimeContext<Long> timeCtx = ctx.timeContext(Long.class);
+            collectObjects(
+                    String.format(
+                            "Timer %s fired at time %s watermark %s",
+                            ctx.currentTimer(), timeCtx.time(), timeCtx.currentWatermark()));
+        }
+
+        protected void collectCreateTimer(TimeContext<Long> timeCtx, String name, long time) {
+            collectObjects(
+                    String.format(
+                            "Registering timer %s for %s at time %s watermark %s",
+                            name, time, timeCtx.time(), timeCtx.currentWatermark()));
+            timeCtx.registerOnTime(name, time);
+        }
+
+        protected void collectCreateTimer(TimeContext<Long> timeCtx, long time) {
+            collectObjects(
+                    String.format(
+                            "Registering timer for %s at time %s watermark %s",
+                            time, timeCtx.time(), timeCtx.currentWatermark()));
+            timeCtx.registerOnTime(time);
+        }
+
+        protected void collectClearTimer(TimeContext<Long> timeCtx, String name) {
+            collectObjects(
+                    String.format(
+                            "Clearing timer %s at time %s watermark %s",
+                            name, timeCtx.time(), timeCtx.currentWatermark()));
+            timeCtx.clearTimer(name);
+        }
+
+        protected void collectClearTimer(TimeContext<Long> timeCtx, long time) {
+            collectObjects(
+                    String.format(
+                            "Clearing timer %s at time %s watermark %s",
+                            time, timeCtx.time(), timeCtx.currentWatermark()));
+            timeCtx.clearTimer(time);
+        }
+
+        protected void collectClearAllTimers(TimeContext<Long> timeCtx) {
+            collectObjects(
+                    String.format(
+                            "Clearing all timers at time %s watermark %s",
+                            timeCtx.time(), timeCtx.currentWatermark()));
+            timeCtx.clearAllTimers();
         }
     }
 
@@ -208,7 +268,6 @@ public class ProcessTableFunctionTestUtils {
 
     /** Testing function. */
     public static class TimeToLiveStateFunction extends ProcessTableFunction<String> {
-        @SuppressWarnings("unused")
         public void eval(
                 Context ctx,
                 @StateHint(type = @DataTypeHint("ROW<emitted BOOLEAN>")) Row s0,
@@ -216,8 +275,8 @@ public class ProcessTableFunctionTestUtils {
                 @StateHint(ttl = "0") Score s2,
                 @StateHint Score s3,
                 @ArgumentHint({TABLE_AS_SET, OPTIONAL_PARTITION_BY}) Row r) {
-            final ProcessTableOperator.ProcessFunctionContext internalContext =
-                    (ProcessTableOperator.ProcessFunctionContext) ctx;
+            final ProcessTableOperator.RunnerContext internalContext =
+                    (ProcessTableOperator.RunnerContext) ctx;
             if (s0.getFieldAs("emitted") == null) {
                 collect(
                         String.format(
@@ -237,6 +296,241 @@ public class ProcessTableFunctionTestUtils {
                 @ArgumentHint(isOptional = true) ColumnList columnList2,
                 @DataTypeHint("DESCRIPTOR NOT NULL") ColumnList columnList3) {
             collectObjects(columnList1, columnList2, columnList3);
+        }
+    }
+
+    /** Testing function. */
+    public static class RequiredTimeFunction extends TestProcessTableFunctionBase {
+        public void eval(@ArgumentHint({ArgumentTrait.TABLE_AS_ROW, REQUIRE_ON_TIME}) Row r) {
+            collectObjects(r);
+        }
+    }
+
+    /** Testing function. */
+    public static class TimeConversionsFunction extends TestProcessTableFunctionBase {
+        public void eval(Context ctx, @ArgumentHint({TABLE_AS_ROW, REQUIRE_ON_TIME}) Row r) {
+            final TimeContext<Long> asLong = ctx.timeContext(Long.class);
+            final TimeContext<Instant> asInstant = ctx.timeContext(Instant.class);
+            final TimeContext<LocalDateTime> asLocalDateTime = ctx.timeContext(LocalDateTime.class);
+            // read
+            collectObjects(
+                    String.format(
+                            "Time (Long: %s, Instant: %s, LocalDateTime: %s), "
+                                    + "Watermark (Long: %s, Instant: %s, LocalDateTime: %s)",
+                            asLong.time(),
+                            asInstant.time(),
+                            asLocalDateTime.time(),
+                            asLong.currentWatermark(),
+                            asInstant.currentWatermark(),
+                            asLocalDateTime.currentWatermark()));
+        }
+    }
+
+    /** Testing function. */
+    @SuppressWarnings("SameParameterValue")
+    public static class NamedTimersFunction extends TestProcessTableFunctionBase {
+        public void eval(Context ctx, @ArgumentHint({TABLE_AS_SET, REQUIRE_ON_TIME}) Row r) {
+            final TimeContext<Long> timeCtx = ctx.timeContext(Long.class);
+            collectEvalEvent(timeCtx, r);
+
+            if (timeCtx.time() == 0) {
+                // create
+                collectCreateTimer(timeCtx, "timeout1", timeCtx.time() + 1);
+                collectCreateTimer(timeCtx, "timeout2", timeCtx.time() + 2);
+                collectCreateTimer(timeCtx, "timeout3", timeCtx.time() + 3);
+                collectCreateTimer(timeCtx, "timeout4", Long.MAX_VALUE);
+                collectCreateTimer(timeCtx, "timeout5", Long.MAX_VALUE);
+            }
+        }
+
+        public void onTimer(OnTimerContext ctx) {
+            final TimeContext<Long> timeCtx = ctx.timeContext(Long.class);
+            // read
+            collectOnTimerEvent(ctx);
+            if (ctx.currentTimer().equals("timeout1")) {
+                // replace
+                collectCreateTimer(timeCtx, "timeout2", timeCtx.time() + 4);
+                // clear
+                collectClearTimer(timeCtx, "timeout3");
+            } else if (ctx.currentTimer().equals("timeout2")) {
+                // clear all
+                collectClearAllTimers(timeCtx);
+            }
+        }
+    }
+
+    /** Testing function. */
+    @SuppressWarnings("SameParameterValue")
+    public static class UnnamedTimersFunction extends TestProcessTableFunctionBase {
+        public void eval(Context ctx, @ArgumentHint({TABLE_AS_SET, REQUIRE_ON_TIME}) Row r) {
+            final TimeContext<Long> timeCtx = ctx.timeContext(Long.class);
+            collectEvalEvent(timeCtx, r);
+
+            if (timeCtx.time() == 0) {
+                // create
+                collectCreateTimer(timeCtx, timeCtx.time() + 1);
+                collectCreateTimer(timeCtx, timeCtx.time() + 2);
+                collectCreateTimer(timeCtx, Long.MAX_VALUE);
+            }
+        }
+
+        public void onTimer(OnTimerContext ctx) {
+            final TimeContext<Long> timeCtx = ctx.timeContext(Long.class);
+            // read
+            collectOnTimerEvent(ctx);
+            if (timeCtx.time() == 1) {
+                // re-create
+                collectCreateTimer(timeCtx, timeCtx.time() + 4);
+                // clear
+                collectClearTimer(timeCtx, 2);
+            } else if (timeCtx.time() == 5) {
+                // clear all
+                collectClearAllTimers(timeCtx);
+            }
+        }
+    }
+
+    /** Testing function. */
+    public static class LateTimersFunction extends TestProcessTableFunctionBase {
+        public void eval(Context ctx, @ArgumentHint({TABLE_AS_SET, REQUIRE_ON_TIME}) Row r) {
+            final TimeContext<Long> timeCtx = ctx.timeContext(Long.class);
+            collectEvalEvent(timeCtx, r);
+            // all timers should be executed once
+            if (timeCtx.time() == 99998) {
+                // will never be fired because it's late
+                collectCreateTimer(timeCtx, "late", 1L);
+            }
+            collectCreateTimer(timeCtx, "t", 0L);
+            collectCreateTimer(timeCtx, 0L);
+        }
+
+        public void onTimer(OnTimerContext ctx) {
+            final TimeContext<Long> timeCtx = ctx.timeContext(Long.class);
+            collectOnTimerEvent(ctx);
+            // will never be fired because it's late
+            collectCreateTimer(timeCtx, "again", timeCtx.time());
+        }
+    }
+
+    /** Testing function. */
+    public static class ScalarArgsTimeFunction extends TestProcessTableFunctionBase {
+        public void eval(Context ctx) {
+            final TimeContext<Long> timeCtx = ctx.timeContext(Long.class);
+            collectObjects(
+                    String.format(
+                            "Time %s and watermark %s",
+                            timeCtx.time(), timeCtx.currentWatermark()));
+        }
+    }
+
+    /** Testing function. */
+    public static class OptionalPartitionOnTimeFunction extends TestProcessTableFunctionBase {
+        public void eval(
+                Context ctx,
+                @ArgumentHint({TABLE_AS_SET, OPTIONAL_PARTITION_BY, REQUIRE_ON_TIME}) Row r) {
+            final TimeContext<Long> timeCtx = ctx.timeContext(Long.class);
+            collectEvalEvent(timeCtx, r);
+            if (timeCtx.time() == 0) {
+                collectCreateTimer(timeCtx, "t", timeCtx.time() + 1);
+            }
+        }
+
+        public void onTimer(OnTimerContext ctx) {
+            final TimeContext<Long> timeCtx = ctx.timeContext(Long.class);
+            collectOnTimerEvent(ctx);
+            if (ctx.currentTimer().equals("t")) {
+                collectCreateTimer(timeCtx, "again", timeCtx.time() + 1);
+            }
+        }
+    }
+
+    /** Testing function. */
+    public static class OptionalOnTimeFunction extends TestProcessTableFunctionBase {
+        public void eval(Context ctx, @ArgumentHint(TABLE_AS_SET) Row r) {
+            final TimeContext<Long> timeCtx = ctx.timeContext(Long.class);
+            collectEvalEvent(timeCtx, r);
+            collectCreateTimer(timeCtx, "t", 2);
+        }
+
+        public void onTimer(OnTimerContext ctx) {
+            final TimeContext<Long> timeCtx = ctx.timeContext(Long.class);
+            collectOnTimerEvent(ctx);
+        }
+    }
+
+    /** Testing function. */
+    public static class PojoStateTimeFunction extends TestProcessTableFunctionBase {
+        public void eval(
+                Context ctx,
+                @StateHint Score s,
+                @ArgumentHint({TABLE_AS_SET, REQUIRE_ON_TIME}) Row r) {
+            final TimeContext<Long> timeCtx = ctx.timeContext(Long.class);
+            collectObjects(s, r);
+            if (s.i == null) {
+                s.i = 1;
+                collectCreateTimer(timeCtx, "t", timeCtx.time() + 2);
+            } else {
+                s.i += 1;
+            }
+        }
+
+        public void onTimer(OnTimerContext ctx, Score s) {
+            final TimeContext<Long> timeCtx = ctx.timeContext(Long.class);
+            collectOnTimerEvent(ctx);
+            s.i *= 10;
+        }
+    }
+
+    /** Testing function. */
+    public static class ChainedSendingFunction extends TestProcessTableFunctionBase {
+        public void eval(
+                Context ctx,
+                @ArgumentHint({TABLE_AS_SET, OPTIONAL_PARTITION_BY, REQUIRE_ON_TIME}) Row r) {
+            final TimeContext<Long> timeCtx = ctx.timeContext(Long.class);
+            collectEvalEvent(timeCtx, r);
+            collectCreateTimer(timeCtx, "t", timeCtx.time() + 1);
+        }
+
+        public void onTimer(OnTimerContext ctx) {
+            final TimeContext<Long> timeCtx = ctx.timeContext(Long.class);
+            collectOnTimerEvent(ctx);
+            collectObjects(timeCtx.time());
+        }
+    }
+
+    /** Testing function. */
+    public static class ChainedReceivingFunction extends TestProcessTableFunctionBase {
+        public void eval(
+                Context ctx,
+                @ArgumentHint({TABLE_AS_SET, OPTIONAL_PARTITION_BY, REQUIRE_ON_TIME}) Row r) {
+            final TimeContext<Long> timeCtx = ctx.timeContext(Long.class);
+            collectEvalEvent(timeCtx, r);
+        }
+    }
+
+    /** Testing function. */
+    public static class InvalidTableAsRowTimersFunction extends TestProcessTableFunctionBase {
+        public void eval(Context ctx, @ArgumentHint(TABLE_AS_ROW) Row r) {
+            final TimeContext<Long> timeCtx = ctx.timeContext(Long.class);
+            timeCtx.registerOnTime(42L);
+        }
+    }
+
+    /** Testing function. */
+    public static class InvalidPassThroughTimersFunction extends TestProcessTableFunctionBase {
+        public void eval(
+                Context ctx,
+                @ArgumentHint({TABLE_AS_SET, PASS_COLUMNS_THROUGH, REQUIRE_ON_TIME}) Row r) {
+            final TimeContext<Long> timeCtx = ctx.timeContext(Long.class);
+            timeCtx.registerOnTime(42L);
+        }
+    }
+
+    /** Testing function. */
+    public static class InvalidUpdatingTimersFunction extends TestProcessTableFunctionBase {
+        public void eval(Context ctx, @ArgumentHint({TABLE_AS_SET, SUPPORT_UPDATES}) Row r) {
+            final TimeContext<Long> timeCtx = ctx.timeContext(Long.class);
+            timeCtx.registerOnTime(42L);
         }
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.functions.TableFunction;
 import org.apache.flink.table.functions.UserDefinedFunction;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.DescriptorFunction;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.EmptyArgFunction;
+import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.RequiredTimeFunction;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.ScalarArgsFunction;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.TableAsRowFunction;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.TableAsRowPassThroughFunction;
@@ -76,6 +77,10 @@ public class ProcessTableFunctionTest extends TableTestBase {
                 .executeSql("CREATE VIEW t_type_diff AS SELECT 'Bob' AS name, TRUE AS isValid");
         util.tableEnv()
                 .executeSql("CREATE VIEW t_updating AS SELECT name, COUNT(*) FROM t GROUP BY name");
+        util.tableEnv()
+                .executeSql(
+                        "CREATE TABLE t_watermarked (name STRING, score INT, ts TIMESTAMP_LTZ(3), WATERMARK FOR ts AS ts) "
+                                + "WITH ('connector' = 'datagen')");
         util.tableEnv()
                 .executeSql("CREATE TABLE t_sink (`out` STRING) WITH ('connector' = 'blackhole')");
         util.tableEnv()
@@ -143,6 +148,13 @@ public class ProcessTableFunctionTest extends TableTestBase {
                         + "columnList1 => DESCRIPTOR(a), "
                         + "columnList2 => DESCRIPTOR(b, c), "
                         + "columnList3 => DESCRIPTOR())");
+    }
+
+    @Test
+    void testOnTime() {
+        util.addTemporarySystemFunction("f", RequiredTimeFunction.class);
+        util.verifyRelPlan(
+                "SELECT `out`, `rowtime` FROM f(r => TABLE t_watermarked, on_time => DESCRIPTOR(ts))");
     }
 
     @Test
@@ -232,7 +244,7 @@ public class ProcessTableFunctionTest extends TableTestBase {
                         // function expects <STRING name, INT score>
                         "SELECT * FROM f(u => TABLE t_type_diff, i => 1)",
                         "No match found for function signature "
-                                + "f(<RecordType(CHAR(3) name, BOOLEAN isValid)>, <NUMERIC>, <CHARACTER>)"),
+                                + "f(<RecordType(CHAR(3) name, BOOLEAN isValid)>, <NUMERIC>, <COLUMN_LIST>, <CHARACTER>)"),
                 ErrorSpec.of(
                         "table as set with missing partition by",
                         TableAsSetFunction.class,
@@ -244,7 +256,7 @@ public class ProcessTableFunctionTest extends TableTestBase {
                         // function expects <STRING name, INT score>
                         "SELECT * FROM f(u => TABLE t_type_diff PARTITION BY name, i => 1)",
                         "No match found for function signature "
-                                + "f(<RecordType(CHAR(3) name, BOOLEAN isValid)>, <NUMERIC>, <CHARACTER>)"),
+                                + "f(<RecordType(CHAR(3) name, BOOLEAN isValid)>, <NUMERIC>, <COLUMN_LIST>, <CHARACTER>)"),
                 ErrorSpec.of(
                         "table function instead of process table function",
                         NoProcessTableFunction.class,
@@ -255,7 +267,7 @@ public class ProcessTableFunctionTest extends TableTestBase {
                         "reserved args",
                         ReservedArgFunction.class,
                         "SELECT * FROM f(uid => 'my-ptf')",
-                        "Function signature must not declare system arguments. Reserved argument names are: [uid]"),
+                        "Function signature must not declare system arguments. Reserved argument names are: [on_time, uid]"),
                 ErrorSpec.of(
                         "multiple table args",
                         MultiTableFunction.class,
@@ -308,7 +320,29 @@ public class ProcessTableFunctionTest extends TableTestBase {
                         "invalid descriptor",
                         DescriptorFunction.class,
                         "SELECT * FROM f(columnList1 => NULL, columnList3 => DESCRIPTOR(b.INVALID))",
-                        "column alias must be a simple identifier"));
+                        "column alias must be a simple identifier"),
+                ErrorSpec.of(
+                        "ambiguous on_time reference",
+                        TableAsRowFunction.class,
+                        "WITH duplicate_ts AS (SELECT ts AS ts1, ts AS ts2 FROM t_watermarked) "
+                                + "SELECT * FROM f(r => TABLE duplicate_ts, i => 1, on_time => DESCRIPTOR(ts1, ts2))",
+                        "Ambiguous time attribute found. The `on_time` argument must reference at "
+                                + "most one column in a table argument. Currently, the columns in "
+                                + "`on_time` point to both 'ts1' and 'ts2' in table argument 'r'."),
+                ErrorSpec.of(
+                        "invalid on_time data type",
+                        RequiredTimeFunction.class,
+                        "SELECT * FROM f(r => TABLE t_watermarked)",
+                        "Table argument 'r' requires a time attribute. "
+                                + "Please provide one using the implicit `on_time` argument. "
+                                + "For example: myFunction(..., on_time => DESCRIPTOR(`my_timestamp`)"),
+                ErrorSpec.of(
+                        "invalid on_time column",
+                        TableAsRowFunction.class,
+                        "SELECT * FROM f(r => TABLE t_watermarked, i => 1, on_time => DESCRIPTOR(ts, INVALID))",
+                        "Invalid time attribute declaration. Each column in the `on_time` argument must "
+                                + "reference at least one column in one of the table arguments. "
+                                + "Unknown references: [INVALID]"));
     }
 
     /** Testing function. */

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.xml
@@ -23,12 +23,12 @@ limitations under the License.
     <Resource name="ast">
       <![CDATA[
 LogicalProject(out=[$0])
-+- LogicalTableFunctionScan(invocation=[f(DESCRIPTOR(_UTF-16LE'a'), DESCRIPTOR(_UTF-16LE'b', _UTF-16LE'c'), DESCRIPTOR(), DEFAULT())], rowType=[RecordType(VARCHAR(2147483647) out)])
++- LogicalTableFunctionScan(invocation=[f(DESCRIPTOR(_UTF-16LE'a'), DESCRIPTOR(_UTF-16LE'b', _UTF-16LE'c'), DESCRIPTOR(), DEFAULT(), DEFAULT())], rowType=[RecordType(VARCHAR(2147483647) out)])
 ]]>
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-ProcessTableFunction(invocation=[f(DESCRIPTOR(_UTF-16LE'a'), DESCRIPTOR(_UTF-16LE'b', _UTF-16LE'c'), DESCRIPTOR(), DEFAULT())], uid=[null], select=[out], rowType=[RecordType(VARCHAR(2147483647) out)])
+ProcessTableFunction(invocation=[f(DESCRIPTOR(_UTF-16LE'a'), DESCRIPTOR(_UTF-16LE'b', _UTF-16LE'c'), DESCRIPTOR(), DEFAULT(), DEFAULT())], uid=[null], select=[out], rowType=[RecordType(VARCHAR(2147483647) out)])
 +- Values(tuples=[[{  }]])
 ]]>
     </Resource>
@@ -40,7 +40,7 @@ ProcessTableFunction(invocation=[f(DESCRIPTOR(_UTF-16LE'a'), DESCRIPTOR(_UTF-16L
     <Resource name="ast">
       <![CDATA[
 LogicalProject(score=[$0], out=[$1])
-+- LogicalTableFunctionScan(invocation=[f(TABLE(#0) PARTITION BY($1), 1, DEFAULT())], rowType=[RecordType(INTEGER score, VARCHAR(2147483647) out)])
++- LogicalTableFunctionScan(invocation=[f(TABLE(#0) PARTITION BY($1), 1, DEFAULT(), DEFAULT())], rowType=[RecordType(INTEGER score, VARCHAR(2147483647) out)])
    +- LogicalProject(name=[$0], score=[$1])
       +- LogicalProject(name=[$0], score=[$1])
          +- LogicalValues(tuples=[[{ _UTF-16LE'Bob', 12 }, { _UTF-16LE'Alice', 42 }]])
@@ -48,7 +48,7 @@ LogicalProject(score=[$0], out=[$1])
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-ProcessTableFunction(invocation=[f(TABLE(#0) PARTITION BY($1), 1, DEFAULT())], uid=[f], select=[score,out], rowType=[RecordType(INTEGER score, VARCHAR(2147483647) out)])
+ProcessTableFunction(invocation=[f(TABLE(#0) PARTITION BY($1), 1, DEFAULT(), DEFAULT())], uid=[f], select=[score,out], rowType=[RecordType(INTEGER score, VARCHAR(2147483647) out)])
 +- Exchange(distribution=[hash[score]])
    +- Values(tuples=[[{ _UTF-16LE'Bob', 12 }, { _UTF-16LE'Alice', 42 }]])
 ]]>
@@ -61,13 +61,34 @@ ProcessTableFunction(invocation=[f(TABLE(#0) PARTITION BY($1), 1, DEFAULT())], u
     <Resource name="ast">
       <![CDATA[
 LogicalProject(out=[$0])
-+- LogicalTableFunctionScan(invocation=[f(_UTF-16LE'my-ptf')], rowType=[RecordType(VARCHAR(2147483647) out)])
++- LogicalTableFunctionScan(invocation=[f(DEFAULT(), _UTF-16LE'my-ptf')], rowType=[RecordType(VARCHAR(2147483647) out)])
 ]]>
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-ProcessTableFunction(invocation=[f(_UTF-16LE'my-ptf')], uid=[my-ptf], select=[out], rowType=[RecordType(VARCHAR(2147483647) out)])
+ProcessTableFunction(invocation=[f(DEFAULT(), _UTF-16LE'my-ptf')], uid=[my-ptf], select=[out], rowType=[RecordType(VARCHAR(2147483647) out)])
 +- Values(tuples=[[{  }]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testOnTime">
+    <Resource name="sql">
+      <![CDATA[SELECT `out`, `rowtime` FROM f(r => TABLE t_watermarked, on_time => DESCRIPTOR(ts))]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(out=[$0], rowtime=[$1])
++- LogicalTableFunctionScan(invocation=[f(TABLE(#0), DESCRIPTOR(_UTF-16LE'ts'), DEFAULT())], rowType=[RecordType(VARCHAR(2147483647) out, TIMESTAMP_LTZ(3) *ROWTIME* rowtime)])
+   +- LogicalProject(name=[$0], score=[$1], ts=[$2])
+      +- LogicalWatermarkAssigner(rowtime=[ts], watermark=[$2])
+         +- LogicalTableScan(table=[[default_catalog, default_database, t_watermarked]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+ProcessTableFunction(invocation=[f(TABLE(#0), DESCRIPTOR(_UTF-16LE'ts'), DEFAULT())], uid=[null], select=[out,rowtime], rowType=[RecordType(VARCHAR(2147483647) out, TIMESTAMP_LTZ(3) *ROWTIME* rowtime)])
++- WatermarkAssigner(rowtime=[ts], watermark=[ts])
+   +- TableSourceScan(table=[[default_catalog, default_database, t_watermarked]], fields=[name, score, ts])
 ]]>
     </Resource>
   </TestCase>
@@ -78,12 +99,12 @@ ProcessTableFunction(invocation=[f(_UTF-16LE'my-ptf')], uid=[my-ptf], select=[ou
     <Resource name="ast">
       <![CDATA[
 LogicalProject(out=[$0])
-+- LogicalTableFunctionScan(invocation=[f(1, true, DEFAULT())], rowType=[RecordType(VARCHAR(2147483647) out)])
++- LogicalTableFunctionScan(invocation=[f(1, true, DEFAULT(), DEFAULT())], rowType=[RecordType(VARCHAR(2147483647) out)])
 ]]>
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-ProcessTableFunction(invocation=[f(1, true, DEFAULT())], uid=[null], select=[out], rowType=[RecordType(VARCHAR(2147483647) out)])
+ProcessTableFunction(invocation=[f(1, true, DEFAULT(), DEFAULT())], uid=[null], select=[out], rowType=[RecordType(VARCHAR(2147483647) out)])
 +- Values(tuples=[[{  }]])
 ]]>
     </Resource>
@@ -93,14 +114,14 @@ ProcessTableFunction(invocation=[f(1, true, DEFAULT())], uid=[null], select=[out
       <![CDATA[
 LogicalSink(table=[default_catalog.default_database.t_keyed_sink], fields=[name, out])
 +- LogicalProject(name=[$0], out=[$1])
-   +- LogicalTableFunctionScan(invocation=[f(TABLE(#0) PARTITION BY($0), 1, _UTF-16LE'a')], rowType=[RecordType(VARCHAR(5) name, VARCHAR(2147483647) out)])
+   +- LogicalTableFunctionScan(invocation=[f(TABLE(#0) PARTITION BY($0), 1, DEFAULT(), _UTF-16LE'a')], rowType=[RecordType(VARCHAR(5) name, VARCHAR(2147483647) out)])
       +- LogicalProject(name=[$0], score=[$1])
          +- LogicalProject(name=[$0], score=[$1])
             +- LogicalValues(tuples=[[{ _UTF-16LE'Bob', 12 }, { _UTF-16LE'Alice', 42 }]])
 
 LogicalSink(table=[default_catalog.default_database.t_keyed_sink], fields=[name, out])
 +- LogicalProject(name=[$0], out=[$1])
-   +- LogicalTableFunctionScan(invocation=[f(TABLE(#0) PARTITION BY($0), 1, _UTF-16LE'b')], rowType=[RecordType(VARCHAR(5) name, VARCHAR(2147483647) out)])
+   +- LogicalTableFunctionScan(invocation=[f(TABLE(#0) PARTITION BY($0), 1, DEFAULT(), _UTF-16LE'b')], rowType=[RecordType(VARCHAR(5) name, VARCHAR(2147483647) out)])
       +- LogicalProject(name=[$0], score=[$1])
          +- LogicalProject(name=[$0], score=[$1])
             +- LogicalValues(tuples=[[{ _UTF-16LE'Bob', 12 }, { _UTF-16LE'Alice', 42 }]])
@@ -112,11 +133,11 @@ Exchange(distribution=[hash[name]])(reuse_id=[1])
 +- Values(tuples=[[{ _UTF-16LE'Bob', 12 }, { _UTF-16LE'Alice', 42 }]])
 
 Sink(table=[default_catalog.default_database.t_keyed_sink], fields=[name, out])
-+- ProcessTableFunction(invocation=[f(TABLE(#0) PARTITION BY($0), 1, _UTF-16LE'a')], uid=[a], select=[name,out], rowType=[RecordType(VARCHAR(5) name, VARCHAR(2147483647) out)])
++- ProcessTableFunction(invocation=[f(TABLE(#0) PARTITION BY($0), 1, DEFAULT(), _UTF-16LE'a')], uid=[a], select=[name,out], rowType=[RecordType(VARCHAR(5) name, VARCHAR(2147483647) out)])
    +- Reused(reference_id=[1])
 
 Sink(table=[default_catalog.default_database.t_keyed_sink], fields=[name, out])
-+- ProcessTableFunction(invocation=[f(TABLE(#0) PARTITION BY($0), 1, _UTF-16LE'b')], uid=[b], select=[name,out], rowType=[RecordType(VARCHAR(5) name, VARCHAR(2147483647) out)])
++- ProcessTableFunction(invocation=[f(TABLE(#0) PARTITION BY($0), 1, DEFAULT(), _UTF-16LE'b')], uid=[b], select=[name,out], rowType=[RecordType(VARCHAR(5) name, VARCHAR(2147483647) out)])
    +- Reused(reference_id=[1])
 ]]>
     </Resource>
@@ -128,12 +149,12 @@ Sink(table=[default_catalog.default_database.t_keyed_sink], fields=[name, out])
     <Resource name="ast">
       <![CDATA[
 LogicalProject(out=[$0])
-+- LogicalTableFunctionScan(invocation=[f(1, true, _UTF-16LE'my-uid')], rowType=[RecordType(VARCHAR(2147483647) out)])
++- LogicalTableFunctionScan(invocation=[f(1, true, DEFAULT(), _UTF-16LE'my-uid')], rowType=[RecordType(VARCHAR(2147483647) out)])
 ]]>
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-ProcessTableFunction(invocation=[f(1, true, _UTF-16LE'my-uid')], uid=[my-uid], select=[out], rowType=[RecordType(VARCHAR(2147483647) out)])
+ProcessTableFunction(invocation=[f(1, true, DEFAULT(), _UTF-16LE'my-uid')], uid=[my-uid], select=[out], rowType=[RecordType(VARCHAR(2147483647) out)])
 +- Values(tuples=[[{  }]])
 ]]>
     </Resource>
@@ -143,14 +164,14 @@ ProcessTableFunction(invocation=[f(1, true, _UTF-16LE'my-uid')], uid=[my-uid], s
       <![CDATA[
 LogicalSink(table=[default_catalog.default_database.t_sink], fields=[out])
 +- LogicalProject(out=[$0])
-   +- LogicalTableFunctionScan(invocation=[f(TABLE(#0), 1, DEFAULT())], rowType=[RecordType(VARCHAR(2147483647) out)])
+   +- LogicalTableFunctionScan(invocation=[f(TABLE(#0), 1, DEFAULT(), DEFAULT())], rowType=[RecordType(VARCHAR(2147483647) out)])
       +- LogicalProject(name=[$0], score=[$1])
          +- LogicalProject(name=[$0], score=[$1])
             +- LogicalValues(tuples=[[{ _UTF-16LE'Bob', 12 }, { _UTF-16LE'Alice', 42 }]])
 
 LogicalSink(table=[default_catalog.default_database.t_sink], fields=[out])
 +- LogicalProject(out=[$0])
-   +- LogicalTableFunctionScan(invocation=[f(TABLE(#0), 42, DEFAULT())], rowType=[RecordType(VARCHAR(2147483647) out)])
+   +- LogicalTableFunctionScan(invocation=[f(TABLE(#0), 42, DEFAULT(), DEFAULT())], rowType=[RecordType(VARCHAR(2147483647) out)])
       +- LogicalProject(name=[$0], score=[$1])
          +- LogicalProject(name=[$0], score=[$1])
             +- LogicalValues(tuples=[[{ _UTF-16LE'Bob', 12 }, { _UTF-16LE'Alice', 42 }]])
@@ -161,11 +182,11 @@ LogicalSink(table=[default_catalog.default_database.t_sink], fields=[out])
 Values(tuples=[[{ _UTF-16LE'Bob', 12 }, { _UTF-16LE'Alice', 42 }]])(reuse_id=[1])
 
 Sink(table=[default_catalog.default_database.t_sink], fields=[out])
-+- ProcessTableFunction(invocation=[f(TABLE(#0), 1, DEFAULT())], uid=[null], select=[out], rowType=[RecordType(VARCHAR(2147483647) out)])
++- ProcessTableFunction(invocation=[f(TABLE(#0), 1, DEFAULT(), DEFAULT())], uid=[null], select=[out], rowType=[RecordType(VARCHAR(2147483647) out)])
    +- Reused(reference_id=[1])
 
 Sink(table=[default_catalog.default_database.t_sink], fields=[out])
-+- ProcessTableFunction(invocation=[f(TABLE(#0), 42, DEFAULT())], uid=[null], select=[out], rowType=[RecordType(VARCHAR(2147483647) out)])
++- ProcessTableFunction(invocation=[f(TABLE(#0), 42, DEFAULT(), DEFAULT())], uid=[null], select=[out], rowType=[RecordType(VARCHAR(2147483647) out)])
    +- Reused(reference_id=[1])
 ]]>
     </Resource>
@@ -177,7 +198,7 @@ Sink(table=[default_catalog.default_database.t_sink], fields=[out])
     <Resource name="ast">
       <![CDATA[
 LogicalProject(name=[$0], score=[$1], out=[$2])
-+- LogicalTableFunctionScan(invocation=[f(TABLE(#0), 1, DEFAULT())], rowType=[RecordType(VARCHAR(5) name, INTEGER score, VARCHAR(2147483647) out)])
++- LogicalTableFunctionScan(invocation=[f(TABLE(#0), 1, DEFAULT(), DEFAULT())], rowType=[RecordType(VARCHAR(5) name, INTEGER score, VARCHAR(2147483647) out)])
    +- LogicalProject(name=[$0], score=[$1])
       +- LogicalProject(name=[$0], score=[$1])
          +- LogicalValues(tuples=[[{ _UTF-16LE'Bob', 12 }, { _UTF-16LE'Alice', 42 }]])
@@ -185,7 +206,7 @@ LogicalProject(name=[$0], score=[$1], out=[$2])
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-ProcessTableFunction(invocation=[f(TABLE(#0), 1, DEFAULT())], uid=[null], select=[name,score,out], rowType=[RecordType(VARCHAR(5) name, INTEGER score, VARCHAR(2147483647) out)])
+ProcessTableFunction(invocation=[f(TABLE(#0), 1, DEFAULT(), DEFAULT())], uid=[null], select=[name,score,out], rowType=[RecordType(VARCHAR(5) name, INTEGER score, VARCHAR(2147483647) out)])
 +- Values(tuples=[[{ _UTF-16LE'Bob', 12 }, { _UTF-16LE'Alice', 42 }]])
 ]]>
     </Resource>
@@ -197,7 +218,7 @@ ProcessTableFunction(invocation=[f(TABLE(#0), 1, DEFAULT())], uid=[null], select
     <Resource name="ast">
       <![CDATA[
 LogicalProject(name=[$0], score=[$1], out=[$2])
-+- LogicalTableFunctionScan(invocation=[f(TABLE(#0) PARTITION BY($0), 1, DEFAULT())], rowType=[RecordType(VARCHAR(5) name, INTEGER score, VARCHAR(2147483647) out)])
++- LogicalTableFunctionScan(invocation=[f(TABLE(#0) PARTITION BY($0), 1, DEFAULT(), DEFAULT())], rowType=[RecordType(VARCHAR(5) name, INTEGER score, VARCHAR(2147483647) out)])
    +- LogicalProject(name=[$0], score=[$1])
       +- LogicalProject(name=[$0], score=[$1])
          +- LogicalValues(tuples=[[{ _UTF-16LE'Bob', 12 }, { _UTF-16LE'Alice', 42 }]])
@@ -205,7 +226,7 @@ LogicalProject(name=[$0], score=[$1], out=[$2])
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-ProcessTableFunction(invocation=[f(TABLE(#0) PARTITION BY($0), 1, DEFAULT())], uid=[f], select=[name,score,out], rowType=[RecordType(VARCHAR(5) name, INTEGER score, VARCHAR(2147483647) out)])
+ProcessTableFunction(invocation=[f(TABLE(#0) PARTITION BY($0), 1, DEFAULT(), DEFAULT())], uid=[f], select=[name,score,out], rowType=[RecordType(VARCHAR(5) name, INTEGER score, VARCHAR(2147483647) out)])
 +- Exchange(distribution=[hash[name]])
    +- Values(tuples=[[{ _UTF-16LE'Bob', 12 }, { _UTF-16LE'Alice', 42 }]])
 ]]>
@@ -216,14 +237,14 @@ ProcessTableFunction(invocation=[f(TABLE(#0) PARTITION BY($0), 1, DEFAULT())], u
       <![CDATA[
 LogicalSink(table=[default_catalog.default_database.t_keyed_sink], fields=[name, out])
 +- LogicalProject(name=[$0], out=[$1])
-   +- LogicalTableFunctionScan(invocation=[f(TABLE(#0) PARTITION BY($0), 1, _UTF-16LE'same')], rowType=[RecordType(VARCHAR(5) name, VARCHAR(2147483647) out)])
+   +- LogicalTableFunctionScan(invocation=[f(TABLE(#0) PARTITION BY($0), 1, DEFAULT(), _UTF-16LE'same')], rowType=[RecordType(VARCHAR(5) name, VARCHAR(2147483647) out)])
       +- LogicalProject(name=[$0], score=[$1])
          +- LogicalProject(name=[$0], score=[$1])
             +- LogicalValues(tuples=[[{ _UTF-16LE'Bob', 12 }, { _UTF-16LE'Alice', 42 }]])
 
 LogicalSink(table=[default_catalog.default_database.t_keyed_sink], fields=[name, out])
 +- LogicalProject(name=[$0], out=[$1])
-   +- LogicalTableFunctionScan(invocation=[f(TABLE(#0) PARTITION BY($0), 1, _UTF-16LE'same')], rowType=[RecordType(VARCHAR(5) name, VARCHAR(2147483647) out)])
+   +- LogicalTableFunctionScan(invocation=[f(TABLE(#0) PARTITION BY($0), 1, DEFAULT(), _UTF-16LE'same')], rowType=[RecordType(VARCHAR(5) name, VARCHAR(2147483647) out)])
       +- LogicalProject(name=[$0], score=[$1])
          +- LogicalProject(name=[$0], score=[$1])
             +- LogicalValues(tuples=[[{ _UTF-16LE'Bob', 12 }, { _UTF-16LE'Alice', 42 }]])
@@ -231,7 +252,7 @@ LogicalSink(table=[default_catalog.default_database.t_keyed_sink], fields=[name,
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-ProcessTableFunction(invocation=[f(TABLE(#0) PARTITION BY($0), 1, _UTF-16LE'same')], uid=[same], select=[name,out], rowType=[RecordType(VARCHAR(5) name, VARCHAR(2147483647) out)])(reuse_id=[1])
+ProcessTableFunction(invocation=[f(TABLE(#0) PARTITION BY($0), 1, DEFAULT(), _UTF-16LE'same')], uid=[same], select=[name,out], rowType=[RecordType(VARCHAR(5) name, VARCHAR(2147483647) out)])(reuse_id=[1])
 +- Exchange(distribution=[hash[name]])
    +- Values(tuples=[[{ _UTF-16LE'Bob', 12 }, { _UTF-16LE'Alice', 42 }]])
 
@@ -249,7 +270,7 @@ Sink(table=[default_catalog.default_database.t_keyed_sink], fields=[name, out])
 LogicalSink(table=[default_catalog.default_database.t_keyed_sink], fields=[name, out])
 +- LogicalProject(name=[$0], out=[$1])
    +- LogicalFilter(condition=[=($0, _UTF-16LE'Bob')])
-      +- LogicalTableFunctionScan(invocation=[f(TABLE(#0) PARTITION BY($0), 1, _UTF-16LE'same')], rowType=[RecordType(VARCHAR(5) name, VARCHAR(2147483647) out)])
+      +- LogicalTableFunctionScan(invocation=[f(TABLE(#0) PARTITION BY($0), 1, DEFAULT(), _UTF-16LE'same')], rowType=[RecordType(VARCHAR(5) name, VARCHAR(2147483647) out)])
          +- LogicalProject(name=[$0], score=[$1])
             +- LogicalProject(name=[$0], score=[$1])
                +- LogicalValues(tuples=[[{ _UTF-16LE'Bob', 12 }, { _UTF-16LE'Alice', 42 }]])
@@ -257,7 +278,7 @@ LogicalSink(table=[default_catalog.default_database.t_keyed_sink], fields=[name,
 LogicalSink(table=[default_catalog.default_database.t_keyed_sink], fields=[name, out])
 +- LogicalProject(name=[$0], out=[$1])
    +- LogicalFilter(condition=[=($0, _UTF-16LE'Alice')])
-      +- LogicalTableFunctionScan(invocation=[f(TABLE(#0) PARTITION BY($0), 1, _UTF-16LE'same')], rowType=[RecordType(VARCHAR(5) name, VARCHAR(2147483647) out)])
+      +- LogicalTableFunctionScan(invocation=[f(TABLE(#0) PARTITION BY($0), 1, DEFAULT(), _UTF-16LE'same')], rowType=[RecordType(VARCHAR(5) name, VARCHAR(2147483647) out)])
          +- LogicalProject(name=[$0], score=[$1])
             +- LogicalProject(name=[$0], score=[$1])
                +- LogicalValues(tuples=[[{ _UTF-16LE'Bob', 12 }, { _UTF-16LE'Alice', 42 }]])
@@ -265,7 +286,7 @@ LogicalSink(table=[default_catalog.default_database.t_keyed_sink], fields=[name,
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-ProcessTableFunction(invocation=[f(TABLE(#0) PARTITION BY($0), 1, _UTF-16LE'same')], uid=[same], select=[name,out], rowType=[RecordType(VARCHAR(5) name, VARCHAR(2147483647) out)])(reuse_id=[1])
+ProcessTableFunction(invocation=[f(TABLE(#0) PARTITION BY($0), 1, DEFAULT(), _UTF-16LE'same')], uid=[same], select=[name,out], rowType=[RecordType(VARCHAR(5) name, VARCHAR(2147483647) out)])(reuse_id=[1])
 +- Exchange(distribution=[hash[name]])
    +- Values(tuples=[[{ _UTF-16LE'Bob', 12 }, { _UTF-16LE'Alice', 42 }]])
 
@@ -286,12 +307,12 @@ Sink(table=[default_catalog.default_database.t_keyed_sink], fields=[name, out])
     <Resource name="ast">
       <![CDATA[
 LogicalProject(out=[$0])
-+- LogicalTableFunctionScan(invocation=[f(1, true, DEFAULT())], rowType=[RecordType(VARCHAR(2147483647) out)])
++- LogicalTableFunctionScan(invocation=[f(1, true, DEFAULT(), DEFAULT())], rowType=[RecordType(VARCHAR(2147483647) out)])
 ]]>
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-ProcessTableFunction(invocation=[f(1, true, DEFAULT())], uid=[null], select=[out], rowType=[RecordType(VARCHAR(2147483647) out)])
+ProcessTableFunction(invocation=[f(1, true, DEFAULT(), DEFAULT())], uid=[null], select=[out], rowType=[RecordType(VARCHAR(2147483647) out)])
 +- Values(tuples=[[{  }]])
 ]]>
     </Resource>
@@ -303,7 +324,7 @@ ProcessTableFunction(invocation=[f(1, true, DEFAULT())], uid=[null], select=[out
     <Resource name="ast">
       <![CDATA[
 LogicalProject(out=[$0])
-+- LogicalTableFunctionScan(invocation=[f(TABLE(#0), 1, DEFAULT())], rowType=[RecordType(VARCHAR(2147483647) out)])
++- LogicalTableFunctionScan(invocation=[f(TABLE(#0), 1, DEFAULT(), DEFAULT())], rowType=[RecordType(VARCHAR(2147483647) out)])
    +- LogicalProject(name=[$0], different=[$1])
       +- LogicalProject(name=[_UTF-16LE'Bob'], different=[12])
          +- LogicalValues(tuples=[[{ 0 }]])
@@ -311,7 +332,7 @@ LogicalProject(out=[$0])
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-ProcessTableFunction(invocation=[f(TABLE(#0), 1, DEFAULT())], uid=[null], select=[out], rowType=[RecordType(VARCHAR(2147483647) out)])
+ProcessTableFunction(invocation=[f(TABLE(#0), 1, DEFAULT(), DEFAULT())], uid=[null], select=[out], rowType=[RecordType(VARCHAR(2147483647) out)])
 +- Calc(select=['Bob' AS name, 12 AS different])
    +- Values(tuples=[[{ 0 }]])
 ]]>

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/generated/ProcessTableRunner.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/generated/ProcessTableRunner.java
@@ -72,11 +72,11 @@ public abstract class ProcessTableRunner extends AbstractRichFunction {
 
     /**
      * Reference to whether the state has been cleared within the function; if yes, a conversion
-     * from external to internal data structure is not necessary anymore
+     * from external to internal data structure is not necessary anymore.
      */
     protected boolean[] stateCleared;
 
-    /** State ready for persistence; null if {@link #stateCleared} was true during conversion */
+    /** State ready for persistence; null if {@link #stateCleared} was true during conversion. */
     protected RowData[] stateFromFunction;
 
     public void initialize(

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/generated/ProcessTableRunner.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/generated/ProcessTableRunner.java
@@ -18,36 +18,205 @@
 
 package org.apache.flink.table.runtime.generated;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.functions.AbstractRichFunction;
+import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.functions.ProcessTableFunction;
+import org.apache.flink.table.runtime.operators.process.PassAllCollector;
+import org.apache.flink.table.runtime.operators.process.PassThroughCollectorBase;
 import org.apache.flink.table.runtime.operators.process.ProcessTableOperator;
-import org.apache.flink.util.Collector;
+import org.apache.flink.table.runtime.operators.process.ProcessTableOperator.RunnerContext;
+import org.apache.flink.table.runtime.operators.process.ProcessTableOperator.RunnerOnTimerContext;
+import org.apache.flink.types.RowKind;
+import org.apache.flink.util.function.RunnableWithException;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.Arrays;
 
 /**
  * Abstraction of code-generated calls to {@link ProcessTableFunction} to be used within {@link
  * ProcessTableOperator}.
  */
+@Internal
 public abstract class ProcessTableRunner extends AbstractRichFunction {
 
-    public Collector<RowData> runnerCollector;
-    public ProcessTableFunction.Context runnerContext;
+    // Constant references after initialization
+    private ValueState<RowData>[] stateHandles;
+    private HashFunction[] stateHashCode;
+    private RecordEqualiser[] stateEquals;
+    private boolean emitRowtime;
+
+    // Contexts
+    protected RunnerContext runnerContext;
+    protected RunnerOnTimerContext runnerOnTimerContext;
+
+    // Collectors
+    protected PassThroughCollectorBase evalCollector;
+    protected PassAllCollector onTimerCollector;
+
+    // Current input table
+    protected int inputIndex = -1;
+    protected RowData inputRow;
+
+    // Current time
+    private long currentWatermark = Long.MIN_VALUE;
+    private @Nullable Long rowtime;
+    private @Nullable StringData timerName;
+
+    /** State entries to be converted into external data structure; null if state is empty. */
+    protected RowData[] stateToFunction;
 
     /**
-     * @param stateToFunction state entries to be converted into external data structure; null if
-     *     state is empty
-     * @param stateCleared reference to whether the state has been cleared within the function; if
-     *     yes, a conversion from external to internal data structure is not necessary anymore
-     * @param stateFromFunction state ready for persistence; null if {@param stateCleared} was true
-     *     during conversion
-     * @param inputIndex index of the currently processed input table
-     * @param row data of the currently processed input table
+     * Reference to whether the state has been cleared within the function; if yes, a conversion
+     * from external to internal data structure is not necessary anymore
      */
-    public abstract void processElement(
-            RowData[] stateToFunction,
-            boolean[] stateCleared,
-            RowData[] stateFromFunction,
-            int inputIndex,
-            RowData row)
-            throws Exception;
+    protected boolean[] stateCleared;
+
+    /** State ready for persistence; null if {@link #stateCleared} was true during conversion */
+    protected RowData[] stateFromFunction;
+
+    public void initialize(
+            ValueState<RowData>[] stateHandles,
+            HashFunction[] stateHashCode,
+            RecordEqualiser[] stateEquals,
+            boolean emitRowtime,
+            RunnerContext runnerContext,
+            RunnerOnTimerContext runnerOnTimerContext,
+            PassThroughCollectorBase evalCollector,
+            PassAllCollector onTimerCollector) {
+        this.stateHandles = stateHandles;
+        this.stateHashCode = stateHashCode;
+        this.stateEquals = stateEquals;
+        this.emitRowtime = emitRowtime;
+
+        // Accessed by generated code
+        this.runnerContext = runnerContext;
+        this.runnerOnTimerContext = runnerOnTimerContext;
+        this.evalCollector = evalCollector;
+        this.onTimerCollector = onTimerCollector;
+        this.stateToFunction = new RowData[stateHandles.length];
+        this.stateCleared = new boolean[stateHandles.length];
+        this.stateFromFunction = new RowData[stateHandles.length];
+    }
+
+    public void ingestTableEvent(int pos, RowData row, int timeColumn) {
+        evalCollector.setPrefix(row);
+        if (timeColumn == -1) {
+            rowtime = null;
+        } else {
+            final long inputTime = row.getTimestamp(timeColumn, 3).getMillisecond();
+            if (emitRowtime) {
+                evalCollector.setRowtime(inputTime);
+            }
+            rowtime = inputTime;
+        }
+        inputIndex = pos;
+        inputRow = row;
+    }
+
+    public void ingestTimerEvent(RowData key, @Nullable StringData name, long timerTime) {
+        onTimerCollector.setPrefix(key);
+        if (emitRowtime) {
+            onTimerCollector.setRowtime(timerTime);
+        }
+        rowtime = timerTime;
+        timerName = name;
+    }
+
+    public void ingestWatermarkEvent(long watermarkTime) {
+        currentWatermark = watermarkTime;
+    }
+
+    public void clearAllState() {
+        Arrays.fill(stateCleared, true);
+    }
+
+    public void clearState(int statePos) {
+        stateCleared[statePos] = true;
+    }
+
+    public long getCurrentWatermark() {
+        return currentWatermark;
+    }
+
+    public @Nullable Long getTime() {
+        return rowtime;
+    }
+
+    public @Nullable StringData getTimerName() {
+        return timerName;
+    }
+
+    public void processEval() throws Exception {
+        // Drop late events
+        if (rowtime != null && rowtime <= currentWatermark) {
+            return;
+        }
+        processMethod(this::callEval);
+    }
+
+    public void processOnTimer() throws Exception {
+        processMethod(this::callOnTimer);
+    }
+
+    public abstract void callEval() throws Exception;
+
+    public abstract void callOnTimer() throws Exception;
+
+    private void processMethod(RunnableWithException method) throws Exception {
+        if (stateHandles.length > 0) {
+            // For each function call:
+            // - the state is read from Flink
+            // - converted into external data structure
+            // - evaluated
+            // - converted into internal data structure (if not cleared)
+            // - the state is written into Flink
+            moveStateToFunction();
+            method.run();
+            moveStateFromFunction();
+        } else {
+            method.run();
+        }
+    }
+
+    private void moveStateToFunction() throws IOException {
+        Arrays.fill(stateCleared, false);
+        for (int i = 0; i < stateHandles.length; i++) {
+            final RowData value = stateHandles[i].value();
+            stateToFunction[i] = value;
+        }
+    }
+
+    private void moveStateFromFunction() throws IOException {
+        for (int i = 0; i < stateHandles.length; i++) {
+            final RowData fromFunction = stateFromFunction[i];
+            if (fromFunction == null || isEmpty(fromFunction)) {
+                // Reduce state size
+                stateHandles[i].clear();
+            } else {
+                final HashFunction hashCode = stateHashCode[i];
+                final RecordEqualiser equals = stateEquals[i];
+                final RowData toFunction = stateToFunction[i];
+                // Reduce state updates by checking if something has changed
+                if (toFunction == null
+                        || hashCode.hashCode(toFunction) != hashCode.hashCode(fromFunction)
+                        || !equals.equals(toFunction, fromFunction)) {
+                    stateHandles[i].update(fromFunction);
+                }
+            }
+        }
+    }
+
+    private static boolean isEmpty(RowData row) {
+        for (int i = 0; i < row.getArity(); i++) {
+            if (!row.isNullAt(i)) {
+                return false;
+            }
+        }
+        return row.getRowKind() == RowKind.INSERT;
+    }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/process/ExternalTimeContext.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/process/ExternalTimeContext.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.process;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.functions.ProcessTableFunction;
+import org.apache.flink.util.Preconditions;
+
+/**
+ * User-facing time context that converts to/from the desired time class.
+ *
+ * @param <TimeConversion> a conversion supported by {@link TimeConverter}
+ */
+@Internal
+class ExternalTimeContext<TimeConversion>
+        implements ProcessTableFunction.TimeContext<TimeConversion> {
+
+    private final ReadableInternalTimeContext internalTimeContext;
+    private final TimeConverter<TimeConversion> timeConverter;
+
+    ExternalTimeContext(
+            ReadableInternalTimeContext internalTimeContext,
+            TimeConverter<TimeConversion> timeConverter) {
+        this.internalTimeContext = internalTimeContext;
+        this.timeConverter = timeConverter;
+    }
+
+    @Override
+    public TimeConversion time() {
+        final Long internal = internalTimeContext.time();
+        if (internal == null) {
+            return null;
+        }
+        return timeConverter.toExternal(internal);
+    }
+
+    @Override
+    public TimeConversion currentWatermark() {
+        final Long internal = internalTimeContext.currentWatermark();
+        if (internal == null) {
+            return null;
+        }
+        return timeConverter.toExternal(internal);
+    }
+
+    @Override
+    public void registerOnTime(String name, TimeConversion time) {
+        Preconditions.checkNotNull(name, "Name must not be null.");
+        Preconditions.checkNotNull(time, "Time must not be null.");
+        internalTimeContext.registerOnTime(name, timeConverter.toInternal(time));
+    }
+
+    @Override
+    public void registerOnTime(TimeConversion time) {
+        Preconditions.checkNotNull(time, "Time must not be null.");
+        internalTimeContext.registerOnTime(timeConverter.toInternal(time));
+    }
+
+    @Override
+    public void clearTimer(String name) {
+        Preconditions.checkNotNull(name, "Name must not be null.");
+        internalTimeContext.clearTimer(name);
+    }
+
+    @Override
+    public void clearTimer(TimeConversion time) {
+        Preconditions.checkNotNull(time, "Time must not be null.");
+        internalTimeContext.clearTimer(timeConverter.toInternal(time));
+    }
+
+    @Override
+    public void clearAllTimers() {
+        internalTimeContext.clearAllTimers();
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/process/PassAllCollector.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/process/PassAllCollector.java
@@ -18,30 +18,20 @@
 
 package org.apache.flink.table.runtime.operators.process;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.data.utils.JoinedRowData;
-import org.apache.flink.table.types.inference.SystemTypeInference;
 
-/** Forwards all input columns in sync with the output strategy of {@link SystemTypeInference}. */
+/** Forwards all columns of the given row. */
+@Internal
 public class PassAllCollector extends PassThroughCollectorBase {
-
-    private final JoinedRowData joinedRowData;
-    private RowData inputRow;
 
     public PassAllCollector(Output<StreamRecord<RowData>> output) {
         super(output);
-        joinedRowData = new JoinedRowData();
     }
 
-    void setInput(RowData input) {
-        inputRow = input;
-    }
-
-    @Override
-    public void collect(RowData functionOutput) {
-        joinedRowData.replace(inputRow, functionOutput);
-        super.collect(joinedRowData);
+    public void setPrefix(RowData input) {
+        prefix = input;
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/process/PassPartitionKeysCollector.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/process/PassPartitionKeysCollector.java
@@ -18,34 +18,22 @@
 
 package org.apache.flink.table.runtime.operators.process;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.data.utils.JoinedRowData;
 import org.apache.flink.table.data.utils.ProjectedRowData;
-import org.apache.flink.table.types.inference.SystemTypeInference;
 
-/**
- * Forwards input partition keys in sync with the output strategy of {@link SystemTypeInference}.
- */
+/** Forwards partition keys of the given row. */
+@Internal
 public class PassPartitionKeysCollector extends PassThroughCollectorBase {
-
-    private final ProjectedRowData projectedInput;
-    private final JoinedRowData joinedRowData;
 
     public PassPartitionKeysCollector(Output<StreamRecord<RowData>> output, int[] partitionKeys) {
         super(output);
-        projectedInput = ProjectedRowData.from(partitionKeys);
-        joinedRowData = new JoinedRowData();
+        prefix = ProjectedRowData.from(partitionKeys);
     }
 
-    void setInput(RowData input) {
-        projectedInput.replaceRow(input);
-    }
-
-    @Override
-    public void collect(RowData functionOutput) {
-        joinedRowData.replace(projectedInput, functionOutput);
-        super.collect(joinedRowData);
+    public void setPrefix(RowData input) {
+        ((ProjectedRowData) prefix).replaceRow(input);
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/process/ProcessTableOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/process/ProcessTableOperator.java
@@ -23,29 +23,44 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.functions.DefaultOpenContext;
 import org.apache.flink.api.common.functions.util.FunctionUtils;
 import org.apache.flink.api.common.state.KeyedStateStore;
+import org.apache.flink.api.common.state.MapState;
+import org.apache.flink.api.common.state.MapStateDescriptor;
 import org.apache.flink.api.common.state.StateTtlConfig;
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.runtime.state.VoidNamespaceSerializer;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.InternalTimer;
+import org.apache.flink.streaming.api.operators.InternalTimerService;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+import org.apache.flink.streaming.api.operators.Triggerable;
+import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.api.TableRuntimeException;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.functions.ProcessTableFunction;
+import org.apache.flink.table.functions.ProcessTableFunction.TimeContext;
 import org.apache.flink.table.functions.TableSemantics;
 import org.apache.flink.table.runtime.generated.HashFunction;
 import org.apache.flink.table.runtime.generated.ProcessTableRunner;
 import org.apache.flink.table.runtime.generated.RecordEqualiser;
+import org.apache.flink.table.runtime.operators.process.TimeConverter.InstantTimeConverter;
+import org.apache.flink.table.runtime.operators.process.TimeConverter.LocalDateTimeConverter;
+import org.apache.flink.table.runtime.operators.process.TimeConverter.LongTimeConverter;
 import org.apache.flink.table.runtime.typeutils.InternalSerializers;
+import org.apache.flink.table.runtime.typeutils.StringDataSerializer;
 import org.apache.flink.table.runtime.util.StateConfigUtil;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.types.RowKind;
 
 import javax.annotation.Nullable;
 
-import java.io.IOException;
-import java.util.Arrays;
+import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -53,7 +68,7 @@ import java.util.Optional;
 
 /** Operator for {@link ProcessTableFunction}. */
 public class ProcessTableOperator extends AbstractStreamOperator<RowData>
-        implements OneInputStreamOperator<RowData, RowData> {
+        implements OneInputStreamOperator<RowData, RowData>, Triggerable<RowData, Object> {
 
     private final @Nullable RuntimeTableSemantics tableSemantics;
     private final List<RuntimeStateInfo> stateInfos;
@@ -61,12 +76,15 @@ public class ProcessTableOperator extends AbstractStreamOperator<RowData>
     private final HashFunction[] stateHashCode;
     private final RecordEqualiser[] stateEquals;
 
-    private transient PassThroughCollectorBase collector;
+    private transient ReadableInternalTimeContext internalTimeContext;
+    private transient PassThroughCollectorBase evalCollector;
+    private transient PassAllCollector onTimerCollector;
     private transient ValueStateDescriptor<RowData>[] stateDescriptors;
     private transient ValueState<RowData>[] stateHandles;
-    private transient RowData[] stateToFunction;
-    private transient boolean[] stateCleared;
-    private transient RowData[] stateFromFunction;
+
+    private transient @Nullable MapState<StringData, Long> namedTimersMapState;
+    private transient @Nullable InternalTimerService<StringData> namedTimerService;
+    private transient @Nullable InternalTimerService<VoidNamespace> unnamedTimerService;
 
     public ProcessTableOperator(
             StreamOperatorParameters<RowData> parameters,
@@ -84,117 +102,108 @@ public class ProcessTableOperator extends AbstractStreamOperator<RowData>
     }
 
     @Override
-    @SuppressWarnings({"rawtypes", "unchecked"})
     public void open() throws Exception {
         super.open();
 
-        // Pass through columns
-        if (tableSemantics == null || tableSemantics.passColumnsThrough()) {
-            collector = new PassAllCollector(output);
-        } else {
-            collector = new PassPartitionKeysCollector(output, tableSemantics.partitionByColumns());
-        }
-        processTableRunner.runnerCollector = this.collector;
+        final RunnerContext runnerContext = new RunnerContext();
+        final RunnerOnTimerContext runnerOnTimerContext = new RunnerOnTimerContext();
 
-        // State
-        final KeyedStateStore keyedStateStore = getKeyedStateStore();
-        stateDescriptors = new ValueStateDescriptor[stateInfos.size()];
-        stateHandles = new ValueState[stateInfos.size()];
-        stateToFunction = new RowData[stateInfos.size()];
-        stateCleared = new boolean[stateInfos.size()];
-        stateFromFunction = new RowData[stateInfos.size()];
-        for (int i = 0; i < stateInfos.size(); i++) {
-            final RuntimeStateInfo stateInfo = stateInfos.get(i);
-            final LogicalType type = stateInfo.getType();
-            final ValueStateDescriptor<RowData> descriptor =
-                    new ValueStateDescriptor(
-                            stateInfo.getStateName(), InternalSerializers.create(type));
-            final StateTtlConfig ttlConfig =
-                    StateConfigUtil.createTtlConfig(stateInfo.getTimeToLive());
-            if (ttlConfig.isEnabled()) {
-                descriptor.enableTimeToLive(ttlConfig);
-            }
-            stateDescriptors[i] = descriptor;
-            stateHandles[i] = keyedStateStore.getState(descriptor);
-        }
+        setTimerServices();
+        setTimeContext();
+        setCollectors();
+        setStateDescriptors();
+        setStateHandles();
 
-        // Context
-        processTableRunner.runnerContext = new ProcessFunctionContext();
+        processTableRunner.initialize(
+                stateHandles,
+                stateHashCode,
+                stateEquals,
+                shouldEmitRowtime(),
+                runnerContext,
+                runnerOnTimerContext,
+                evalCollector,
+                onTimerCollector);
 
-        // Prepare runner
+        // Open runner
         FunctionUtils.setFunctionRuntimeContext(processTableRunner, getRuntimeContext());
         FunctionUtils.openFunction(processTableRunner, DefaultOpenContext.INSTANCE);
     }
 
     @Override
     public void processElement(StreamRecord<RowData> element) throws Exception {
-        collector.setInput(element.getValue());
-
-        // For each function call:
-        // - the state is read from Flink
-        // - converted into external data structure
-        // - evaluated
-        // - converted into internal data structure (if not cleared)
-        // - the state is written into Flink
-
-        moveStateToFunction();
-        processTableRunner.processElement(
-                stateToFunction, stateCleared, stateFromFunction, 0, element.getValue());
-        moveStateFromFunction();
-    }
-
-    private void moveStateToFunction() throws IOException {
-        Arrays.fill(stateCleared, false);
-        for (int i = 0; i < stateHandles.length; i++) {
-            final RowData value = stateHandles[i].value();
-            stateToFunction[i] = value;
+        // Set table argument
+        if (tableSemantics != null) {
+            processTableRunner.ingestTableEvent(0, element.getValue(), tableSemantics.timeColumn());
         }
+        processTableRunner.processEval();
     }
 
-    private void moveStateFromFunction() throws IOException {
-        for (int i = 0; i < stateHandles.length; i++) {
-            final RowData fromFunction = stateFromFunction[i];
-            if (fromFunction == null || isEmpty(fromFunction)) {
-                // Reduce state size
-                stateHandles[i].clear();
-            } else {
-                final HashFunction hashCode = this.stateHashCode[i];
-                final RecordEqualiser equals = this.stateEquals[i];
-                final RowData toFunction = stateToFunction[i];
-                // Reduce state updates by checking if something has changed
-                if (toFunction == null
-                        || hashCode.hashCode(toFunction) != hashCode.hashCode(fromFunction)
-                        || !equals.equals(toFunction, fromFunction)) {
-                    stateHandles[i].update(fromFunction);
-                }
-            }
-        }
+    @Override
+    public void processWatermark(Watermark mark) throws Exception {
+        super.processWatermark(mark);
+        processTableRunner.ingestWatermarkEvent(mark.getTimestamp());
     }
 
-    private static boolean isEmpty(RowData row) {
-        for (int i = 0; i < row.getArity(); i++) {
-            if (!row.isNullAt(i)) {
-                return false;
-            }
-        }
-        return row.getRowKind() == RowKind.INSERT;
+    @Override
+    public void onEventTime(InternalTimer<RowData, Object> timer) throws Exception {
+        final Object namedTimer = timer.getNamespace();
+        processTableRunner.ingestTimerEvent(
+                timer.getKey(),
+                namedTimer == VoidNamespace.INSTANCE ? null : (StringData) namedTimer,
+                timer.getTimestamp());
+        processTableRunner.processOnTimer();
     }
 
+    @Override
+    public void onProcessingTime(InternalTimer<RowData, Object> timer) throws Exception {}
+
+    /** Implementation of {@link ProcessTableFunction.Context}. */
     @Internal
-    public class ProcessFunctionContext implements ProcessTableFunction.Context {
+    public class RunnerContext implements ProcessTableFunction.Context {
 
         private final Map<String, RuntimeTableSemantics> tableSemanticsMap;
         private final Map<String, Integer> stateNameToPosMap;
 
-        ProcessFunctionContext() {
-            this.tableSemanticsMap =
-                    Optional.ofNullable(tableSemantics)
-                            .map(s -> Map.of(tableSemantics.getArgName(), tableSemantics))
-                            .orElse(Map.of());
-            this.stateNameToPosMap = new HashMap<>();
+        RunnerContext() {
+            this.tableSemanticsMap = createTableSemanticsMap();
+            this.stateNameToPosMap = createStateNameToPosMap();
+        }
+
+        private Map<String, RuntimeTableSemantics> createTableSemanticsMap() {
+            return Optional.ofNullable(tableSemantics)
+                    .map(s -> Map.of(tableSemantics.getArgName(), tableSemantics))
+                    .orElse(Map.of());
+        }
+
+        private Map<String, Integer> createStateNameToPosMap() {
+            final Map<String, Integer> stateNameToPosMap = new HashMap<>();
             for (int i = 0; i < stateInfos.size(); i++) {
-                this.stateNameToPosMap.put(stateInfos.get(i).getStateName(), i);
+                stateNameToPosMap.put(stateInfos.get(i).getStateName(), i);
             }
+            return stateNameToPosMap;
+        }
+
+        @Override
+        @SuppressWarnings({"unchecked"})
+        public <TimeType> TimeContext<TimeType> timeContext(Class<TimeType> conversionClass) {
+            final TimeConverter<?> timeConverter;
+            if (conversionClass == Instant.class) {
+                timeConverter = InstantTimeConverter.INSTANCE;
+            } else if (conversionClass == LocalDateTime.class) {
+                timeConverter = LocalDateTimeConverter.INSTANCE;
+            } else if (conversionClass == Long.class) {
+                timeConverter = LongTimeConverter.INSTANCE;
+            } else {
+                throw new TableRuntimeException(
+                        "Unsupported conversion class for TimeContext: "
+                                + conversionClass.getName());
+            }
+
+            internalTimeContext.setTime(
+                    processTableRunner.getCurrentWatermark(), processTableRunner.getTime());
+
+            return (TimeContext<TimeType>)
+                    new ExternalTimeContext<>(internalTimeContext, timeConverter);
         }
 
         @Override
@@ -212,12 +221,23 @@ public class ProcessTableOperator extends AbstractStreamOperator<RowData>
             if (statePos == null) {
                 throw new TableRuntimeException("Unknown state entry: " + stateName);
             }
-            stateCleared[statePos] = true;
+            processTableRunner.clearState(statePos);
         }
 
         @Override
         public void clearAllState() {
-            Arrays.fill(stateCleared, true);
+            processTableRunner.clearAllState();
+        }
+
+        @Override
+        public void clearAllTimers() {
+            internalTimeContext.clearAllTimers();
+        }
+
+        @Override
+        public void clearAll() {
+            clearAllState();
+            clearAllTimers();
         }
 
         @VisibleForTesting
@@ -228,5 +248,107 @@ public class ProcessTableOperator extends AbstractStreamOperator<RowData>
             }
             return stateDescriptors[statePos];
         }
+    }
+
+    /** Implementation of {@link ProcessTableFunction.OnTimerContext}. */
+    @Internal
+    public class RunnerOnTimerContext extends RunnerContext
+            implements ProcessTableFunction.OnTimerContext {
+
+        @Override
+        public @Nullable String currentTimer() {
+            final StringData timerName = processTableRunner.getTimerName();
+            return timerName == null ? null : timerName.toString();
+        }
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Instances from table semantics
+    // --------------------------------------------------------------------------------------------
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private void setTimerServices() {
+        if (shouldEnableTimers()) {
+            final KeyedStateStore keyedStateStore = getKeyedStateStore();
+            final MapStateDescriptor<StringData, Long> namedTimersDescriptor =
+                    new MapStateDescriptor<>(
+                            "internal-named-timers-map",
+                            StringDataSerializer.INSTANCE,
+                            LongSerializer.INSTANCE);
+            namedTimersMapState = keyedStateStore.getMapState(namedTimersDescriptor);
+            namedTimerService =
+                    getInternalTimerService(
+                            "user-named-timers", StringDataSerializer.INSTANCE, (Triggerable) this);
+            unnamedTimerService =
+                    getInternalTimerService(
+                            "user-unnamed-timers",
+                            VoidNamespaceSerializer.INSTANCE,
+                            (Triggerable) this);
+        } else {
+            namedTimersMapState = null;
+            namedTimerService = null;
+            unnamedTimerService = null;
+        }
+    }
+
+    private void setTimeContext() {
+        if (shouldEnableTimers()) {
+            internalTimeContext =
+                    new WritableInternalTimeContext(
+                            namedTimersMapState, namedTimerService, unnamedTimerService);
+        } else {
+            internalTimeContext = new ReadableInternalTimeContext();
+        }
+    }
+
+    private void setCollectors() {
+        if (tableSemantics == null || tableSemantics.passColumnsThrough()) {
+            evalCollector = new PassAllCollector(output);
+        } else {
+            evalCollector =
+                    new PassPartitionKeysCollector(output, tableSemantics.partitionByColumns());
+        }
+        onTimerCollector = new PassAllCollector(output);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void setStateDescriptors() {
+        final ValueStateDescriptor<RowData>[] stateDescriptors =
+                new ValueStateDescriptor[stateInfos.size()];
+        for (int i = 0; i < stateInfos.size(); i++) {
+            final RuntimeStateInfo stateInfo = stateInfos.get(i);
+            final LogicalType type = stateInfo.getType();
+            final ValueStateDescriptor<RowData> stateDescriptor =
+                    new ValueStateDescriptor<>(
+                            stateInfo.getStateName(), InternalSerializers.create(type));
+            final StateTtlConfig ttlConfig =
+                    StateConfigUtil.createTtlConfig(stateInfo.getTimeToLive());
+            if (ttlConfig.isEnabled()) {
+                stateDescriptor.enableTimeToLive(ttlConfig);
+            }
+            stateDescriptors[i] = stateDescriptor;
+        }
+        this.stateDescriptors = stateDescriptors;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void setStateHandles() {
+        final KeyedStateStore keyedStateStore = getKeyedStateStore();
+        final ValueState<RowData>[] stateHandles = new ValueState[stateDescriptors.length];
+        for (int i = 0; i < stateInfos.size(); i++) {
+            stateHandles[i] = keyedStateStore.getState(stateDescriptors[i]);
+        }
+        this.stateHandles = stateHandles;
+    }
+
+    private boolean shouldEmitRowtime() {
+        return tableSemantics != null && tableSemantics.timeColumn() != -1;
+    }
+
+    private boolean shouldEnableTimers() {
+        return tableSemantics != null
+                && tableSemantics.hasSetSemantics()
+                && !tableSemantics.passColumnsThrough()
+                && tableSemantics.getChangelogMode().containsOnly(RowKind.INSERT);
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/process/ReadableInternalTimeContext.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/process/ReadableInternalTimeContext.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.process;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.TableRuntimeException;
+import org.apache.flink.table.functions.ProcessTableFunction;
+import org.apache.flink.table.types.inference.StaticArgumentTrait;
+
+import javax.annotation.Nullable;
+
+import static org.apache.flink.table.functions.ProcessTableFunction.TimeContext;
+
+/**
+ * Internal {@link TimeContext} for PTFs with row semantics, PTFs without table arguments, or traits
+ * {@link StaticArgumentTrait#PASS_COLUMNS_THROUGH} and {@link StaticArgumentTrait#SUPPORT_UPDATES}.
+ */
+@Internal
+class ReadableInternalTimeContext implements ProcessTableFunction.TimeContext<Long> {
+
+    protected long currentWatermark;
+    protected @Nullable Long time;
+
+    void setTime(long currentWatermark, @Nullable Long time) {
+        this.currentWatermark = currentWatermark;
+        this.time = time;
+    }
+
+    @Override
+    public Long time() {
+        if (time == null) {
+            return null;
+        }
+        return time;
+    }
+
+    @Override
+    public Long currentWatermark() {
+        if (currentWatermark == Long.MIN_VALUE) {
+            return null;
+        }
+        return currentWatermark;
+    }
+
+    @Override
+    public void registerOnTime(String name, Long time) {
+        throw readOnlyException();
+    }
+
+    @Override
+    public void registerOnTime(Long time) {
+        throw readOnlyException();
+    }
+
+    @Override
+    public void clearTimer(String name) {}
+
+    @Override
+    public void clearTimer(Long time) {}
+
+    @Override
+    public void clearAllTimers() {}
+
+    private static TableRuntimeException readOnlyException() {
+        return new TableRuntimeException(
+                "Timers are not supported in the current PTF declaration. "
+                        + "Note that only PTFs that take set semantic tables support timers. "
+                        + "Also timers are not available for advanced traits such as supporting pass-through columns or updates.");
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/process/RuntimeTableSemantics.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/process/RuntimeTableSemantics.java
@@ -43,6 +43,7 @@ public class RuntimeTableSemantics implements TableSemantics, Serializable {
     private final byte[] expectedChanges;
     private final boolean passColumnsThrough;
     private final boolean hasSetSemantics;
+    private final int timeColumn;
 
     private transient ChangelogMode changelogMode;
 
@@ -53,7 +54,8 @@ public class RuntimeTableSemantics implements TableSemantics, Serializable {
             int[] partitionByColumns,
             byte[] expectedChanges,
             boolean passColumnsThrough,
-            boolean hasSetSemantics) {
+            boolean hasSetSemantics,
+            int timeColumn) {
         this.argName = argName;
         this.inputIndex = inputIndex;
         this.dataType = dataType;
@@ -61,6 +63,7 @@ public class RuntimeTableSemantics implements TableSemantics, Serializable {
         this.expectedChanges = expectedChanges;
         this.passColumnsThrough = passColumnsThrough;
         this.hasSetSemantics = hasSetSemantics;
+        this.timeColumn = timeColumn;
     }
 
     public String getArgName() {
@@ -77,6 +80,17 @@ public class RuntimeTableSemantics implements TableSemantics, Serializable {
 
     public boolean hasSetSemantics() {
         return hasSetSemantics;
+    }
+
+    public ChangelogMode getChangelogMode() {
+        if (changelogMode == null) {
+            final ChangelogMode.Builder builder = ChangelogMode.newBuilder();
+            for (byte expectedChange : expectedChanges) {
+                builder.addContainedKind(RowKind.fromByteValue(expectedChange));
+            }
+            changelogMode = builder.build();
+        }
+        return changelogMode;
     }
 
     @Override
@@ -96,7 +110,7 @@ public class RuntimeTableSemantics implements TableSemantics, Serializable {
 
     @Override
     public int timeColumn() {
-        return -1;
+        return timeColumn;
     }
 
     @Override
@@ -106,13 +120,6 @@ public class RuntimeTableSemantics implements TableSemantics, Serializable {
 
     @Override
     public Optional<ChangelogMode> changelogMode() {
-        if (changelogMode == null) {
-            final ChangelogMode.Builder builder = ChangelogMode.newBuilder();
-            for (byte expectedChange : expectedChanges) {
-                builder.addContainedKind(RowKind.fromByteValue(expectedChange));
-            }
-            changelogMode = builder.build();
-        }
-        return Optional.of(changelogMode);
+        return Optional.of(getChangelogMode());
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/process/TimeConverter.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/process/TimeConverter.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.process;
+
+import org.apache.flink.annotation.Internal;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+/** Time converter between internal and external time conversion classes. */
+@Internal
+abstract class TimeConverter<TimeConversion> {
+
+    abstract TimeConversion toExternal(long timeInternal);
+
+    abstract long toInternal(TimeConversion timeExternal);
+
+    private TimeConverter() {}
+
+    static class InstantTimeConverter extends TimeConverter<Instant> {
+
+        static final TimeConverter<Instant> INSTANCE = new InstantTimeConverter();
+
+        private InstantTimeConverter() {}
+
+        @Override
+        Instant toExternal(long timeInternal) {
+            return Instant.ofEpochMilli(timeInternal);
+        }
+
+        @Override
+        long toInternal(Instant timeExternal) {
+            return timeExternal.toEpochMilli();
+        }
+    }
+
+    static class LocalDateTimeConverter extends TimeConverter<LocalDateTime> {
+
+        static final LocalDateTimeConverter INSTANCE = new LocalDateTimeConverter();
+
+        private LocalDateTimeConverter() {}
+
+        @Override
+        LocalDateTime toExternal(long timeInternal) {
+            return LocalDateTime.ofInstant(Instant.ofEpochMilli(timeInternal), ZoneOffset.UTC);
+        }
+
+        @Override
+        long toInternal(LocalDateTime timeExternal) {
+            return timeExternal.toInstant(ZoneOffset.UTC).toEpochMilli();
+        }
+    }
+
+    static class LongTimeConverter extends TimeConverter<Long> {
+
+        static final LongTimeConverter INSTANCE = new LongTimeConverter();
+
+        private LongTimeConverter() {}
+
+        @Override
+        Long toExternal(long timeInternal) {
+            return timeInternal;
+        }
+
+        @Override
+        long toInternal(Long timeExternal) {
+            return timeExternal;
+        }
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/process/WritableInternalTimeContext.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/process/WritableInternalTimeContext.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.process;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.state.MapState;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.streaming.api.operators.InternalTimerService;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.functions.ProcessTableFunction.TimeContext;
+import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/** Internal {@link TimeContext} for PTFs with set semantics. */
+@Internal
+class WritableInternalTimeContext extends ReadableInternalTimeContext {
+
+    private final MapState<StringData, Long> namedTimersMapState;
+    private final InternalTimerService<StringData> namedTimerService;
+    private final InternalTimerService<VoidNamespace> unnamedTimerService;
+
+    WritableInternalTimeContext(
+            MapState<StringData, Long> namedTimersMapState,
+            InternalTimerService<StringData> namedTimerService,
+            InternalTimerService<VoidNamespace> unnamedTimerService) {
+        this.namedTimersMapState = namedTimersMapState;
+        this.namedTimerService = namedTimerService;
+        this.unnamedTimerService = unnamedTimerService;
+    }
+
+    @Override
+    public Long currentWatermark() {
+        final long currentWatermark = unnamedTimerService.currentWatermark();
+        if (currentWatermark == Long.MIN_VALUE) {
+            return null;
+        }
+        return currentWatermark;
+    }
+
+    @Override
+    public void registerOnTime(String name, Long time) {
+        registerOnTimeInternal(name, time);
+    }
+
+    @Override
+    public void registerOnTime(Long time) {
+        registerOnTimeInternal(null, time);
+    }
+
+    @Override
+    public void clearTimer(String name) {
+        Preconditions.checkNotNull(name, "Timer name must not be null.");
+        deleteTimerInternal(name);
+    }
+
+    @Override
+    public void clearTimer(Long time) {
+        deleteTimerInternal(time);
+    }
+
+    @Override
+    public void clearAllTimers() {
+        clearUnnamedTimers();
+        clearNamedTimers();
+    }
+
+    private void registerOnTimeInternal(@Nullable String name, long newTime) {
+        if (newTime <= unnamedTimerService.currentWatermark()) {
+            // Do not register timers for late events.
+            // Otherwise, the next watermark would trigger an onTimer() that emits late events.
+            return;
+        }
+        if (name != null) {
+            replaceNamedTimer(StringData.fromString(name), newTime);
+        } else {
+            registerUnnamedTimer(newTime);
+        }
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Unnamed timers
+    // --------------------------------------------------------------------------------------------
+
+    protected void deleteTimerInternal(long time) {
+        deleteUnnamedTimer(time);
+    }
+
+    private void registerUnnamedTimer(long time) {
+        unnamedTimerService.registerEventTimeTimer(VoidNamespace.INSTANCE, time);
+    }
+
+    private void deleteUnnamedTimer(long time) {
+        unnamedTimerService.deleteEventTimeTimer(VoidNamespace.INSTANCE, time);
+    }
+
+    private void clearUnnamedTimers() {
+        final List<Long> unnamedTimers = new ArrayList<>();
+        try {
+            unnamedTimerService.forEachEventTimeTimer((namespace, time) -> unnamedTimers.add(time));
+        } catch (Exception e) {
+            throw new FlinkRuntimeException(e);
+        }
+        unnamedTimers.forEach(
+                time -> unnamedTimerService.deleteEventTimeTimer(VoidNamespace.INSTANCE, time));
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Named timers
+    // --------------------------------------------------------------------------------------------
+
+    private void deleteTimerInternal(String name) {
+        deleteNamedTimer(StringData.fromString(name));
+    }
+
+    private void replaceNamedTimer(StringData internalName, long newTime) {
+        final Long existingTime;
+        try {
+            existingTime = namedTimersMapState.get(internalName);
+        } catch (Exception e) {
+            throw new FlinkRuntimeException(e);
+        }
+        if (existingTime != null) {
+            namedTimerService.deleteEventTimeTimer(internalName, existingTime);
+        }
+        registerNamedTimer(internalName, newTime);
+    }
+
+    private void registerNamedTimer(StringData internalName, long newTime) {
+        try {
+            namedTimersMapState.put(internalName, newTime);
+        } catch (Exception e) {
+            throw new FlinkRuntimeException(e);
+        }
+        namedTimerService.registerEventTimeTimer(internalName, newTime);
+    }
+
+    private void deleteNamedTimer(StringData internalName) {
+        final Long existingTime;
+        try {
+            existingTime = namedTimersMapState.get(internalName);
+        } catch (Exception e) {
+            throw new FlinkRuntimeException(e);
+        }
+        if (existingTime != null) {
+            namedTimerService.deleteEventTimeTimer(internalName, existingTime);
+            try {
+                namedTimersMapState.remove(internalName);
+            } catch (Exception e) {
+                throw new FlinkRuntimeException(e);
+            }
+        }
+    }
+
+    private void clearNamedTimers() {
+        final Iterable<Map.Entry<StringData, Long>> entries;
+        try {
+            entries = namedTimersMapState.entries();
+        } catch (Exception e) {
+            throw new FlinkRuntimeException(e);
+        }
+        entries.forEach(e -> namedTimerService.deleteEventTimeTimer(e.getKey(), e.getValue()));
+        namedTimersMapState.clear();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This introduces time and timer support for PTFs according to section 5.2.1 in [FLIP-440]([url](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=298781093#FLIP440:UserdefinedSQLoperators/ProcessTableFunction(PTF)-TimeSemantics)).

In a nutshell:
- Every PTF takes an `on_time` DESCRIPTOR argument.
- The `on_time` is optional by default but can be made mandatory (esp. useful for built-in functions).
- If `on_time` is declared, the PTFs output contains a `rowtime` column for subsequent time-based operations.
- A `TimeContext` is available in the `Context` of a PTF's `eval()` method.
- Timers can be created, replaced, deleted and fired.
- An `onTimer()` can be implemented for reacting to timer firings.
- Timers can named or unnamed.
- Late events are dropped.

## Brief change log

- Adapt SystemTypeInference accordingly.
- Refactor the `ProcessTableOperator` and `ProcessTableRunner` for supporting both table row events and timer events.
- Add TimeContext and OnTimerContext to `ProcessTableFunction` including extensive JavaDocs

## Verifying this change

This change added tests and can be verified as follows:

```
ProcessTableFunctionTestPrograms.PROCESS_TIME_CONVERSIONS,
ProcessTableFunctionTestPrograms.PROCESS_REGULAR_TIMESTAMP,
ProcessTableFunctionTestPrograms.PROCESS_NAMED_TIMERS,
ProcessTableFunctionTestPrograms.PROCESS_UNNAMED_TIMERS,
ProcessTableFunctionTestPrograms.PROCESS_LATE_EVENTS,
ProcessTableFunctionTestPrograms.PROCESS_SCALAR_ARGS_TIME,
ProcessTableFunctionTestPrograms.PROCESS_OPTIONAL_PARTITION_BY_TIME,
ProcessTableFunctionTestPrograms.PROCESS_OPTIONAL_ON_TIME,
ProcessTableFunctionTestPrograms.PROCESS_POJO_STATE_TIME,
ProcessTableFunctionTestPrograms.PROCESS_CHAINED_TIME,
ProcessTableFunctionTestPrograms.PROCESS_INVALID_TABLE_AS_ROW_TIMERS,
ProcessTableFunctionTestPrograms.PROCESS_INVALID_PASS_THROUGH_TIMERS,
ProcessTableFunctionTestPrograms.PROCESS_INVALID_UPDATING_TIMERS
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
