### PR TITLE
[FLINK-37570][metrics] Export default watermark if split doesn't have any

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/InternalSourceSplitMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/InternalSourceSplitMetricGroup.java
@@ -83,9 +83,9 @@ public class InternalSourceSplitMetricGroup extends ProxyMetricGroup<MetricGroup
 
     @VisibleForTesting
     public static InternalSourceSplitMetricGroup mock(
-            MetricGroup metricGroup, String splitId, Gauge<Long> currentWatermakr) {
+            MetricGroup metricGroup, String splitId, Gauge<Long> currentWatermark) {
         return new InternalSourceSplitMetricGroup(
-                metricGroup, SystemClock.getInstance(), splitId, currentWatermakr);
+                metricGroup, SystemClock.getInstance(), splitId, currentWatermark);
     }
 
     @VisibleForTesting

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
@@ -358,7 +358,11 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
         if (!this.splitMetricGroups.containsKey(splitId)) {
             InternalSourceSplitMetricGroup splitMetricGroup =
                     InternalSourceSplitMetricGroup.wrap(
-                            getMetricGroup(), splitId, () -> splitCurrentWatermarks.get(splitId));
+                            getMetricGroup(),
+                            splitId,
+                            () ->
+                                    splitCurrentWatermarks.getOrDefault(
+                                            splitId, Watermark.UNINITIALIZED.getTimestamp()));
             splitMetricGroup.markSplitStart();
             this.splitMetricGroups.put(splitId, splitMetricGroup);
         }


### PR DESCRIPTION
Following up on https://github.com/apache/flink/pull/26276
Accounting for splits that have no watermarks assigned to them