### PR TITLE
[FLINK-37441] Rename `factoryHierarchy` to `typeHierarchy` for `TypeExtractor`

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
@@ -1346,16 +1346,15 @@ public class TypeExtractor {
             List<Type> typeHierarchy,
             TypeInformation<IN1> in1Type,
             TypeInformation<IN2> in2Type) {
-
-        final List<Type> factoryHierarchy = new ArrayList<>(typeHierarchy);
-        final TypeInfoFactory<? super OUT> factory = getClosestFactory(factoryHierarchy, t);
+        final List<Type> newTypeHierarchy = new ArrayList<>(typeHierarchy);
+        final TypeInfoFactory<? super OUT> factory = getClosestFactory(newTypeHierarchy, t);
         if (factory == null) {
             return null;
         }
-        final Type factoryDefiningType = factoryHierarchy.get(factoryHierarchy.size() - 1);
+        final Type factoryDefiningType = newTypeHierarchy.get(newTypeHierarchy.size() - 1);
 
         return createTypeInfoFromFactory(
-                t, in1Type, in2Type, factoryHierarchy, factory, factoryDefiningType);
+                t, in1Type, in2Type, newTypeHierarchy, factory, factoryDefiningType);
     }
 
     /** Creates type information using a given factory. */
@@ -1364,7 +1363,7 @@ public class TypeExtractor {
             Type t,
             TypeInformation<IN1> in1Type,
             TypeInformation<IN2> in2Type,
-            List<Type> factoryHierarchy,
+            List<Type> typeHierarchy,
             TypeInfoFactory<? super OUT> factory,
             Type factoryDefiningType) {
         // infer possible type parameters from input
@@ -1375,8 +1374,7 @@ public class TypeExtractor {
             final Type[] args = typeToClass(paramDefiningType).getTypeParameters();
 
             final TypeInformation<?>[] subtypeInfo =
-                    createSubTypesInfo(
-                            t, paramDefiningType, factoryHierarchy, in1Type, in2Type, true);
+                    createSubTypesInfo(t, paramDefiningType, typeHierarchy, in1Type, in2Type, true);
             assert subtypeInfo != null;
             for (int i = 0; i < subtypeInfo.length; i++) {
                 genericParams.put(args[i].toString(), subtypeInfo[i]);


### PR DESCRIPTION
## What is the purpose of the change

This PR proposes to rename `factoryHierarchy` to `typeHierarchy` due to it is just a `List<Type>` and doesn't related to factory.


## Brief change log

Rename `factoryHierarchy` to `typeHierarchy` for `TypeExtractor`


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
