### PR TITLE
[FLINK-37511][rest] Use Jackson serialization in JobPlanInfo.Plan

### DIFF
--- a/docs/layouts/shortcodes/generated/rest_v1_dispatcher.html
+++ b/docs/layouts/shortcodes/generated/rest_v1_dispatcher.html
@@ -509,7 +509,72 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
   "properties" : {
     "plan" : {
       "type" : "object",
-      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobPlanInfo:RawJson"
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobPlanInfo:Plan",
+      "properties" : {
+        "jid" : {
+          "type" : "string"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "nodes" : {
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobPlanInfo:Plan:Node",
+            "properties" : {
+              "description" : {
+                "type" : "string"
+              },
+              "id" : {
+                "type" : "string"
+              },
+              "inputs" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "object",
+                  "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobPlanInfo:Plan:Node:Input",
+                  "properties" : {
+                    "caching" : {
+                      "type" : "string"
+                    },
+                    "exchange" : {
+                      "type" : "string"
+                    },
+                    "id" : {
+                      "type" : "string"
+                    },
+                    "local_strategy" : {
+                      "type" : "string"
+                    },
+                    "num" : {
+                      "type" : "integer"
+                    },
+                    "ship_strategy" : {
+                      "type" : "string"
+                    }
+                  }
+                }
+              },
+              "operator" : {
+                "type" : "string"
+              },
+              "operator_strategy" : {
+                "type" : "string"
+              },
+              "optimizer_properties" : {
+                "type" : "string"
+              },
+              "parallelism" : {
+                "type" : "integer"
+              }
+            }
+          }
+        },
+        "type" : {
+          "type" : "string"
+        }
+      }
     }
   }
 }</code></pre>
@@ -1126,7 +1191,72 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
     },
     "plan" : {
       "type" : "object",
-      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobPlanInfo:RawJson"
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobPlanInfo:Plan",
+      "properties" : {
+        "jid" : {
+          "type" : "string"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "nodes" : {
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobPlanInfo:Plan:Node",
+            "properties" : {
+              "description" : {
+                "type" : "string"
+              },
+              "id" : {
+                "type" : "string"
+              },
+              "inputs" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "object",
+                  "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobPlanInfo:Plan:Node:Input",
+                  "properties" : {
+                    "caching" : {
+                      "type" : "string"
+                    },
+                    "exchange" : {
+                      "type" : "string"
+                    },
+                    "id" : {
+                      "type" : "string"
+                    },
+                    "local_strategy" : {
+                      "type" : "string"
+                    },
+                    "num" : {
+                      "type" : "integer"
+                    },
+                    "ship_strategy" : {
+                      "type" : "string"
+                    }
+                  }
+                }
+              },
+              "operator" : {
+                "type" : "string"
+              },
+              "operator_strategy" : {
+                "type" : "string"
+              },
+              "optimizer_properties" : {
+                "type" : "string"
+              },
+              "parallelism" : {
+                "type" : "integer"
+              }
+            }
+          }
+        },
+        "type" : {
+          "type" : "string"
+        }
+      }
     },
     "start-time" : {
       "type" : "integer"
@@ -1143,7 +1273,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
     },
     "stream-graph" : {
       "type" : "object",
-      "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobPlanInfo:RawJson"
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobPlanInfo:RawJson"
     },
     "timestamps" : {
       "type" : "object",
@@ -2879,7 +3009,72 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
   "properties" : {
     "plan" : {
       "type" : "object",
-      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobPlanInfo:RawJson"
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobPlanInfo:Plan",
+      "properties" : {
+        "jid" : {
+          "type" : "string"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "nodes" : {
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobPlanInfo:Plan:Node",
+            "properties" : {
+              "description" : {
+                "type" : "string"
+              },
+              "id" : {
+                "type" : "string"
+              },
+              "inputs" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "object",
+                  "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobPlanInfo:Plan:Node:Input",
+                  "properties" : {
+                    "caching" : {
+                      "type" : "string"
+                    },
+                    "exchange" : {
+                      "type" : "string"
+                    },
+                    "id" : {
+                      "type" : "string"
+                    },
+                    "local_strategy" : {
+                      "type" : "string"
+                    },
+                    "num" : {
+                      "type" : "integer"
+                    },
+                    "ship_strategy" : {
+                      "type" : "string"
+                    }
+                  }
+                }
+              },
+              "operator" : {
+                "type" : "string"
+              },
+              "operator_strategy" : {
+                "type" : "string"
+              },
+              "optimizer_properties" : {
+                "type" : "string"
+              },
+              "parallelism" : {
+                "type" : "integer"
+              }
+            }
+          }
+        },
+        "type" : {
+          "type" : "string"
+        }
+      }
     }
   }
 }</code></pre>

--- a/docs/static/generated/rest_v1_dispatcher.yml
+++ b/docs/static/generated/rest_v1_dispatcher.yml
@@ -6,7 +6,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: v1/2.0-SNAPSHOT
+  version: v1/2.1-SNAPSHOT
 paths:
   /cluster:
     delete:
@@ -2149,6 +2149,22 @@ components:
       enum:
       - IN_PROGRESS
       - COMPLETED
+    Input:
+      type: object
+      properties:
+        caching:
+          type: string
+        exchange:
+          type: string
+        id:
+          type: string
+        local_strategy:
+          type: string
+        num:
+          type: integer
+          format: int64
+        ship_strategy:
+          type: string
     IntermediateDataSetID:
       pattern: "[0-9a-f]{32}"
       type: string
@@ -2337,7 +2353,7 @@ components:
           type: integer
           format: int32
         plan:
-          $ref: '#/components/schemas/RawJson'
+          $ref: '#/components/schemas/Plan'
         start-time:
           type: integer
           format: int64
@@ -2436,7 +2452,7 @@ components:
       type: object
       properties:
         plan:
-          $ref: '#/components/schemas/RawJson'
+          $ref: '#/components/schemas/Plan'
     JobResourceRequirementsBody:
       type: object
       additionalProperties:
@@ -2663,6 +2679,39 @@ components:
       type: object
       allOf:
       - $ref: '#/components/schemas/SubtaskCheckpointStatistics'
