### PR TITLE
[FLINK-37638] Avoid duplicate call on getEffectiveConfiguration

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -187,7 +187,10 @@ public class CliFrontend {
         final CustomCommandLine activeCommandLine =
                 validateAndGetActiveCommandLine(checkNotNull(commandLine));
 
-        if (isDeploymentTargetApplication(activeCommandLine, commandLine)) {
+        final Configuration initEffectiveConfiguration =
+                getEffectiveConfiguration(activeCommandLine, commandLine);
+
+        if (isDeploymentTargetApplication(initEffectiveConfiguration)) {
             final ApplicationDeployer deployer =
                     new ApplicationClusterDeployer(clusterClientServiceLoader);
 
@@ -199,8 +202,7 @@ public class CliFrontend {
                 programOptions = ProgramOptionsUtils.createPythonProgramOptions(commandLine);
                 effectiveConfiguration =
                         getEffectiveConfiguration(
-                                activeCommandLine,
-                                commandLine,
+                                initEffectiveConfiguration,
                                 programOptions,
                                 Collections.emptyList());
             } else {
@@ -209,8 +211,7 @@ public class CliFrontend {
                 final URI uri = PackagedProgramUtils.resolveURI(programOptions.getJarFilePath());
                 effectiveConfiguration =
                         getEffectiveConfiguration(
-                                activeCommandLine,
-                                commandLine,
+                                initEffectiveConfiguration,
                                 programOptions,
                                 Collections.singletonList(uri.toString()));
             }
@@ -226,8 +227,7 @@ public class CliFrontend {
             final List<URL> jobJars = getJobJarAndDependencies(programOptions);
 
             final Configuration effectiveConfiguration =
-                    getEffectiveConfiguration(
-                            activeCommandLine, commandLine, programOptions, jobJars);
+                    getEffectiveConfiguration(initEffectiveConfiguration, programOptions, jobJars);
 
             LOG.debug("Effective executor configuration: {}", effectiveConfiguration);
 
@@ -238,12 +238,7 @@ public class CliFrontend {
         }
     }
 
-    protected boolean isDeploymentTargetApplication(
-            final CustomCommandLine activeCustomCommandLine, final CommandLine commandLine)
-            throws FlinkException {
-        final Configuration effectiveConfiguration =
-                getEffectiveConfiguration(activeCustomCommandLine, commandLine);
-
+    protected boolean isDeploymentTargetApplication(final Configuration effectiveConfiguration) {
         final String executionTarget =
                 effectiveConfiguration
                         .getOptional(DeploymentOptions.TARGET)
@@ -301,14 +296,9 @@ public class CliFrontend {
     }
 
     private <T> Configuration getEffectiveConfiguration(
-            final CustomCommandLine activeCustomCommandLine,
-            final CommandLine commandLine,
+            final Configuration effectiveConfiguration,
             final ProgramOptions programOptions,
-            final List<T> jobJars)
-            throws FlinkException {
-
-        final Configuration effectiveConfiguration =
-                getEffectiveConfiguration(activeCustomCommandLine, commandLine);
+            final List<T> jobJars) {
 
         final ExecutionConfigAccessor executionParameters =
                 ExecutionConfigAccessor.fromProgramOptions(
@@ -354,10 +344,12 @@ public class CliFrontend {
             final CustomCommandLine activeCommandLine =
                     validateAndGetActiveCommandLine(checkNotNull(commandLine));
 
+            final Configuration initEffectiveConfiguration =
+                    getEffectiveConfiguration(activeCommandLine, commandLine);
+
             final Configuration effectiveConfiguration =
                     getEffectiveConfiguration(
-                            activeCommandLine,
-                            commandLine,
+                            initEffectiveConfiguration,
                             programOptions,
                             getJobJarAndDependencies(programOptions));
 

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -187,33 +187,28 @@ public class CliFrontend {
         final CustomCommandLine activeCommandLine =
                 validateAndGetActiveCommandLine(checkNotNull(commandLine));
 
-        final Configuration initEffectiveConfiguration =
+        final Configuration effectiveConfiguration =
                 getEffectiveConfiguration(activeCommandLine, commandLine);
 
-        if (isDeploymentTargetApplication(initEffectiveConfiguration)) {
+        if (isDeploymentTargetApplication(effectiveConfiguration)) {
             final ApplicationDeployer deployer =
                     new ApplicationClusterDeployer(clusterClientServiceLoader);
 
             final ProgramOptions programOptions;
-            final Configuration effectiveConfiguration;
 
             // No need to set a jarFile path for PyFlink job.
             if (ProgramOptionsUtils.isPythonEntryPoint(commandLine)) {
                 programOptions = ProgramOptionsUtils.createPythonProgramOptions(commandLine);
-                effectiveConfiguration =
-                        getEffectiveConfiguration(
-                                initEffectiveConfiguration,
-                                programOptions,
-                                Collections.emptyList());
+                updateEffectiveConfiguration(
+                        effectiveConfiguration, programOptions, Collections.emptyList());
             } else {
                 programOptions = new ProgramOptions(commandLine);
                 programOptions.validate();
                 final URI uri = PackagedProgramUtils.resolveURI(programOptions.getJarFilePath());
-                effectiveConfiguration =
-                        getEffectiveConfiguration(
-                                initEffectiveConfiguration,
-                                programOptions,
-                                Collections.singletonList(uri.toString()));
+                updateEffectiveConfiguration(
+                        effectiveConfiguration,
+                        programOptions,
+                        Collections.singletonList(uri.toString()));
             }
 
             final ApplicationConfiguration applicationConfiguration =
@@ -226,8 +221,7 @@ public class CliFrontend {
 
             final List<URL> jobJars = getJobJarAndDependencies(programOptions);
 
-            final Configuration effectiveConfiguration =
-                    getEffectiveConfiguration(initEffectiveConfiguration, programOptions, jobJars);
+            updateEffectiveConfiguration(effectiveConfiguration, programOptions, jobJars);
 
             LOG.debug("Effective executor configuration: {}", effectiveConfiguration);
 
@@ -295,7 +289,7 @@ public class CliFrontend {
         return effectiveConfiguration;
     }
 
-    private <T> Configuration getEffectiveConfiguration(
+    private <T> void updateEffectiveConfiguration(
             final Configuration effectiveConfiguration,
             final ProgramOptions programOptions,
             final List<T> jobJars) {
@@ -309,7 +303,6 @@ public class CliFrontend {
         LOG.debug(
                 "Effective configuration after Flink conf, custom commandline, and program options: {}",
                 effectiveConfiguration);
-        return effectiveConfiguration;
     }
 
     /**
@@ -344,14 +337,13 @@ public class CliFrontend {
             final CustomCommandLine activeCommandLine =
                     validateAndGetActiveCommandLine(checkNotNull(commandLine));
 
-            final Configuration initEffectiveConfiguration =
+            final Configuration effectiveConfiguration =
                     getEffectiveConfiguration(activeCommandLine, commandLine);
 
-            final Configuration effectiveConfiguration =
-                    getEffectiveConfiguration(
-                            initEffectiveConfiguration,
-                            programOptions,
-                            getJobJarAndDependencies(programOptions));
+            updateEffectiveConfiguration(
+                    effectiveConfiguration,
+                    programOptions,
+                    getJobJarAndDependencies(programOptions));
 
             program = buildProgram(programOptions, effectiveConfiguration);
 

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
@@ -28,7 +28,6 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.core.execution.RecoveryClaimMode;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
-import org.apache.flink.util.FlinkException;
 
 import org.apache.commons.cli.CommandLine;
 import org.junit.jupiter.api.AfterAll;
@@ -376,10 +375,8 @@ public class CliFrontendRunTest extends CliFrontendTestBase {
         }
 
         @Override
-        protected boolean isDeploymentTargetApplication(
-                CustomCommandLine activeCustomCommandLine, CommandLine commandLine)
-                throws FlinkException {
-            application = super.isDeploymentTargetApplication(activeCustomCommandLine, commandLine);
+        protected boolean isDeploymentTargetApplication(Configuration effectiveConfiguration) {
+            application = super.isDeploymentTargetApplication(effectiveConfiguration);
             return application;
         }
 


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to avoid duplicate call on `getEffectiveConfiguration`.
The code of `getEffectiveConfiguration` show below, I think it has a lot of overhead.
```
    private Configuration getEffectiveConfiguration(
            final CustomCommandLine activeCustomCommandLine, final CommandLine commandLine)
            throws FlinkException {

        final Configuration effectiveConfiguration = new Configuration(configuration);

        final Configuration commandLineConfiguration =
                checkNotNull(activeCustomCommandLine).toConfiguration(commandLine);

        effectiveConfiguration.addAll(commandLineConfiguration);

        return effectiveConfiguration;
    }
```


## Brief change log

Avoid duplicate call on `getEffectiveConfiguration`.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
