### PR TITLE
[FLINK-37401] Add Job ID to logging context

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -373,95 +373,102 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
         checkNotNull(jobManagerAddress);
         checkNotNull(jobId);
 
-        if (!jobLeaderIdService.containsJob(jobId)) {
+        try (MdcCloseable ignored = MdcUtils.withContext(MdcUtils.asContextData(jobId))) {
+            if (!jobLeaderIdService.containsJob(jobId)) {
+                try {
+                    jobLeaderIdService.addJob(jobId);
+                } catch (Exception e) {
+                    ResourceManagerException exception =
+                            new ResourceManagerException(
+                                    "Could not add the job "
+                                            + jobId
+                                            + " to the job id leader service.",
+                                    e);
+
+                    onFatalError(exception);
+
+                    log.error("Could not add job {} to job leader id service.", jobId, e);
+                    return FutureUtils.completedExceptionally(exception);
+                }
+            }
+
+            log.info(
+                    "Registering job manager {}@{} for job {}.",
+                    jobMasterId,
+                    jobManagerAddress,
+                    jobId);
+
+            CompletableFuture<JobMasterId> jobMasterIdFuture;
+
             try {
-                jobLeaderIdService.addJob(jobId);
+                jobMasterIdFuture = jobLeaderIdService.getLeaderId(jobId);
             } catch (Exception e) {
+                // we cannot check the job leader id so let's fail
+                // TODO: Maybe it's also ok to skip this check in case that we cannot check the
+                // leader id
                 ResourceManagerException exception =
                         new ResourceManagerException(
-                                "Could not add the job " + jobId + " to the job id leader service.",
+                                "Cannot obtain the "
+                                        + "job leader id future to verify the correct job leader.",
                                 e);
 
                 onFatalError(exception);
 
-                log.error("Could not add job {} to job leader id service.", jobId, e);
+                log.debug(
+                        "Could not obtain the job leader id future to verify the correct job leader.");
                 return FutureUtils.completedExceptionally(exception);
             }
-        }
 
-        log.info(
-                "Registering job manager {}@{} for job {}.", jobMasterId, jobManagerAddress, jobId);
+            CompletableFuture<JobMasterGateway> jobMasterGatewayFuture =
+                    getRpcService().connect(jobManagerAddress, jobMasterId, JobMasterGateway.class);
 
-        CompletableFuture<JobMasterId> jobMasterIdFuture;
+            CompletableFuture<RegistrationResponse> registrationResponseFuture =
+                    jobMasterGatewayFuture.thenCombineAsync(
+                            jobMasterIdFuture,
+                            (JobMasterGateway jobMasterGateway, JobMasterId leadingJobMasterId) -> {
+                                if (Objects.equals(leadingJobMasterId, jobMasterId)) {
+                                    return registerJobMasterInternal(
+                                            jobMasterGateway,
+                                            jobId,
+                                            jobManagerAddress,
+                                            jobManagerResourceId);
+                                } else {
+                                    final String declineMessage =
+                                            String.format(
+                                                    "The leading JobMaster id %s did not match the received JobMaster id %s. "
+                                                            + "This indicates that a JobMaster leader change has happened.",
+                                                    leadingJobMasterId, jobMasterId);
+                                    log.debug(declineMessage);
+                                    return new RegistrationResponse.Failure(
+                                            new FlinkException(declineMessage));
+                                }
+                            },
+                            getMainThreadExecutor(jobId));
 
-        try {
-            jobMasterIdFuture = jobLeaderIdService.getLeaderId(jobId);
-        } catch (Exception e) {
-            // we cannot check the job leader id so let's fail
-            // TODO: Maybe it's also ok to skip this check in case that we cannot check the leader
-            // id
-            ResourceManagerException exception =
-                    new ResourceManagerException(
-                            "Cannot obtain the "
-                                    + "job leader id future to verify the correct job leader.",
-                            e);
-
-            onFatalError(exception);
-
-            log.debug(
-                    "Could not obtain the job leader id future to verify the correct job leader.");
-            return FutureUtils.completedExceptionally(exception);
-        }
-
-        CompletableFuture<JobMasterGateway> jobMasterGatewayFuture =
-                getRpcService().connect(jobManagerAddress, jobMasterId, JobMasterGateway.class);
-
-        CompletableFuture<RegistrationResponse> registrationResponseFuture =
-                jobMasterGatewayFuture.thenCombineAsync(
-                        jobMasterIdFuture,
-                        (JobMasterGateway jobMasterGateway, JobMasterId leadingJobMasterId) -> {
-                            if (Objects.equals(leadingJobMasterId, jobMasterId)) {
-                                return registerJobMasterInternal(
-                                        jobMasterGateway,
-                                        jobId,
+            // handle exceptions which might have occurred in one of the futures inputs of combine
+            return registrationResponseFuture.handleAsync(
+                    (RegistrationResponse registrationResponse, Throwable throwable) -> {
+                        if (throwable != null) {
+                            if (log.isDebugEnabled()) {
+                                log.debug(
+                                        "Registration of job manager {}@{} failed.",
+                                        jobMasterId,
                                         jobManagerAddress,
-                                        jobManagerResourceId);
+                                        throwable);
                             } else {
-                                final String declineMessage =
-                                        String.format(
-                                                "The leading JobMaster id %s did not match the received JobMaster id %s. "
-                                                        + "This indicates that a JobMaster leader change has happened.",
-                                                leadingJobMasterId, jobMasterId);
-                                log.debug(declineMessage);
-                                return new RegistrationResponse.Failure(
-                                        new FlinkException(declineMessage));
+                                log.info(
+                                        "Registration of job manager {}@{} failed.",
+                                        jobMasterId,
+                                        jobManagerAddress);
                             }
-                        },
-                        getMainThreadExecutor(jobId));
 
-        // handle exceptions which might have occurred in one of the futures inputs of combine
-        return registrationResponseFuture.handleAsync(
-                (RegistrationResponse registrationResponse, Throwable throwable) -> {
-                    if (throwable != null) {
-                        if (log.isDebugEnabled()) {
-                            log.debug(
-                                    "Registration of job manager {}@{} failed.",
-                                    jobMasterId,
-                                    jobManagerAddress,
-                                    throwable);
+                            return new RegistrationResponse.Failure(throwable);
                         } else {
-                            log.info(
-                                    "Registration of job manager {}@{} failed.",
-                                    jobMasterId,
-                                    jobManagerAddress);
+                            return registrationResponse;
                         }
-
-                        return new RegistrationResponse.Failure(throwable);
-                    } else {
-                        return registrationResponse;
-                    }
-                },
-                ioExecutor);
+                    },
+                    ioExecutor);
+        }
     }
 
     @Override
@@ -563,10 +570,12 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
     @Override
     public void disconnectJobManager(
             final JobID jobId, JobStatus jobStatus, final Exception cause) {
-        if (jobStatus.isGloballyTerminalState()) {
-            removeJob(jobId, cause);
-        } else {
-            closeJobManagerConnection(jobId, ResourceRequirementHandling.RETAIN, cause);
+        try (MdcUtils.MdcCloseable ignored = MdcUtils.withContext(MdcUtils.asContextData(jobId))) {
+            if (jobStatus.isGloballyTerminalState()) {
+                removeJob(jobId, cause);
+            } else {
+                closeJobManagerConnection(jobId, ResourceRequirementHandling.RETAIN, cause);
+            }
         }
     }
 
@@ -1422,28 +1431,28 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
         @Override
         public void jobLeaderLostLeadership(final JobID jobId, final JobMasterId oldJobMasterId) {
             runAsync(
-                    new Runnable() {
-                        @Override
-                        public void run() {
-                            ResourceManager.this.jobLeaderLostLeadership(jobId, oldJobMasterId);
-                        }
-                    });
+                    MdcUtils.wrapRunnable(
+                            MdcUtils.asContextData(jobId),
+                            () ->
+                                    ResourceManager.this.jobLeaderLostLeadership(
+                                            jobId, oldJobMasterId)));
         }
 
         @Override
         public void notifyJobTimeout(final JobID jobId, final UUID timeoutId) {
             runAsync(
-                    new Runnable() {
-                        @Override
-                        public void run() {
-                            if (jobLeaderIdService.isValidTimeout(jobId, timeoutId)) {
-                                removeJob(
-                                        jobId,
-                                        new Exception(
-                                                "Job " + jobId + "was removed because of timeout"));
-                            }
-                        }
-                    });
+                    MdcUtils.wrapRunnable(
+                            MdcUtils.asContextData(jobId),
+                            () -> {
+                                if (jobLeaderIdService.isValidTimeout(jobId, timeoutId)) {
+                                    removeJob(
+                                            jobId,
+                                            new Exception(
+                                                    "Job "
+                                                            + jobId
+                                                            + "was removed because of timeout"));
+                                }
+                            }));
         }
 
         @Override
