### PR TITLE
[FLINK-37457][python] Support asArgument in Python Table API

### DIFF
--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -140,6 +140,7 @@ arithmetic functions
     Expression.collect
     Expression.array_agg
     Expression.alias
+    Expression.as_argument
     Expression.cast
     Expression.try_cast
     Expression.asc

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -859,6 +859,31 @@ class Expression(Generic[T]):
         gateway = get_gateway()
         return _ternary_op("as")(self, name, to_jarray(gateway.jvm.String, extra_names))
 
+    def as_argument(self, name: str) -> 'Expression':
+        """
+        Converts this expression into a named argument.
+
+        If the function declares a static signature (usually indicated by the "=>" assignment
+        operator), the framework is able to reorder named arguments and consider optional arguments
+        accordingly, before passing them into the function call.
+
+        .. note::
+            Not every function supports named arguments. Named arguments are not available for
+            signatures that are overloaded, use varargs, or any other kind of input type strategy.
+
+        Example:
+        ::
+
+            >>> table.select(
+            ...     call(
+            ...         "MyFunction",
+            ...         col("my_column").as_argument("input"),
+            ...         lit(42).as_argument("threshold")
+            ...     )
+            ... )
+        """
+        return _binary_op("asArgument")(self, name)
+
     def cast(self, data_type: DataType) -> 'Expression':
         """
         Returns a new value being cast to type type.

--- a/flink-python/pyflink/table/tests/test_expression.py
+++ b/flink-python/pyflink/table/tests/test_expression.py
@@ -132,6 +132,8 @@ class PyFlinkBatchExpressionTests(PyFlinkTestCase):
         self.assertEqual('PERCENTILE(a, array(0.1, 0.5))', str(expr1.percentile(array(0.1, 0.5))))
         self.assertEqual('PERCENTILE(a, array(0.1, 0.5), b)',
                          str(expr1.percentile(array(0.1, 0.5), expr2)))
+        self.assertEqual("ASSIGNMENT('a2', a)", str(expr1.as_argument('a2')))
+        self.assertEqual("ASSIGNMENT('a', 10)", str(expr5.as_argument('a')))
 
         # string functions
         self.assertEqual('substring(a, b)', str(expr1.substring(expr2)))

--- a/flink-python/pyflink/table/tests/test_expression_completeness.py
+++ b/flink-python/pyflink/table/tests/test_expression_completeness.py
@@ -58,7 +58,6 @@ class ExpressionCompletenessTests(PythonAPICompletenessTestCase, PyFlinkTestCase
             'times',
             'mod',
             'power',
-            'asArgument',
         }
 
     @classmethod


### PR DESCRIPTION
## What is the purpose of the change

https://github.com/apache/flink/pull/26282 introduces the `asArgument` expression in the Java table API. This PR adds a corresponding expression to the Python table API.

## Brief change log

  - *Added `as_argument` expression to Python table API.*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added tests for `as_argument` to existing expressions test suite.*
  
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive):no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
