### PR TITLE
[FLINK-37460][state] Make state processor API checkpoint ID configurable

### DIFF
--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/KeyedStateTransformation.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/KeyedStateTransformation.java
@@ -43,6 +43,9 @@ public class KeyedStateTransformation<K, T> {
     /** The data set containing the data to bootstrap the operator state with. */
     private final DataStream<T> stream;
 
+    /** Checkpoint ID. */
+    private final long checkpointId;
+
     /** Local max parallelism for the bootstrapped operator. */
     private final OptionalInt operatorMaxParallelism;
 
@@ -54,10 +57,12 @@ public class KeyedStateTransformation<K, T> {
 
     KeyedStateTransformation(
             DataStream<T> stream,
+            long checkpointId,
             OptionalInt operatorMaxParallelism,
             KeySelector<T, K> keySelector,
             TypeInformation<K> keyType) {
         this.stream = stream;
+        this.checkpointId = checkpointId;
         this.operatorMaxParallelism = operatorMaxParallelism;
         this.keySelector = keySelector;
         this.keyType = keyType;
@@ -77,7 +82,8 @@ public class KeyedStateTransformation<K, T> {
             KeyedStateBootstrapFunction<K, T> processFunction) {
         SavepointWriterOperatorFactory factory =
                 (timestamp, path) ->
-                        new KeyedStateBootstrapOperator<>(timestamp, path, processFunction);
+                        new KeyedStateBootstrapOperator<>(
+                                checkpointId, timestamp, path, processFunction);
         return transform(factory);
     }
 
@@ -109,6 +115,6 @@ public class KeyedStateTransformation<K, T> {
     public <W extends Window> WindowedStateTransformation<T, K, W> window(
             WindowAssigner<? super T, W> assigner) {
         return new WindowedStateTransformation<>(
-                stream, operatorMaxParallelism, keySelector, keyType, assigner);
+                stream, checkpointId, operatorMaxParallelism, keySelector, keyType, assigner);
     }
 }

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/OperatorTransformation.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/OperatorTransformation.java
@@ -72,6 +72,22 @@ public final class OperatorTransformation {
     }
 
     /**
+     * Create a new {@link OperatorTransformation} from a {@link DataSet}.
+     *
+     * @param dataSet A dataset of elements.
+     * @param checkpointId checkpoint ID.
+     * @param <T> The type of the input.
+     * @return A {@link OneInputOperatorTransformation}.
+     * @deprecated use {@link #bootstrapWith(DataStream)} to bootstrap a savepoint using the data
+     *     stream api under batch execution.
+     */
+    @Deprecated
+    public static <T> OneInputOperatorTransformation<T> bootstrapWith(
+            DataSet<T> dataSet, long checkpointId) {
+        return new OneInputOperatorTransformation<>(dataSet, checkpointId);
+    }
+
+    /**
      * Create a new {@link OneInputStateTransformation} from a {@link DataStream}.
      *
      * @param stream A data stream of elements.
@@ -80,5 +96,18 @@ public final class OperatorTransformation {
      */
     public static <T> OneInputStateTransformation<T> bootstrapWith(DataStream<T> stream) {
         return new OneInputStateTransformation<>(stream);
+    }
+
+    /**
+     * Create a new {@link OneInputStateTransformation} from a {@link DataStream}.
+     *
+     * @param stream A data stream of elements.
+     * @param checkpointId checkpoint ID.
+     * @param <T> The type of the input.
+     * @return A {@link OneInputStateTransformation}.
+     */
+    public static <T> OneInputStateTransformation<T> bootstrapWith(
+            DataStream<T> stream, long checkpointId) {
+        return new OneInputStateTransformation<>(stream, checkpointId);
     }
 }

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/Savepoint.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/Savepoint.java
@@ -73,7 +73,10 @@ public final class Savepoint {
 
         SavepointMetadata savepointMetadata =
                 new SavepointMetadata(
-                        maxParallelism, metadata.getMasterStates(), metadata.getOperatorStates());
+                        metadata.getCheckpointId(),
+                        maxParallelism,
+                        metadata.getMasterStates(),
+                        metadata.getOperatorStates());
         return new ExistingSavepoint(env, savepointMetadata, null);
     }
 
