### PR TITLE
[hotfix] Rename VoidBlobStore to NoOperationBlobStore

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
@@ -85,7 +85,7 @@ public class BlobUtils {
         if (HighAvailabilityMode.isHighAvailabilityModeActivated(config)) {
             return createFileSystemBlobStore(config);
         } else {
-            return new VoidBlobStore();
+            return new NoOperationBlobStore();
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/NoOperationBlobStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/NoOperationBlobStore.java
@@ -24,7 +24,7 @@ import java.io.File;
 import java.io.IOException;
 
 /** A blob store doing nothing. */
-public class VoidBlobStore implements BlobStoreService {
+public class NoOperationBlobStore implements BlobStoreService {
 
     @Override
     public boolean put(File localFile, JobID jobId, BlobKey blobKey) throws IOException {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/TransientBlobCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/TransientBlobCache.java
@@ -90,7 +90,7 @@ public class TransientBlobCache extends AbstractBlobCache implements TransientBl
         super(
                 blobClientConfig,
                 storageDir,
-                new VoidBlobStore(),
+                new NoOperationBlobStore(),
                 LoggerFactory.getLogger(TransientBlobCache.class),
                 serverAddress);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/AbstractNonHaServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/AbstractNonHaServices.java
@@ -19,7 +19,7 @@
 package org.apache.flink.runtime.highavailability.nonha;
 
 import org.apache.flink.runtime.blob.BlobStore;
-import org.apache.flink.runtime.blob.VoidBlobStore;
+import org.apache.flink.runtime.blob.NoOperationBlobStore;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
@@ -45,13 +45,13 @@ public abstract class AbstractNonHaServices implements HighAvailabilityServices 
 
     private final JobResultStore jobResultStore;
 
-    private final VoidBlobStore voidBlobStore;
+    private final NoOperationBlobStore noOperationBlobStore;
 
     private boolean shutdown;
 
     public AbstractNonHaServices() {
         this.jobResultStore = new EmbeddedJobResultStore();
-        this.voidBlobStore = new VoidBlobStore();
+        this.noOperationBlobStore = new NoOperationBlobStore();
 
         shutdown = false;
     }
@@ -92,7 +92,7 @@ public abstract class AbstractNonHaServices implements HighAvailabilityServices 
         synchronized (lock) {
             checkNotShutdown();
 
-            return voidBlobStore;
+            return noOperationBlobStore;
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheCleanupTest.java
@@ -220,7 +220,9 @@ class BlobCacheCleanupTest {
             Configuration config = new Configuration();
             config.set(BlobServerOptions.CLEANUP_INTERVAL, cleanupInterval);
 
-            server = new BlobServer(config, TempDirUtils.newFolder(tempDir), new VoidBlobStore());
+            server =
+                    new BlobServer(
+                            config, TempDirUtils.newFolder(tempDir), new NoOperationBlobStore());
             server.start();
 
             final BlobCacheSizeTracker tracker =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheGetTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheGetTest.java
@@ -514,8 +514,8 @@ class BlobCacheGetTest {
             final JobID jobId, final BlobKey.BlobType blobType, final boolean cacheAccessesHAStore)
             throws IOException, InterruptedException, ExecutionException {
 
-        final BlobStore blobStoreServer = new VoidBlobStore();
-        final BlobStore blobStoreCache = new VoidBlobStore();
+        final BlobStore blobStoreServer = new NoOperationBlobStore();
+        final BlobStore blobStoreCache = new NoOperationBlobStore();
 
         final int numberConcurrentGetOperations = 3;
         final List<CompletableFuture<File>> getOperations =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheRetriesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheRetriesTest.java
@@ -49,7 +49,7 @@ class BlobCacheRetriesTest {
      */
     @Test
     void testBlobFetchRetries() throws IOException {
-        testBlobFetchRetries(new VoidBlobStore(), null, TRANSIENT_BLOB);
+        testBlobFetchRetries(new NoOperationBlobStore(), null, TRANSIENT_BLOB);
     }
 
     /**
@@ -58,7 +58,7 @@ class BlobCacheRetriesTest {
      */
     @Test
     void testBlobForJobFetchRetries() throws IOException {
-        testBlobFetchRetries(new VoidBlobStore(), new JobID(), TRANSIENT_BLOB);
+        testBlobFetchRetries(new NoOperationBlobStore(), new JobID(), TRANSIENT_BLOB);
     }
 
     /**
@@ -119,7 +119,7 @@ class BlobCacheRetriesTest {
      */
     @Test
     void testBlobNoJobFetchWithTooManyFailures() throws IOException {
-        testBlobFetchWithTooManyFailures(new VoidBlobStore(), null, TRANSIENT_BLOB);
+        testBlobFetchWithTooManyFailures(new NoOperationBlobStore(), null, TRANSIENT_BLOB);
     }
 
     /**
@@ -128,7 +128,7 @@ class BlobCacheRetriesTest {
      */
     @Test
     void testBlobForJobFetchWithTooManyFailures() throws IOException {
-        testBlobFetchWithTooManyFailures(new VoidBlobStore(), new JobID(), TRANSIENT_BLOB);
+        testBlobFetchWithTooManyFailures(new NoOperationBlobStore(), new JobID(), TRANSIENT_BLOB);
     }
 
     /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientTest.java
@@ -500,7 +500,7 @@ class BlobClientTest {
                 new TestBlobServer(
                         clientConfig,
                         tempDir.resolve("test_server").toFile(),
-                        new VoidBlobStore(),
+                        new NoOperationBlobStore(),
                         10_000L)) {
             testBlobServer.start();
             InetSocketAddress serverAddress =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerCleanupTest.java
@@ -79,7 +79,8 @@ class BlobServerCleanupTest {
 
     private static BlobServer createTestInstance(String storageDirectoryPath, long cleanupInterval)
             throws IOException {
-        return createTestInstance(storageDirectoryPath, cleanupInterval, new VoidBlobStore());
+        return createTestInstance(
+                storageDirectoryPath, cleanupInterval, new NoOperationBlobStore());
     }
 
     private static BlobServer createTestInstance(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerGetTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerGetTest.java
@@ -357,7 +357,9 @@ class BlobServerGetTest {
         final File storageDir = TempDirUtils.newFolder(tempDir);
         try (final BlobServer blobServer =
                 new BlobServer(
-                        new Configuration(), Reference.borrowed(storageDir), new VoidBlobStore())) {
+                        new Configuration(),
+                        Reference.borrowed(storageDir),
+                        new NoOperationBlobStore())) {
             final BlobKey blobKey = put(blobServer, jobId, data, blobType);
 
             blobServer.close();
@@ -370,7 +372,7 @@ class BlobServerGetTest {
                     new BlobServer(
                             new Configuration(),
                             Reference.borrowed(storageDir),
-                            new VoidBlobStore())) {
+                            new NoOperationBlobStore())) {
                 assertThatThrownBy(() -> get(restartedBlobServer, jobId, blobKey))
                         .isInstanceOf(IOException.class);
             }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerSslTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerSslTest.java
@@ -48,7 +48,10 @@ class BlobServerSslTest {
         config.set(SecurityOptions.SSL_TRUSTSTORE_PASSWORD, "password");
         config.set(SecurityOptions.SSL_ALGORITHMS, "TLSv1,TLSv1.1");
 
-        assertThatThrownBy(() -> new BlobServer(config, new File("foobar"), new VoidBlobStore()))
+        assertThatThrownBy(
+                        () ->
+                                new BlobServer(
+                                        config, new File("foobar"), new NoOperationBlobStore()))
                 .isInstanceOf(IOException.class)
                 .hasMessage("Unable to open BLOB Server in specified port range: 0");
     }
@@ -64,7 +67,10 @@ class BlobServerSslTest {
         config.set(SecurityOptions.SSL_TRUSTSTORE, "invalid.keystore");
         config.set(SecurityOptions.SSL_TRUSTSTORE_PASSWORD, "password");
 
-        assertThatThrownBy(() -> new BlobServer(config, new File("foobar"), new VoidBlobStore()))
+        assertThatThrownBy(
+                        () ->
+                                new BlobServer(
+                                        config, new File("foobar"), new NoOperationBlobStore()))
                 .isInstanceOf(IOException.class)
                 .hasMessage("Failed to initialize SSL for the blob server");
     }
@@ -75,7 +81,10 @@ class BlobServerSslTest {
 
         config.set(SecurityOptions.SSL_INTERNAL_ENABLED, true);
 
-        assertThatThrownBy(() -> new BlobServer(config, new File("foobar"), new VoidBlobStore()))
+        assertThatThrownBy(
+                        () ->
+                                new BlobServer(
+                                        config, new File("foobar"), new NoOperationBlobStore()))
                 .isInstanceOf(IOException.class)
                 .hasMessage("Failed to initialize SSL for the blob server");
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/PermanentBlobCacheSizeLimitTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/PermanentBlobCacheSizeLimitTest.java
@@ -198,7 +198,7 @@ class PermanentBlobCacheSizeLimitTest {
                 new PermanentBlobCache(
                         config,
                         tempDir.resolve("permanent_cache").toFile(),
-                        new VoidBlobStore(),
+                        new NoOperationBlobStore(),
                         serverAddress,
                         new BlobCacheSizeTracker(MAX_NUM_OF_ACCEPTED_BLOBS * BLOB_SIZE));
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/PermanentBlobCacheTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/PermanentBlobCacheTest.java
@@ -52,7 +52,7 @@ class PermanentBlobCacheTest {
                 new PermanentBlobCache(
                         new Configuration(),
                         storageDirectory.toFile(),
-                        new VoidBlobStore(),
+                        new NoOperationBlobStore(),
                         null)) {
             final File blob = permanentBlobCache.getFile(jobId, blobKey);
 
@@ -79,7 +79,7 @@ class PermanentBlobCacheTest {
                 new PermanentBlobCache(
                         new Configuration(),
                         storageDirectory.toFile(),
-                        new VoidBlobStore(),
+                        new NoOperationBlobStore(),
                         null)) {
             assertThatThrownBy(() -> permanentBlobCache.getFile(jobId, blobKey))
                     .isInstanceOf(IOException.class);
@@ -100,7 +100,10 @@ class PermanentBlobCacheTest {
 
         try (final PermanentBlobCache permanentBlobCache =
                 new PermanentBlobCache(
-                        configuration, storageDirectory.toFile(), new VoidBlobStore(), null)) {
+                        configuration,
+                        storageDirectory.toFile(),
+                        new NoOperationBlobStore(),
+                        null)) {
             CommonTestUtils.waitUntilCondition(() -> !blobFile.exists());
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/TestingBlobHelpers.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/TestingBlobHelpers.java
@@ -236,7 +236,7 @@ public final class TestingBlobHelpers {
                         new BlobCacheService(
                                 config,
                                 new File(blobStorage, "cache"),
-                                corruptOnHAStore ? blobStore : new VoidBlobStore(),
+                                corruptOnHAStore ? blobStore : new NoOperationBlobStore(),
                                 new InetSocketAddress("localhost", server.getPort()))) {
 
             server.start();
@@ -306,7 +306,7 @@ public final class TestingBlobHelpers {
                         new BlobCacheService(
                                 config,
                                 new File(blobStorage, "cache1"),
-                                new VoidBlobStore(),
+                                new NoOperationBlobStore(),
                                 new InetSocketAddress("localhost", server1.getPort()))) {
 
             server0.start();
@@ -390,13 +390,13 @@ public final class TestingBlobHelpers {
                         new BlobCacheService(
                                 config,
                                 new File(blobStorage, "cache0"),
-                                new VoidBlobStore(),
+                                new NoOperationBlobStore(),
                                 new InetSocketAddress("localhost", server0.getPort()));
                 BlobCacheService cache1 =
                         new BlobCacheService(
                                 config,
                                 new File(blobStorage, "cache1"),
-                                new VoidBlobStore(),
+                                new NoOperationBlobStore(),
                                 new InetSocketAddress("localhost", server1.getPort()))) {
 
             server0.start();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/TestingBlobUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/TestingBlobUtils.java
@@ -71,12 +71,12 @@ class TestingBlobUtils {
 
     @Nonnull
     static BlobServer createServer(Path tempDir) throws IOException {
-        return createServer(tempDir, new Configuration(), new VoidBlobStore());
+        return createServer(tempDir, new Configuration(), new NoOperationBlobStore());
     }
 
     @Nonnull
     static BlobServer createServer(Path tempDir, Configuration config) throws IOException {
-        return createServer(tempDir, config, new VoidBlobStore());
+        return createServer(tempDir, config, new NoOperationBlobStore());
     }
 
     @Nonnull
@@ -127,24 +127,28 @@ class TestingBlobUtils {
             throws IOException {
         if (tracker == null) {
             return new PermanentBlobCache(
-                    config, getCacheDir(tempDir), new VoidBlobStore(), serverAddress);
+                    config, getCacheDir(tempDir), new NoOperationBlobStore(), serverAddress);
         }
 
         return new PermanentBlobCache(
-                config, getCacheDir(tempDir), new VoidBlobStore(), serverAddress, tracker);
+                config, getCacheDir(tempDir), new NoOperationBlobStore(), serverAddress, tracker);
     }
 
     @Nonnull
     static Tuple2<BlobServer, BlobCacheService> createServerAndCache(Path tempDir)
             throws IOException {
         return createServerAndCache(
-                tempDir, new Configuration(), new VoidBlobStore(), new VoidBlobStore());
+                tempDir,
+                new Configuration(),
+                new NoOperationBlobStore(),
+                new NoOperationBlobStore());
     }
 
     @Nonnull
     static Tuple2<BlobServer, BlobCacheService> createServerAndCache(
             Path tempDir, Configuration config) throws IOException {
-        return createServerAndCache(tempDir, config, new VoidBlobStore(), new VoidBlobStore());
+        return createServerAndCache(
+                tempDir, config, new NoOperationBlobStore(), new NoOperationBlobStore());
     }
 
     @Nonnull
@@ -191,7 +195,7 @@ class TestingBlobUtils {
                 new BlobCacheService(
                         config,
                         getCacheDir(tempDir),
-                        new VoidBlobStore(),
+                        new NoOperationBlobStore(),
                         new InetSocketAddress("localhost", server.getPort()));
 
         return Tuple2.of(server, cache);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/client/ClientUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/client/ClientUtilsTest.java
@@ -24,8 +24,8 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.blob.BlobClient;
 import org.apache.flink.runtime.blob.BlobServer;
+import org.apache.flink.runtime.blob.NoOperationBlobStore;
 import org.apache.flink.runtime.blob.PermanentBlobKey;
-import org.apache.flink.runtime.blob.VoidBlobStore;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
 import org.apache.flink.testutils.junit.utils.TempDirUtils;
@@ -57,7 +57,9 @@ public class ClientUtilsTest {
         Configuration config = new Configuration();
         blobServer =
                 new BlobServer(
-                        config, TempDirUtils.newFolder(temporaryFolder), new VoidBlobStore());
+                        config,
+                        TempDirUtils.newFolder(temporaryFolder),
+                        new NoOperationBlobStore());
         blobServer.start();
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTest.java
@@ -25,8 +25,8 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.blob.BlobWriter;
+import org.apache.flink.runtime.blob.NoOperationBlobStore;
 import org.apache.flink.runtime.blob.PermanentBlobKey;
-import org.apache.flink.runtime.blob.VoidBlobStore;
 import org.apache.flink.runtime.checkpoint.JobManagerTaskRestore;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
@@ -222,7 +222,9 @@ class TaskDeploymentDescriptorTest {
         config.set(BlobServerOptions.OFFLOAD_MINSIZE, 0);
         BlobServer blobServer =
                 new BlobServer(
-                        config, TempDirUtils.newFolder(temporaryFolder), new VoidBlobStore());
+                        config,
+                        TempDirUtils.newFolder(temporaryFolder),
+                        new NoOperationBlobStore());
         blobServer.start();
         return blobServer;
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/AbstractDispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/AbstractDispatcherTest.java
@@ -21,7 +21,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobServer;
-import org.apache.flink.runtime.blob.VoidBlobStore;
+import org.apache.flink.runtime.blob.NoOperationBlobStore;
 import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
 import org.apache.flink.runtime.dispatcher.cleanup.CheckpointResourcesCleanupRunnerFactory;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
@@ -100,7 +100,8 @@ public class AbstractDispatcherTest extends TestLogger {
 
         configuration = new Configuration();
         blobServer =
-                new BlobServer(configuration, temporaryFolder.newFolder(), new VoidBlobStore());
+                new BlobServer(
+                        configuration, temporaryFolder.newFolder(), new NoOperationBlobStore());
     }
 
     protected TestingDispatcher.Builder createTestingDispatcherBuilder() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
@@ -23,10 +23,10 @@ import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.blob.BlobServer;
+import org.apache.flink.runtime.blob.NoOperationBlobStore;
 import org.apache.flink.runtime.blob.PermanentBlobCache;
 import org.apache.flink.runtime.blob.PermanentBlobKey;
 import org.apache.flink.runtime.blob.PermanentBlobService;
-import org.apache.flink.runtime.blob.VoidBlobStore;
 import org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser;
 import org.apache.flink.util.FlinkUserCodeClassLoaders;
 import org.apache.flink.util.OperatingSystem;
@@ -96,14 +96,15 @@ public class BlobLibraryCacheManagerTest extends TestLogger {
             Configuration config = new Configuration();
             config.set(BlobServerOptions.CLEANUP_INTERVAL, 1L);
 
-            server = new BlobServer(config, temporaryFolder.newFolder(), new VoidBlobStore());
+            server =
+                    new BlobServer(config, temporaryFolder.newFolder(), new NoOperationBlobStore());
             server.start();
             InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
             cache =
                     new PermanentBlobCache(
                             config,
                             temporaryFolder.newFolder(),
-                            new VoidBlobStore(),
+                            new NoOperationBlobStore(),
                             serverAddress);
 
             keys1.add(server.putPermanent(jobId1, buf));
@@ -229,14 +230,15 @@ public class BlobLibraryCacheManagerTest extends TestLogger {
             Configuration config = new Configuration();
             config.set(BlobServerOptions.CLEANUP_INTERVAL, 1L);
 
-            server = new BlobServer(config, temporaryFolder.newFolder(), new VoidBlobStore());
+            server =
+                    new BlobServer(config, temporaryFolder.newFolder(), new NoOperationBlobStore());
             server.start();
             InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
             cache =
                     new PermanentBlobCache(
                             config,
                             temporaryFolder.newFolder(),
-                            new VoidBlobStore(),
+                            new NoOperationBlobStore(),
                             serverAddress);
 
             keys.add(server.putPermanent(jobId, buf));
@@ -339,14 +341,15 @@ public class BlobLibraryCacheManagerTest extends TestLogger {
             Configuration config = new Configuration();
             config.set(BlobServerOptions.CLEANUP_INTERVAL, 1_000_000L);
 
-            server = new BlobServer(config, temporaryFolder.newFolder(), new VoidBlobStore());
+            server =
+                    new BlobServer(config, temporaryFolder.newFolder(), new NoOperationBlobStore());
             server.start();
             InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
             cache =
                     new PermanentBlobCache(
                             config,
                             temporaryFolder.newFolder(),
-                            new VoidBlobStore(),
+                            new NoOperationBlobStore(),
                             serverAddress);
 
             // upload some meaningless data to the server
@@ -639,7 +642,7 @@ public class BlobLibraryCacheManagerTest extends TestLogger {
                     new PermanentBlobCache(
                             blobClientConfig,
                             temporaryFolder.newFolder(),
-                            new VoidBlobStore(),
+                            new NoOperationBlobStore(),
                             null);
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentWithBlobCacheTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentWithBlobCacheTest.java
@@ -21,8 +21,8 @@ package org.apache.flink.runtime.executiongraph;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobServer;
+import org.apache.flink.runtime.blob.NoOperationBlobStore;
 import org.apache.flink.runtime.blob.PermanentBlobCache;
-import org.apache.flink.runtime.blob.VoidBlobStore;
 import org.apache.flink.testutils.junit.utils.TempDirUtils;
 
 import org.junit.jupiter.api.AfterEach;
@@ -46,7 +46,9 @@ class DefaultExecutionGraphDeploymentWithBlobCacheTest
         config.set(BlobServerOptions.OFFLOAD_MINSIZE, 0);
         blobServer =
                 new BlobServer(
-                        config, TempDirUtils.newFolder(temporaryFolder), new VoidBlobStore());
+                        config,
+                        TempDirUtils.newFolder(temporaryFolder),
+                        new NoOperationBlobStore());
         blobServer.start();
         blobWriter = blobServer;
 
@@ -55,7 +57,7 @@ class DefaultExecutionGraphDeploymentWithBlobCacheTest
                 new PermanentBlobCache(
                         config,
                         TempDirUtils.newFolder(temporaryFolder),
-                        new VoidBlobStore(),
+                        new NoOperationBlobStore(),
                         serverAddress);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentWithBlobServerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentWithBlobServerTest.java
@@ -23,8 +23,8 @@ import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.blob.BlobStore;
+import org.apache.flink.runtime.blob.NoOperationBlobStore;
 import org.apache.flink.runtime.blob.PermanentBlobKey;
-import org.apache.flink.runtime.blob.VoidBlobStore;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.testutils.junit.utils.TempDirUtils;
@@ -66,7 +66,9 @@ class DefaultExecutionGraphDeploymentWithBlobServerTest
         config.set(BlobServerOptions.OFFLOAD_MINSIZE, 0);
         blobServer =
                 new AssertBlobServer(
-                        config, TempDirUtils.newFolder(temporaryFolder), new VoidBlobStore());
+                        config,
+                        TempDirUtils.newFolder(temporaryFolder),
+                        new NoOperationBlobStore());
         blobWriter = blobServer;
         blobCache = blobServer;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentWithSmallBlobCacheSizeLimitTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentWithSmallBlobCacheSizeLimitTest.java
@@ -23,8 +23,8 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.blob.BlobCacheSizeTracker;
 import org.apache.flink.runtime.blob.BlobServer;
+import org.apache.flink.runtime.blob.NoOperationBlobStore;
 import org.apache.flink.runtime.blob.PermanentBlobCache;
-import org.apache.flink.runtime.blob.VoidBlobStore;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
@@ -79,7 +79,9 @@ class DefaultExecutionGraphDeploymentWithSmallBlobCacheSizeLimitTest
         config.set(BlobServerOptions.OFFLOAD_MINSIZE, 0);
         blobServer =
                 new BlobServer(
-                        config, TempDirUtils.newFolder(temporaryFolder), new VoidBlobStore());
+                        config,
+                        TempDirUtils.newFolder(temporaryFolder),
+                        new NoOperationBlobStore());
         blobServer.start();
         blobWriter = blobServer;
 
@@ -90,7 +92,7 @@ class DefaultExecutionGraphDeploymentWithSmallBlobCacheSizeLimitTest
                 new PermanentBlobCache(
                         config,
                         TempDirUtils.newFolder(temporaryFolder),
-                        new VoidBlobStore(),
+                        new NoOperationBlobStore(),
                         serverAddress,
                         blobCacheSizeTracker);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/TestingHighAvailabilityServices.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/TestingHighAvailabilityServices.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.highavailability;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.blob.BlobStore;
-import org.apache.flink.runtime.blob.VoidBlobStore;
+import org.apache.flink.runtime.blob.NoOperationBlobStore;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.highavailability.nonha.embedded.EmbeddedJobResultStore;
 import org.apache.flink.runtime.jobmanager.ExecutionPlanStore;
@@ -266,7 +266,7 @@ public class TestingHighAvailabilityServices implements HighAvailabilityServices
 
     @Override
     public BlobStore createBlobStore() throws IOException {
-        return new VoidBlobStore();
+        return new NoOperationBlobStore();
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobManagerSharedServicesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobManagerSharedServicesTest.java
@@ -22,7 +22,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.blob.BlobServer;
-import org.apache.flink.runtime.blob.VoidBlobStore;
+import org.apache.flink.runtime.blob.NoOperationBlobStore;
 import org.apache.flink.runtime.util.Hardware;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.util.function.ThrowingRunnable;
@@ -114,7 +114,7 @@ class JobManagerSharedServicesTest {
             throws Exception {
         return JobManagerSharedServices.fromConfiguration(
                 configuration,
-                new BlobServer(configuration, TEMPORARY_FOLDER, new VoidBlobStore()),
+                new BlobServer(configuration, TEMPORARY_FOLDER, new NoOperationBlobStore()),
                 new TestingFatalErrorHandler());
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalTest.java
@@ -21,7 +21,7 @@ package org.apache.flink.runtime.leaderretrieval;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.core.testutils.EachCallbackWrapper;
-import org.apache.flink.runtime.blob.VoidBlobStore;
+import org.apache.flink.runtime.blob.NoOperationBlobStore;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.zookeeper.ZooKeeperLeaderElectionHaServices;
 import org.apache.flink.runtime.jobmaster.JobMaster;
@@ -94,7 +94,7 @@ class ZooKeeperLeaderRetrievalTest {
                                 testingFatalErrorHandlerResource.getTestingFatalErrorHandler()),
                         config,
                         EXECUTOR_RESOURCE.getExecutor(),
-                        new VoidBlobStore());
+                        new NoOperationBlobStore());
     }
 
     @AfterEach

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobSubmitHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobSubmitHandlerTest.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.cache.DistributedCache;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobServer;
-import org.apache.flink.runtime.blob.VoidBlobStore;
+import org.apache.flink.runtime.blob.NoOperationBlobStore;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
@@ -96,7 +96,9 @@ public class JobSubmitHandlerTest {
 
         blobServer =
                 new BlobServer(
-                        config, TempDirUtils.newFolder(temporaryFolder), new VoidBlobStore());
+                        config,
+                        TempDirUtils.newFolder(temporaryFolder),
+                        new NoOperationBlobStore());
         blobServer.start();
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/taskmanager/AbstractTaskManagerFileHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/taskmanager/AbstractTaskManagerFileHandlerTest.java
@@ -20,8 +20,8 @@ package org.apache.flink.runtime.rest.handler.taskmanager;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobServer;
+import org.apache.flink.runtime.blob.NoOperationBlobStore;
 import org.apache.flink.runtime.blob.TransientBlobKey;
-import org.apache.flink.runtime.blob.VoidBlobStore;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
@@ -84,7 +84,7 @@ class AbstractTaskManagerFileHandlerTest {
     static void setup() throws IOException, HandlerRequestException {
         final Configuration configuration = new Configuration();
 
-        blobServer = new BlobServer(configuration, temporaryFolder, new VoidBlobStore());
+        blobServer = new BlobServer(configuration, temporaryFolder, new NoOperationBlobStore());
 
         handlerRequest =
                 HandlerRequest.resolveParametersAndCreate(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerStdoutFileHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerStdoutFileHandlerTest.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.rest.handler.taskmanager;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobServer;
-import org.apache.flink.runtime.blob.VoidBlobStore;
+import org.apache.flink.runtime.blob.NoOperationBlobStore;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
@@ -71,7 +71,7 @@ class TaskManagerStdoutFileHandlerTest {
     static void setup() throws IOException, HandlerRequestException {
         final Configuration configuration = new Configuration();
 
-        blobServer = new BlobServer(configuration, temporaryFolder, new VoidBlobStore());
+        blobServer = new BlobServer(configuration, temporaryFolder, new NoOperationBlobStore());
 
         handlerRequest =
                 HandlerRequest.resolveParametersAndCreate(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/BlobServerExtension.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/BlobServerExtension.java
@@ -21,7 +21,7 @@ package org.apache.flink.runtime.util;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.CustomExtension;
 import org.apache.flink.runtime.blob.BlobServer;
-import org.apache.flink.runtime.blob.VoidBlobStore;
+import org.apache.flink.runtime.blob.NoOperationBlobStore;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.rules.TemporaryFolder;
@@ -46,7 +46,8 @@ public class BlobServerExtension implements CustomExtension {
 
         Configuration config = new Configuration();
 
-        blobServer = new BlobServer(config, temporaryFolder.newFolder(), new VoidBlobStore());
+        blobServer =
+                new BlobServer(config, temporaryFolder.newFolder(), new NoOperationBlobStore());
         blobServer.start();
     }
 


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to rename `VoidBlobStore` to `NoOperationBlobStore`.
The original name `VoidBlobStore` looks confusing. I think `NoOperationBlobStore` is a perfect name.


## Brief change log

Rename `VoidBlobStore` to `NoOperationBlobStore`.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
