### PR TITLE
[FLINK-37523][CI] Fix Python test/e2e tests missing libpython/python headers

### DIFF
--- a/.github/workflows/template.flink-ci.yml
+++ b/.github/workflows/template.flink-ci.yml
@@ -209,6 +209,12 @@ jobs:
           source_directory: ${{ env.MOUNTED_WORKING_DIR }}
           target_directory: ${{ env.CONTAINER_LOCAL_WORKING_DIR }}
 
+      - name: "Setup python"
+        if: matrix.module == 'python'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
       - name: "Set coredump pattern"
         working-directory: ${{ env.CONTAINER_LOCAL_WORKING_DIR }}
         run: sudo sysctl -w kernel.core_pattern=core.%p
@@ -314,6 +320,11 @@ jobs:
         with:
           jdk_version: ${{ inputs.jdk_version }}
           maven_repo_folder: ${{ env.MAVEN_REPO_FOLDER }}
+
+      - name: "Setup python"
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
 
       - name: "Install missing packages"
         run: sudo apt-get install -y net-tools docker zip


### PR DESCRIPTION
## What is the purpose of the change

After migrating the test infrastructure away from `conda` to `uv`, we ran into issues with missing `libpython` and `Python.h` headers in the tests. This is because while `conda` creates a fully portable python environment, `uv` does not.

This was [addressed](https://github.com/apache/flink/blob/master/tools/azure-pipelines/e2e-template.yml#L51:L53) in the initial migration in the azure pipelines, but was missing from the Github actions pipelines. This PR fixes this. An example of a GHA with this commit is fully green: https://github.com/autophagy/flink/actions/runs/14679294188/job/41200060044

(As a note - it might be better for the docker image used for the GHA pipelines to handle ensuring `libpython` etc is present instead of in the pipelines directly, but I figured this was the easiest way to get everything passing again).

## Brief change log

  - *Added Python 3.11 setup step to Python and E2E tests in Github Actions pipelines.*

## Verifying this change

See: https://github.com/autophagy/flink/actions/runs/14679294188/job/41200060044

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)
 
## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
