### PR TITLE
[FLINK-37695][table] Fix parsing for built-in function JSON in JSON_OBJECT for all positions

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
@@ -29,7 +29,7 @@ import org.apache.flink.table.planner.calcite.{FlinkTypeFactory, RexDistinctKeyV
 import org.apache.flink.table.planner.codegen.CodeGenUtils._
 import org.apache.flink.table.planner.codegen.GeneratedExpression.{NEVER_NULL, NO_CODE}
 import org.apache.flink.table.planner.codegen.GenerateUtils._
-import org.apache.flink.table.planner.codegen.JsonGenerateUtils.{isJsonArrayOperand, isJsonFunctionOperand, isJsonObjectOperand}
+import org.apache.flink.table.planner.codegen.JsonGenerateUtils.{inValuesParam, isJsonArrayOperand, isJsonFunctionOperand, isJsonObjectOperand}
 import org.apache.flink.table.planner.codegen.calls._
 import org.apache.flink.table.planner.codegen.calls.ScalarOperatorGens._
 import org.apache.flink.table.planner.codegen.calls.SearchOperatorGen.generateSearch
@@ -489,7 +489,7 @@ class ExprCodeGenerator(ctx: CodeGeneratorContext, nullableInput: Boolean)
       // We only support JSON function operands as the value param of a JSON_OBJECT or JSON_ARRAY function
       case (operand: RexNode, i)
           if isJsonFunctionOperand(operand) &&
-            (isJsonArrayOperand(call) || i == 2 && isJsonObjectOperand(call)) =>
+            (isJsonArrayOperand(call) || isJsonObjectOperand(call) && inValuesParam(i)) =>
         generateJsonCall(operand)
 
       case (o @ _, _) => o.accept(this)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
@@ -29,7 +29,7 @@ import org.apache.flink.table.planner.calcite.{FlinkTypeFactory, RexDistinctKeyV
 import org.apache.flink.table.planner.codegen.CodeGenUtils._
 import org.apache.flink.table.planner.codegen.GeneratedExpression.{NEVER_NULL, NO_CODE}
 import org.apache.flink.table.planner.codegen.GenerateUtils._
-import org.apache.flink.table.planner.codegen.JsonGenerateUtils.{inValuesParam, isJsonArrayOperand, isJsonFunctionOperand, isJsonObjectOperand}
+import org.apache.flink.table.planner.codegen.JsonGenerateUtils.{isJsonFunctionOperand, isSupportedJsonOperand}
 import org.apache.flink.table.planner.codegen.calls._
 import org.apache.flink.table.planner.codegen.calls.ScalarOperatorGens._
 import org.apache.flink.table.planner.codegen.calls.SearchOperatorGen.generateSearch
@@ -486,10 +486,8 @@ class ExprCodeGenerator(ctx: CodeGeneratorContext, nullableInput: Boolean)
             call.getOperator.getReturnTypeInference == ReturnTypes.ARG0 =>
         generateNullLiteral(resultType)
 
-      // We only support JSON function operands as the value param of a JSON_OBJECT or JSON_ARRAY function
-      case (operand: RexNode, i)
-          if isJsonFunctionOperand(operand) &&
-            (isJsonArrayOperand(call) || isJsonObjectOperand(call) && inValuesParam(i)) =>
+      // We only support the JSON function inside of JSON_OBJECT or JSON_ARRAY
+      case (operand: RexNode, i) if isSupportedJsonOperand(operand, call, i) =>
         generateJsonCall(operand)
 
       case (o @ _, _) => o.accept(this)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
@@ -464,8 +464,8 @@ class ExprCodeGenerator(ctx: CodeGeneratorContext, nullableInput: Boolean)
     // throw exception if json function is called outside JSON_OBJECT or JSON_ARRAY function
     if (isJsonFunctionOperand(call)) {
       throw new ValidationException(
-        "The JSON() function is currently only supported inside a JSON_OBJECT() or JSON_ARRAY()" +
-          " function. Example: JSON_OBJECT('a', JSON('{\"key\": \"value\"}')) or " +
+        "The JSON() function is currently only supported inside JSON_ARRAY() or as the VALUE param" +
+          " of JSON_OBJECT(). Example: JSON_OBJECT('a', JSON('{\"key\": \"value\"}')) or " +
           "JSON_ARRAY(JSON('{\"key\": \"value\"}')).")
     }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/JsonGenerateUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/JsonGenerateUtils.scala
@@ -228,11 +228,14 @@ object JsonGenerateUtils {
   }
 
   /**
-   * Determines if the parameter index is % 2, which means checking that we only allow JSON calls
-   * for the VALUE parameter of a JSON_OBJECT call.
+   * Determines whether a JSON function is allowed in the current context. JSON functions are
+   * allowed as values in JSON_ARRAY calls or as value parameters in JSON_OBJECT calls. In the case
+   * of a JSON_OBJECT call, we do (i % 2) == 0 to check if it's being used in second parameter, the
+   * values' parameter.
    */
-  def inValuesParam(i: Int): Boolean = {
-    (i % 2) == 0
+  def isSupportedJsonOperand(operand: RexNode, call: RexNode, i: Int): Boolean = {
+    isJsonFunctionOperand(operand) &&
+    (isJsonArrayOperand(call) || isJsonObjectOperand(call) && (i % 2) == 0)
   }
 
   /** Generates a method to convert arrays into [[ArrayNode]]. */

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/JsonGenerateUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/JsonGenerateUtils.scala
@@ -227,6 +227,14 @@ object JsonGenerateUtils {
     }
   }
 
+  /**
+   * Determines if the parameter index is % 2, which means checking that we only allow JSON calls
+   * for the VALUE parameter of a JSON_OBJECT call.
+   */
+  def inValuesParam(i: Int): Boolean = {
+    (i % 2) == 0
+  }
+
   /** Generates a method to convert arrays into [[ArrayNode]]. */
   private def generateArrayConverter(
       ctx: CodeGeneratorContext,

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
@@ -821,12 +821,15 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                                         json("[1, 2, 3]")),
                                 "JSON_OBJECT(KEY 'p1' VALUE JSON(f0), KEY 'p2' VALUE JSON(f1), KEY 'p3' VALUE JSON('[1, 2, 3]'))",
                                 "{\"p1\":{\"key\":\"value\"},\"p2\":{\"key\":{\"value\":42}},\"p3\":[1,2,3]}",
-                                STRING().notNull()),
-
-                // Tests for JSON calls inside of JSON_ARRAY
-                TestSetSpec.forFunction(BuiltInFunctionDefinitions.JSON_ARRAY)
-                        .onFieldsWithData("{\"key\":\"value\"}", "{\"key\": {\"value\": 42}}")
-                        .andDataTypes(STRING(), STRING())
+                                STRING().notNull())
+                        .testSqlValidationError(
+                                "JSON_OBJECT(KEY JSON('{}') VALUE 'value' ABSENT ON NULL)",
+                                "The JSON() function is currently only supported inside JSON_ARRAY() or as the VALUE param of JSON_OBJECT()")
+                        .testTableApiValidationError(
+                                jsonObject(JsonOnNull.NULL, json($("f0")), "value"),
+                                "Invalid function call:\n"
+                                        + "JSON_OBJECT(SYMBOL NOT NULL, STRING, CHAR(5) NOT NULL)")
+                        // Tests for JSON calls inside of JSON_ARRAY
                         .testResult(
                                 jsonArray(JsonOnNull.NULL, json("{}")),
                                 "JSON_ARRAY(JSON('{}'))",
@@ -905,10 +908,10 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                                 "line: 1, column: 1")
                         .testTableApiValidationError(
                                 json($("f0")),
-                                "The JSON() function is currently only supported inside a JSON_OBJECT() or JSON_ARRAY() function.")
+                                "The JSON() function is currently only supported inside JSON_ARRAY() or as the VALUE param of JSON_OBJECT()")
                         .testSqlValidationError(
                                 "JSON(f0)",
-                                "The JSON() function is currently only supported inside a JSON_OBJECT() or JSON_ARRAY() function."));
+                                "The JSON() function is currently only supported inside JSON_ARRAY() or as the VALUE param of JSON_OBJECT()"));
     }
 
     private static List<TestSetSpec> jsonObjectSpec() {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
@@ -782,7 +782,47 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                         .testTableApiRuntimeError(
                                 jsonObject(JsonOnNull.NULL, "K", json("{")),
                                 TableRuntimeException.class,
-                                "Invalid JSON string in JSON(value) function"),
+                                "Invalid JSON string in JSON(value) function")
+
+                        // Tests for JSON_OBJECT with multiple parameters
+                        .testResult(
+                                jsonObject(JsonOnNull.NULL, "key1", "val", "key2", json($("f1"))),
+                                "JSON_OBJECT(KEY 'key1' VALUE 'val', KEY 'key2' VALUE JSON(f1))",
+                                "{\"key1\":\"val\",\"key2\":{\"key\":{\"value\":42}}}",
+                                STRING().notNull())
+                        .testResult(
+                                jsonObject(
+                                        JsonOnNull.NULL,
+                                        "key1",
+                                        json($("f0")),
+                                        "key2",
+                                        json($("f1"))),
+                                "JSON_OBJECT(KEY 'key1' VALUE JSON(f0), KEY 'key2' VALUE JSON(f1))",
+                                "{\"key1\":{\"key\":\"value\"},\"key2\":{\"key\":{\"value\":42}}}",
+                                STRING().notNull())
+                        .testResult(
+                                jsonObject(
+                                        JsonOnNull.NULL,
+                                        "outerKey",
+                                        "outerValue",
+                                        "nestedObject",
+                                        jsonObject(JsonOnNull.NULL, "innerKey", json($("f0")))),
+                                "JSON_OBJECT(KEY 'outerKey' VALUE 'outerValue', KEY 'nestedObject' VALUE JSON_OBJECT(KEY 'innerKey' VALUE JSON(f0)))",
+                                "{\"nestedObject\":{\"innerKey\":{\"key\":\"value\"}},\"outerKey\":\"outerValue\"}",
+                                STRING().notNull())
+                        .testResult(
+                                jsonObject(
+                                        JsonOnNull.NULL,
+                                        "p1",
+                                        json($("f0")),
+                                        "p2",
+                                        json($("f1")),
+                                        "p3",
+                                        json("[1, 2, 3]")),
+                                "JSON_OBJECT(KEY 'p1' VALUE JSON(f0), KEY 'p2' VALUE JSON(f1), KEY 'p3' VALUE JSON('[1, 2, 3]'))",
+                                "{\"p1\":{\"key\":\"value\"},\"p2\":{\"key\":{\"value\":42}},\"p3\":[1,2,3]}",
+                                STRING().notNull()),
+
                 // Tests for JSON calls inside of JSON_ARRAY
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.JSON_ARRAY)
                         .onFieldsWithData("{\"key\":\"value\"}", "{\"key\": {\"value\": 42}}")


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Parsing for a JSON() function call fails if its position is not the first param of JSON_OBJECT.

`SELECT JSON_OBJECT('key' VALUE JSON('{}'), 'key_2' VALUE JSON('{}'));`

Outputs:

```
The JSON() function is currently only supported inside a JSON_OBJECT() or JSON_ARRAY() function. Example: JSON_OBJECT('a', JSON('{\"key\": \"value\"}')) or JSON_ARRAY(JSON('{\"key\": \"value\"}'))
```

This is incorrect, we were too strict with the limitations. We're strictly allowing json to be called only as the second param in the function, when it should be allowed for every second. 

## Brief change log

*(for example:)*
  - Check if the `JSON` call is for any of the VALUES param inside a `JSON_OBJECT` and not only the first one
  


## Verifying this change
This change added tests and can be verified as follows:
  - Added unit tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (already covered by docs / JavaDocs)
