### PR TITLE
[hotfix] Avoid copy Set for variable implementedRpcGateways

### DIFF
--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/pekko/PekkoRpcService.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/pekko/PekkoRpcService.java
@@ -60,7 +60,6 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -284,8 +283,8 @@ public class PekkoRpcService implements RpcService {
             hostname = host.get();
         }
 
-        Set<Class<?>> implementedRpcGateways =
-                new HashSet<>(RpcUtils.extractImplementedRpcGateways(rpcEndpoint.getClass()));
+        Set<Class<? extends RpcGateway>> implementedRpcGateways =
+                RpcUtils.extractImplementedRpcGateways(rpcEndpoint.getClass());
 
         implementedRpcGateways.add(RpcServer.class);
         implementedRpcGateways.add(PekkoBasedEndpoint.class);


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to avoid copy `Set` for variable `implementedRpcGateways`.



## Brief change log

Avoid copy `Set` for variable `implementedRpcGateways`.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
