### PR TITLE
[hotfix] Unify the name for the collection of SlotOffer with slotOffers

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -717,7 +717,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId>
     @Override
     public CompletableFuture<Collection<SlotOffer>> offerSlots(
             final ResourceID taskManagerId,
-            final Collection<SlotOffer> slots,
+            final Collection<SlotOffer> slotOffers,
             final Duration timeout) {
 
         TaskManagerRegistration taskManagerRegistration = registeredTaskManagers.get(taskManagerId);
@@ -735,7 +735,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId>
                 slotPoolService.offerSlots(
                         taskManagerRegistration.getTaskManagerLocation(),
                         rpcTaskManagerGateway,
-                        slots));
+                        slotOffers));
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
@@ -130,16 +130,17 @@ public interface JobMasterGateway
             final ResourceManagerId resourceManagerId, final Exception cause);
 
     /**
-     * Offers the given slots to the job manager. The response contains the set of accepted slots.
+     * Offers the given slots to the job manager. The response contains the set of accepted slot
+     * offers.
      *
      * @param taskManagerId identifying the task manager
-     * @param slots to offer to the job manager
+     * @param slotOffers the slot offers to the job manager
      * @param timeout for the rpc call
-     * @return Future set of accepted slots.
+     * @return Future set of accepted slot offers.
      */
     CompletableFuture<Collection<SlotOffer>> offerSlots(
             final ResourceID taskManagerId,
-            final Collection<SlotOffer> slots,
+            final Collection<SlotOffer> slotOffers,
             @RpcTimeout final Duration timeout);
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/BlocklistDeclarativeSlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/BlocklistDeclarativeSlotPool.java
@@ -73,14 +73,15 @@ public class BlocklistDeclarativeSlotPool extends DefaultDeclarativeSlotPool {
 
     @Override
     public Collection<SlotOffer> offerSlots(
-            Collection<? extends SlotOffer> offers,
+            Collection<? extends SlotOffer> slotOffers,
             TaskManagerLocation taskManagerLocation,
             TaskManagerGateway taskManagerGateway,
             long currentTime) {
         if (!isBlockedTaskManager(taskManagerLocation.getResourceID())) {
-            return super.offerSlots(offers, taskManagerLocation, taskManagerGateway, currentTime);
+            return super.offerSlots(
+                    slotOffers, taskManagerLocation, taskManagerGateway, currentTime);
         } else {
-            return internalOfferSlotsFromBlockedTaskManager(offers, taskManagerLocation);
+            return internalOfferSlotsFromBlockedTaskManager(slotOffers, taskManagerLocation);
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPool.java
@@ -73,7 +73,7 @@ public interface DeclarativeSlotPool {
     /**
      * Offers slots to this slot pool. The slot pool is free to accept as many slots as it needs.
      *
-     * @param offers offers containing the list of slots offered to this slot pool
+     * @param slotOffers offers containing the list of slots offered to this slot pool
      * @param taskManagerLocation taskManagerLocation is the location of the offering TaskExecutor
      * @param taskManagerGateway taskManagerGateway is the gateway to talk to the offering
      *     TaskExecutor
@@ -81,7 +81,7 @@ public interface DeclarativeSlotPool {
      * @return collection of accepted slots; the other slot offers are implicitly rejected
      */
     Collection<SlotOffer> offerSlots(
-            Collection<? extends SlotOffer> offers,
+            Collection<? extends SlotOffer> slotOffers,
             TaskManagerLocation taskManagerLocation,
             TaskManagerGateway taskManagerGateway,
             long currentTime);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridge.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridge.java
@@ -148,7 +148,7 @@ public class DeclarativeSlotPoolBridge extends DeclarativeSlotPoolService implem
     public Collection<SlotOffer> offerSlots(
             TaskManagerLocation taskManagerLocation,
             TaskManagerGateway taskManagerGateway,
-            Collection<SlotOffer> offers) {
+            Collection<SlotOffer> slotOffers) {
         assertHasBeenStarted();
 
         if (!isTaskManagerRegistered(taskManagerLocation.getResourceID())) {
@@ -161,7 +161,7 @@ public class DeclarativeSlotPoolBridge extends DeclarativeSlotPoolService implem
         if (isJobRestarting) {
             return getDeclarativeSlotPool()
                     .registerSlots(
-                            offers,
+                            slotOffers,
                             taskManagerLocation,
                             taskManagerGateway,
                             getRelativeTimeMillis());
@@ -169,7 +169,7 @@ public class DeclarativeSlotPoolBridge extends DeclarativeSlotPoolService implem
         } else {
             return getDeclarativeSlotPool()
                     .offerSlots(
-                            offers,
+                            slotOffers,
                             taskManagerLocation,
                             taskManagerGateway,
                             getRelativeTimeMillis());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolService.java
@@ -174,7 +174,7 @@ public class DeclarativeSlotPoolService implements SlotPoolService {
     public Collection<SlotOffer> offerSlots(
             TaskManagerLocation taskManagerLocation,
             TaskManagerGateway taskManagerGateway,
-            Collection<SlotOffer> offers) {
+            Collection<SlotOffer> slotOffers) {
         assertHasBeenStarted();
 
         if (!isTaskManagerRegistered(taskManagerLocation.getResourceID())) {
@@ -185,7 +185,7 @@ public class DeclarativeSlotPoolService implements SlotPoolService {
         }
 
         return declarativeSlotPool.offerSlots(
-                offers, taskManagerLocation, taskManagerGateway, clock.relativeTimeMillis());
+                slotOffers, taskManagerLocation, taskManagerGateway, clock.relativeTimeMillis());
     }
 
     boolean isTaskManagerRegistered(ResourceID taskManagerId) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPool.java
@@ -208,15 +208,15 @@ public class DefaultDeclarativeSlotPool implements DeclarativeSlotPool {
 
     @Override
     public Collection<SlotOffer> offerSlots(
-            Collection<? extends SlotOffer> offers,
+            Collection<? extends SlotOffer> slotOffers,
             TaskManagerLocation taskManagerLocation,
             TaskManagerGateway taskManagerGateway,
             long currentTime) {
 
-        log.debug("Received {} slot offers from TaskExecutor {}.", offers, taskManagerLocation);
+        log.debug("Received {} slot offers from TaskExecutor {}.", slotOffers, taskManagerLocation);
 
         return internalOfferSlots(
-                offers,
+                slotOffers,
                 taskManagerLocation,
                 taskManagerGateway,
                 currentTime,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolService.java
@@ -71,14 +71,14 @@ public interface SlotPoolService extends AutoCloseable {
      *
      * @param taskManagerLocation from which the slot offers originate
      * @param taskManagerGateway to talk to the slot offerer
-     * @param offers slot offers which are offered to the {@link SlotPoolService}
+     * @param slotOffers slot offers which are offered to the {@link SlotPoolService}
      * @return A collection of accepted slot offers. The remaining slot offers are implicitly
      *     rejected.
      */
     Collection<SlotOffer> offerSlots(
             TaskManagerLocation taskManagerLocation,
             TaskManagerGateway taskManagerGateway,
-            Collection<SlotOffer> offers);
+            Collection<SlotOffer> slotOffers);
 
     /**
      * Fails the allocation with the given allocationId.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -553,7 +553,7 @@ class JobMasterTest {
         public Collection<SlotOffer> offerSlots(
                 TaskManagerLocation taskManagerLocation,
                 TaskManagerGateway taskManagerGateway,
-                Collection<SlotOffer> offers) {
+                Collection<SlotOffer> slotOffers) {
             hasReceivedSlotOffers.trigger();
             final Collection<PhysicalSlot> slotInfos =
                     Optional.ofNullable(registeredSlots.get(taskManagerLocation.getResourceID()))
@@ -562,7 +562,7 @@ class JobMasterTest {
 
             int slotIndex = slotInfos.size();
 
-            for (SlotOffer offer : offers) {
+            for (SlotOffer offer : slotOffers) {
                 slotInfos.add(
                         TestingPhysicalSlot.builder()
                                 .withAllocationID(offer.getAllocationId())
@@ -573,7 +573,7 @@ class JobMasterTest {
                 slotIndex++;
             }
 
-            return offers;
+            return slotOffers;
         }
 
         @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/TestingDeclarativeSlotPool.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/TestingDeclarativeSlotPool.java
@@ -156,12 +156,12 @@ final class TestingDeclarativeSlotPool implements DeclarativeSlotPool {
 
     @Override
     public Collection<SlotOffer> offerSlots(
-            Collection<? extends SlotOffer> offers,
+            Collection<? extends SlotOffer> slotOffers,
             TaskManagerLocation taskManagerLocation,
             TaskManagerGateway taskManagerGateway,
             long currentTime) {
         return offerSlotsFunction.apply(
-                offers, taskManagerLocation, taskManagerGateway, currentTime);
+                slotOffers, taskManagerLocation, taskManagerGateway, currentTime);
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/TestingSlotPoolService.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/TestingSlotPoolService.java
@@ -120,8 +120,8 @@ public class TestingSlotPoolService implements SlotPoolService {
     public Collection<SlotOffer> offerSlots(
             TaskManagerLocation taskManagerLocation,
             TaskManagerGateway taskManagerGateway,
-            Collection<SlotOffer> offers) {
-        return offerSlotsFunction.apply(taskManagerLocation, taskManagerGateway, offers);
+            Collection<SlotOffer> slotOffers) {
+        return offerSlotsFunction.apply(taskManagerLocation, taskManagerGateway, slotOffers);
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
@@ -405,8 +405,8 @@ public class TestingJobMasterGateway implements JobMasterGateway {
 
     @Override
     public CompletableFuture<Collection<SlotOffer>> offerSlots(
-            ResourceID taskManagerId, Collection<SlotOffer> slots, Duration timeout) {
-        return offerSlotsFunction.apply(taskManagerId, slots);
+            ResourceID taskManagerId, Collection<SlotOffer> slotOffers, Duration timeout) {
+        return offerSlotsFunction.apply(taskManagerId, slotOffers);
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to unify the name for the collection of `SlotOffer`.
Currently, there are two name of variable about collection of `SlotOffer`. One is `slots` and another is `offers`.
I think `slotOffers` have better readability than them.

## Brief change log

Unify the name for the collection of `SlotOffer` with `slotOffers`.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