@@ -1528,10 +1537,14 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
                         jmResourceIdRegistrations.get(resourceID);
 
                 if (jobManagerRegistration != null) {
-                    closeJobManagerConnection(
-                            jobManagerRegistration.getJobID(),
-                            ResourceRequirementHandling.RETAIN,
-                            cause);
+                    try (MdcUtils.MdcCloseable ignored =
+                            MdcUtils.withContext(
+                                    MdcUtils.asContextData(jobManagerRegistration.getJobID()))) {
+                        closeJobManagerConnection(
+                                jobManagerRegistration.getJobID(),
+                                ResourceRequirementHandling.RETAIN,
+                                cause);
+                    }
                 }
             }
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultSlotStatusSyncer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultSlotStatusSyncer.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.taskexecutor.SlotReport;
 import org.apache.flink.runtime.taskexecutor.SlotStatus;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
 import org.apache.flink.runtime.taskexecutor.exceptions.SlotOccupiedException;
+import org.apache.flink.util.MdcUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.concurrent.FutureUtils;
 
@@ -101,47 +102,54 @@ public class DefaultSlotStatusSyncer implements SlotStatusSyncer {
         Preconditions.checkNotNull(targetAddress);
         Preconditions.checkNotNull(resourceProfile);
         checkStarted();
-        final AllocationID allocationId = new AllocationID();
         final Optional<TaskManagerInfo> taskManager =
                 taskManagerTracker.getRegisteredTaskManager(instanceId);
         Preconditions.checkState(
                 taskManager.isPresent(),
                 "Could not find a registered task manager for instance id " + instanceId + '.');
-        final TaskExecutorGateway gateway =
-                taskManager.get().getTaskExecutorConnection().getTaskExecutorGateway();
-        final ResourceID resourceId = taskManager.get().getTaskExecutorConnection().getResourceID();
 
-        LOG.info(
-                "Starting allocation of slot {} from {} for job {} with resource profile {}.",
-                allocationId,
-                resourceId,
-                jobId,
-                resourceProfile);
+        try (MdcUtils.MdcCloseable ignored = MdcUtils.withContext(MdcUtils.asContextData(jobId))) {
+            final AllocationID allocationId = new AllocationID();
+            final TaskExecutorGateway gateway =
+                    taskManager.get().getTaskExecutorConnection().getTaskExecutorGateway();
+            final ResourceID resourceId =
+                    taskManager.get().getTaskExecutorConnection().getResourceID();
+            LOG.info(
+                    "Starting allocation of slot {} from {} for job {} with resource profile {}.",
+                    allocationId,
+                    resourceId,
+                    jobId,
+                    resourceProfile);
 
-        taskManagerTracker.notifySlotStatus(
-                allocationId, jobId, instanceId, resourceProfile, SlotState.PENDING);
-        resourceTracker.notifyAcquiredResource(jobId, resourceProfile);
-        pendingSlotAllocations.add(allocationId);
+            taskManagerTracker.notifySlotStatus(
+                    allocationId, jobId, instanceId, resourceProfile, SlotState.PENDING);
+            resourceTracker.notifyAcquiredResource(jobId, resourceProfile);
+            pendingSlotAllocations.add(allocationId);
 
-        // RPC call to the task manager
-        CompletableFuture<Acknowledge> requestFuture =
-                gateway.requestSlot(
-                        SlotID.getDynamicSlotID(resourceId),
-                        jobId,
-                        allocationId,
-                        resourceProfile,
-                        targetAddress,
-                        resourceManagerId,
-                        taskManagerRequestTimeout);
+            // RPC call to the task manager
+            CompletableFuture<Acknowledge> requestFuture =
+                    gateway.requestSlot(
+                            SlotID.getDynamicSlotID(resourceId),
+                            jobId,
+                            allocationId,
+                            resourceProfile,
+                            targetAddress,
+                            resourceManagerId,
+                            taskManagerRequestTimeout);
 
-        CompletableFuture<Void> returnedFuture = new CompletableFuture<>();
+            CompletableFuture<Void> returnedFuture = new CompletableFuture<>();
 
-        FutureUtils.assertNoException(
-                requestFuture.handleAsync(
-                        handleSlotAllocation(
-                                instanceId, jobId, resourceProfile, allocationId, returnedFuture),
-                        mainThreadExecutor));
-        return returnedFuture;
+            FutureUtils.assertNoException(
+                    requestFuture.handleAsync(
+                            handleSlotAllocation(
+                                    instanceId,
+                                    jobId,
+                                    resourceProfile,
+                                    allocationId,
+                                    returnedFuture),
+                            mainThreadExecutor));
+            return returnedFuture;
+        }
     }
 
     private BiFunction<Acknowledge, Throwable, Object> handleSlotAllocation(
@@ -151,43 +159,51 @@ public class DefaultSlotStatusSyncer implements SlotStatusSyncer {
             AllocationID allocationId,
             CompletableFuture<Void> returnedFuture) {
         return (Acknowledge acknowledge, Throwable throwable) -> {
-            if (!pendingSlotAllocations.remove(allocationId)) {
-                LOG.debug(
-                        "Ignoring slot allocation update from task manager {} for allocation {} and job {}, because the allocation was already completed or cancelled.",
-                        instanceId,
-                        allocationId,
-                        jobId);
-                returnedFuture.complete(null);
-                return null;
-            }
-            if (!taskManagerTracker.getAllocatedOrPendingSlot(allocationId).isPresent()) {
-                LOG.debug("The slot {} has been removed before. Ignore the future.", allocationId);
-                returnedFuture.complete(null);
-                return null;
-            }
-            if (acknowledge != null) {
-                LOG.trace("Completed allocation of allocation {} for job {}.", allocationId, jobId);
-                taskManagerTracker.notifySlotStatus(
-                        allocationId, jobId, instanceId, resourceProfile, SlotState.ALLOCATED);
-                returnedFuture.complete(null);
-            } else {
-                if (throwable instanceof SlotOccupiedException) {
-                    LOG.error("Should not get this exception.", throwable);
-                } else {
-                    // TODO If the taskManager does not have enough resource, we
-                    // may endlessly allocate slot on it until the next heartbeat.
-                    LOG.warn(
-                            "Slot allocation for allocation {} for job {} failed.",
+            try (MdcUtils.MdcCloseable ignored =
+                    MdcUtils.withContext(MdcUtils.asContextData(jobId))) {
+                if (!pendingSlotAllocations.remove(allocationId)) {
+                    LOG.debug(
+                            "Ignoring slot allocation update from task manager {} for allocation {} and job {}, because the allocation was already completed or cancelled.",
+                            instanceId,
                             allocationId,
-                            jobId,
-                            throwable);
-                    resourceTracker.notifyLostResource(jobId, resourceProfile);
-                    taskManagerTracker.notifySlotStatus(
-                            allocationId, jobId, instanceId, resourceProfile, SlotState.FREE);
+                            jobId);
+                    returnedFuture.complete(null);
+                    return null;
                 }
-                returnedFuture.completeExceptionally(throwable);
+                if (!taskManagerTracker.getAllocatedOrPendingSlot(allocationId).isPresent()) {
+                    LOG.debug(
+                            "The slot {} has been removed before. Ignore the future.",
+                            allocationId);
+                    returnedFuture.complete(null);
+                    return null;
+                }
+                if (acknowledge != null) {
+                    LOG.trace(
+                            "Completed allocation of allocation {} for job {}.",
+                            allocationId,
+                            jobId);
+                    taskManagerTracker.notifySlotStatus(
+                            allocationId, jobId, instanceId, resourceProfile, SlotState.ALLOCATED);
+                    returnedFuture.complete(null);
+                } else {
+                    if (throwable instanceof SlotOccupiedException) {
+                        LOG.error("Should not get this exception.", throwable);
+                    } else {
+                        // TODO If the taskManager does not have enough resource, we
+                        // may endlessly allocate slot on it until the next heartbeat.
+                        LOG.warn(
+                                "Slot allocation for allocation {} for job {} failed.",
+                                allocationId,
+                                jobId,
+                                throwable);
+                        resourceTracker.notifyLostResource(jobId, resourceProfile);
+                        taskManagerTracker.notifySlotStatus(
+                                allocationId, jobId, instanceId, resourceProfile, SlotState.FREE);
+                    }
+                    returnedFuture.completeExceptionally(throwable);
+                }
+                return null;
             }
-            return null;
         };
     }
 
@@ -195,7 +211,6 @@ public class DefaultSlotStatusSyncer implements SlotStatusSyncer {
     public void freeSlot(AllocationID allocationId) {
         Preconditions.checkNotNull(allocationId);
         checkStarted();
-        LOG.info("Freeing slot {}.", allocationId);
 
         final Optional<TaskManagerSlotInformation> slotOptional =
                 taskManagerTracker.getAllocatedOrPendingSlot(allocationId);
@@ -205,16 +220,20 @@ public class DefaultSlotStatusSyncer implements SlotStatusSyncer {
         }
 
         final TaskManagerSlotInformation slot = slotOptional.get();
-        if (slot.getState() == SlotState.PENDING) {
-            pendingSlotAllocations.remove(allocationId);
+        try (MdcUtils.MdcCloseable ignored =
+                MdcUtils.withContext(MdcUtils.asContextData(slot.getJobId()))) {
+            LOG.info("Freeing slot {}.", allocationId);
+            if (slot.getState() == SlotState.PENDING) {
+                pendingSlotAllocations.remove(allocationId);
+            }
+            resourceTracker.notifyLostResource(slot.getJobId(), slot.getResourceProfile());
+            taskManagerTracker.notifySlotStatus(
+                    allocationId,
+                    slot.getJobId(),
+                    slot.getInstanceId(),
+                    slot.getResourceProfile(),
+                    SlotState.FREE);
         }
-        resourceTracker.notifyLostResource(slot.getJobId(), slot.getResourceProfile());
-        taskManagerTracker.notifySlotStatus(
-                allocationId,
-                slot.getJobId(),
-                slot.getInstanceId(),
-                slot.getResourceProfile(),
-                SlotState.FREE);
     }
 
     @Override
@@ -247,15 +266,18 @@ public class DefaultSlotStatusSyncer implements SlotStatusSyncer {
             // the next slot report or the acknowledgement of the allocation request.
             if (!reportedAllocationIds.contains(slot.getAllocationId())
                     && slot.getState() == SlotState.ALLOCATED) {
-                LOG.info("Freeing slot {} by slot report.", slot.getAllocationId());
-                taskManagerTracker.notifySlotStatus(
-                        slot.getAllocationId(),
-                        slot.getJobId(),
-                        slot.getInstanceId(),
-                        slot.getResourceProfile(),
-                        SlotState.FREE);
-                resourceTracker.notifyLostResource(slot.getJobId(), slot.getResourceProfile());
-                canApplyPreviousAllocations = false;
+                try (MdcUtils.MdcCloseable ignored =
+                        MdcUtils.withContext(MdcUtils.asContextData(slot.getJobId()))) {
+                    LOG.info("Freeing slot {} by slot report.", slot.getAllocationId());
+                    taskManagerTracker.notifySlotStatus(
+                            slot.getAllocationId(),
+                            slot.getJobId(),
+                            slot.getInstanceId(),
+                            slot.getResourceProfile(),
+                            SlotState.FREE);
+                    resourceTracker.notifyLostResource(slot.getJobId(), slot.getResourceProfile());
+                    canApplyPreviousAllocations = false;
+                }
             }
         }
 
@@ -273,35 +295,38 @@ public class DefaultSlotStatusSyncer implements SlotStatusSyncer {
     private boolean syncAllocatedSlotStatus(SlotStatus slotStatus, TaskManagerInfo taskManager) {
         final AllocationID allocationId = Preconditions.checkNotNull(slotStatus.getAllocationID());
         final JobID jobId = Preconditions.checkNotNull(slotStatus.getJobID());
-        final ResourceProfile resourceProfile =
-                Preconditions.checkNotNull(slotStatus.getResourceProfile());
+        try (MdcUtils.MdcCloseable ignored = MdcUtils.withContext(MdcUtils.asContextData(jobId))) {
+            final ResourceProfile resourceProfile =
+                    Preconditions.checkNotNull(slotStatus.getResourceProfile());
 
-        if (taskManager.getAllocatedSlots().containsKey(allocationId)) {
-            if (taskManager.getAllocatedSlots().get(allocationId).getState() == SlotState.PENDING) {
-                // Allocation Complete
-                final TaskManagerSlotInformation slot =
-                        taskManager.getAllocatedSlots().get(allocationId);
-                pendingSlotAllocations.remove(slot.getAllocationId());
+            if (taskManager.getAllocatedSlots().containsKey(allocationId)) {
+                if (taskManager.getAllocatedSlots().get(allocationId).getState()
+                        == SlotState.PENDING) {
+                    // Allocation Complete
+                    final TaskManagerSlotInformation slot =
+                            taskManager.getAllocatedSlots().get(allocationId);
+                    pendingSlotAllocations.remove(slot.getAllocationId());
+                    taskManagerTracker.notifySlotStatus(
+                            slot.getAllocationId(),
+                            slot.getJobId(),
+                            slot.getInstanceId(),
+                            slot.getResourceProfile(),
+                            SlotState.ALLOCATED);
+                }
+                return true;
+            } else {
+                Preconditions.checkState(
+                        !taskManagerTracker.getAllocatedOrPendingSlot(allocationId).isPresent(),
+                        "Duplicated allocation for " + allocationId);
                 taskManagerTracker.notifySlotStatus(
-                        slot.getAllocationId(),
-                        slot.getJobId(),
-                        slot.getInstanceId(),
-                        slot.getResourceProfile(),
+                        allocationId,
+                        jobId,
+                        taskManager.getInstanceId(),
+                        resourceProfile,
                         SlotState.ALLOCATED);
+                resourceTracker.notifyAcquiredResource(jobId, resourceProfile);
+                return false;
             }
-            return true;
-        } else {
-            Preconditions.checkState(
-                    !taskManagerTracker.getAllocatedOrPendingSlot(allocationId).isPresent(),
-                    "Duplicated allocation for " + allocationId);
-            taskManagerTracker.notifySlotStatus(
-                    allocationId,
-                    jobId,
-                    taskManager.getInstanceId(),
-                    resourceProfile,
-                    SlotState.ALLOCATED);
-            resourceTracker.notifyAcquiredResource(jobId, resourceProfile);
-            return false;
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
@@ -38,6 +38,7 @@ import org.apache.flink.runtime.slots.ResourceRequirement;
 import org.apache.flink.runtime.slots.ResourceRequirements;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
 import org.apache.flink.runtime.util.ResourceCounter;
+import org.apache.flink.util.MdcUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.concurrent.FutureUtils;
 import org.apache.flink.util.concurrent.ScheduledExecutor;
@@ -664,9 +665,12 @@ public class FineGrainedSlotManager implements SlotManager {
         // Notify jobs that can not be fulfilled
         if (sendNotEnoughResourceNotifications) {
             for (JobID jobId : unfulfillableJobs) {
-                LOG.warn("Could not fulfill resource requirements of job {}.", jobId);
-                resourceEventListener.notEnoughResourceAvailable(
-                        jobId, resourceTracker.getAcquiredResources(jobId));
+                try (MdcUtils.MdcCloseable ignored =
+                        MdcUtils.withContext(MdcUtils.asContextData(jobId))) {
+                    LOG.warn("Could not fulfill resource requirements of job {}.", jobId);
+                    resourceEventListener.notEnoughResourceAvailable(
+                            jobId, resourceTracker.getAcquiredResources(jobId));
+                }
             }
         }
 

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/util/JobIDLoggingUtil.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/util/JobIDLoggingUtil.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util;
+
+import org.apache.flink.testutils.logging.LoggerAuditingExtension;
+
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.util.ReadOnlyStringMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Utility class for verifying the presence and correctness of a specific key-value pair in the
+ * logging context of log events.
+ */
+public class JobIDLoggingUtil {
+    private static final Logger logger = LoggerFactory.getLogger(JobIDLoggingUtil.class);
+
+    /**
+     * Asserts that the specified key is present in the log events with the expected value.
+     *
+     * @param key the key to look for
+     * @param expectedValue the expected value of the key
+     * @param ext the LoggerAuditingExtension instance
+     * @param expectedPatterns the list of expected patterns
+     * @param ignoredPatterns the array of ignore patterns
+     */
+    public static void assertKeyPresent(
+            String key,
+            String expectedValue,
+            LoggerAuditingExtension ext,
+            List<String> expectedPatterns,
+            String... ignoredPatterns) {
+        final List<LogEvent> eventsWithMissingKey = new ArrayList<>();
+        final List<LogEvent> eventsWithWrongValue = new ArrayList<>();
+        final List<LogEvent> ignoredEvents = new ArrayList<>();
+        final List<Pattern> expected =
+                expectedPatterns.stream().map(Pattern::compile).collect(toList());
+        final List<Pattern> ignorePatterns =
+                Arrays.stream(ignoredPatterns).map(Pattern::compile).collect(toList());
+
+        for (LogEvent e : ext.getEvents()) {
+            ReadOnlyStringMap context = e.getContextData();
+            if (context.containsKey(key)) {
+                if (Objects.equals(context.getValue(key), expectedValue)) {
+                    expected.removeIf(
+                            pattern ->
+                                    pattern.matcher(e.getMessage().getFormattedMessage())
+                                            .matches());
+                } else {
+                    eventsWithWrongValue.add(e);
+                }
+            } else if (matchesAny(ignorePatterns, e.getMessage().getFormattedMessage())) {
+                ignoredEvents.add(e);
+            } else {
+                eventsWithMissingKey.add(e);
+            }
+        }
+
+        logger.debug(
+                "checked events for {}:\n  {};\n  ignored: {},\n  wrong value: {},\n missing key: {}",
+                ext.getLoggerName(),
+                ext.getEvents(),
+                ignoredEvents,
+                eventsWithWrongValue,
+                eventsWithMissingKey);
+        assertThat(eventsWithWrongValue).as("events with a wrong value").isEmpty();
+        assertThat(expected)
+                .as(
+                        "not all expected events logged by %s, logged:\n%s",
+                        ext.getLoggerName(), ext.getEvents())
+                .isEmpty();
+        assertThat(eventsWithMissingKey)
+                .as("too many events without key logged by %s", ext.getLoggerName())
+                .isEmpty();
+    }
+
+    private static boolean matchesAny(List<Pattern> patterns, String message) {
+        return patterns.stream().anyMatch(pattern -> pattern.matcher(message).matches());
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change
These changes add JobID to MDC, making analyzing problems more convenient. 

## Brief change log
  - *An existing method that checks JobID existence in MDC has been extracted to a new UtilityClass*
  - *Existing ITCase test was migrated from JUnit4 to JUnit5+Jupiter*
  - *JobID has been added to MDC in several classes that are commonly used to analyze logs*

## Verifying this change
This change added tests and can be verified as follows:
  - *Each class that now has JobID in MDC got additional assertions that verify JobID existence in LogEvents*

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation
  - Does this pull request introduce a new feature? no