### PR TITLE
[FLINK-37424][release] Using JDK11 for the binary convenience release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1403,7 +1403,7 @@ under the License.
 				</property>
 			</activation>
 			<properties>
-				<target.java.version>17</target.java.version>
+				<target.java.version>11</target.java.version>
 			</properties>
 			<build>
 				<plugins>


### PR DESCRIPTION
We should use JDK11 instead of JDK17(in release profile now) for the binary release. Otherwise :

- We can not provide the docker image of jdk11, because it package flink from binary convenience release not compile from source.
- Users cannot use the flink dist downloaded from the official website directly in the setup of jdk11. But we still claim to support jdk11 in 2.0.