### PR TITLE
[FLINK-37643] Support partial deletes when converting to external data structures

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/ArrayData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/ArrayData.java
@@ -230,6 +230,12 @@ public interface ArrayData {
      */
     @PublicEvolving
     interface ElementGetter extends Serializable {
+
+        /**
+         * Converters and serializers always support nullability. The NOT NULL constraint is only
+         * considered on SQL semantic level but not data transfer. E.g. partial deletes (i.e.
+         * key-only upserts) set all non-key fields to null, regardless of logical type.
+         */
         @Nullable
         Object getElementOrNull(ArrayData array, int pos);
     }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/ArrayData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/ArrayData.java
@@ -215,9 +215,6 @@ public interface ArrayData {
             default:
                 throw new IllegalArgumentException();
         }
-        if (!elementType.isNullable()) {
-            return elementGetter;
-        }
         return (array, pos) -> {
             if (array.isNullAt(pos)) {
                 return null;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/RowData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/RowData.java
@@ -302,6 +302,11 @@ public interface RowData {
      */
     @PublicEvolving
     interface FieldGetter extends Serializable {
+        /**
+         * Converters and serializers always support nullability. The NOT NULL constraint is only
+         * considered on SQL semantic level but not data transfer. E.g. partial deletes (i.e.
+         * key-only upserts) set all non-key fields to null, regardless of logical type.
+         */
         @Nullable
         Object getFieldOrNull(RowData row);
     }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/RowData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/RowData.java
@@ -287,9 +287,6 @@ public interface RowData {
             default:
                 throw new IllegalArgumentException();
         }
-        if (!fieldType.isNullable()) {
-            return fieldGetter;
-        }
         return row -> {
             if (row.isNullAt(fieldPos)) {
                 return null;

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/DataStructureConvertersTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/DataStructureConvertersTest.java
@@ -378,15 +378,22 @@ class DataStructureConvertersTest {
                                         DataTypes.FIELD("f15", DataTypes.DECIMAL(10, 2).notNull()),
                                         DataTypes.FIELD(
                                                 "f16",
-                                                DataTypes.MAP(DataTypes.INT(), DataTypes.STRING())
+                                                DataTypes.MAP(
+                                                                DataTypes.INT().notNull(),
+                                                                DataTypes.STRING().notNull())
                                                         .notNull()),
                                         DataTypes.FIELD(
-                                                "f17", DataTypes.ARRAY(DataTypes.INT()).notNull()),
+                                                "f17",
+                                                DataTypes.ARRAY(DataTypes.INT().notNull())
+                                                        .notNull()),
                                         DataTypes.FIELD(
-                                                "f18", DataTypes.ARRAY(DataTypes.INT()).notNull()),
+                                                "f18",
+                                                DataTypes.ARRAY(DataTypes.INT().notNull())
+                                                        .notNull()),
                                         DataTypes.FIELD(
                                                 "f19",
-                                                DataTypes.MULTISET(DataTypes.INT()).notNull())))
+                                                DataTypes.MULTISET(DataTypes.INT().notNull())
+                                                        .notNull())))
                         .convertedTo(
                                 Row.class,
                                 Row.ofKind(

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/DataStructureConvertersTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/DataStructureConvertersTest.java
@@ -355,7 +355,62 @@ class DataStructureConvertersTest {
                 TestSpec.forDataType(
                                 DataTypes.STRUCTURED(GenericPojo.class, FIELD("value", DATE())))
                         .convertedTo(
-                                GenericPojo.class, new GenericPojo<>(LocalDate.ofEpochDay(123))));
+                                GenericPojo.class, new GenericPojo<>(LocalDate.ofEpochDay(123))),
+
+                // partial delete messages
+                TestSpec.forDataType(
+                                DataTypes.ROW(
+                                        DataTypes.FIELD("f0", DataTypes.TINYINT().notNull()),
+                                        DataTypes.FIELD("f1", DataTypes.SMALLINT().notNull()),
+                                        DataTypes.FIELD("f2", DataTypes.INT().notNull()),
+                                        DataTypes.FIELD("f3", DataTypes.BIGINT().notNull()),
+                                        DataTypes.FIELD("f4", DataTypes.DOUBLE().notNull()),
+                                        DataTypes.FIELD("f5", DataTypes.FLOAT().notNull()),
+                                        DataTypes.FIELD("f6", DataTypes.DATE().notNull()),
+                                        DataTypes.FIELD("f7", DataTypes.BINARY(12).notNull()),
+                                        DataTypes.FIELD("f8", DataTypes.VARBINARY(12).notNull()),
+                                        DataTypes.FIELD("f9", DataTypes.CHAR(12).notNull()),
+                                        DataTypes.FIELD("f10", DataTypes.VARCHAR(12).notNull()),
+                                        DataTypes.FIELD("f11", DataTypes.BOOLEAN().notNull()),
+                                        DataTypes.FIELD("f12", DataTypes.TIME().notNull()),
+                                        DataTypes.FIELD("f13", DataTypes.TIMESTAMP().notNull()),
+                                        DataTypes.FIELD("f14", DataTypes.TIMESTAMP_LTZ().notNull()),
+                                        DataTypes.FIELD("f15", DataTypes.DECIMAL(10, 2).notNull()),
+                                        DataTypes.FIELD(
+                                                "f16",
+                                                DataTypes.MAP(DataTypes.INT(), DataTypes.STRING())
+                                                        .notNull()),
+                                        DataTypes.FIELD(
+                                                "f17", DataTypes.ARRAY(DataTypes.INT()).notNull()),
+                                        DataTypes.FIELD(
+                                                "f18", DataTypes.ARRAY(DataTypes.INT()).notNull()),
+                                        DataTypes.FIELD(
+                                                "f19",
+                                                DataTypes.MULTISET(DataTypes.INT()).notNull())))
+                        .convertedTo(
+                                Row.class,
+                                Row.ofKind(
+                                        RowKind.DELETE,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        new Integer[] {null, null},
+                                        null)));
     }
 
     @ParameterizedTest(name = "{index}: {0}")

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/typeutils/RowDataSerializerTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/typeutils/RowDataSerializerTest.java
@@ -411,8 +411,8 @@ abstract class RowDataSerializerTest extends SerializerTestInstance<RowData> {
 
     /**
      * Converters and serializers always support nullability. The NOT NULL constraint is only
-     * considered on SQL semantic level but not data transfer. E.g. partial deletes (i.e.
-     * key-only upserts) set all non-key fields to null, regardless of logical type.
+     * considered on SQL semantic level but not data transfer. E.g. partial deletes (i.e. key-only
+     * upserts) set all non-key fields to null, regardless of logical type.
      */
     static final class RowDataSerializerWithNullForNotNullTypeTest extends RowDataSerializerTest {
         public RowDataSerializerWithNullForNotNullTypeTest() {

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/typeutils/RowDataSerializerTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/typeutils/RowDataSerializerTest.java
@@ -409,6 +409,11 @@ abstract class RowDataSerializerTest extends SerializerTestInstance<RowData> {
         }
     }
 
+    /**
+     * Converters and serializers always support nullability. The NOT NULL constraint is only
+     * considered on SQL semantic level but not data transfer. E.g. partial deletes (i.e.
+     * key-only upserts) set all non-key fields to null, regardless of logical type.
+     */
     static final class RowDataSerializerWithNullForNotNullTypeTest extends RowDataSerializerTest {
         public RowDataSerializerWithNullForNotNullTypeTest() {
             super(getRowSerializer(), getData());

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/typeutils/RowDataSerializerTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/typeutils/RowDataSerializerTest.java
@@ -33,11 +33,21 @@ import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.data.writer.BinaryArrayWriter;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BinaryType;
+import org.apache.flink.table.types.logical.CharType;
+import org.apache.flink.table.types.logical.DateType;
+import org.apache.flink.table.types.logical.DayTimeIntervalType;
+import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.RawType;
+import org.apache.flink.table.types.logical.SmallIntType;
+import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.testutils.DeeplyEqualsChecker;
 
@@ -396,6 +406,51 @@ abstract class RowDataSerializerTest extends SerializerTestInstance<RowData> {
         private static RowDataSerializer getRowSerializer() {
             return (RowDataSerializer)
                     InternalSerializers.<RowData>create(NESTED_DATA_TYPE.getLogicalType());
+        }
+    }
+
+    static final class RowDataSerializerWithNullForNotNullTypeTest extends RowDataSerializerTest {
+        public RowDataSerializerWithNullForNotNullTypeTest() {
+            super(getRowSerializer(), getData());
+        }
+
+        private static RowData[] getData() {
+            GenericRowData row = new GenericRowData(13);
+            row.setField(0, 2);
+            row.setField(1, null);
+            row.setField(3, null);
+            row.setField(4, null);
+            row.setField(5, null);
+            row.setField(6, null);
+            row.setField(7, null);
+            row.setField(8, null);
+            row.setField(9, null);
+            row.setField(10, null);
+            row.setField(11, null);
+            row.setField(12, null);
+
+            return new RowData[] {row};
+        }
+
+        private static RowDataSerializer getRowSerializer() {
+            InternalTypeInfo<RowData> typeInfo =
+                    InternalTypeInfo.ofFields(
+                            new IntType(false),
+                            new SmallIntType(false),
+                            new BigIntType(false),
+                            new VarCharType(false, VarCharType.MAX_LENGTH),
+                            new CharType(false, CharType.MAX_LENGTH),
+                            new BinaryType(false, BinaryType.MAX_LENGTH),
+                            new VarBinaryType(false, VarBinaryType.MAX_LENGTH),
+                            new DateType(false),
+                            new DayTimeIntervalType(
+                                    false, DayTimeIntervalType.DayTimeResolution.DAY, 1, 6),
+                            new DecimalType(false, 10, 2),
+                            new FloatType(false),
+                            new DoubleType(false),
+                            new LocalZonedTimestampType(false, 3));
+
+            return typeInfo.toRowSerializer();
         }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR makes it possible to convert `RowData` that represents partial deletes with `NOT NULL` fields to `Row`.



## Verifying this change

Added tests in `DataStructureConvertersTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (**yes** / no / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
