### PR TITLE
[FLINK-37665]: Simplify DoubleMaximum.clone() Implementation

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/accumulators/DoubleMaximum.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/accumulators/DoubleMaximum.java
@@ -61,9 +61,7 @@ public class DoubleMaximum implements SimpleAccumulator<Double> {
 
     @Override
     public DoubleMaximum clone() {
-        DoubleMaximum clone = new DoubleMaximum();
-        clone.max = this.max;
-        return clone;
+        return new DoubleMaximum(this.max);
     }
 
     // ------------------------------------------------------------------------


### PR DESCRIPTION
What is the purpose of the change

The purpose of this change is to simplify the implementation of the clone() method in the DoubleMaximum class by leveraging the existing constructor DoubleMaximum(double value) instead of manually setting the max field


Brief change log:

The current implementation of the clone() method in the DoubleMaximum class uses the default constructor and manually sets the max field:

// Some comments here
@Override
public DoubleMaximum clone() {
    DoubleMaximum clone = new DoubleMaximum();
    clone.max = this.max;
    return clone;
}
This can be simplified by directly using the existing constructor DoubleMaximum(double value) to initialize the cloned object. The proposed change is:

@Override
public DoubleMaximum clone() {
    return new DoubleMaximum(this.max);
}




Verifying this change: 

This change is a trivial rework / code cleanup without any test coverage.


Does this pull request potentially affect one of the following parts:

Dependencies (does it add or upgrade a dependency): no
The serializers: no
The runtime per-record code paths (performance sensitive): no
Anything that affects deployment or recovery: no
The S3 file system connector: no

Documentation
Does this pull request introduce a new feature? no
If yes, how is the feature documented? not applicable