### PR TITLE
[FLINK-37672] Bump protobuf-maven-plugin

### DIFF
--- a/flink-formats/flink-parquet/pom.xml
+++ b/flink-formats/flink-parquet/pom.xml
@@ -326,7 +326,7 @@ under the License.
 			<plugin>
 				<groupId>org.xolstice.maven.plugins</groupId>
 				<artifactId>protobuf-maven-plugin</artifactId>
-				<version>0.5.1</version>
+				<version>0.6.1</version>
 				<extensions>true</extensions>
 				<configuration>
 					<!-- Currently Flink azure test pipeline would first pre-compile and then upload the compiled


### PR DESCRIPTION
## What is the purpose of the change

Bump protobuf-maven-plugin from 0.5.1 to 0.6.1

## Brief change log

Bumping the plugin version would remediate the findings in the dependencies

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
