### PR TITLE
[FLINK-37308] Support pauseOrResumeSplits in HybridSource

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReader.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReader.java
@@ -31,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -246,5 +247,11 @@ public class HybridSourceReader<T> implements SourceReader<T, HybridSourceSplit>
             }
             addSplits(splits);
         }
+    }
+
+    @Override
+    public void pauseOrResumeSplits(
+            Collection<String> splitsToPause, Collection<String> splitsToResume) {
+        currentReader.pauseOrResumeSplits(splitsToPause, splitsToResume);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

*This PR added the pauseOrResumeSplits implementation in HybridSourceReader.*


## Brief change log

Delegate it to the current reader.

## Verifying this change

A new `testPauseResumeCurrentSourceSplits` test was added to `HybridSourceReaderTest.java`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
