### PR TITLE
[FLINK-36536] Bumped `commons-text` from 1.10.0 to 1.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -544,7 +544,7 @@ under the License.
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-text</artifactId>
-				<version>1.10.0</version>
+				<version>1.12.0</version>
 			</dependency>
 
 			<dependency>


### PR DESCRIPTION

## What is the purpose of the change

Bumped `commons-text` from 1.10.0 to 1.12.0 to resolve the vulnerability [CVE-2024-47554](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-47554) 

## Brief change log

Updated `commons-text` version to `10.12.0` in parent pom.xml to resolve vulnerability `CVE-2024-47554`.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector. no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
