### PR TITLE
[hotfix] Remove unnecessary exclude in japicmp plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2338,24 +2338,11 @@ under the License.
 								<exclude>org.apache.flink.api.common.functions.RichMapFunction</exclude>
 								<exclude>org.apache.flink.api.common.functions.RichMapPartitionFunction</exclude>
 								<exclude>org.apache.flink.api.common.functions.RichReduceFunction</exclude>
-								<!-- FLINK-34085 Deprecated string config should be removed in 2.0 -->
-								<exclude>org.apache.flink.configuration.ConfigConstants</exclude>
 								<!-- FLINK-35886: WatermarksWithIdleness constructor was marked as deprecated -->
 								<exclude>org.apache.flink.api.common.eventtime.WatermarksWithIdleness</exclude>
 								<!-- FLINK-35812 move tuple interfaces into flink-core-api, should be removed in 2.0 -->
 								<exclude>org.apache.flink.api.java.tuple.*</exclude>
 								<exclude>org.apache.flink.types.NullFieldException</exclude>
-								<!-- FLINK-36225 Remove deprecated methods marked in FLIP-382 -->
-								<exclude>org.apache.flink.api.common.functions.RuntimeContext#getAttemptNumber()</exclude>
-								<exclude>org.apache.flink.api.common.functions.RuntimeContext#getIndexOfThisSubtask()</exclude>
-								<exclude>org.apache.flink.api.common.functions.RuntimeContext#getJobId()</exclude>
-								<exclude>org.apache.flink.api.common.functions.RuntimeContext#getNumberOfParallelSubtasks()</exclude>
-								<exclude>org.apache.flink.api.common.functions.RuntimeContext#getTaskName()</exclude>
-								<exclude>org.apache.flink.api.common.functions.RuntimeContext#getTaskNameWithSubtasks()</exclude>
-								<exclude>org.apache.flink.api.connector.sink2.Sink$InitContextWrapper#getAttemptNumber()</exclude>
-								<exclude>org.apache.flink.api.connector.sink2.Sink$InitContextWrapper#getJobId()</exclude>
-								<exclude>org.apache.flink.api.connector.sink2.Sink$InitContextWrapper#getNumberOfParallelSubtasks()</exclude>
-								<exclude>org.apache.flink.api.connector.sink2.Sink$InitContextWrapper#getSubtaskId()</exclude>
 								<!-- The following exclusions are due to classes being relocated from the flink-streaming-java
 									module to the flink-runtime module. -->
 								<exclude>org.apache.flink.streaming.api.functions.windowing.AllWindowFunction</exclude>
@@ -2386,10 +2373,6 @@ under the License.
 								<exclude>org.apache.flink.streaming.api.functions.source.RichSourceFunction</exclude>
 								<exclude>org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction</exclude>
 								<exclude>org.apache.flink.streaming.api.functions.source.ParallelSourceFunction</exclude>
-								<!-- FLINK-33712 deprecated the RuntimeContext#getExecutionConfig; this will be removed in Flink 2.0. -->
-								<exclude>
-									org.apache.flink.api.common.functions.RuntimeContext#getExecutionConfig()
-								</exclude>
 								<!-- FLINK-3992 Do not implement deprecated Key interface in flink 2.0 -->
 								<exclude>org.apache.flink.types.DoubleValue</exclude>
 								<exclude>org.apache.flink.types.FloatValue</exclude>


### PR DESCRIPTION
## What is the purpose of the change

Some exclusions in japicmp config are unnecessary as they overlap with the exclusion of @deprecated. This PR remove those unnecessary exclusions.


## Brief change log

- Remove unnecessary exclude in japicmp plugin


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
