### PR TITLE
[FLINK-37660] Reenable Kryo serializer upgrade tests

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializerUpgradeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializerUpgradeTest.java
@@ -31,7 +31,6 @@ import org.apache.flink.api.java.typeutils.runtime.kryo.KryoPojosForMigrationTes
 
 import com.esotericsoftware.kryo.serializers.DefaultSerializers;
 import org.assertj.core.api.Condition;
-import org.junit.jupiter.api.Disabled;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -39,12 +38,10 @@ import java.util.Collection;
 import static org.apache.flink.api.common.typeutils.TypeSerializerConditions.hasSameCompatibilityAs;
 import static org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility.compatibleWithReconfiguredSerializer;
 
-// These tests are disabled because Flink 2.0 is doing a major Kryo 2.x -> 5.x upgrade and
-// the new Flink is not compatible with older Kryo state.
-// Restore tests when there is a Flink 2.1 that should test compatibility with Flink 2.0
+// Flink 2.0 has done a major Kryo 2.x -> 5.x upgrade and the new Flink is not compatible with older
+// Kryo state.
 /** Tests migrations for {@link KryoSerializerSnapshot}. */
 @SuppressWarnings("WeakerAccess")
-@Disabled("disable tests for Flink 2.0 involving compatibility with older Kryo state")
 class KryoSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Object, Object> {
     public Collection<TestSpecification<?, ?>> createTestSpecifications(FlinkVersion flinkVersion)
             throws Exception {


### PR DESCRIPTION
KryoSerializerUpgradeTest are disabled because Flink 2.0 is doing a major Kryo 2.x -> 5.x upgrade and the new Flink is not compatible with older Kryo state. Restore it in 2.1.