### PR TITLE
[FLINK-37658][docs] Improve the Datagen connector docs

### DIFF
--- a/docs/content.zh/docs/connectors/table/datagen.md
+++ b/docs/content.zh/docs/connectors/table/datagen.md
@@ -314,7 +314,7 @@ CREATE TABLE Orders (
       <td>可选</td>
       <td style="word-wrap: break-word;">0</td>
       <td>Duration</td>
-      <td>对于 string/bytes 类型为 100，对于 array/map/multiset 类型为 3</td>
+      <td>对于 string/bytes 类型为 100，对于 array/map/multiset 类型为 3。</td>
     </tr>
     <tr>
       <td><h5>fields.#.length</h5></td>

--- a/docs/content.zh/docs/connectors/table/datagen.md
+++ b/docs/content.zh/docs/connectors/table/datagen.md
@@ -97,6 +97,21 @@ CREATE TABLE Orders (
 )
 ```
 
+对于集合类型，您可以指定集合的大小(元素个数)。
+
+```sql
+CREATE TABLE Orders (
+    f0 Array<INT>,
+    f1 Map<INT, STRING>,
+    f2 MULTISET<INT>
+) WITH (
+  'connector' = 'datagen',
+  'fields.f0.length' = '10',
+  'fields.f1.length' = '11',
+  'fields.f2.length' = '12'
+);
+```
+
 字段类型
 -----
 
@@ -285,21 +300,21 @@ CREATE TABLE Orders (
       <td>可选</td>
       <td style="word-wrap: break-word;">(Minimum value of type)</td>
       <td>(Type of field)</td>
-      <td>随机生成器的最小值，适用于数字类型。</td>
+      <td>随机生成器的最小值，仅适用于数字类型。</td>
     </tr>
     <tr>
       <td><h5>fields.#.max</h5></td>
       <td>可选</td>
       <td style="word-wrap: break-word;">(Maximum value of type)</td>
       <td>(Type of field)</td>
-      <td>随机生成器的最大值，适用于数字类型。</td>
+      <td>随机生成器的最大值，仅适用于数字类型。</td>
     </tr>
     <tr>
       <td><h5>fields.#.max-past</h5></td>
       <td>可选</td>
       <td style="word-wrap: break-word;">0</td>
       <td>Duration</td>
-      <td>随机生成器生成相对当前时间向过去偏移的最大值，适用于 timestamp 类型。</td>
+      <td>对于 string/bytes 类型为 100，对于 array/map/multiset 类型为 3</td>
     </tr>
     <tr>
       <td><h5>fields.#.length</h5></td>
@@ -337,7 +352,7 @@ CREATE TABLE Orders (
     <tr>
       <td><h5>fields.#.null-rate</h5></td>
       <td>optional</td>
-      <td style="word-wrap: break-word;">(none)</td>
+      <td style="word-wrap: break-word;">0</td>
       <td>(Type of field)</td>
       <td>空值比例。</td>
     </tr>

--- a/docs/content.zh/docs/connectors/table/datagen.md
+++ b/docs/content.zh/docs/connectors/table/datagen.md
@@ -97,7 +97,7 @@ CREATE TABLE Orders (
 )
 ```
 
-对于集合类型，您可以指定集合的大小(元素个数)。
+对于集合类型，你可以指定集合的大小（元素个数）。
 
 ```sql
 CREATE TABLE Orders (

--- a/docs/content/docs/connectors/table/datagen.md
+++ b/docs/content/docs/connectors/table/datagen.md
@@ -99,6 +99,21 @@ CREATE TABLE Orders (
 )
 ```
 
+And for collections it is possible to specify different sized collections.
+
+```sql
+CREATE TABLE Orders (
+    f0 Array<INT>,
+    f1 Map<INT, STRING>,
+    f2 MULTISET<INT>
+) WITH (
+  'connector' = 'datagen',
+  'fields.f0.length' = '10',
+  'fields.f1.length' = '11',
+  'fields.f2.length' = '12'
+);
+```
+
 Types
 -----
 
@@ -289,14 +304,14 @@ Connector Options
       <td>optional</td>
       <td style="word-wrap: break-word;">(Minimum value of type)</td>
       <td>(Type of field)</td>
-      <td>Minimum value of random generator, work for numeric types.</td>
+      <td>Minimum value of random generator, only works for numeric types.</td>
     </tr>
     <tr>
       <td><h5>fields.#.max</h5></td>
       <td>optional</td>
       <td style="word-wrap: break-word;">(Maximum value of type)</td>
       <td>(Type of field)</td>
-      <td>Maximum value of random generator, work for numeric types.</td>
+      <td>Maximum value of random generator, only works for numeric types.</td>
     </tr>
     <tr>
       <td><h5>fields.#.max-past</h5></td>
@@ -308,13 +323,13 @@ Connector Options
     <tr>
       <td><h5>fields.#.length</h5></td>
       <td>optional</td>
-      <td style="word-wrap: break-word;">100</td>
+      <td style="word-wrap: break-word;">100 for string/bytes, 3 for array/map/multiset </td>
       <td>Integer</td>
       <td>
           Size or length of the collection for generating varchar/varbinary/string/bytes/array/map/multiset types. 
-          Please notice that for variable-length fields (varchar/varbinary), the default length is defined by the schema and cannot be set to a length greater than it.
-          for super-long fields (string/bytes), the default length is 100 and can be set to a length less than 2^31.
-          for constructed fields (array/map/multiset), the default number of elements is 3 and can be customized.
+          Please note that for variable-length fields (varchar/varbinary), the default length is defined by the schema and cannot be set to a length greater than it.
+          For super-long fields (string/bytes), the default length is 100 and can be set to a length less than 2^31.
+          For constructed fields (array/map/multiset), the default number of elements is 3.
       </td>
     </tr>
     <tr>
@@ -322,7 +337,7 @@ Connector Options
       <td>optional</td>
       <td style="word-wrap: break-word;">false</td>
       <td>Boolean</td>
-      <td>Whether to generate a variable-length data, please notice that it should only be used for variable-length types (varchar, string, varbinary, bytes).</td>
+      <td>Whether to generate a variable-length data, only works for variable-length types (varchar, string, varbinary, bytes).</td>
     </tr>
     <tr>
       <td><h5>fields.#.start</h5></td>
@@ -341,7 +356,7 @@ Connector Options
     <tr>
       <td><h5>fields.#.null-rate</h5></td>
       <td>optional</td>
-      <td style="word-wrap: break-word;">(none)</td>
+      <td style="word-wrap: break-word;">0</td>
       <td>(Type of field)</td>
       <td>The proportion of null values.</td>
     </tr>


### PR DESCRIPTION

Amend the DataGen connector docs as agreed in PR [26437](https://github.com/apache/flink/pull/26437).

I have added the example from the PR into the docs and have made small improvements to the text. I have added a Chinese version of the doc change. 


## What is the purpose of the change

Include a length example for collections - which now works after  PR [26437](https://github.com/apache/flink/pull/26437).
Also make minor improvements to the test in this section.

## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

*(Please pick either of the following options)*

Doc change - this change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs )
