### PR TITLE
[FLINK-37524] Make ForStState Restore from previous StateMetaInfo

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/AbstractAggregatingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/AbstractAggregatingState.java
@@ -20,8 +20,8 @@ package org.apache.flink.runtime.state.v2;
 
 import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.api.common.state.v2.AggregatingState;
-import org.apache.flink.api.common.state.v2.AggregatingStateDescriptor;
 import org.apache.flink.api.common.state.v2.StateFuture;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.state.StateFutureUtils;
 import org.apache.flink.runtime.asyncprocessing.StateRequestHandler;
 import org.apache.flink.runtime.asyncprocessing.StateRequestType;
@@ -50,13 +50,14 @@ public class AbstractAggregatingState<K, N, IN, ACC, OUT> extends AbstractKeyedS
      * Creates a new AbstractKeyedState with the given asyncExecutionController and stateDescriptor.
      *
      * @param stateRequestHandler The async request handler for handling all requests.
-     * @param stateDescriptor The properties of the state.
+     * @param valueSerializer The type serializer for the values in the state.
      */
     public AbstractAggregatingState(
             StateRequestHandler stateRequestHandler,
-            AggregatingStateDescriptor<IN, ACC, OUT> stateDescriptor) {
-        super(stateRequestHandler, stateDescriptor);
-        this.aggregateFunction = stateDescriptor.getAggregateFunction();
+            AggregateFunction<IN, ACC, OUT> aggregateFunction,
+            TypeSerializer<ACC> valueSerializer) {
+        super(stateRequestHandler, valueSerializer);
+        this.aggregateFunction = aggregateFunction;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/AbstractKeyedState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/AbstractKeyedState.java
@@ -19,7 +19,6 @@ package org.apache.flink.runtime.state.v2;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.state.v2.State;
-import org.apache.flink.api.common.state.v2.StateDescriptor;
 import org.apache.flink.api.common.state.v2.StateFuture;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.asyncprocessing.AsyncExecutionController;
@@ -42,19 +41,15 @@ import org.apache.flink.runtime.state.v2.internal.InternalKeyedState;
 public abstract class AbstractKeyedState<K, N, V> implements InternalKeyedState<K, N, V> {
 
     protected final StateRequestHandler stateRequestHandler;
-
-    private final StateDescriptor<V> stateDescriptor;
-
     private final ThreadLocal<TypeSerializer<V>> valueSerializer;
 
     /**
      * Creates a new AbstractKeyedState with the given asyncExecutionController and stateDescriptor.
      */
     public AbstractKeyedState(
-            StateRequestHandler stateRequestHandler, StateDescriptor<V> stateDescriptor) {
+            StateRequestHandler stateRequestHandler, TypeSerializer<V> valueSerializer) {
         this.stateRequestHandler = stateRequestHandler;
-        this.stateDescriptor = stateDescriptor;
-        this.valueSerializer = ThreadLocal.withInitial(stateDescriptor::getSerializer);
+        this.valueSerializer = ThreadLocal.withInitial(valueSerializer::duplicate);
     }
 
     /**
@@ -85,11 +80,6 @@ public abstract class AbstractKeyedState<K, N, V> implements InternalKeyedState<
 
     public final void clear() {
         handleRequestSync(StateRequestType.CLEAR, null);
-    }
-
-    /** Return specific {@code StateDescriptor}. */
-    public StateDescriptor<V> getStateDescriptor() {
-        return stateDescriptor;
     }
 
     /** Return related value serializer. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/AbstractListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/AbstractListState.java
@@ -18,9 +18,9 @@
 package org.apache.flink.runtime.state.v2;
 
 import org.apache.flink.api.common.state.v2.ListState;
-import org.apache.flink.api.common.state.v2.ListStateDescriptor;
 import org.apache.flink.api.common.state.v2.StateFuture;
 import org.apache.flink.api.common.state.v2.StateIterator;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.asyncprocessing.StateRequestHandler;
 import org.apache.flink.runtime.asyncprocessing.StateRequestType;
 import org.apache.flink.runtime.state.v2.internal.InternalListState;
@@ -39,8 +39,8 @@ public class AbstractListState<K, N, V> extends AbstractKeyedState<K, N, V>
         implements InternalListState<K, N, V> {
 
     public AbstractListState(
-            StateRequestHandler stateRequestHandler, ListStateDescriptor<V> stateDescriptor) {
-        super(stateRequestHandler, stateDescriptor);
+            StateRequestHandler stateRequestHandler, TypeSerializer<V> serializer) {
+        super(stateRequestHandler, serializer);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/AbstractMapState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/AbstractMapState.java
@@ -18,9 +18,9 @@
 package org.apache.flink.runtime.state.v2;
 
 import org.apache.flink.api.common.state.v2.MapState;
-import org.apache.flink.api.common.state.v2.MapStateDescriptor;
 import org.apache.flink.api.common.state.v2.StateFuture;
 import org.apache.flink.api.common.state.v2.StateIterator;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.asyncprocessing.StateRequestHandler;
 import org.apache.flink.runtime.asyncprocessing.StateRequestType;
@@ -40,9 +40,8 @@ import java.util.Map;
 public class AbstractMapState<K, N, UK, V> extends AbstractKeyedState<K, N, V>
         implements InternalMapState<K, N, UK, V> {
 
-    public AbstractMapState(
-            StateRequestHandler stateRequestHandler, MapStateDescriptor<UK, V> stateDescriptor) {
-        super(stateRequestHandler, stateDescriptor);
+    public AbstractMapState(StateRequestHandler stateRequestHandler, TypeSerializer<V> serializer) {
+        super(stateRequestHandler, serializer);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/AbstractReducingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/AbstractReducingState.java
@@ -19,8 +19,8 @@ package org.apache.flink.runtime.state.v2;
 
 import org.apache.flink.api.common.functions.ReduceFunction;
 import org.apache.flink.api.common.state.v2.ReducingState;
-import org.apache.flink.api.common.state.v2.ReducingStateDescriptor;
 import org.apache.flink.api.common.state.v2.StateFuture;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.state.StateFutureUtils;
 import org.apache.flink.runtime.asyncprocessing.StateRequestHandler;
 import org.apache.flink.runtime.asyncprocessing.StateRequestType;
@@ -44,9 +44,11 @@ public class AbstractReducingState<K, N, V> extends AbstractKeyedState<K, N, V>
     protected final ReduceFunction<V> reduceFunction;
 
     public AbstractReducingState(
-            StateRequestHandler stateRequestHandler, ReducingStateDescriptor<V> stateDescriptor) {
-        super(stateRequestHandler, stateDescriptor);
-        this.reduceFunction = stateDescriptor.getReduceFunction();
+            StateRequestHandler stateRequestHandler,
+            ReduceFunction<V> reduceFunction,
+            TypeSerializer<V> valueSerializer) {
+        super(stateRequestHandler, valueSerializer);
+        this.reduceFunction = reduceFunction;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/AbstractValueState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/AbstractValueState.java
@@ -19,7 +19,7 @@ package org.apache.flink.runtime.state.v2;
 
 import org.apache.flink.api.common.state.v2.StateFuture;
 import org.apache.flink.api.common.state.v2.ValueState;
-import org.apache.flink.api.common.state.v2.ValueStateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.asyncprocessing.AsyncExecutionController;
 import org.apache.flink.runtime.asyncprocessing.StateRequestHandler;
 import org.apache.flink.runtime.asyncprocessing.StateRequestType;
@@ -36,8 +36,8 @@ public class AbstractValueState<K, N, V> extends AbstractKeyedState<K, N, V>
         implements InternalValueState<K, N, V> {
 
     public AbstractValueState(
-            StateRequestHandler stateRequestHandler, ValueStateDescriptor<V> valueStateDescriptor) {
-        super(stateRequestHandler, valueStateDescriptor);
+            StateRequestHandler stateRequestHandler, TypeSerializer<V> valueSerializer) {
+        super(stateRequestHandler, valueSerializer);
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionControllerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionControllerTest.java
@@ -866,7 +866,7 @@ class AsyncExecutionControllerTest {
                 StateRequestHandler stateRequestHandler,
                 TestUnderlyingState underlyingState,
                 ValueStateDescriptor<Integer> stateDescriptor) {
-            super(stateRequestHandler, stateDescriptor);
+            super(stateRequestHandler, stateDescriptor.getSerializer());
             this.underlyingState = underlyingState;
             assertThat(this.getValueSerializer()).isEqualTo(IntSerializer.INSTANCE);
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AbstractAggregatingStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AbstractAggregatingStateTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.state.v2;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.api.common.state.v2.AggregatingStateDescriptor;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
@@ -79,8 +80,12 @@ class AbstractAggregatingStateTest extends AbstractKeyedStateTestBase {
         AggregatingStateDescriptor<Integer, Integer, Integer> descriptor =
                 new AggregatingStateDescriptor<>(
                         "testAggState", aggregator, BasicTypeInfo.INT_TYPE_INFO);
+        descriptor.initializeSerializerUnlessSet(new ExecutionConfig());
         AbstractAggregatingState<String, Void, Integer, Integer, Integer> state =
-                new AbstractAggregatingState<>(aec, descriptor);
+                new AbstractAggregatingState<>(
+                        aec,
+                        descriptor.getAggregateFunction(),
+                        descriptor.getSerializer().duplicate());
 
         aec.setCurrentContext(aec.buildContext("test", "test"));
 
@@ -107,6 +112,7 @@ class AbstractAggregatingStateTest extends AbstractKeyedStateTestBase {
         AggregatingStateDescriptor<Integer, Integer, Integer> descriptor =
                 new AggregatingStateDescriptor<>(
                         "testState", aggregator, BasicTypeInfo.INT_TYPE_INFO);
+        descriptor.initializeSerializerUnlessSet(new ExecutionConfig());
         AggregatingStateExecutor aggregatingStateExecutor = new AggregatingStateExecutor();
         AsyncExecutionController<String> aec =
                 new AsyncExecutionController<>(
@@ -121,7 +127,8 @@ class AbstractAggregatingStateTest extends AbstractKeyedStateTestBase {
                         null,
                         null);
         AbstractAggregatingState<String, String, Integer, Integer, Integer> aggregatingState =
-                new AbstractAggregatingState<>(aec, descriptor);
+                new AbstractAggregatingState<>(
+                        aec, descriptor.getAggregateFunction(), descriptor.getSerializer());
         aec.setCurrentContext(aec.buildContext("test", "test"));
         aec.setCurrentNamespaceForState(aggregatingState, "1");
         aggregatingState.add(1);
@@ -143,6 +150,7 @@ class AbstractAggregatingStateTest extends AbstractKeyedStateTestBase {
         AggregatingStateDescriptor<Integer, Integer, Integer> descriptor =
                 new AggregatingStateDescriptor<>(
                         "testState", aggregator, BasicTypeInfo.INT_TYPE_INFO);
+        descriptor.initializeSerializerUnlessSet(new ExecutionConfig());
         AggregatingStateExecutor aggregatingStateExecutor = new AggregatingStateExecutor();
         AsyncExecutionController<String> aec =
                 new AsyncExecutionController<>(
@@ -157,7 +165,8 @@ class AbstractAggregatingStateTest extends AbstractKeyedStateTestBase {
                         null,
                         null);
         AbstractAggregatingState<String, String, Integer, Integer, Integer> aggregatingState =
-                new AbstractAggregatingState<>(aec, descriptor);
+                new AbstractAggregatingState<>(
+                        aec, descriptor.getAggregateFunction(), descriptor.getSerializer());
         aec.setCurrentContext(aec.buildContext("test", "test"));
         aec.setCurrentNamespaceForState(aggregatingState, "1");
         aggregatingState.asyncAdd(1);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AbstractListStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AbstractListStateTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.state.v2;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.state.v2.ListStateDescriptor;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.runtime.asyncprocessing.StateRequestType;
@@ -35,8 +36,9 @@ public class AbstractListStateTest extends AbstractKeyedStateTestBase {
     public void testEachOperation() {
         ListStateDescriptor<Integer> descriptor =
                 new ListStateDescriptor<>("testState", BasicTypeInfo.INT_TYPE_INFO);
+        descriptor.initializeSerializerUnlessSet(new ExecutionConfig());
         AbstractListState<String, Void, Integer> listState =
-                new AbstractListState<>(aec, descriptor);
+                new AbstractListState<>(aec, descriptor.getSerializer());
         aec.setCurrentContext(aec.buildContext("test", "test"));
 
         listState.asyncClear();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AbstractMapStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AbstractMapStateTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.state.v2;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.state.v2.MapStateDescriptor;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.java.tuple.Tuple2;
@@ -37,8 +38,9 @@ public class AbstractMapStateTest extends AbstractKeyedStateTestBase {
         MapStateDescriptor<String, Integer> descriptor =
                 new MapStateDescriptor<>(
                         "testState", BasicTypeInfo.STRING_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO);
+        descriptor.initializeSerializerUnlessSet(new ExecutionConfig());
         AbstractMapState<String, Void, String, Integer> mapState =
-                new AbstractMapState<>(aec, descriptor);
+                new AbstractMapState<>(aec, descriptor.getSerializer());
         aec.setCurrentContext(aec.buildContext("test", "test"));
 
         mapState.asyncClear();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AbstractReducingStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AbstractReducingStateTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.state.v2;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.ReduceFunction;
 import org.apache.flink.api.common.state.v2.ReducingStateDescriptor;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
@@ -51,8 +52,10 @@ public class AbstractReducingStateTest extends AbstractKeyedStateTestBase {
         ReduceFunction<Integer> reducer = Integer::sum;
         ReducingStateDescriptor<Integer> descriptor =
                 new ReducingStateDescriptor<>("testState", reducer, BasicTypeInfo.INT_TYPE_INFO);
+        descriptor.initializeSerializerUnlessSet(new ExecutionConfig());
         AbstractReducingState<String, Void, Integer> reducingState =
-                new AbstractReducingState<>(aec, descriptor);
+                new AbstractReducingState<>(
+                        aec, descriptor.getReduceFunction(), descriptor.getSerializer());
         aec.setCurrentContext(aec.buildContext("test", "test"));
 
         reducingState.asyncClear();
@@ -81,6 +84,7 @@ public class AbstractReducingStateTest extends AbstractKeyedStateTestBase {
         ReduceFunction<Integer> reducer = Integer::sum;
         ReducingStateDescriptor<Integer> descriptor =
                 new ReducingStateDescriptor<>("testState", reducer, BasicTypeInfo.INT_TYPE_INFO);
+        descriptor.initializeSerializerUnlessSet(new ExecutionConfig());
         AsyncExecutionController<String> aec =
                 new AsyncExecutionController<>(
                         new SyncMailboxExecutor(),
@@ -94,7 +98,8 @@ public class AbstractReducingStateTest extends AbstractKeyedStateTestBase {
                         null,
                         null);
         AbstractReducingState<String, String, Integer> reducingState =
-                new AbstractReducingState<>(aec, descriptor);
+                new AbstractReducingState<>(
+                        aec, descriptor.getReduceFunction(), descriptor.getSerializer());
         aec.setCurrentContext(aec.buildContext("test", "test"));
         aec.setCurrentNamespaceForState(reducingState, "1");
         reducingState.asyncAdd(1);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AbstractValueStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AbstractValueStateTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.state.v2;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.state.v2.ValueStateDescriptor;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.runtime.asyncprocessing.StateRequestType;
@@ -32,8 +33,9 @@ public class AbstractValueStateTest extends AbstractKeyedStateTestBase {
     public void testEachOperation() {
         ValueStateDescriptor<Integer> descriptor =
                 new ValueStateDescriptor<>("testState", BasicTypeInfo.INT_TYPE_INFO);
+        descriptor.initializeSerializerUnlessSet(new ExecutionConfig());
         AbstractValueState<String, Void, Integer> valueState =
-                new AbstractValueState<>(aec, descriptor);
+                new AbstractValueState<>(aec, descriptor.getSerializer());
         aec.setCurrentContext(aec.buildContext("test", "test"));
 
         valueState.asyncClear();

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStAggregatingState.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStAggregatingState.java
@@ -18,8 +18,8 @@
 
 package org.apache.flink.state.forst;
 
+import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.api.common.state.v2.AggregatingState;
-import org.apache.flink.api.common.state.v2.AggregatingStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
@@ -77,7 +77,8 @@ public class ForStAggregatingState<K, N, IN, ACC, OUT>
      * @param stateDescriptor     The properties of the state.
      */
     public ForStAggregatingState(
-            AggregatingStateDescriptor<IN, ACC, OUT> stateDescriptor,
+            AggregateFunction<IN, ACC, OUT> aggregateFunction,
+            TypeSerializer<ACC> valueSerializer,
             StateRequestHandler stateRequestHandler,
             ColumnFamilyHandle columnFamily,
             Supplier<SerializedCompositeKeyBuilder<K>> serializedKeyBuilderInitializer,
@@ -85,7 +86,7 @@ public class ForStAggregatingState<K, N, IN, ACC, OUT>
             Supplier<TypeSerializer<N>> namespaceSerializerInitializer,
             Supplier<DataOutputSerializer> valueSerializerViewInitializer,
             Supplier<DataInputDeserializer> valueDeserializerViewInitializer) {
-        super(stateRequestHandler, stateDescriptor);
+        super(stateRequestHandler, aggregateFunction, valueSerializer);
         this.columnFamilyHandle = columnFamily;
         this.serializedKeyBuilder = ThreadLocal.withInitial(serializedKeyBuilderInitializer);
         this.namespaceSerializer = ThreadLocal.withInitial(namespaceSerializerInitializer);

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStListState.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStListState.java
@@ -19,7 +19,6 @@
 package org.apache.flink.state.forst;
 
 import org.apache.flink.api.common.state.v2.ListState;
-import org.apache.flink.api.common.state.v2.ListStateDescriptor;
 import org.apache.flink.api.common.state.v2.StateFuture;
 import org.apache.flink.api.common.state.v2.StateIterator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -83,13 +82,13 @@ public class ForStListState<K, N, V> extends AbstractListState<K, N, V>
     public ForStListState(
             StateRequestHandler stateRequestHandler,
             ColumnFamilyHandle columnFamily,
-            ListStateDescriptor<V> listStateDescriptor,
+            TypeSerializer<V> valueSerializer,
             Supplier<SerializedCompositeKeyBuilder<K>> serializedKeyBuilderInitializer,
             N defaultNamespace,
             Supplier<TypeSerializer<N>> namespaceSerializerInitializer,
             Supplier<DataOutputSerializer> valueSerializerViewInitializer,
             Supplier<DataInputDeserializer> valueDeserializerViewInitializer) {
-        super(stateRequestHandler, listStateDescriptor);
+        super(stateRequestHandler, valueSerializer);
         this.columnFamilyHandle = columnFamily;
         this.serializedKeyBuilder = ThreadLocal.withInitial(serializedKeyBuilderInitializer);
         this.defaultNamespace = defaultNamespace;

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStMapState.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStMapState.java
@@ -18,9 +18,7 @@
 package org.apache.flink.state.forst;
 
 import org.apache.flink.api.common.state.v2.MapState;
-import org.apache.flink.api.common.state.v2.MapStateDescriptor;
 import org.apache.flink.api.common.state.v2.State;
-import org.apache.flink.api.common.state.v2.StateDescriptor;
 import org.apache.flink.api.common.state.v2.StateIterator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
@@ -84,7 +82,8 @@ public class ForStMapState<K, N, UK, UV> extends AbstractMapState<K, N, UK, UV>
     public ForStMapState(
             StateRequestHandler stateRequestHandler,
             ColumnFamilyHandle columnFamily,
-            MapStateDescriptor<UK, UV> stateDescriptor,
+            TypeSerializer<UK> userKeySerializer,
+            TypeSerializer<UV> valueSerializer,
             Supplier<SerializedCompositeKeyBuilder<K>> serializedKeyBuilderInitializer,
             N defaultNamespace,
             Supplier<TypeSerializer<N>> namespaceSerializerInitializer,
@@ -92,7 +91,7 @@ public class ForStMapState<K, N, UK, UV> extends AbstractMapState<K, N, UK, UV>
             Supplier<DataInputDeserializer> keyDeserializerViewInitializer,
             Supplier<DataInputDeserializer> valueDeserializerViewInitializer,
             int keyGroupPrefixBytes) {
-        super(stateRequestHandler, stateDescriptor);
+        super(stateRequestHandler, valueSerializer);
         this.columnFamilyHandle = columnFamily;
         this.serializedKeyBuilder = ThreadLocal.withInitial(serializedKeyBuilderInitializer);
         this.defaultNamespace = defaultNamespace;
@@ -100,8 +99,8 @@ public class ForStMapState<K, N, UK, UV> extends AbstractMapState<K, N, UK, UV>
         this.valueSerializerView = ThreadLocal.withInitial(valueSerializerViewInitializer);
         this.keyDeserializerView = ThreadLocal.withInitial(keyDeserializerViewInitializer);
         this.valueDeserializerView = ThreadLocal.withInitial(valueDeserializerViewInitializer);
-        this.userKeySerializer = ThreadLocal.withInitial(stateDescriptor::getUserKeySerializer);
-        this.userValueSerializer = ThreadLocal.withInitial(stateDescriptor::getSerializer);
+        this.userKeySerializer = ThreadLocal.withInitial(userKeySerializer::duplicate);
+        this.userValueSerializer = ThreadLocal.withInitial(valueSerializer::duplicate);
         this.keyGroupPrefixBytes = keyGroupPrefixBytes;
     }
 
@@ -299,7 +298,8 @@ public class ForStMapState<K, N, UK, UV> extends AbstractMapState<K, N, UK, UV>
 
     @SuppressWarnings("unchecked")
     static <N, UK, UV, K, SV, S extends State> S create(
-            StateDescriptor<SV> stateDescriptor,
+            TypeSerializer<UK> userKeySerializer,
+            TypeSerializer<UV> valueSerializer,
             StateRequestHandler stateRequestHandler,
             ColumnFamilyHandle columnFamily,
             Supplier<SerializedCompositeKeyBuilder<K>> serializedKeyBuilderInitializer,
@@ -313,7 +313,8 @@ public class ForStMapState<K, N, UK, UV> extends AbstractMapState<K, N, UK, UV>
                 new ForStMapState<>(
                         stateRequestHandler,
                         columnFamily,
-                        (MapStateDescriptor<UK, UV>) stateDescriptor,
+                        userKeySerializer,
+                        valueSerializer,
                         serializedKeyBuilderInitializer,
                         defaultNamespace,
                         namespaceSerializerInitializer,

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStReducingState.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStReducingState.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.state.forst;
 
-import org.apache.flink.api.common.state.v2.ReducingStateDescriptor;
+import org.apache.flink.api.common.functions.ReduceFunction;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
@@ -72,13 +72,14 @@ public class ForStReducingState<K, N, V> extends AbstractReducingState<K, N, V>
     public ForStReducingState(
             StateRequestHandler stateRequestHandler,
             ColumnFamilyHandle columnFamily,
-            ReducingStateDescriptor<V> reducingStateDescriptor,
+            ReduceFunction<V> reduceFunction,
+            TypeSerializer<V> valueSerializer,
             Supplier<SerializedCompositeKeyBuilder<K>> serializedKeyBuilderInitializer,
             N defaultNamespace,
             Supplier<TypeSerializer<N>> namespaceSerializerInitializer,
             Supplier<DataOutputSerializer> valueSerializerViewInitializer,
             Supplier<DataInputDeserializer> valueDeserializerViewInitializer) {
-        super(stateRequestHandler, reducingStateDescriptor);
+        super(stateRequestHandler, reduceFunction, valueSerializer);
         this.columnFamilyHandle = columnFamily;
         this.serializedKeyBuilder = ThreadLocal.withInitial(serializedKeyBuilderInitializer);
         this.defaultNamespace = defaultNamespace;

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStValueState.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStValueState.java
@@ -19,7 +19,6 @@
 package org.apache.flink.state.forst;
 
 import org.apache.flink.api.common.state.v2.ValueState;
-import org.apache.flink.api.common.state.v2.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
@@ -72,13 +71,13 @@ public class ForStValueState<K, N, V> extends AbstractValueState<K, N, V>
     public ForStValueState(
             StateRequestHandler stateRequestHandler,
             ColumnFamilyHandle columnFamily,
-            ValueStateDescriptor<V> valueStateDescriptor,
+            TypeSerializer<V> valueSerializer,
             Supplier<SerializedCompositeKeyBuilder<K>> serializedKeyBuilderInitializer,
             N defaultNamespace,
             Supplier<TypeSerializer<N>> namespaceSerializerInitializer,
             Supplier<DataOutputSerializer> valueSerializerViewInitializer,
             Supplier<DataInputDeserializer> valueDeserializerViewInitializer) {
-        super(stateRequestHandler, valueStateDescriptor);
+        super(stateRequestHandler, valueSerializer);
         this.columnFamilyHandle = columnFamily;
         this.serializedKeyBuilder = ThreadLocal.withInitial(serializedKeyBuilderInitializer);
         this.defaultNamespace = defaultNamespace;

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStDBOperationTestBase.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStDBOperationTestBase.java
@@ -136,7 +136,7 @@ public class ForStDBOperationTestBase {
         return new ForStValueState<>(
                 stateRequestHandler,
                 cf,
-                valueStateDescriptor,
+                valueStateDescriptor.getSerializer(),
                 serializedKeyBuilder,
                 VoidNamespace.INSTANCE,
                 () -> VoidNamespaceSerializer.INSTANCE,
@@ -157,7 +157,7 @@ public class ForStDBOperationTestBase {
         return new ForStListState<>(
                 buildMockStateRequestHandler(),
                 cf,
-                valueStateDescriptor,
+                valueStateDescriptor.getSerializer(),
                 serializedKeyBuilder,
                 VoidNamespace.INSTANCE,
                 () -> VoidNamespaceSerializer.INSTANCE,
@@ -200,7 +200,8 @@ public class ForStDBOperationTestBase {
                 () -> new DataInputDeserializer(new byte[128]);
 
         return new ForStAggregatingState<>(
-                valueStateDescriptor,
+                valueStateDescriptor.getAggregateFunction(),
+                valueStateDescriptor.getSerializer(),
                 buildMockStateRequestHandler(),
                 cf,
                 serializedKeyBuilder,
@@ -226,7 +227,8 @@ public class ForStDBOperationTestBase {
         return new ForStMapState<>(
                 stateRequestHandler,
                 cf,
-                mapStateDescriptor,
+                mapStateDescriptor.getUserKeySerializer(),
+                mapStateDescriptor.getSerializer(),
                 serializedKeyBuilder,
                 VoidNamespace.INSTANCE,
                 () -> VoidNamespaceSerializer.INSTANCE,

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStStateMigrationTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStStateMigrationTest.java
@@ -18,10 +18,16 @@
 
 package org.apache.flink.state.forst;
 
+import org.apache.flink.api.common.serialization.SerializerConfigImpl;
 import org.apache.flink.api.common.state.v2.MapState;
 import org.apache.flink.api.common.state.v2.MapStateDescriptor;
+import org.apache.flink.api.common.state.v2.ValueState;
+import org.apache.flink.api.common.state.v2.ValueStateDescriptor;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.api.java.typeutils.GenericTypeInfo;
+import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.testutils.CommonTestUtils;
@@ -29,15 +35,20 @@ import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.SnapshotResult;
+import org.apache.flink.runtime.state.StateBackendTestBase;
+import org.apache.flink.runtime.state.v2.AbstractKeyedState;
 import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.StateMigrationException;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.io.File;
 import java.util.Collections;
 import java.util.concurrent.RunnableFuture;
 
 import static org.apache.flink.state.forst.ForStTestUtils.createKeyedStateBackend;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
 /** Tests for {@link ForStListState}. */
@@ -98,5 +109,160 @@ public class ForStStateMigrationTest extends ForStStateTestBase {
                 throw e;
             }
         }
+    }
+
+    @Test
+    void testKryoRestoreResilienceWithDifferentRegistrationOrder(@TempDir File newTmpDir)
+            throws Exception {
+
+        // register A first then B
+        ((SerializerConfigImpl) env.getExecutionConfig().getSerializerConfig())
+                .registerKryoType(StateBackendTestBase.TestNestedPojoClassA.class);
+        ((SerializerConfigImpl) env.getExecutionConfig().getSerializerConfig())
+                .registerKryoType(StateBackendTestBase.TestNestedPojoClassB.class);
+
+        TypeInformation<StateBackendTestBase.TestPojo> pojoType =
+                new GenericTypeInfo<>(StateBackendTestBase.TestPojo.class);
+
+        // make sure that we are in fact using the KryoSerializer
+        assertThat(pojoType.createSerializer(env.getExecutionConfig().getSerializerConfig()))
+                .isInstanceOf(KryoSerializer.class);
+
+        ValueStateDescriptor<StateBackendTestBase.TestPojo> stateDescriptor =
+                new ValueStateDescriptor<>("id", pojoType);
+
+        ValueState<StateBackendTestBase.TestPojo> state =
+                keyedBackend.getOrCreateKeyedState(1, IntSerializer.INSTANCE, stateDescriptor);
+
+        // access the internal state representation to retrieve the original Kryo registration
+        // ids;
+        // these will be later used to check that on restore, the new Kryo serializer has
+        // reconfigured itself to
+        // have identical mappings
+        AbstractKeyedState abstractKeyedState = (AbstractKeyedState) state;
+        KryoSerializer<StateBackendTestBase.TestPojo> kryoSerializer =
+                (KryoSerializer<StateBackendTestBase.TestPojo>)
+                        abstractKeyedState.getValueSerializer();
+        int mainPojoClassRegistrationId =
+                kryoSerializer
+                        .getKryo()
+                        .getRegistration(StateBackendTestBase.TestPojo.class)
+                        .getId();
+        int nestedPojoClassARegistrationId =
+                kryoSerializer
+                        .getKryo()
+                        .getRegistration(StateBackendTestBase.TestNestedPojoClassA.class)
+                        .getId();
+        int nestedPojoClassBRegistrationId =
+                kryoSerializer
+                        .getKryo()
+                        .getRegistration(StateBackendTestBase.TestNestedPojoClassB.class)
+                        .getId();
+
+        // ============== create snapshot of current configuration ==============
+
+        // make some more modifications
+        setCurrentContext("test", "test");
+        state.asyncUpdate(
+                new StateBackendTestBase.TestPojo(
+                        "u1",
+                        1,
+                        new StateBackendTestBase.TestNestedPojoClassA(1.0, 2),
+                        new StateBackendTestBase.TestNestedPojoClassB(2.3, "foo")));
+
+        drain();
+        RunnableFuture<SnapshotResult<KeyedStateHandle>> snapshot =
+                keyedBackend.snapshot(
+                        1L,
+                        System.currentTimeMillis(),
+                        env.getCheckpointStorageAccess()
+                                .resolveCheckpointStorageLocation(
+                                        1L, CheckpointStorageLocationReference.getDefault()),
+                        CheckpointOptions.forCheckpointWithDefaultLocation());
+
+        if (!snapshot.isDone()) {
+            snapshot.run();
+        }
+        SnapshotResult<KeyedStateHandle> snapshotResult = snapshot.get();
+        KeyedStateHandle stateHandle = snapshotResult.getJobManagerOwnedSnapshot();
+        IOUtils.closeQuietly(keyedBackend);
+        keyedBackend.dispose();
+
+        env = getMockEnvironment(newTmpDir);
+        ((SerializerConfigImpl) env.getExecutionConfig().getSerializerConfig())
+                .registerKryoType(
+                        StateBackendTestBase.TestNestedPojoClassB
+                                .class); // this time register B first
+        ((SerializerConfigImpl) env.getExecutionConfig().getSerializerConfig())
+                .registerKryoType(StateBackendTestBase.TestNestedPojoClassA.class);
+
+        FileSystem.initialize(new Configuration(), null);
+        Configuration configuration = new Configuration();
+        ForStStateBackend forStStateBackend =
+                new ForStStateBackend().configure(configuration, null);
+        ForStKeyedStateBackend<String> restoredKeyedStateBackend =
+                createKeyedStateBackend(
+                        forStStateBackend,
+                        env,
+                        StringSerializer.INSTANCE,
+                        Collections.singletonList(stateHandle));
+        restoredKeyedStateBackend.setup(aec);
+
+        // re-initialize to ensure that we create the KryoSerializer from scratch, otherwise
+        // initializeSerializerUnlessSet would not pick up our new config
+        stateDescriptor = new ValueStateDescriptor<>("id", pojoType);
+        state =
+                restoredKeyedStateBackend.getOrCreateKeyedState(
+                        1, IntSerializer.INSTANCE, stateDescriptor);
+
+        // verify that on restore, the serializer that the state handle uses has reconfigured
+        // itself to have
+        // identical Kryo registration ids compared to the previous execution
+        abstractKeyedState = (AbstractKeyedState) state;
+        kryoSerializer =
+                (KryoSerializer<StateBackendTestBase.TestPojo>)
+                        abstractKeyedState.getValueSerializer();
+        assertThat(
+                        kryoSerializer
+                                .getKryo()
+                                .getRegistration(StateBackendTestBase.TestPojo.class)
+                                .getId())
+                .isEqualTo(mainPojoClassRegistrationId);
+        assertThat(
+                        kryoSerializer
+                                .getKryo()
+                                .getRegistration(StateBackendTestBase.TestNestedPojoClassA.class)
+                                .getId())
+                .isEqualTo(nestedPojoClassARegistrationId);
+        assertThat(
+                        kryoSerializer
+                                .getKryo()
+                                .getRegistration(StateBackendTestBase.TestNestedPojoClassB.class)
+                                .getId())
+                .isEqualTo(nestedPojoClassBRegistrationId);
+
+        setCurrentContext("test", "test");
+
+        // update to test state backends that eagerly serialize, such as RocksDB
+        state.asyncUpdate(
+                new StateBackendTestBase.TestPojo(
+                        "u1",
+                        11,
+                        new StateBackendTestBase.TestNestedPojoClassA(22.1, 12),
+                        new StateBackendTestBase.TestNestedPojoClassB(1.23, "foobar")));
+
+        RunnableFuture<SnapshotResult<KeyedStateHandle>> snapshot1 =
+                restoredKeyedStateBackend.snapshot(
+                        1L,
+                        System.currentTimeMillis(),
+                        env.getCheckpointStorageAccess()
+                                .resolveCheckpointStorageLocation(
+                                        1L, CheckpointStorageLocationReference.getDefault()),
+                        CheckpointOptions.forCheckpointWithDefaultLocation());
+
+        if (!snapshot1.isDone()) {
+            snapshot1.run();
+        }
+        snapshot1.get().discardState();
     }
 }

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStStateTestBase.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStStateTestBase.java
@@ -106,7 +106,7 @@ public class ForStStateTestBase {
         aec.drainInflightRecords(0);
     }
 
-    private static MockEnvironment getMockEnvironment(File tempDir) throws IOException {
+    protected static MockEnvironment getMockEnvironment(File tempDir) throws IOException {
         MockEnvironment env =
                 MockEnvironment.builder()
                         .setUserCodeClassLoader(ForStStateBackendConfigTest.class.getClassLoader())


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Make ForStState Restore from previous StateMetaInfo

Currently, when creating using ForStKeyedStateBackend create a new State , AbstractKeyedState will directly use the serializer in StateDescriptor regardless of whether it is restored from a Checkpoint.
However, this may cause data to be unable to be restored when the last serializer changes (for example, the class registration order in KryoSerializer has changed, for specific cases, please refer to StateBackendTestBase#testKryoRestoreResilienceWithDifferentRegistrationOrder). Therefore, when creating a State from a Checkpoint, oldStateInfo should be used as the new State's Serializer.


## Brief change log

1. Add TypeSerializer to the constructor of AbstractKeyedState
2. ForStKeyedStateBackend uses oldStateMetaInfo as Serializer when creating State




## Verifying this change




This change is already covered by existing tests, such as ForStStateMigrationTest #testKryoRestoreResilienceWithDifferentRegistrationOrder



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector:  no /)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
