### PR TITLE
[FLINK-36158][FOLLOWUP] Replace the ZK HA path from jobgraphs to execution-plans

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperLeaderElectionHaServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperLeaderElectionHaServices.java
@@ -51,7 +51,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *      |            |       /job-id-2/connection_info
  *      |            |
  *      |            |
- *      |            +jobgraphs/job-id-1
+ *      |            +execution-plans/job-id-1
  *      |            |         /job-id-2
  *      |            +jobs/job-id-1/checkpoints/latest
  *      |                 |                    /latest-1

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/ZooKeeperExecutionPlanStoreWatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/ZooKeeperExecutionPlanStoreWatcher.java
@@ -37,11 +37,11 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * <p>Each job graph creates ZNode:
  *
  * <pre>
- * +----O /flink/jobgraphs/&lt;job-id&gt; 1 [persistent]
+ * +----O /flink/execution-plans/&lt;job-id&gt; 1 [persistent]
  * .
  * .
  * .
- * +----O /flink/jobgraphs/&lt;job-id&gt; N [persistent]
+ * +----O /flink/execution-plans/&lt;job-id&gt; N [persistent]
  * </pre>
  *
  * <p>The root path is watched to detect concurrent modifications in corner situations where


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to replace the ZK HA path from `jobgraphs` to `execution-plans`.
This PR also follows up https://github.com/apache/flink/pull/25492


## Brief change log

Replace the ZK HA path from `jobgraphs` to `execution-plans`


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
