### PR TITLE
[FLINK-37709][metrics] add file descriptor jvm metrics

### DIFF
--- a/docs/content.zh/docs/ops/metrics.md
+++ b/docs/content.zh/docs/ops/metrics.md
@@ -632,6 +632,35 @@ Some metrics might not be exposed when using other JVM implementations (e.g. IBM
   </tbody>                                                         
 </table>
 
+### File Descriptors
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th class="text-left" style="width: 18%">Scope</th>
+      <th class="text-left" style="width: 22%">Infix</th>
+      <th class="text-left" style="width: 20%">Metrics</th>
+      <th class="text-left" style="width: 32%">Description</th>
+      <th class="text-left" style="width: 8%">Type</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th rowspan="1"><strong>Job-/TaskManager</strong></th>
+      <td rowspan="1">Status.FileDescriptor.Max</td>
+      <td>Count</td>
+      <td>The max number of file descriptors.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <th rowspan="1"><strong>Job-/TaskManager</strong></th>
+      <td rowspan="1">Status.FileDescriptor.Open</td>
+      <td>Count</td>
+      <td>The total open of file descriptors.</td>
+      <td>Gauge</td>
+    </tr>
+  </tbody>
+</table>
+
 ### Threads
 <table class="table table-bordered">
   <thead>

--- a/docs/content/docs/ops/metrics.md
+++ b/docs/content/docs/ops/metrics.md
@@ -624,6 +624,35 @@ Some metrics might not be exposed when using other JVM implementations (e.g. IBM
   </tbody>                                                         
 </table>
 
+### File Descriptors
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th class="text-left" style="width: 18%">Scope</th>
+      <th class="text-left" style="width: 22%">Infix</th>
+      <th class="text-left" style="width: 20%">Metrics</th>
+      <th class="text-left" style="width: 32%">Description</th>
+      <th class="text-left" style="width: 8%">Type</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th rowspan="1"><strong>Job-/TaskManager</strong></th>
+      <td rowspan="1">Status.FileDescriptor.Max</td>
+      <td>Count</td>
+      <td>The max number of file descriptors.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <th rowspan="1"><strong>Job-/TaskManager</strong></th>
+      <td rowspan="1">Status.FileDescriptor.Open</td>
+      <td>Count</td>
+      <td>The total open of file descriptors.</td>
+      <td>Gauge</td>
+    </tr>
+  </tbody>
+</table>
+
 ### Threads
 <table class="table table-bordered">
   <thead>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
@@ -58,6 +58,9 @@ public class MetricNames {
     public static final String MEMORY_COMMITTED = "Committed";
     public static final String MEMORY_MAX = "Max";
 
+    public static final String FILE_DESCRIPTOR_MAX = "Max";
+    public static final String FILE_DESCRIPTOR_OPEN = "Open";
+
     public static final String IS_BACK_PRESSURED = "isBackPressured";
 
     public static final String CHECKPOINT_ALIGNMENT_TIME = "checkpointAlignmentTime";

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/util/MetricUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/util/MetricUtilsTest.java
@@ -177,6 +177,16 @@ class MetricUtilsTest {
         assertThat(heapMetrics.get(MetricNames.MEMORY_MAX)).isNotNull();
     }
 
+    @Test
+    void testFileDescriptorMetricsCompleteness() {
+        final InterceptingOperatorMetricGroup heapMetrics = new InterceptingOperatorMetricGroup();
+
+        MetricUtils.instantiateFileDescriptorMetrics(heapMetrics);
+
+        assertThat(heapMetrics.get(MetricNames.FILE_DESCRIPTOR_MAX)).isNotNull();
+        assertThat(heapMetrics.get(MetricNames.FILE_DESCRIPTOR_OPEN)).isNotNull();
+    }
+
     /**
      * Tests that heap/non-heap metrics do not rely on a static MemoryUsage instance.
      *


### PR DESCRIPTION
## What is the purpose of the change

Add file descriptor related JVM metrics

## Brief change log
  - Add the default registration in MetricUtils
  - Added test in MetricUtilsTest



## Verifying this change

This change added tests and can be verified as follows:
  - Added test in MetricUtilsTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs)
