### PR TITLE
[FLINK-37721] Fixes janino bug returning incorrect results

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/table/AsyncCalcITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/table/AsyncCalcITCase.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.functions.AsyncScalarFunction;
 import org.apache.flink.table.functions.FunctionContext;
 import org.apache.flink.table.planner.runtime.utils.StreamingTestBase;
 import org.apache.flink.types.Row;
+import org.apache.flink.types.RowKind;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -46,6 +47,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.apache.flink.table.api.Expressions.row;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** IT Case tests for {@link AsyncScalarFunction}. */
@@ -238,6 +240,35 @@ public class AsyncCalcITCase extends StreamingTestBase {
         assertThat(results).containsSequence(expectedRows);
     }
 
+    @Test
+    public void testMultiArgumentAsyncWithAdditionalProjection() {
+        // This was the cause of a bug previously where the reference to the sync projection was
+        // getting garbled by janino. See issue https://issues.apache.org/jira/browse/FLINK-37721
+        Table t1 =
+                tEnv.fromValues(row("a1", "b1", "c1"), row("a2", "b2", "c2")).as("f1", "f2", "f3");
+        tEnv.createTemporaryView("t1", t1);
+        tEnv.createTemporarySystemFunction("func", new AsyncFuncThreeParams());
+        final List<Row> results = executeSql("select f1, func(f1, f2, f3) FROM t1");
+        final List<Row> expectedRows =
+                Arrays.asList(Row.of("a1", "val a1b1c1"), Row.of("a2", "val a2b2c2"));
+        assertThat(results).containsSequence(expectedRows);
+    }
+
+    @Test
+    public void testGroupBy() {
+        Table t1 = tEnv.fromValues(row(1, 1), row(2, 2), row(1, 3)).as("f1", "f2");
+        tEnv.createTemporaryView("t1", t1);
+        tEnv.createTemporarySystemFunction("func", new AsyncFuncAdd10());
+        final List<Row> results = executeSql("select f1, func(SUM(f2)) FROM t1 group by f1");
+        final List<Row> expectedRows =
+                Arrays.asList(
+                        Row.of(1, 11),
+                        Row.of(2, 12),
+                        Row.ofKind(RowKind.UPDATE_BEFORE, 1, 11),
+                        Row.ofKind(RowKind.UPDATE_AFTER, 1, 14));
+        assertThat(results).containsSequence(expectedRows);
+    }
+
     private List<Row> executeSql(String sql) {
         TableResult result = tEnv.executeSql(sql);
         final List<Row> rows = new ArrayList<>();
@@ -252,6 +283,16 @@ public class AsyncCalcITCase extends StreamingTestBase {
 
         public void eval(CompletableFuture<String> future, Integer param) {
             executor.schedule(() -> future.complete("val " + param), 10, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    /** Test function. */
+    public static class AsyncFuncThreeParams extends AsyncFuncBase {
+
+        private static final long serialVersionUID = 1L;
+
+        public void eval(CompletableFuture<String> future, String a, String b, String c) {
+            executor.schedule(() -> future.complete("val " + a + b + c), 10, TimeUnit.MILLISECONDS);
         }
     }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The bug comes from the fact that previously, we were creating an anonymous function callback within the janino generated code. This function was then referencing the local `DelegatingAsyncResultFuture`, effectively creating a closure. When the function was called back from different threads, they seemed to both reference the same `DelegatingAsyncResultFuture` rather than their own local ones. The result was returning incorrect "synchronous" results, so queries like the following might have issues:

```
SELECT f1, func(f1, f2, f3) FROM Table1;
```

Here, the f1 column returned was retrieved by asking for it from the local `DelegatingAsyncResultFuture`, and so getting the wrong instance meant getting the wrong result.

To fix it, I removed the inner anonymous function and just added the same logic on `DelegatingAsyncResultFuture`. It requires setting it up with all of the metadata (indexes, sync results), and when the result is complete, rather than calling the generated function, it just creates the result `RowData` itself.

## Brief change log

  - Changes how codegen works for async calcs to avoid anonymous functions


## Verifying this change

This change added tests and can be verified as follows:
- Added ITCase that previously gave incorrect result, but which now gives the right result.
- Added test which shows that changelog type is propagated

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
    - The former generated code and static code in `DelegatingAsyncResultFuture` shouldn't differ in any significant way, so should be a no-op.
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
