### PR TITLE
[hotfix] Rename prefix to tag for FileChannelManagerImpl

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/FileChannelManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/FileChannelManagerImpl.java
@@ -53,8 +53,8 @@ public class FileChannelManagerImpl implements FileChannelManager {
     /** The number of the next path to use. */
     private final AtomicLong nextPath = new AtomicLong(0);
 
-    /** Prefix of the temporary directories to create. */
-    private final String prefix;
+    /** Tag of the temporary directories to create. */
+    private final String tag;
 
     /**
      * Flag to signal that the file channel manager has been shutdown already. The flag should
@@ -65,27 +65,27 @@ public class FileChannelManagerImpl implements FileChannelManager {
     /** Shutdown hook to make sure that the directories are removed on exit. */
     private final Thread shutdownHook;
 
-    public FileChannelManagerImpl(String[] tempDirs, String prefix) {
+    public FileChannelManagerImpl(String[] tempDirs, String tag) {
         checkNotNull(tempDirs, "The temporary directories must not be null.");
         checkArgument(tempDirs.length > 0, "The temporary directories must not be empty.");
 
         this.random = new Random();
-        this.prefix = prefix;
+        this.tag = tag;
 
         shutdownHook =
                 ShutdownHookUtil.addShutdownHook(
-                        this, String.format("%s-%s", getClass().getSimpleName(), prefix), LOG);
+                        this, String.format("%s-%s", getClass().getSimpleName(), tag), LOG);
 
         // Creates directories after registering shutdown hook to ensure the directories can be
         // removed if required.
-        this.paths = createFiles(tempDirs, prefix);
+        this.paths = createFiles(tempDirs, tag);
     }
 
-    private static File[] createFiles(String[] tempDirs, String prefix) {
+    private static File[] createFiles(String[] tempDirs, String tag) {
         File[] files = new File[tempDirs.length];
         for (int i = 0; i < tempDirs.length; i++) {
             File baseDir = new File(tempDirs[i]);
-            String subfolder = String.format("flink-%s-%s", prefix, UUID.randomUUID().toString());
+            String subfolder = String.format("flink-%s-%s", tag, UUID.randomUUID().toString());
             File storageDir = new File(baseDir, subfolder);
 
             if (!storageDir.exists() && !storageDir.mkdirs()) {
@@ -139,7 +139,7 @@ public class FileChannelManagerImpl implements FileChannelManager {
                         .collect(Collectors.toList()));
 
         ShutdownHookUtil.removeShutdownHook(
-                shutdownHook, String.format("%s-%s", getClass().getSimpleName(), prefix), LOG);
+                shutdownHook, String.format("%s-%s", getClass().getSimpleName(), tag), LOG);
     }
 
     private static AutoCloseable getFileCloser(File path) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/FileChannelManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/FileChannelManagerImpl.java
@@ -53,8 +53,8 @@ public class FileChannelManagerImpl implements FileChannelManager {
     /** The number of the next path to use. */
     private final AtomicLong nextPath = new AtomicLong(0);
 
-    /** Tag of the temporary directories to create. */
-    private final String tag;
+    /** The name of Component used to create temporary directories. */
+    private final String component;
 
     /**
      * Flag to signal that the file channel manager has been shutdown already. The flag should
@@ -65,27 +65,28 @@ public class FileChannelManagerImpl implements FileChannelManager {
     /** Shutdown hook to make sure that the directories are removed on exit. */
     private final Thread shutdownHook;
 
-    public FileChannelManagerImpl(String[] tempDirs, String tag) {
+    public FileChannelManagerImpl(String[] tempDirs, String component) {
         checkNotNull(tempDirs, "The temporary directories must not be null.");
         checkArgument(tempDirs.length > 0, "The temporary directories must not be empty.");
 
         this.random = new Random();
-        this.tag = tag;
+        this.component = component;
 
         shutdownHook =
                 ShutdownHookUtil.addShutdownHook(
-                        this, String.format("%s-%s", getClass().getSimpleName(), tag), LOG);
+                        this, String.format("%s-%s", getClass().getSimpleName(), component), LOG);
 
         // Creates directories after registering shutdown hook to ensure the directories can be
         // removed if required.
-        this.paths = createFiles(tempDirs, tag);
+        this.paths = createFiles(tempDirs, component);
     }
 
-    private static File[] createFiles(String[] tempDirs, String tag) {
+    private static File[] createFiles(String[] tempDirs, String component) {
         File[] files = new File[tempDirs.length];
         for (int i = 0; i < tempDirs.length; i++) {
             File baseDir = new File(tempDirs[i]);
-            String subfolder = String.format("flink-%s-%s", tag, UUID.randomUUID().toString());
+            String subfolder =
+                    String.format("flink-%s-%s", component, UUID.randomUUID().toString());
             File storageDir = new File(baseDir, subfolder);
 
             if (!storageDir.exists() && !storageDir.mkdirs()) {
@@ -139,7 +140,7 @@ public class FileChannelManagerImpl implements FileChannelManager {
                         .collect(Collectors.toList()));
 
         ShutdownHookUtil.removeShutdownHook(
-                shutdownHook, String.format("%s-%s", getClass().getSimpleName(), tag), LOG);
+                shutdownHook, String.format("%s-%s", getClass().getSimpleName(), component), LOG);
     }
 
     private static AutoCloseable getFileCloser(File path) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/iomanager/IOManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/iomanager/IOManager.java
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
 public abstract class IOManager implements AutoCloseable {
     protected static final Logger LOG = LoggerFactory.getLogger(IOManager.class);
 
-    private static final String DIR_NAME_TAG = "io";
+    private static final String COMPONENT_DIR_NAME = "io";
 
     private final FileChannelManager fileChannelManager;
 
@@ -58,7 +58,8 @@ public abstract class IOManager implements AutoCloseable {
      */
     protected IOManager(String[] tempDirs, ExecutorService executorService) {
         this.fileChannelManager =
-                new FileChannelManagerImpl(Preconditions.checkNotNull(tempDirs), DIR_NAME_TAG);
+                new FileChannelManagerImpl(
+                        Preconditions.checkNotNull(tempDirs), COMPONENT_DIR_NAME);
         if (LOG.isInfoEnabled()) {
             LOG.info(
                     "Created a new {} for spilling of task related data to disk (joins, sorting, ...). Used directories:\n\t{}",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/iomanager/IOManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/iomanager/IOManager.java
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
 public abstract class IOManager implements AutoCloseable {
     protected static final Logger LOG = LoggerFactory.getLogger(IOManager.class);
 
-    private static final String DIR_NAME_PREFIX = "io";
+    private static final String DIR_NAME_TAG = "io";
 
     private final FileChannelManager fileChannelManager;
 
@@ -58,7 +58,7 @@ public abstract class IOManager implements AutoCloseable {
      */
     protected IOManager(String[] tempDirs, ExecutorService executorService) {
         this.fileChannelManager =
-                new FileChannelManagerImpl(Preconditions.checkNotNull(tempDirs), DIR_NAME_PREFIX);
+                new FileChannelManagerImpl(Preconditions.checkNotNull(tempDirs), DIR_NAME_TAG);
         if (LOG.isInfoEnabled()) {
             LOG.info(
                     "Created a new {} for spilling of task related data to disk (joins, sorting, ...). Used directories:\n\t{}",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
@@ -63,7 +63,7 @@ public class NettyShuffleServiceFactory
         implements ShuffleServiceFactory<NettyShuffleDescriptor, ResultPartition, SingleInputGate> {
 
     private static final Logger LOG = LoggerFactory.getLogger(NettyShuffleServiceFactory.class);
-    private static final String DIR_NAME_PREFIX = "netty-shuffle";
+    private static final String DIR_NAME_TAG = "netty-shuffle";
 
     @Override
     public NettyShuffleMaster createShuffleMaster(ShuffleMasterContext shuffleMasterContext) {
@@ -163,7 +163,7 @@ public class NettyShuffleServiceFactory
         checkNotNull(connectionManager);
 
         FileChannelManager fileChannelManager =
-                new FileChannelManagerImpl(config.getTempDirs(), DIR_NAME_PREFIX);
+                new FileChannelManagerImpl(config.getTempDirs(), DIR_NAME_TAG);
         if (LOG.isInfoEnabled()) {
             LOG.info(
                     "Created a new {} for storing result partitions of BLOCKING shuffles. Used directories:\n\t{}",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
@@ -63,7 +63,7 @@ public class NettyShuffleServiceFactory
         implements ShuffleServiceFactory<NettyShuffleDescriptor, ResultPartition, SingleInputGate> {
 
     private static final Logger LOG = LoggerFactory.getLogger(NettyShuffleServiceFactory.class);
-    private static final String DIR_NAME_TAG = "netty-shuffle";
+    private static final String COMPONENT_DIR_NAME = "netty-shuffle";
 
     @Override
     public NettyShuffleMaster createShuffleMaster(ShuffleMasterContext shuffleMasterContext) {
@@ -163,7 +163,7 @@ public class NettyShuffleServiceFactory
         checkNotNull(connectionManager);
 
         FileChannelManager fileChannelManager =
-                new FileChannelManagerImpl(config.getTempDirs(), DIR_NAME_TAG);
+                new FileChannelManagerImpl(config.getTempDirs(), COMPONENT_DIR_NAME);
         if (LOG.isInfoEnabled()) {
             LOG.info(
                     "Created a new {} for storing result partitions of BLOCKING shuffles. Used directories:\n\t{}",

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/FileChannelManagerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/FileChannelManagerImplTest.java
@@ -42,7 +42,7 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 class FileChannelManagerImplTest {
     private static final Logger LOG = LoggerFactory.getLogger(FileChannelManagerImplTest.class);
 
-    private static final String DIR_NAME_PREFIX = "manager-test";
+    private static final String DIR_NAME_TAG = "manager-test";
 
     /**
      * Marker file indicating the test process is ready to be killed. We could not simply kill the
@@ -150,7 +150,7 @@ class FileChannelManagerImplTest {
                     .isFalse();
 
             // Checks if the directories are cleared.
-            assertThat(fileOrDirExists(fileChannelDir, DIR_NAME_PREFIX))
+            assertThat(fileOrDirExists(fileChannelDir, DIR_NAME_TAG))
                     .withFailMessage(
                             "The file channel manager test process does not remove the tmp shuffle directories after termination, its output is \n%s",
                             fileChannelManagerTestProcess.getProcessOutput())
@@ -206,7 +206,7 @@ class FileChannelManagerImplTest {
             LOG.info("The FileChannelManagerCleanupRunner process has started");
 
             FileChannelManager manager =
-                    new FileChannelManagerImpl(new String[] {tmpDirectory}, DIR_NAME_PREFIX);
+                    new FileChannelManagerImpl(new String[] {tmpDirectory}, DIR_NAME_TAG);
 
             if (callerHasHook) {
                 // Verifies the case that both FileChannelManager and its upper component

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/FileChannelManagerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/FileChannelManagerImplTest.java
@@ -42,7 +42,7 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 class FileChannelManagerImplTest {
     private static final Logger LOG = LoggerFactory.getLogger(FileChannelManagerImplTest.class);
 
-    private static final String DIR_NAME_TAG = "manager-test";
+    private static final String COMPONENT_DIR_NAME = "manager-test";
 
     /**
      * Marker file indicating the test process is ready to be killed. We could not simply kill the
@@ -150,7 +150,7 @@ class FileChannelManagerImplTest {
                     .isFalse();
 
             // Checks if the directories are cleared.
-            assertThat(fileOrDirExists(fileChannelDir, DIR_NAME_TAG))
+            assertThat(fileOrDirExists(fileChannelDir, COMPONENT_DIR_NAME))
                     .withFailMessage(
                             "The file channel manager test process does not remove the tmp shuffle directories after termination, its output is \n%s",
                             fileChannelManagerTestProcess.getProcessOutput())
@@ -206,7 +206,7 @@ class FileChannelManagerImplTest {
             LOG.info("The FileChannelManagerCleanupRunner process has started");
 
             FileChannelManager manager =
-                    new FileChannelManagerImpl(new String[] {tmpDirectory}, DIR_NAME_TAG);
+                    new FileChannelManagerImpl(new String[] {tmpDirectory}, COMPONENT_DIR_NAME);
 
             if (callerHasHook) {
                 // Verifies the case that both FileChannelManager and its upper component


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to rename `prefix` to `tag` for `FileChannelManagerImpl`.
Currently, `FileChannelManagerImpl` have a field `prefix`. But in reality, it will create a directory named `flink-{prefix}-{UUID.randomUUID()}`.
Obviously, it is not used as a prefix.


## Brief change log

Rename `prefix` to `tag` for `FileChannelManagerImpl`.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