+    Plan:
+      type: object
+      properties:
+        jid:
+          type: string
+        name:
+          type: string
+        nodes:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlanNode'
+        type:
+          type: string
+    PlanNode:
+      type: object
+      properties:
+        description:
+          type: string
+        id:
+          type: string
+        inputs:
+          type: array
+          items:
+            $ref: '#/components/schemas/Input'
+        operator:
+          type: string
+        operator_strategy:
+          type: string
+        optimizer_properties:
+          type: string
+        parallelism:
+          type: integer
+          format: int64
     ProcessingMode:
       type: string
       enum:

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
@@ -1277,7 +1277,7 @@ class RestClusterClientTest {
                         Collections.singletonMap(JobStatus.RUNNING, 1L),
                         jobVertexDetailsInfos,
                         Collections.singletonMap(ExecutionState.RUNNING, 1),
-                        new JobPlanInfo.RawJson("{\"id\":\"1234\"}"),
+                        new JobPlanInfo.Plan("1243", "", "", new ArrayList<>()),
                         new JobPlanInfo.RawJson("{\"id\":\"1234\"}"),
                         0);
         final TestJobDetailsInfoHandler jobDetailsInfoHandler =

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarSubmissionITCase.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarSubmissionITCase.java
@@ -94,7 +94,7 @@ class JarSubmissionITCase {
         final JobPlanInfo planResponse = showPlan(planHandler, storedJarName, restfulGateway);
         // we're only interested in the core functionality so checking for a small detail is
         // sufficient
-        assertThat(planResponse.getJsonPlan()).contains("\"name\":\"Flink Streaming Job\"");
+        assertThat(planResponse.getPlan().getName()).isEqualTo("Flink Streaming Job");
 
         runJar(runHandler, storedJarName, restfulGateway);
 

--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -333,7 +333,72 @@
       "properties" : {
         "plan" : {
           "type" : "object",
-          "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobPlanInfo:RawJson"
+          "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobPlanInfo:Plan",
+          "properties" : {
+            "jid" : {
+              "type" : "string"
+            },
+            "name" : {
+              "type" : "string"
+            },
+            "type" : {
+              "type" : "string"
+            },
+            "nodes" : {
+              "type" : "array",
+              "items" : {
+                "type" : "object",
+                "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobPlanInfo:Plan:Node",
+                "properties" : {
+                  "id" : {
+                    "type" : "string"
+                  },
+                  "operator" : {
+                    "type" : "string"
+                  },
+                  "parallelism" : {
+                    "type" : "integer"
+                  },
+                  "operator_strategy" : {
+                    "type" : "string"
+                  },
+                  "description" : {
+                    "type" : "string"
+                  },
+                  "optimizer_properties" : {
+                    "type" : "string"
+                  },
+                  "inputs" : {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "object",
+                      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobPlanInfo:Plan:Node:Input",
+                      "properties" : {
+                        "id" : {
+                          "type" : "string"
+                        },
+                        "num" : {
+                          "type" : "integer"
+                        },
+                        "exchange" : {
+                          "type" : "string"
+                        },
+                        "ship_strategy" : {
+                          "type" : "string"
+                        },
+                        "local_strategy" : {
+                          "type" : "string"
+                        },
+                        "caching" : {
+                          "type" : "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -392,7 +457,72 @@
       "properties" : {
         "plan" : {
           "type" : "object",
-          "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobPlanInfo:RawJson"
+          "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobPlanInfo:Plan",
+          "properties" : {
+            "jid" : {
+              "type" : "string"
+            },
+            "name" : {
+              "type" : "string"
+            },
+            "type" : {
+              "type" : "string"
+            },
+            "nodes" : {
+              "type" : "array",
+              "items" : {
+                "type" : "object",
+                "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobPlanInfo:Plan:Node",
+                "properties" : {
+                  "id" : {
+                    "type" : "string"
+                  },
+                  "operator" : {
+                    "type" : "string"
+                  },
+                  "parallelism" : {
+                    "type" : "integer"
+                  },
+                  "operator_strategy" : {
+                    "type" : "string"
+                  },
+                  "description" : {
+                    "type" : "string"
+                  },
+                  "optimizer_properties" : {
+                    "type" : "string"
+                  },
+                  "inputs" : {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "object",
+                      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobPlanInfo:Plan:Node:Input",
+                      "properties" : {
+                        "id" : {
+                          "type" : "string"
+                        },
+                        "num" : {
+                          "type" : "integer"
+                        },
+                        "exchange" : {
+                          "type" : "string"
+                        },
+                        "ship_strategy" : {
+                          "type" : "string"
+                        },
+                        "local_strategy" : {
+                          "type" : "string"
+                        },
+                        "caching" : {
+                          "type" : "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -969,11 +1099,76 @@
         },
         "plan" : {
           "type" : "object",
-          "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobPlanInfo:RawJson"
+          "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobPlanInfo:Plan",
+          "properties" : {
+            "jid" : {
+              "type" : "string"
+            },
+            "name" : {
+              "type" : "string"
+            },
+            "type" : {
+              "type" : "string"
+            },
+            "nodes" : {
+              "type" : "array",
+              "items" : {
+                "type" : "object",
+                "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobPlanInfo:Plan:Node",
+                "properties" : {
+                  "id" : {
+                    "type" : "string"
+                  },
+                  "operator" : {
+                    "type" : "string"
+                  },
+                  "parallelism" : {
+                    "type" : "integer"
+                  },
+                  "operator_strategy" : {
+                    "type" : "string"
+                  },
+                  "description" : {
+                    "type" : "string"
+                  },
+                  "optimizer_properties" : {
+                    "type" : "string"
+                  },
+                  "inputs" : {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "object",
+                      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobPlanInfo:Plan:Node:Input",
+                      "properties" : {
+                        "id" : {
+                          "type" : "string"
+                        },
+                        "num" : {
+                          "type" : "integer"
+                        },
+                        "exchange" : {
+                          "type" : "string"
+                        },
+                        "ship_strategy" : {
+                          "type" : "string"
+                        },
+                        "local_strategy" : {
+                          "type" : "string"
+                        },
+                        "caching" : {
+                          "type" : "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
         },
         "stream-graph" : {
           "type" : "object",
-          "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobPlanInfo:RawJson"
+          "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobPlanInfo:RawJson"
         },
         "pending-operators" : {
           "type" : "integer"
@@ -2219,7 +2414,72 @@
       "properties" : {
         "plan" : {
           "type" : "object",
-          "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobPlanInfo:RawJson"
+          "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobPlanInfo:Plan",
+          "properties" : {
+            "jid" : {
+              "type" : "string"
+            },
+            "name" : {
+              "type" : "string"
+            },
+            "type" : {
+              "type" : "string"
+            },
+            "nodes" : {
+              "type" : "array",
+              "items" : {
+                "type" : "object",
+                "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobPlanInfo:Plan:Node",
+                "properties" : {
+                  "id" : {
+                    "type" : "string"
+                  },
+                  "operator" : {
+                    "type" : "string"
+                  },
+                  "parallelism" : {
+                    "type" : "integer"
+                  },
+                  "operator_strategy" : {
+                    "type" : "string"
+                  },
+                  "description" : {
+                    "type" : "string"
+                  },
+                  "optimizer_properties" : {
+                    "type" : "string"
+                  },
+                  "inputs" : {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "object",
+                      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobPlanInfo:Plan:Node:Input",
+                      "properties" : {
+                        "id" : {
+                          "type" : "string"
+                        },
+                        "num" : {
+                          "type" : "integer"
+                        },
+                        "exchange" : {
+                          "type" : "string"
+                        },
+                        "ship_strategy" : {
+                          "type" : "string"
+                        },
+                        "local_strategy" : {
+                          "type" : "string"
+                        },
+                        "caching" : {
+                          "type" : "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/AccessExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/AccessExecutionGraph.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.checkpoint.CheckpointStatsSnapshot;
 import org.apache.flink.runtime.jobgraph.JobType;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
+import org.apache.flink.runtime.rest.messages.JobPlanInfo;
 import org.apache.flink.util.OptionalFailure;
 import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.TernaryBoolean;
@@ -41,11 +42,11 @@ import java.util.Optional;
  */
 public interface AccessExecutionGraph extends JobStatusProvider {
     /**
-     * Returns the job plan as a JSON string.
+     * Returns the job plan as a JobPlanInfo.Plan.
      *
-     * @return job plan as a JSON string
+     * @return job plan as a JobPlanInfo.Plan
      */
-    String getJsonPlan();
+    JobPlanInfo.Plan getPlan();
 
     /**
      * Returns the stream graph as a JSON string.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
@@ -67,6 +67,7 @@ import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.operators.coordination.CoordinatorStore;
 import org.apache.flink.runtime.operators.coordination.CoordinatorStoreImpl;
 import org.apache.flink.runtime.query.KvStateLocationRegistry;
+import org.apache.flink.runtime.rest.messages.JobPlanInfo;
 import org.apache.flink.runtime.scheduler.DefaultVertexParallelismStore;
 import org.apache.flink.runtime.scheduler.InternalFailuresListener;
 import org.apache.flink.runtime.scheduler.SsgNetworkMemoryCalculationUtils;
@@ -280,7 +281,7 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
 
     @Nullable private TernaryBoolean stateChangelogEnabled;
 
-    private String jsonPlan;
+    private JobPlanInfo.Plan plan;
 
     /** Shuffle master to register partitions for task deployment. */
     private final ShuffleMaster<?> shuffleMaster;
@@ -613,8 +614,8 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
     // --------------------------------------------------------------------------------------------
 
     @Override
-    public void setJsonPlan(String jsonPlan) {
-        this.jsonPlan = jsonPlan;
+    public void setPlan(JobPlanInfo.Plan plan) {
+        this.plan = plan;
     }
 
     @Override
@@ -623,8 +624,8 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
     }
 
     @Override
-    public String getJsonPlan() {
-        return jsonPlan;
+    public JobPlanInfo.Plan getPlan() {
+        return plan;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphBuilder.java
@@ -44,6 +44,7 @@ import org.apache.flink.runtime.jobgraph.jsonplan.JsonPlanGenerator;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
 import org.apache.flink.runtime.jobgraph.tasks.JobCheckpointingSettings;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
+import org.apache.flink.runtime.rest.messages.JobPlanInfo;
 import org.apache.flink.runtime.scheduler.VertexParallelismStore;
 import org.apache.flink.runtime.scheduler.adaptivebatch.ExecutionPlanSchedulingContext;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
@@ -175,11 +176,11 @@ public class DefaultExecutionGraphBuilder {
         // set the basic properties
 
         try {
-            executionGraph.setJsonPlan(JsonPlanGenerator.generatePlan(jobGraph));
+            executionGraph.setPlan(JsonPlanGenerator.generatePlan(jobGraph));
         } catch (Throwable t) {
-            log.warn("Cannot create JSON plan for job", t);
+            log.warn("Cannot create plan for job", t);
             // give the graph an empty plan
-            executionGraph.setJsonPlan("{}");
+            executionGraph.setPlan(new JobPlanInfo.Plan("", "", "", new ArrayList<>()));
         }
 
         initJobVerticesOnMaster(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -39,6 +39,7 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.query.KvStateLocationRegistry;
+import org.apache.flink.runtime.rest.messages.JobPlanInfo;
 import org.apache.flink.runtime.scheduler.InternalFailuresListener;
 import org.apache.flink.runtime.scheduler.VertexParallelismStore;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingTopology;
@@ -99,7 +100,7 @@ public interface ExecutionGraph extends AccessExecutionGraph {
 
     KvStateLocationRegistry getKvStateLocationRegistry();
 
-    void setJsonPlan(String jsonPlan);
+    void setPlan(JobPlanInfo.Plan plan);
 
     Configuration getJobConfiguration();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobDetailsHandler.java
@@ -160,7 +160,7 @@ public class JobDetailsHandler
                 timestamps,
                 jobVertexInfos,
                 jobVerticesPerStateMap,
-                new JobPlanInfo.RawJson(executionGraph.getJsonPlan()),
+                executionGraph.getPlan(),
                 streamGraphJson,
                 executionGraph.getPendingOperatorCount());
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobPlanHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobPlanHandler.java
@@ -75,6 +75,6 @@ public class JobPlanHandler
     }
 
     private static JobPlanInfo createJobPlanInfo(AccessExecutionGraph executionGraph) {
-        return new JobPlanInfo(executionGraph.getJsonPlan());
+        return new JobPlanInfo(executionGraph.getPlan());
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobPlanInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobPlanInfo.java
@@ -37,7 +37,13 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.deser.std
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import javax.annotation.Nullable;
+
 import java.io.IOException;
+import java.io.Serializable;
+import java.util.Collection;
 import java.util.Objects;
 
 /** Response type of the {@link JobPlanHandler}. */
@@ -46,20 +52,16 @@ public class JobPlanInfo implements ResponseBody {
     private static final String FIELD_NAME_PLAN = "plan";
 
     @JsonProperty(FIELD_NAME_PLAN)
-    private final RawJson jsonPlan;
-
-    public JobPlanInfo(String jsonPlan) {
-        this(new RawJson(Preconditions.checkNotNull(jsonPlan)));
-    }
+    private final Plan plan;
 
     @JsonCreator
-    public JobPlanInfo(@JsonProperty(FIELD_NAME_PLAN) RawJson jsonPlan) {
-        this.jsonPlan = jsonPlan;
+    public JobPlanInfo(@JsonProperty(FIELD_NAME_PLAN) Plan plan) {
+        this.plan = plan;
     }
 
     @JsonIgnore
-    public String getJsonPlan() {
-        return jsonPlan.json;
+    public Plan getPlan() {
+        return plan;
     }
 
     @Override
@@ -71,17 +73,17 @@ public class JobPlanInfo implements ResponseBody {
             return false;
         }
         JobPlanInfo that = (JobPlanInfo) o;
-        return Objects.equals(jsonPlan, that.jsonPlan);
+        return Objects.equals(plan, that.plan);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(jsonPlan);
+        return Objects.hash(plan);
     }
 
     @Override
     public String toString() {
-        return "JobPlanInfo{" + "jsonPlan=" + jsonPlan + '}';
+        return "JobPlanInfo{" + "plan=" + plan + '}';
     }
 
     /** Simple wrapper around a raw JSON string. */
@@ -161,6 +163,316 @@ public class JobPlanInfo implements ResponseBody {
                     throws IOException {
                 final JsonNode rootNode = jsonParser.readValueAsTree();
                 return new RawJson(rootNode.toString());
+            }
+        }
+    }
+
+    // ---------------------------------------------------
+    // Static inner classes
+    // ---------------------------------------------------
+
+    /** An inner class for the plan reference. */
+    @Schema(name = "Plan")
+    public static final class Plan implements Serializable {
+        private static final String FIELD_NAME_JOB_ID = "jid";
+
+        @JsonProperty(FIELD_NAME_JOB_ID)
+        private final String jobId;
+
+        private static final String FIELD_NAME_NAME = "name";
+
+        @JsonProperty(FIELD_NAME_NAME)
+        private final String name;
+
+        private static final String FIELD_NAME_TYPE = "type";
+
+        @JsonProperty(FIELD_NAME_TYPE)
+        private final String type;
+
+        private static final String FIELD_NAME_NODES = "nodes";
+
+        @JsonProperty(FIELD_NAME_NODES)
+        private final Collection<Node> nodes;
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            Plan that = (Plan) o;
+            return Objects.equals(jobId, that.jobId)
+                    && Objects.equals(name, that.name)
+                    && Objects.equals(type, that.type)
+                    && Objects.equals(nodes, that.nodes);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(jobId, name, type, nodes);
+        }
+
+        @JsonCreator
+        public Plan(
+                @JsonProperty(FIELD_NAME_JOB_ID) String jobId,
+                @JsonProperty(FIELD_NAME_NAME) String name,
+                @JsonProperty(FIELD_NAME_TYPE) String type,
+                @JsonProperty(FIELD_NAME_NODES) Collection<Node> nodes) {
+            this.jobId = Preconditions.checkNotNull(jobId);
+            this.name = Preconditions.checkNotNull(name);
+            this.type = Preconditions.checkNotNull(type);
+            this.nodes = Preconditions.checkNotNull(nodes);
+        }
+
+        @JsonIgnore
+        public String getJobId() {
+            return jobId;
+        }
+
+        @JsonIgnore
+        public String getName() {
+            return name;
+        }
+
+        @JsonIgnore
+        public String getType() {
+            return type;
+        }
+
+        @JsonIgnore
+        public Collection<Node> getNodes() {
+            return nodes;
+        }
+
+        /** An inner class containing node (vertex) level info. */
+        @Schema(name = "PlanNode")
+        public static final class Node implements Serializable {
+            private static final String FIELD_NAME_ID = "id";
+
+            @JsonProperty(FIELD_NAME_ID)
+            private final String id;
+
+            private static final String FIELD_NAME_PARALLELISM = "parallelism";
+
+            @JsonProperty(FIELD_NAME_PARALLELISM)
+            private final long parallelism;
+
+            private static final String FIELD_NAME_OPERATOR = "operator";
+
+            @JsonProperty(FIELD_NAME_OPERATOR)
+            private final String operator;
+
+            private static final String FIELD_NAME_OPERATOR_STRATEGY = "operator_strategy";
+
+            @JsonProperty(FIELD_NAME_OPERATOR_STRATEGY)
+            private final String operatorStrategy;
+
+            private static final String FIELD_NAME_DESCRIPTION = "description";
+
+            @JsonProperty(FIELD_NAME_DESCRIPTION)
+            private final String description;
+
+            private static final String FIELD_NAME_OPTIMIZER_PROPERTIES = "optimizer_properties";
+
+            @JsonProperty(FIELD_NAME_OPTIMIZER_PROPERTIES)
+            private final String optimizerProperties;
+
+            private static final String FIELD_NAME_INPUTS = "inputs";
+
+            @JsonProperty(FIELD_NAME_INPUTS)
+            private final Collection<Input> inputs;
+
+            @Override
+            public boolean equals(Object o) {
+                if (this == o) {
+                    return true;
+                }
+                if (o == null || getClass() != o.getClass()) {
+                    return false;
+                }
+                Node that = (Node) o;
+                return Objects.equals(id, that.id)
+                        && Objects.equals(operator, that.operator)
+                        && Objects.equals(operatorStrategy, that.operatorStrategy)
+                        && Objects.equals(description, that.description)
+                        && Objects.equals(optimizerProperties, that.optimizerProperties)
+                        && Objects.equals(inputs, that.inputs)
+                        && parallelism == that.parallelism;
+            }
+
+            @Override
+            public int hashCode() {
+                return Objects.hash(
+                        id,
+                        operator,
+                        parallelism,
+                        operatorStrategy,
+                        description,
+                        optimizerProperties,
+                        inputs);
+            }
+
+            @JsonCreator
+            public Node(
+                    @JsonProperty(FIELD_NAME_ID) String id,
+                    @JsonProperty(FIELD_NAME_OPERATOR) String operator,
+                    @JsonProperty(FIELD_NAME_PARALLELISM) long parallelism,
+                    @JsonProperty(FIELD_NAME_OPERATOR_STRATEGY) String operatorStrategy,
+                    @JsonProperty(FIELD_NAME_DESCRIPTION) String description,
+                    @JsonProperty(FIELD_NAME_OPTIMIZER_PROPERTIES) String optimizerProperties,
+                    @JsonProperty(FIELD_NAME_INPUTS) Collection<Input> inputs) {
+                this.id = Preconditions.checkNotNull(id);
+                this.operator = Preconditions.checkNotNull(operator);
+                this.parallelism = Preconditions.checkNotNull(parallelism);
+                this.operatorStrategy = Preconditions.checkNotNull(operatorStrategy);
+                this.description = Preconditions.checkNotNull(description);
+                this.optimizerProperties = Preconditions.checkNotNull(optimizerProperties);
+                this.inputs = Preconditions.checkNotNull(inputs);
+            }
+
+            @JsonIgnore
+            public String getId() {
+                return id;
+            }
+
+            @JsonIgnore
+            public long getParallelism() {
+                return parallelism;
+            }
+
+            @JsonIgnore
+            public String getOperator() {
+                return operator;
+            }
+
+            @JsonIgnore
+            public String getOperatorStrategy() {
+                return operatorStrategy;
+            }
+
+            @JsonIgnore
+            public String getDescription() {
+                return description;
+            }
+
+            @JsonIgnore
+            public String getOptimizerProperties() {
+                return optimizerProperties;
+            }
+
+            @JsonIgnore
+            public Collection<Input> getInputs() {
+                return inputs;
+            }
+
+            /**
+             * An inner class containing information on what input nodes should be linked to this
+             * node.
+             */
+            @Schema(name = "Input")
+            public static final class Input implements Serializable {
+                private static final String FIELD_NAME_NUM = "num";
+
+                @JsonProperty(FIELD_NAME_NUM)
+                private final long num;
+
+                private static final String FIELD_NAME_ID = "id";
+
+                @JsonProperty(FIELD_NAME_ID)
+                private final String id;
+
+                private static final String FIELD_NAME_SHIP_STRATEGY = "ship_strategy";
+
+                @Nullable
+                @JsonProperty(FIELD_NAME_SHIP_STRATEGY)
+                private final String shipStrategy;
+
+                private static final String FIELD_NAME_LOCAL_STRATEGY = "local_strategy";
+
+                @Nullable
+                @JsonProperty(FIELD_NAME_LOCAL_STRATEGY)
+                private final String localStrategy;
+
+                private static final String FIELD_NAME_CACHING = "caching";
+
+                @Nullable
+                @JsonProperty(FIELD_NAME_CACHING)
+                private final String caching;
+
+                private static final String FIELD_NAME_EXCHANGE = "exchange";
+
+                @JsonProperty(FIELD_NAME_EXCHANGE)
+                private final String exchange;
+
+                @Override
+                public boolean equals(Object o) {
+                    if (this == o) {
+                        return true;
+                    }
+                    if (o == null || getClass() != o.getClass()) {
+                        return false;
+                    }
+                    Input that = (Input) o;
+                    return Objects.equals(id, that.id)
+                            && num == that.num
+                            && Objects.equals(shipStrategy, that.shipStrategy)
+                            && Objects.equals(localStrategy, that.localStrategy)
+                            && Objects.equals(caching, that.caching)
+                            && Objects.equals(exchange, that.exchange);
+                }
+
+                @Override
+                public int hashCode() {
+                    return Objects.hash(id, num, shipStrategy, localStrategy, caching, exchange);
+                }
+
+                @JsonCreator
+                public Input(
+                        @JsonProperty(FIELD_NAME_ID) String id,
+                        @JsonProperty(FIELD_NAME_NUM) long num,
+                        @JsonProperty(FIELD_NAME_EXCHANGE) String exchange,
+                        @Nullable @JsonProperty(FIELD_NAME_SHIP_STRATEGY) String shipStrategy,
+                        @Nullable @JsonProperty(FIELD_NAME_LOCAL_STRATEGY) String localStrategy,
+                        @Nullable @JsonProperty(FIELD_NAME_CACHING) String caching) {
+                    this.id = Preconditions.checkNotNull(id);
+                    this.num = Preconditions.checkNotNull(num);
+                    this.exchange = Preconditions.checkNotNull(exchange);
+                    this.shipStrategy = shipStrategy;
+                    this.localStrategy = localStrategy;
+                    this.caching = caching;
+                }
+
+                @JsonIgnore
+                public long getNum() {
+                    return num;
+                }
+
+                @JsonIgnore
+                public String getId() {
+                    return id;
+                }
+
+                @JsonIgnore
+                public String getShipStrategy() {
+                    return shipStrategy;
+                }
+
+                @JsonIgnore
+                public String getLocalStrategy() {
+                    return localStrategy;
+                }
+
+                @JsonIgnore
+                public String getCaching() {
+                    return caching;
+                }
+
+                @JsonIgnore
+                public String getExchange() {
+                    return exchange;
+                }
             }
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobDetailsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobDetailsInfo.java
@@ -131,7 +131,7 @@ public class JobDetailsInfo implements ResponseBody {
     private final Map<ExecutionState, Integer> jobVerticesPerState;
 
     @JsonProperty(FIELD_NAME_JSON_PLAN)
-    private final JobPlanInfo.RawJson jsonPlan;
+    private final JobPlanInfo.Plan plan;
 
     @JsonProperty(FIELD_NAME_STREAM_GRAPH_JSON)
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -159,7 +159,7 @@ public class JobDetailsInfo implements ResponseBody {
                     Collection<JobVertexDetailsInfo> jobVertexInfos,
             @JsonProperty(FIELD_NAME_JOB_VERTICES_PER_STATE)
                     Map<ExecutionState, Integer> jobVerticesPerState,
-            @JsonProperty(FIELD_NAME_JSON_PLAN) JobPlanInfo.RawJson jsonPlan,
+            @JsonProperty(FIELD_NAME_JSON_PLAN) JobPlanInfo.Plan plan,
             @JsonProperty(FIELD_NAME_STREAM_GRAPH_JSON) @Nullable
                     JobPlanInfo.RawJson streamGraphJson,
             @JsonProperty(FIELD_NAME_PENDING_OPERATORS) int pendingOperators) {
@@ -176,7 +176,7 @@ public class JobDetailsInfo implements ResponseBody {
         this.timestamps = Preconditions.checkNotNull(timestamps);
         this.jobVertexInfos = Preconditions.checkNotNull(jobVertexInfos);
         this.jobVerticesPerState = Preconditions.checkNotNull(jobVerticesPerState);
-        this.jsonPlan = Preconditions.checkNotNull(jsonPlan);
+        this.plan = Preconditions.checkNotNull(plan);
         this.streamGraphJson = streamGraphJson;
         this.pendingOperators = pendingOperators;
     }
@@ -203,7 +203,7 @@ public class JobDetailsInfo implements ResponseBody {
                 && Objects.equals(timestamps, that.timestamps)
                 && Objects.equals(jobVertexInfos, that.jobVertexInfos)
                 && Objects.equals(jobVerticesPerState, that.jobVerticesPerState)
-                && Objects.equals(jsonPlan, that.jsonPlan)
+                && Objects.equals(plan, that.plan)
                 && Objects.equals(streamGraphJson, that.streamGraphJson)
                 && Objects.equals(pendingOperators, that.pendingOperators);
     }
@@ -224,7 +224,7 @@ public class JobDetailsInfo implements ResponseBody {
                 timestamps,
                 jobVertexInfos,
                 jobVerticesPerState,
-                jsonPlan,
+                plan,
                 streamGraphJson,
                 pendingOperators);
     }
@@ -295,8 +295,8 @@ public class JobDetailsInfo implements ResponseBody {
     }
 
     @JsonIgnore
-    public String getJsonPlan() {
-        return jsonPlan.toString();
+    public JobPlanInfo.Plan getPlan() {
+        return plan;
     }
 
     @JsonIgnore

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/CreatingExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/CreatingExecutionGraph.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.jobgraph.JobType;
 import org.apache.flink.runtime.jobgraph.jsonplan.JsonPlanGenerator;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
+import org.apache.flink.runtime.rest.messages.JobPlanInfo;
 import org.apache.flink.runtime.scheduler.DefaultOperatorCoordinatorHandler;
 import org.apache.flink.runtime.scheduler.ExecutionGraphHandler;
 import org.apache.flink.runtime.scheduler.GlobalFailureHandler;
@@ -123,7 +124,7 @@ public class CreatingExecutionGraph extends StateWithoutExecutionGraph {
                         operatorCoordinatorHandlerFactory.create(executionGraph, context);
                 operatorCoordinatorHandler.initializeOperatorCoordinators(
                         context.getMainThreadExecutor());
-                final String updatedPlan =
+                final JobPlanInfo.Plan updatedPlan =
                         JsonPlanGenerator.generatePlan(
                                 executionGraph.getJobID(),
                                 executionGraph.getJobName(),
@@ -135,7 +136,7 @@ public class CreatingExecutionGraph extends StateWithoutExecutionGraph {
                                                 .map(ExecutionJobVertex::getJobVertex)
                                                 .iterator(),
                                 executionGraphWithVertexParallelism.getVertexParallelism());
-                executionGraph.setJsonPlan(updatedPlan);
+                executionGraph.setPlan(updatedPlan);
 
                 executionGraph.transitionToRunning();
                 operatorCoordinatorHandler.startAllOperatorCoordinators();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchScheduler.java
@@ -64,6 +64,7 @@ import org.apache.flink.runtime.jobgraph.topology.DefaultLogicalTopology;
 import org.apache.flink.runtime.jobgraph.topology.DefaultLogicalVertex;
 import org.apache.flink.runtime.jobmaster.event.ExecutionJobVertexFinishedEvent;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
+import org.apache.flink.runtime.rest.messages.JobPlanInfo;
 import org.apache.flink.runtime.scheduler.DefaultExecutionDeployer;
 import org.apache.flink.runtime.scheduler.DefaultScheduler;
 import org.apache.flink.runtime.scheduler.ExecutionGraphFactory;
@@ -274,7 +275,7 @@ public class AdaptiveBatchScheduler extends DefaultScheduler implements JobGraph
         logicalTopology = DefaultLogicalTopology.fromJobGraph(getJobGraph());
 
         // 4. update json plan
-        getExecutionGraph().setJsonPlan(JsonPlanGenerator.generatePlan(getJobGraph()));
+        getExecutionGraph().setPlan(JsonPlanGenerator.generatePlan(getJobGraph()));
 
         // 5. In broadcast join optimization, results might be written first with a hash
         // method and then read with a broadcast method. Therefore, we need to update the
@@ -837,11 +838,11 @@ public class AdaptiveBatchScheduler extends DefaultScheduler implements JobGraph
         // job vertices
         jobVertex.getJobVertex().setDynamicParallelism(parallelism);
         try {
-            getExecutionGraph().setJsonPlan(JsonPlanGenerator.generatePlan(getJobGraph()));
+            getExecutionGraph().setPlan(JsonPlanGenerator.generatePlan(getJobGraph()));
         } catch (Throwable t) {
-            log.warn("Cannot create JSON plan for job", t);
+            log.warn("Cannot create plan for job", t);
             // give the graph an empty plan
-            getExecutionGraph().setJsonPlan("{}");
+            getExecutionGraph().setPlan(new JobPlanInfo.Plan("", "", "", new ArrayList<>()));
         }
 
         jobVertex.setParallelism(parallelism);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/ExecutionGraphInfoStoreTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/ExecutionGraphInfoStoreTestUtils.java
@@ -121,8 +121,7 @@ public class ExecutionGraphInfoStoreTestUtils {
                     && Objects.equals(
                             thisExecutionGraph.getJobName(), thatExecutionGraph.getJobName())
                     && thisExecutionGraph.getState() == thatExecutionGraph.getState()
-                    && Objects.equals(
-                            thisExecutionGraph.getJsonPlan(), thatExecutionGraph.getJsonPlan())
+                    && Objects.equals(thisExecutionGraph.getPlan(), thatExecutionGraph.getPlan())
                     && Objects.equals(
                             thisExecutionGraph.getAccumulatorsSerialized(),
                             thatExecutionGraph.getAccumulatorsSerialized())

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
@@ -254,7 +254,7 @@ public class ArchivedExecutionGraphTest {
         // -------------------------------------------------------------------------------------------------------------
         // ExecutionGraph
         // -------------------------------------------------------------------------------------------------------------
-        assertThat(runtimeGraph.getJsonPlan()).isEqualTo(archivedGraph.getJsonPlan());
+        assertThat(runtimeGraph.getPlan()).isEqualTo(archivedGraph.getPlan());
         assertThat(runtimeGraph.getJobID()).isEqualTo(archivedGraph.getJobID());
         assertThat(runtimeGraph.getJobName()).isEqualTo(archivedGraph.getJobName());
         assertThat(runtimeGraph.getState()).isEqualTo(archivedGraph.getState());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/utils/ArchivedExecutionGraphBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/utils/ArchivedExecutionGraphBuilder.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.executiongraph.ArchivedExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ErrorInfo;
 import org.apache.flink.runtime.jobgraph.JobType;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.rest.messages.JobPlanInfo;
 import org.apache.flink.util.OptionalFailure;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.SerializedValue;
@@ -51,7 +52,7 @@ public class ArchivedExecutionGraphBuilder {
     private long[] stateTimestamps;
     private JobStatus state;
     private ErrorInfo failureCause;
-    private String jsonPlan;
+    private JobPlanInfo.Plan plan;
     private StringifiedAccumulatorResult[] archivedUserAccumulators;
     private ArchivedExecutionConfig archivedExecutionConfig;
     private boolean isStoppable;
@@ -98,8 +99,8 @@ public class ArchivedExecutionGraphBuilder {
         return this;
     }
 
-    public ArchivedExecutionGraphBuilder setJsonPlan(String jsonPlan) {
-        this.jsonPlan = jsonPlan;
+    public ArchivedExecutionGraphBuilder setPlan(JobPlanInfo.Plan plan) {
+        this.plan = plan;
         return this;
     }
 
@@ -161,13 +162,9 @@ public class ArchivedExecutionGraphBuilder {
                 state != null ? state : JobStatus.FINISHED,
                 JobType.STREAMING,
                 failureCause,
-                jsonPlan != null
-                        ? jsonPlan
-                        : "{\"jobid\":\""
-                                + jobID
-                                + "\", \"name\":\""
-                                + jobName
-                                + "\", \"nodes\":[]}",
+                plan != null
+                        ? plan
+                        : new JobPlanInfo.Plan(jobID.toString(), jobName, "", new ArrayList<>()),
                 archivedUserAccumulators != null
                         ? archivedUserAccumulators
                         : new StringifiedAccumulatorResult[0],

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/JobDetailsInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/JobDetailsInfoTest.java
@@ -50,7 +50,7 @@ class JobDetailsInfoTest extends RestResponseMarshallingTestBase<JobDetailsInfo>
     protected JobDetailsInfo getTestResponseInstance() throws Exception {
         final Random random = new Random();
         final int numJobVertexDetailsInfos = 4;
-        final String jsonPlan = "{\"id\":\"1234\"}";
+        final JobPlanInfo.Plan plan = new JobPlanInfo.Plan("1234", "", "", new ArrayList<>());
 
         final Map<JobStatus, Long> timestamps = new HashMap<>(JobStatus.values().length);
         final Collection<JobDetailsInfo.JobVertexDetailsInfo> jobVertexInfos =
@@ -84,7 +84,7 @@ class JobDetailsInfoTest extends RestResponseMarshallingTestBase<JobDetailsInfo>
                 timestamps,
                 jobVertexInfos,
                 jobVerticesPerState,
-                new JobPlanInfo.RawJson(jsonPlan),
+                plan,
                 null,
                 0);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
@@ -121,7 +121,6 @@ import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.IterableUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.concurrent.FutureUtils;
-import org.apache.flink.util.jackson.JacksonMapperFactory;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -459,12 +458,7 @@ public class AdaptiveSchedulerTest {
         assertThat(executionGraph.getJobVertex(JOB_VERTEX.getID()).getParallelism())
                 .isEqualTo(numAvailableSlots);
 
-        assertThat(
-                        JacksonMapperFactory.createObjectMapper()
-                                .readTree(executionGraph.getJsonPlan())
-                                .get("nodes")
-                                .size())
-                .isOne();
+        assertThat(executionGraph.getPlan().getNodes().size()).isOne();
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/StateTrackingMockExecutionGraph.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/StateTrackingMockExecutionGraph.java
@@ -56,6 +56,7 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.query.KvStateLocationRegistry;
+import org.apache.flink.runtime.rest.messages.JobPlanInfo;
 import org.apache.flink.runtime.scheduler.InternalFailuresListener;
 import org.apache.flink.runtime.scheduler.VertexParallelismStore;
 import org.apache.flink.runtime.scheduler.exceptionhistory.TestingAccessExecution;
@@ -73,6 +74,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -183,8 +185,8 @@ class StateTrackingMockExecutionGraph implements ExecutionGraph {
     }
 
     @Override
-    public String getJsonPlan() {
-        return "";
+    public JobPlanInfo.Plan getPlan() {
+        return new JobPlanInfo.Plan("", "", "", new ArrayList<>());
     }
 
     @Override
@@ -193,7 +195,7 @@ class StateTrackingMockExecutionGraph implements ExecutionGraph {
     }
 
     @Override
-    public void setJsonPlan(String jsonPlan) {}
+    public void setPlan(JobPlanInfo.Plan jsonPlan) {}
 
     @Override
     public JobID getJobID() {

--- a/flink-tests/src/test/java/org/apache/flink/test/scheduling/ReactiveModeITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/scheduling/ReactiveModeITCase.java
@@ -37,9 +37,6 @@ import org.apache.flink.streaming.api.functions.source.legacy.SourceFunction;
 import org.apache.flink.streaming.util.RestartStrategyUtils;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
 import org.apache.flink.util.TestLogger;
-import org.apache.flink.util.jackson.JacksonMapperFactory;
-
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -55,8 +52,6 @@ public class ReactiveModeITCase extends TestLogger {
     private static final int INITIAL_NUMBER_TASK_MANAGERS = 1;
 
     private static final Configuration configuration = getReactiveModeConfiguration();
-
-    private static final ObjectMapper OBJECT_MAPPER = JacksonMapperFactory.createObjectMapper();
 
     @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
 
@@ -140,10 +135,8 @@ public class ReactiveModeITCase extends TestLogger {
                         .get();
 
         assertThat(
-                        OBJECT_MAPPER
-                                .readTree(archivedExecutionGraph.getJsonPlan())
-                                .findValues("parallelism"))
-                .allMatch(n -> n.asInt() == initialParallelism);
+                archivedExecutionGraph.getPlan().getNodes().stream()
+                        .allMatch(n -> n.getParallelism() == (long) initialParallelism));
 
         // scale up to 2 TaskManagers:
         miniClusterResource.getMiniCluster().startTaskManager();
@@ -162,10 +155,8 @@ public class ReactiveModeITCase extends TestLogger {
                         .get();
 
         assertThat(
-                        OBJECT_MAPPER
-                                .readTree(archivedExecutionGraph.getJsonPlan())
-                                .findValues("parallelism"))
-                .allMatch(n -> n.asInt() == rescaledParallelism);
+                archivedExecutionGraph.getPlan().getNodes().stream()
+                        .allMatch(n -> n.getParallelism() == (long) rescaledParallelism));
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

The pr follows refactors done over time to transition rest object classes to use modern auto-serialization instead of implementing their own serializations.
Doing the same for `org.apache.flink.runtime.rest.messages.JobPlanInfo.Plan` improves error handling and makes the restAPI more informative about expected response.

## Brief change log

- `org.apache.flink.runtime.rest.messages.JobPlanInfo.Plan` type refactored to object instead of a string
- References updated as well

## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.
- `org.apache.flink.runtime.jobgraph.jsonplan.JsonGeneratorTest#testGeneratorWithoutAnyAttachements`
- `org.apache.flink.runtime.rest.messages.JobPlanInfoTest#testJsonMarshalling`

### Compatibility
We don't have any compatibility tests in place but there are no visible changes to the API, except nullable fields which are now present on the plan.
#### Manual testing with `examples/streaming/WindowJoin.jar`:
[window-join-example-plan-master.json](https://github.com/user-attachments/files/19621342/window-join-example-plan-master.json)
[window-join-example-plan-FLINK-37511.json](https://github.com/user-attachments/files/19621343/window-join-example-plan-FLINK-37511.json)

<details>
<summary>plan diff</summary>

```diff
--- window-join-example-plan-master.json        2025-04-06 13:35:38.421548136 +0300
+++ window-join-example-plan-FLINK-37511.json   2025-04-06 12:51:17.420334205 +0300
@@ -1,46 +1,52 @@
 {
     "plan": {
-        "jid": "a2206eb0ae1bc8c28e2d8b943df0b37f",
+        "jid": "51dfcbe975a8136fad931fc19c26d419",
         "name": "Windowed Join Example",
         "type": "STREAMING",
         "nodes": [
             {
                 "id": "8b481b930a189b6b1762a9d95a61ada1",
-                "parallelism": 1,
                 "operator": "",
+                "parallelism": 1,
                 "operator_strategy": "",
                 "description": "Window(TumblingEventTimeWindows(2000), EventTimeTrigger, CoGroupWindowFunction)<br/>+- Sink: Print to Std. Out<br/>",
+                "optimizer_properties": "{}",
                 "inputs": [
                     {
-                        "num": 0,
                         "id": "cbc357ccb763df2852fee8c4fc7d55f2",
+                        "num": 0,
+                        "exchange": "pipelined_bounded",
                         "ship_strategy": "HASH",
-                        "exchange": "pipelined_bounded"
+                        "local_strategy": null,
+                        "caching": null
                     },
                     {
-                        "num": 1,
                         "id": "6cdc5bb954874d922eaee11a8e7b5dd5",
+                        "num": 1,
+                        "exchange": "pipelined_bounded",
                         "ship_strategy": "HASH",
-                        "exchange": "pipelined_bounded"
+                        "local_strategy": null,
+                        "caching": null
                     }
-                ],
-                "optimizer_properties": {}
+                ]
             },
             {
                 "id": "cbc357ccb763df2852fee8c4fc7d55f2",
-                "parallelism": 1,
                 "operator": "",
+                "parallelism": 1,
                 "operator_strategy": "",
                 "description": "Source: Grades Data Generator<br/>+- Map<br/>",
-                "optimizer_properties": {}
+                "optimizer_properties": "{}",
+                "inputs": []
             },
             {
                 "id": "6cdc5bb954874d922eaee11a8e7b5dd5",
-                "parallelism": 1,
                 "operator": "",
+                "parallelism": 1,
                 "operator_strategy": "",
                 "description": "Source: Grades Data Generator<br/>+- Map<br/>",
-                "optimizer_properties": {}
+                "optimizer_properties": "{}",
+                "inputs": []
             }
         ]
     }
```

</details>


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: Not sure which serializers we are talking about here
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

## Open questions / follow ups
To be able to completely get rid of `org.apache.flink.runtime.rest.messages.JobPlanInfo.RawJson#RawJson` I would need to refactor [StreamGraphs](https://github.com/apache/flink/blob/master/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/jsonplan/JsonPlanGenerator.java#L178) as well - Should probably separate it to a follow up PR to reduce blast radius? cc @zentol 