### PR TITLE
[FLINK-26425][yarn] Support rolling log aggregation

### DIFF
--- a/docs/layouts/shortcodes/generated/yarn_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/yarn_config_configuration.html
@@ -153,6 +153,18 @@
             <td>The provided usrlib directory in remote. It should be pre-uploaded and world-readable. Flink will use it to exclude the local usrlib directory(i.e. usrlib/ under the parent directory of FLINK_LIB_DIR). Unlike yarn.provided.lib.dirs, YARN will not cache it on the nodes as it is for each application. An example could be hdfs://$namenode_address/path/of/flink/usrlib</td>
         </tr>
         <tr>
+            <td><h5>yarn.rolled-logs.exclude-pattern</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Java regular expression to exclude certain log files from rolling log aggregation. Log files matching the defined exclude pattern will be ignored during aggregation. If a log file matches both the include and exclude patterns, the exclude pattern takes precedence and the file will be excluded from aggregation.</td>
+        </tr>
+        <tr>
+            <td><h5>yarn.rolled-logs.include-pattern</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Java regular expression to match log file names for inclusion in rolling log aggregation. This regex is used by YARN’s log aggregation mechanism to identify which log files to collect. To enable rolling aggregation in YARN, set the `yarn.nodemanager.log-aggregation.roll-monitoring-interval-seconds` property in `yarn-site.xml`. Ensure that Flink’s Log4J configuration uses FileAppender or a compatible appender that can handle file deletions during runtime. The regex pattern (e.g., `jobmanager*`) must align with the log file names defined in the Log4J configuration (e.g., `jobmanager.log`) to ensure all relevant files will be aggregated.</td>
+        </tr>
+        <tr>
             <td><h5>yarn.security.appmaster.delegation.token.services</h5></td>
             <td style="word-wrap: break-word;">"hadoopfs"</td>
             <td>List&lt;String&gt;</td>

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
@@ -401,6 +401,26 @@ public class YarnConfigOptions {
                                     + " Unlike yarn.provided.lib.dirs, YARN will not cache it on the nodes as it is for each application. An example could be "
                                     + "hdfs://$namenode_address/path/of/flink/usrlib");
 
+    public static final ConfigOption<String> ROLLED_LOGS_INCLUDE_PATTERN =
+            key("yarn.rolled-logs.include-pattern")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Java regular expression to match log file names for inclusion in rolling log aggregation."
+                                    + " This regex is used by YARN’s log aggregation mechanism to identify which log files to collect."
+                                    + " To enable rolling aggregation in YARN, set the `yarn.nodemanager.log-aggregation.roll-monitoring-interval-seconds` property in `yarn-site.xml`."
+                                    + " Ensure that Flink’s Log4J configuration uses FileAppender or a compatible appender that can handle file deletions during runtime."
+                                    + " The regex pattern (e.g., `jobmanager*`) must align with the log file names defined in the Log4J configuration (e.g., `jobmanager.log`) to ensure all relevant files will be aggregated.");
+
+    public static final ConfigOption<String> ROLLED_LOGS_EXCLUDE_PATTERN =
+            key("yarn.rolled-logs.exclude-pattern")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Java regular expression to exclude certain log files from rolling log aggregation."
+                                    + " Log files matching the defined exclude pattern will be ignored during aggregation."
+                                    + " If a log file matches both the include and exclude patterns, the exclude pattern takes precedence and the file will be excluded from aggregation.");
+
     @SuppressWarnings("unused")
     public static final ConfigOption<String> HADOOP_CONFIG_KEY =
             key("flink.hadoop.<key>")


### PR DESCRIPTION
## What is the purpose of the change

A long-running YARN app will eventually fill the local disk with logs, unless there is a rolling Log4J strategy is applied to limit the log files to X archive with Y size. But if there is a policy to store the logs for months or years, throwing away the logs too early is also problematic. YARN is able to aggregate specific files for running applications, so this way, it is possible to aggregate the rolled over logs to external storage and store it until the end of times if that's the reqquirement. :)

## Brief change log

- Added new optional config options to define `include` and `exclude` regex patterns.
- Wired in these values into YARN's `LogAggregationContext` during cluster deployment.
- Updated docs.

## Verifying this change

- Added new unit test for the added logic.
- Existing unit tests guarantee that by default the deployment will work exactly as before.
- Also E2E tested on a YARN cluster, and log aggregation is triggered for the given files as expected.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
