### PR TITLE
[FLINK-30687][table] Fix wrong result of agg with fiter which references first input column

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/agg/AggsHandlerCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/agg/AggsHandlerCodeGenerator.scala
@@ -230,7 +230,7 @@ class AggsHandlerCodeGenerator(
     val aggCodeGens = aggInfoList.aggInfos.map {
       aggInfo =>
         val filterExpr =
-          createFilterExpression(aggInfo.agg.filterArg, aggInfo.aggIndex, aggInfo.agg.name)
+          createFilterExpression(aggInfo.agg.filterArg, aggInfo.agg.name)
 
         val codegen = aggInfo.function match {
           case _: DeclarativeAggregateFunction =>
@@ -282,9 +282,8 @@ class AggsHandlerCodeGenerator(
     val distinctCodeGens = aggInfoList.distinctInfos.zipWithIndex.map {
       case (distinctInfo, index) =>
         val innerCodeGens = distinctInfo.aggIndexes.map(aggCodeGens(_)).toArray
-        val distinctIndex = aggCodeGens.length + index
-        val filterExpr = distinctInfo.filterArgs.map(
-          createFilterExpression(_, distinctIndex, "distinct aggregate"))
+        val filterExpr =
+          distinctInfo.filterArgs.map(createFilterExpression(_, "distinct aggregate"))
         val codegen = new DistinctAggCodeGen(
           ctx,
           distinctInfo,
@@ -325,12 +324,9 @@ class AggsHandlerCodeGenerator(
   }
 
   /** Creates filter argument access expression, none if no filter */
-  private def createFilterExpression(
-      filterArg: Int,
-      aggIndex: Int,
-      aggName: String): Option[Expression] = {
+  private def createFilterExpression(filterArg: Int, aggName: String): Option[Expression] = {
 
-    if (filterArg > 0) {
+    if (filterArg >= 0) {
       val filterType = inputFieldTypes(filterArg)
       if (!filterType.isInstanceOf[BooleanType]) {
         throw new TableException(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/codegen/agg/AggTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/codegen/agg/AggTestBase.scala
@@ -66,6 +66,7 @@ abstract class AggTestBase(isBatchMode: Boolean) {
   val aggInfo1: AggregateInfo = {
     val aggInfo = mock(classOf[AggregateInfo])
     val call = mock(classOf[AggregateCall])
+    updateFilter(call, -1)
     when(aggInfo.agg).thenReturn(call)
     when(call.getName).thenReturn("avg1")
     when(call.hasFilter).thenReturn(false)
@@ -81,6 +82,7 @@ abstract class AggTestBase(isBatchMode: Boolean) {
   val aggInfo2: AggregateInfo = {
     val aggInfo = mock(classOf[AggregateInfo])
     val call = mock(classOf[AggregateCall])
+    updateFilter(call, -1)
     when(aggInfo.agg).thenReturn(call)
     when(call.getName).thenReturn("avg2")
     when(call.hasFilter).thenReturn(false)
@@ -97,6 +99,7 @@ abstract class AggTestBase(isBatchMode: Boolean) {
   val aggInfo3: AggregateInfo = {
     val aggInfo = mock(classOf[AggregateInfo])
     val call = mock(classOf[AggregateCall])
+    updateFilter(call, -1)
     when(aggInfo.agg).thenReturn(call)
     when(call.getName).thenReturn("avg3")
     when(call.hasFilter).thenReturn(false)
@@ -117,4 +120,10 @@ abstract class AggTestBase(isBatchMode: Boolean) {
   val classLoader: ClassLoader = Thread.currentThread().getContextClassLoader
   val context: ExecutionContext = mock(classOf[ExecutionContext])
   when(context.getRuntimeContext).thenReturn(mock(classOf[RuntimeContext]))
+
+  private def updateFilter(call: AggregateCall, v: Int): Unit = {
+    val field = call.getClass.getField("filterArg")
+    field.setAccessible(true)
+    field.set(call, v)
+  }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/AggregateITCaseBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/AggregateITCaseBase.scala
@@ -1224,6 +1224,11 @@ abstract class AggregateITCaseBase(testName: String) extends BatchTestBase {
     checkResult(sql, Seq(row("11, 11"), row("12, 12"), row("null, null")))
   }
 
+  @Test
+  def testAggFilterReferenceFirstColumn(): Unit = {
+    checkResult("select count(*) filter (where a < 10) from Table3", Seq(row(9)))
+  }
+
   // TODO support csv
 //  @Test
 //  def testMultiGroupBys(): Unit = {


### PR DESCRIPTION
## What is the purpose of the change
Currently under the stream mode when an global agg with filter arg which actually references the first input column, then the corresponding agg column result will be incorrect(this issue doesn't exist in batch mode).

## Brief change log
Add new agg cases 

## Verifying this change
`AggregateITCase`

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (no)