### PR TITLE
[hotfix] Correct the comments for FlinkSecurityManager

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/security/FlinkSecurityManager.java
+++ b/flink-core/src/main/java/org/apache/flink/core/security/FlinkSecurityManager.java
@@ -89,8 +89,8 @@ public class FlinkSecurityManager extends SecurityManager {
 
         boolean haltOnSystemExit = configuration.get(ClusterOptions.HALT_ON_FATAL_ERROR);
 
-        // If no check is needed, return null so that caller can avoid setting security manager not
-        // to incur any runtime cost.
+        // If no check is needed, return null so that caller can avoid setting security manager and
+        // avoid any runtime overhead.
         if (userSystemExitMode == ClusterOptions.UserSystemExitMode.DISABLED && !haltOnSystemExit) {
             return null;
         }


### PR DESCRIPTION
## What is the purpose of the change

This PR aim to correct the comments for `FlinkSecurityManager`.
The original comments means cannot avoid the overhead. It is wrong.


## Brief change log

Correct the comments for `FlinkSecurityManager`


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
