### PR TITLE
[FLINK-37540][table-planner] Introduce SupportsTargetColumnWriting sink ability

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/DynamicTableSink.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/DynamicTableSink.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.connector.RuntimeConverter;
 import org.apache.flink.table.connector.sink.abilities.SupportsBucketing;
 import org.apache.flink.table.connector.sink.abilities.SupportsOverwrite;
 import org.apache.flink.table.connector.sink.abilities.SupportsPartitioning;
+import org.apache.flink.table.connector.sink.abilities.SupportsTargetColumnWriting;
 import org.apache.flink.table.connector.sink.abilities.SupportsWritingMetadata;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
@@ -71,6 +72,7 @@ import java.util.Optional;
  *   <li>{@link SupportsPartitioning}
  *   <li>{@link SupportsOverwrite}
  *   <li>{@link SupportsWritingMetadata}
+ *   <li>{@link SupportsTargetColumnWriting}
  * </ul>
  *
  * <p>In the last step, the planner will call {@link #getSinkRuntimeProvider(Context)} for obtaining

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/abilities/SupportsTargetColumnWriting.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/abilities/SupportsTargetColumnWriting.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.sink.abilities;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+
+/**
+ * Interface for {@link DynamicTableSink}s that support target column writing.
+ *
+ * <p>The planner will parse target columns from the DML clause and call {@link
+ * #applyTargetColumns(int[][])} to pass an array of column index paths to the sink.
+ *
+ * <p>The array indices are 0-based and support composite columns within (possibly nested)
+ * structures. This information comes from the column list of the DML clause, e.g., for a sink table
+ * t1 whose schema is: {@code a STRING, b ROW < b1 INT, b2 STRING>, c BIGINT}
+ *
+ * <ul>
+ *   <li>insert: 'insert into t1(a, b.b2) ...', the column list will be 'a, b.b2', and will provide
+ *       {@code [[0], [1, 1]]}. The statement 'insert into t1 select ...' will provide an empty list
+ *       and will not apply this ability.
+ *   <li>update: 'update t1 set a=1, b.b1=2 where ...', the column list will be 'a, b.b1', and will
+ *       provide {@code [[0], [1, 0]]}.
+ * </ul>
+ *
+ * <p>Note: Planner will not apply this ability for the delete statement because it has no column
+ * list.
+ *
+ * <p>A sink can use this information to perform target columns writing.
+ *
+ * <p>If this interface is implemented and {@link #applyTargetColumns(int[][])} returns true. The
+ * planner will use this information for plan optimization such as sink reuse.
+ */
+@PublicEvolving
+public interface SupportsTargetColumnWriting {
+
+    /**
+     * Provides an array of column index paths related to user specified target column list.
+     *
+     * <p>See the documentation of {@link SupportsTargetColumnWriting} for more information.
+     *
+     * @param targetColumns column index paths
+     * @return true if the target columns are applied successfully, false otherwise.
+     */
+    boolean applyTargetColumns(int[][] targetColumns);
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/sink/SinkAbilitySpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/sink/SinkAbilitySpec.java
@@ -37,7 +37,8 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTyp
     @JsonSubTypes.Type(value = PartitioningSpec.class),
     @JsonSubTypes.Type(value = WritingMetadataSpec.class),
     @JsonSubTypes.Type(value = RowLevelDeleteSpec.class),
-    @JsonSubTypes.Type(value = RowLevelUpdateSpec.class)
+    @JsonSubTypes.Type(value = RowLevelUpdateSpec.class),
+    @JsonSubTypes.Type(value = TargetColumnWritingSpec.class)
 })
 @Internal
 public interface SinkAbilitySpec {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/sink/TargetColumnWritingSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/sink/TargetColumnWritingSpec.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.abilities.sink;
+
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.sink.abilities.SupportsTargetColumnWriting;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeName;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * A sub-class of {@link SinkAbilitySpec} that can not only serialize/deserialize the writing target
+ * column indices to/from JSON, but also can write the target columns for {@link
+ * SupportsTargetColumnWriting}.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonTypeName("TargetColumnWriting")
+public class TargetColumnWritingSpec implements SinkAbilitySpec {
+    public static final String FIELD_NAME_TARGET_COLUMNS = "targetColumns";
+
+    @JsonProperty(FIELD_NAME_TARGET_COLUMNS)
+    private final int[][] targetColumns;
+
+    @JsonCreator
+    public TargetColumnWritingSpec(@JsonProperty(FIELD_NAME_TARGET_COLUMNS) int[][] targetColumns) {
+        this.targetColumns = targetColumns;
+    }
+
+    @Override
+    public void apply(DynamicTableSink tableSink) {
+        if (tableSink instanceof SupportsTargetColumnWriting) {
+            ((SupportsTargetColumnWriting) tableSink).applyTargetColumns(targetColumns);
+        } else {
+            throw new TableException(
+                    String.format(
+                            "%s does not support SupportsTargetColumnWriting.",
+                            tableSink.getClass().getName()));
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TargetColumnWritingSpec that = (TargetColumnWritingSpec) o;
+        return Objects.deepEquals(targetColumns, that.targetColumns);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.deepHashCode(targetColumns);
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
@@ -53,6 +53,7 @@ import org.apache.flink.table.connector.sink.OutputFormatProvider;
 import org.apache.flink.table.connector.sink.abilities.SupportsBucketing;
 import org.apache.flink.table.connector.sink.abilities.SupportsOverwrite;
 import org.apache.flink.table.connector.sink.abilities.SupportsPartitioning;
+import org.apache.flink.table.connector.sink.abilities.SupportsTargetColumnWriting;
 import org.apache.flink.table.connector.sink.abilities.SupportsWritingMetadata;
 import org.apache.flink.table.connector.sink.legacy.SinkFunctionProvider;
 import org.apache.flink.table.connector.source.DataStreamScanProvider;
@@ -786,7 +787,8 @@ public final class TestValuesTableFactory
                     rowTimeIndex,
                     tableSchema,
                     requireBucketCount,
-                    supportsDeleteByKey);
+                    supportsDeleteByKey,
+                    null);
         } else {
             try {
                 return InstantiationUtil.instantiate(
@@ -2221,9 +2223,11 @@ public final class TestValuesTableFactory
                     SupportsWritingMetadata,
                     SupportsPartitioning,
                     SupportsOverwrite,
-                    SupportsBucketing {
+                    SupportsBucketing,
+                    SupportsTargetColumnWriting {
 
         private DataType consumedDataType;
+        private int[][] targetColumns;
         private int[] primaryKeyIndices;
         private final String tableName;
         private final boolean isInsertOnly;
@@ -2250,7 +2254,8 @@ public final class TestValuesTableFactory
                 int rowtimeIndex,
                 TableSchema tableSchema,
                 boolean requireBucketCount,
-                boolean supportsDeleteByKey) {
+                boolean supportsDeleteByKey,
+                int[][] targetColumns) {
             this.consumedDataType = consumedDataType;
             this.primaryKeyIndices = primaryKeyIndices;
             this.tableName = tableName;
@@ -2264,6 +2269,7 @@ public final class TestValuesTableFactory
             this.tableSchema = tableSchema;
             this.requireBucketCount = requireBucketCount;
             this.supportsDeleteByKey = supportsDeleteByKey;
+            this.targetColumns = targetColumns;
         }
 
         @Override
@@ -2416,7 +2422,8 @@ public final class TestValuesTableFactory
                     rowtimeIndex,
                     tableSchema,
                     requireBucketCount,
-                    supportsDeleteByKey);
+                    supportsDeleteByKey,
+                    targetColumns);
         }
 
         @Override
@@ -2453,6 +2460,12 @@ public final class TestValuesTableFactory
         @Override
         public boolean requiresBucketCount() {
             return requireBucketCount;
+        }
+
+        @Override
+        public boolean applyTargetColumns(int[][] targetColumns) {
+            this.targetColumns = targetColumns;
+            return true;
         }
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DynamicTableSinkSpecSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DynamicTableSinkSpecSerdeTest.java
@@ -38,6 +38,7 @@ import org.apache.flink.table.factories.TestFormatFactory;
 import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 import org.apache.flink.table.planner.plan.abilities.sink.OverwriteSpec;
 import org.apache.flink.table.planner.plan.abilities.sink.PartitioningSpec;
+import org.apache.flink.table.planner.plan.abilities.sink.TargetColumnWritingSpec;
 import org.apache.flink.table.planner.plan.abilities.sink.WritingMetadataSpec;
 import org.apache.flink.table.planner.plan.nodes.exec.spec.DynamicTableSinkSpec;
 import org.apache.flink.table.planner.utils.PlannerMocks;
@@ -173,7 +174,37 @@ class DynamicTableSinkSpecSerdeTest {
                                         RowType.of(new BigIntType(), new IntType()))),
                         null);
 
