### PR TITLE
[FLINK-37471] Simplify the code for PrintSink

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/PrintSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/PrintSink.java
@@ -45,8 +45,8 @@ import java.io.IOException;
 public class PrintSink<IN> implements Sink<IN>, SupportsConcurrentExecutionAttempts {
 
     private static final long serialVersionUID = 1L;
-    private final String sinkIdentifier;
-    private final boolean stdErr;
+
+    private final PrintSinkOutputWriter<IN> writer;
 
     /** Instantiates a print sink function that prints to STDOUT. */
     public PrintSink() {
@@ -80,14 +80,11 @@ public class PrintSink<IN> implements Sink<IN>, SupportsConcurrentExecutionAttem
      * @param stdErr True if the sink should print to STDERR instead of STDOUT.
      */
     public PrintSink(final String sinkIdentifier, final boolean stdErr) {
-        this.sinkIdentifier = sinkIdentifier;
-        this.stdErr = stdErr;
+        this.writer = new PrintSinkOutputWriter<>(sinkIdentifier, stdErr);
     }
 
     @Override
     public SinkWriter<IN> createWriter(WriterInitContext context) throws IOException {
-        final PrintSinkOutputWriter<IN> writer =
-                new PrintSinkOutputWriter<>(sinkIdentifier, stdErr);
         writer.open(
                 context.getTaskInfo().getIndexOfThisSubtask(),
                 context.getTaskInfo().getNumberOfParallelSubtasks());
@@ -96,6 +93,6 @@ public class PrintSink<IN> implements Sink<IN>, SupportsConcurrentExecutionAttem
 
     @Override
     public String toString() {
-        return "Print to " + (stdErr ? "System.err" : "System.out");
+        return writer.toString();
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR aim to simplify the code for `PrintSink`.
The toString of `PrintSink` should reuse the `PrintSinkOutputWriter`'s one.
After this change, we can also avoid to declare two field for `sinkIdentifier` and `stdErr`.


## Brief change log

Simplify the code for `PrintSink`


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
