### PR TITLE
[FLINK-37558] Check right variable in addSpan

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistryImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistryImpl.java
@@ -463,7 +463,7 @@ public class MetricRegistryImpl implements MetricRegistry, AutoCloseableAsync {
             if (LOG.isTraceEnabled()) {
                 LOG.trace("addSpan");
             }
-            if (reporters != null) {
+            if (traceReporters != null) {
                 notifyTraceReportersOfAddedSpan(spanBuilder.build());
             }
         }


### PR DESCRIPTION
## What is the purpose of the change

Looking at the null check cases for 'reporters' in `MetricRegistryImpl`, the null check in addSpan should be changed to the null check for 'traceReporters' rather than 'reporters', because `notifyTraceReportersOfAddedSpan` method uses 'traceReporters', not 'reporters'.

The null check may be meaningless because all reporters values are initialized to empty `ArrayList` from the constructor, but I'd like to make the change for the correct check.

## Brief change log

Replace the null check variable 'reporters' to 'traceReporters' in `MetricRegistryImpl#addSpan`

## Verifying this change

This change is already covered by existing tests, `MetricRegistryImplTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes (public method)
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
