### PR TITLE
 [BP-1.19][FLINK-37609][format]  Bump parquet to 1.15.1

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-hive/src/main/resources/META-INF/NOTICE
@@ -6,9 +6,9 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- org.apache.parquet:parquet-hadoop:1.13.1
-- org.apache.parquet:parquet-column:1.13.1
-- org.apache.parquet:parquet-common:1.13.1
-- org.apache.parquet:parquet-encoding:1.13.1
-- org.apache.parquet:parquet-format-structures:1.13.1
-- org.apache.parquet:parquet-jackson:1.13.1
+- org.apache.parquet:parquet-hadoop:1.14.4
+- org.apache.parquet:parquet-column:1.14.4
+- org.apache.parquet:parquet-common:1.14.4
+- org.apache.parquet:parquet-encoding:1.14.4
+- org.apache.parquet:parquet-format-structures:1.14.4
+- org.apache.parquet:parquet-jackson:1.14.4

--- a/flink-connectors/flink-connector-hive/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-hive/src/main/resources/META-INF/NOTICE
@@ -6,9 +6,9 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- org.apache.parquet:parquet-hadoop:1.14.4
-- org.apache.parquet:parquet-column:1.14.4
-- org.apache.parquet:parquet-common:1.14.4
-- org.apache.parquet:parquet-encoding:1.14.4
-- org.apache.parquet:parquet-format-structures:1.14.4
-- org.apache.parquet:parquet-jackson:1.14.4
+- org.apache.parquet:parquet-hadoop:1.15.1
+- org.apache.parquet:parquet-column:1.15.1
+- org.apache.parquet:parquet-common:1.15.1
+- org.apache.parquet:parquet-encoding:1.15.1
+- org.apache.parquet:parquet-format-structures:1.15.1
+- org.apache.parquet:parquet-jackson:1.15.1

--- a/flink-formats/flink-sql-parquet/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-parquet/src/main/resources/META-INF/NOTICE
@@ -6,11 +6,11 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- org.apache.parquet:parquet-avro:1.13.1
-- org.apache.parquet:parquet-hadoop:1.13.1
-- org.apache.parquet:parquet-column:1.13.1
-- org.apache.parquet:parquet-common:1.13.1
-- org.apache.parquet:parquet-encoding:1.13.1
-- org.apache.parquet:parquet-format-structures:1.13.1
-- org.apache.parquet:parquet-jackson:1.13.1
+- org.apache.parquet:parquet-avro:1.14.4
+- org.apache.parquet:parquet-hadoop:1.14.4
+- org.apache.parquet:parquet-column:1.14.4
+- org.apache.parquet:parquet-common:1.14.4
+- org.apache.parquet:parquet-encoding:1.14.4
+- org.apache.parquet:parquet-format-structures:1.14.4
+- org.apache.parquet:parquet-jackson:1.14.4
 - commons-pool:commons-pool:1.6

--- a/flink-formats/flink-sql-parquet/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-parquet/src/main/resources/META-INF/NOTICE
@@ -6,11 +6,11 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- org.apache.parquet:parquet-avro:1.14.4
-- org.apache.parquet:parquet-hadoop:1.14.4
-- org.apache.parquet:parquet-column:1.14.4
-- org.apache.parquet:parquet-common:1.14.4
-- org.apache.parquet:parquet-encoding:1.14.4
-- org.apache.parquet:parquet-format-structures:1.14.4
-- org.apache.parquet:parquet-jackson:1.14.4
+- org.apache.parquet:parquet-avro:1.15.1
+- org.apache.parquet:parquet-hadoop:1.15.1
+- org.apache.parquet:parquet-column:1.15.1
+- org.apache.parquet:parquet-common:1.15.1
+- org.apache.parquet:parquet-encoding:1.15.1
+- org.apache.parquet:parquet-format-structures:1.15.1
+- org.apache.parquet:parquet-jackson:1.15.1
 - commons-pool:commons-pool:1.6

--- a/flink-formats/pom.xml
+++ b/flink-formats/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<properties>
-		<flink.format.parquet.version>1.14.4</flink.format.parquet.version>
+		<flink.format.parquet.version>1.15.1</flink.format.parquet.version>
 	</properties>
 
 	<artifactId>flink-formats</artifactId>

--- a/flink-formats/pom.xml
+++ b/flink-formats/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<properties>
-		<flink.format.parquet.version>1.13.1</flink.format.parquet.version>
+		<flink.format.parquet.version>1.14.4</flink.format.parquet.version>
 	</properties>
 
 	<artifactId>flink-formats</artifactId>

--- a/flink-python/pom.xml
+++ b/flink-python/pom.xml
@@ -380,6 +380,12 @@ under the License.
 			<artifactId>commons-lang3</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>com.fasterxml.jackson.datatype</groupId>
+			<artifactId>jackson-datatype-jdk8</artifactId>
+			<version>${jackson-bom.version}</version>
+		</dependency>
+
 	</dependencies>
 
 	<dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -2293,7 +2293,13 @@ under the License.
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-shade-plugin</artifactId>
-					<version>3.5.1</version>
+					<version>3.5.3</version>
+				</plugin>
+				<!-- Pin the version of the maven remote resource plugin -->
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-remote-resources-plugin</artifactId>
+					<version>3.2.0</version>
 				</plugin>
 
 				<plugin>


### PR DESCRIPTION
1.19 backport of https://github.com/apache/flink/commit/986f89ac120fdff0d3b9bd738e06e39c28617785, 
 https://github.com/apache/flink/commit/5aaff07fe925b289a2cabe9269a015ebc2255223
and https://github.com/apache/flink/commit/d8cd5591d3136187695727202dc16bc96ce2caae