### PR TITLE
[FLINK-37440] Fix the bug that parallelism.default do not always adopts 1 as the default value.

### DIFF
--- a/docs/content/docs/dev/datastream/execution/execution_configuration.md
+++ b/docs/content/docs/dev/datastream/execution/execution_configuration.md
@@ -51,7 +51,7 @@ The following configuration options are available: (the default is bold)
 With the closure cleaner disabled, it might happen that an anonymous user function is referencing the surrounding class, which is usually not Serializable. This will lead to exceptions by the serializer. The settings are:
 `NONE`: disable the closure cleaner completely, `TOP_LEVEL`: clean only the top-level class without recursing into fields, `RECURSIVE`: clean all the fields recursively.
 
-- `getParallelism()` / `setParallelism(int parallelism)` Set the default parallelism for the job.
+- `getParallelism()` / `setParallelism(int parallelism)` Set the default parallelism for the job. There are two special cases. In the first case, when creating a LocalStreamEnvironment without specifying parallelism.default, the number of processors available to the Java virtual machine will be used. In the second case, when creating mini cluster without specifying parallelism.default, the total number of slots in mini cluster will be used.
 
 - `getMaxParallelism()` / `setMaxParallelism(int parallelism)` Set the default maximum parallelism for the job. This setting determines the maximum degree of parallelism and specifies the upper limit for dynamic scaling.
 

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -74,7 +74,7 @@ This check should only be disabled if such a leak prevents further jobs from run
             <td><h5>parallelism.default</h5></td>
             <td style="word-wrap: break-word;">1</td>
             <td>Integer</td>
-            <td>Default parallelism for jobs.</td>
+            <td>Default parallelism for jobs. There are two special cases. In the first case, when creating a LocalStreamEnvironment without specifying parallelism.default, the number of processors available to the Java virtual machine will be used. In the second case, when creating mini cluster without specifying parallelism.default, the total number of slots in mini cluster will be used.</td>
         </tr>
     </tbody>
 </table>

--- a/docs/layouts/shortcodes/generated/sink_configuration.html
+++ b/docs/layouts/shortcodes/generated/sink_configuration.html
@@ -1,0 +1,18 @@
+<table class="configuration table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>sink.committer.retries</h5></td>
+            <td style="word-wrap: break-word;">10</td>
+            <td>Integer</td>
+            <td>The number of retries a Flink application attempts for committable operations (such as transactions) on retriable errors, as specified by the sink connector, before Flink fails and potentially restarts.</td>
+        </tr>
+    </tbody>
+</table>

--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
@@ -495,7 +495,6 @@ class ClientTest {
                 @Override
                 public PipelineExecutor getExecutor(@Nonnull Configuration configuration) {
                     return (pipeline, config, classLoader) -> {
-                        final int parallelism = config.get(CoreOptions.DEFAULT_PARALLELISM);
                         final JobGraph jobGraph = streamGraph.getJobGraph();
                         // The job graphs from different cases are generated from the same stream
                         // graph, resulting in the same job ID, which can lead to exceptions.

--- a/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
@@ -470,7 +470,8 @@ public class CoreOptions {
             ConfigOptions.key("parallelism.default")
                     .intType()
                     .defaultValue(1)
-                    .withDescription("Default parallelism for jobs.");
+                    .withDescription(
+                            "Default parallelism for jobs. There are two special cases. In the first case, when creating a LocalStreamEnvironment without specifying parallelism.default, the number of processors available to the Java virtual machine will be used. In the second case, when creating mini cluster without specifying parallelism.default, the total number of slots in mini cluster will be used.");
 
     // ------------------------------------------------------------------------
     //  file systems


### PR DESCRIPTION
## What is the purpose of the change

This PR proposes to fix the bug that parallelism.default do not always adopts 1 as the default value.
The config parallelism.default defined as follows.
```
    public static final ConfigOption<Integer> DEFAULT_PARALLELISM =
            ConfigOptions.key("parallelism.default")
                    .intType()
                    .defaultValue(1)
                    .withDescription("Default parallelism for jobs.");
```
It means the value of parallelism.default will be 1 if users do not specify it.
But the default is not always 1. I checked all the code and found two special case.
1. `createLocalEnvironment` in the `StreamExecutionEnvironment` at line 2248.
```
    public static LocalStreamEnvironment createLocalEnvironment(Configuration configuration) {
        if (configuration.getOptional(CoreOptions.DEFAULT_PARALLELISM).isPresent()) {
            return new LocalStreamEnvironment(configuration);
        } else {
            Configuration copyOfConfiguration = new Configuration();
            copyOfConfiguration.addAll(configuration);
            copyOfConfiguration.set(CoreOptions.DEFAULT_PARALLELISM, defaultLocalParallelism);
            return new LocalStreamEnvironment(copyOfConfiguration);
        }
    }
```

2. `registerEnv` in the `MiniClusterExtension` at line 264.
```
private void registerEnv(InternalMiniClusterExtension internalMiniClusterExtension) {
        final Configuration configuration =
                internalMiniClusterExtension.getMiniCluster().getConfiguration();

        final int defaultParallelism =
                configuration
                        .getOptional(CoreOptions.DEFAULT_PARALLELISM)
                        .orElse(internalMiniClusterExtension.getNumberSlots());

        TestStreamEnvironment.setAsContext(
                internalMiniClusterExtension.getMiniCluster(), defaultParallelism);
        this.streamExecutionEnvironment =
                new TestStreamEnvironment(
                        internalMiniClusterExtension.getMiniCluster(),
                        internalMiniClusterExtension.getNumberSlots());
    }
```

I think the DEFAULT_PARALLELISM is a open API, we'd better not change the behavior. So I add extra comments for this config.

## Brief change log

Fix the bug that parallelism.default do not always adopts 1 as the default value.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs)
