### PR TITLE
[FLINK-37460][state] Make state processor API checkpoint ID configurable

### DIFF
--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/KeyedStateTransformation.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/KeyedStateTransformation.java
@@ -44,6 +44,9 @@ public class KeyedStateTransformation<K, T> {
     /** The data set containing the data to bootstrap the operator state with. */
     private final DataStream<T> stream;
 
+    /** Checkpoint ID. */
+    private final long checkpointId;
+
     /** Local max parallelism for the bootstrapped operator. */
     private final OptionalInt operatorMaxParallelism;
 
@@ -55,10 +58,12 @@ public class KeyedStateTransformation<K, T> {
 
     KeyedStateTransformation(
             DataStream<T> stream,
+            long checkpointId,
             OptionalInt operatorMaxParallelism,
             KeySelector<T, K> keySelector,
             TypeInformation<K> keyType) {
         this.stream = stream;
+        this.checkpointId = checkpointId;
         this.operatorMaxParallelism = operatorMaxParallelism;
         this.keySelector = keySelector;
         this.keyType = keyType;
@@ -80,7 +85,7 @@ public class KeyedStateTransformation<K, T> {
                 (timestamp, path) ->
                         SimpleOperatorFactory.of(
                                 new KeyedStateBootstrapOperator<>(
-                                        timestamp, path, processFunction));
+                                        checkpointId, timestamp, path, processFunction));
         return transform(factory);
     }
 
@@ -112,6 +117,6 @@ public class KeyedStateTransformation<K, T> {
     public <W extends Window> WindowedStateTransformation<T, K, W> window(
             WindowAssigner<? super T, W> assigner) {
         return new WindowedStateTransformation<>(
-                stream, operatorMaxParallelism, keySelector, keyType, assigner);
+                stream, checkpointId, operatorMaxParallelism, keySelector, keyType, assigner);
     }
 }

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/OperatorTransformation.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/OperatorTransformation.java
@@ -64,6 +64,19 @@ public final class OperatorTransformation {
      * @return A {@link OneInputStateTransformation}.
      */
     public static <T> OneInputStateTransformation<T> bootstrapWith(DataStream<T> stream) {
-        return new OneInputStateTransformation<>(stream);
+        return new OneInputStateTransformation<>(stream, 0L);
+    }
+
+    /**
+     * Create a new {@link OneInputStateTransformation} from a {@link DataStream}.
+     *
+     * @param stream A data stream of elements.
+     * @param checkpointId checkpoint ID.
+     * @param <T> The type of the input.
+     * @return A {@link OneInputStateTransformation}.
+     */
+    public static <T> OneInputStateTransformation<T> bootstrapWith(
+            DataStream<T> stream, long checkpointId) {
+        return new OneInputStateTransformation<>(stream, checkpointId);
     }
 }

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/SavepointReader.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/SavepointReader.java
@@ -82,7 +82,10 @@ public class SavepointReader {
 
         SavepointMetadataV2 savepointMetadata =
                 new SavepointMetadataV2(
-                        maxParallelism, metadata.getMasterStates(), metadata.getOperatorStates());
+                        metadata.getCheckpointId(),
+                        maxParallelism,
+                        metadata.getMasterStates(),
+                        metadata.getOperatorStates());
         return new SavepointReader(env, savepointMetadata, null);
     }
 
