### PR TITLE
[FLINK-37510] Avoid duplicate calculations for SlidingEventTimeWindows

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/windowing/assigners/SlidingEventTimeWindows.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/windowing/assigners/SlidingEventTimeWindows.java
@@ -70,8 +70,8 @@ public class SlidingEventTimeWindows extends WindowAssigner<Object, TimeWindow> 
             Object element, long timestamp, WindowAssignerContext context) {
         if (timestamp > Long.MIN_VALUE) {
             List<TimeWindow> windows = new ArrayList<>((int) (size / slide));
-            long lastStart = TimeWindow.getWindowStartWithOffset(timestamp, offset, slide);
-            long lower = timestamp - size;
+            final long lastStart = TimeWindow.getWindowStartWithOffset(timestamp, offset, slide);
+            final long lower = timestamp - size;
             for (long start = lastStart; start > lower; start -= slide) {
                 windows.add(new TimeWindow(start, start + size));
             }

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/windowing/assigners/SlidingEventTimeWindows.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/windowing/assigners/SlidingEventTimeWindows.java
@@ -71,7 +71,8 @@ public class SlidingEventTimeWindows extends WindowAssigner<Object, TimeWindow> 
         if (timestamp > Long.MIN_VALUE) {
             List<TimeWindow> windows = new ArrayList<>((int) (size / slide));
             long lastStart = TimeWindow.getWindowStartWithOffset(timestamp, offset, slide);
-            for (long start = lastStart; start > timestamp - size; start -= slide) {
+            long lower = timestamp - size;
+            for (long start = lastStart; start > lower; start -= slide) {
                 windows.add(new TimeWindow(start, start + size));
             }
             return windows;


### PR DESCRIPTION
## What is the purpose of the change

This PR aim to avoid duplicate calculations for `SlidingEventTimeWindows`.
The original code put the expression `timestamp - size` into the loop, so it causes duplicate calculation.
We should put them out of the loop and just calculate once.


## Brief change log

Avoid duplicate calculations for `SlidingEventTimeWindows`


## Verifying this change

This change is already covered by existing tests, such as *(SlidingEventTimeWindowsTest)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
