### PR TITLE
[FLINK-37568] Improve the method flatten of class GlobalConfiguration

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java
@@ -191,18 +191,18 @@ public final class GlobalConfiguration {
      *
      * @param config an arbitrarily nested config map
      * @param keyPrefix The string to prefix the keys in the current config level
-     * @return A flattened, 1 level deep map
+     * @param flattenedMap The flattened, 1 level deep map contains all key-value pairs to be
+     *     returned.
      */
     @SuppressWarnings("unchecked")
-    private static Map<String, Object> flatten(Map<String, Object> config, String keyPrefix) {
-        final Map<String, Object> flattenedMap = new HashMap<>();
-
+    private static void flatten(
+            Map<String, Object> config, String keyPrefix, Map<String, Object> flattenedMap) {
         config.forEach(
                 (key, value) -> {
                     String flattenedKey = keyPrefix + key;
                     if (value instanceof Map) {
-                        Map<String, Object> e = (Map<String, Object>) value;
-                        flattenedMap.putAll(flatten(e, flattenedKey + KEY_SEPARATOR));
+                        Map<String, Object> nestedMap = (Map<String, Object>) value;
+                        flatten(nestedMap, flattenedKey + KEY_SEPARATOR, flattenedMap);
                     } else {
                         if (value instanceof List) {
                             flattenedMap.put(flattenedKey, YamlParserUtils.toYAMLString(value));
@@ -211,13 +211,13 @@ public final class GlobalConfiguration {
                         }
                     }
                 });
-
-        return flattenedMap;
     }
 
     private static Map<String, Object> flatten(Map<String, Object> config) {
         // Since we start flattening from the root, keys should not be prefixed with anything.
-        return flatten(config, "");
+        final Map<String, Object> flattenedMap = new HashMap<>();
+        flatten(config, "", flattenedMap);
+        return flattenedMap;
     }
 
     /**


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to improve the method `flatten` of class `GlobalConfiguration`.
Currently, the method `flatten` of class `GlobalConfiguration` adopts the recursion to flatten the nested or multi-level map to flattened, 1 level deep map.
Every time method `flatten` is entered, a new map is created.
We can avoid the duplication of create map.


## Brief change log

Improve the method `flatten` of class `GlobalConfiguration`.


## Verifying this change

This change is already covered by existing tests, such as *(YamlParserUtilsTest)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (JavaDocs)
