### PR TITLE
[hotfix] Avoid duplicate call on checkNotNull while calling fromProgramOptions

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -311,8 +311,7 @@ public class CliFrontend {
                 getEffectiveConfiguration(activeCustomCommandLine, commandLine);
 
         final ExecutionConfigAccessor executionParameters =
-                ExecutionConfigAccessor.fromProgramOptions(
-                        checkNotNull(programOptions), checkNotNull(jobJars));
+                ExecutionConfigAccessor.fromProgramOptions(programOptions, jobJars);
 
         executionParameters.applyToConfiguration(effectiveConfiguration);
 


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to avoid duplicate call on `checkNotNull`. The method fromProgramOptions already contains the check show below.
```
    public static <T> ExecutionConfigAccessor fromProgramOptions(
            final ProgramOptions options, final List<T> jobJars) {
        checkNotNull(options);
        checkNotNull(jobJars);

        // ignore others.
    }
```


## Brief change log

Avoid duplicate call on `checkNotNull` while calling `fromProgramOptions`.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