@@ -102,7 +105,10 @@ public final class Savepoint {
 
         SavepointMetadata savepointMetadata =
                 new SavepointMetadata(
-                        maxParallelism, metadata.getMasterStates(), metadata.getOperatorStates());
+                        metadata.getCheckpointId(),
+                        maxParallelism,
+                        metadata.getMasterStates(),
+                        metadata.getOperatorStates());
         return new ExistingSavepoint(env, savepointMetadata, stateBackend);
     }
 
@@ -124,7 +130,7 @@ public final class Savepoint {
 
         SavepointMetadata metadata =
                 new SavepointMetadata(
-                        maxParallelism, Collections.emptyList(), Collections.emptyList());
+                        0L, maxParallelism, Collections.emptyList(), Collections.emptyList());
         return new NewSavepoint(metadata, null);
     }
 
@@ -147,7 +153,7 @@ public final class Savepoint {
 
         SavepointMetadata metadata =
                 new SavepointMetadata(
-                        maxParallelism, Collections.emptyList(), Collections.emptyList());
+                        0L, maxParallelism, Collections.emptyList(), Collections.emptyList());
         return new NewSavepoint(metadata, stateBackend);
     }
 }

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/SavepointReader.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/SavepointReader.java
@@ -82,7 +82,10 @@ public class SavepointReader {
 
         SavepointMetadataV2 savepointMetadata =
                 new SavepointMetadataV2(
-                        maxParallelism, metadata.getMasterStates(), metadata.getOperatorStates());
+                        metadata.getCheckpointId(),
+                        maxParallelism,
+                        metadata.getMasterStates(),
+                        metadata.getOperatorStates());
         return new SavepointReader(env, savepointMetadata, null);
     }
 
