### PR TITLE
[FLINK-37531] Respect the design of chain programming for RpcServiceBuilder

### DIFF
--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/pekko/PekkoRpcServiceUtils.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/pekko/PekkoRpcServiceUtils.java
@@ -78,13 +78,9 @@ public class PekkoRpcServiceUtils {
             throws Exception {
         final PekkoRpcServiceBuilder rpcServiceBuilder =
                 PekkoRpcServiceUtils.remoteServiceBuilder(
-                        configuration, externalAddress, externalPortRange);
-
-        if (bindAddress != null) {
-            rpcServiceBuilder.withBindAddress(bindAddress);
-        }
-
-        bindPort.ifPresent(rpcServiceBuilder::withBindPort);
+                                configuration, externalAddress, externalPortRange)
+                        .withBindAddress(bindAddress)
+                        .withBindPort(bindPort);
 
         return rpcServiceBuilder.createAndStart();
     }
@@ -294,15 +290,20 @@ public class PekkoRpcServiceUtils {
 
         @Override
         public PekkoRpcServiceBuilder withBindAddress(final String bindAddress) {
-            this.bindAddress = Preconditions.checkNotNull(bindAddress);
+            if (bindAddress != null) {
+                this.bindAddress = bindAddress;
+            }
             return this;
         }
 
         @Override
-        public PekkoRpcServiceBuilder withBindPort(int bindPort) {
-            Preconditions.checkArgument(
-                    NetUtils.isValidHostPort(bindPort), "Invalid port number: " + bindPort);
-            this.bindPort = bindPort;
+        public PekkoRpcServiceBuilder withBindPort(Optional<Integer> bindPort) {
+            if (bindPort.isPresent()) {
+                Preconditions.checkArgument(
+                        NetUtils.isValidHostPort(bindPort.get()),
+                        "Invalid port number: " + bindPort);
+                this.bindPort = bindPort.get();
+            }
             return this;
         }
 

--- a/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/RpcSystem.java
+++ b/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/RpcSystem.java
@@ -25,6 +25,7 @@ import javax.annotation.Nullable;
 
 import java.util.Comparator;
 import java.util.Iterator;
+import java.util.Optional;
 import java.util.PriorityQueue;
 import java.util.ServiceLoader;
 
@@ -66,7 +67,7 @@ public interface RpcSystem extends RpcSystemUtils, AutoCloseable {
 
         RpcServiceBuilder withBindAddress(String bindAddress);
 
-        RpcServiceBuilder withBindPort(int bindPort);
+        RpcServiceBuilder withBindPort(Optional<Integer> bindPort);
 
         RpcServiceBuilder withExecutorConfiguration(
                 FixedThreadPoolExecutorConfiguration executorConfiguration);

--- a/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/RpcUtils.java
+++ b/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/RpcUtils.java
@@ -147,15 +147,11 @@ public class RpcUtils {
             @Nullable String bindAddress,
             @SuppressWarnings("OptionalUsedAsFieldOrParameterType") Optional<Integer> bindPort)
             throws Exception {
-        RpcSystem.RpcServiceBuilder rpcServiceBuilder =
-                rpcSystem.remoteServiceBuilder(configuration, externalAddress, externalPortRange);
-        if (bindAddress != null) {
-            rpcServiceBuilder = rpcServiceBuilder.withBindAddress(bindAddress);
-        }
-        if (bindPort.isPresent()) {
-            rpcServiceBuilder = rpcServiceBuilder.withBindPort(bindPort.get());
-        }
-        return rpcServiceBuilder.createAndStart();
+        return rpcSystem
+                .remoteServiceBuilder(configuration, externalAddress, externalPortRange)
+                .withBindAddress(bindAddress)
+                .withBindPort(bindPort)
+                .createAndStart();
     }
 
     // We don't want this class to be instantiable

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/MetricUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/MetricUtils.java
@@ -194,27 +194,21 @@ public class MetricUtils {
             RpcSystem rpcSystem)
             throws Exception {
         final String portRange = configuration.get(MetricOptions.QUERY_SERVICE_PORT);
-
-        final RpcSystem.RpcServiceBuilder rpcServiceBuilder =
-                rpcSystem.remoteServiceBuilder(configuration, externalAddress, portRange);
-        if (bindAddress != null) {
-            rpcServiceBuilder.withBindAddress(bindAddress);
-        }
-
-        return startMetricRpcService(configuration, rpcServiceBuilder);
+        final int threadPriority = configuration.get(MetricOptions.QUERY_SERVICE_THREAD_PRIORITY);
+        return rpcSystem
+                .remoteServiceBuilder(configuration, externalAddress, portRange)
+                .withBindAddress(bindAddress)
+                .withComponentName(METRICS_ACTOR_SYSTEM_NAME)
+                .withExecutorConfiguration(
+                        new RpcSystem.FixedThreadPoolExecutorConfiguration(1, 1, threadPriority))
+                .createAndStart();
     }
 
     public static RpcService startLocalMetricsRpcService(
             Configuration configuration, RpcSystem rpcSystem) throws Exception {
-        return startMetricRpcService(configuration, rpcSystem.localServiceBuilder(configuration));
-    }
-
-    private static RpcService startMetricRpcService(
-            Configuration configuration, RpcSystem.RpcServiceBuilder rpcServiceBuilder)
-            throws Exception {
         final int threadPriority = configuration.get(MetricOptions.QUERY_SERVICE_THREAD_PRIORITY);
-
-        return rpcServiceBuilder
+        return rpcSystem
+                .localServiceBuilder(configuration)
                 .withComponentName(METRICS_ACTOR_SYSTEM_NAME)
                 .withExecutorConfiguration(
                         new RpcSystem.FixedThreadPoolExecutorConfiguration(1, 1, threadPriority))

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -1206,7 +1206,7 @@ public class MiniCluster implements AutoCloseableAsync {
         return rpcSystem
                 .remoteServiceBuilder(configuration, bindAddress, String.valueOf(bindPort))
                 .withBindAddress(bindAddress)
-                .withBindPort(bindPort)
+                .withBindPort(Optional.of(bindPort))
                 .withExecutorConfiguration(RpcUtils.getTestForkJoinExecutorConfiguration())
                 .createAndStart();
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcConnectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcConnectionTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -48,7 +49,7 @@ class RpcConnectionTest {
                     rpcSystem
                             .remoteServiceBuilder(configuration, null, "8000-9000")
                             .withBindAddress("localhost")
-                            .withBindPort(0)
+                            .withBindPort(Optional.of(0))
                             .createAndStart();
 
             final String invalidAddress =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcSSLAuthITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcSSLAuthITCase.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -89,13 +90,13 @@ class RpcSSLAuthITCase {
                     RpcSystem.load()
                             .localServiceBuilder(sslConfig1)
                             .withBindAddress("localhost")
-                            .withBindPort(0)
+                            .withBindPort(Optional.of(0))
                             .createAndStart();
             rpcService2 =
                     RpcSystem.load()
                             .localServiceBuilder(sslConfig2)
                             .withBindAddress("localhost")
-                            .withBindPort(0)
+                            .withBindPort(Optional.of(0))
                             .createAndStart();
 
             TestEndpoint endpoint = new TestEndpoint(rpcService1);

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/IPv6HostnamesITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/IPv6HostnamesITCase.java
@@ -50,6 +50,7 @@ import java.net.NetworkInterface;
 import java.net.ServerSocket;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.Assert.fail;
 
@@ -165,7 +166,7 @@ public class IPv6HostnamesITCase extends TestLogger {
                                             // conflicts) since we explicitly provide a bind port
                                             .remoteServiceBuilder(new Configuration(), null, "8081")
                                             .withBindAddress(addr.getHostAddress())
-                                            .withBindPort(0)
+                                            .withBindPort(Optional.of(0))
                                             .createAndStart();
                             rpcService.closeAsync().get();
 


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to respect the design of chain programming for `RpcServiceBuilder`.
According to the design of `RpcServiceBuilder`, the implementation should follow the style of chain programming.
But `PekkoRpcServiceBuilder` doesn't follow this design and lead to the caller's code appears scattered.


## Brief change log

Respect the design of chain programming for `RpcServiceBuilder`.


## Verifying this change

This change is already covered by existing tests, such as *(RpcConnectionTest, RpcSSLAuthITCase, IPv6HostnamesITCase)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
