### PR TITLE
[FLINK-37557] Fix ResolvedSchema#getPrimaryKeyIndexes

### DIFF
--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/SchemaResolutionTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/SchemaResolutionTest.java
@@ -425,6 +425,20 @@ class SchemaResolutionTest {
                 .isFalse();
     }
 
+    @Test
+    void testPrimaryKeyIndices() {
+        final ResolvedSchema resolvedSchema =
+                resolveSchema(
+                        Schema.newBuilder()
+                                .columnByMetadata("orig_ts", DataTypes.TIMESTAMP(3), "timestamp")
+                                .column("id", DataTypes.INT().notNull())
+                                .column("counter", DataTypes.INT().notNull())
+                                .primaryKey("id")
+                                .build());
+
+        assertThat(resolvedSchema.getPrimaryKeyIndexes()).isEqualTo(new int[] {0});
+    }
+
     // --------------------------------------------------------------------------------------------
 
     private static void testError(Schema schema, String errorMessage) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ResolvedSchema.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ResolvedSchema.java
@@ -163,9 +163,16 @@ public final class ResolvedSchema {
         return Optional.ofNullable(primaryKey);
     }
 
-    /** Returns the primary key indexes, if any, otherwise returns an empty array. */
+    /**
+     * Returns the primary key indexes in the {@link #toPhysicalRowDataType()}, if any, otherwise
+     * returns an empty array.
+     */
     public int[] getPrimaryKeyIndexes() {
-        final List<String> columns = getColumnNames();
+        final List<String> columns =
+                getColumns().stream()
+                        .filter(Column::isPhysical)
+                        .map(Column::getName)
+                        .collect(Collectors.toList());
         return getPrimaryKey()
                 .map(UniqueConstraint::getColumns)
                 .map(pkColumns -> pkColumns.stream().mapToInt(columns::indexOf).toArray())


### PR DESCRIPTION
## What is the purpose of the change

Fixes the `getPrimaryKeyIndexes` method to return indexes in the `physicalRowDataType`


## Verifying this change

All existing tests pass. Added a specific test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (n**ot applicable** / docs / JavaDocs / not documented)
