### PR TITLE
[BP-2.0][FLINK-37425] Sanity check before ForSt cache created

### DIFF
--- a/docs/layouts/shortcodes/generated/forst_configuration.html
+++ b/docs/layouts/shortcodes/generated/forst_configuration.html
@@ -30,13 +30,13 @@
             <td><h5>state.backend.forst.cache.reserve-size</h5></td>
             <td style="word-wrap: break-word;">256 mb</td>
             <td>MemorySize</td>
-            <td>The reserved size of cache, when set to a positive number. Meaning that the cache will reserve the specified size of disk space. This option and the 'state.backend.forst.cache.size-based-limit' option can be set simultaneously, the smaller cache limit will be used as the upper limit. The default value is '256 mb', meaning the disk will be reserved that much and remaining of which can be used for cache.</td>
+            <td>The amount of reserved size on disk space, and remaining space can be leveraged by the cache. The cache will evict the oldest files when the reserved space on disk (the disk where cache directory is) is not enough. User should specify at least one cache size limit to enable the cache, either this option or the 'state.backend.forst.cache.size-based-limit' option. They can be set simultaneously, and in this case, cache will grow if meet the requirements of both two options. If the specified file system of the cache directory does not support reading the remaining space, the cache will not be able to reserve the specified space, hence this option will be ignored. The default value is '256 mb', meaning the disk will be reserved that much space, and the remaining of the disk can be used for cache. A configured value of '0 bytes' means that this option is disabled.</td>
         </tr>
         <tr>
             <td><h5>state.backend.forst.cache.size-based-limit</h5></td>
             <td style="word-wrap: break-word;">0 bytes</td>
             <td>MemorySize</td>
-            <td>The size-based capacity limit of cache.The default value is '0 bytes', which means that the cache size is not limited by size.</td>
+            <td>An upper-bound of the size that can be used for cache. User should specify at least one cache size limit to enable the cache, either this option or the 'state.backend.forst.cache.reserve-size' option. They can be set simultaneously, and in this case, cache will grow if meet the requirements of both two options. The default value is '0 bytes', meaning that this option is disabled. </td>
         </tr>
         <tr>
             <td><h5>state.backend.forst.executor.inline-coordinator</h5></td>

--- a/docs/layouts/shortcodes/generated/state_backend_forst_section.html
+++ b/docs/layouts/shortcodes/generated/state_backend_forst_section.html
@@ -18,13 +18,13 @@
             <td><h5>state.backend.forst.cache.reserve-size</h5></td>
             <td style="word-wrap: break-word;">256 mb</td>
             <td>MemorySize</td>
-            <td>The reserved size of cache, when set to a positive number. Meaning that the cache will reserve the specified size of disk space. This option and the 'state.backend.forst.cache.size-based-limit' option can be set simultaneously, the smaller cache limit will be used as the upper limit. The default value is '256 mb', meaning the disk will be reserved that much and remaining of which can be used for cache.</td>
+            <td>The amount of reserved size on disk space, and remaining space can be leveraged by the cache. The cache will evict the oldest files when the reserved space on disk (the disk where cache directory is) is not enough. User should specify at least one cache size limit to enable the cache, either this option or the 'state.backend.forst.cache.size-based-limit' option. They can be set simultaneously, and in this case, cache will grow if meet the requirements of both two options. If the specified file system of the cache directory does not support reading the remaining space, the cache will not be able to reserve the specified space, hence this option will be ignored. The default value is '256 mb', meaning the disk will be reserved that much space, and the remaining of the disk can be used for cache. A configured value of '0 bytes' means that this option is disabled.</td>
         </tr>
         <tr>
             <td><h5>state.backend.forst.cache.size-based-limit</h5></td>
             <td style="word-wrap: break-word;">0 bytes</td>
             <td>MemorySize</td>
