### PR TITLE
[hotfix] Remove unnecessary InternalPriorityQueue

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/KeyGroupPartitionedPriorityQueue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/KeyGroupPartitionedPriorityQueue.java
@@ -48,7 +48,7 @@ import static org.apache.flink.util.Preconditions.checkArgument;
  */
 public class KeyGroupPartitionedPriorityQueue<
                 T, PQ extends InternalPriorityQueue<T> & HeapPriorityQueueElement>
-        implements InternalPriorityQueue<T>, KeyGroupedInternalPriorityQueue<T> {
+        implements KeyGroupedInternalPriorityQueue<T> {
 
     /** A heap of heap sets. Each sub-heap represents the partition for a key-group. */
     @Nonnull private final HeapPriorityQueue<PQ> heapOfKeyGroupedHeaps;


### PR DESCRIPTION
## What is the purpose of the change

This PR proposes to remove unnecessary `InternalPriorityQueue`.
Since `KeyGroupedInternalPriorityQueue` already extends `InternalPriorityQueue`.


## Brief change log

Remove unnecessary `InternalPriorityQueue`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
