### PR TITLE
[FLINK-37438] Improve the createLocalEnvironment by reduce duplicate operation on Configuration

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -2218,9 +2218,8 @@ public class StreamExecutionEnvironment implements AutoCloseable {
      * @return A local execution environment with the specified parallelism.
      */
     public static LocalStreamEnvironment createLocalEnvironment(int parallelism) {
-        Configuration configuration = new Configuration();
-        configuration.set(CoreOptions.DEFAULT_PARALLELISM, parallelism);
-        return createLocalEnvironment(configuration);
+        return createLocalEnvironment(
+                new Configuration().set(CoreOptions.DEFAULT_PARALLELISM, parallelism));
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -2218,7 +2218,9 @@ public class StreamExecutionEnvironment implements AutoCloseable {
      * @return A local execution environment with the specified parallelism.
      */
     public static LocalStreamEnvironment createLocalEnvironment(int parallelism) {
-        return createLocalEnvironment(parallelism, new Configuration());
+        Configuration configuration = new Configuration();
+        configuration.set(CoreOptions.DEFAULT_PARALLELISM, parallelism);
+        return createLocalEnvironment(configuration);
     }
 
     /**


### PR DESCRIPTION
## What is the purpose of the change

This PR proposes to improve the `createLocalEnvironment` by reduce duplicate operation on `Configuration`.


## Brief change log

Improve the `createLocalEnvironment` by reduce duplicate operation on `Configuration`
Currently, `StreamExecutionEnvironment` provides a `createLocalEnvironment` with one parameter parallelism.
```
    public static LocalStreamEnvironment createLocalEnvironment(int parallelism) {
        return createLocalEnvironment(parallelism, new Configuration());
    }
```
Above method will create a new instance of `Configuration` and then calling the below override one.
```
    public static LocalStreamEnvironment createLocalEnvironment(
            int parallelism, Configuration configuration) {
        Configuration copyOfConfiguration = new Configuration();
        copyOfConfiguration.addAll(configuration);
        copyOfConfiguration.set(CoreOptions.DEFAULT_PARALLELISM, parallelism);
        return createLocalEnvironment(copyOfConfiguration);
    }
```
The second will create another instance of `Configuration` and name it with `copyOfConfiguration`.
You can see add `configuration` into `copyOfConfiguration` with `addAll`.
The issue is create `Configuration` duplicately and an extra operation `addAll`.


## Verifying this change

This change is already covered by existing tests, such as `ExpressionTestBase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
