### PR TITLE
[hotfix] Avoid duplicate fetch the size of memory segment

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
@@ -304,7 +304,8 @@ public class NettyShuffleEnvironmentConfiguration {
                         configuration,
                         localTaskManagerCommunication,
                         taskManagerAddress,
-                        dataBindPortRange);
+                        dataBindPortRange,
+                        pageSize);
 
         final int numberOfNetworkBuffers =
                 calculateNumberOfNetworkBuffers(networkMemorySize, pageSize);
@@ -454,6 +455,8 @@ public class NettyShuffleEnvironmentConfiguration {
      * @param taskManagerAddress identifying the IP address under which the TaskManager will be
      *     accessible
      * @param dataPortRange data port range for communication and data exchange
+     * @param memorySegmentSize size of memory buffers used by the network stack and the memory
+     *     manager
      * @return the netty configuration or {@code null} if communication is in the same task manager
      */
     @Nullable
@@ -461,7 +464,8 @@ public class NettyShuffleEnvironmentConfiguration {
             Configuration configuration,
             boolean localTaskManagerCommunication,
             InetAddress taskManagerAddress,
-            PortRange dataPortRange) {
+            PortRange dataPortRange,
+            int memorySegmentSize) {
 
         final NettyConfig nettyConfig;
         if (!localTaskManagerCommunication) {
@@ -472,7 +476,7 @@ public class NettyShuffleEnvironmentConfiguration {
                     new NettyConfig(
                             taskManagerInetSocketAddress.getAddress(),
                             dataPortRange,
-                            ConfigurationParserUtils.getPageSize(configuration),
+                            memorySegmentSize,
                             ConfigurationParserUtils.getSlot(configuration),
                             configuration);
         } else {


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to avoid duplicate fetch the size of memory segment.
Currently, we fetch pageSize at `NettyShuffleEnvironmentConfiguration.fromConfiguration` and then we fetch the pageSize at `NettyShuffleEnvironmentConfiguration.createNettyConfig` again.
To fetch pageSize, we call `ConfigurationParserUtils.getPageSize(configuration)` which have a lot of overhead.
```
    public static int getPageSize(Configuration configuration) {
        final int pageSize =
                checkedDownCast(
                        configuration.get(TaskManagerOptions.MEMORY_SEGMENT_SIZE).getBytes());

        // check page size of for minimum size
        checkConfigParameter(
                pageSize >= MemoryManager.MIN_PAGE_SIZE,
                pageSize,
                TaskManagerOptions.MEMORY_SEGMENT_SIZE.key(),
                "Minimum memory segment size is " + MemoryManager.MIN_PAGE_SIZE);
        // check page size for power of two
        checkConfigParameter(
                MathUtils.isPowerOf2(pageSize),
                pageSize,
                TaskManagerOptions.MEMORY_SEGMENT_SIZE.key(),
                "Memory segment size must be a power of 2.");

        return pageSize;
    }
```
We just add a new parameter to the private method `createNettyConfig` and avoid duplicate fetch the size of memory segment.


## Brief change log

Avoid duplicate fetch the size of memory segment.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
