### PR TITLE
[hotfix] Rename loadJarFile to checkJarFile

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
@@ -132,8 +132,8 @@ public class PackagedProgram implements AutoCloseable {
         // whether the job is a Python job.
         this.isPython = isPython(entryPointClassName);
 
-        // load the jar file if exists
-        this.jarFile = loadJarFile(jarFile);
+        // check the jar file if valid
+        this.jarFile = checkJarFile(jarFile);
 
         assert this.jarFile != null || entryPointClassName != null;
 
@@ -272,7 +272,7 @@ public class PackagedProgram implements AutoCloseable {
     /** Returns all provided libraries needed to run the program. */
     public static List<URL> getJobJarAndDependencies(
             File jarFile, @Nullable String entryPointClassName) throws ProgramInvocationException {
-        URL jarFileUrl = loadJarFile(jarFile);
+        URL jarFileUrl = checkJarFile(jarFile);
 
         List<File> extractedTempLibraries =
                 jarFileUrl == null
@@ -440,7 +440,7 @@ public class PackagedProgram implements AutoCloseable {
     }
 
     @Nullable
-    private static URL loadJarFile(File jar) throws ProgramInvocationException {
+    private static URL checkJarFile(File jar) throws ProgramInvocationException {
         if (jar != null) {
             URL jarFileUrl;
 


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to rename `loadJarFile` to `checkJarFile`.
The reason is `loadJarFile` just checking if the jar file is valid and is not related to load.


## Brief change log

Rename `loadJarFile` to `checkJarFile`.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
