### PR TITLE
[FLINK-36443][table][test] Improve flaky table source sink tests

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/PartitionPushDownSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/PartitionPushDownSpec.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.planner.plan.abilities.source;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.abilities.SupportsPartitionPushDown;
+import org.apache.flink.table.planner.utils.PartitionUtils;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
@@ -30,7 +31,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -74,9 +74,7 @@ public final class PartitionPushDownSpec extends SourceAbilitySpecBase {
 
     @Override
     public String getDigests(SourceAbilityContext context) {
-        return "partitions=["
-                + this.partitions.stream().map(Object::toString).collect(Collectors.joining(", "))
-                + "]";
+        return "partitions=[" + PartitionUtils.sortPartitionsByKey(this.partitions) + "]";
     }
 
     @Override

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/PartitionUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/PartitionUtils.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.utils;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/** Helper functions for partitions. */
+public class PartitionUtils {
+
+    private PartitionUtils() {}
+
+    /**
+     * Returns partitions sorted by key.
+     *
+     * @param partitions list of partition key value pairs
+     * @return sorted partitions
+     */
+    public static String sortPartitionsByKey(final List<Map<String, String>> partitions) {
+        return partitions.stream()
+                .map(PartitionUtils::sortPartitionByKey)
+                .collect(Collectors.joining(", "));
+    }
+
+    private static String sortPartitionByKey(final Map<String, String> partition) {
+        return partition.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(entry -> entry.getKey() + "=" + entry.getValue())
+                .collect(Collectors.joining(", ", "{", "}"));
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/abilities/source/PartitionPushDownSpecTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/abilities/source/PartitionPushDownSpecTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.abilities.source;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PartitionPushDownSpecTest {
+
+    private List<Map<String, String>> partitions;
+
+    @BeforeEach
+    void beforeEach() {
+        partitions =
+                List.of(
+                        Map.of("part2", "A", "part1", "B", "part3", "C"),
+                        Map.of("part1", "C", "part2", "D"));
+    }
+
+    @Test
+    void testDigestsEmpty() {
+        PartitionPushDownSpec spec = new PartitionPushDownSpec(Collections.emptyList());
+        assertThat(spec.getDigests(null)).isEqualTo("partitions=[]");
+    }
+
+    @Test
+    void testDigestsSorted() {
+        PartitionPushDownSpec spec = new PartitionPushDownSpec(partitions);
+        assertThat(spec.getDigests(null))
+                .isEqualTo("partitions=[{part1=B, part2=A, part3=C}, {part1=C, part2=D}]");
+    }
+}

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/testTableSourceSinks.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/testTableSourceSinks.scala
@@ -329,19 +329,10 @@ class TestPartitionableTableSource(
 
   override def explainSource(): String = {
     if (remainingPartitions != null) {
-      s"partitions=${sortPartitionKeys(remainingPartitions).mkString(", ")}"
+      s"partitions=${PartitionUtils.sortPartitionsByKey(remainingPartitions)}"
     } else {
       ""
     }
-  }
-
-  private def sortPartitionKeys(partitions: JList[JMap[String, String]]): JList[String] = {
-    partitions
-      .map(_.toSeq.sortBy(_._1))
-      .map(
-        seq => {
-          seq.map { case (k, v) => s"$k=$v" }.mkString("{", ", ", "}")
-        })
   }
 
   override def getReturnType: TypeInformation[Row] = returnType

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/testTableSourceSinks.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/testTableSourceSinks.scala
@@ -329,10 +329,19 @@ class TestPartitionableTableSource(
 
   override def explainSource(): String = {
     if (remainingPartitions != null) {
-      s"partitions=${remainingPartitions.mkString(", ")}"
+      s"partitions=${sortPartitionKeys(remainingPartitions).mkString(", ")}"
     } else {
       ""
     }
+  }
+
+  private def sortPartitionKeys(partitions: JList[JMap[String, String]]): JList[String] = {
+    partitions
+      .map(_.toSeq.sortBy(_._1))
+      .map(
+        seq => {
+          seq.map { case (k, v) => s"$k=$v" }.mkString("{", ", ", "}")
+        })
   }
 
   override def getReturnType: TypeInformation[Row] = returnType


### PR DESCRIPTION

## What is the purpose of the change

Improves flaky tests for partitionable table source in the tests that is compared using the explain plan.


## Brief change log

- Sort the partitions map pairs on the keys so that explained plan have them in sorted order (e.g, `part1`, `part2`)


## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no