@@ -111,7 +114,10 @@ public class SavepointReader {
 
         SavepointMetadataV2 savepointMetadata =
                 new SavepointMetadataV2(
-                        maxParallelism, metadata.getMasterStates(), metadata.getOperatorStates());
+                        metadata.getCheckpointId(),
+                        maxParallelism,
+                        metadata.getMasterStates(),
+                        metadata.getOperatorStates());
         return new SavepointReader(env, savepointMetadata, stateBackend);
     }
 

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/SavepointWriter.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/SavepointWriter.java
@@ -108,7 +108,10 @@ public class SavepointWriter {
                                                 "Savepoint must contain at least one operator state."));
 
         return new SavepointMetadataV2(
-                maxParallelism, metadata.getMasterStates(), metadata.getOperatorStates());
+                metadata.getCheckpointId(),
+                maxParallelism,
+                metadata.getMasterStates(),
+                metadata.getOperatorStates());
     }
 
     /**
@@ -123,7 +126,25 @@ public class SavepointWriter {
     public static SavepointWriter newSavepoint(
             StreamExecutionEnvironment executionEnvironment, int maxParallelism) {
         return new SavepointWriter(
-                createSavepointMetadata(maxParallelism), null, executionEnvironment);
+                createSavepointMetadata(0L, maxParallelism), null, executionEnvironment);
+    }
+
+    /**
+     * Creates a new savepoint. The savepoint will be written using the state backend defined via
+     * the clusters configuration.
+     *
+     * @param maxParallelism The max parallelism of the savepoint.
+     * @param checkpointId checkpoint ID.
+     * @return A {@link SavepointWriter}.
+     * @see #newSavepoint(StreamExecutionEnvironment, StateBackend, int)
+     * @see #withConfiguration(ConfigOption, Object)
+     */
+    public static SavepointWriter newSavepoint(
+            StreamExecutionEnvironment executionEnvironment,
+            long checkpointId,
+            int maxParallelism) {
+        return new SavepointWriter(
+                createSavepointMetadata(checkpointId, maxParallelism), null, executionEnvironment);
     }
 
     /**
@@ -139,10 +160,31 @@ public class SavepointWriter {
             StateBackend stateBackend,
             int maxParallelism) {
         return new SavepointWriter(
-                createSavepointMetadata(maxParallelism), stateBackend, executionEnvironment);
+                createSavepointMetadata(0L, maxParallelism), stateBackend, executionEnvironment);
     }
 
-    private static SavepointMetadataV2 createSavepointMetadata(int maxParallelism) {
+    /**
+     * Creates a new savepoint.
+     *
+     * @param stateBackend The state backend of the savepoint used for keyed state.
+     * @param checkpointId checkpoint ID.
+     * @param maxParallelism The max parallelism of the savepoint.
+     * @return A {@link SavepointWriter}.
+     * @see #newSavepoint(StreamExecutionEnvironment, int)
+     */
+    public static SavepointWriter newSavepoint(
+            StreamExecutionEnvironment executionEnvironment,
+            StateBackend stateBackend,
+            long checkpointId,
+            int maxParallelism) {
+        return new SavepointWriter(
+                createSavepointMetadata(checkpointId, maxParallelism),
+                stateBackend,
+                executionEnvironment);
+    }
+
+    private static SavepointMetadataV2 createSavepointMetadata(
+            long checkpointId, int maxParallelism) {
         Preconditions.checkArgument(
                 maxParallelism > 0 && maxParallelism <= UPPER_BOUND_MAX_PARALLELISM,
                 "Maximum parallelism must be between 1 and "
@@ -151,7 +193,7 @@ public class SavepointWriter {
                         + maxParallelism);
 
         return new SavepointMetadataV2(
-                maxParallelism, Collections.emptyList(), Collections.emptyList());
+                checkpointId, maxParallelism, Collections.emptyList(), Collections.emptyList());
     }
 
     /**
@@ -295,7 +337,8 @@ public class SavepointWriter {
                         "reduce(OperatorState)",
                         TypeInformation.of(CheckpointMetadata.class),
                         new GroupReduceOperator<>(
-                                new MergeOperatorStates(metadata.getMasterStates())))
+                                new MergeOperatorStates(
+                                        metadata.getCheckpointId(), metadata.getMasterStates())))
                 .forceNonParallel()
                 .map(new CheckpointMetadataCheckpointMetadataMapFunction(this.uidTransformationMap))
                 .setParallelism(1)

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/WindowedStateTransformation.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/WindowedStateTransformation.java
@@ -57,6 +57,8 @@ public class WindowedStateTransformation<T, K, W extends Window> {
 
     private final WindowOperatorBuilder<T, K, W> builder;
 
+    private final long checkpointId;
+
     private final OptionalInt operatorMaxParallelism;
 
     private final KeySelector<T, K> keySelector;
@@ -65,11 +67,13 @@ public class WindowedStateTransformation<T, K, W extends Window> {
 
     WindowedStateTransformation(
             DataStream<T> input,
+            long checkpointId,
             OptionalInt operatorMaxParallelism,
             KeySelector<T, K> keySelector,
             TypeInformation<K> keyType,
             WindowAssigner<? super T, W> windowAssigner) {
         this.input = input;
+        this.checkpointId = checkpointId;
         this.operatorMaxParallelism = operatorMaxParallelism;
         this.keySelector = keySelector;
         this.keyType = keyType;
@@ -158,7 +162,8 @@ public class WindowedStateTransformation<T, K, W extends Window> {
 
         SavepointWriterOperatorFactory factory =
                 (timestamp, path) ->
-                        new StateBootstrapWrapperOperatorFactory<>(timestamp, path, operator);
+                        new StateBootstrapWrapperOperatorFactory<>(
+                                checkpointId, timestamp, path, operator);
         return new StateBootstrapTransformation<>(
                 input, operatorMaxParallelism, factory, keySelector, keyType);
     }
@@ -186,7 +191,8 @@ public class WindowedStateTransformation<T, K, W extends Window> {
 
         SavepointWriterOperatorFactory factory =
                 (timestamp, path) ->
-                        new StateBootstrapWrapperOperatorFactory<>(timestamp, path, operator);
+                        new StateBootstrapWrapperOperatorFactory<>(
+                                checkpointId, timestamp, path, operator);
         return new StateBootstrapTransformation<>(
                 input, operatorMaxParallelism, factory, keySelector, keyType);
     }
@@ -323,7 +329,8 @@ public class WindowedStateTransformation<T, K, W extends Window> {
 
         SavepointWriterOperatorFactory factory =
                 (timestamp, path) ->
-                        new StateBootstrapWrapperOperatorFactory<>(timestamp, path, operator);
+                        new StateBootstrapWrapperOperatorFactory<>(
+                                checkpointId, timestamp, path, operator);
         return new StateBootstrapTransformation<>(
                 input, operatorMaxParallelism, factory, keySelector, keyType);
     }
@@ -402,7 +409,8 @@ public class WindowedStateTransformation<T, K, W extends Window> {
 
         SavepointWriterOperatorFactory factory =
                 (timestamp, path) ->
-                        new StateBootstrapWrapperOperatorFactory<>(timestamp, path, operator);
+                        new StateBootstrapWrapperOperatorFactory<>(
+                                checkpointId, timestamp, path, operator);
         return new StateBootstrapTransformation<>(
                 input, operatorMaxParallelism, factory, keySelector, keyType);
     }
@@ -428,7 +436,8 @@ public class WindowedStateTransformation<T, K, W extends Window> {
 
         SavepointWriterOperatorFactory factory =
                 (timestamp, path) ->
-                        new StateBootstrapWrapperOperatorFactory<>(timestamp, path, operator);
+                        new StateBootstrapWrapperOperatorFactory<>(
+                                checkpointId, timestamp, path, operator);
         return new StateBootstrapTransformation<>(
                 input, operatorMaxParallelism, factory, keySelector, keyType);
     }
@@ -454,7 +463,8 @@ public class WindowedStateTransformation<T, K, W extends Window> {
 
         SavepointWriterOperatorFactory factory =
                 (timestamp, path) ->
-                        new StateBootstrapWrapperOperatorFactory<>(timestamp, path, operator);
+                        new StateBootstrapWrapperOperatorFactory<>(
+                                checkpointId, timestamp, path, operator);
         return new StateBootstrapTransformation<>(
                 input, operatorMaxParallelism, factory, keySelector, keyType);
     }
@@ -477,7 +487,8 @@ public class WindowedStateTransformation<T, K, W extends Window> {
 
         SavepointWriterOperatorFactory factory =
                 (timestamp, path) ->
-                        new StateBootstrapWrapperOperatorFactory<>(timestamp, path, operator);
+                        new StateBootstrapWrapperOperatorFactory<>(
+                                checkpointId, timestamp, path, operator);
         return new StateBootstrapTransformation<>(
                 input, operatorMaxParallelism, factory, keySelector, keyType);
     }

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/MergeOperatorStates.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/MergeOperatorStates.java
@@ -39,11 +39,14 @@ public class MergeOperatorStates implements GroupReduceFunction<OperatorState, C
 
     private static final long serialVersionUID = 1L;
 
+    private final long checkpointId;
+
     private final Collection<MasterState> masterStates;
 
-    public MergeOperatorStates(Collection<MasterState> masterStates) {
+    public MergeOperatorStates(long checkpointId, Collection<MasterState> masterStates) {
         Preconditions.checkNotNull(masterStates, "Master state metadata must not be null");
 
+        this.checkpointId = checkpointId;
         this.masterStates = masterStates;
     }
 
@@ -51,7 +54,7 @@ public class MergeOperatorStates implements GroupReduceFunction<OperatorState, C
     public void reduce(Iterable<OperatorState> values, Collector<CheckpointMetadata> out) {
         CheckpointMetadata metadata =
                 new CheckpointMetadata(
-                        SnapshotUtils.CHECKPOINT_ID,
+                        checkpointId,
                         StreamSupport.stream(values.spliterator(), false)
                                 .collect(Collectors.toList()),
                         masterStates);

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/operators/BroadcastStateBootstrapOperator.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/operators/BroadcastStateBootstrapOperator.java
@@ -44,6 +44,8 @@ public class BroadcastStateBootstrapOperator<IN>
 
     private static final long serialVersionUID = 1L;
 
+    private final long checkpointId;
+
     private final long timestamp;
 
     private final Path savepointPath;
@@ -51,10 +53,14 @@ public class BroadcastStateBootstrapOperator<IN>
     private transient ContextImpl context;
 
     public BroadcastStateBootstrapOperator(
-            long timestamp, Path savepointPath, BroadcastStateBootstrapFunction<IN> function) {
+            long checkpointId,
+            long timestamp,
+            Path savepointPath,
+            BroadcastStateBootstrapFunction<IN> function) {
         super(function);
-        this.timestamp = timestamp;
 
+        this.checkpointId = checkpointId;
+        this.timestamp = timestamp;
         this.savepointPath = savepointPath;
     }
 
@@ -73,6 +79,7 @@ public class BroadcastStateBootstrapOperator<IN>
     public void endInput() throws Exception {
         TaggedOperatorSubtaskState state =
                 SnapshotUtils.snapshot(
+                        checkpointId,
                         this,
                         getRuntimeContext().getTaskInfo().getIndexOfThisSubtask(),
                         timestamp,

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/operators/KeyedStateBootstrapOperator.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/operators/KeyedStateBootstrapOperator.java
@@ -48,6 +48,8 @@ public class KeyedStateBootstrapOperator<K, IN>
 
     private static final long serialVersionUID = 1L;
 
+    private final long checkpointId;
+
     private final long timestamp;
 
     private final Path savepointPath;
@@ -55,9 +57,13 @@ public class KeyedStateBootstrapOperator<K, IN>
     private transient KeyedStateBootstrapOperator<K, IN>.ContextImpl context;
 
     public KeyedStateBootstrapOperator(
-            long timestamp, Path savepointPath, KeyedStateBootstrapFunction<K, IN> function) {
+            long checkpointId,
+            long timestamp,
+            Path savepointPath,
+            KeyedStateBootstrapFunction<K, IN> function) {
         super(function);
 
+        this.checkpointId = checkpointId;
         this.timestamp = timestamp;
         this.savepointPath = savepointPath;
     }
@@ -88,6 +94,7 @@ public class KeyedStateBootstrapOperator<K, IN>
     public void endInput() throws Exception {
         TaggedOperatorSubtaskState state =
                 SnapshotUtils.snapshot(
+                        checkpointId,
                         this,
                         getRuntimeContext().getTaskInfo().getIndexOfThisSubtask(),
                         timestamp,

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/operators/StateBootstrapOperator.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/operators/StateBootstrapOperator.java
@@ -40,6 +40,8 @@ public class StateBootstrapOperator<IN>
 
     private static final long serialVersionUID = 1L;
 
+    private final long checkpointId;
+
     private final long timestamp;
 
     private final Path savepointPath;
@@ -47,9 +49,13 @@ public class StateBootstrapOperator<IN>
     private transient ContextImpl context;
 
     public StateBootstrapOperator(
-            long timestamp, Path savepointPath, StateBootstrapFunction<IN> function) {
+            long checkpointId,
+            long timestamp,
+            Path savepointPath,
+            StateBootstrapFunction<IN> function) {
         super(function);
 
+        this.checkpointId = checkpointId;
         this.timestamp = timestamp;
         this.savepointPath = savepointPath;
     }
@@ -69,6 +75,7 @@ public class StateBootstrapOperator<IN>
     public void endInput() throws Exception {
         TaggedOperatorSubtaskState state =
                 SnapshotUtils.snapshot(
+                        checkpointId,
                         this,
                         getRuntimeContext().getTaskInfo().getIndexOfThisSubtask(),
                         timestamp,

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/operators/StateBootstrapWrapperOperator.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/operators/StateBootstrapWrapperOperator.java
@@ -53,6 +53,8 @@ public final class StateBootstrapWrapperOperator<
 
     private static final long serialVersionUID = 1L;
 
+    private final long checkpointId;
+
     private final long timestamp;
 
     private final Path savepointPath;
@@ -62,7 +64,11 @@ public final class StateBootstrapWrapperOperator<
     private final WindowOperator<?, IN, ?, ?, ?> operator;
 
     public StateBootstrapWrapperOperator(
-            long timestamp, Path savepointPath, WindowOperator<?, IN, ?, ?, ?> operator) {
+            long checkpointId,
+            long timestamp,
+            Path savepointPath,
+            WindowOperator<?, IN, ?, ?, ?> operator) {
+        this.checkpointId = checkpointId;
         this.timestamp = timestamp;
         this.savepointPath = savepointPath;
         this.operator = operator;
@@ -172,6 +178,7 @@ public final class StateBootstrapWrapperOperator<
     public void endInput() throws Exception {
         TaggedOperatorSubtaskState state =
                 SnapshotUtils.snapshot(
+                        checkpointId,
                         this,
                         operator.getContainingTask()
                                 .getEnvironment()

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/operators/StateBootstrapWrapperOperatorFactory.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/operators/StateBootstrapWrapperOperatorFactory.java
@@ -47,6 +47,8 @@ public class StateBootstrapWrapperOperatorFactory<
                 OPF extends OneInputStreamOperatorFactory<IN, OUT>>
         extends AbstractStreamOperatorFactory<TaggedOperatorSubtaskState> {
 
+    private final long checkpointId;
+
     private final long timestamp;
 
     private final Path savepointPath;
@@ -56,7 +58,11 @@ public class StateBootstrapWrapperOperatorFactory<
     private final WindowOperator<?, IN, ?, ?, ?> operator;
 
     public StateBootstrapWrapperOperatorFactory(
-            long timestamp, Path savepointPath, WindowOperator<?, IN, ?, ?, ?> operator) {
+            long checkpointId,
+            long timestamp,
+            Path savepointPath,
+            WindowOperator<?, IN, ?, ?, ?> operator) {
+        this.checkpointId = checkpointId;
         this.timestamp = timestamp;
         this.savepointPath = savepointPath;
         this.operator = operator;
@@ -67,7 +73,8 @@ public class StateBootstrapWrapperOperatorFactory<
     public <T extends StreamOperator<TaggedOperatorSubtaskState>> T createStreamOperator(
             StreamOperatorParameters<TaggedOperatorSubtaskState> parameters) {
         StateBootstrapWrapperOperator<IN, OUT, OP> wrapperOperator =
-                new StateBootstrapWrapperOperator<>(timestamp, savepointPath, operator);
+                new StateBootstrapWrapperOperator<>(
+                        checkpointId, timestamp, savepointPath, operator);
         wrapperOperator.setup(
                 parameters.getContainingTask(),
                 parameters.getStreamConfig(),

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/metadata/SavepointMetadataV2.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/metadata/SavepointMetadataV2.java
@@ -41,6 +41,8 @@ import static org.apache.flink.runtime.state.KeyGroupRangeAssignment.UPPER_BOUND
 @Internal
 public class SavepointMetadataV2 {
 
+    private final long checkpointId;
+
     private final int maxParallelism;
 
     private final Collection<MasterState> masterStates;
@@ -48,6 +50,7 @@ public class SavepointMetadataV2 {
     private final Map<OperatorID, OperatorStateSpecV2> operatorStateIndex;
 
     public SavepointMetadataV2(
+            long checkpointId,
             int maxParallelism,
             Collection<MasterState> masterStates,
             Collection<OperatorState> initialStates) {
@@ -59,6 +62,7 @@ public class SavepointMetadataV2 {
                         + maxParallelism);
         Preconditions.checkNotNull(masterStates);
 
+        this.checkpointId = checkpointId;
         this.maxParallelism = maxParallelism;
         this.masterStates = new ArrayList<>(masterStates);
         this.operatorStateIndex = CollectionUtil.newHashMapWithExpectedSize(initialStates.size());
@@ -68,6 +72,10 @@ public class SavepointMetadataV2 {
                         operatorStateIndex.put(
                                 existingState.getOperatorID(),
                                 OperatorStateSpecV2.existing(existingState)));
+    }
+
+    public long getCheckpointId() {
+        return checkpointId;
     }
 
     public int getMaxParallelism() {

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/output/KeyedStateBootstrapOperatorTest.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/output/KeyedStateBootstrapOperatorTest.java
@@ -62,7 +62,7 @@ public class KeyedStateBootstrapOperatorTest {
 
         OperatorSubtaskState state;
         KeyedStateBootstrapOperator<Long, Long> bootstrapOperator =
-                new KeyedStateBootstrapOperator<>(0L, path, new TimerBootstrapFunction());
+                new KeyedStateBootstrapOperator<>(0L, 0L, path, new TimerBootstrapFunction());
         try (KeyedOneInputStreamOperatorTestHarness<Long, Long, TaggedOperatorSubtaskState>
                 harness = getHarness(bootstrapOperator)) {
             processElements(harness, 1L, 2L, 3L);
@@ -93,7 +93,7 @@ public class KeyedStateBootstrapOperatorTest {
 
         OperatorSubtaskState state;
         KeyedStateBootstrapOperator<Long, Long> bootstrapOperator =
-                new KeyedStateBootstrapOperator<>(0L, path, new SimpleBootstrapFunction());
+                new KeyedStateBootstrapOperator<>(0L, 0L, path, new SimpleBootstrapFunction());
         try (KeyedOneInputStreamOperatorTestHarness<Long, Long, TaggedOperatorSubtaskState>
                 harness = getHarness(bootstrapOperator)) {
             processElements(harness, 1L, 2L, 3L);

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/output/SnapshotUtilsTest.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/output/SnapshotUtilsTest.java
@@ -77,7 +77,7 @@ public class SnapshotUtilsTest {
         Path path = new Path(folder.newFolder().getAbsolutePath());
 
         SnapshotUtils.snapshot(
-                operator, 0, 0L, true, false, new Configuration(), path, savepointFormatType);
+                0L, operator, 0, 0L, true, false, new Configuration(), path, savepointFormatType);
 
         Assert.assertEquals(SavepointType.savepoint(savepointFormatType), actualSnapshotType);
         Assert.assertEquals(EXPECTED_CALL_OPERATOR_SNAPSHOT, ACTUAL_ORDER_TRACKING);


### PR DESCRIPTION
## What is the purpose of the change

At the moment the state processor API is using hardcoded `0` as checkpoint ID.
In this PR I've made it configurable and savepoint modification keeps the original checkpoint ID.

## Brief change log

Made state processor API checkpoint ID configurable and savepoint modification keeps the original ID.

## Verifying this change

Changed automated tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
