### PR TITLE
[FLINK-37609][format] Bump parquet from 1.14.4 to 1.15.1

### DIFF
--- a/flink-formats/flink-sql-parquet/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-parquet/src/main/resources/META-INF/NOTICE
@@ -6,11 +6,11 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- org.apache.parquet:parquet-avro:1.14.4
-- org.apache.parquet:parquet-hadoop:1.14.4
-- org.apache.parquet:parquet-column:1.14.4
-- org.apache.parquet:parquet-common:1.14.4
-- org.apache.parquet:parquet-encoding:1.14.4
-- org.apache.parquet:parquet-format-structures:1.14.4
-- org.apache.parquet:parquet-jackson:1.14.4
+- org.apache.parquet:parquet-avro:1.15.1
+- org.apache.parquet:parquet-hadoop:1.15.1
+- org.apache.parquet:parquet-column:1.15.1
+- org.apache.parquet:parquet-common:1.15.1
+- org.apache.parquet:parquet-encoding:1.15.1
+- org.apache.parquet:parquet-format-structures:1.15.1
+- org.apache.parquet:parquet-jackson:1.15.1
 - commons-pool:commons-pool:1.6

--- a/flink-formats/pom.xml
+++ b/flink-formats/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<properties>
-		<flink.format.parquet.version>1.14.4</flink.format.parquet.version>
+		<flink.format.parquet.version>1.15.1</flink.format.parquet.version>
 	</properties>
 
 	<artifactId>flink-formats</artifactId>


### PR DESCRIPTION
## What is the purpose of the change

The PR bumps dependency from 1.14.4 to 1.15.1
to mitigate https://nvd.nist.gov/vuln/detail/CVE-2025-30065

## Brief change log
pom and NOTICE files


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
