### PR TITLE
[FLINK-37616][python] Fix incorrect unpickling of Row fields

### DIFF
--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -700,8 +700,11 @@ class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
                                1.98932, bytearray(b'pyflink'), 'pyflink',
                                datetime.date(2014, 9, 13), datetime.time(12, 0, 0, 123000),
                                datetime.datetime(2018, 3, 11, 3, 0, 0, 123000),
+                               [['a', 'b'], ['c', 'd'], ['e', 'f']],
                                [Row('pyflink'), Row('pyflink'), Row('pyflink')],
                                {1: Row('flink'), 2: Row('pyflink')},
+                               [Row('a1', {1: Row('b1')}, [Row('c1', 'd1'), Row('e1', 'f1')]),
+                                Row('a2', {2: Row('b2')}, [Row('c2', 'd2'), Row('e2', 'f2')])],
                                decimal.Decimal('1000000000000000000.050000000000000000'),
                                decimal.Decimal('1000000000000000000.059999999999999999'))]
         source = self.t_env.from_elements(
@@ -709,10 +712,16 @@ class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
               datetime.date(2014, 9, 13), datetime.time(hour=12, minute=0, second=0,
                                                         microsecond=123000),
               datetime.datetime(2018, 3, 11, 3, 0, 0, 123000),
+              [['a', 'b'], ['c', 'd'], ['e', 'f']],
               [Row('pyflink'), Row('pyflink'), Row('pyflink')],
-              {1: Row('flink'), 2: Row('pyflink')}, decimal.Decimal('1000000000000000000.05'),
-              decimal.Decimal('1000000000000000000.05999999999999999899999999999'))], DataTypes.ROW(
-                [DataTypes.FIELD("a", DataTypes.BIGINT()), DataTypes.FIELD("b", DataTypes.BIGINT()),
+              {1: Row('flink'), 2: Row('pyflink')},
+              [Row('a1', {1: Row('b1')}, [Row('c1', 'd1'), Row('e1', 'f1')]),
+               Row('a2', {2: Row('b2')}, [Row('c2', 'd2'), Row('e2', 'f2')])],
+              decimal.Decimal('1000000000000000000.05'),
+              decimal.Decimal('1000000000000000000.05999999999999999899999999999'))],
+            DataTypes.ROW(
+                [DataTypes.FIELD("a", DataTypes.BIGINT()),
+                 DataTypes.FIELD("b", DataTypes.BIGINT()),
                  DataTypes.FIELD("c", DataTypes.TINYINT()),
                  DataTypes.FIELD("d", DataTypes.BOOLEAN()),
                  DataTypes.FIELD("e", DataTypes.SMALLINT()),
@@ -724,12 +733,52 @@ class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
                  DataTypes.FIELD("k", DataTypes.DATE()),
                  DataTypes.FIELD("l", DataTypes.TIME()),
                  DataTypes.FIELD("m", DataTypes.TIMESTAMP(3)),
-                 DataTypes.FIELD("n", DataTypes.ARRAY(DataTypes.ROW([DataTypes.FIELD('ss2',
-                                                                     DataTypes.STRING())]))),
-                 DataTypes.FIELD("o", DataTypes.MAP(DataTypes.BIGINT(), DataTypes.ROW(
-                     [DataTypes.FIELD('ss', DataTypes.STRING())]))),
-                 DataTypes.FIELD("p", DataTypes.DECIMAL(38, 18)), DataTypes.FIELD("q",
-                 DataTypes.DECIMAL(38, 18))]))
+                 DataTypes.FIELD("n", DataTypes.ARRAY(DataTypes.ARRAY(DataTypes.STRING()))),
+                 DataTypes.FIELD(
+                     "o",
+                     DataTypes.ARRAY(
+                         DataTypes.ROW([DataTypes.FIELD("ss2", DataTypes.STRING())])
+                     )),
+                 DataTypes.FIELD(
+                     "p",
+                     DataTypes.MAP(
+                         DataTypes.BIGINT(),
+                         DataTypes.ROW([DataTypes.FIELD("ss", DataTypes.STRING())]),
+                     )),
+                 DataTypes.FIELD(
+                     "q",
+                     DataTypes.ARRAY(
+                         DataTypes.ROW(
+                             [
+                                 DataTypes.FIELD("a1", DataTypes.STRING()),
+                                 DataTypes.FIELD(
+                                     "a2",
+                                     DataTypes.MAP(
+                                         DataTypes.BIGINT(),
+                                         DataTypes.ROW(
+                                             [DataTypes.FIELD("ss", DataTypes.STRING())]
+                                         ),
+                                     ),
+                                 ),
+                                 DataTypes.FIELD(
+                                     "a3",
+                                     DataTypes.ARRAY(
+                                         DataTypes.ROW(
+                                             [
+                                                 DataTypes.FIELD("a1", DataTypes.STRING()),
+                                                 DataTypes.FIELD("a2", DataTypes.STRING()),
+                                             ]
+                                         )
+                                     ),
+                                 ),
+                             ]
+                         )
+                     )),
+                 DataTypes.FIELD("r", DataTypes.DECIMAL(38, 18)),
+                 DataTypes.FIELD("s", DataTypes.DECIMAL(38, 18))
+                 ]
+            )
+        )
         table_result = source.execute()
         with table_result.collect() as result:
             collected_result = []

