### PR TITLE
[FLINK-37666]: Address CWE-378: Creation of Temporary File With Insec…

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
@@ -45,6 +45,7 @@ import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -568,7 +569,8 @@ public class PackagedProgram implements AutoCloseable {
     private static File createTempFile(Random rnd, JarEntry entry, String name)
             throws ProgramInvocationException {
         try {
-            final File tempFile = File.createTempFile(rnd.nextInt(Integer.MAX_VALUE) + "_", name);
+            final File tempFile =
+                    Files.createTempFile(rnd.nextInt(Integer.MAX_VALUE) + "_", name).toFile();
             tempFile.deleteOnExit();
             return tempFile;
         } catch (IOException e) {

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/ChangelogStreamHandleReaderWithCache.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/ChangelogStreamHandleReaderWithCache.java
@@ -128,7 +128,8 @@ class ChangelogStreamHandleReaderWithCache implements ChangelogStreamHandleReade
         File directory = cacheDirectories[next.getAndIncrement() % cacheDirectories.length];
         File file;
         try {
-            file = File.createTempFile(CACHE_FILE_PREFIX, null, directory);
+            file = Files.createTempFile(directory.toPath(), CACHE_FILE_PREFIX, null).toFile();
+            file.deleteOnExit();
         } catch (IOException e) {
             ExceptionUtils.rethrow(e);
             return null;

--- a/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/basics/StreamWindowSQLExample.java
+++ b/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/basics/StreamWindowSQLExample.java
@@ -24,6 +24,7 @@ import org.apache.flink.util.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 
 /**
  * Simple example for demonstrating the use of SQL in Java.
@@ -91,7 +92,7 @@ public class StreamWindowSQLExample {
 
     /** Creates a temporary file with the contents and returns the absolute path. */
     private static String createTempFile(String contents) throws IOException {
-        File tempFile = File.createTempFile("orders", ".csv");
+        File tempFile = Files.createTempFile("orders", ".csv").toFile();
         tempFile.deleteOnExit();
         FileUtils.writeFileUtf8(tempFile, contents);
         return tempFile.toURI().toString();

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -118,6 +118,7 @@ import java.net.URI;
 import java.net.URLDecoder;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -1023,7 +1024,8 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
         if (jobGraph != null) {
             File tmpJobGraphFile = null;
             try {
-                tmpJobGraphFile = File.createTempFile(appId.toString(), null);
+                tmpJobGraphFile = Files.createTempFile(appId.toString(), null).toFile();
+                tmpJobGraphFile.deleteOnExit();
                 try (FileOutputStream output = new FileOutputStream(tmpJobGraphFile);
                         ObjectOutputStream obOutput = new ObjectOutputStream(output)) {
                     obOutput.writeObject(jobGraph);
@@ -1055,7 +1057,9 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
         File tmpConfigurationFile = null;
         try {
             String flinkConfigFileName = GlobalConfiguration.getFlinkConfFilename();
-            tmpConfigurationFile = File.createTempFile(appId + "-" + flinkConfigFileName, null);
+            tmpConfigurationFile =
+                    Files.createTempFile(appId + "-" + flinkConfigFileName, null).toFile();
+            tmpConfigurationFile.deleteOnExit();
 
             // remove localhost bind hosts as they render production clusters unusable
             removeLocalhostBindHostSetting(configuration, JobManagerOptions.BIND_HOST);


### PR DESCRIPTION
…ure Permissions in Temporary File Creation

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The purpose of the change is to replace the usage of File.createTempFile with Files.createTempFile across multiple classes in the Flink project. This change ensures better alignment with modern Java APIs (java.nio.file.Files) for creating temporary files, which provide improved functionality and flexibility.



## Brief change log

PackagedProgram.java:  
- Replaced File.createTempFile with Files.createTempFile in the createTempFile method.

ChangelogStreamHandleReaderWithCache.java:  
- Updated the downloadToCacheFile method to use Files.createTempFile instead of File.createTempFile.

StreamWindowSQLExample.java:  
- Modified the createTempFile method to use Files.createTempFile for creating temporary files.

YarnClusterDescriptor.java:
- Replaced File.createTempFile with Files.createTempFile in two locations:
- While creating a temporary file for the jobGraph.
- While creating a temporary file for the Flink configuration file.


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 
