### PR TITLE
[FLINK-37533][CI] Reduce the stale PR github action timeouts

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,14 +19,13 @@
 name: Stale PRs
 on:
   schedule:
-    #- cron: '15 6 * * *' # Run once a day at 6:15 UTC
-    - cron: '0 */6 * * *' # Initially we run every 6 hours until we have reached steady state
+    - cron: '15 6 * * *' # Run once a day at 6:15 UTC
   workflow_dispatch:
     inputs:
       operationsPerRun:
         description: 'Max GitHub API operations'
         required: true
-        default: 200 # Initially we set this at a high level to clear the backlog
+        default: 20
         type: number
 
 permissions:
@@ -41,11 +40,11 @@ jobs:
         with:
           operations-per-run: ${{ inputs.operationsPerRun || 500 }}
           ascending: true
-          days-before-stale: 180 # This should eventually be reduced to 90
-          days-before-close: 90  # This should eventually be reduced to 30
+          days-before-stale: 90
+          days-before-close: 30
           stale-pr-label: 'stale'
           stale-pr-message: |
-            This PR is being marked as stale since it has not had any activity in the last 180 days. 
+            This PR is being marked as stale since it has not had any activity in the last 90 days. 
             If you would like to keep this PR alive, please leave a comment asking for a review. 
             If the PR has merge conflicts, update it with the latest from the base branch.
 
@@ -53,9 +52,9 @@ jobs:
             community, contact details can be found here: https://flink.apache.org/what-is-flink/community/
 
             If this PR is no longer valid or desired, please feel free to close it. 
-            If no activity occurs in the next 90 days, it will be automatically closed.
+            If no activity occurs in the next 30 days, it will be automatically closed.
           close-pr-label: 'closed-stale'
           close-pr-message: |
-            This PR has been closed since it has not had any activity in 270 days. 
+            This PR has been closed since it has not had any activity in 120 days. 
             If you feel like this was a mistake, or you would like to continue working on it, 
             please feel free to re-open the PR and ask for a review.


### PR DESCRIPTION
[FLINK-37026](https://issues.apache.org/jira/browse/FLINK-37026) enabled the Stale PR GitHub Action and this has been running successfully for several months, [labelling PRs older than 6 months as "stale"](https://github.com/apache/flink/labels/stale).

The initial time-outs for the Stale PR action were 6 months inactive with 3 further months of no action before closing. This was done to give time for PR authors to react to the new action. However, during the [discussion](https://lists.apache.org/thread/6yoclzmvymxors8vlpt4nn9r7t3stcsz) it was suggested that 3 months inactive with 1 month to respond was the typical configuration used on other Apache projects and should also be used for Flink. It was decided to start with longer time-outs and move to the standard ones once the stability of the action was confirmed.

Now that the action has been running for some time with no issues, we should reduce the time-outs to the proposed Apache standard configuration (90 days inactive with 30 to respond). This will allow us to start clearing the oldest stale PRs.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