-            <td>The size-based capacity limit of cache.The default value is '0 bytes', which means that the cache size is not limited by size.</td>
+            <td>An upper-bound of the size that can be used for cache. User should specify at least one cache size limit to enable the cache, either this option or the 'state.backend.forst.cache.reserve-size' option. They can be set simultaneously, and in this case, cache will grow if meet the requirements of both two options. The default value is '0 bytes', meaning that this option is disabled. </td>
         </tr>
         <tr>
             <td><h5>state.backend.forst.executor.read-io-parallelism</h5></td>

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStOptions.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStOptions.java
@@ -85,8 +85,14 @@ public class ForStOptions {
                     .withDescription(
                             Description.builder()
                                     .text(
-                                            "The size-based capacity limit of cache."
-                                                    + "The default value is '%s', which means that the cache size is not limited by size.",
+                                            "An upper-bound of the size that can be used for cache. User "
+                                                    + "should specify at least one cache size limit to enable the cache, "
+                                                    + "either this option or the '%s' option. "
+                                                    + "They can be set simultaneously, and in this case, cache "
+                                                    + "will grow if meet the requirements of both two options. "
+                                                    + "The default value is '%s', meaning that this option is disabled. ",
+                                            // can not ref the static member before definition.
+                                            text("state.backend.forst.cache.reserve-size"),
                                             text(MemorySize.ZERO.toString()))
                                     .build());
 
@@ -98,14 +104,22 @@ public class ForStOptions {
                     .withDescription(
                             Description.builder()
                                     .text(
-                                            "The reserved size of cache, when set to a positive number. Meaning that "
-                                                    + "the cache will reserve the specified size of disk space. "
-                                                    + "This option and the '%s' option can be set simultaneously, the "
-                                                    + "smaller cache limit will be used as the upper limit. "
-                                                    + "The default value is '%s', meaning the disk will be reserved that much "
-                                                    + "and remaining of which can be used for cache.",
+                                            "The amount of reserved size on disk space, and remaining space can be "
+                                                    + "leveraged by the cache. The cache will evict the oldest files when "
+                                                    + "the reserved space on disk (the disk where cache directory is) is not "
+                                                    + "enough. User should specify at least one cache size limit to enable the cache, "
+                                                    + "either this option or the '%s' option. "
+                                                    + "They can be set simultaneously, and in this case, "
+                                                    + "cache will grow if meet the requirements of both two options. "
+                                                    + "If the specified file system of the cache directory does not support "
+                                                    + "reading the remaining space, the cache will not be able to reserve "
+                                                    + "the specified space, hence this option will be ignored. "
+                                                    + "The default value is '%s', meaning the disk will be reserved that much space, "
+                                                    + "and the remaining of the disk can be used for cache. "
+                                                    + "A configured value of '%s' means that this option is disabled.",
                                             text(CACHE_SIZE_BASE_LIMIT.key()),
-                                            text(MemorySize.ofMebiBytes(256).toString()))
+                                            text(MemorySize.ofMebiBytes(256).toString()),
+                                            text(MemorySize.ZERO.toString()))
                                     .build());
 
     @Documentation.Section(Documentation.Sections.EXPERT_FORST)

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/fs/cache/SpaceBasedCacheLimitPolicy.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/fs/cache/SpaceBasedCacheLimitPolicy.java
@@ -67,6 +67,12 @@ public class SpaceBasedCacheLimitPolicy implements CacheLimitPolicy {
                 reservedSize);
     }
 
+    public static boolean worksOn(File instanceBasePath) {
+        // We could detect the free space of the instance base path to determine whether the cache
+        // limit policy works.
+        return instanceBasePath.getFreeSpace() > 0;
+    }
+
     private boolean isOverSpace(long toAddSize, long leftSpace) {
         return toAddSize > instanceBasePath.getFreeSpace() - leftSpace;
     }


### PR DESCRIPTION
## What is the purpose of the change

There is a chance that the space based cache limit policy in ForStStateBackend could not work on the specified cache path, resulting in the whole cache fail to store anything. This PR fixes this.


## Brief change log

 - Create cache path before policy created.
 - Sanity check before the policy created.


## Verifying this change

This change is a trivial work without any test coverage. I have tested it manually via a job in specific env.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
