### PR TITLE
[FLINK-37596][metrics] Close metric group of a finished split

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/InternalSourceSplitMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/InternalSourceSplitMetricGroup.java
@@ -47,6 +47,7 @@ public class InternalSourceSplitMetricGroup extends ProxyMetricGroup<MetricGroup
     private static final String WATERMARK = "watermark";
     private static final long SPLIT_NOT_STARTED = -1L;
     private long splitStartTime = SPLIT_NOT_STARTED;
+    private final MetricGroup splitWatermarkMetricGroup;
 
     private InternalSourceSplitMetricGroup(
             MetricGroup parentMetricGroup,
@@ -55,8 +56,7 @@ public class InternalSourceSplitMetricGroup extends ProxyMetricGroup<MetricGroup
             Gauge<Long> currentWatermark) {
         super(parentMetricGroup);
         this.clock = clock;
-        MetricGroup splitWatermarkMetricGroup =
-                parentMetricGroup.addGroup(SPLIT, splitId).addGroup(WATERMARK);
+        splitWatermarkMetricGroup = parentMetricGroup.addGroup(SPLIT, splitId).addGroup(WATERMARK);
         pausedTimePerSecond =
                 splitWatermarkMetricGroup.gauge(
                         MetricNames.SPLIT_PAUSED_TIME, new TimerGauge(clock));
@@ -190,5 +190,22 @@ public class InternalSourceSplitMetricGroup extends ProxyMetricGroup<MetricGroup
 
     public Boolean isActive() {
         return !isPaused() && !isIdle();
+    }
+
+    public void onSplitFinished() {
+        if (splitWatermarkMetricGroup instanceof AbstractMetricGroup) {
+            ((AbstractMetricGroup) splitWatermarkMetricGroup).close();
+        } else {
+            if (splitWatermarkMetricGroup != null) {
+                LOG.warn(
+                        "Split watermark metric group can not be closed, expecting an instance of AbstractMetricGroup but got: ",
+                        splitWatermarkMetricGroup.getClass().getName());
+            }
+        }
+    }
+
+    @VisibleForTesting
+    public MetricGroup getSplitWatermarkMetricGroup() {
+        return splitWatermarkMetricGroup;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
@@ -729,6 +729,7 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
     @Override
     public void splitFinished(String splitId) {
         splitCurrentWatermarks.remove(splitId);
+        getOrCreateSplitMetricGroup(splitId).onSplitFinished();
         this.splitMetricGroups.remove(splitId);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/source/TestingSourceOperator.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/source/TestingSourceOperator.java
@@ -27,7 +27,6 @@ import org.apache.flink.api.connector.source.mocks.MockSourceSplitSerializer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.runtime.execution.Environment;
-import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.operators.coordination.MockOperatorEventGateway;
 import org.apache.flink.runtime.operators.coordination.OperatorEventGateway;
 import org.apache.flink.runtime.operators.testutils.MockEnvironmentBuilder;
@@ -103,7 +102,6 @@ public class TestingSourceOperator<T> extends SourceOperator<T, MockSourceSplit>
 
         this.subtaskIndex = subtaskIndex;
         this.parallelism = parallelism;
-        this.metrics = UnregisteredMetricGroups.createUnregisteredOperatorMetricGroup();
         initSourceMetricGroup();
 
         // unchecked wrapping is okay to keep tests simpler


### PR DESCRIPTION
Closing the metric group of a finished split
Added a test to verify the group is closed and metrics are deregistered.
For the test setup I removed a redundant initialization of `org.apache.flink.streaming.api.operators.AbstractStreamOperator#metrics` (since an `UnregisteredMetricGroup` is already passed to it via the `org.apache.flink.streaming.runtime.tasks.StreamMockEnvironment#taskMetricGroup`)