### PR TITLE
[FLINK-37575] Simplify the code for creating Netty shuffle environment.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
@@ -88,7 +88,7 @@ public class NettyShuffleServiceFactory
                 shuffleEnvironmentContext.getIoExecutor(),
                 shuffleEnvironmentContext.getScheduledExecutor(),
                 shuffleEnvironmentContext.getNumberOfSlots(),
-                shuffleEnvironmentContext.getTmpDirPaths());
+                shuffleEnvironmentContext.getTmpDirs().length);
     }
 
     @VisibleForTesting
@@ -100,7 +100,7 @@ public class NettyShuffleServiceFactory
             Executor ioExecutor,
             ScheduledExecutor scheduledExecutor,
             int numberOfSlots,
-            String[] tmpDirPaths) {
+            int numberOfTmpDirs) {
         return createNettyShuffleEnvironment(
                 config,
                 taskExecutorResourceId,
@@ -110,7 +110,7 @@ public class NettyShuffleServiceFactory
                 metricGroup,
                 ioExecutor,
                 numberOfSlots,
-                tmpDirPaths);
+                numberOfTmpDirs);
     }
 
     @VisibleForTesting
@@ -122,7 +122,7 @@ public class NettyShuffleServiceFactory
             MetricGroup metricGroup,
             Executor ioExecutor,
             int numberOfSlots,
-            String[] tmpDirPaths) {
+            int numberOfTmpDirs) {
         NettyConfig nettyConfig = config.nettyConfig();
         ConnectionManager connectionManager =
                 nettyConfig != null
@@ -141,7 +141,7 @@ public class NettyShuffleServiceFactory
                 metricGroup,
                 ioExecutor,
                 numberOfSlots,
-                tmpDirPaths);
+                numberOfTmpDirs);
     }
 
     @VisibleForTesting
@@ -154,7 +154,7 @@ public class NettyShuffleServiceFactory
             MetricGroup metricGroup,
             Executor ioExecutor,
             int numberOfSlots,
-            String[] tmpDirPaths) {
+            int numberOfTmpDirs) {
         checkNotNull(config);
         checkNotNull(taskExecutorResourceId);
         checkNotNull(taskEventPublisher);
@@ -195,7 +195,7 @@ public class NettyShuffleServiceFactory
                                 1,
                                 Math.min(
                                         batchShuffleReadBufferPool.getMaxConcurrentRequests(),
-                                        Math.max(numberOfSlots, tmpDirPaths.length))),
+                                        Math.max(numberOfSlots, numberOfTmpDirs))),
                         new ExecutorThreadFactory("blocking-shuffle-io"));
 
         registerShuffleMetrics(metricGroup, networkBufferPool);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleEnvironmentContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleEnvironmentContext.java
