### PR TITLE
[hotfix] Short circuit judgment for create blob storage dir

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
@@ -161,7 +161,7 @@ public class BlobUtils {
             if (fallbackStorageDirectory != null) {
                 baseDir = fallbackStorageDirectory.deref();
 
-                if (baseDir.mkdirs() || baseDir.exists()) {
+                if (baseDir.exists() || baseDir.mkdirs()) {
                     return fallbackStorageDirectory;
                 }
             }


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to short circuit judgment for create blob storage dir
According to https://github.com/apache/flink/blob/df058589affe786f5dcbf253cd3769502c28b207/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/WorkingDirectory.java#L49
, there are already existing the blob storage dir.
The original judgment executes `baseDir.mkdirs()` first, but it returns false. And then we need to execute `baseDir.exists()`.
We can only need execute `baseDir.exists()` first and short circuit judgment for `baseDir.mkdirs()`.
According to the current code path, I think this is the mainly logic.
And this PR will not lead to any regression even if there exists some corner case. 


## Brief change log

Short circuit judgment for create blob storage dir


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
