### PR TITLE
[FLINK-37525] Introduce a overload findModuleFactory to improve the performance of installModules

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/NoMatchSecurityFactoryException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/NoMatchSecurityFactoryException.java
@@ -19,26 +19,29 @@
 package org.apache.flink.runtime.security;
 
 import java.util.List;
+import java.util.Set;
 
 /** Exception for not finding suitable security factories. */
 public class NoMatchSecurityFactoryException extends RuntimeException {
+
+    private Set<String> missingFactoryClasses;
 
     /**
      * Exception for not finding suitable security factories.
      *
      * @param message message that indicates the current matching step
-     * @param factoryClassCanonicalName required factory class
+     * @param factoryClassCanonicalNames required factory classes
      * @param matchingFactories all found factories
      * @param cause the cause
      */
     public NoMatchSecurityFactoryException(
             String message,
-            String factoryClassCanonicalName,
+            String factoryClassCanonicalNames,
             List<?> matchingFactories,
             Throwable cause) {
         super(
                 "Could not find a suitable security factory for '"
-                        + factoryClassCanonicalName
+                        + factoryClassCanonicalNames
                         + "' in the classpath. all matching factories: "
                         + matchingFactories
                         + ". Reason: "
@@ -50,11 +53,16 @@ public class NoMatchSecurityFactoryException extends RuntimeException {
      * Exception for not finding suitable security factories.
      *
      * @param message message that indicates the current matching step
-     * @param factoryClassCanonicalName required factory class
+     * @param factoryClassCanonicalNames required factory classes
      * @param matchingFactories all found factories
      */
     public NoMatchSecurityFactoryException(
-            String message, String factoryClassCanonicalName, List<?> matchingFactories) {
-        this(message, factoryClassCanonicalName, matchingFactories, null);
+            String message, Set<String> factoryClassCanonicalNames, List<?> matchingFactories) {
+        this(message, String.join(",", factoryClassCanonicalNames), matchingFactories, null);
+        this.missingFactoryClasses = factoryClassCanonicalNames;
+    }
+
+    public Set<String> getMissingFactoryClasses() {
+        return missingFactoryClasses;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/SecurityUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/SecurityUtils.java
@@ -62,14 +62,17 @@ public class SecurityUtils {
 
         // install the security module factories
         List<SecurityModule> modules = new ArrayList<>();
-        for (String moduleFactoryClass : config.getSecurityModuleFactories()) {
-            SecurityModuleFactory moduleFactory = null;
-            try {
-                moduleFactory = SecurityFactoryServiceLoader.findModuleFactory(moduleFactoryClass);
-            } catch (NoMatchSecurityFactoryException ne) {
-                LOG.error("Unable to instantiate security module factory {}", moduleFactoryClass);
-                throw new IllegalArgumentException("Unable to find module factory class", ne);
-            }
+        List<String> moduleFactoryClasses = config.getSecurityModuleFactories();
+        List<SecurityModuleFactory> moduleFactories = null;
+        try {
+            moduleFactories = SecurityFactoryServiceLoader.findModuleFactory(moduleFactoryClasses);
+        } catch (NoMatchSecurityFactoryException ne) {
+            LOG.error(
+                    "Unable to instantiate security module factories {}",
+                    String.join(",", ne.getMissingFactoryClasses()));
+            throw new IllegalArgumentException("Unable to find module factory classes", ne);
+        }
+        for (SecurityModuleFactory moduleFactory : moduleFactories) {
             SecurityModule module = moduleFactory.createModule(config);
             // can be null if a SecurityModule is not supported in the current environment
             if (module != null) {

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestingSecurityContext.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestingSecurityContext.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.security.modules.SecurityModuleFactory;
 
 import javax.security.auth.login.AppConfigurationEntry;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -46,10 +47,11 @@ public class TestingSecurityContext {
         SecurityUtils.install(config);
 
         // install dynamic JAAS entries
-        for (String factoryClassName : config.getSecurityModuleFactories()) {
-            SecurityModuleFactory factory =
-                    SecurityFactoryServiceLoader.findModuleFactory(factoryClassName);
-            if (factory instanceof JaasModuleFactory) {
+        List<String> moduleFactoryClasses = config.getSecurityModuleFactories();
+        List<SecurityModuleFactory> moduleFactories =
+                SecurityFactoryServiceLoader.findModuleFactory(moduleFactoryClasses);
+        for (SecurityModuleFactory moduleFactory : moduleFactories) {
+            if (moduleFactory instanceof JaasModuleFactory) {
                 DynamicConfiguration jaasConf =
                         (DynamicConfiguration)
                                 javax.security.auth.login.Configuration.getConfiguration();


### PR DESCRIPTION
## What is the purpose of the change

This PR aim to improve the performance of `installModules` by introduce an overload `findModuleFactory`.

Currently, the implementation of `installModules` has the logic show below.

```
for (String moduleFactoryClass : config.getSecurityModuleFactories()) {
    ...
    moduleFactory = SecurityFactoryServiceLoader.findModuleFactory(moduleFactoryClass);
    ...
}
```

The implementation of `findModuleFactory` show below.

```
    public static SecurityModuleFactory findModuleFactory(String securityModuleFactoryClass)
            throws NoMatchSecurityFactoryException {
        return findFactoryInternal(
                securityModuleFactoryClass,
                SecurityModuleFactory.class,
                SecurityModuleFactory.class.getClassLoader());
    }
```

You can see no matter what the `securityModuleFactoryClass` is, the `SecurityModuleFactory.class` and `SecurityModuleFactory.class.getClassLoader()` are certain.

The implementation of `findFactoryInternal` show below.

```
    private static <T> T findFactoryInternal(
            String factoryClassCanonicalName, Class<T> factoryClass, ClassLoader classLoader)
            throws NoMatchSecurityFactoryException {

        Preconditions.checkNotNull(factoryClassCanonicalName);

        ServiceLoader<T> serviceLoader;
        if (classLoader != null) {
            serviceLoader = ServiceLoader.load(factoryClass, classLoader);
        } else {
            serviceLoader = ServiceLoader.load(factoryClass);
        }

        List<T> matchingFactories = new ArrayList<>();
        Iterator<T> classFactoryIterator = serviceLoader.iterator();
        classFactoryIterator.forEachRemaining(
                classFactory -> {
                    if (factoryClassCanonicalName.matches(
                            classFactory.getClass().getCanonicalName())) {
                        matchingFactories.add(classFactory);
                    }
                });

        if (matchingFactories.size() != 1) {
            throw new NoMatchSecurityFactoryException(
                    "zero or more than one security factory found",
                    factoryClassCanonicalName,
                    matchingFactories);
        }
        return matchingFactories.get(0);
    }
```

You can see `findFactoryInternal` load `ServiceLoader` and match the `classFactory`.
These code lead to repeatedly loading `ServiceLoader` and match the `classFactory`.

## Brief change log

Introduce a overload `findModuleFactory` to improve the performance of `installModules`


## Verifying this change

This change is already covered by existing tests, such as *(`TestingSecurityContext`)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
