### PR TITLE
[FLINK-37468]fix maven version  is greater than 3.8.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1881,7 +1881,7 @@ under the License.
 						<configuration>
 							<rules>
 								<requireMavenVersion>
-									<version>[3.8.6]</version>
+									<version>[3.8.6,]</version>
 								</requireMavenVersion>
 								<requireJavaVersion>
 									<version>${target.java.version}</version>


### PR DESCRIPTION
### What is the purpose of the change
---
Flink version requirements

Maven 3.8.6 (recommended or later)
Java 8 (deprecated) or Java 11
But the pom file under Flink is configured
```
<configuration>
    <rules>
       <requireMavenVersion>
          <version>[3.8.6]</version>
       </requireMavenVersion>
       <requireJavaVersion>
          <version>${target.java.version}</version>
       </requireJavaVersion>
    </rules>
</configuration> 
```
### What have I done
---
I changed the version limits in the corresponding pom file in the flink root directory
```
<configuration>
    <rules>
       <requireMavenVersion>
          <version>[3.8.6,]</version>
       </requireMavenVersion>
       <requireJavaVersion>
          <version>${target.java.version}</version>
       </requireJavaVersion>
    </rules>
</configuration> 
```