### PR TITLE
[hotfix][docs] Fix broken tabs and PTF example argument errors

### DIFF
--- a/docs/content.zh/docs/dev/table/functions/ptfs.md
+++ b/docs/content.zh/docs/dev/table/functions/ptfs.md
@@ -1153,6 +1153,7 @@ notification queue, while the checkout process would be finalized by a separate 
 ```sql
 CREATE VIEW Checkouts AS SELECT * FROM CheckoutProcessor(
   events => TABLE Events PARTITION BY `user`,
+  on_time => DESCRIPTOR(ts),
   reminderInterval => INTERVAL '1' DAY,
   timeoutInterval => INTERVAL '2' DAY, uid => 'cart-processor'
 )

--- a/docs/content.zh/docs/dev/table/functions/ptfs.md
+++ b/docs/content.zh/docs/dev/table/functions/ptfs.md
@@ -787,7 +787,7 @@ Once an `on_time` argument is provided, timers can be used. The following motiva
 public static class PingLaterFunction extends ProcessTableFunction<String> {
   public void eval(
     Context ctx,
-    @ArgumentHint({ArgumentTrait.TABLE_AS_SET, ArgumentTrait.REQUIRE_ON_TIME}) Row event
+    @ArgumentHint({ArgumentTrait.TABLE_AS_SET, ArgumentTrait.REQUIRE_ON_TIME}) Row input
     ) {
       TimeContext<Instant> timeCtx = ctx.timeContext(Instant.class);
       // Replaces an existing timer and thus potentially resets the minute if necessary

--- a/docs/content.zh/docs/dev/table/types.md
+++ b/docs/content.zh/docs/dev/table/types.md
@@ -1395,7 +1395,7 @@ return types of this type.
 
 **Declaration**
 
-{{< tabs "8dfc33fb-c7e5-43c4-ade0-bfc197d46aef" >}}
+{{< tabs "25c30432-8460-441d-a036-9416d8202882" >}}
 {{< tab "SQL" >}}
 ```text
 DESCRIPTOR

--- a/docs/content/docs/dev/table/functions/ptfs.md
+++ b/docs/content/docs/dev/table/functions/ptfs.md
@@ -1153,6 +1153,7 @@ notification queue, while the checkout process would be finalized by a separate 
 ```sql
 CREATE VIEW Checkouts AS SELECT * FROM CheckoutProcessor(
   events => TABLE Events PARTITION BY `user`,
+  on_time => DESCRIPTOR(ts),
   reminderInterval => INTERVAL '1' DAY,
   timeoutInterval => INTERVAL '2' DAY, uid => 'cart-processor'
 )

--- a/docs/content/docs/dev/table/functions/ptfs.md
+++ b/docs/content/docs/dev/table/functions/ptfs.md
@@ -787,7 +787,7 @@ Once an `on_time` argument is provided, timers can be used. The following motiva
 public static class PingLaterFunction extends ProcessTableFunction<String> {
   public void eval(
     Context ctx,
-    @ArgumentHint({ArgumentTrait.TABLE_AS_SET, ArgumentTrait.REQUIRE_ON_TIME}) Row event
+    @ArgumentHint({ArgumentTrait.TABLE_AS_SET, ArgumentTrait.REQUIRE_ON_TIME}) Row input
     ) {
       TimeContext<Instant> timeCtx = ctx.timeContext(Instant.class);
       // Replaces an existing timer and thus potentially resets the minute if necessary

--- a/docs/content/docs/dev/table/types.md
+++ b/docs/content/docs/dev/table/types.md
@@ -1404,7 +1404,7 @@ return types of this type.
 
 **Declaration**
 
-{{< tabs "8dfc33fb-c7e5-43c4-ade0-bfc197d46aef" >}}
+{{< tabs "25c30432-8460-441d-a036-9416d8202882" >}}
 {{< tab "SQL" >}}
 ```text
 DESCRIPTOR


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*Fix broken tabs and Process table function(PTF) time example `PingLaterFunction` param err*


## Brief change log

- `DESCRIPTOR` tabs id is same with `BOOLEAN`.

-  `PingLaterFunction` param err:
<img width="846" alt="image" src="https://github.com/user-attachments/assets/2a31b3ae-47a6-4a34-8ab3-31502d809787" />


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
