### PR TITLE
[hotfix] Avoid duplicate loop for configuration

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java
@@ -150,8 +150,6 @@ public final class GlobalConfiguration {
             configuration = loadYAMLResource(yamlConfigFile);
         }
 
-        logConfiguration("Loading", configuration);
-
         if (dynamicProperties != null) {
             logConfiguration("Loading dynamic", dynamicProperties);
             configuration.addAll(dynamicProperties);
@@ -250,7 +248,14 @@ public final class GlobalConfiguration {
 
         try {
             Map<String, Object> configDocument = flatten(YamlParserUtils.loadYamlFile(file));
-            configDocument.forEach((k, v) -> config.setValueInternal(k, v, false));
+            configDocument.forEach(
+                    (k, v) -> {
+                        config.setValueInternal(k, v, false);
+                        LOG.info(
+                                "Loading configuration property: {}, {}",
+                                k,
+                                isSensitive(k) ? HIDDEN_CONTENT : v);
+                    });
 
             return config;
         } catch (Exception e) {


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to avoid duplicate loop for configuration.


## Brief change log

Avoid duplicate loop for configuration


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
