### PR TITLE
[hotfix][kubernetes] Minor polish codes in flink-kubernetes/src/main/java/org/apache/flink/kubernetes/cli/KubernetesSessionCli.java to reduce premature and unnecessary variable declarations

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/cli/KubernetesSessionCli.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/cli/KubernetesSessionCli.java
@@ -102,7 +102,6 @@ public class KubernetesSessionCli {
         try {
             final ClusterClient<String> clusterClient;
             String clusterId = kubernetesClusterClientFactory.getClusterId(configuration);
-            final boolean detached = !configuration.get(DeploymentOptions.ATTACHED);
             final FlinkKubeClient kubeClient =
                     FlinkKubeClientFactory.getInstance().fromConfiguration(configuration, "client");
 
@@ -123,7 +122,7 @@ public class KubernetesSessionCli {
             }
 
             try {
-                if (!detached) {
+                if (configuration.get(DeploymentOptions.ATTACHED)) {
                     Tuple2<Boolean, Boolean> continueRepl = new Tuple2<>(true, false);
                     try (BufferedReader in = new BufferedReader(new InputStreamReader(System.in))) {
                         while (continueRepl.f0) {


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to avoid duplicate operation `!` and remove the variable `detached`.


## Brief change log

Avoid duplicate operation `!`.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
