### PR TITLE
[FLINK-37584] Bump assertj-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@ under the License.
 		<archunit.version>1.2.0</archunit.version>
 		<mockito.version>5.14.2</mockito.version>
 		<hamcrest.version>1.3</hamcrest.version>
-		<assertj.version>3.23.1</assertj.version>
+		<assertj.version>3.27.3</assertj.version>
 		<py4j.version>0.10.9.7</py4j.version>
 		<beam.version>2.54.0</beam.version>
 		<protoc.version>3.21.7</protoc.version>


### PR DESCRIPTION
## What is the purpose of the change

Bump assertj-core version from 3.23.1 to 3.27.3

## Brief change log

The current version has vulnerability in the dependant package, bumping it to the latest version will remediate.

Vulnerabilities from dependencies:
[CVE-2024-47554](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-47554)
[CVE-2023-2976](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2976)
[CVE-2022-42004](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-42004)
[CVE-2022-42003](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-42003)
[CVE-2020-8908](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8908)

Package details:
https://mvnrepository.com/artifact/org.assertj/assertj-core/3.27.3


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

