### PR TITLE
[FLINK-37628] Fix reference counting in ForSt file cache

### DIFF
--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/fs/cache/FileBasedCache.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/fs/cache/FileBasedCache.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.state.forst.fs.cache;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.core.fs.FSDataInputStream;
@@ -144,6 +145,11 @@ public final class FileBasedCache extends DoubleListLru<String, FileCacheEntry>
      */
     public static void setFlinkThread() {
         isFlinkThread.set(true);
+    }
+
+    @VisibleForTesting
+    public static void unsetFlinkThread() {
+        isFlinkThread.set(false);
     }
 
     /**


### PR DESCRIPTION
## What is the purpose of the change

There is a concurrency issue for reference counting in ForSt file cache, which could lead to a read error in some special scenarios (e.g. extremely frequent cache thrashing)


## Brief change log

Two problem:

 - All the read interfaces in `CachedDataInputStream` should release the reference **only after** the stream is not the `originalStream`
 - The stream retrieving methods in task threads should consider the latency of status switch.


## Verifying this change

This change is already covered by existing tests, such as `ForStFlinkFileSystemTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
