### PR TITLE
[FLINK-37728][python] add support org.apache.flink.table.runtime.operators.window.GlobalWindow

### DIFF
--- a/flink-python/pyflink/datastream/data_stream.py
+++ b/flink-python/pyflink/datastream/data_stream.py
@@ -2806,7 +2806,7 @@ def _get_one_input_stream_operator(data_stream: DataStream,
                 gateway.jvm.org.apache.flink.table.runtime.operators.window.CountWindow.Serializer()
         elif isinstance(window_serializer, GlobalWindowSerializer):
             j_namespace_serializer = \
-                gateway.jvm.org.apache.flink.streaming.api.windowing.windows.GlobalWindow \
+                gateway.jvm.org.apache.flink.table.runtime.operators.window.GlobalWindow \
                 .Serializer()
         else:
             j_namespace_serializer = \

--- a/flink-python/pyflink/fn_execution/embedded/converters.py
+++ b/flink-python/pyflink/fn_execution/embedded/converters.py
@@ -33,7 +33,7 @@ OUT = TypeVar('OUT')
 # Java Window
 JTimeWindow = findClass('org.apache.flink.table.runtime.operators.window.TimeWindow')
 JCountWindow = findClass('org.apache.flink.table.runtime.operators.window.CountWindow')
-JGlobalWindow = findClass('org.apache.flink.streaming.api.windowing.windows.GlobalWindow')
+JGlobalWindow = findClass('org.apache.flink.table.runtime.operators.window.GlobalWindow')
 
 
 class DataConverter(ABC):

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/window/GlobalWindow.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/window/GlobalWindow.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.window;
+
+import org.apache.flink.api.common.typeutils.SimpleTypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.base.TypeSerializerSingleton;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+import java.io.IOException;
+
+public class GlobalWindow extends Window {
+    private static final GlobalWindow INSTANCE = new GlobalWindow();
+
+    private GlobalWindow() {}
+
+    public static GlobalWindow get() {
+        return INSTANCE;
+    }
+
+    @Override
+    public long maxTimestamp() {
+        return Long.MAX_VALUE;
+    }
+
+    @Override
+    public int hashCode() {
+        return 0;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return this == o || !(o == null || getClass() != o.getClass());
+    }
+
+    @Override
+    public int compareTo(Window o) {
+        return 0;
+    }
+
+    public static class Serializer extends TypeSerializerSingleton<GlobalWindow> {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public boolean isImmutableType() {
+            return true;
+        }
+
+        @Override
+        public GlobalWindow createInstance() {
+            return GlobalWindow.INSTANCE;
+        }
+
+        @Override
+        public GlobalWindow copy(GlobalWindow from) {
+            return from;
+        }
+
+        @Override
+        public GlobalWindow copy(GlobalWindow from, GlobalWindow reuse) {
+            return from;
+        }
+
+        @Override
+        public int getLength() {
+            return Byte.BYTES;
+        }
+
+        @Override
+        public void serialize(GlobalWindow record, DataOutputView target) throws IOException {
+            target.writeByte(0);
+        }
+
+        @Override
+        public GlobalWindow deserialize(DataInputView source) throws IOException {
+            source.readByte();
+            return GlobalWindow.INSTANCE;
+        }
+
+        @Override
+        public GlobalWindow deserialize(GlobalWindow reuse, DataInputView source)
+                throws IOException {
+            source.readByte();
+            return GlobalWindow.INSTANCE;
+        }
+
+        @Override
+        public void copy(DataInputView source, DataOutputView target) throws IOException {
+            source.readByte();
+            target.writeByte(0);
+        }
+
+        // ------------------------------------------------------------------------
+
+        @Override
+        public TypeSerializerSnapshot<GlobalWindow> snapshotConfiguration() {
+            return new GlobalWindow.Serializer.GlobalWindowSerializerSnapshot();
+        }
+
+        /** Serializer configuration snapshot for compatibility and format evolution. */
+        @SuppressWarnings("WeakerAccess")
+        public static final class GlobalWindowSerializerSnapshot
+                extends SimpleTypeSerializerSnapshot<GlobalWindow> {
+
+            public GlobalWindowSerializerSnapshot() {
+                super(GlobalWindow.Serializer::new);
+            }
+        }
+    }
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/completeness/TypeSerializerTestCoverageTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/completeness/TypeSerializerTestCoverageTest.java
@@ -156,6 +156,9 @@ public class TypeSerializerTestCoverageTest extends TestLogger {
                         TwoPhaseCommitSinkFunction.StateSerializer.class.getName(),
                         IntervalJoinOperator.BufferEntrySerializer.class.getName(),
                         GlobalWindow.Serializer.class.getName(),
+                        org.apache.flink.table.runtime.operators.window.GlobalWindow.Serializer
+                                .class
+                                .getName(),
                         org.apache.flink.queryablestate.client.VoidNamespaceSerializer.class
                                 .getName(),
                         org.apache.flink.runtime.state.VoidNamespaceSerializer.class.getName(),
@@ -218,6 +221,9 @@ public class TypeSerializerTestCoverageTest extends TestLogger {
                         InternalTimersSnapshotReaderWriters.LegacyTimerSerializer.class.getName(),
                         TwoPhaseCommitSinkFunction.StateSerializer.class.getName(),
                         GlobalWindow.Serializer.class.getName(),
+                        org.apache.flink.table.runtime.operators.window.GlobalWindow.Serializer
+                                .class
+                                .getName(),
                         TestDuplicateSerializer.class.getName(),
                         LinkedListSerializer.class.getName(),
                         WindowKeySerializer.class.getName(),


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

add support for org.apache.flink.table.runtime.operators.window.GlobalWindow. In flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/embedded/EmbeddedPythonWindowOperator.java, org.apache.flink.table.runtime.operators.window.Window is used, but we only have implementation for org.apache.flink.streaming.api.windowing.windows.GlobalWindow, which can't be cast to org.apache.flink.table.runtime.operators.window.Window. 


## Brief change log

 - add implementation for org.apache.flink.table.runtime.operators.window.GlobalWindow
 - modify pyflink to use org.apache.flink.table.runtime.operators.window.GlobalWindow instead of org.apache.flink.streaming.api.windowing.windows.GlobalWindow.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (o)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
