### PR TITLE
[hotfix] Avoid invalid thread for state reader

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -862,15 +862,17 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
                 INITIALIZE_STATE_DURATION, initializeStateEndTs - readOutputDataTs);
         IndexedInputGate[] inputGates = getEnvironment().getAllInputGates();
 
-        channelIOExecutor.execute(
-                () -> {
-                    try {
-                        reader.readInputData(inputGates);
-                    } catch (Exception e) {
-                        asyncExceptionHandler.handleAsyncException(
-                                "Unable to read channel state", e);
-                    }
-                });
+        if (inputGates.length > 0) {
+            channelIOExecutor.execute(
+                    () -> {
+                        try {
+                            reader.readInputData(inputGates);
+                        } catch (Exception e) {
+                            asyncExceptionHandler.handleAsyncException(
+                                    "Unable to read channel state", e);
+                        }
+                    });
+        }
 
         // We wait for all input channel state to recover before we go into RUNNING state, and thus
         // start checkpointing. If we implement incremental checkpointing of input channel state


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to avoid invalid thread for state reader.
Sometimes, the `inputGates` is an empty array. We can avoid creating thread for it.


## Brief change log

Avoid invalid thread for state reader.


## Verifying this change

This change is already covered by existing tests, such as *(StreamTaskTest)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
