### PR TITLE
[FLINK-36245][FOLLOWUP] Remove the @Deprecated for ArrowSourceFunction and SinkFunction

### DIFF
--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/sources/ArrowSourceFunction.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/sources/ArrowSourceFunction.java
@@ -63,7 +63,6 @@ import java.util.Deque;
  * @deprecated This class is based on the {@link SourceFunction} API, which is due to be removed.
  *     Use the new {@link org.apache.flink.api.connector.source.Source} API instead.
  */
-@Deprecated
 @Internal
 public class ArrowSourceFunction extends RichParallelSourceFunction<RowData>
         implements ResultTypeQueryable<RowData>, CheckpointedFunction {

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
@@ -864,7 +864,11 @@ public class DataStream<T> {
      *
      * @param sinkFunction The object containing the sink's invoke function.
      * @return The closed DataStream.
+     * @deprecated This method relies on the {@link SinkFunction} API, which is due to be removed.
+     *     Use the {@link #sinkTo(Sink)} method based on the new {@link
+     *     org.apache.flink.api.connector.sink2.Sink} API instead.
      */
+    @Deprecated
     public DataStreamSink<T> addSink(SinkFunction<T> sinkFunction) {
 
         // read the output type of the input Transform to coax out errors about MissingTypeInfo

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/datastream/KeyedStream.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/datastream/KeyedStream.java
@@ -301,6 +301,7 @@ public class KeyedStream<T, KEY> extends DataStream<T> {
     }
 
     @Override
+    @Deprecated
     public DataStreamSink<T> addSink(SinkFunction<T> sinkFunction) {
         DataStreamSink<T> result = super.addSink(sinkFunction);
         result.getLegacyTransformation().setStateKeySelector(keySelector);

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/sink/legacy/SinkFunction.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/sink/legacy/SinkFunction.java
@@ -32,7 +32,6 @@ import java.io.Serializable;
  *     org.apache.flink.api.connector.sink2.Sink} interface instead.
  */
 @Internal
-@Deprecated
 public interface SinkFunction<IN> extends Function, Serializable {
 
     /**


### PR DESCRIPTION
## What is the purpose of the change

This PR follows up https://github.com/apache/flink/pull/25331
It seems missing the two classes.


## Brief change log

Remove the @Deprecated for ArrowSourceFunction and SinkFunction


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
