### PR TITLE
[FLINK-37522][docs] Add description for the config about file system connection limit

### DIFF
--- a/docs/content.zh/docs/deployment/filesystems/common.md
+++ b/docs/content.zh/docs/deployment/filesystems/common.md
@@ -50,9 +50,9 @@ fs.default-scheme: <default-fs>
 要限制文件系统的连接数，可将下列配置添加至 Flink 配置中。设置限制的文件系统由其 scheme 指定：
 
 ```yaml
-fs.<scheme>.limit.total: (数量，0/-1 表示无限制)
-fs.<scheme>.limit.input: (数量，0/-1 表示无限制)
-fs.<scheme>.limit.output: (数量，0/-1 表示无限制)
+fs.<scheme>.limit.total: (数量，0/-1 表示无连接限制)
+fs.<scheme>.limit.input: (数量，0/-1 表示无输入连接限制)
+fs.<scheme>.limit.output: (数量，0/-1 表示无输出连接限制)
 fs.<scheme>.limit.timeout: (毫秒，0 表示无穷)
 fs.<scheme>.limit.stream-timeout: (毫秒，0 表示无穷)
 ```

--- a/docs/content/docs/deployment/filesystems/common.md
+++ b/docs/content/docs/deployment/filesystems/common.md
@@ -52,9 +52,9 @@ To limit a specific file system's connections, add the following entries to the 
 its scheme.
 
 ```yaml
-fs.<scheme>.limit.total: (number, 0/-1 mean no limit)
-fs.<scheme>.limit.input: (number, 0/-1 mean no limit)
-fs.<scheme>.limit.output: (number, 0/-1 mean no limit)
+fs.<scheme>.limit.total: (number, 0/-1 means there is no connection limit)
+fs.<scheme>.limit.input: (number, 0/-1 means there is no input connection limit)
+fs.<scheme>.limit.output: (number, 0/-1 means there is no output connection limit)
 fs.<scheme>.limit.timeout: (milliseconds, 0 means infinite)
 fs.<scheme>.limit.stream-timeout: (milliseconds, 0 means infinite)
 ```

--- a/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
@@ -527,7 +527,13 @@ public class CoreOptions {
      * open. Unlimited be default.
      */
     public static ConfigOption<Integer> fileSystemConnectionLimit(String scheme) {
-        return ConfigOptions.key("fs." + scheme + ".limit.total").intType().defaultValue(-1);
+        return ConfigOptions.key("fs." + scheme + ".limit.total")
+                .intType()
+                .defaultValue(-1)
+                .withDescription(
+                        "The connection limit for the file system "
+                                + scheme
+                                + ". The valid value must >= -1. Values of -1 or 0 means there is no connection limit.");
     }
 
     /**
@@ -535,7 +541,13 @@ public class CoreOptions {
      * Unlimited be default.
      */
     public static ConfigOption<Integer> fileSystemConnectionLimitIn(String scheme) {
-        return ConfigOptions.key("fs." + scheme + ".limit.input").intType().defaultValue(-1);
+        return ConfigOptions.key("fs." + scheme + ".limit.input")
+                .intType()
+                .defaultValue(-1)
+                .withDescription(
+                        "Input connection limit for the file system "
+                                + scheme
+                                + ". The valid value must >= -1. Values of -1 or 0 means there is no input connection limit.");
     }
 
     /**
@@ -543,7 +555,13 @@ public class CoreOptions {
      * Unlimited be default.
      */
     public static ConfigOption<Integer> fileSystemConnectionLimitOut(String scheme) {
-        return ConfigOptions.key("fs." + scheme + ".limit.output").intType().defaultValue(-1);
+        return ConfigOptions.key("fs." + scheme + ".limit.output")
+                .intType()
+                .defaultValue(-1)
+                .withDescription(
+                        "Output connection limit for the file system "
+                                + scheme
+                                + ". The valid value must >= -1. Values of -1 or 0 means there is no output connection limit.");
     }
 
     /**


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to add description for the config about file system connection limit.
These descriptions refer to
https://github.com/apache/flink/blob/1d447895760308bc3ef45d5beddb8b0bb6090101/flink-core/src/main/java/org/apache/flink/core/fs/LimitedConnectionsFileSystem.java#L1053


## Brief change log

Add description for the config about file system connection limit


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
