### PR TITLE
[hotfix] make previousCpuTicks and previousProcCpuTicks volatile to increase visibility for all threads

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/SystemResourcesCounter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/SystemResourcesCounter.java
@@ -54,7 +54,7 @@ public class SystemResourcesCounter extends Thread {
     private volatile boolean running = true;
 
     private volatile long[] previousCpuTicks;
-    private long[][] previousProcCpuTicks;
+    private volatile long[][] previousProcCpuTicks;
     private long[] bytesReceivedPerInterface;
     private long[] bytesSentPerInterface;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/SystemResourcesCounter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/SystemResourcesCounter.java
@@ -53,7 +53,7 @@ public class SystemResourcesCounter extends Thread {
 
     private volatile boolean running = true;
 
-    private long[] previousCpuTicks;
+    private volatile long[] previousCpuTicks;
     private long[][] previousProcCpuTicks;
     private long[] bytesReceivedPerInterface;
     private long[] bytesSentPerInterface;


### PR DESCRIPTION
## What is the purpose of the change
This pull request fixes a visibility issue in the `SystemResourcesCounter `class by marking `previousCpuTicks `and `previousProcCpuTicks `as volatile.

Previously, these variables were not declared as volatile, meaning updates made by one thread might not be immediately visible to others. This could lead to stale values being read by different threads.

By making these variables volatile, we ensure that all threads see the most up-to-date values, preventing inconsistencies.

## Brief change log

- Marked `previousCpuTicks` and `previousProcCpuTicks` as volatile to ensure proper visibility across threads.

## Verifying this change
This change is a trivial rework/code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts?

- Dependencies (does it add or upgrade a dependency)? No
- The public API (i.e., is any changed class annotated with `@Public(Evolving)`)? No
- The serializers? Unsure
- The runtime per-record code paths (performance sensitive)? Unsure
- Anything that affects deployment or recovery (JobManager, Checkpointing, Kubernetes/Yarn, ZooKeeper)? Unsure
- The S3 file system connector? Unsure

## Documentation

- Does this pull request introduce a new feature? No
- If yes, how is the feature documented? Not applicable