### PR TITLE
[FLINK-37424][release] Using JDK11 for the nightly binary release

### DIFF
--- a/tools/azure-pipelines/build-apache-repo.yml
+++ b/tools/azure-pipelines/build-apache-repo.yml
@@ -105,6 +105,8 @@ stages:
           stage_name: cron_snapshot_deployment
           environment: PROFILE="-Djdk11 -Pjava11-target"
           container: flink-build-container
+          # In order for other repository's(e.g. flink-docker, flink-benchmarks) CI to cover all supported jdks, keep it to the minimum supported version.
+          # Upgrade this only when we drop support for this jdk version.
           jdk: 11
       - template: jobs-template.yml
         parameters:

--- a/tools/azure-pipelines/build-apache-repo.yml
+++ b/tools/azure-pipelines/build-apache-repo.yml
@@ -103,9 +103,9 @@ stages:
       - template: build-nightly-dist.yml
         parameters:
           stage_name: cron_snapshot_deployment
-          environment: PROFILE="-Djdk17 -Pjava17-target"
+          environment: PROFILE="-Djdk11 -Pjava11-target"
           container: flink-build-container
-          jdk: 17
+          jdk: 11
       - template: jobs-template.yml
         parameters:
           stage_name: cron_azure


### PR DESCRIPTION
## What is the purpose of the change

*We should put the nightly binary release build from the minimum supported jdk version. Otherwise, some ci(e.g. ci of flink-docker dev-2.0 branch) can not run in jdk11 setup(but we still want to provide the jdk11 flink image).*


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
