### PR TITLE
[FLINK-37581] Avoid duplicate calculation for total Flink memory

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorMemoryConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorMemoryConfiguration.java
@@ -106,6 +106,7 @@ public class TaskExecutorMemoryConfiguration implements Serializable {
      * @return The newly instantiated TaskExecutorMemoryConfiguration.
      */
     public static TaskExecutorMemoryConfiguration create(Configuration config) {
+        final long totalFlinkMemory = calculateTotalFlinkMemoryFromComponents(config);
         return new TaskExecutorMemoryConfiguration(
                 getConfigurationValue(config, FRAMEWORK_HEAP_MEMORY),
                 getConfigurationValue(config, TASK_HEAP_MEMORY),
@@ -115,8 +116,8 @@ public class TaskExecutorMemoryConfiguration implements Serializable {
                 getConfigurationValue(config, MANAGED_MEMORY_SIZE),
                 getConfigurationValue(config, JVM_METASPACE),
                 getConfigurationValue(config, JVM_OVERHEAD_MAX),
-                calculateTotalFlinkMemoryFromComponents(config),
-                calculateTotalProcessMemoryFromComponents(config));
+                totalFlinkMemory,
+                calculateTotalProcessMemoryFromComponents(config, totalFlinkMemory));
     }
 
     @JsonCreator

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorResourceUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorResourceUtils.java
@@ -176,14 +176,15 @@ public class TaskExecutorResourceUtils {
                 .getBytes();
     }
 
-    public static long calculateTotalProcessMemoryFromComponents(Configuration config) {
+    public static long calculateTotalProcessMemoryFromComponents(
+            Configuration config, long totalFlinkMemory) {
         Preconditions.checkArgument(config.contains(TaskManagerOptions.JVM_METASPACE));
         Preconditions.checkArgument(config.contains(TaskManagerOptions.JVM_OVERHEAD_MAX));
         Preconditions.checkArgument(config.contains(TaskManagerOptions.JVM_OVERHEAD_MIN));
         Preconditions.checkArgument(
                 config.get(TaskManagerOptions.JVM_OVERHEAD_MAX)
                         .equals(config.get(TaskManagerOptions.JVM_OVERHEAD_MIN)));
-        return calculateTotalFlinkMemoryFromComponents(config)
+        return totalFlinkMemory
                 + config.get(TaskManagerOptions.JVM_METASPACE)
                         .add(config.get(TaskManagerOptions.JVM_OVERHEAD_MAX))
                         .getBytes();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorResourceUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorResourceUtilsTest.java
@@ -189,7 +189,14 @@ class TaskExecutorResourceUtilsTest {
         config.set(TaskManagerOptions.JVM_OVERHEAD_MAX, new MemorySize(10));
         config.set(TaskManagerOptions.JVM_OVERHEAD_MIN, new MemorySize(10));
 
-        assertThat(TaskExecutorResourceUtils.calculateTotalProcessMemoryFromComponents(config))
+        final long totalFlinkMemory =
+                TaskExecutorResourceUtils.calculateTotalFlinkMemoryFromComponents(config);
+
+        assertThat(totalFlinkMemory).isEqualTo(23L);
+
+        assertThat(
+                        TaskExecutorResourceUtils.calculateTotalProcessMemoryFromComponents(
+                                config, totalFlinkMemory))
                 .isEqualTo(41L);
     }
 
@@ -207,7 +214,9 @@ class TaskExecutorResourceUtilsTest {
         assertThatThrownBy(
                         () ->
                                 TaskExecutorResourceUtils.calculateTotalProcessMemoryFromComponents(
-                                        config))
+                                        config,
+                                        TaskExecutorResourceUtils
+                                                .calculateTotalFlinkMemoryFromComponents(config)))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to avoid duplicate calculation for total Flink memory.
Currently, there are duplicate calling on `calculateTotalFlinkMemoryFromComponents` while creating `TaskExecutorMemoryConfiguration`.
The first caller is the method `create` of `TaskExecutorMemoryConfiguration`.
The second caller is the method `calculateTotalProcessMemoryFromComponents` of `TaskExecutorResourceUtils`.


## Brief change log

Avoid duplicate calculation for total Flink memory.


## Verifying this change

This change is already covered by existing tests, such as *(TaskExecutorResourceUtilsTest)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
