### PR TITLE
[hotfix][python] Add pandas type annotations for TableEnvironment.from_pandas and Table.to_pandas

### DIFF
--- a/flink-python/docs/conf.py
+++ b/flink-python/docs/conf.py
@@ -64,6 +64,7 @@ extensions = [
     'sphinx.ext.inheritance_diagram',
     'sphinx.ext.doctest',
     'sphinx.ext.autosummary',
+    'sphinx.ext.intersphinx',
     'sphinx_mdinclude'
 ]
 
@@ -101,6 +102,11 @@ pygments_style = 'sphinx'
 # Look at the first line of the docstring for function and method signatures.
 autosummary_generate = True
 autodoc_docstring_signature = True
+
+# Map to external docs for type annotations
+intersphinx_mapping = {
+    "pandas": ("https://pandas.pydata.org/docs/", None),
+}
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/flink-python/pyflink/table/table.py
+++ b/flink-python/pyflink/table/table.py
@@ -17,7 +17,10 @@
 ################################################################################
 
 from py4j.java_gateway import get_method
-from typing import Union
+from typing import Union, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pandas
 
 from pyflink.java_gateway import get_gateway
 from pyflink.table import ExplainDetail
@@ -914,7 +917,7 @@ class Table(object):
                 func = func(with_columns(col("*")))
             return FlatAggregateTable(self._j_table.flatAggregate(func._j_expr), self._t_env)
 
-    def to_pandas(self):
+    def to_pandas(self) -> 'pandas.DataFrame':
         """
         Converts the table to a pandas DataFrame. It will collect the content of the table to
         the client side and so please make sure that the content of the table could fit in memory

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -19,7 +19,10 @@ import atexit
 import os
 import sys
 import tempfile
-from typing import Union, List, Tuple, Iterable, Optional
+from typing import Union, List, Tuple, Iterable, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pandas
 
 from py4j.java_gateway import get_java_class, get_method
 
@@ -1330,7 +1333,7 @@ class TableEnvironment(object):
         finally:
             atexit.register(lambda: os.unlink(temp_file.name))
 
-    def from_pandas(self, pdf,
+    def from_pandas(self, pdf: 'pandas.DataFrame',
                     schema: Union[RowType, List[str], Tuple[str], List[DataType],
                                   Tuple[DataType]] = None,
                     splits_num: int = 1) -> Table:


### PR DESCRIPTION
## What is the purpose of the change

Currently, the `pdf` argument of `TableEnvironment.from_pandas` and the return type of `Table.to_pandas` are not type annotated. This PR adds a pandas import during type checking (and so should not affect/import it outside of that, since it's an optional module) so that users get better type information out of these functions.

I also enabled the [intersphinx](https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html) extension for Sphinx so that type annotations for `pandas` classes link to their corresponding classes in the `pandas` documentation. So the live docs currently show:

![20250426_16h14m52s_grim](https://github.com/user-attachments/assets/e74effe9-8275-41ac-8bbd-9c29ac4fbc02)

After this change:

![20250426_16h02m09s_grim](https://github.com/user-attachments/assets/3396a77b-fb2e-4be1-8997-b536dbc29d95)

Where the `pandas.DataFrame` return type links to https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html#pandas.DataFrame

## Brief change log

  - *Added pandas type annotions to `TableEnvironment.from_pandas` and `Table.to_pandas`*
  - *Enabled intersphinx extension so pandas type annotations in the docs link to the corresponding pandas documentation*

## Verifying this change

This change is already covered by existing docs building and type checking tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
