### PR TITLE
[FLINK-37471] Tag the subclass of SourceFunction with @Deprecated

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/checkpoint/ExternallyInducedSource.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/checkpoint/ExternallyInducedSource.java
@@ -40,6 +40,7 @@ import org.apache.flink.util.FlinkException;
  *     removed. Use the new {@link org.apache.flink.api.connector.source.Source} API instead.
  */
 @Internal
+@Deprecated
 public interface ExternallyInducedSource<T, CD>
         extends SourceFunction<T>, WithMasterCheckpointHook<CD> {
 

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/source/legacy/FileMonitoringFunction.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/source/legacy/FileMonitoringFunction.java
@@ -42,6 +42,7 @@ import java.util.Map;
  *     Use the new {@link org.apache.flink.api.connector.source.Source} API instead.
  */
 @Internal
+@Deprecated
 public class FileMonitoringFunction implements SourceFunction<Tuple3<String, Long, Long>> {
     private static final long serialVersionUID = 1L;
 

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/source/legacy/FromElementsFunction.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/source/legacy/FromElementsFunction.java
@@ -69,6 +69,7 @@ import java.util.Objects;
  *     Use the new {@link org.apache.flink.api.connector.source.Source} API instead.
  */
 @Internal
+@Deprecated
 public class FromElementsFunction<T>
         implements SourceFunction<T>,
                 CheckpointedFunction,

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/source/legacy/FromIteratorFunction.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/source/legacy/FromIteratorFunction.java
@@ -28,6 +28,7 @@ import java.util.Iterator;
  *     Use the new {@link org.apache.flink.api.connector.source.Source} API instead.
  */
 @Internal
+@Deprecated
 public class FromIteratorFunction<T> implements SourceFunction<T> {
 
     private static final long serialVersionUID = 1L;

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/source/legacy/ParallelSourceFunction.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/source/legacy/ParallelSourceFunction.java
@@ -33,4 +33,5 @@ import org.apache.flink.annotation.Internal;
  *     removed. Use the new {@link org.apache.flink.api.connector.source.Source} API instead.
  */
 @Internal
+@Deprecated
 public interface ParallelSourceFunction<OUT> extends SourceFunction<OUT> {}

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/source/legacy/RichSourceFunction.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/source/legacy/RichSourceFunction.java
@@ -46,6 +46,7 @@ import org.apache.flink.api.common.functions.RuntimeContext;
  *     Use the new {@link org.apache.flink.api.connector.source.Source} API instead.
  */
 @Internal
+@Deprecated
 public abstract class RichSourceFunction<OUT> extends AbstractRichFunction
         implements SourceFunction<OUT> {
 

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/source/legacy/SocketTextStreamFunction.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/source/legacy/SocketTextStreamFunction.java
@@ -47,6 +47,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *     Use the new {@link org.apache.flink.api.connector.source.Source} API instead.
  */
 @Internal
+@Deprecated
 public class SocketTextStreamFunction implements SourceFunction<String> {
 
     private static final long serialVersionUID = 1L;

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/source/legacy/SourceFunction.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/source/legacy/SourceFunction.java
@@ -100,6 +100,7 @@ import java.io.Serializable;
  *     FLINK-28045 must be closed before this API can be completely removed.
  */
 @Internal
+@Deprecated
 public interface SourceFunction<T> extends Function, Serializable {
 
     /**


### PR DESCRIPTION
## What is the purpose of the change

This PR aim to tag the subclass of `SourceFunction` with `@Deprecated`
Currently, `SourceFunction` is placed at src/main/java/org/apache/flink/streaming/api/functions/source/legacy/ but not tagged with `@Deprecated`. It looks very weird.
There are a lot of classes like `SourceFunction`.


## Brief change log

Tag the subclass of `SourceFunction` with `@Deprecated`.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
