### PR TITLE
[FLINK-36767] Bumped `cyclonedx-maven-plugin` to `2.9.1` to resolve CVE-2024-38374

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2073,7 +2073,7 @@ under the License.
 			<plugin>
 				<groupId>org.cyclonedx</groupId>
 				<artifactId>cyclonedx-maven-plugin</artifactId>
-				<version>2.7.7</version>
+				<version>2.9.1</version>
 				<executions>
 					<execution>
 						<phase>package</phase>


### PR DESCRIPTION
## What is the purpose of the change
Bumped `cyclonedx-maven-plugin` to `2.9.1` to resolve the vulnerability [CVE-2024-38374](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-38374)

## Brief change log
Updated cyclonedx-maven-plugin version to 2.9.1 in parent pom.xml to resolve vulnerability CVE-2024-38374.

## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:
 - Dependencies (does it add or upgrade a dependency): yes
 - The public API, i.e., is any changed class annotated with @Public(Evolving): no
 - The serializers: no
 - The runtime per-record code paths (performance sensitive): no
 - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, - - ZooKeeper: no
 - The S3 file system connector. no

## Documentation
- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)