### PR TITLE
[hotfix] Rename JobRestEndpointFactory to ApplicationRestEndpointFactory

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/ApplicationClusterEntryPoint.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/ApplicationClusterEntryPoint.java
@@ -34,7 +34,7 @@ import org.apache.flink.runtime.entrypoint.ClusterEntrypoint;
 import org.apache.flink.runtime.entrypoint.component.DefaultDispatcherResourceManagerComponentFactory;
 import org.apache.flink.runtime.entrypoint.component.DispatcherResourceManagerComponentFactory;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerFactory;
-import org.apache.flink.runtime.rest.JobRestEndpointFactory;
+import org.apache.flink.runtime.rest.ApplicationRestEndpointFactory;
 import org.apache.flink.util.concurrent.ScheduledExecutor;
 
 import java.io.IOException;
@@ -74,7 +74,7 @@ public class ApplicationClusterEntryPoint extends ClusterEntrypoint {
                         ApplicationDispatcherLeaderProcessFactoryFactory.create(
                                 configuration, SessionDispatcherFactory.INSTANCE, program)),
                 resourceManagerFactory,
-                JobRestEndpointFactory.INSTANCE);
+                ApplicationRestEndpointFactory.INSTANCE);
     }
 
     @Override

--- a/flink-clients/src/test/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrapITCase.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrapITCase.java
@@ -51,7 +51,7 @@ import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.runtime.minicluster.TestingMiniCluster;
 import org.apache.flink.runtime.minicluster.TestingMiniClusterConfiguration;
 import org.apache.flink.runtime.resourcemanager.StandaloneResourceManagerFactory;
-import org.apache.flink.runtime.rest.JobRestEndpointFactory;
+import org.apache.flink.runtime.rest.ApplicationRestEndpointFactory;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.runtime.testutils.TestingJobResultStore;
 import org.apache.flink.testutils.TestingUtils;
@@ -91,7 +91,7 @@ class ApplicationDispatcherBootstrapITCase {
                     new DefaultDispatcherRunnerFactory(
                             applicationDispatcherLeaderProcessFactoryFactory),
                     StandaloneResourceManagerFactory.getInstance(),
-                    JobRestEndpointFactory.INSTANCE);
+                    ApplicationRestEndpointFactory.INSTANCE);
         };
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/ApplicationRestEndpointFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/ApplicationRestEndpointFactory.java
@@ -34,7 +34,7 @@ import org.apache.flink.runtime.webmonitor.retriever.LeaderGatewayRetriever;
 import java.util.concurrent.ScheduledExecutorService;
 
 /** {@link RestEndpointFactory} which creates a {@link MiniDispatcherRestEndpoint}. */
-public enum JobRestEndpointFactory implements RestEndpointFactory<RestfulGateway> {
+public enum ApplicationRestEndpointFactory implements RestEndpointFactory<RestfulGateway> {
     INSTANCE;
 
     @Override

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/application/ScriptRunnerITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/application/ScriptRunnerITCase.java
@@ -36,7 +36,7 @@ import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.runtime.minicluster.TestingMiniCluster;
 import org.apache.flink.runtime.minicluster.TestingMiniClusterConfiguration;
 import org.apache.flink.runtime.resourcemanager.StandaloneResourceManagerFactory;
-import org.apache.flink.runtime.rest.JobRestEndpointFactory;
+import org.apache.flink.runtime.rest.ApplicationRestEndpointFactory;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.table.gateway.service.utils.MockHttpServer;
 import org.apache.flink.table.planner.factories.TestValuesTableFactory;
@@ -249,7 +249,7 @@ class ScriptRunnerITCase {
                     new DefaultDispatcherRunnerFactory(
                             applicationDispatcherLeaderProcessFactoryFactory),
                     StandaloneResourceManagerFactory.getInstance(),
-                    JobRestEndpointFactory.INSTANCE);
+                    ApplicationRestEndpointFactory.INSTANCE);
         };
     }
 


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to rename `JobRestEndpointFactory` to `ApplicationRestEndpointFactory`.
AFAIK, Flink already removed `Job-Cluster` or renamed it with `Application-Cluster`. There are many classes renamed from `Job*` to `Application*`. I guess we missing the `JobRestEndpointFactory`.


## Brief change log

Rename `JobRestEndpointFactory` to `ApplicationRestEndpointFactory`.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
