### PR TITLE
[hotfix] [docs] Fix flink-connector-kafka version in "How to use Maven.." doc of Flink master

### DIFF
--- a/docs/content/docs/dev/configuration/maven.md
+++ b/docs/content/docs/dev/configuration/maven.md
@@ -74,7 +74,7 @@ For example, you can add the Kafka connector as a dependency like this:
     <dependency>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-connector-kafka</artifactId>
-        <version>{{< version >}}</version>
+        <version>1.17-SNAPSHOT</version>
     </dependency>
     
 </dependencies>


### PR DESCRIPTION
The "Using Maven" page in Flink's latest release documentation populates version of flink-connector-kafka in an example using Flink's version initialized in the config.toml file. As Flink version is set as 2.1-SNAPSHOT in config.toml, the version of flink-connector-kafka also gets populated as the same. However, checking flink-connector-kafka's repository, there is no 2.1-SNAPSHOT there. This causes the mvn build to break at the doc reader's end. To avoid the problem, either we can initialize a new dedicated version variable for flink-connector-kafka in config.toml and use it in this doc page. Or, if it looks like too much of a change for one mention, can we populate an existing flink-connector-kafka version in the doc example so that the reader's build does not break.

https://repository.apache.org/content/repositories/snapshots/org/apache/flink/flink-connector-kafka/


*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  A- This pertains to one minor change in the Flink docs. There is no JIRA issue created for it hence.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.
  A- Done.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  A- Working on it.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).
  A- Working on it.

  - Each pull request should address only one issue, not mix up code from multiple issues.
  A- This pull request tries to fix only one issue.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)
  A- I have provided a meaningful title and description to the best of my knowledge for this pull request.

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**


## What is the purpose of the change

The version of Flink Connector Kafka given in Flink doc master causes MVN build to fail. This is because the doc reuses the latest version of Flink to populate the Flink Connector Kafka version also. The version given in the doc does not exist in the Flink Connector Kafka repository causing the build to fail. The purpose of this change is to update the Flink Connector Kafka version in the doc to an existing one.


## Brief change log

Replace the Flink version variable (initialized in config.toml file) used in maven.md doc with actual existing version of Flink Connector Kafka.


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

This change is a trivial rework / code cleanup without any test coverage.
The CI build results are shared [below](https://github.com/apache/flink/pull/26366#issuecomment-2759306562).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
