### PR TITLE
[FLINK-37410][runtime/metrics] Split level Watermark metrics

### DIFF
--- a/docs/content/docs/ops/metrics.md
+++ b/docs/content/docs/ops/metrics.md
@@ -1741,6 +1741,56 @@ Note that the metrics are only available via reporters.
       <td>The total number of InputSplits this data source has processed (if the operator is a data source).</td>
       <td>Gauge</td>
     </tr>
+    <tr>
+      <th rowspan="7"><strong>Split</strong></th>
+      <td>watermark.currentWatermark</td>
+      <td>
+        The last watermark this split has received (in milliseconds).
+      </td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>watermark.activeTimeMsPerSecond</td>
+      <td>
+        The time (in milliseconds) this split has been active (i.e. not paused due to watermark alignment or idle due to idleness detection) per second.
+      </td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>watermark.pausedTimeMsPerSecond</td>
+      <td>
+        The time (in milliseconds) this split has been paused due to watermark alignment per second.
+      </td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>watermark.idleTimeMsPerSecond</td>
+      <td>
+        The time (in milliseconds) this split has been marked idle by idleness detection per second.
+      </td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>watermark.accumulatedActiveTimeMs</td>
+      <td>
+        Accumulated time (in milliseconds) this split was active since it was registered
+      </td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>watermark.accumulatedPausedTimeMs</td>
+      <td>
+        Accumulated time (in milliseconds) this split was paused since it was registered
+      </td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>watermark.accumulatedIdleTimeMs</td>
+      <td>
+        Accumulated time (in milliseconds) this split was idle since it was registered
+      </td>
+      <td>Gauge</td>
+    </tr>
   </tbody>
 </table>
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/eventtime/CombinedWatermarkStatus.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/eventtime/CombinedWatermarkStatus.java
@@ -118,7 +118,7 @@ final class CombinedWatermarkStatus {
          * <p>Setting a watermark will clear the idleness flag.
          */
         public boolean setWatermark(long watermark) {
-            this.idle = false;
+            setIdle(false);
             final boolean updated = watermark > this.watermark;
             if (updated) {
                 this.onWatermarkUpdate.onWatermarkUpdate(watermark);
@@ -133,6 +133,7 @@ final class CombinedWatermarkStatus {
 
         public void setIdle(boolean idle) {
             this.idle = idle;
+            this.onWatermarkUpdate.onIdleUpdate(idle);
         }
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/eventtime/IndexedCombinedWatermarkStatus.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/eventtime/IndexedCombinedWatermarkStatus.java
@@ -19,6 +19,7 @@
 package org.apache.flink.api.common.eventtime;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.eventtime.WatermarkOutputMultiplexer.NoOpWatermarkUpdateListener;
 
 import java.util.stream.IntStream;
 
@@ -43,7 +44,9 @@ public final class IndexedCombinedWatermarkStatus {
         CombinedWatermarkStatus.PartialWatermark[] partialWatermarks =
                 IntStream.range(0, inputsCount)
                         .mapToObj(
-                                i -> new CombinedWatermarkStatus.PartialWatermark(watermark -> {}))
+                                i ->
+                                        new CombinedWatermarkStatus.PartialWatermark(
+                                                new NoOpWatermarkUpdateListener()))
                         .toArray(CombinedWatermarkStatus.PartialWatermark[]::new);
         CombinedWatermarkStatus combinedWatermarkStatus = new CombinedWatermarkStatus();
         for (CombinedWatermarkStatus.PartialWatermark partialWatermark : partialWatermarks) {

--- a/flink-core/src/test/java/org/apache/flink/api/common/eventtime/WatermarkOutputMultiplexerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/eventtime/WatermarkOutputMultiplexerTest.java
@@ -263,7 +263,7 @@ class WatermarkOutputMultiplexerTest {
                 new WatermarkOutputMultiplexer(underlyingWatermarkOutput);
 
         final String id = "test-id";
-        multiplexer.registerNewOutput(id, watermark -> {});
+        multiplexer.registerNewOutput(id);
         WatermarkOutput immediateOutput = multiplexer.getImmediateOutput(id);
         WatermarkOutput deferredOutput = multiplexer.getDeferredOutput(id);
 
@@ -287,7 +287,7 @@ class WatermarkOutputMultiplexerTest {
                 new WatermarkOutputMultiplexer(underlyingWatermarkOutput);
 
         final String id = "1234-test";
-        multiplexer.registerNewOutput(id, watermark -> {});
+        multiplexer.registerNewOutput(id);
         WatermarkOutput immediateOutput = multiplexer.getImmediateOutput(id);
         WatermarkOutput deferredOutput = multiplexer.getDeferredOutput(id);
 
@@ -305,8 +305,8 @@ class WatermarkOutputMultiplexerTest {
         final long lowTimestamp = 156765L;
         final long highTimestamp = lowTimestamp + 10;
 
-        multiplexer.registerNewOutput("lower", watermark -> {});
-        multiplexer.registerNewOutput("higher", watermark -> {});
+        multiplexer.registerNewOutput("lower");
+        multiplexer.registerNewOutput("higher");
         multiplexer.getImmediateOutput("lower").emitWatermark(new Watermark(lowTimestamp));
 
         multiplexer.unregisterOutput("lower");
@@ -324,8 +324,8 @@ class WatermarkOutputMultiplexerTest {
         final long lowTimestamp = -4343L;
         final long highTimestamp = lowTimestamp + 10;
 
-        multiplexer.registerNewOutput("lower", watermark -> {});
-        multiplexer.registerNewOutput("higher", watermark -> {});
+        multiplexer.registerNewOutput("lower");
+        multiplexer.registerNewOutput("higher");
         multiplexer.getImmediateOutput("lower").emitWatermark(new Watermark(lowTimestamp));
         multiplexer.getImmediateOutput("higher").emitWatermark(new Watermark(highTimestamp));
 
@@ -343,11 +343,11 @@ class WatermarkOutputMultiplexerTest {
         final long lowTimestamp = 1L;
         final long highTimestamp = 2L;
 
-        multiplexer.registerNewOutput("higher", watermark -> {});
+        multiplexer.registerNewOutput("higher");
         multiplexer.getImmediateOutput("higher").emitWatermark(new Watermark(highTimestamp));
         multiplexer.unregisterOutput("higher");
 
-        multiplexer.registerNewOutput("lower", watermark -> {});
+        multiplexer.registerNewOutput("lower");
         multiplexer.getImmediateOutput("lower").emitWatermark(new Watermark(lowTimestamp));
 
         assertThat(underlyingWatermarkOutput.lastWatermark().getTimestamp())
@@ -359,7 +359,7 @@ class WatermarkOutputMultiplexerTest {
         final TestingWatermarkOutput underlyingWatermarkOutput = createTestingWatermarkOutput();
         final WatermarkOutputMultiplexer multiplexer =
                 new WatermarkOutputMultiplexer(underlyingWatermarkOutput);
-        multiplexer.registerNewOutput("does-exist", watermark -> {});
+        multiplexer.registerNewOutput("does-exist");
 
         final boolean unregistered = multiplexer.unregisterOutput("does-exist");
 
@@ -385,7 +385,7 @@ class WatermarkOutputMultiplexerTest {
 
         Watermark emittedWatermark = new Watermark(1);
         final String id = UUID.randomUUID().toString();
-        multiplexer.registerNewOutput(id, watermark -> {});
+        multiplexer.registerNewOutput(id);
         WatermarkOutput immediateOutput = multiplexer.getImmediateOutput(id);
         immediateOutput.emitWatermark(emittedWatermark);
         multiplexer.unregisterOutput(id);
@@ -401,7 +401,7 @@ class WatermarkOutputMultiplexerTest {
      */
     private static WatermarkOutput createImmediateOutput(WatermarkOutputMultiplexer multiplexer) {
         final String id = UUID.randomUUID().toString();
-        multiplexer.registerNewOutput(id, watermark -> {});
+        multiplexer.registerNewOutput(id);
         return multiplexer.getImmediateOutput(id);
     }
 
@@ -411,7 +411,7 @@ class WatermarkOutputMultiplexerTest {
      */
     private static WatermarkOutput createDeferredOutput(WatermarkOutputMultiplexer multiplexer) {
         final String id = UUID.randomUUID().toString();
-        multiplexer.registerNewOutput(id, watermark -> {});
+        multiplexer.registerNewOutput(id);
         return multiplexer.getDeferredOutput(id);
     }
 

--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/groups/SourceSplitMetricGroup.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/groups/SourceSplitMetricGroup.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.metrics.groups;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * Pre-defined metrics for {@code SplitEnumerator}.
+ *
+ * <p>You should only update the metrics in the main operator thread.
+ */
+@PublicEvolving
+public interface SourceSplitMetricGroup extends OperatorCoordinatorMetricGroup {
+    long getCurrentWatermark();
+
+    double getActiveTimePerSecond();
+
+    long getPausedTimePerSecond();
+
+    long getIdleTimePerSecond();
+
+    double getAccumulatedActiveTime();
+
+    long getAccumulatedPausedTime();
+
+    long getAccumulatedIdleTime();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
@@ -145,4 +145,13 @@ public class MetricNames {
     public static final String FAILED_COMMITTABLES = "failedCommittables";
     public static final String RETRIED_COMMITTABLES = "retriedCommittables";
     public static final String PENDING_COMMITTABLES = "pendingCommittables";
+
+    // FLIP-513 split level metrics
+    public static final String SPLIT_CURRENT_WATERMARK = "currentWatermark";
+    public static final String SPLIT_ACTIVE_TIME = "activeTimeMs" + SUFFIX_RATE;
+    public static final String SPLIT_PAUSED_TIME = "pausedTimeMs" + SUFFIX_RATE;
+    public static final String SPLIT_IDLE_TIME = "idleTimeMs" + SUFFIX_RATE;
+    public static final String ACC_SPLIT_PAUSED_TIME = "accumulatedPausedTimeMs";
+    public static final String ACC_SPLIT_ACTIVE_TIME = "accumulatedActiveTimeMs";
+    public static final String ACC_SPLIT_IDLE_TIME = "accumulatedIdleTimeMs";
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/TimerGauge.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/TimerGauge.java
@@ -194,7 +194,6 @@ public class TimerGauge implements Gauge<Long>, View {
         return currentCount;
     }
 
-    @VisibleForTesting
     public synchronized boolean isMeasuring() {
         return currentMeasurementStartTS != 0;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/InternalSourceSplitMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/InternalSourceSplitMetricGroup.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.metrics.groups;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.groups.OperatorMetricGroup;
+import org.apache.flink.metrics.groups.SourceSplitMetricGroup;
+import org.apache.flink.runtime.metrics.MetricNames;
+import org.apache.flink.runtime.metrics.TimerGauge;
+import org.apache.flink.util.clock.Clock;
+import org.apache.flink.util.clock.SystemClock;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Special {@link MetricGroup} representing an {@link SplitEnumerator}. */
+@Internal
+public class InternalSourceSplitMetricGroup extends ProxyMetricGroup<MetricGroup>
+        implements SourceSplitMetricGroup {
+
+    static final Logger LOG = LoggerFactory.getLogger(InternalSourceSplitMetricGroup.class);
+    private final TimerGauge pausedTimePerSecond;
+    private final TimerGauge idleTimePerSecond;
+    private final Gauge<Long> currentWatermarkGauge;
+    private final Clock clock;
+    private static final String SPLIT = "split";
+    private static final String WATERMARK = "watermark";
+    private static final long SPLIT_NOT_STARTED = -1L;
+    private long splitStartTime = SPLIT_NOT_STARTED;
+
+    private InternalSourceSplitMetricGroup(
+            MetricGroup parentMetricGroup,
+            Clock clock,
+            String splitId,
+            Gauge<Long> currentWatermark) {
+        super(parentMetricGroup);
+        this.clock = clock;
+        MetricGroup splitWatermarkMetricGroup =
+                parentMetricGroup.addGroup(SPLIT, splitId).addGroup(WATERMARK);
+        pausedTimePerSecond =
+                splitWatermarkMetricGroup.gauge(
+                        MetricNames.SPLIT_PAUSED_TIME, new TimerGauge(clock));
+        idleTimePerSecond =
+                splitWatermarkMetricGroup.gauge(MetricNames.SPLIT_IDLE_TIME, new TimerGauge(clock));
+        splitWatermarkMetricGroup.gauge(
+                MetricNames.SPLIT_ACTIVE_TIME, this::getActiveTimePerSecond);
+        splitWatermarkMetricGroup.gauge(
+                MetricNames.ACC_SPLIT_PAUSED_TIME, this::getAccumulatedPausedTime);
+        splitWatermarkMetricGroup.gauge(
+                MetricNames.ACC_SPLIT_ACTIVE_TIME, this::getAccumulatedActiveTime);
+        splitWatermarkMetricGroup.gauge(
+                MetricNames.ACC_SPLIT_IDLE_TIME, this::getAccumulatedIdleTime);
+        currentWatermarkGauge =
+                splitWatermarkMetricGroup.gauge(
+                        MetricNames.SPLIT_CURRENT_WATERMARK, currentWatermark);
+    }
+
+    public static InternalSourceSplitMetricGroup wrap(
+            OperatorMetricGroup operatorMetricGroup, String splitId, Gauge<Long> currentWatermark) {
+        return new InternalSourceSplitMetricGroup(
+                operatorMetricGroup, SystemClock.getInstance(), splitId, currentWatermark);
+    }
+
+    @VisibleForTesting
+    public static InternalSourceSplitMetricGroup mock(
+            MetricGroup metricGroup, String splitId, Gauge<Long> currentWatermakr) {
+        return new InternalSourceSplitMetricGroup(
+                metricGroup, SystemClock.getInstance(), splitId, currentWatermakr);
+    }
+
+    @VisibleForTesting
+    public static InternalSourceSplitMetricGroup wrap(
+            OperatorMetricGroup operatorMetricGroup,
+            Clock clock,
+            String splitId,
+            Gauge<Long> currentWatermark) {
+        return new InternalSourceSplitMetricGroup(
+                operatorMetricGroup, clock, splitId, currentWatermark);
+    }
+
+    public void markSplitStart() {
+        splitStartTime = clock.absoluteTimeMillis();
+    }
+
+    public void maybeMarkSplitStart() {
+        if (splitStartTime == SPLIT_NOT_STARTED) {
+            markSplitStart();
+        }
+    }
+
+    public long getCurrentWatermark() {
+        return this.currentWatermarkGauge.getValue();
+    }
+
+    public void markPaused() {
+        maybeMarkSplitStart();
+        if (isIdle()) {
+            // If a split got paused it means it emitted records,
+            // hence it shouldn't be considered idle anymore
+            markNotIdle();
+            LOG.warn("Split marked paused while still idle");
+        }
+        this.pausedTimePerSecond.markStart();
+    }
+
+    public void markIdle() {
+        maybeMarkSplitStart();
+        if (isPaused()) {
+            // If a split is marked idle, it has no records to emit.
+            // hence it shouldn't be considered paused anymore
+            markNotPaused();
+            LOG.warn("Split marked idle while still paused");
+        }
+        this.idleTimePerSecond.markStart();
+    }
+
+    public void markNotPaused() {
+        maybeMarkSplitStart();
+        this.pausedTimePerSecond.markEnd();
+    }
+
+    public void markNotIdle() {
+        maybeMarkSplitStart();
+        this.idleTimePerSecond.markEnd();
+    }
+
+    public double getActiveTimePerSecond() {
+        if (splitStartTime == SPLIT_NOT_STARTED) {
+            return 0L;
+        }
+        double activeTimePerSecond = 1000.0 - getPausedTimePerSecond() - getIdleTimePerSecond();
+        return Math.max(activeTimePerSecond, 0);
+    }
+
+    public double getAccumulatedActiveTime() {
+        if (splitStartTime == SPLIT_NOT_STARTED) {
+            return 0L;
+        }
+        return Math.max(
+                clock.absoluteTimeMillis()
+                        - splitStartTime
+                        - getAccumulatedPausedTime()
+                        - getAccumulatedIdleTime(),
+                0);
+    }
+
+    public long getAccumulatedIdleTime() {
+        return idleTimePerSecond.getAccumulatedCount();
+    }
+
+    public long getIdleTimePerSecond() {
+        return idleTimePerSecond.getValue();
+    }
+
+    public long getPausedTimePerSecond() {
+        return pausedTimePerSecond.getValue();
+    }
+
+    public long getAccumulatedPausedTime() {
+        return pausedTimePerSecond.getAccumulatedCount();
+    }
+
+    public Boolean isPaused() {
+        return pausedTimePerSecond.isMeasuring();
+    }
+
+    public Boolean isIdle() {
+        return idleTimePerSecond.isMeasuring();
+    }
+
+    public Boolean isActive() {
+        return !isPaused() && !isIdle();
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
@@ -38,6 +38,7 @@ import org.apache.flink.runtime.event.WatermarkEvent;
 import org.apache.flink.runtime.io.AvailabilityProvider;
 import org.apache.flink.runtime.io.network.api.StopMode;
 import org.apache.flink.runtime.metrics.groups.InternalSourceReaderMetricGroup;
+import org.apache.flink.runtime.metrics.groups.InternalSourceSplitMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.operators.coordination.OperatorEventGateway;
@@ -175,7 +176,10 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
     private final List<SplitT> splitsToInitializeOutput = new ArrayList<>();
 
     private final Map<String, Long> splitCurrentWatermarks = new HashMap<>();
+
     private final Set<String> currentlyPausedSplits = new HashSet<>();
+
+    private final Map<String, InternalSourceSplitMetricGroup> splitMetricGroups = new HashMap<>();
 
     private enum OperatingMode {
         READING,
@@ -350,6 +354,22 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
         return sourceMetricGroup;
     }
 
+    protected InternalSourceSplitMetricGroup getOrCreateSplitMetricGroup(String splitId) {
+        if (!this.splitMetricGroups.containsKey(splitId)) {
+            InternalSourceSplitMetricGroup splitMetricGroup =
+                    InternalSourceSplitMetricGroup.wrap(
+                            getMetricGroup(), splitId, () -> splitCurrentWatermarks.get(splitId));
+            splitMetricGroup.markSplitStart();
+            this.splitMetricGroups.put(splitId, splitMetricGroup);
+        }
+        return this.splitMetricGroups.get(splitId);
+    }
+
+    @VisibleForTesting
+    public InternalSourceSplitMetricGroup getSplitMetricGroup(String splitId) {
+        return this.splitMetricGroups.get(splitId);
+    }
+
     @Override
     public void open() throws Exception {
         mainInputActivityClock = new PausableRelativeClock(getProcessingTimeService().getClock());
@@ -381,6 +401,9 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
         final List<SplitT> splits = CollectionUtil.iterableToList(readerState.get());
         if (!splits.isEmpty()) {
             LOG.info("Restoring state for {} split(s) to reader.", splits.size());
+            for (SplitT s : splits) {
+                getOrCreateSplitMetricGroup(s.splitId());
+            }
             splitsToInitializeOutput.addAll(splits);
             sourceReader.addSplits(splits);
         }
@@ -647,6 +670,7 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
                 createOutputForSplits(newSplits);
             }
             sourceReader.addSplits(newSplits);
+            createMetricGroupForSplits(newSplits);
         } catch (IOException e) {
             throw new FlinkRuntimeException("Failed to deserialize the splits.", e);
         }
@@ -655,6 +679,12 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
     private void createOutputForSplits(List<SplitT> newSplits) {
         for (SplitT split : newSplits) {
             currentMainOutput.createOutputForSplit(split.splitId());
+        }
+    }
+
+    private void createMetricGroupForSplits(List<SplitT> newSplits) {
+        for (SplitT split : newSplits) {
+            getOrCreateSplitMetricGroup(split.splitId());
         }
     }
 
@@ -684,8 +714,18 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
     }
 
     @Override
+    public void updateCurrentSplitIdle(String splitId, boolean idle) {
+        if (idle) {
+            this.getOrCreateSplitMetricGroup(splitId).markIdle();
+        } else {
+            this.getOrCreateSplitMetricGroup(splitId).markNotIdle();
+        }
+    }
+
+    @Override
     public void splitFinished(String splitId) {
         splitCurrentWatermarks.remove(splitId);
+        this.splitMetricGroups.remove(splitId);
     }
 
     /**
@@ -718,10 +758,21 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
         try {
             sourceReader.pauseOrResumeSplits(splitsToPause, splitsToResume);
             eventTimeLogic.pauseOrResumeSplits(splitsToPause, splitsToResume);
+            reportPausedOrResumed(splitsToPause, splitsToResume);
         } catch (UnsupportedOperationException e) {
             if (!allowUnalignedSourceSplits) {
                 throw e;
             }
+        }
+    }
+
+    private void reportPausedOrResumed(
+            Collection<String> splitsToPause, Collection<String> splitsToResume) {
+        for (String splitId : splitsToResume) {
+            getOrCreateSplitMetricGroup(splitId).markNotPaused();
+        }
+        for (String splitId : splitsToPause) {
+            getOrCreateSplitMetricGroup(splitId).markPaused();
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/source/ProgressiveTimestampsAndWatermarks.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/source/ProgressiveTimestampsAndWatermarks.java
@@ -272,9 +272,17 @@ public class ProgressiveTimestampsAndWatermarks<T> implements TimestampsAndWater
             PausableRelativeClock inputActivityClock = createInputActivityClock(splitId);
             watermarkMultiplexer.registerNewOutput(
                     splitId,
-                    watermark ->
-                            watermarkUpdateListener.updateCurrentSplitWatermark(
-                                    splitId, watermark));
+                    new WatermarkOutputMultiplexer.WatermarkUpdateListener() {
+                        @Override
+                        public void onWatermarkUpdate(long watermark) {
+                            watermarkUpdateListener.updateCurrentSplitWatermark(splitId, watermark);
+                        }
+
+                        @Override
+                        public void onIdleUpdate(boolean idle) {
+                            watermarkUpdateListener.updateCurrentSplitIdle(splitId, idle);
+                        }
+                    });
             final WatermarkOutput onEventOutput = watermarkMultiplexer.getImmediateOutput(splitId);
             final WatermarkOutput periodicOutput = watermarkMultiplexer.getDeferredOutput(splitId);
 

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/source/TimestampsAndWatermarks.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/source/TimestampsAndWatermarks.java
@@ -63,6 +63,9 @@ public interface TimestampsAndWatermarks<T> {
         /** Notifies about changes to per split watermarks. */
         void updateCurrentSplitWatermark(String splitId, long watermark);
 
+        /** Notifies about changes to per split idleness. */
+        void updateCurrentSplitIdle(String splitId, boolean idle);
+
         /** Notifies that split has finished. */
         void splitFinished(String splitId);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/source/WatermarkToDataOutput.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/source/WatermarkToDataOutput.java
@@ -55,6 +55,9 @@ public final class WatermarkToDataOutput implements WatermarkOutput {
                     public void updateCurrentSplitWatermark(String splitId, long watermark) {}
 
                     @Override
+                    public void updateCurrentSplitIdle(String splitId, boolean isIdle) {}
+
+                    @Override
                     public void splitFinished(String splitId) {}
                 });
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/InternalSourceSplitMetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/InternalSourceSplitMetricGroupTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.metrics.groups;
+
+import org.apache.flink.runtime.metrics.MetricRegistry;
+import org.apache.flink.runtime.metrics.util.TestingMetricRegistry;
+import org.apache.flink.util.clock.ManualClock;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for the {@link InternalSourceSplitMetricGroup}. */
+class InternalSourceSplitMetricGroupTest {
+    private static final MetricRegistry registry = TestingMetricRegistry.builder().build();
+
+    InternalSourceSplitMetricGroup getMetricGroupWithClock(ManualClock clock) {
+        return InternalSourceSplitMetricGroup.wrap(
+                UnregisteredMetricGroups.createUnregisteredOperatorMetricGroup(),
+                clock,
+                "splitId",
+                null);
+    }
+
+    @Test
+    void testClocksStartTickingAfterSplitStarted() throws InterruptedException {
+        ManualClock clock = new ManualClock(System.currentTimeMillis());
+        InternalSourceSplitMetricGroup metricGroup = getMetricGroupWithClock(clock);
+        long timeBeforeSplitStart = 4L;
+        clock.advanceTime(Duration.ofMillis(timeBeforeSplitStart));
+        // assert clocks aren't ticking before the split has started:
+        assertThat(
+                        metricGroup.getAccumulatedIdleTime()
+                                + metricGroup.getAccumulatedPausedTime()
+                                + metricGroup.getAccumulatedActiveTime())
+                .isEqualTo(0);
+
+        // start split
+        metricGroup.markSplitStart();
+        long timeAfterSplitStart = 6L;
+        clock.advanceTime(Duration.ofMillis(timeAfterSplitStart));
+        assertThat(
+                        metricGroup.getAccumulatedIdleTime()
+                                + metricGroup.getAccumulatedPausedTime()
+                                + metricGroup.getAccumulatedActiveTime())
+                .isEqualTo(timeAfterSplitStart);
+    }
+
+    @Test
+    void testConsistencyOfTime() throws InterruptedException {
+        ManualClock clock = new ManualClock(System.currentTimeMillis());
+        InternalSourceSplitMetricGroup metricGroup = getMetricGroupWithClock(clock);
+        metricGroup.markSplitStart();
+        final long startTime = clock.absoluteTimeMillis();
+
+        long pausedTime = 2L;
+        metricGroup.markPaused();
+        clock.advanceTime(Duration.ofMillis(pausedTime));
+        metricGroup.markNotPaused();
+
+        long activeTime = 4L;
+        clock.advanceTime(Duration.ofMillis(activeTime));
+
+        long idleTime = 1000 - pausedTime - activeTime;
+        metricGroup.markIdle();
+        clock.advanceTime(Duration.ofMillis(idleTime));
+        metricGroup.markNotIdle();
+
+        assertThat(metricGroup.getAccumulatedPausedTime()).isEqualTo(pausedTime);
+        assertThat(metricGroup.getAccumulatedActiveTime()).isEqualTo(activeTime);
+        assertThat(metricGroup.getAccumulatedIdleTime()).isEqualTo(idleTime);
+
+        long totalDuration = clock.absoluteTimeMillis() - startTime;
+        assertThat((double) metricGroup.getAccumulatedPausedTime())
+                .isEqualTo(
+                        totalDuration
+                                - metricGroup.getAccumulatedActiveTime()
+                                - metricGroup.getAccumulatedIdleTime());
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change
This pull request adds split level watermark metrics, covering watermark progress and per-split state gauges (active, idle and paused)
The change is widely described in [FLIP-513: Split-level Watermark Metrics](https://cwiki.apache.org/confluence/display/FLINK/FLIP-513%3A+Split-level+Watermark+Metrics)


## Brief change log
- A new metric group `InternalSourceSplitMetricGroup` introduced as a sub-group of [OperatorMetricGroup](https://github.com/apache/flink/blob/4091e85b62845680c450b7db6301903de10877e4/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/InternalOperatorMetricGroup.java#L37), containing a watermark reference and pauseable timers for states.
- The MG is initialized per split by [SourceOperator](https://github.com/apache/flink/blob/master/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java), which already keeps track of splits pause/resume splits. 
- [TimestampsAndWatermarks.WatermarkUpdateListener](https://github.com/apache/flink/blob/4091e85b62845680c450b7db6301903de10877e4/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/source/TimestampsAndWatermarks.java#L51-L68) and [WatermarkOutputMultiplexer.WatermarkUpdateListener](https://github.com/apache/flink/blob/4091e85b62845680c450b7db6301903de10877e4/flink-core/src/main/java/org/apache/flink/api/common/eventtime/WatermarkOutputMultiplexer.java#L54-L57) interfaces were extended to bubble split-level idleness updates, upstream to SourceOperator. (so it can switch the split idle timer on and off as well)
- `WatermarkUpdateListener` usages were updated to match the new signature.

## Verifying this change
This change added tests and can be verified as follows:
- The new metric group, as well as state transitions reporting under alignment / idleness are unit tested.
- The change was manually verified by running a flink job reading from 2 sources, fast and slow, and verifying split level metrics reports were aligned with the watermark, paused and idle status of each split. 
- 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes (metrics)
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
