### PR TITLE
[FLINK-37466][table-api-java] Make DEFAULT explicit from Table API to planner

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -2901,13 +2901,16 @@ public final class BuiltInFunctionDefinitions {
             BuiltInFunctionDefinition.newBuilder()
                     .name("ASSIGNMENT")
                     .kind(OTHER)
-                    .inputTypeStrategy(
-                            sequence(
-                                    and(
-                                            InputTypeStrategies.LITERAL,
-                                            logical(LogicalTypeFamily.CHARACTER_STRING)),
-                                    or(OUTPUT_IF_NULL, InputTypeStrategies.ANY)))
-                    .outputTypeStrategy(TypeStrategies.argument(1))
+                    .outputTypeStrategy(TypeStrategies.MISSING)
+                    .build();
+
+    public static final BuiltInFunctionDefinition DEFAULT =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("DEFAULT")
+                    .callSyntax(SqlCallSyntax.NO_PARENTHESIS)
+                    .kind(SCALAR)
+                    .inputTypeStrategy(NO_ARGS)
+                    .outputTypeStrategy(TypeStrategies.MISSING)
                     .build();
 
     public static final BuiltInFunctionDefinition STREAM_RECORD_TIMESTAMP =

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/StaticArgument.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/StaticArgument.java
@@ -261,7 +261,7 @@ public class StaticArgument {
         }
         // e.g. for untyped table arguments
         if (dataType == null) {
-            return;
+            throw new ValidationException("Untyped table arguments must not be optional.");
         }
 
         final LogicalType type = dataType.getLogicalType();

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/TypeInferenceExtractorTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/TypeInferenceExtractorTest.java
@@ -667,7 +667,7 @@ class TypeInferenceExtractorTest {
                                 StaticArgument.table(
                                         "rowTable",
                                         Row.class,
-                                        true,
+                                        false,
                                         EnumSet.of(StaticArgumentTrait.TABLE_AS_ROW)))
                         .expectStaticArgument(StaticArgument.scalar("s", DataTypes.STRING(), true))
                         .expectState("s1", TypeStrategies.explicit(MyFirstState.TYPE))
@@ -693,7 +693,7 @@ class TypeInferenceExtractorTest {
                                 StaticArgument.table(
                                         "rowTable",
                                         Row.class,
-                                        true,
+                                        false,
                                         EnumSet.of(StaticArgumentTrait.TABLE_AS_ROW)))
                         .expectStaticArgument(StaticArgument.scalar("s", DataTypes.STRING(), true))
                         .expectState("s1", TypeStrategies.explicit(MyFirstState.TYPE))
@@ -2328,8 +2328,7 @@ class TypeInferenceExtractorTest {
                 @ArgumentHint(name = "i") Integer i,
                 @ArgumentHint(
                                 value = {ArgumentTrait.TABLE_AS_ROW},
-                                name = "rowTable",
-                                isOptional = true)
+                                name = "rowTable")
                         Row t2,
                 @ArgumentHint(isOptional = true, name = "s") String s) {}
     }
@@ -2347,8 +2346,7 @@ class TypeInferenceExtractorTest {
                 @ArgumentHint(name = "i", type = @DataTypeHint("INT")),
                 @ArgumentHint(
                         name = "rowTable",
-                        value = {ArgumentTrait.TABLE_AS_ROW},
-                        isOptional = true),
+                        value = {ArgumentTrait.TABLE_AS_ROW}),
                 @ArgumentHint(name = "s", isOptional = true, type = @DataTypeHint("STRING"))
             },
             output = @DataTypeHint("ROW<b BOOLEAN>"))

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/converters/CustomizedConverters.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/converters/CustomizedConverters.java
@@ -59,6 +59,7 @@ public class CustomizedConverters {
         CONVERTERS.put(BuiltInFunctionDefinitions.JSON_QUERY, new JsonQueryConverter());
         CONVERTERS.put(BuiltInFunctionDefinitions.JSON_OBJECT, new JsonObjectConverter());
         CONVERTERS.put(BuiltInFunctionDefinitions.JSON_ARRAY, new JsonArrayConverter());
+        CONVERTERS.put(BuiltInFunctionDefinitions.DEFAULT, new DefaultConverter());
         CONVERTERS.put(InternalFunctionDefinitions.THROW_EXCEPTION, new ThrowExceptionConverter());
     }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/converters/DefaultConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/converters/DefaultConverter.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.expressions.converter.converters;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.expressions.CallExpression;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.planner.expressions.converter.CallExpressionConvertRule;
+import org.apache.flink.table.planner.functions.sql.SqlDefaultArgOperator;
+import org.apache.flink.table.types.logical.LogicalType;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexNode;
+
+/** Conversion for {@link BuiltInFunctionDefinitions#DEFAULT}. */
+@Internal
+class DefaultConverter extends CustomizedConverter {
+
+    @Override
+    public RexNode convert(CallExpression call, CallExpressionConvertRule.ConvertContext context) {
+        final LogicalType outputType = call.getOutputDataType().getLogicalType();
+        final RelDataType relDataType =
+                context.getTypeFactory().createFieldTypeFromLogicalType(outputType);
+        return context.getRelBuilder()
+                .getRexBuilder()
+                .makeCall(new SqlDefaultArgOperator(relDataType));
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionTestUtils.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionTestUtils.java
@@ -534,6 +534,14 @@ public class ProcessTableFunctionTestUtils {
         }
     }
 
+    /** Testing function. */
+    public static class OptionalFunction extends TestProcessTableFunctionBase {
+        public void eval(
+                Context ctx, @ArgumentHint(value = TABLE_AS_ROW, isOptional = true) Row r) {
+            collectObjects(r);
+        }
+    }
+
     // --------------------------------------------------------------------------------------------
     // Helpers
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.java
@@ -342,7 +342,12 @@ public class ProcessTableFunctionTest extends TableTestBase {
                         "SELECT * FROM f(r => TABLE t_watermarked, i => 1, on_time => DESCRIPTOR(ts, INVALID))",
                         "Invalid time attribute declaration. Each column in the `on_time` argument must "
                                 + "reference at least one column in one of the table arguments. "
-                                + "Unknown references: [INVALID]"));
+                                + "Unknown references: [INVALID]"),
+                ErrorSpec.of(
+                        "invalid optional table argument",
+                        OptionalUntypedTable.class,
+                        "SELECT * FROM f()",
+                        "Untyped table arguments must not be optional."));
     }
 
     /** Testing function. */
@@ -390,6 +395,12 @@ public class ProcessTableFunctionTest extends TableTestBase {
         @SuppressWarnings("unused")
         public void eval(
                 @ArgumentHint({TABLE_AS_SET, SUPPORT_UPDATES, PASS_COLUMNS_THROUGH}) Row r) {}
+    }
+
+    /** Testing function. */
+    public static class OptionalUntypedTable extends ProcessTableFunction<String> {
+        @SuppressWarnings("unused")
+        public void eval(@ArgumentHint(value = TABLE_AS_ROW, isOptional = true) Row r) {}
     }
 
     private static class ErrorSpec {


### PR DESCRIPTION
## What is the purpose of the change

Followup PR of #26282 that improves the PTF behavior. A prerequisite of FLINK-37423.

## Brief change log

- Convert missing optional args to the DEFAULT operator.


## Verifying this change

This change is already covered by existing tests: `MiscFunctionITCase`

More sophisticated tests will follow as part of FLINK-37423.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
