### PR TITLE
[FLINK-36402] edgeRemapings typo fixed to edgeRemappings

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/JSONGenerator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/JSONGenerator.java
@@ -130,7 +130,7 @@ public class JSONGenerator {
             ArrayNode jsonArray,
             List<Integer> toVisit,
             int headId,
-            Map<Integer, Integer> edgeRemapings,
+            Map<Integer, Integer> edgeRemappings,
             ArrayNode iterationInEdges) {
 
         Integer vertexID = toVisit.get(0);
@@ -148,15 +148,15 @@ public class JSONGenerator {
             for (StreamEdge inEdge : vertex.getInEdges()) {
                 int inputID = inEdge.getSourceId();
 
-                if (edgeRemapings.keySet().contains(inputID)) {
+                if (edgeRemappings.keySet().contains(inputID)) {
                     decorateEdge(inEdges, inEdge, inputID);
                 } else if (!streamGraph.vertexIDtoLoopTimeout.containsKey(inputID)) {
                     decorateEdge(iterationInEdges, inEdge, inputID);
                 }
             }
 
-            edgeRemapings.put(vertexID, headId);
-            visitIteration(jsonArray, toVisit, headId, edgeRemapings, iterationInEdges);
+            edgeRemappings.put(vertexID, headId);
+            visitIteration(jsonArray, toVisit, headId, edgeRemappings, iterationInEdges);
         }
     }
 


### PR DESCRIPTION

## What is the purpose of the change

Follow up for https://github.com/apache/flink/pull/26220




## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
