### PR TITLE
[hotfix] Simplify the variable checkpointStatsSnapshotCacheExpireAfterWrite

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/RestHandlerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/RestHandlerConfiguration.java
@@ -114,9 +114,7 @@ public class RestHandlerConfiguration {
 
         final int checkpointHistorySize = configuration.get(WebOptions.CHECKPOINTS_HISTORY_SIZE);
         final Duration checkpointStatsSnapshotCacheExpireAfterWrite =
-                configuration
-                        .getOptional(RestOptions.CACHE_CHECKPOINT_STATISTICS_TIMEOUT)
-                        .orElse(Duration.ofMillis(refreshInterval));
+                configuration.get(RestOptions.CACHE_CHECKPOINT_STATISTICS_TIMEOUT);
         final int checkpointStatsSnapshotCacheSize =
                 configuration.get(RestOptions.CACHE_CHECKPOINT_STATISTICS_SIZE);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/RestHandlerConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/RestHandlerConfigurationTest.java
@@ -106,12 +106,16 @@ class RestHandlerConfigurationTest {
 
     @Test
     void testCheckpointCacheExpireAfterWrite() {
-        final Duration testDuration = Duration.ofMillis(100L);
         final Configuration config = new Configuration();
-        config.set(RestOptions.CACHE_CHECKPOINT_STATISTICS_TIMEOUT, testDuration);
-
+        final Duration defaultDuration = Duration.ofMillis(3000L);
         RestHandlerConfiguration restHandlerConfiguration =
                 RestHandlerConfiguration.fromConfiguration(config);
+        assertThat(restHandlerConfiguration.getCheckpointCacheExpireAfterWrite())
+                .isEqualTo(defaultDuration);
+
+        final Duration testDuration = Duration.ofMillis(100L);
+        config.set(RestOptions.CACHE_CHECKPOINT_STATISTICS_TIMEOUT, testDuration);
+        restHandlerConfiguration = RestHandlerConfiguration.fromConfiguration(config);
         assertThat(restHandlerConfiguration.getCheckpointCacheExpireAfterWrite())
                 .isEqualTo(testDuration);
     }


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to simplify the variable `checkpointStatsSnapshotCacheExpireAfterWrite`.
The `checkpointStatsSnapshotCacheExpireAfterWrite` comes from `RestOptions.CACHE_CHECKPOINT_STATISTICS_TIMEOUT` that have the default value reference the `WebOptions.REFRESH_INTERVAL` as show below.
```
public static final ConfigOption<Duration> CACHE_CHECKPOINT_STATISTICS_TIMEOUT =
            key("rest.cache.checkpoint-statistics.timeout")
                    .durationType()
                    .defaultValue(WebOptions.REFRESH_INTERVAL.defaultValue())
                    .withFallbackKeys(WebOptions.REFRESH_INTERVAL.key())
                    .withDescription(
                            Description.builder()
                                    .text(
                                            "Duration from write after which cached checkpoints statistics are cleaned up. For backwards compatibility, if no value is configured, %s will be used instead.",
                                            code(WebOptions.REFRESH_INTERVAL.key()))
                                    .build());
```
It means we do not need set the default value for `CACHE_CHECKPOINT_STATISTICS_TIMEOUT`.


## Brief change log

Simplify the variable `checkpointStatsSnapshotCacheExpireAfterWrite`


## Verifying this change

This change added tests and can be verified as follows:

  - *Updated test `testCheckpointCacheExpireAfterWrite` that validates `checkpointStatsSnapshotCacheExpireAfterWrite`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
