### PR TITLE
[FLINK-37533][CI] Add action: write permission to stale PR github action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -31,6 +31,7 @@ on:
 permissions:
   issues: write
   pull-requests: write
+  actions: write
 
 jobs:
   stale:


### PR DESCRIPTION
## What is the purpose of the change

#26336 Reduced the timeouts on the Stale PR GitHub action. However, changing these means that the action need to change the cache it keeps of PRs it has checked and (as per the 403 errors in the Actions log) it does not seem to have these.

Some digging [shows](https://github.com/actions/stale/issues/1131#issuecomment-1959835001) that the issue can be fixed by adding the `actions: write` permission to the workflow.

## Brief change log

- Add `actions: write`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no

