### PR TITLE
[hotfix] Remove redundant config operation for ADDRESS and PORT

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -286,10 +286,6 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
         synchronized (lock) {
             initializeServices(configuration, pluginManager);
 
-            // write host information into configuration
-            configuration.set(JobManagerOptions.ADDRESS, commonRpcService.getAddress());
-            configuration.set(JobManagerOptions.PORT, commonRpcService.getPort());
-
             final DispatcherResourceManagerComponentFactory
                     dispatcherResourceManagerComponentFactory =
                             createDispatcherResourceManagerComponentFactory(configuration);


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to remove redundant config operation.


## Brief change log

Remove redundant config operation for ADDRESS and PORT


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
