### PR TITLE
[FLINK-36465] Bump okhttp3 to 4.12.0

### DIFF
--- a/flink-kubernetes/src/main/resources/META-INF/NOTICE
+++ b/flink-kubernetes/src/main/resources/META-INF/NOTICE
@@ -11,8 +11,8 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-databind:2.18.2
 - com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.18.2
 - com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.2
-- com.squareup.okhttp3:logging-interceptor:3.14.9
-- com.squareup.okhttp3:okhttp:3.14.9
+- com.squareup.okhttp3:logging-interceptor:4.12.0
+- com.squareup.okhttp3:okhttp:4.12.0
 - com.squareup.okio:okio:1.17.2
 - io.fabric8:kubernetes-client:6.13.4
 - io.fabric8:kubernetes-client-api:6.13.4

--- a/flink-kubernetes/src/main/resources/META-INF/NOTICE
+++ b/flink-kubernetes/src/main/resources/META-INF/NOTICE
@@ -13,7 +13,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.2
 - com.squareup.okhttp3:logging-interceptor:4.12.0
 - com.squareup.okhttp3:okhttp:4.12.0
-- com.squareup.okio:okio:1.17.2
+- com.squareup.okio:okio:3.6.0
 - io.fabric8:kubernetes-client:6.13.4
 - io.fabric8:kubernetes-client-api:6.13.4
 - io.fabric8:kubernetes-httpclient-okhttp:6.13.4

--- a/flink-metrics/flink-metrics-datadog/src/main/resources/META-INF/NOTICE
+++ b/flink-metrics/flink-metrics-datadog/src/main/resources/META-INF/NOTICE
@@ -6,5 +6,5 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.squareup.okhttp3:okhttp:3.14.9
+- com.squareup.okhttp3:okhttp:4.12.0
 - com.squareup.okio:okio:1.17.2

--- a/flink-metrics/flink-metrics-datadog/src/main/resources/META-INF/NOTICE
+++ b/flink-metrics/flink-metrics-datadog/src/main/resources/META-INF/NOTICE
@@ -7,4 +7,5 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.squareup.okhttp3:okhttp:4.12.0
-- com.squareup.okio:okio:1.17.2
+- com.squareup.okio:okio:3.6.0
+- com.squareup.okio:okio-jvm:3.6.0

--- a/flink-metrics/flink-metrics-influxdb/src/main/resources/META-INF/NOTICE
+++ b/flink-metrics/flink-metrics-influxdb/src/main/resources/META-INF/NOTICE
@@ -7,8 +7,8 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.squareup.moshi:moshi:1.8.0
-- com.squareup.okhttp3:logging-interceptor:3.14.9
-- com.squareup.okhttp3:okhttp:3.14.9
+- com.squareup.okhttp3:logging-interceptor:4.12.0
+- com.squareup.okhttp3:okhttp:4.12.0
 - com.squareup.okio:okio:1.17.2
 - com.squareup.retrofit2:converter-moshi:2.6.2
 - com.squareup.retrofit2:retrofit:2.6.2

--- a/flink-metrics/flink-metrics-influxdb/src/main/resources/META-INF/NOTICE
+++ b/flink-metrics/flink-metrics-influxdb/src/main/resources/META-INF/NOTICE
@@ -9,7 +9,8 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.squareup.moshi:moshi:1.8.0
 - com.squareup.okhttp3:logging-interceptor:4.12.0
 - com.squareup.okhttp3:okhttp:4.12.0
-- com.squareup.okio:okio:1.17.2
+- com.squareup.okio:okio:3.6.0
+- com.squareup.okio:okio-jvm:3.6.0
 - com.squareup.retrofit2:converter-moshi:2.6.2
 - com.squareup.retrofit2:retrofit:2.6.2
 

