### PR TITLE
[hotfix][doc] two modes instead of three

### DIFF
--- a/docs/content.zh/docs/deployment/overview.md
+++ b/docs/content.zh/docs/deployment/overview.md
@@ -170,9 +170,9 @@ covered by [FLINK-26606](https://issues.apache.org/jira/browse/FLINK-26606).
 
 ## Deployment Modes
 
-Flink can execute applications in one of three ways:
-- in Application Mode,
-- in Session Mode.
+Flink can execute applications in two modes:
+- Application Mode,
+- Session Mode.
 
  The above modes differ in:
  - the cluster lifecycle and resource isolation guarantees

--- a/docs/content/docs/deployment/overview.md
+++ b/docs/content/docs/deployment/overview.md
@@ -171,9 +171,9 @@ covered by [FLINK-26606](https://issues.apache.org/jira/browse/FLINK-26606).
 
 ## Deployment Modes
 
-Flink can execute applications in one of three ways:
-- in Application Mode,
-- in Session Mode,
+Flink can execute applications in two modes:
+- Application Mode,
+- Session Mode.
 
  The above modes differ in:
  - the cluster lifecycle and resource isolation guarantees


### PR DESCRIPTION
fix the content in doc: Flink can execute applications in two modes instead of three after the Per-Job Mode has been removed.
