### PR TITLE
[hotfix] Preconditions.checkState should follows the Flink code style

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/memory/MemoryUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/MemoryUtils.java
@@ -169,10 +169,9 @@ public class MemoryUtils {
         Preconditions.checkState(offHeapAddress > 0, "negative pointer or size");
         Preconditions.checkState(
                 offHeapAddress < Long.MAX_VALUE - Integer.MAX_VALUE,
-                "Segment initialized with too large address: "
-                        + offHeapAddress
-                        + " ; Max allowed address is "
-                        + (Long.MAX_VALUE - Integer.MAX_VALUE - 1));
+                "Segment initialized with too large address: %s ; Max allowed address is %d",
+                offHeapAddress,
+                (Long.MAX_VALUE - Integer.MAX_VALUE - 1));
 
         return offHeapAddress;
     }


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to make `Preconditions.checkState` follows the Flink code style.
Please refer to https://flink.apache.org/how-to-contribute/code-style-and-quality-java/#collections


## Brief change log

`Preconditions.checkState` should follows the Flink code style.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
