### PR TITLE
[FLINK-37729][flink-formats] ResultTypeQueryable for Avro serialization schema

### DIFF
--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDataSerializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDataSerializationSchema.java
@@ -19,8 +19,11 @@
 package org.apache.flink.formats.avro;
 
 import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.formats.avro.AvroFormatOptions.AvroEncoding;
 import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
+import org.apache.flink.formats.avro.typeutils.GenericRecordAvroTypeInfo;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
 
@@ -38,7 +41,8 @@ import java.util.Objects;
  * <p>Note: Changes in this class need to be kept in sync with the corresponding runtime class
  * {@link AvroRowDataDeserializationSchema} and schema converter {@link AvroSchemaConverter}.
  */
-public class AvroRowDataSerializationSchema implements SerializationSchema<RowData> {
+public class AvroRowDataSerializationSchema
+        implements SerializationSchema<RowData>, ResultTypeQueryable<GenericRecord> {
 
     private static final long serialVersionUID = 1L;
 
@@ -138,5 +142,15 @@ public class AvroRowDataSerializationSchema implements SerializationSchema<RowDa
     @Override
     public int hashCode() {
         return Objects.hash(nestedSchema, rowType);
+    }
+
+    @Override
+    public TypeInformation<GenericRecord> getProducedType() {
+        if (schema == null) {
+            throw new IllegalStateException(
+                    "The produced type is not available before the schema is initialized.");
+        } else {
+            return new GenericRecordAvroTypeInfo(schema);
+        }
     }
 }


### PR DESCRIPTION
Implement `ResultTypeQueryable` interface for `AvroSerializationSchema` and `AvroRowDataSerializationSchema` to make it exposed via existing lineage interfaces. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): No
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (no) no
