### PR TITLE
[hotfix] Rename executionVertexId to executionVertex

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/partitionrelease/RegionPartitionGroupReleaseStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/partitionrelease/RegionPartitionGroupReleaseStrategy.java
@@ -70,8 +70,8 @@ public class RegionPartitionGroupReleaseStrategy
         for (SchedulingPipelinedRegion pipelinedRegion : newRegions) {
             final PipelinedRegionExecutionView regionExecutionView =
                     new PipelinedRegionExecutionView(pipelinedRegion);
-            for (SchedulingExecutionVertex executionVertexId : pipelinedRegion.getVertices()) {
-                regionExecutionViewByVertex.put(executionVertexId.getId(), regionExecutionView);
+            for (SchedulingExecutionVertex executionVertex : pipelinedRegion.getVertices()) {
+                regionExecutionViewByVertex.put(executionVertex.getId(), regionExecutionView);
             }
         }
     }


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to rename `executionVertexId` to `executionVertex`.
pipelinedRegion.getVertices() returns SchedulingExecutionVertex that is not a ID or number. We shouldn't use `executionVertexId`.


## Brief change log

Rename `executionVertexId` to `executionVertex`.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
