### PR TITLE
[FLINK-37482] Improve the code for PrintSinkOutputWriter, PrintSinkFunction and PrintSink

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/util/PrintSinkOutputWriter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/util/PrintSinkOutputWriter.java
@@ -33,7 +33,7 @@ public class PrintSinkOutputWriter<IN> implements Serializable, SinkWriter<IN> {
     private static final boolean STD_OUT = false;
     private static final boolean STD_ERR = true;
 
-    private final boolean target;
+    private final boolean isStdErr;
     private transient PrintStream stream;
     private final String sinkIdentifier;
     private transient String completedPrefix;
@@ -42,18 +42,18 @@ public class PrintSinkOutputWriter<IN> implements Serializable, SinkWriter<IN> {
         this("", STD_OUT);
     }
 
-    public PrintSinkOutputWriter(final boolean stdErr) {
-        this("", stdErr);
+    public PrintSinkOutputWriter(final boolean isStdErr) {
+        this("", isStdErr);
     }
 
-    public PrintSinkOutputWriter(final String sinkIdentifier, final boolean stdErr) {
-        this.target = stdErr;
+    public PrintSinkOutputWriter(final String sinkIdentifier, final boolean isStdErr) {
+        this.isStdErr = isStdErr;
         this.sinkIdentifier = (sinkIdentifier == null ? "" : sinkIdentifier);
     }
 
     public void open(int subtaskIndex, int numParallelSubtasks) {
         // get the target stream
-        stream = target == STD_OUT ? System.out : System.err;
+        stream = isStdErr ? System.err : System.out;
 
         completedPrefix = sinkIdentifier;
 
@@ -88,6 +88,6 @@ public class PrintSinkOutputWriter<IN> implements Serializable, SinkWriter<IN> {
 
     @Override
     public String toString() {
-        return "Print to " + (target == STD_OUT ? "System.out" : "System.err");
+        return "Print to " + (isStdErr ? "System.err" : "System.out");
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/util/PrintSinkOutputWriter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/util/PrintSinkOutputWriter.java
@@ -30,16 +30,13 @@ public class PrintSinkOutputWriter<IN> implements Serializable, SinkWriter<IN> {
 
     private static final long serialVersionUID = 1L;
 
-    private static final boolean STD_OUT = false;
-    private static final boolean STD_ERR = true;
-
     private final boolean isStdErr;
     private transient PrintStream stream;
     private final String sinkIdentifier;
     private transient String completedPrefix;
 
     public PrintSinkOutputWriter() {
-        this("", STD_OUT);
+        this("", false);
     }
 
     public PrintSinkOutputWriter(final boolean isStdErr) {

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/sink/legacy/PrintSinkFunction.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/sink/legacy/PrintSinkFunction.java
@@ -52,20 +52,20 @@ public class PrintSinkFunction<IN> extends RichSinkFunction<IN>
     /**
      * Instantiates a print sink function that prints to standard out.
      *
-     * @param stdErr True, if the format should print to standard error instead of standard out.
+     * @param isStdErr True, if the format should print to standard error instead of standard out.
      */
-    public PrintSinkFunction(final boolean stdErr) {
-        writer = new PrintSinkOutputWriter<>(stdErr);
+    public PrintSinkFunction(final boolean isStdErr) {
+        writer = new PrintSinkOutputWriter<>(isStdErr);
     }
 
     /**
      * Instantiates a print sink function that prints to standard out and gives a sink identifier.
      *
-     * @param stdErr True, if the format should print to standard error instead of standard out.
+     * @param isStdErr True, if the format should print to standard error instead of standard out.
      * @param sinkIdentifier Message that identify sink and is prefixed to the output of the value
      */
-    public PrintSinkFunction(final String sinkIdentifier, final boolean stdErr) {
-        writer = new PrintSinkOutputWriter<>(sinkIdentifier, stdErr);
+    public PrintSinkFunction(final String sinkIdentifier, final boolean isStdErr) {
+        writer = new PrintSinkOutputWriter<>(sinkIdentifier, isStdErr);
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/PrintSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/PrintSink.java
@@ -46,7 +46,7 @@ public class PrintSink<IN> implements Sink<IN>, SupportsConcurrentExecutionAttem
 
     private static final long serialVersionUID = 1L;
     private final String sinkIdentifier;
-    private final boolean stdErr;
+    private final boolean isStdErr;
 
     /** Instantiates a print sink function that prints to STDOUT. */
     public PrintSink() {
@@ -56,10 +56,10 @@ public class PrintSink<IN> implements Sink<IN>, SupportsConcurrentExecutionAttem
     /**
      * Instantiates a print sink that prints to STDOUT or STDERR.
      *
-     * @param stdErr True, if the format should print to standard error instead of standard out.
+     * @param isStdErr True, if the format should print to standard error instead of standard out.
      */
-    public PrintSink(final boolean stdErr) {
-        this("", stdErr);
+    public PrintSink(final boolean isStdErr) {
+        this("", isStdErr);
     }
 
     /**
@@ -77,17 +77,17 @@ public class PrintSink<IN> implements Sink<IN>, SupportsConcurrentExecutionAttem
      *
      * @param sinkIdentifier Message that identifies the sink and is prefixed to the output of the
      *     value
-     * @param stdErr True if the sink should print to STDERR instead of STDOUT.
+     * @param isStdErr True if the sink should print to STDERR instead of STDOUT.
      */
-    public PrintSink(final String sinkIdentifier, final boolean stdErr) {
+    public PrintSink(final String sinkIdentifier, final boolean isStdErr) {
         this.sinkIdentifier = sinkIdentifier;
-        this.stdErr = stdErr;
+        this.isStdErr = isStdErr;
     }
 
     @Override
     public SinkWriter<IN> createWriter(WriterInitContext context) throws IOException {
         final PrintSinkOutputWriter<IN> writer =
-                new PrintSinkOutputWriter<>(sinkIdentifier, stdErr);
+                new PrintSinkOutputWriter<>(sinkIdentifier, isStdErr);
         writer.open(
                 context.getTaskInfo().getIndexOfThisSubtask(),
                 context.getTaskInfo().getNumberOfParallelSubtasks());
@@ -96,6 +96,6 @@ public class PrintSink<IN> implements Sink<IN>, SupportsConcurrentExecutionAttem
 
     @Override
     public String toString() {
-        return "Print to " + (stdErr ? "System.err" : "System.out");
+        return "Print to " + (isStdErr ? "System.err" : "System.out");
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR aim to improve the code for `PrintSinkOutputWriter`, `PrintSinkFunction` and `PrintSink`.

1.  Rename the variable `target` with a meaning name.
2. Simplify the code like `stream = target == STD_OUT ? System.out : System.err;`.


## Brief change log

Simplify the code for `PrintSink`


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)

