### PR TITLE
[FLINK-37542][table-planner] Support sink reuse in streaming mode

### DIFF
--- a/docs/layouts/shortcodes/generated/optimizer_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/optimizer_config_configuration.html
@@ -84,7 +84,7 @@ ONE_PHASE: Enforce to use one stage aggregate which only has CompleteGlobalAggre
             <td>When true, the optimizer will try to find out duplicated sub-plans by digest to build optimize blocks (a.k.a. common sub-graphs). Each optimize block will be optimized independently.</td>
         </tr>
         <tr>
-            <td><h5>table.optimizer.reuse-sink-enabled</h5><br> <span class="label label-primary">Batch</span></td>
+            <td><h5>table.optimizer.reuse-sink-enabled</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
             <td>When it is true, the optimizer will try to find out duplicated table sinks and reuse them. This works only when table.optimizer.reuse-sub-plan-enabled is true.</td>

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/OptimizerConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/OptimizerConfigOptions.java
@@ -105,7 +105,7 @@ public class OptimizerConfigOptions {
                                     + TABLE_OPTIMIZER_REUSE_SUB_PLAN_ENABLED.key()
                                     + " is true.");
 
-    @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH)
+    @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH_STREAMING)
     public static final ConfigOption<Boolean> TABLE_OPTIMIZER_REUSE_SINK_ENABLED =
             key("table.optimizer.reuse-sink-enabled")
                     .booleanType()

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalSink.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalSink.scala
@@ -46,7 +46,7 @@ class StreamPhysicalSink(
     contextResolvedTable: ContextResolvedTable,
     tableSink: DynamicTableSink,
     targetColumns: Array[Array[Int]],
-    abilitySpecs: Array[SinkAbilitySpec],
+    val abilitySpecs: Array[SinkAbilitySpec],
     val upsertMaterialize: Boolean = false)
   extends Sink(cluster, traitSet, inputRel, hints, targetColumns, contextResolvedTable, tableSink)
   with StreamPhysicalRel {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/reuse/SubplanReuser.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/reuse/SubplanReuser.scala
@@ -71,8 +71,8 @@ object SubplanReuser {
       newRels = new ScanReuser(flinkContext, flinkTypeFactory).reuseDuplicatedScan(rels)
     }
 
-    if (tableSinkReuseEnabled && flinkContext.isBatchMode) {
-      newRels = new SinkReuser().reuseDuplicatedSink(newRels)
+    if (tableSinkReuseEnabled) {
+      newRels = new SinkReuser(!flinkContext.isBatchMode).reuseDuplicatedSink(newRels)
     }
 
     val context = new SubplanReuseContext(tableSourceReuseEnabled, newRels: _*)

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/common/SinkReuseTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/common/SinkReuseTestBase.java
@@ -33,7 +33,7 @@ public abstract class SinkReuseTestBase extends TableTestBase {
     protected TableTestUtil util;
 
     @BeforeEach
-    void setup() {
+    protected void setup() {
         TableConfig tableConfig = TableConfig.getDefault();
         tableConfig.set(OptimizerConfigOptions.TABLE_OPTIMIZER_REUSE_SUB_PLAN_ENABLED, true);
         tableConfig.set(OptimizerConfigOptions.TABLE_OPTIMIZER_REUSE_SINK_ENABLED, true);

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/StreamSinkReuseTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/StreamSinkReuseTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.stream.sql;
+
+import org.apache.flink.table.api.StatementSet;
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.planner.plan.common.SinkReuseTestBase;
+import org.apache.flink.table.planner.plan.reuse.SinkReuser;
+import org.apache.flink.table.planner.utils.TableTestUtil;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link SinkReuser} in streaming mode. */
+public class StreamSinkReuseTest extends SinkReuseTestBase {
+    @Override
+    protected TableTestUtil getTableTestUtil(TableConfig tableConfig) {
+        return streamTestUtil(tableConfig);
+    }
+
+    @Override
+    @BeforeEach
+    protected void setup() {
+        super.setup();
+        util.tableEnv()
+                .executeSql(
+                        "CREATE TABLE retractSource (\n"
+                                + "  x INT,\n"
+                                + "  y INT\n"
+                                + ")  WITH (\n"
+                                + " 'connector' = 'values',\n"
+                                + " 'disable-lookup' = 'true',\n"
+                                + " 'changelog-mode' = 'I, UA, UB, D',\n"
+                                + " 'bounded' = 'true'\n"
+                                + ")");
+        util.tableEnv()
+                .executeSql(
+                        "CREATE TABLE upsertSource (\n"
+                                + "  x INT,\n"
+                                + "  y INT,\n"
+                                + "  PRIMARY KEY (`x`) NOT ENFORCED \n"
+                                + ")  WITH (\n"
+                                + " 'connector' = 'values',\n"
+                                + " 'disable-lookup' = 'true',\n"
+                                + " 'changelog-mode' = 'I, UA, D',\n"
+                                + " 'bounded' = 'true'\n"
+                                + ")");
+        util.tableEnv()
+                .executeSql(
+                        "CREATE TABLE upsertSource2 (\n"
+                                + "  x INT,\n"
+                                + "  y INT,\n"
+                                + "  PRIMARY KEY (`y`) NOT ENFORCED \n"
+                                + ")  WITH (\n"
+                                + " 'connector' = 'values',\n"
+                                + " 'disable-lookup' = 'true',\n"
+                                + " 'changelog-mode' = 'I, UA, D',\n"
+                                + " 'bounded' = 'true'\n"
+                                + ")");
+        util.tableEnv()
+                .executeSql(
+                        "CREATE TABLE upsertSink (\n"
+                                + "  a BIGINT,\n"
+                                + "  b BIGINT\n"
+                                + ") WITH (\n"
+                                + " 'connector' = 'values', \n"
+                                + " 'sink-insert-only' = 'false' \n"
+                                + ")");
+
+        util.tableEnv()
+                .executeSql(
+                        "CREATE TABLE upsertPKSink (\n"
+                                + "  a BIGINT,\n"
+                                + "  b BIGINT,\n"
+                                + "  PRIMARY KEY (`b`) NOT ENFORCED \n"
+                                + ") WITH (\n"
+                                + " 'connector' = 'values', \n"
+                                + " 'sink-insert-only' = 'false' \n"
+                                + ")");
+    }
+
+    @Test
+    public void testSinkReuseWithUpsertAndRetract() {
+        StatementSet statementSet = util.tableEnv().createStatementSet();
+        statementSet.addInsertSql("INSERT INTO upsertSink (SELECT * FROM retractSource)");
+        statementSet.addInsertSql("INSERT INTO upsertSink (SELECT * FROM source1)");
+        statementSet.addInsertSql("INSERT INTO upsertSink (SELECT * FROM upsertSource)");
+        util.verifyExecPlan(statementSet);
+    }
+
+    @Test
+    public void testSinkReuseWithUpsertMaterialize() {
+        StatementSet statementSet = util.tableEnv().createStatementSet();
+        statementSet.addInsertSql("INSERT INTO upsertPKSink (SELECT * FROM upsertSource)");
+        statementSet.addInsertSql("INSERT INTO upsertPKSink (SELECT * FROM upsertSource)");
+        statementSet.addInsertSql("INSERT INTO upsertPKSink (SELECT * FROM upsertSource2)");
+        util.verifyExecPlan(statementSet);
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/common/sql/SinkReuseITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/common/sql/SinkReuseITCase.java
@@ -52,7 +52,7 @@ public class SinkReuseITCase extends AbstractTestBase {
 
     @Parameters(name = "isBatch: {0}")
     public static Collection<Boolean> parameters() {
-        return List.of(true);
+        return List.of(true, false);
     }
 
     TableEnvironment tEnv;

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/StreamSinkReuseTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/StreamSinkReuseTest.xml
@@ -1,0 +1,310 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+	<TestCase name="testSinkReuse">
+		<Resource name="ast">
+			<![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink1], fields=[x, y])
++- LogicalProject(x=[$0], y=[$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, source1]])
+
+LogicalSink(table=[default_catalog.default_database.sink1], fields=[x, y])
++- LogicalProject(x=[$0], y=[$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, source2]])
+
+LogicalSink(table=[default_catalog.default_database.sink2], fields=[x, y])
++- LogicalProject(x=[$0], y=[$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, source3]])
+
+LogicalSink(table=[default_catalog.default_database.sink2], fields=[x, y])
++- LogicalProject(x=[$0], y=[$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, source4]])
+]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+Sink(table=[default_catalog.default_database.sink1], fields=[x, y])
++- Union(all=[true], union=[x, y])
+   :- TableSourceScan(table=[[default_catalog, default_database, source1]], fields=[x, y])
+   +- TableSourceScan(table=[[default_catalog, default_database, source2]], fields=[x, y])
+
+Sink(table=[default_catalog.default_database.sink2], fields=[x, y])
++- Union(all=[true], union=[x, y])
+   :- TableSourceScan(table=[[default_catalog, default_database, source3]], fields=[x, y])
+   +- TableSourceScan(table=[[default_catalog, default_database, source4]], fields=[x, y])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testSinkReuseFromSameSource">
+		<Resource name="ast">
+			<![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink1], fields=[x, y])
++- LogicalProject(x=[$0], y=[$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, source1]])
+
+LogicalSink(table=[default_catalog.default_database.sink1], fields=[x, y])
++- LogicalProject(x=[$0], y=[$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, source1]])
+]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+Sink(table=[default_catalog.default_database.sink1], fields=[x, y])
++- Union(all=[true], union=[x, y])
+   :- TableSourceScan(table=[[default_catalog, default_database, source1]], fields=[x, y])(reuse_id=[1])
+   +- Reused(reference_id=[1])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testSinkReuseWithDifferentFieldNames">
+		<Resource name="ast">
+			<![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink1], fields=[x, y])
++- LogicalProject(x=[$0], y=[$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, source1]])
+
+LogicalSink(table=[default_catalog.default_database.sink1], fields=[x1, y1])
++- LogicalProject(x1=[$0], y1=[$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, filed_name_change_source]])
+]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+Sink(table=[default_catalog.default_database.sink1], fields=[x, y])
++- Union(all=[true], union=[x, y])
+   :- TableSourceScan(table=[[default_catalog, default_database, source1]], fields=[x, y])
+   +- TableSourceScan(table=[[default_catalog, default_database, filed_name_change_source]], fields=[x1, y1])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testSinkReuseWithHint">
+		<Resource name="ast">
+			<![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink1], fields=[x, y], hints=[[[OPTIONS options:{path=ignore1}]]])
++- LogicalProject(x=[$0], y=[$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, source1]])
+
+LogicalSink(table=[default_catalog.default_database.sink1], fields=[x, y], hints=[[[OPTIONS options:{path=ignore2}]]])
++- LogicalProject(x=[$0], y=[$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, source2]])
+
+LogicalSink(table=[default_catalog.default_database.sink1], fields=[x, y], hints=[[[OPTIONS options:{path=ignore1}]]])
++- LogicalProject(x=[$0], y=[$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, source3]])
+]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+Sink(table=[default_catalog.default_database.sink1], fields=[x, y], hints=[[[OPTIONS options:{path=ignore1}]]])
++- Union(all=[true], union=[x, y])
+   :- TableSourceScan(table=[[default_catalog, default_database, source1]], fields=[x, y])
+   +- TableSourceScan(table=[[default_catalog, default_database, source3]], fields=[x, y])
+
+Sink(table=[default_catalog.default_database.sink1], fields=[x, y], hints=[[[OPTIONS options:{path=ignore2}]]])
++- TableSourceScan(table=[[default_catalog, default_database, source2]], fields=[x, y])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testSinkReuseWithOverwrite">
+		<Resource name="ast">
+			<![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink1], fields=[x, y])
++- LogicalProject(x=[$0], y=[$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, source1]])
+
+LogicalSink(table=[default_catalog.default_database.sink1], fields=[x, y])
++- LogicalProject(x=[$0], y=[$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, source2]])
+
+LogicalSink(table=[default_catalog.default_database.sink1], fields=[x, y])
++- LogicalProject(x=[$0], y=[$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, source3]])
+]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+Sink(table=[default_catalog.default_database.sink1], fields=[x, y])
++- Union(all=[true], union=[x, y])
+   :- TableSourceScan(table=[[default_catalog, default_database, source1]], fields=[x, y])
+   +- TableSourceScan(table=[[default_catalog, default_database, source3]], fields=[x, y])
+
+Sink(table=[default_catalog.default_database.sink1], fields=[x, y])
++- TableSourceScan(table=[[default_catalog, default_database, source2]], fields=[x, y])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testSinkReuseWithPartialColumns">
+		<Resource name="ast">
+			<![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink1], targetColumns=[[0]], fields=[x, EXPR$1])
++- LogicalProject(x=[$0], EXPR$1=[null:BIGINT])
+   +- LogicalTableScan(table=[[default_catalog, default_database, source1]])
+
+LogicalSink(table=[default_catalog.default_database.sink1], targetColumns=[[1]], fields=[EXPR$0, y])
++- LogicalProject(EXPR$0=[null:BIGINT], y=[$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, source1]])
+
+LogicalSink(table=[default_catalog.default_database.sink1], targetColumns=[[0]], fields=[x, EXPR$1])
++- LogicalProject(x=[$0], EXPR$1=[null:BIGINT])
+   +- LogicalTableScan(table=[[default_catalog, default_database, source3]])
+]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+TableSourceScan(table=[[default_catalog, default_database, source1, project=[x, y], metadata=[]]], fields=[x, y])(reuse_id=[1])
+
+Sink(table=[default_catalog.default_database.sink1], targetColumns=[[0]], fields=[x, EXPR$1])
++- Union(all=[true], union=[x, EXPR$1])
+   :- Calc(select=[x, null:BIGINT AS EXPR$1])
+   :  +- Reused(reference_id=[1])
+   +- Calc(select=[x, null:BIGINT AS EXPR$1])
+      +- TableSourceScan(table=[[default_catalog, default_database, source3, project=[x], metadata=[]]], fields=[x])
+
+Sink(table=[default_catalog.default_database.sink1], targetColumns=[[1]], fields=[EXPR$0, y])
++- Calc(select=[null:BIGINT AS EXPR$0, y])
+   +- Reused(reference_id=[1])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testSinkReuseWithPartition">
+		<Resource name="ast">
+			<![CDATA[
+LogicalSink(table=[default_catalog.default_database.partitionedSink], fields=[EXPR$0, y])
++- LogicalProject(EXPR$0=[1:BIGINT], y=[$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, source1]])
+
+LogicalSink(table=[default_catalog.default_database.partitionedSink], fields=[EXPR$0, y])
++- LogicalProject(EXPR$0=[1:BIGINT], y=[$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, source2]])
+
+LogicalSink(table=[default_catalog.default_database.partitionedSink], fields=[EXPR$0, y])
++- LogicalProject(EXPR$0=[2:BIGINT], y=[$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, source3]])
+
+LogicalSink(table=[default_catalog.default_database.partitionedSink], fields=[x, y])
++- LogicalProject(x=[$0], y=[$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, source4]])
+]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+Sink(table=[default_catalog.default_database.partitionedSink], fields=[EXPR$0, y])
++- Union(all=[true], union=[EXPR$0, y])
+   :- Calc(select=[1 AS EXPR$0, y])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, source1, project=[y], metadata=[]]], fields=[y])
+   +- Calc(select=[1 AS EXPR$0, y])
+      +- TableSourceScan(table=[[default_catalog, default_database, source2, project=[y], metadata=[]]], fields=[y])
+
+Sink(table=[default_catalog.default_database.partitionedSink], fields=[EXPR$0, y])
++- Calc(select=[2 AS EXPR$0, y])
+   +- TableSourceScan(table=[[default_catalog, default_database, source3, project=[y], metadata=[]]], fields=[y])
+
+Sink(table=[default_catalog.default_database.partitionedSink], fields=[x, y])
++- TableSourceScan(table=[[default_catalog, default_database, source4]], fields=[x, y])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testSinkReuseWithTypeCoercionSource">
+		<Resource name="ast">
+			<![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink1], fields=[x, y])
++- LogicalProject(x=[$0], y=[$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, source1]])
+
+LogicalSink(table=[default_catalog.default_database.sink1], fields=[x, y])
++- LogicalProject(x=[CAST($0):BIGINT], y=[CAST($1):BIGINT])
+   +- LogicalTableScan(table=[[default_catalog, default_database, type_coercion_source]])
+]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+Sink(table=[default_catalog.default_database.sink1], fields=[x, y])
++- Union(all=[true], union=[x, y])
+   :- TableSourceScan(table=[[default_catalog, default_database, source1]], fields=[x, y])
+   +- Calc(select=[CAST(x AS BIGINT) AS x, CAST(y AS BIGINT) AS y])
+      +- TableSourceScan(table=[[default_catalog, default_database, type_coercion_source]], fields=[x, y])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testSinkReuseWithUpsertAndRetract">
+		<Resource name="ast">
+			<![CDATA[
+LogicalSink(table=[default_catalog.default_database.upsertSink], fields=[a, b])
++- LogicalProject(a=[CAST($0):BIGINT], b=[CAST($1):BIGINT])
+   +- LogicalTableScan(table=[[default_catalog, default_database, retractSource]])
+
+LogicalSink(table=[default_catalog.default_database.upsertSink], fields=[x, y])
++- LogicalProject(x=[$0], y=[$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, source1]])
+
+LogicalSink(table=[default_catalog.default_database.upsertSink], fields=[a, b])
++- LogicalProject(a=[CAST($0):BIGINT], b=[CAST($1):BIGINT])
+   +- LogicalTableScan(table=[[default_catalog, default_database, upsertSource]])
+]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+Sink(table=[default_catalog.default_database.upsertSink], fields=[a, b])
++- Union(all=[true], union=[a, b])
+   :- Calc(select=[CAST(x AS BIGINT) AS a, CAST(y AS BIGINT) AS b])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, retractSource]], fields=[x, y])
+   +- Calc(select=[CAST(x AS BIGINT) AS a, CAST(y AS BIGINT) AS b])
+      +- ChangelogNormalize(key=[x])
+         +- Exchange(distribution=[hash[x]])
+            +- TableSourceScan(table=[[default_catalog, default_database, upsertSource]], fields=[x, y])
+
+Sink(table=[default_catalog.default_database.upsertSink], fields=[x, y])
++- TableSourceScan(table=[[default_catalog, default_database, source1]], fields=[x, y])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testSinkReuseWithUpsertMaterialize">
+		<Resource name="ast">
+			<![CDATA[
+LogicalSink(table=[default_catalog.default_database.upsertPKSink], fields=[a, b])
++- LogicalProject(a=[CAST($0):BIGINT], b=[CAST($1):BIGINT])
+   +- LogicalTableScan(table=[[default_catalog, default_database, upsertSource]])
+
+LogicalSink(table=[default_catalog.default_database.upsertPKSink], fields=[a, b])
++- LogicalProject(a=[CAST($0):BIGINT], b=[CAST($1):BIGINT])
+   +- LogicalTableScan(table=[[default_catalog, default_database, upsertSource]])
+
+LogicalSink(table=[default_catalog.default_database.upsertPKSink], fields=[a, b])
++- LogicalProject(a=[CAST($0):BIGINT], b=[CAST($1):BIGINT])
+   +- LogicalTableScan(table=[[default_catalog, default_database, upsertSource2]])
+]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+Calc(select=[CAST(x AS BIGINT) AS a, CAST(y AS BIGINT) AS b])(reuse_id=[1])
++- ChangelogNormalize(key=[x])
+   +- Exchange(distribution=[hash[x]])
+      +- TableSourceScan(table=[[default_catalog, default_database, upsertSource]], fields=[x, y])
+
+Sink(table=[default_catalog.default_database.upsertPKSink], fields=[a, b], upsertMaterialize=[true])
++- Union(all=[true], union=[a, b])
+   :- Reused(reference_id=[1])
+   +- Reused(reference_id=[1])
+
+Sink(table=[default_catalog.default_database.upsertPKSink], fields=[a, b])
++- Calc(select=[CAST(x AS BIGINT) AS a, CAST(y AS BIGINT) AS b])
+   +- TableSourceScan(table=[[default_catalog, default_database, upsertSource2]], fields=[x, y])
+]]>
+		</Resource>
+	</TestCase>
+</Root>


### PR DESCRIPTION
## What is the purpose of the change

Support sink reuse in streaming mode

## Brief change log

  - Introduce SinkReuser to reuse sink node in Batch mode

## Verifying this change

This change is covered by tests, such as *(please describe tests)*.

StreamSinkReuseTest
SinkReuseITCase

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented?  FLIP-506
