### PR TITLE
[FLINK-37649][datagen] Datagen connector cannot set length for collection type

### DIFF
--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/RandomGeneratorVisitor.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/RandomGeneratorVisitor.java
@@ -74,7 +74,7 @@ public class RandomGeneratorVisitor extends DataGenVisitorBase {
 
     public static final int RANDOM_BYTES_LENGTH_DEFAULT = 100;
 
-    private static final int RANDOM_COLLECTION_LENGTH_DEFAULT = 3;
+    public static final int RANDOM_COLLECTION_LENGTH_DEFAULT = 3;
 
     private static final float NULL_RATE_DEFAULT = 0f;
 

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/RandomGeneratorVisitor.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/RandomGeneratorVisitor.java
@@ -352,6 +352,7 @@ public class RandomGeneratorVisitor extends DataGenVisitorBase {
                 RandomGenerator.arrayGenerator(container.getGenerator(), config.get(lenOption));
         Set<ConfigOption<?>> options = container.getOptions();
         options.add(nr);
+        options.add(lenOption);
         return DataGeneratorContainer.of(
                 new DataGeneratorMapper<>(generator, (GenericArrayData::new), config.get(nr)),
                 options.toArray(new ConfigOption<?>[0]));
@@ -374,6 +375,7 @@ public class RandomGeneratorVisitor extends DataGenVisitorBase {
         Set<ConfigOption<?>> options = container.getOptions();
         ConfigOption<Float> nr = nullRate.floatType().defaultValue(NULL_RATE_DEFAULT);
         options.add(nr);
+        options.add(lenOption);
 
         return DataGeneratorContainer.of(
                 new DataGeneratorMapper<>(mapGenerator, GenericMapData::new, config.get(nr)),
@@ -397,6 +399,7 @@ public class RandomGeneratorVisitor extends DataGenVisitorBase {
         Set<ConfigOption<?>> options = keyContainer.getOptions();
         options.addAll(valContainer.getOptions());
         options.add(nr);
+        options.add(lenOption);
 
         DataGenerator<Map<Object, Object>> mapGenerator =
                 RandomGenerator.mapGenerator(

--- a/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/factories/DataGenTableSourceFactoryTest.java
+++ b/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/factories/DataGenTableSourceFactoryTest.java
@@ -56,6 +56,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.apache.flink.connector.datagen.table.RandomGeneratorVisitor.RANDOM_COLLECTION_LENGTH_DEFAULT;
 import static org.apache.flink.core.testutils.FlinkAssertions.anyCauseMatches;
 import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSource;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -359,6 +360,18 @@ class DataGenTableSourceFactoryTest {
         final int collectionSize = 10;
         descriptor.putString(FactoryUtil.CONNECTOR.key(), "datagen");
         descriptor.putLong(DataGenConnectorOptions.NUMBER_OF_ROWS.key(), rowsNumber);
+        // test for default length.
+        List<RowData> results = runGenerator(COLLECTION_SCHEMA, descriptor);
+        assertThat(results).hasSize(rowsNumber);
+        for (RowData row : results) {
+            assertThat(row.getArray(0).size()).isEqualTo(RANDOM_COLLECTION_LENGTH_DEFAULT);
+            assertThat(row.getMap(1).size())
+                    .isEqualTo(RandomGeneratorVisitor.RANDOM_COLLECTION_LENGTH_DEFAULT);
+            assertThat(row.getMap(2).size())
+                    .isEqualTo(RandomGeneratorVisitor.RANDOM_COLLECTION_LENGTH_DEFAULT);
+        }
+
+        // test for provided length.
         descriptor.putLong(
                 DataGenConnectorOptionsUtil.FIELDS + ".f0." + DataGenConnectorOptionsUtil.LENGTH,
                 collectionSize);
@@ -368,7 +381,7 @@ class DataGenTableSourceFactoryTest {
         descriptor.putLong(
                 DataGenConnectorOptionsUtil.FIELDS + ".f2." + DataGenConnectorOptionsUtil.LENGTH,
                 collectionSize);
-        List<RowData> results = runGenerator(COLLECTION_SCHEMA, descriptor);
+        results = runGenerator(COLLECTION_SCHEMA, descriptor);
         assertThat(results).hasSize(rowsNumber);
         for (RowData row : results) {
             assertThat(row.getArray(0).size()).isEqualTo(collectionSize);


### PR DESCRIPTION
## What is the purpose of the change

*Fix the bug that datagen connector cannot set length for collection type.*


## Brief change log

  - *Add `lenOption` to the legitimate set of options*.


## Verifying this change

Introduce a unit test case to cover this.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
