### PR TITLE
[FLINK-37645] Improve existsUnboundedSource by avoiding duplicate check transformations

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -93,6 +93,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
@@ -438,16 +439,26 @@ public class StreamGraphGenerator {
     }
 
     private boolean existsUnboundedSource() {
+        final HashSet<Integer> checkedTransformations = new HashSet<>();
         return transformations.stream()
                 .anyMatch(
                         transformation ->
-                                isUnboundedSource(transformation)
+                                isUnboundedSource(transformation, checkedTransformations)
                                         || transformation.getTransitivePredecessors().stream()
-                                                .anyMatch(this::isUnboundedSource));
+                                                .anyMatch(
+                                                        t ->
+                                                                isUnboundedSource(
+                                                                        t,
+                                                                        checkedTransformations)));
     }
 
-    private boolean isUnboundedSource(final Transformation<?> transformation) {
+    private boolean isUnboundedSource(
+            final Transformation<?> transformation, HashSet<Integer> checkedTransformations) {
         checkNotNull(transformation);
+        if (checkedTransformations.contains(transformation.getId())) {
+            return false;
+        }
+        checkedTransformations.add(transformation.getId());
         return transformation instanceof WithBoundedness
                 && ((WithBoundedness) transformation).getBoundedness() != Boundedness.BOUNDED;
     }


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to improve existsUnboundedSource by avoiding duplicate check transformations.


## Brief change log

Improve existsUnboundedSource by avoiding duplicate check transformations


## Verifying this change

This change is already covered by existing tests, such as *(JobGraphGeneratorTestBase)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