@@ -40,7 +40,7 @@ public class ShuffleEnvironmentContext {
     private final TaskEventPublisher eventPublisher;
     private final MetricGroup parentMetricGroup;
     private final int numberOfSlots;
-    private final String[] tmpDirPaths;
+    private final String[] tmpDirs;
 
     private final Executor ioExecutor;
     private final ScheduledExecutor scheduledExecutor;
@@ -52,7 +52,7 @@ public class ShuffleEnvironmentContext {
             boolean localCommunicationOnly,
             InetAddress hostAddress,
             int numberOfSlots,
-            String[] tmpDirPaths,
+            String[] tmpDirs,
             TaskEventPublisher eventPublisher,
             MetricGroup parentMetricGroup,
             Executor ioExecutor,
@@ -67,7 +67,7 @@ public class ShuffleEnvironmentContext {
         this.ioExecutor = ioExecutor;
         this.scheduledExecutor = scheduledExecutor;
         this.numberOfSlots = numberOfSlots;
-        this.tmpDirPaths = checkNotNull(tmpDirPaths);
+        this.tmpDirs = checkNotNull(tmpDirs);
     }
 
     public Configuration getConfiguration() {
@@ -110,7 +110,7 @@ public class ShuffleEnvironmentContext {
         return numberOfSlots;
     }
 
-    public String[] getTmpDirPaths() {
-        return tmpDirPaths;
+    public String[] getTmpDirs() {
+        return tmpDirs;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
@@ -333,13 +333,13 @@ public class TaskManagerServices {
             throws Exception {
 
         // pre-start checks
-        checkTempDirs(taskManagerServicesConfiguration.getTmpDirPaths());
+        checkTempDirs(taskManagerServicesConfiguration.getTmpDirs());
 
         final TaskEventDispatcher taskEventDispatcher = new TaskEventDispatcher();
 
         // start the I/O manager, it will create some temp directories.
         final IOManager ioManager =
-                new IOManagerAsync(taskManagerServicesConfiguration.getTmpDirPaths(), ioExecutor);
+                new IOManagerAsync(taskManagerServicesConfiguration.getTmpDirs(), ioExecutor);
 
         final ShuffleEnvironment<?, ?> shuffleEnvironment =
                 createShuffleEnvironment(
@@ -501,7 +501,7 @@ public class TaskManagerServices {
                         taskManagerServicesConfiguration.isLocalCommunicationOnly(),
                         taskManagerServicesConfiguration.getBindAddress(),
                         taskManagerServicesConfiguration.getNumberOfSlots(),
-                        taskManagerServicesConfiguration.getTmpDirPaths(),
+                        taskManagerServicesConfiguration.getTmpDirs(),
                         taskEventDispatcher,
                         taskManagerMetricGroup,
                         ioExecutor,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
@@ -69,7 +69,7 @@ public class TaskManagerServicesConfiguration {
 
     private final boolean localCommunicationOnly;
 
-    private final String[] tmpDirPaths;
+    private final String[] tmpDirs;
 
     private final Reference<File[]> localRecoveryStateDirectories;
 
@@ -104,7 +104,7 @@ public class TaskManagerServicesConfiguration {
             InetAddress bindAddress,
             int externalDataPort,
             boolean localCommunicationOnly,
-            String[] tmpDirPaths,
+            String[] tmpDirs,
             Reference<File[]> localRecoveryStateDirectories,
             boolean localRecoveryEnabled,
             boolean localBackupEnabled,
@@ -126,7 +126,7 @@ public class TaskManagerServicesConfiguration {
         this.bindAddress = checkNotNull(bindAddress);
         this.externalDataPort = externalDataPort;
         this.localCommunicationOnly = localCommunicationOnly;
-        this.tmpDirPaths = checkNotNull(tmpDirPaths);
+        this.tmpDirs = checkNotNull(tmpDirs);
         this.localRecoveryStateDirectories = checkNotNull(localRecoveryStateDirectories);
         this.localRecoveryEnabled = localRecoveryEnabled;
         this.localBackupEnabled = localBackupEnabled;
@@ -180,8 +180,8 @@ public class TaskManagerServicesConfiguration {
         return localCommunicationOnly;
     }
 
-    public String[] getTmpDirPaths() {
-        return tmpDirPaths;
+    public String[] getTmpDirs() {
+        return tmpDirs;
     }
 
     Reference<File[]> getLocalRecoveryStateDirectories() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
@@ -292,6 +292,6 @@ public class NettyShuffleEnvironmentBuilder {
                 metricGroup,
                 ioExecutor,
                 DEFAULT_NUM_SLOTS,
-                DEFAULT_TEMP_DIRS);
+                DEFAULT_TEMP_DIRS.length);
     }
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SharedPoolNettyShuffleServiceFactory.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SharedPoolNettyShuffleServiceFactory.java
@@ -100,6 +100,6 @@ public final class SharedPoolNettyShuffleServiceFactory
                 shuffleEnvironmentContext.getParentMetricGroup(),
                 shuffleEnvironmentContext.getIoExecutor(),
                 shuffleEnvironmentContext.getNumberOfSlots(),
-                shuffleEnvironmentContext.getTmpDirPaths());
+                shuffleEnvironmentContext.getTmpDirs().length);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to simplify the code for creating Netty shuffle environment.
Currently, `NettyShuffleServiceFactory.createNettyShuffleEnvironment` has a parameter 'String[] tmpDirPaths', but its true purpose is only to use its length.

Even if developers want to use the value of `String [] tmpDirPaths` in the future, it's no problem due to the parameter `NettyShuffleEnvironmentConfiguration config` of `NettyShuffleServiceFactory.createNettyShuffleEnvironment` has the field `private final String[] tempDirs;` too. We can use it by calling the `getTempDirs` show below.
```
    public String[] getTempDirs() {
        return tempDirs;
    }
```

This PR also unify the temp directory with `tempDirs`.


## Brief change log

Simplify the code for creating Netty shuffle environment.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
