### PR TITLE
[FLINK-37480][build] Bump japicmp to avoid false positives

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2335,7 +2335,7 @@ under the License.
 				<plugin>
 					<groupId>com.github.siom79.japicmp</groupId>
 					<artifactId>japicmp-maven-plugin</artifactId>
-					<version>0.17.1</version>
+					<version>0.18.5</version>
 					<configuration>
 						<oldVersion>
 							<dependency>


### PR DESCRIPTION
This is backport of https://github.com/apache/flink/pull/26304.

## What is the purpose of the change

This limitation has been found during development of https://github.com/apache/flink/pull/26299.
Japicmp now gives false positive in case of generic templates:

```
[ERROR] Failed to execute goal com.github.siom79.japicmp:japicmp-maven-plugin:0.17.1:cmp (default) on project flink-state-processor-api: There is at least one incompatibility: org.apache.flink.state.api.OperatorTransformation.bootstrapWith(org.apache.flink.api.java.DataSet,long):CLASS_GENERIC_TEMPLATE_CHANGED,org.apache.flink.state.api.OperatorTransformation.bootstrapWith(org.apache.flink.streaming.api.datastream.DataStream,long):CLASS_GENERIC_TEMPLATE_CHANGED -> [Help 1]
```
The problem is caused by https://github.com/siom79/japicmp/issues/368. In this PR I've bumped `japicmp` to the minimum version where this has been resolved.

## Brief change log

Bumped `japicmp` version.

## Verifying this change

Manually during compile.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