--- a/flink-metrics/flink-metrics-otel/src/main/resources/META-INF/NOTICE
+++ b/flink-metrics/flink-metrics-otel/src/main/resources/META-INF/NOTICE
@@ -22,5 +22,5 @@ This project bundles the following dependencies under the Apache Software Licens
 - io.opentelemetry:opentelemetry-exporter-otlp-common:1.30.1
 - io.opentelemetry:opentelemetry-exporter-common:1.30.1
 - io.opentelemetry:opentelemetry-exporter-sender-okhttp:1.30.1
-- com.squareup.okhttp3:okhttp:3.14.9
+- com.squareup.okhttp3:okhttp:4.12.0
 - com.squareup.okio:okio:1.17.2

--- a/flink-metrics/flink-metrics-otel/src/main/resources/META-INF/NOTICE
+++ b/flink-metrics/flink-metrics-otel/src/main/resources/META-INF/NOTICE
@@ -23,4 +23,5 @@ This project bundles the following dependencies under the Apache Software Licens
 - io.opentelemetry:opentelemetry-exporter-common:1.30.1
 - io.opentelemetry:opentelemetry-exporter-sender-okhttp:1.30.1
 - com.squareup.okhttp3:okhttp:4.12.0
-- com.squareup.okio:okio:1.17.2
+- com.squareup.okio:okio:3.6.0
+- com.squareup.okio:okio-jvm:3.6.0

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -288,7 +288,6 @@ under the License.
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>okhttp</artifactId>
-			<version>3.7.0</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@ under the License.
 		<py4j.version>0.10.9.7</py4j.version>
 		<beam.version>2.54.0</beam.version>
 		<protoc.version>3.21.7</protoc.version>
-		<okhttp.version>3.14.9</okhttp.version>
+		<okhttp.version>4.12.0</okhttp.version>
 		<testcontainers.version>1.20.2</testcontainers.version>
 		<lz4.version>1.8.0</lz4.version>
 		<commons.io.version>2.15.1</commons.io.version>
@@ -413,6 +413,10 @@ under the License.
 					<exclusion>
 						<groupId>org.slf4j</groupId>
 						<artifactId>slf4j-reload4j</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>com.squareup.okhttp</groupId>
+						<artifactId>okhttp</artifactId>
 					</exclusion>
 				</exclusions>
 			</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -933,14 +933,8 @@ under the License.
 
 			<dependency>
 				<groupId>org.jetbrains.kotlin</groupId>
-				<artifactId>kotlin-stdlib-jdk8</artifactId>
-				<version>1.9.10</version>
-			</dependency>
-
-			<dependency>
-				<groupId>org.jetbrains</groupId>
-				<artifactId>annotations</artifactId>
-				<version>17.0.0</version>
+				<artifactId>kotlin-stdlib-common</artifactId>
+				<version>1.8.21</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -930,6 +930,12 @@ under the License.
 				<version>${mockito.version}</version>
 				<scope>test</scope>
 			</dependency>
+
+			<dependency>
+				<groupId>org.jetbrains.kotlin</groupId>
+				<artifactId>kotlin-stdlib-jdk8</artifactId>
+				<version>1.9.10</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -936,6 +936,12 @@ under the License.
 				<artifactId>kotlin-stdlib-jdk8</artifactId>
 				<version>1.9.10</version>
 			</dependency>
+
+			<dependency>
+				<groupId>org.jetbrains</groupId>
+				<artifactId>annotations</artifactId>
+				<version>17.0.0</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 


### PR DESCRIPTION
## What is the purpose of the change

Bump okhttp from 3.14.9 to 4.12.0

## Brief change log

Bump okhttp from 3.14.9 to 4.12.0. This will remediate vulnerabilities in underlying dependencies and brings in a lot of bugfixes and features.

Package details:

https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp/4.12.0

https://mvnrepository.com/artifact/com.squareup.okhttp3/logging-interceptor/4.12.0

Release notes:

https://square.github.io/okhttp/changelogs/upgrading_to_okhttp_4


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
