### PR TITLE
[hotfix] change bytesReceivedPerInterface to AtomicLongArray for  thread safety

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/SystemResourcesCounter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/SystemResourcesCounter.java
@@ -54,8 +54,8 @@ public class SystemResourcesCounter extends Thread {
 
     private long[] previousCpuTicks;
     private long[][] previousProcCpuTicks;
-    private long[] bytesReceivedPerInterface;
-    private AtomicLongArray bytesSentPerInterface;
+    private AtomicLongArray bytesReceivedPerInterface;
+    private long[] bytesSentPerInterface;
 
     private volatile double cpuUser;
     private volatile double cpuNice;
@@ -89,8 +89,8 @@ public class SystemResourcesCounter extends Thread {
                         hardwareAbstractionLayer.getProcessor().getLogicalProcessorCount());
 
         List<NetworkIF> networkIFs = hardwareAbstractionLayer.getNetworkIFs();
-        bytesReceivedPerInterface = new long[networkIFs.size()];
-        bytesSentPerInterface = new AtomicLongArray(networkIFs.size());
+        bytesReceivedPerInterface = new AtomicLongArray(networkIFs.size());
+        bytesSentPerInterface = new long[networkIFs.size()];
         receiveRatePerInterface = new AtomicLongArray(networkIFs.size());
         sendRatePerInterface = new AtomicLongArray(networkIFs.size());
         networkInterfaceNames = new String[networkIFs.size()];
@@ -269,15 +269,15 @@ public class SystemResourcesCounter extends Thread {
 
             receiveRatePerInterface.set(
                     i,
-                    (networkIF.getBytesRecv() - bytesReceivedPerInterface[i])
+                    (networkIF.getBytesRecv() - bytesReceivedPerInterface.get(i))
                             * 1000
                             / probeIntervalMs);
             sendRatePerInterface.set(
                     i,
-                    (networkIF.getBytesSent() - bytesSentPerInterface.get(i)) * 1000 / probeIntervalMs);
+                    (networkIF.getBytesSent() - bytesSentPerInterface[i]) * 1000 / probeIntervalMs);
 
-            bytesReceivedPerInterface[i] = networkIF.getBytesRecv();
-            bytesSentPerInterface.get(i) = networkIF.getBytesSent();
+            bytesReceivedPerInterface.set(i, networkIF.getBytesRecv());
+            bytesSentPerInterface[i] = networkIF.getBytesSent();
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/SystemResourcesCounter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/SystemResourcesCounter.java
@@ -55,7 +55,7 @@ public class SystemResourcesCounter extends Thread {
     private long[] previousCpuTicks;
     private long[][] previousProcCpuTicks;
     private long[] bytesReceivedPerInterface;
-    private long[] bytesSentPerInterface;
+    private AtomicLongArray bytesSentPerInterface;
 
     private volatile double cpuUser;
     private volatile double cpuNice;
@@ -90,7 +90,7 @@ public class SystemResourcesCounter extends Thread {
 
         List<NetworkIF> networkIFs = hardwareAbstractionLayer.getNetworkIFs();
         bytesReceivedPerInterface = new long[networkIFs.size()];
-        bytesSentPerInterface = new long[networkIFs.size()];
+        bytesSentPerInterface = new AtomicLongArray(networkIFs.size());
         receiveRatePerInterface = new AtomicLongArray(networkIFs.size());
         sendRatePerInterface = new AtomicLongArray(networkIFs.size());
         networkInterfaceNames = new String[networkIFs.size()];
@@ -274,10 +274,10 @@ public class SystemResourcesCounter extends Thread {
                             / probeIntervalMs);
             sendRatePerInterface.set(
                     i,
-                    (networkIF.getBytesSent() - bytesSentPerInterface[i]) * 1000 / probeIntervalMs);
+                    (networkIF.getBytesSent() - bytesSentPerInterface.get(i)) * 1000 / probeIntervalMs);
 
             bytesReceivedPerInterface[i] = networkIF.getBytesRecv();
-            bytesSentPerInterface[i] = networkIF.getBytesSent();
+            bytesSentPerInterface.get(i) = networkIF.getBytesSent();
         }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change
This pull request improves thread safety in the SystemResourcesCounter class by replacing the bytesReceivedPerInterface array with an AtomicLongArray.

Previously, bytesReceivedPerInterface was a plain long array, meaning concurrent updates from multiple threads could lead to data inconsistencies or race conditions. By using AtomicLongArray, we ensure that updates are performed atomically, preventing potential visibility and synchronization issues.

## Brief change log

- Replaced long[] bytesReceivedPerInterface with AtomicLongArray bytesReceivedPerInterface for improved thread safety.
- Updated the initialization of bytesReceivedPerInterface to use AtomicLongArray.
- Replaced direct array assignments with atomic set() and get() calls.

## Verifying this change
This change is a trivial rework/code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts?

- Dependencies (does it add or upgrade a dependency)? No
- The public API (i.e., is any changed class annotated with @Public(Evolving))? No
- The serializers? No
- The runtime per-record code paths (performance sensitive)? Potentially, as it changes how network usage data is stored and updated.
- Anything that affects deployment or recovery (JobManager, Checkpointing, Kubernetes/Yarn, ZooKeeper)? No
- The S3 file system connector? No

## Documentation

- Does this pull request introduce a new feature? No
- If yes, how is the feature documented? Not applicable