### PR TITLE
[FLINK-37579] Avoid duplicate generate ResourceProfile

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerConfiguration.java
@@ -182,7 +182,8 @@ public class TaskManagerConfiguration implements TaskManagerRuntimeInfo {
 
     public static TaskManagerConfiguration fromConfiguration(
             Configuration configuration,
-            TaskExecutorResourceSpec taskExecutorResourceSpec,
+            final ResourceProfile defaultSlotResourceProfile,
+            final ResourceProfile totalAvailableResourceProfile,
             String externalAddress,
             File tmpWorkingDirectory) {
         int numberSlots = configuration.get(TaskManagerOptions.NUM_TASK_SLOTS, 1);
@@ -235,10 +236,8 @@ public class TaskManagerConfiguration implements TaskManagerRuntimeInfo {
 
         return new TaskManagerConfiguration(
                 numberSlots,
-                TaskExecutorResourceUtils.generateDefaultSlotResourceProfile(
-                        taskExecutorResourceSpec, numberSlots),
-                TaskExecutorResourceUtils.generateTotalAvailableResourceProfile(
-                        taskExecutorResourceSpec),
+                defaultSlotResourceProfile,
+                totalAvailableResourceProfile,
                 tmpDirPaths,
                 rpcTimeout,
                 slotTimeout,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -653,7 +653,8 @@ public class TaskManagerRunner implements FatalErrorHandler {
         TaskManagerConfiguration taskManagerConfiguration =
                 TaskManagerConfiguration.fromConfiguration(
                         configuration,
-                        taskExecutorResourceSpec,
+                        taskManagerServicesConfiguration.getDefaultSlotResourceProfile(),
+                        taskManagerServicesConfiguration.getTotalAvailableResourceProfile(),
                         externalAddress,
                         workingDirectory.getTmpDirectory());
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.blob.PermanentBlobKey;
 import org.apache.flink.runtime.blob.PermanentBlobService;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptorFactory.ShuffleDescriptorGroup;
 import org.apache.flink.runtime.entrypoint.WorkingDirectory;
 import org.apache.flink.runtime.execution.librarycache.BlobLibraryCacheManager;
@@ -374,7 +375,8 @@ public class TaskManagerServices {
         final TaskSlotTable<Task> taskSlotTable =
                 createTaskSlotTable(
                         taskManagerServicesConfiguration.getNumberOfSlots(),
-                        taskManagerServicesConfiguration.getTaskExecutorResourceSpec(),
+                        taskManagerServicesConfiguration.getTotalAvailableResourceProfile(),
+                        taskManagerServicesConfiguration.getDefaultSlotResourceProfile(),
                         taskManagerServicesConfiguration.getTimerServiceShutdownTimeout(),
                         taskManagerServicesConfiguration.getPageSize(),
                         ioExecutor);
@@ -467,7 +469,8 @@ public class TaskManagerServices {
 
     private static TaskSlotTable<Task> createTaskSlotTable(
             final int numberOfSlots,
-            final TaskExecutorResourceSpec taskExecutorResourceSpec,
+            final ResourceProfile totalAvailableResourceProfile,
+            final ResourceProfile defaultSlotResourceProfile,
             final long timerServiceShutdownTimeout,
             final int pageSize,
             final Executor memoryVerificationExecutor) {
@@ -476,10 +479,8 @@ public class TaskManagerServices {
                         new ScheduledThreadPoolExecutor(1), timerServiceShutdownTimeout);
         return new TaskSlotTableImpl<>(
                 numberOfSlots,
-                TaskExecutorResourceUtils.generateTotalAvailableResourceProfile(
-                        taskExecutorResourceSpec),
-                TaskExecutorResourceUtils.generateDefaultSlotResourceProfile(
-                        taskExecutorResourceSpec, numberOfSlots),
+                totalAvailableResourceProfile,
+                defaultSlotResourceProfile,
                 pageSize,
                 timerService,
                 memoryVerificationExecutor);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
@@ -29,6 +29,7 @@ import org.apache.flink.configuration.StateRecoveryOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.configuration.TaskManagerOptionsInternal;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.entrypoint.ClusterEntrypointUtils;
 import org.apache.flink.runtime.entrypoint.WorkingDirectory;
 import org.apache.flink.runtime.registration.RetryingRegistrationConfiguration;
@@ -91,6 +92,10 @@ public class TaskManagerServicesConfiguration {
 
     private final TaskExecutorResourceSpec taskExecutorResourceSpec;
 
+    private final ResourceProfile totalAvailableResourceProfile;
+
+    private final ResourceProfile defaultSlotResourceProfile;
+
     private final FlinkUserCodeClassLoaders.ResolveOrder classLoaderResolveOrder;
 
     private final String[] alwaysParentFirstLoaderPatterns;
@@ -136,6 +141,12 @@ public class TaskManagerServicesConfiguration {
         this.pageSize = pageSize;
 
         this.taskExecutorResourceSpec = taskExecutorResourceSpec;
+        this.totalAvailableResourceProfile =
+                TaskExecutorResourceUtils.generateTotalAvailableResourceProfile(
+                        taskExecutorResourceSpec);
+        this.defaultSlotResourceProfile =
+                TaskExecutorResourceUtils.generateDefaultSlotResourceProfile(
+                        taskExecutorResourceSpec, numberOfSlots);
         this.classLoaderResolveOrder = classLoaderResolveOrder;
         this.alwaysParentFirstLoaderPatterns = alwaysParentFirstLoaderPatterns;
         this.numIoThreads = numIoThreads;
@@ -211,6 +222,14 @@ public class TaskManagerServicesConfiguration {
 
     public TaskExecutorResourceSpec getTaskExecutorResourceSpec() {
         return taskExecutorResourceSpec;
+    }
+
+    public ResourceProfile getTotalAvailableResourceProfile() {
+        return totalAvailableResourceProfile;
+    }
+
+    public ResourceProfile getDefaultSlotResourceProfile() {
+        return defaultSlotResourceProfile;
     }
 
     public MemorySize getNetworkMemorySize() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorBuilder.java
@@ -37,6 +37,7 @@ import org.apache.flink.runtime.rest.util.NoOpFatalErrorHandler;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.security.token.DelegationTokenReceiverRepository;
+import org.apache.flink.runtime.util.ConfigurationParserUtils;
 import org.apache.flink.util.concurrent.Executors;
 
 import javax.annotation.Nullable;
@@ -115,7 +116,11 @@ public class TaskExecutorBuilder {
             resolvedTaskManagerConfiguration =
                     TaskManagerConfiguration.fromConfiguration(
                             configuration,
-                            taskExecutorResourceSpec,
+                            TaskExecutorResourceUtils.generateDefaultSlotResourceProfile(
+                                    taskExecutorResourceSpec,
+                                    ConfigurationParserUtils.getSlot(configuration)),
+                            TaskExecutorResourceUtils.generateTotalAvailableResourceProfile(
+                                    taskExecutorResourceSpec),
                             rpcService.getAddress(),
                             workingDirectory.getTmpDirectory());
         } else {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorExecutionDeploymentReconciliationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorExecutionDeploymentReconciliationTest.java
@@ -55,6 +55,7 @@ import org.apache.flink.runtime.rpc.TestingRpcServiceExtension;
 import org.apache.flink.runtime.security.token.DelegationTokenReceiverRepository;
 import org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotUtils;
+import org.apache.flink.runtime.util.ConfigurationParserUtils;
 import org.apache.flink.runtime.util.TestingFatalErrorHandlerExtension;
 import org.apache.flink.testutils.TestFileUtils;
 import org.apache.flink.testutils.TestingUtils;
@@ -234,12 +235,17 @@ class TaskExecutorExecutionDeploymentReconciliationTest {
     private TestingTaskExecutor createTestingTaskExecutor(TaskManagerServices taskManagerServices)
             throws IOException {
         final Configuration configuration = new Configuration();
+        final TaskExecutorResourceSpec taskExecutorResourceSpec =
+                TaskExecutorResourceUtils.resourceSpecFromConfigForLocalExecution(configuration);
         return new TestingTaskExecutor(
                 RPC_SERVICE_EXTENSION_WRAPPER.getCustomExtension().getTestingRpcService(),
                 TaskManagerConfiguration.fromConfiguration(
                         configuration,
-                        TaskExecutorResourceUtils.resourceSpecFromConfigForLocalExecution(
-                                configuration),
+                        TaskExecutorResourceUtils.generateDefaultSlotResourceProfile(
+                                taskExecutorResourceSpec,
+                                ConfigurationParserUtils.getSlot(configuration)),
+                        TaskExecutorResourceUtils.generateTotalAvailableResourceProfile(
+                                taskExecutorResourceSpec),
                         InetAddress.getLoopbackAddress().getHostAddress(),
                         TestFileUtils.createTempDir()),
                 haServices,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
@@ -66,6 +66,7 @@ import org.apache.flink.runtime.taskexecutor.slot.TaskSlotTable;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotUtils;
 import org.apache.flink.runtime.taskmanager.NoOpTaskManagerActions;
 import org.apache.flink.runtime.taskmanager.Task;
+import org.apache.flink.runtime.util.ConfigurationParserUtils;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.testutils.TestFileUtils;
 import org.apache.flink.testutils.TestingUtils;
@@ -679,12 +680,17 @@ class TaskExecutorPartitionLifecycleTest {
     private TestingTaskExecutor createTestingTaskExecutor(
             TaskManagerServices taskManagerServices, TaskExecutorPartitionTracker partitionTracker)
             throws IOException {
+        final TaskExecutorResourceSpec taskExecutorResourceSpec =
+                TaskExecutorResourceUtils.resourceSpecFromConfigForLocalExecution(configuration);
         return new TestingTaskExecutor(
                 rpc,
                 TaskManagerConfiguration.fromConfiguration(
                         configuration,
-                        TaskExecutorResourceUtils.resourceSpecFromConfigForLocalExecution(
-                                configuration),
+                        TaskExecutorResourceUtils.generateDefaultSlotResourceProfile(
+                                taskExecutorResourceSpec,
+                                ConfigurationParserUtils.getSlot(configuration)),
+                        TaskExecutorResourceUtils.generateTotalAvailableResourceProfile(
+                                taskExecutorResourceSpec),
                         InetAddress.getLoopbackAddress().getHostAddress(),
                         TestFileUtils.createTempDir()),
                 haServices,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorSlotLifetimeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorSlotLifetimeTest.java
@@ -50,6 +50,7 @@ import org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotUtils;
 import org.apache.flink.runtime.taskmanager.LocalUnresolvedTaskManagerLocation;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
+import org.apache.flink.runtime.util.ConfigurationParserUtils;
 import org.apache.flink.runtime.util.TestingFatalErrorHandlerExtension;
 import org.apache.flink.testutils.TestFileUtils;
 import org.apache.flink.testutils.TestingUtils;
@@ -216,12 +217,17 @@ class TaskExecutorSlotLifetimeTest {
             TestingHighAvailabilityServices haServices,
             LocalUnresolvedTaskManagerLocation unresolvedTaskManagerLocation)
             throws IOException {
+        final TaskExecutorResourceSpec taskExecutorResourceSpec =
+                TaskExecutorResourceUtils.resourceSpecFromConfigForLocalExecution(configuration);
         return new TaskExecutor(
                 rpcService,
                 TaskManagerConfiguration.fromConfiguration(
                         configuration,
-                        TaskExecutorResourceUtils.resourceSpecFromConfigForLocalExecution(
-                                configuration),
+                        TaskExecutorResourceUtils.generateDefaultSlotResourceProfile(
+                                taskExecutorResourceSpec,
+                                ConfigurationParserUtils.getSlot(configuration)),
+                        TaskExecutorResourceUtils.generateTotalAvailableResourceProfile(
+                                taskExecutorResourceSpec),
                         InetAddress.getLoopbackAddress().getHostAddress(),
                         TestFileUtils.createTempDir()),
                 haServices,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -103,6 +103,7 @@ import org.apache.flink.runtime.taskmanager.UnresolvedTaskManagerLocation;
 import org.apache.flink.runtime.testtasks.BlockingNoOpInvokable;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
+import org.apache.flink.runtime.util.ConfigurationParserUtils;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.testutils.TestFileUtils;
 import org.apache.flink.testutils.TestingUtils;
@@ -2783,7 +2784,10 @@ class TaskExecutorTest {
                 rpc,
                 TaskManagerConfiguration.fromConfiguration(
                         configuration,
-                        TM_RESOURCE_SPEC,
+                        TaskExecutorResourceUtils.generateDefaultSlotResourceProfile(
+                                TM_RESOURCE_SPEC, ConfigurationParserUtils.getSlot(configuration)),
+                        TaskExecutorResourceUtils.generateTotalAvailableResourceProfile(
+                                TM_RESOURCE_SPEC),
                         InetAddress.getLoopbackAddress().getHostAddress(),
                         TestFileUtils.createTempDir()),
                 haServices,
@@ -2819,7 +2823,10 @@ class TaskExecutorTest {
                 rpc,
                 TaskManagerConfiguration.fromConfiguration(
                         configuration,
-                        TM_RESOURCE_SPEC,
+                        TaskExecutorResourceUtils.generateDefaultSlotResourceProfile(
+                                TM_RESOURCE_SPEC, ConfigurationParserUtils.getSlot(configuration)),
+                        TaskExecutorResourceUtils.generateTotalAvailableResourceProfile(
+                                TM_RESOURCE_SPEC),
                         InetAddress.getLoopbackAddress().getHostAddress(),
                         TestFileUtils.createTempDir()),
                 haServices,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
@@ -255,13 +255,18 @@ class TaskSubmissionTestEnvironment implements AutoCloseable {
             Configuration configuration)
             throws IOException {
         final Configuration copiedConf = new Configuration(configuration);
+        final TaskExecutorResourceSpec taskExecutorResourceSpec =
+                TaskExecutorResourceUtils.resourceSpecFromConfigForLocalExecution(copiedConf);
 
         return new TestingTaskExecutor(
                 testingRpcService,
                 TaskManagerConfiguration.fromConfiguration(
                         copiedConf,
-                        TaskExecutorResourceUtils.resourceSpecFromConfigForLocalExecution(
-                                copiedConf),
+                        TaskExecutorResourceUtils.generateDefaultSlotResourceProfile(
+                                taskExecutorResourceSpec,
+                                ConfigurationParserUtils.getSlot(copiedConf)),
+                        TaskExecutorResourceUtils.generateTotalAvailableResourceProfile(
+                                taskExecutorResourceSpec),
                         InetAddress.getLoopbackAddress().getHostAddress(),
                         TestFileUtils.createTempDir()),
                 haServices,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
@@ -61,6 +61,7 @@ import org.apache.flink.runtime.state.changelog.StateChangelogStorage;
 import org.apache.flink.runtime.state.changelog.inmemory.InMemoryStateChangelogStorage;
 import org.apache.flink.runtime.taskexecutor.KvStateService;
 import org.apache.flink.runtime.taskexecutor.NoOpPartitionProducerStateChecker;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorResourceSpec;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorResourceUtils;
 import org.apache.flink.runtime.taskexecutor.TaskManagerConfiguration;
 import org.apache.flink.runtime.taskexecutor.TestGlobalAggregateManager;
@@ -192,12 +193,18 @@ class JvmExitOnFatalErrorTest {
                         new NettyShuffleEnvironmentBuilder().build();
 
                 final Configuration copiedConf = new Configuration(taskManagerConfig);
+                final TaskExecutorResourceSpec taskExecutorResourceSpec =
+                        TaskExecutorResourceUtils.resourceSpecFromConfigForLocalExecution(
+                                copiedConf);
                 final File tmpWorkingDirectory = new File(args[0]);
                 final TaskManagerRuntimeInfo tmInfo =
                         TaskManagerConfiguration.fromConfiguration(
                                 taskManagerConfig,
-                                TaskExecutorResourceUtils.resourceSpecFromConfigForLocalExecution(
-                                        copiedConf),
+                                TaskExecutorResourceUtils.generateDefaultSlotResourceProfile(
+                                        taskExecutorResourceSpec,
+                                        ConfigurationParserUtils.getSlot(copiedConf)),
+                                TaskExecutorResourceUtils.generateTotalAvailableResourceProfile(
+                                        taskExecutorResourceSpec),
                                 InetAddress.getLoopbackAddress().getHostAddress(),
                                 tmpWorkingDirectory);
 


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to avoid duplicate generate `ResourceProfile`.
Currently, `TaskManagerRunner` generates `ResourceProfile` repeatedly.
Obviously, generation of `ResourceProfile` has a lot of overhead. You can see the implementation show below.
```
    @VisibleForTesting
    public static ResourceProfile generateTotalAvailableResourceProfile(
            TaskExecutorResourceSpec taskExecutorResourceSpec) {
        return ResourceProfile.newBuilder()
                .setCpuCores(taskExecutorResourceSpec.getCpuCores())
                .setTaskHeapMemory(taskExecutorResourceSpec.getTaskHeapSize())
                .setTaskOffHeapMemory(taskExecutorResourceSpec.getTaskOffHeapSize())
                .setManagedMemory(taskExecutorResourceSpec.getManagedMemorySize())
                .setNetworkMemory(taskExecutorResourceSpec.getNetworkMemSize())
                .setExtendedResources(taskExecutorResourceSpec.getExtendedResources().values())
                .build();
    }
```
```
    @VisibleForTesting
    public static ResourceProfile generateDefaultSlotResourceProfile(
            TaskExecutorResourceSpec taskExecutorResourceSpec, int numberOfSlots) {
        final ResourceProfile.Builder resourceProfileBuilder =
                ResourceProfile.newBuilder()
                        .setCpuCores(taskExecutorResourceSpec.getCpuCores().divide(numberOfSlots))
                        .setTaskHeapMemory(
                                taskExecutorResourceSpec.getTaskHeapSize().divide(numberOfSlots))
                        .setTaskOffHeapMemory(
                                taskExecutorResourceSpec.getTaskOffHeapSize().divide(numberOfSlots))
                        .setManagedMemory(
                                taskExecutorResourceSpec
                                        .getManagedMemorySize()
                                        .divide(numberOfSlots))
                        .setNetworkMemory(
                                taskExecutorResourceSpec.getNetworkMemSize().divide(numberOfSlots));
        taskExecutorResourceSpec
                .getExtendedResources()
                .forEach(
                        (name, resource) ->
                                resourceProfileBuilder.setExtendedResource(
                                        resource.divide(numberOfSlots)));
        return resourceProfileBuilder.build();
    }
```


## Brief change log

Avoid duplicate generate `ResourceProfile`.


## Verifying this change

This change is already covered by existing tests, such as *(TaskExecutorLocalStateStoresManagerTest)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
