### PR TITLE
[FLINK-37437][state/forst] Fix #exist and #getFileStatus to give the information of writing files

### DIFF
--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/fs/filemapping/FSDataOutputStreamWithEntry.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/fs/filemapping/FSDataOutputStreamWithEntry.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.forst.fs.filemapping;
+
+import org.apache.flink.core.fs.FSDataOutputStream;
+import org.apache.flink.core.fs.FSDataOutputStreamWrapper;
+
+import java.io.IOException;
+
+/** A {@link FSDataOutputStream} that is associated with a {@link MappingEntry}. */
+public class FSDataOutputStreamWithEntry extends FSDataOutputStreamWrapper {
+
+    private final MappingEntry entry;
+
+    public FSDataOutputStreamWithEntry(FSDataOutputStream outputStream, MappingEntry entry) {
+        super(outputStream);
+        this.entry = entry;
+    }
+
+    @Override
+    public void close() throws IOException {
+        // Synchronize on the entry to ensure the atomicity of endWriting and close
+        // also see invokers of MappingEntry.isWriting
+        synchronized (entry) {
+            super.close();
+            entry.endWriting();
+        }
+    }
+}

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/fs/filemapping/FileMappingManager.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/fs/filemapping/FileMappingManager.java
@@ -68,7 +68,7 @@ public class FileMappingManager {
         }
 
         return addFileToMappingTable(
-                key, toUUIDPath(filePath), FileOwnershipDecider.decideForNewFile(filePath));
+                key, toUUIDPath(filePath), FileOwnershipDecider.decideForNewFile(filePath), true);
     }
 
     /** Register a file restored from checkpoints to the mapping table. */
@@ -87,16 +87,16 @@ public class FileMappingManager {
         MappingEntrySource source = new HandleBackedMappingEntrySource(stateHandle);
         MappingEntry existingEntry = getExistingMappingEntry(key, source, fileOwnership);
         return existingEntry == null
-                ? addMappingEntry(key, new MappingEntry(1, source, fileOwnership, false))
+                ? addMappingEntry(key, new MappingEntry(1, source, fileOwnership, false, false))
                 : existingEntry;
     }
 
     private MappingEntry addFileToMappingTable(
-            String key, Path filePath, FileOwnership fileOwnership) {
+            String key, Path filePath, FileOwnership fileOwnership, boolean writing) {
         MappingEntrySource source = new FileBackedMappingEntrySource(filePath);
         MappingEntry existingEntry = getExistingMappingEntry(key, source, fileOwnership);
         return existingEntry == null
-                ? addMappingEntry(key, new MappingEntry(1, source, fileOwnership, false))
+                ? addMappingEntry(key, new MappingEntry(1, source, fileOwnership, false, writing))
                 : existingEntry;
     }
 

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/fs/filemapping/MappingEntry.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/fs/filemapping/MappingEntry.java
@@ -42,6 +42,8 @@ public class MappingEntry extends ReferenceCounted {
 
     final boolean isDirectory;
 
+    volatile boolean writing;
+
     /** When delete a directory, if the directory is the parent of this source file, track it. */
     @Nullable MappingEntry parentDir;
 
@@ -54,7 +56,8 @@ public class MappingEntry extends ReferenceCounted {
                 initReference,
                 new HandleBackedMappingEntrySource(stateHandle),
                 fileOwnership,
-                isDirectory);
+                isDirectory,
+                false);
     }
 
     public MappingEntry(
@@ -63,19 +66,22 @@ public class MappingEntry extends ReferenceCounted {
                 initReference,
                 new FileBackedMappingEntrySource(sourcePath),
                 fileOwnership,
-                isDirectory);
+                isDirectory,
+                false);
     }
 
     public MappingEntry(
             int initReference,
             MappingEntrySource source,
             FileOwnership fileOwnership,
-            boolean isDirectory) {
+            boolean isDirectory,
+            boolean writing) {
         super(initReference);
         this.source = source;
         this.parentDir = null;
         this.fileOwnership = fileOwnership;
         this.isDirectory = isDirectory;
+        this.writing = writing;
     }
 
     public void setFileOwnership(FileOwnership ownership) {
@@ -106,6 +112,14 @@ public class MappingEntry extends ReferenceCounted {
 
     public FileOwnership getFileOwnership() {
         return fileOwnership;
+    }
+
+    public boolean isWriting() {
+        return writing;
+    }
+
+    public void endWriting() {
+        writing = false;
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

We leverage `disableFileDeletions` and `enableFileDeletions` of ForSt to keep files alive during checkpoint. When checkpoint finished, the `enableFileDeletions` will be invoked, while ForSt will list all the files and check status. These files, however, include the writing ones, which is not visible in some DFS (e.g. oss or s3) yet. Although the checkpoints are actually not missing, the thrown exception make the finalization of checkpoint failed, resulting in consecutive cp failures.

The root cause would be the `ForStFlinkFileSystem` does not give correct information of files which are being written. This PR fixes this.


## Brief change log

*(for example:)*
  - Fixes `#exist` and `getFileStatus` to give information of writing files.
  - Enrich `MappingEntry` and introduce `FSDataOutputStreamWithEntry` to maintain the writing flag of file.


## Verifying this change

New UT added.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
