### PR TITLE
[FLINK-37439][state/forst] Support file override in wrapped file system

### DIFF
--- a/flink-dist/src/main/resources/META-INF/NOTICE
+++ b/flink-dist/src/main/resources/META-INF/NOTICE
@@ -8,7 +8,7 @@ This project bundles the following dependencies under the Apache Software Licens
 
 - com.google.code.findbugs:jsr305:1.3.9
 - com.ververica:frocksdbjni:8.10.0-ververica-1.0
-- com.ververica:forstjni:0.1.7
+- com.ververica:forstjni:0.1.8
 - commons-cli:commons-cli:1.5.0
 - commons-collections:commons-collections:3.2.2
 - commons-io:commons-io:2.15.1

--- a/flink-state-backends/flink-statebackend-forst/pom.xml
+++ b/flink-state-backends/flink-statebackend-forst/pom.xml
@@ -63,7 +63,7 @@ under the License.
 		<dependency>
 			<groupId>com.ververica</groupId>
 			<artifactId>forstjni</artifactId>
-			<version>0.1.7</version>
+			<version>0.1.8</version>
 		</dependency>
 
 		<!-- test dependencies -->

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackendBuilder.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackendBuilder.java
@@ -298,6 +298,9 @@ public class ForStKeyedStateBackendBuilder<K>
             IOUtils.closeQuietly(restoreOperation);
             try {
                 optionsContainer.clearDirectories();
+                // TODO: Remove this after FLINK-37442, if we could properly handl the directory
+                //       deletion in file mapping manager.
+                optionsContainer.forceClearRemoteDirectories();
             } catch (Exception ex) {
                 logger.warn(
                         "Failed to delete ForSt local base path {}, remote base path {}.",

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStResourceContainer.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStResourceContainer.java
@@ -435,6 +435,12 @@ public final class ForStResourceContainer implements AutoCloseable {
         }
     }
 
+    public void forceClearRemoteDirectories() throws Exception {
+        if (remoteBasePath != null) {
+            clearDirectories(remoteBasePath);
+        }
+    }
+
     private static void clearDirectories(Path basePath) throws IOException {
         FileSystem fileSystem = basePath.getFileSystem();
         if (fileSystem.exists(basePath)) {

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/fs/ForStFlinkFileSystem.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/fs/ForStFlinkFileSystem.java
@@ -186,7 +186,8 @@ public class ForStFlinkFileSystem extends FileSystem implements Closeable {
     public synchronized ByteBufferWritableFSDataOutputStream create(
             Path dbFilePath, WriteMode overwriteMode) throws IOException {
         // Create a file in the mapping table
-        MappingEntry createdMappingEntry = fileMappingManager.createNewFile(dbFilePath);
+        MappingEntry createdMappingEntry =
+                fileMappingManager.createNewFile(dbFilePath, overwriteMode == WriteMode.OVERWRITE);
 
         // The source must be backed by a file
         FileBackedMappingEntrySource source =

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/fs/filemapping/FileMappingManager.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/fs/filemapping/FileMappingManager.java
@@ -276,9 +276,15 @@ public class FileMappingManager {
             }
         }
 
+        // We always treat parentEntry not owned for now, to avoid deleting directory.
+        // This is a safety guard but no good reason to keep it if we have a better solution.
+        // TODO: Reconsider the directory deletion strategy in FLINK-37442.
+        parentEntry.setFileOwnership(FileOwnership.NOT_OWNED);
+
         boolean status = true;
         // step 2.2: release file under directory
-        if (parentEntry.getReferenceCount() == 0) {
+        if (parentEntry.getReferenceCount() == 0
+                && parentEntry.getFileOwnership() != FileOwnership.NOT_OWNED) {
             // an empty directory
             status = fileSystem.delete(file, recursive);
         }

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/fs/filemapping/FileMappingManager.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/fs/filemapping/FileMappingManager.java
@@ -338,10 +338,7 @@ public class FileMappingManager {
     }
 
     private Path forceLocalPath(Path filePath) {
-        if (isParentDir(filePath.toString(), remoteBase)) {
-            return new Path(localBase, filePath.getName());
-        }
-        return filePath;
+        return new Path(localBase, filePath.getName());
     }
 
     private Path toUUIDPath(Path filePath) {

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStResourceContainerTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStResourceContainerTest.java
@@ -333,6 +333,9 @@ public class ForStResourceContainerTest {
 
             optionsContainer.clearDirectories();
             assertFalse(new File(localBasePath.getPath()).exists());
+
+            assertTrue(new File(remoteBasePath.getPath()).exists());
+            optionsContainer.forceClearRemoteDirectories();
             assertFalse(new File(remoteBasePath.getPath()).exists());
         }
     }

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/fs/FileMappingManagerTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/fs/FileMappingManagerTest.java
@@ -55,7 +55,7 @@ public class FileMappingManagerTest {
             return manager.registerReusedRestoredFile(
                     filePath.toString(), new FileStateHandle(filePath, 0), filePath);
         } else {
-            return manager.createNewFile(filePath);
+            return manager.createNewFile(filePath, false);
         }
     }
 

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/fs/FileMappingManagerTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/fs/FileMappingManagerTest.java
@@ -53,9 +53,9 @@ public class FileMappingManagerTest {
     private MappingEntry registerFile(FileMappingManager manager, Path filePath) {
         if (reuseCp) {
             return manager.registerReusedRestoredFile(
-                    filePath.toString(), new FileStateHandle(filePath, 0), filePath);
+                    filePath.toString(), new FileStateHandle(filePath, 0), filePath, null);
         } else {
-            return manager.createNewFile(filePath, false);
+            return manager.createNewFile(filePath, false, null);
         }
     }
 

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/fs/FileMappingManagerTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/fs/FileMappingManagerTest.java
@@ -160,8 +160,9 @@ public class FileMappingManagerTest {
 
         // delete dst
         fileMappingManager.deleteFileOrDirectory(new Path(dst), false);
-        assertThat(localFS.exists(new Path(src))).isFalse();
-        assertThat(localFS.exists(new Path(testDir))).isFalse();
+        // TODO FLINK-37442: properly clear directory
+        assertThat(localFS.exists(new Path(src))).isTrue();
+        assertThat(localFS.exists(new Path(testDir))).isTrue();
     }
 
     @TestTemplate
@@ -191,7 +192,7 @@ public class FileMappingManagerTest {
         // delete src
         assertThat(fileMappingManager.deleteFileOrDirectory(new Path(src), false)).isEqualTo(true);
         assertThat(localFS.exists(new Path(testDir))).isTrue();
-        assertThat(localFS.exists(new Path(linkedDirTmp))).isFalse();
+        assertThat(localFS.exists(new Path(linkedDirTmp))).isTrue();
         assertThat(localFS.exists(new Path(linkedDir))).isTrue();
         assertThat(localFS.exists(new Path(src))).isTrue();
 
@@ -204,16 +205,17 @@ public class FileMappingManagerTest {
         // delete linkedSrc
         assertThat(fileMappingManager.deleteFileOrDirectory(new Path(linkedSrc), false))
                 .isEqualTo(true);
-        assertThat(localFS.exists(new Path(src))).isFalse();
-        assertThat(localFS.exists(new Path(testDir))).isFalse();
+        // file from cp cannot be deleted
+        assertThat(localFS.exists(new Path(src))).isTrue();
+        assertThat(localFS.exists(new Path(testDir))).isTrue();
 
         // delete linkedDir
         assertThat(fileMappingManager.deleteFileOrDirectory(new Path(linkedDir), true))
                 .isEqualTo(true);
-        assertThat(localFS.exists(new Path(testDir))).isFalse();
-        assertThat(localFS.exists(new Path(linkedDirTmp))).isFalse();
-        assertThat(localFS.exists(new Path(linkedDir))).isFalse();
-        assertThat(localFS.exists(new Path(src))).isFalse();
+        assertThat(localFS.exists(new Path(testDir))).isTrue();
+        assertThat(localFS.exists(new Path(linkedDirTmp))).isTrue();
+        assertThat(localFS.exists(new Path(linkedDir))).isTrue();
+        assertThat(localFS.exists(new Path(src))).isTrue();
     }
 
     @TestTemplate
@@ -267,8 +269,8 @@ public class FileMappingManagerTest {
         // delete linkedSrc
         assertThat(fileMappingManager.deleteFileOrDirectory(new Path(linkedSrc), false))
                 .isEqualTo(true);
-        assertThat(localFS.exists(new Path(src))).isFalse();
-        assertThat(localFS.exists(new Path(testDir))).isFalse();
+        assertThat(localFS.exists(new Path(src))).isTrue();
+        assertThat(localFS.exists(new Path(testDir))).isTrue();
         assertThat(localFS.exists(new Path(linkedDir))).isTrue();
         assertThat(localFS.exists(new Path(linkedDirTmp))).isTrue();
 
@@ -281,13 +283,13 @@ public class FileMappingManagerTest {
         if (reuseCp) {
             assertThat(localFS.exists(new Path(linkedDirTmp))).isTrue();
         } else {
-            assertThat(localFS.exists(new Path(linkedDirTmp))).isFalse();
+            assertThat(localFS.exists(new Path(linkedDirTmp))).isTrue();
         }
-        assertThat(localFS.exists(new Path(testDir))).isFalse();
+        assertThat(localFS.exists(new Path(testDir))).isTrue();
 
         // delete linkedDir
         assertThat(fileMappingManager.deleteFileOrDirectory(new Path(linkedDir), true))
                 .isEqualTo(true);
-        assertThat(localFS.exists(new Path(testDir))).isFalse();
+        assertThat(localFS.exists(new Path(testDir))).isTrue();
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

ForSt may create LOG files twice with overwrite, however, the ForSt wrapped file system does not support overwriting files. Exception thrown in this case.

This PR fixes the bug above, as well as some file ownership problem that may cause a ForSt coredump.


## Brief change log

Please check each commit for code changes:

 - Support file override in wrapped file system, modified the `FileMappingManager`
 - Unguarded file system to enable stream sharing between threads
 - Avoid the deletion of primary directory in ForSt


## Verifying this change

Multiple UTs added.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
