### PR TITLE
[FLINK-37745] Serialize partial deletes in ChangelogMode to JSON

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/ChangelogMode.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/ChangelogMode.java
@@ -24,7 +24,6 @@ import org.apache.flink.util.Preconditions;
 
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -128,19 +127,19 @@ public final class ChangelogMode {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        ChangelogMode that = (ChangelogMode) o;
-        return kinds.equals(that.kinds);
+
+        final ChangelogMode that = (ChangelogMode) o;
+        return keyOnlyDeletes == that.keyOnlyDeletes && kinds.equals(that.kinds);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(kinds);
+        int result = kinds.hashCode();
+        result = 31 * result + Boolean.hashCode(keyOnlyDeletes);
+        return result;
     }
 
     @Override

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ChangelogModeJsonDeserializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ChangelogModeJsonDeserializer.java
@@ -28,6 +28,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 
 import java.io.IOException;
+import java.util.Objects;
 
 /**
  * JSON deserializer for {@link ChangelogMode}.
@@ -37,6 +38,7 @@ import java.io.IOException;
 @Internal
 final class ChangelogModeJsonDeserializer extends StdDeserializer<ChangelogMode> {
     private static final long serialVersionUID = 1L;
+    private static final String PARTIAL_DELETE = "~" + RowKind.DELETE.name();
 
     ChangelogModeJsonDeserializer() {
         super(ChangelogMode.class);
@@ -49,8 +51,14 @@ final class ChangelogModeJsonDeserializer extends StdDeserializer<ChangelogMode>
         ChangelogMode.Builder builder = ChangelogMode.newBuilder();
         JsonNode rowKindsNode = jsonParser.readValueAsTree();
         for (JsonNode rowKindNode : rowKindsNode) {
-            RowKind rowKind = RowKind.valueOf(rowKindNode.asText().toUpperCase());
-            builder.addContainedKind(rowKind);
+            final String rowKindText = rowKindNode.asText().toUpperCase();
+            if (Objects.equals(PARTIAL_DELETE, rowKindText)) {
+                builder.keyOnlyDeletes(true);
+                builder.addContainedKind(RowKind.DELETE);
+            } else {
+                RowKind rowKind = RowKind.valueOf(rowKindText);
+                builder.addContainedKind(rowKind);
+            }
         }
         return builder.build();
     }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ChangelogModeJsonDeserializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ChangelogModeJsonDeserializer.java
@@ -51,7 +51,7 @@ final class ChangelogModeJsonDeserializer extends StdDeserializer<ChangelogMode>
         ChangelogMode.Builder builder = ChangelogMode.newBuilder();
         JsonNode rowKindsNode = jsonParser.readValueAsTree();
         for (JsonNode rowKindNode : rowKindsNode) {
-            final String rowKindText = rowKindNode.asText().toUpperCase();
+            final String rowKindText = rowKindNode.asText();
             if (Objects.equals(PARTIAL_DELETE, rowKindText)) {
                 builder.keyOnlyDeletes(true);
                 builder.addContainedKind(RowKind.DELETE);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ChangelogModeJsonSerializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ChangelogModeJsonSerializer.java
@@ -27,6 +27,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.Serialize
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
 import java.io.IOException;
+import java.util.Objects;
 
 /**
  * JSON serializer for {@link ChangelogMode}.
@@ -49,7 +50,12 @@ final class ChangelogModeJsonSerializer extends StdSerializer<ChangelogMode> {
             throws IOException {
         jsonGenerator.writeStartArray();
         for (RowKind rowKind : changelogMode.getContainedKinds()) {
-            jsonGenerator.writeString(rowKind.name());
+            if (Objects.requireNonNull(rowKind) == RowKind.DELETE
+                    && changelogMode.keyOnlyDeletes()) {
+                jsonGenerator.writeString("~" + rowKind.name());
+            } else {
+                jsonGenerator.writeString(rowKind.name());
+            }
         }
         jsonGenerator.writeEndArray();
     }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ChangelogModeJsonSerializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ChangelogModeJsonSerializer.java
@@ -27,7 +27,6 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.Serialize
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
 import java.io.IOException;
-import java.util.Objects;
 
 /**
  * JSON serializer for {@link ChangelogMode}.
@@ -50,8 +49,7 @@ final class ChangelogModeJsonSerializer extends StdSerializer<ChangelogMode> {
             throws IOException {
         jsonGenerator.writeStartArray();
         for (RowKind rowKind : changelogMode.getContainedKinds()) {
-            if (Objects.requireNonNull(rowKind) == RowKind.DELETE
-                    && changelogMode.keyOnlyDeletes()) {
+            if (rowKind == RowKind.DELETE && changelogMode.keyOnlyDeletes()) {
                 jsonGenerator.writeString("~" + rowKind.name());
             } else {
                 jsonGenerator.writeString(rowKind.name());

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ChangelogModeJsonSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ChangelogModeJsonSerdeTest.java
@@ -21,9 +21,10 @@ package org.apache.flink.table.planner.plan.nodes.exec.serde;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.types.RowKind;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 
@@ -33,14 +34,16 @@ import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeTest
 @Execution(ExecutionMode.CONCURRENT)
 class ChangelogModeJsonSerdeTest {
 
-    @Test
-    void testChangelogModeSerde() throws IOException {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testChangelogModeSerde(boolean keyOnlyDeletes) throws IOException {
         ChangelogMode changelogMode =
                 ChangelogMode.newBuilder()
                         .addContainedKind(RowKind.INSERT)
                         .addContainedKind(RowKind.DELETE)
                         .addContainedKind(RowKind.UPDATE_AFTER)
                         .addContainedKind(RowKind.UPDATE_BEFORE)
+                        .keyOnlyDeletes(keyOnlyDeletes)
                         .build();
 
         testJsonRoundTrip(changelogMode, ChangelogMode.class);


### PR DESCRIPTION
## What is the purpose of the change

Make it possible to serialize partial deletes into a compiled plan

## Verifying this change

Added a test in `ChangelogModeJsonSerdeTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (**yes** / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