--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -700,8 +700,8 @@ class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
                                1.98932, bytearray(b'pyflink'), 'pyflink',
                                datetime.date(2014, 9, 13), datetime.time(12, 0, 0, 123000),
                                datetime.datetime(2018, 3, 11, 3, 0, 0, 123000),
-                               [Row(['[pyflink]']), Row(['[pyflink]']), Row(['[pyflink]'])],
-                               {1: Row(['[flink]']), 2: Row(['[pyflink]'])},
+                               [Row('pyflink'), Row('pyflink'), Row('pyflink')],
+                               {1: Row('flink'), 2: Row('pyflink')},
                                decimal.Decimal('1000000000000000000.050000000000000000'),
                                decimal.Decimal('1000000000000000000.059999999999999999'))]
         source = self.t_env.from_elements(
@@ -709,8 +709,8 @@ class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
               datetime.date(2014, 9, 13), datetime.time(hour=12, minute=0, second=0,
                                                         microsecond=123000),
               datetime.datetime(2018, 3, 11, 3, 0, 0, 123000),
-              [Row(['pyflink']), Row(['pyflink']), Row(['pyflink'])],
-              {1: Row(['flink']), 2: Row(['pyflink'])}, decimal.Decimal('1000000000000000000.05'),
+              [Row('pyflink'), Row('pyflink'), Row('pyflink')],
+              {1: Row('flink'), 2: Row('pyflink')}, decimal.Decimal('1000000000000000000.05'),
               decimal.Decimal('1000000000000000000.05999999999999999899999999999'))], DataTypes.ROW(
                 [DataTypes.FIELD("a", DataTypes.BIGINT()), DataTypes.FIELD("b", DataTypes.BIGINT()),
                  DataTypes.FIELD("c", DataTypes.TINYINT()),

--- a/flink-python/pyflink/table/utils.py
+++ b/flink-python/pyflink/table/utils.py
@@ -111,7 +111,7 @@ def pickled_bytes_to_python_converter(data, field_type: DataType):
         fields = []
         for d, d_type in data:
             fields.append(pickled_bytes_to_python_converter(d, d_type))
-        result_row = Row(fields)
+        result_row = Row(*fields)
         result_row.set_row_kind(row_kind)
         return result_row
     else:


### PR DESCRIPTION
## What is the purpose of the change

If you call `TableEnvironment.from_elements` where one of the fields in the row contains a `Row`, for example where one of the values you pass in is:

```
[
    Row("pyflink1A", "pyflink2A", "pyflink3A"),
    Row("pyflink1B", "pyflink2B", "pyflink3B"),
    Row("pyflink1C", "pyflink2C", "pyflink3C"),
],
```

where the schema for the field is:

```
DataTypes.ARRAY(
    DataTypes.ROW(
        [
            DataTypes.FIELD("a", DataTypes.STRING()),
            DataTypes.FIELD("b", DataTypes.STRING()),
            DataTypes.FIELD("c", DataTypes.STRING()),
        ]
    )
),
```

When you call `execute().collect()` on the table, the array is returned as:

```
[
    Row(['pyflink1a', 'pyflink2a', 'pyflink3a']),
    Row(['pyflink1b', 'pyflink2b', 'pyflink3b']),
    Row(['pyflink1c', 'pyflink2c', 'pyflink3c'])
]
```

Instead of each `Row` having 3 values, the collected row only has 1 value, which is now a list of the actual values in the row. The input and output rows are no longer equal (as their internal `_values` collection are no longer equal, one being a list of strings and the other being a list of a list of strings). The `len()` of the source Row is correctly returned as 3, but the collected row incorrectly reports a `len()` of 1.

The constructor for `Row` is such that it takes an arbitrary number of parameters as values, so that:

```
Row("hello", "world', 1, 2, 3, ["hello", "world"])
```

Produces a `Row` whose internal `_values` would be a list of those values: `["hello", "world", 1, 2, 3, ["hello", "world"]`

The `pickled_bytes_to_python_converter` builds a list of fields from the pickled bytes, but then passes this list to the `Row` constructor as one, single argument - essentially constructing the Row with just one field (when it should have all the fields that were collected). This list of fields should be unpacked with `*` when passing them into the `Row` constructor, such that each field acts as a parameter to the constructor.


## Brief change log

 - *Fixed issue when converting a pickled row field to a `Row` type during collection.*

## Verifying this change

This change added tests and can be verified as follows:

*(example:)*
  - *Modified existing `StreamTableEnvironmentTests.test_collect_for_all_data_types` test to properly construct source `Row`s, and to check that the `Row`s returned from `execute().collect()` have the same internal structure as the source `Row`s.*
  - 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (*no*)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (*maybe?*)
  - The serializers: (*no*)
  - The runtime per-record code paths (performance sensitive): (*no*)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (*no*)
  - The S3 file system connector: (*no*)

## Documentation

  - Does this pull request introduce a new feature? (*no*)
  - If yes, how is the feature documented? (*not applicable*)
