### PR TITLE
[FLINK-37691] Do not remove ChangelogNormalize if deduplication was requested

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/optimize/ChangelogNormalizeRequirementResolver.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/optimize/ChangelogNormalizeRequirementResolver.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.plan.optimize;
 
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.connector.source.abilities.SupportsReadingMetadata;
 import org.apache.flink.table.planner.connectors.DynamicSourceUtils;
@@ -31,6 +32,7 @@ import org.apache.flink.table.planner.plan.schema.TableSourceTable;
 import org.apache.flink.table.planner.plan.trait.UpdateKindTrait$;
 import org.apache.flink.table.planner.plan.trait.UpdateKindTraitDef$;
 import org.apache.flink.table.planner.plan.utils.FlinkRelUtil;
+import org.apache.flink.table.planner.utils.ShortcutUtils;
 
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.SingleRel;
@@ -65,6 +67,12 @@ public class ChangelogNormalizeRequirementResolver {
         if (!Objects.equals(
                 normalize.getTraitSet().getTrait(UpdateKindTraitDef$.MODULE$.INSTANCE()),
                 UpdateKindTrait$.MODULE$.ONLY_UPDATE_AFTER())) {
+            return true;
+        }
+
+        // the changelog normalize is requested to perform deduplication on a retract stream
+        if (ShortcutUtils.unwrapTableConfig(normalize)
+                .get(ExecutionConfigOptions.TABLE_EXEC_SOURCE_CDC_EVENTS_DUPLICATE)) {
             return true;
         }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ChangelogNormalizeOptimizationTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ChangelogNormalizeOptimizationTest.java
@@ -110,7 +110,7 @@ public class ChangelogNormalizeOptimizationTest extends TableTestBase {
     @ParameterizedTest()
     @MethodSource("getTests")
     void testChangelogNormalizePlan(TestSpec spec) {
-        spec.sessionProperties.forEach((key, value) -> util.tableEnv().getConfig().set(key, value));
+        spec.sessionOptions.forEach((key, value) -> util.tableEnv().getConfig().set(key, value));
         for (TableProperties tableProperties : spec.tablesToCreate) {
             final String additionalColumns =
                     String.join(",\n", tableProperties.getAdditionalColumns());
@@ -263,7 +263,7 @@ public class ChangelogNormalizeOptimizationTest extends TableTestBase {
     private static class TestSpec {
 
         private final Set<TableProperties> tablesToCreate;
-        private final Map<String, String> sessionProperties = new HashMap<>();
+        private final Map<String, String> sessionOptions = new HashMap<>();
         private final String query;
         private final String description;
 
@@ -323,7 +323,7 @@ public class ChangelogNormalizeOptimizationTest extends TableTestBase {
         }
 
         public TestSpec withSessionOption(String key, String value) {
-            this.sessionProperties.put(key, value);
+            this.sessionOptions.put(key, value);
             return this;
         }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ChangelogNormalizeOptimizationTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ChangelogNormalizeOptimizationTest.java
@@ -30,8 +30,10 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -94,7 +96,9 @@ public class ChangelogNormalizeOptimizationTest extends TableTestBase {
                         SinkTable.UPSERT_SINK_METADATA),
                 TestSpec.selectWithoutMetadata(
                         SourceTable.UPSERT_SOURCE_PARTIAL_DELETES_METADATA_NO_PUSHDOWN,
-                        SinkTable.UPSERT_SINK));
+                        SinkTable.UPSERT_SINK),
+                TestSpec.select(SourceTable.RETRACT_SOURCE_PARTIAL_DELETES, SinkTable.UPSERT_SINK)
+                        .withSessionOption("table.exec.source.cdc-events-duplicate", "true"));
     }
 
     @AfterEach
@@ -106,6 +110,7 @@ public class ChangelogNormalizeOptimizationTest extends TableTestBase {
     @ParameterizedTest()
     @MethodSource("getTests")
     void testChangelogNormalizePlan(TestSpec spec) {
+        spec.sessionProperties.forEach((key, value) -> util.tableEnv().getConfig().set(key, value));
         for (TableProperties tableProperties : spec.tablesToCreate) {
             final String additionalColumns =
                     String.join(",\n", tableProperties.getAdditionalColumns());
@@ -149,6 +154,10 @@ public class ChangelogNormalizeOptimizationTest extends TableTestBase {
                 "'changelog-mode' = 'UA,D'",
                 "'source.produces-delete-by-key'='true'",
                 "'readable-metadata' = 'offset:BIGINT'"),
+        RETRACT_SOURCE_PARTIAL_DELETES(
+                "retract_table_partial_deletes",
+                "'changelog-mode' = 'I,UA,UB,D'",
+                "'source.produces-delete-by-key'='true'"),
         UPSERT_SOURCE_PARTIAL_DELETES_METADATA_NO_PUSHDOWN(
                 "upsert_table_partial_deletes_metadata_no_pushdown",
                 List.of("`offset` BIGINT METADATA"),
@@ -254,6 +263,7 @@ public class ChangelogNormalizeOptimizationTest extends TableTestBase {
     private static class TestSpec {
 
         private final Set<TableProperties> tablesToCreate;
+        private final Map<String, String> sessionProperties = new HashMap<>();
         private final String query;
         private final String description;
 
@@ -310,6 +320,11 @@ public class ChangelogNormalizeOptimizationTest extends TableTestBase {
                             sinkTable.getTableName(),
                             leftTable.getTableName(),
                             rightTable.getTableName()));
+        }
+
+        public TestSpec withSessionOption(String key, String value) {
+            this.sessionProperties.put(key, value);
+            return this;
         }
 
         @Override

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/ChangelogNormalizeOptimizationTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/ChangelogNormalizeOptimizationTest.xml
@@ -296,6 +296,27 @@ Sink(table=[default_catalog.default_database.upsert_sink_table], fields=[id, col
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testChangelogNormalizePlan[[21] select_retract_table_partial_deletes_into_upsert_sink_table]">
+    <Resource name="sql">
+      <![CDATA[INSERT INTO upsert_sink_table SELECT * FROM retract_table_partial_deletes]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.upsert_sink_table], fields=[id, col1, col2])
++- LogicalProject(id=[$0], col1=[$1], col2=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, retract_table_partial_deletes]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.upsert_sink_table], fields=[id, col1, col2], changelogMode=[NONE])
++- ChangelogNormalize(key=[id], changelogMode=[I,UA,D])
+   +- Exchange(distribution=[hash[id]], changelogMode=[I,UA,PD])
+      +- DropUpdateBefore(changelogMode=[I,UA,PD])
+         +- TableSourceScan(table=[[default_catalog, default_database, retract_table_partial_deletes]], fields=[id, col1, col2], changelogMode=[I,UB,UA,PD])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testChangelogNormalizePlan[[2] select_upsert_table_full_deletes_into_upsert_sink_table]">
     <Resource name="sql">
       <![CDATA[INSERT INTO upsert_sink_table SELECT * FROM upsert_table_full_deletes]]>


### PR DESCRIPTION

## What is the purpose of the change

Do not try removing `ChangelogNormalize` if `"table.exec.source.cdc-events-duplicate" = "true"`

## Verifying this change

Added a plan test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
