### PR TITLE
[hotfix] Simplify the calling on addShutdownHook

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/iomanager/IOManagerAsync.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/iomanager/IOManagerAsync.java
@@ -121,8 +121,7 @@ public class IOManagerAsync extends IOManager implements UncaughtExceptionHandle
         }
 
         // install a shutdown hook that makes sure the temp directories get deleted
-        this.shutdownHook =
-                ShutdownHookUtil.addShutdownHook(this::close, getClass().getSimpleName(), LOG);
+        this.shutdownHook = ShutdownHookUtil.addShutdownHook(this, getClass().getSimpleName(), LOG);
     }
 
     /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/FileChannelManagerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/FileChannelManagerImplTest.java
@@ -211,7 +211,7 @@ class FileChannelManagerImplTest {
             if (callerHasHook) {
                 // Verifies the case that both FileChannelManager and its upper component
                 // have registered shutdown hooks, like in IOManager.
-                ShutdownHookUtil.addShutdownHook(() -> manager.close(), "Caller", LOG);
+                ShutdownHookUtil.addShutdownHook(manager, "Caller", LOG);
             }
 
             LOG.info("The FileChannelManagerCleanupRunner is going to create the new file");


### PR DESCRIPTION
## What is the purpose of the change

This PR proposes to simplify the calling on `addShutdownHook`.


## Brief change log

Simplify the calling on `addShutdownHook`.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
