### PR TITLE
[BP-2.0][FLINK-37609][format] Bump parquet to 1.15.1

### DIFF
--- a/flink-formats/flink-sql-parquet/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-parquet/src/main/resources/META-INF/NOTICE
@@ -6,11 +6,11 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- org.apache.parquet:parquet-avro:1.14.4
-- org.apache.parquet:parquet-hadoop:1.14.4
-- org.apache.parquet:parquet-column:1.14.4
-- org.apache.parquet:parquet-common:1.14.4
-- org.apache.parquet:parquet-encoding:1.14.4
-- org.apache.parquet:parquet-format-structures:1.14.4
-- org.apache.parquet:parquet-jackson:1.14.4
+- org.apache.parquet:parquet-avro:1.15.1
+- org.apache.parquet:parquet-hadoop:1.15.1
+- org.apache.parquet:parquet-column:1.15.1
+- org.apache.parquet:parquet-common:1.15.1
+- org.apache.parquet:parquet-encoding:1.15.1
+- org.apache.parquet:parquet-format-structures:1.15.1
+- org.apache.parquet:parquet-jackson:1.15.1
 - commons-pool:commons-pool:1.6

--- a/flink-formats/pom.xml
+++ b/flink-formats/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<properties>
-		<flink.format.parquet.version>1.14.4</flink.format.parquet.version>
+		<flink.format.parquet.version>1.15.1</flink.format.parquet.version>
 	</properties>
 
 	<artifactId>flink-formats</artifactId>


### PR DESCRIPTION
2.0 backport of https://github.com/apache/flink/pull/26398