### PR TITLE
[FLINK-37637] Avoid dead lock for Configuration's addAll

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
@@ -239,19 +239,19 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
     }
 
     public void addAll(Configuration other) {
-        Object lock1 = this.confData;
-        Object lock2 = other.confData;
+        Object thisLock = this.confData;
+        Object otherLock = other.confData;
 
         // Ensure consistent lock sequence
-        if (System.identityHashCode(lock1) < System.identityHashCode(lock2)) {
-            synchronized (lock1) {
-                synchronized (lock2) {
+        if (System.identityHashCode(thisLock) < System.identityHashCode(otherLock)) {
+            synchronized (thisLock) {
+                synchronized (otherLock) {
                     this.confData.putAll(other.confData);
                 }
             }
         } else {
-            synchronized (lock2) {
-                synchronized (lock1) {
+            synchronized (otherLock) {
+                synchronized (thisLock) {
                     this.confData.putAll(other.confData);
                 }
             }
@@ -270,13 +270,13 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
         bld.append(prefix);
         final int pl = bld.length();
 
-        Object lock1 = this.confData;
-        Object lock2 = other.confData;
+        Object thisLock = this.confData;
+        Object otherLock = other.confData;
 
         // Ensure consistent lock sequence
-        if (System.identityHashCode(lock1) < System.identityHashCode(lock2)) {
-            synchronized (lock1) {
-                synchronized (lock2) {
+        if (System.identityHashCode(thisLock) < System.identityHashCode(otherLock)) {
+            synchronized (thisLock) {
+                synchronized (otherLock) {
                     for (Map.Entry<String, Object> entry : other.confData.entrySet()) {
                         bld.setLength(pl);
                         bld.append(entry.getKey());
@@ -285,8 +285,8 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
                 }
             }
         } else {
-            synchronized (lock2) {
-                synchronized (lock1) {
+            synchronized (otherLock) {
+                synchronized (thisLock) {
                     for (Map.Entry<String, Object> entry : other.confData.entrySet()) {
                         bld.setLength(pl);
                         bld.append(entry.getKey());


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to avoid dead lock for Configuration's `addAll`.
When multiple threads call the `addAll` method simultaneously and the passed Configuration objects are each other's parameters, a deadlock may occur:
```
// Thread 1
configA.addAll(configB);  // First lock configA.confData, then try locking configB.confData

// Thread 2
configB.addAll(configA);  // First lock configB.confData, then try locking configA.confData
```


## Brief change log

Avoid dead lock for Configuration's `addAll`.


## Verifying this change

This change is already covered by existing tests, such as *(JobManagerProcessUtilsTest)*.
There are many test cases using the `addAll`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