-        return Stream.of(spec1, spec2, spec3);
+        Map<String, String> options4 = new HashMap<>();
+        options4.put("connector", TestValuesTableFactory.IDENTIFIER);
+        int[][] targetColumnIndices = new int[][] {{0}, {1}};
+
+        // Todo: add test cases for nested columns in schema after FLINK-31301 is fixed.
+        final ResolvedSchema resolvedSchema4 =
+                new ResolvedSchema(
+                        Arrays.asList(
+                                Column.physical("a", DataTypes.BIGINT()),
+                                Column.physical("b", DataTypes.INT()),
+                                Column.metadata("p", DataTypes.STRING(), null, false)),
+                        Collections.emptyList(),
+                        null);
+        final CatalogTable catalogTable4 =
+                CatalogTable.newBuilder()
+                        .schema(Schema.newBuilder().fromResolvedSchema(resolvedSchema4).build())
+                        .options(options4)
+                        .build();
+
+        DynamicTableSinkSpec spec4 =
+                new DynamicTableSinkSpec(
+                        ContextResolvedTable.temporary(
+                                ObjectIdentifier.of(
+                                        CatalogManagerMocks.DEFAULT_CATALOG,
+                                        CatalogManagerMocks.DEFAULT_DATABASE,
+                                        "MyTable"),
+                                new ResolvedCatalogTable(catalogTable4, resolvedSchema4)),
+                        Collections.singletonList(new TargetColumnWritingSpec(targetColumnIndices)),
+                        targetColumnIndices);
+
+        return Stream.of(spec1, spec2, spec3, spec4);
     }
 
     @ParameterizedTest


### PR DESCRIPTION

## What is the purpose of the change

Introduce new SupportsTargetColumnWriting sink ability and TargetColumnWritingSpec

## Brief change log

  - Introduce new SupportsTargetColumnWriting sink ability and TargetColumnWritingSpec

## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

DynamicTableSinkSpecSerdeTest#testDynamicTableSinkSpecSerde

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented?  FLIP-506
