### PR TITLE
[FLINK-37512] Fix the OOM for SlidingEventTimeWindows

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/windowing/assigners/SlidingEventTimeWindows.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/windowing/assigners/SlidingEventTimeWindows.java
@@ -59,6 +59,11 @@ public class SlidingEventTimeWindows extends WindowAssigner<Object, TimeWindow> 
                     "SlidingEventTimeWindows parameters must satisfy "
                             + "abs(offset) < slide and size > 0");
         }
+        if (size / slide > 10000000) {
+            throw new IllegalArgumentException(
+                    "SlidingEventTimeWindows parameters must satisfy "
+                            + "size / slide <= 10000000");
+        }
 
         this.size = size;
         this.slide = slide;

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/SlidingEventTimeWindowsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/SlidingEventTimeWindowsTest.java
@@ -215,6 +215,13 @@ class SlidingEventTimeWindowsTest {
                                         Duration.ofSeconds(11)))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("abs(offset) < slide and size > 0");
+
+        assertThatThrownBy(
+                        () ->
+                                SlidingEventTimeWindows.of(
+                                        Duration.ofMillis(10000001), Duration.ofMillis(1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("size / slide <= 10000000");
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

This PR aim to fix the OOM for `SlidingEventTimeWindows`.
`SlidingEventTimeWindows` has potential OOM risks if the window size is big and the slide is small. The OOM issue show below.
```
Caused by: java.util.concurrent.ExecutionException: java.lang.OutOfMemoryError
	at java.base/java.util.concurrent.ForkJoinTask.reportExecutionException(ForkJoinTask.java:605)
	at java.base/java.util.concurrent.ForkJoinTask.get(ForkJoinTask.java:981)
Caused by: java.lang.OutOfMemoryError
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:480)
	at java.base/java.util.concurrent.ForkJoinTask.getThrowableException(ForkJoinTask.java:564)
	at java.base/java.util.concurrent.ForkJoinTask.reportExecutionException(ForkJoinTask.java:604)
	... 1 more
Caused by: java.lang.OutOfMemoryError: Requested array size exceeds VM limit
	at java.base/java.util.ArrayList.<init>(ArrayList.java:156)
	at org.apache.flink.streaming.api.windowing.assigners.SlidingEventTimeWindows.assignWindows(SlidingEventTimeWindows.java:72)
	at org.apache.flink.streaming.runtime.operators.windowing.SlidingEventTimeWindowsTest.testWindowAssignment2(SlidingEventTimeWindowsTest.java:79)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
```



## Brief change log

Fix the OOM for `SlidingEventTimeWindows`.


## Verifying this change

This change added tests and can be verified as follows:

  - *Added test that validates that `IllegalArgumentException`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
