### PR TITLE
[BP-2.0][FLINK-37576][runtime] Fix the incorrect status of the isBroadcast field in AllToAllBlockingResultInfo when submitting a job graph.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AllToAllBlockingResultInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AllToAllBlockingResultInfo.java
@@ -74,6 +74,7 @@ public class AllToAllBlockingResultInfo extends AbstractBlockingResultInfo {
             Map<Integer, long[]> subpartitionBytesByPartitionIndex) {
         super(resultId, numOfPartitions, numOfSubpartitions, subpartitionBytesByPartitionIndex);
         this.singleSubpartitionContainsAllData = singleSubpartitionContainsAllData;
+        this.isBroadcast = singleSubpartitionContainsAllData;
     }
 
     @Override


### PR DESCRIPTION
[BP-2.0][FLINK-37576][runtime] Fix the incorrect status of the isBroadcast field in AllToAllBlockingResultInfo when submitting a job graph.