@@ -111,7 +114,10 @@ public class SavepointReader {
 
         SavepointMetadataV2 savepointMetadata =
                 new SavepointMetadataV2(
-                        maxParallelism, metadata.getMasterStates(), metadata.getOperatorStates());
+                        metadata.getCheckpointId(),
+                        maxParallelism,
+                        metadata.getMasterStates(),
+                        metadata.getOperatorStates());
         return new SavepointReader(env, savepointMetadata, stateBackend);
     }
 

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/WindowedOperatorTransformation.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/WindowedOperatorTransformation.java
@@ -60,6 +60,8 @@ public class WindowedOperatorTransformation<T, K, W extends Window> {
 
     private final WindowOperatorBuilder<T, K, W> builder;
 
+    private final long checkpointId;
+
     private final OptionalInt operatorMaxParallelism;
 
     @Nullable private final Timestamper<T> timestamper;
@@ -70,12 +72,14 @@ public class WindowedOperatorTransformation<T, K, W extends Window> {
 
     WindowedOperatorTransformation(
             DataSet<T> input,
+            long checkpointId,
             OptionalInt operatorMaxParallelism,
             @Nullable Timestamper<T> timestamper,
             KeySelector<T, K> keySelector,
             TypeInformation<K> keyType,
             WindowAssigner<? super T, W> windowAssigner) {
         this.input = input;
+        this.checkpointId = checkpointId;
         this.operatorMaxParallelism = operatorMaxParallelism;
         this.timestamper = timestamper;
         this.keySelector = keySelector;
@@ -163,7 +167,9 @@ public class WindowedOperatorTransformation<T, K, W extends Window> {
         WindowOperator<K, T, ?, R, W> operator = builder.reduce(reduceFunction, function);
 
         SavepointWriterOperatorFactory factory =
-                (timestamp, path) -> new StateBootstrapWrapperOperator<>(timestamp, path, operator);
+                (timestamp, path) ->
+                        new StateBootstrapWrapperOperator<>(
+                                checkpointId, timestamp, path, operator);
         return new BootstrapTransformation<>(
                 input, operatorMaxParallelism, timestamper, factory, keySelector, keyType);
     }
@@ -189,7 +195,9 @@ public class WindowedOperatorTransformation<T, K, W extends Window> {
         WindowOperator<K, T, ?, R, W> operator = builder.reduce(reduceFunction, function);
 
         SavepointWriterOperatorFactory factory =
-                (timestamp, path) -> new StateBootstrapWrapperOperator<>(timestamp, path, operator);
+                (timestamp, path) ->
+                        new StateBootstrapWrapperOperator<>(
+                                checkpointId, timestamp, path, operator);
         return new BootstrapTransformation<>(
                 input, operatorMaxParallelism, timestamper, factory, keySelector, keyType);
     }
@@ -323,7 +331,9 @@ public class WindowedOperatorTransformation<T, K, W extends Window> {
                 builder.aggregate(aggregateFunction, windowFunction, accumulatorType);
 
         SavepointWriterOperatorFactory factory =
-                (timestamp, path) -> new StateBootstrapWrapperOperator<>(timestamp, path, operator);
+                (timestamp, path) ->
+                        new StateBootstrapWrapperOperator<>(
+                                checkpointId, timestamp, path, operator);
         return new BootstrapTransformation<>(
                 input, operatorMaxParallelism, timestamper, factory, keySelector, keyType);
     }
@@ -400,7 +410,9 @@ public class WindowedOperatorTransformation<T, K, W extends Window> {
                 builder.aggregate(aggregateFunction, windowFunction, accumulatorType);
 
         SavepointWriterOperatorFactory factory =
-                (timestamp, path) -> new StateBootstrapWrapperOperator<>(timestamp, path, operator);
+                (timestamp, path) ->
+                        new StateBootstrapWrapperOperator<>(
+                                checkpointId, timestamp, path, operator);
         return new BootstrapTransformation<>(
                 input, operatorMaxParallelism, timestamper, factory, keySelector, keyType);
     }
@@ -424,7 +436,9 @@ public class WindowedOperatorTransformation<T, K, W extends Window> {
         WindowOperator<K, T, ?, R, W> operator = builder.apply(function);
 
         SavepointWriterOperatorFactory factory =
-                (timestamp, path) -> new StateBootstrapWrapperOperator<>(timestamp, path, operator);
+                (timestamp, path) ->
+                        new StateBootstrapWrapperOperator<>(
+                                checkpointId, timestamp, path, operator);
         return new BootstrapTransformation<>(
                 input, operatorMaxParallelism, timestamper, factory, keySelector, keyType);
     }
@@ -448,7 +462,9 @@ public class WindowedOperatorTransformation<T, K, W extends Window> {
         WindowOperator<K, T, ?, R, W> operator = builder.apply(function);
 
         SavepointWriterOperatorFactory factory =
-                (timestamp, path) -> new StateBootstrapWrapperOperator<>(timestamp, path, operator);
+                (timestamp, path) ->
+                        new StateBootstrapWrapperOperator<>(
+                                checkpointId, timestamp, path, operator);
         return new BootstrapTransformation<>(
                 input, operatorMaxParallelism, timestamper, factory, keySelector, keyType);
     }
@@ -469,7 +485,9 @@ public class WindowedOperatorTransformation<T, K, W extends Window> {
         WindowOperator<K, T, ?, R, W> operator = builder.process(function);
 
         SavepointWriterOperatorFactory factory =
-                (timestamp, path) -> new StateBootstrapWrapperOperator<>(timestamp, path, operator);
+                (timestamp, path) ->
+                        new StateBootstrapWrapperOperator<>(
+                                checkpointId, timestamp, path, operator);
         return new BootstrapTransformation<>(
                 input, operatorMaxParallelism, timestamper, factory, keySelector, keyType);
     }

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/WindowedStateTransformation.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/WindowedStateTransformation.java
@@ -57,6 +57,8 @@ public class WindowedStateTransformation<T, K, W extends Window> {
 
     private final WindowOperatorBuilder<T, K, W> builder;
 
+    private final long checkpointId;
+
     private final OptionalInt operatorMaxParallelism;
 
     private final KeySelector<T, K> keySelector;
@@ -65,11 +67,13 @@ public class WindowedStateTransformation<T, K, W extends Window> {
 
     WindowedStateTransformation(
             DataStream<T> input,
+            long checkpointId,
             OptionalInt operatorMaxParallelism,
             KeySelector<T, K> keySelector,
             TypeInformation<K> keyType,
             WindowAssigner<? super T, W> windowAssigner) {
         this.input = input;
+        this.checkpointId = checkpointId;
         this.operatorMaxParallelism = operatorMaxParallelism;
         this.keySelector = keySelector;
         this.keyType = keyType;
@@ -156,7 +160,9 @@ public class WindowedStateTransformation<T, K, W extends Window> {
         WindowOperator<K, T, ?, R, W> operator = builder.reduce(reduceFunction, function);
 
         SavepointWriterOperatorFactory factory =
-                (timestamp, path) -> new StateBootstrapWrapperOperator<>(timestamp, path, operator);
+                (timestamp, path) ->
+                        new StateBootstrapWrapperOperator<>(
+                                checkpointId, timestamp, path, operator);
         return new StateBootstrapTransformation<>(
                 input, operatorMaxParallelism, factory, keySelector, keyType);
     }
@@ -182,7 +188,9 @@ public class WindowedStateTransformation<T, K, W extends Window> {
         WindowOperator<K, T, ?, R, W> operator = builder.reduce(reduceFunction, function);
 
         SavepointWriterOperatorFactory factory =
-                (timestamp, path) -> new StateBootstrapWrapperOperator<>(timestamp, path, operator);
+                (timestamp, path) ->
+                        new StateBootstrapWrapperOperator<>(
+                                checkpointId, timestamp, path, operator);
         return new StateBootstrapTransformation<>(
                 input, operatorMaxParallelism, factory, keySelector, keyType);
     }
@@ -317,7 +325,9 @@ public class WindowedStateTransformation<T, K, W extends Window> {
                 builder.aggregate(aggregateFunction, windowFunction, accumulatorType);
 
         SavepointWriterOperatorFactory factory =
-                (timestamp, path) -> new StateBootstrapWrapperOperator<>(timestamp, path, operator);
+                (timestamp, path) ->
+                        new StateBootstrapWrapperOperator<>(
+                                checkpointId, timestamp, path, operator);
         return new StateBootstrapTransformation<>(
                 input, operatorMaxParallelism, factory, keySelector, keyType);
     }
@@ -394,7 +404,9 @@ public class WindowedStateTransformation<T, K, W extends Window> {
                 builder.aggregate(aggregateFunction, windowFunction, accumulatorType);
 
         SavepointWriterOperatorFactory factory =
-                (timestamp, path) -> new StateBootstrapWrapperOperator<>(timestamp, path, operator);
+                (timestamp, path) ->
+                        new StateBootstrapWrapperOperator<>(
+                                checkpointId, timestamp, path, operator);
         return new StateBootstrapTransformation<>(
                 input, operatorMaxParallelism, factory, keySelector, keyType);
     }
@@ -418,7 +430,9 @@ public class WindowedStateTransformation<T, K, W extends Window> {
         WindowOperator<K, T, ?, R, W> operator = builder.apply(function);
 
         SavepointWriterOperatorFactory factory =
-                (timestamp, path) -> new StateBootstrapWrapperOperator<>(timestamp, path, operator);
+                (timestamp, path) ->
+                        new StateBootstrapWrapperOperator<>(
+                                checkpointId, timestamp, path, operator);
         return new StateBootstrapTransformation<>(
                 input, operatorMaxParallelism, factory, keySelector, keyType);
     }
@@ -442,7 +456,9 @@ public class WindowedStateTransformation<T, K, W extends Window> {
         WindowOperator<K, T, ?, R, W> operator = builder.apply(function);
 
         SavepointWriterOperatorFactory factory =
-                (timestamp, path) -> new StateBootstrapWrapperOperator<>(timestamp, path, operator);
+                (timestamp, path) ->
+                        new StateBootstrapWrapperOperator<>(
+                                checkpointId, timestamp, path, operator);
         return new StateBootstrapTransformation<>(
                 input, operatorMaxParallelism, factory, keySelector, keyType);
     }
@@ -463,7 +479,9 @@ public class WindowedStateTransformation<T, K, W extends Window> {
         WindowOperator<K, T, ?, R, W> operator = builder.process(function);
 
         SavepointWriterOperatorFactory factory =
-                (timestamp, path) -> new StateBootstrapWrapperOperator<>(timestamp, path, operator);
+                (timestamp, path) ->
+                        new StateBootstrapWrapperOperator<>(
+                                checkpointId, timestamp, path, operator);
         return new StateBootstrapTransformation<>(
                 input, operatorMaxParallelism, factory, keySelector, keyType);
     }

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/WritableSavepoint.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/WritableSavepoint.java
@@ -140,7 +140,9 @@ public abstract class WritableSavepoint<F extends WritableSavepoint> {
             finalOperatorStates = newOperatorStates.union(existingOperatorStates);
         }
         finalOperatorStates
-                .reduceGroup(new MergeOperatorStates(metadata.getMasterStates()))
+                .reduceGroup(
+                        new MergeOperatorStates(
+                                metadata.getCheckpointId(), metadata.getMasterStates()))
                 .name("reduce(OperatorState)")
                 .output(new SavepointOutputFormat(savepointPath))
                 .name(path);

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/MergeOperatorStates.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/MergeOperatorStates.java
@@ -39,11 +39,14 @@ public class MergeOperatorStates implements GroupReduceFunction<OperatorState, C
 
     private static final long serialVersionUID = 1L;
 
+    private final long checkpointId;
+
     private final Collection<MasterState> masterStates;
 
-    public MergeOperatorStates(Collection<MasterState> masterStates) {
+    public MergeOperatorStates(long checkpointId, Collection<MasterState> masterStates) {
         Preconditions.checkNotNull(masterStates, "Master state metadata must not be null");
 
+        this.checkpointId = checkpointId;
         this.masterStates = masterStates;
     }
 
@@ -51,7 +54,7 @@ public class MergeOperatorStates implements GroupReduceFunction<OperatorState, C
     public void reduce(Iterable<OperatorState> values, Collector<CheckpointMetadata> out) {
         CheckpointMetadata metadata =
                 new CheckpointMetadata(
-                        SnapshotUtils.CHECKPOINT_ID,
+                        checkpointId,
                         StreamSupport.stream(values.spliterator(), false)
                                 .collect(Collectors.toList()),
                         masterStates);

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/operators/BroadcastStateBootstrapOperator.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/operators/BroadcastStateBootstrapOperator.java
@@ -44,6 +44,8 @@ public class BroadcastStateBootstrapOperator<IN>
 
     private static final long serialVersionUID = 1L;
 
+    private final long checkpointId;
+
     private final long timestamp;
 
     private final Path savepointPath;
@@ -51,10 +53,13 @@ public class BroadcastStateBootstrapOperator<IN>
     private transient ContextImpl context;
 
     public BroadcastStateBootstrapOperator(
-            long timestamp, Path savepointPath, BroadcastStateBootstrapFunction<IN> function) {
+            long checkpointId,
+            long timestamp,
+            Path savepointPath,
+            BroadcastStateBootstrapFunction<IN> function) {
         super(function);
+        this.checkpointId = checkpointId;
         this.timestamp = timestamp;
-
         this.savepointPath = savepointPath;
     }
 
@@ -73,6 +78,7 @@ public class BroadcastStateBootstrapOperator<IN>
     public void endInput() throws Exception {
         TaggedOperatorSubtaskState state =
                 SnapshotUtils.snapshot(
+                        checkpointId,
                         this,
                         getRuntimeContext().getTaskInfo().getIndexOfThisSubtask(),
                         timestamp,

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/operators/KeyedStateBootstrapOperator.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/operators/KeyedStateBootstrapOperator.java
@@ -48,6 +48,8 @@ public class KeyedStateBootstrapOperator<K, IN>
 
     private static final long serialVersionUID = 1L;
 
+    private final long checkpointId;
+
     private final long timestamp;
 
     private final Path savepointPath;
@@ -55,9 +57,12 @@ public class KeyedStateBootstrapOperator<K, IN>
     private transient KeyedStateBootstrapOperator<K, IN>.ContextImpl context;
 
     public KeyedStateBootstrapOperator(
-            long timestamp, Path savepointPath, KeyedStateBootstrapFunction<K, IN> function) {
+            long checkpointId,
+            long timestamp,
+            Path savepointPath,
+            KeyedStateBootstrapFunction<K, IN> function) {
         super(function);
-
+        this.checkpointId = checkpointId;
         this.timestamp = timestamp;
         this.savepointPath = savepointPath;
     }
@@ -88,6 +93,7 @@ public class KeyedStateBootstrapOperator<K, IN>
     public void endInput() throws Exception {
         TaggedOperatorSubtaskState state =
                 SnapshotUtils.snapshot(
+                        checkpointId,
                         this,
                         getRuntimeContext().getTaskInfo().getIndexOfThisSubtask(),
                         timestamp,

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/operators/StateBootstrapOperator.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/operators/StateBootstrapOperator.java
@@ -40,6 +40,8 @@ public class StateBootstrapOperator<IN>
 
     private static final long serialVersionUID = 1L;
 
+    private final long checkpointId;
+
     private final long timestamp;
 
     private final Path savepointPath;
@@ -47,9 +49,12 @@ public class StateBootstrapOperator<IN>
     private transient ContextImpl context;
 
     public StateBootstrapOperator(
-            long timestamp, Path savepointPath, StateBootstrapFunction<IN> function) {
+            long checkpointId,
+            long timestamp,
+            Path savepointPath,
+            StateBootstrapFunction<IN> function) {
         super(function);
-
+        this.checkpointId = checkpointId;
         this.timestamp = timestamp;
         this.savepointPath = savepointPath;
     }
@@ -69,6 +74,7 @@ public class StateBootstrapOperator<IN>
     public void endInput() throws Exception {
         TaggedOperatorSubtaskState state =
                 SnapshotUtils.snapshot(
+                        checkpointId,
                         this,
                         getRuntimeContext().getTaskInfo().getIndexOfThisSubtask(),
                         timestamp,

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/operators/StateBootstrapWrapperOperator.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/operators/StateBootstrapWrapperOperator.java
@@ -55,6 +55,8 @@ public final class StateBootstrapWrapperOperator<
 
     private static final long serialVersionUID = 1L;
 
+    private final long checkpointId;
+
     private final long timestamp;
 
     private final Path savepointPath;
@@ -63,8 +65,9 @@ public final class StateBootstrapWrapperOperator<
 
     private final OP operator;
 
-    public StateBootstrapWrapperOperator(long timestamp, Path savepointPath, OP operator) {
-
+    public StateBootstrapWrapperOperator(
+            long checkpointId, long timestamp, Path savepointPath, OP operator) {
+        this.checkpointId = checkpointId;
         this.timestamp = timestamp;
         this.savepointPath = savepointPath;
         this.operator = operator;
@@ -185,6 +188,7 @@ public final class StateBootstrapWrapperOperator<
     public void endInput() throws Exception {
         TaggedOperatorSubtaskState state =
                 SnapshotUtils.snapshot(
+                        checkpointId,
                         this,
                         operator.getContainingTask()
                                 .getEnvironment()

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/metadata/SavepointMetadata.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/metadata/SavepointMetadata.java
@@ -41,6 +41,8 @@ import static org.apache.flink.runtime.state.KeyGroupRangeAssignment.UPPER_BOUND
 @Deprecated
 public class SavepointMetadata {
 
+    private final long checkpointId;
+
     private final int maxParallelism;
 
     private final Collection<MasterState> masterStates;
@@ -48,6 +50,7 @@ public class SavepointMetadata {
     private final Map<OperatorID, OperatorStateSpec> operatorStateIndex;
 
     public SavepointMetadata(
+            long checkpointId,
             int maxParallelism,
             Collection<MasterState> masterStates,
             Collection<OperatorState> initialStates) {
@@ -57,6 +60,7 @@ public class SavepointMetadata {
                         + UPPER_BOUND_MAX_PARALLELISM
                         + ". Found: "
                         + maxParallelism);
+        this.checkpointId = checkpointId;
         this.maxParallelism = maxParallelism;
 
         this.masterStates = Preconditions.checkNotNull(masterStates);
@@ -67,6 +71,10 @@ public class SavepointMetadata {
                         operatorStateIndex.put(
                                 existingState.getOperatorID(),
                                 OperatorStateSpec.existing(existingState)));
+    }
+
+    public long getCheckpointId() {
+        return checkpointId;
     }
 
     public int getMaxParallelism() {

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/metadata/SavepointMetadataV2.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/metadata/SavepointMetadataV2.java
@@ -41,6 +41,8 @@ import static org.apache.flink.runtime.state.KeyGroupRangeAssignment.UPPER_BOUND
 @Internal
 public class SavepointMetadataV2 {
 
+    private final long checkpointId;
+
     private final int maxParallelism;
 
     private final Collection<MasterState> masterStates;
@@ -48,6 +50,7 @@ public class SavepointMetadataV2 {
     private final Map<OperatorID, OperatorStateSpecV2> operatorStateIndex;
 
     public SavepointMetadataV2(
+            long checkpointId,
             int maxParallelism,
             Collection<MasterState> masterStates,
             Collection<OperatorState> initialStates) {
@@ -59,6 +62,7 @@ public class SavepointMetadataV2 {
                         + maxParallelism);
         Preconditions.checkNotNull(masterStates);
 
+        this.checkpointId = checkpointId;
         this.maxParallelism = maxParallelism;
         this.masterStates = new ArrayList<>(masterStates);
         this.operatorStateIndex = CollectionUtil.newHashMapWithExpectedSize(initialStates.size());
@@ -68,6 +72,10 @@ public class SavepointMetadataV2 {
                         operatorStateIndex.put(
                                 existingState.getOperatorID(),
                                 OperatorStateSpecV2.existing(existingState)));
+    }
+
+    public long getCheckpointId() {
+        return checkpointId;
     }
 
     public int getMaxParallelism() {

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointTest.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointTest.java
@@ -51,7 +51,7 @@ public class SavepointTest {
                         .transform(new ExampleStateBootstrapFunction());
 
         SavepointMetadata metadata =
-                new SavepointMetadata(1, Collections.emptyList(), Collections.emptyList());
+                new SavepointMetadata(0L, 1, Collections.emptyList(), Collections.emptyList());
 
         new NewSavepoint(metadata, new MemoryStateBackend())
                 .withOperator(UID, transformation)
@@ -74,7 +74,7 @@ public class SavepointTest {
                         new OperatorState(OperatorIDGenerator.fromUid(UID), 1, 4));
 
         SavepointMetadata metadata =
-                new SavepointMetadata(4, Collections.emptyList(), operatorStates);
+                new SavepointMetadata(0L, 4, Collections.emptyList(), operatorStates);
 
         new ExistingSavepoint(env, metadata, new MemoryStateBackend())
                 .withOperator(UID, transformation)
@@ -97,7 +97,7 @@ public class SavepointTest {
                         new OperatorState(OperatorIDGenerator.fromUid(UID), 1, 4));
 
         SavepointMetadata metadata =
-                new SavepointMetadata(4, Collections.emptyList(), operatorStates);
+                new SavepointMetadata(0L, 4, Collections.emptyList(), operatorStates);
 
         new ExistingSavepoint(env, metadata, new MemoryStateBackend())
                 .withOperator(UID, transformation)

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/output/KeyedStateBootstrapOperatorTest.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/output/KeyedStateBootstrapOperatorTest.java
@@ -61,7 +61,7 @@ public class KeyedStateBootstrapOperatorTest {
 
         OperatorSubtaskState state;
         KeyedStateBootstrapOperator<Long, Long> bootstrapOperator =
-                new KeyedStateBootstrapOperator<>(0L, path, new TimerBootstrapFunction());
+                new KeyedStateBootstrapOperator<>(0L, 0L, path, new TimerBootstrapFunction());
         try (KeyedOneInputStreamOperatorTestHarness<Long, Long, TaggedOperatorSubtaskState>
                 harness = getHarness(bootstrapOperator)) {
             processElements(harness, 1L, 2L, 3L);
@@ -92,7 +92,7 @@ public class KeyedStateBootstrapOperatorTest {
 
         OperatorSubtaskState state;
         KeyedStateBootstrapOperator<Long, Long> bootstrapOperator =
-                new KeyedStateBootstrapOperator<>(0L, path, new SimpleBootstrapFunction());
+                new KeyedStateBootstrapOperator<>(0L, 0L, path, new SimpleBootstrapFunction());
         try (KeyedOneInputStreamOperatorTestHarness<Long, Long, TaggedOperatorSubtaskState>
                 harness = getHarness(bootstrapOperator)) {
             processElements(harness, 1L, 2L, 3L);

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/output/SnapshotUtilsTest.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/output/SnapshotUtilsTest.java
@@ -77,7 +77,7 @@ public class SnapshotUtilsTest {
         Path path = new Path(folder.newFolder().getAbsolutePath());
 
         SnapshotUtils.snapshot(
-                operator, 0, 0L, true, false, new Configuration(), path, savepointFormatType);
+                0L, operator, 0, 0L, true, false, new Configuration(), path, savepointFormatType);
 
         Assert.assertEquals(SavepointType.savepoint(savepointFormatType), actualSnapshotType);
         Assert.assertEquals(EXPECTED_CALL_OPERATOR_SNAPSHOT, ACTUAL_ORDER_TRACKING);


### PR DESCRIPTION
This is backport of https://github.com/apache/flink/pull/26285.

## What is the purpose of the change

At the moment the state processor API is using hardcoded `0` as checkpoint ID.
In this PR I've made it configurable and savepoint modification keeps the original checkpoint ID.

## Brief change log

Made state processor API checkpoint ID configurable and savepoint modification keeps the original ID.

## Verifying this change

Changed automated tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
