### PR TITLE
[FLINK-37747][runtime] Use old subtask count for restored committable objects

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperator.java
@@ -183,6 +183,8 @@ class CommitterOperator<CommT> extends AbstractStreamOperator<CommittableMessage
 
     private void emit(CheckpointCommittableManager<CommT> committableManager) {
         int subtaskId = getRuntimeContext().getTaskInfo().getIndexOfThisSubtask();
+        // Ensure that numberOfSubtasks is in sync with the number of actually emitted
+        // CommittableSummaries during upscaling recovery (see FLINK-37747).
         int numberOfSubtasks =
                 Math.min(
                         getRuntimeContext().getTaskInfo().getNumberOfParallelSubtasks(),

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperator.java
@@ -183,7 +183,10 @@ class CommitterOperator<CommT> extends AbstractStreamOperator<CommittableMessage
 
     private void emit(CheckpointCommittableManager<CommT> committableManager) {
         int subtaskId = getRuntimeContext().getTaskInfo().getIndexOfThisSubtask();
-        int numberOfSubtasks = getRuntimeContext().getTaskInfo().getNumberOfParallelSubtasks();
+        int numberOfSubtasks =
+                Math.min(
+                        getRuntimeContext().getTaskInfo().getNumberOfParallelSubtasks(),
+                        committableManager.getNumberOfSubtasks());
         long checkpointId = committableManager.getCheckpointId();
         Collection<CommT> committables = committableManager.getSuccessfulCommittables();
         output.collect(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/SinkV2CommitterOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/SinkV2CommitterOperatorTest.java
@@ -226,7 +226,8 @@ class SinkV2CommitterOperatorTest {
                 records.element(0, as(committableSummary()))
                         .hasCheckpointId(checkpointId)
                         .hasFailedCommittables(0)
-                        .hasSubtaskId(subtaskIdAfterRecovery);
+                        .hasSubtaskId(subtaskIdAfterRecovery)
+                        .hasNumberOfSubtasks(1);
         objectCommittableSummaryAssert.hasOverallCommittables(2);
 
         // Expect the same checkpointId that the original snapshot was made with.

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2ITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2ITCase.java
@@ -162,14 +162,11 @@ public class SinkV2ITCase extends AbstractTestBase {
             throws Exception {
         SharedReference<Queue<Committer.CommitRequest<Record<Integer>>>> committed =
                 SHARED_OBJECTS.add(new ConcurrentLinkedQueue<>());
-        TrackingCommitter trackingCommitter = new TrackingCommitter(committed);
-        StreamExecutionEnvironment env;
-        Source<Integer, ?, ?> source;
-        JobID jobID;
-        Configuration config = createConfigForScalingTest(checkpointDir, initialParallelism);
+        final TrackingCommitter trackingCommitter = new TrackingCommitter(committed);
+        final Configuration config = createConfigForScalingTest(checkpointDir, initialParallelism);
 
         // first run
-        jobID =
+        final JobID jobID =
                 runStreamingWithScalingTest(
                         config,
                         initialParallelism,

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2ITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2ITCase.java
@@ -17,37 +17,63 @@
 
 package org.apache.flink.test.streaming.runtime;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.state.CheckpointListener;
 import org.apache.flink.api.common.typeinfo.IntegerTypeInfo;
 import org.apache.flink.api.connector.sink2.Committer;
 import org.apache.flink.api.connector.source.Source;
 import org.apache.flink.api.connector.source.util.ratelimit.GatedRateLimiter;
 import org.apache.flink.api.connector.source.util.ratelimit.RateLimiter;
 import org.apache.flink.api.connector.source.util.ratelimit.RateLimiterStrategy;
+import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.configuration.ExternalizedCheckpointRetention;
+import org.apache.flink.configuration.RestartStrategyOptions;
+import org.apache.flink.configuration.StateBackendOptions;
+import org.apache.flink.configuration.StateRecoveryOptions;
 import org.apache.flink.connector.datagen.source.DataGeneratorSource;
+import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.runtime.operators.sink.TestSinkV2;
 import org.apache.flink.streaming.runtime.operators.sink.TestSinkV2.Record;
 import org.apache.flink.streaming.runtime.operators.sink.TestSinkV2.RecordSerializer;
+import org.apache.flink.streaming.util.TestStreamEnvironment;
+import org.apache.flink.test.junit5.InjectClusterClient;
+import org.apache.flink.test.junit5.InjectMiniCluster;
 import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.testutils.junit.SharedObjectsExtension;
 import org.apache.flink.testutils.junit.SharedReference;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -125,6 +151,48 @@ public class SinkV2ITCase extends AbstractTestBase {
         return r.withValue(-r.getValue());
     }
 
+    @ParameterizedTest
+    @MethodSource("getScalingParallelism")
+    public void writerAndCommitterExecuteInStreamingModeWithScalingUp(
+            int initialParallelism,
+            int scaledParallelism,
+            @TempDir File checkpointDir,
+            @InjectMiniCluster MiniCluster miniCluster,
+            @InjectClusterClient ClusterClient<?> clusterClient)
+            throws Exception {
+        SharedReference<Queue<Committer.CommitRequest<Record<Integer>>>> committed =
+                SHARED_OBJECTS.add(new ConcurrentLinkedQueue<>());
+        TrackingCommitter trackingCommitter = new TrackingCommitter(committed);
+        StreamExecutionEnvironment env;
+        Source<Integer, ?, ?> source;
+        JobID jobID;
+        Configuration config = createConfigForScalingTest(checkpointDir, initialParallelism);
+
+        // first run
+        jobID =
+                runStreamingWithScalingTest(
+                        config,
+                        initialParallelism,
+                        trackingCommitter,
+                        true,
+                        miniCluster,
+                        clusterClient);
+
+        // second run
+        config.set(StateRecoveryOptions.SAVEPOINT_PATH, getCheckpointPath(miniCluster, jobID));
+        config.set(CoreOptions.DEFAULT_PARALLELISM, scaledParallelism);
+        runStreamingWithScalingTest(
+                config, initialParallelism, trackingCommitter, false, miniCluster, clusterClient);
+
+        assertThat(committed.get())
+                .extracting(Committer.CommitRequest::getCommittable)
+                .containsExactlyInAnyOrderElementsOf(EXPECTED_COMMITTED_DATA_IN_STREAMING_MODE);
+    }
+
+    static Stream<Arguments> getScalingParallelism() {
+        return Stream.of(Arguments.of(1, 2), Arguments.of(2, 1), Arguments.of(1, 1));
+    }
+
     @Test
     public void writerAndCommitterExecuteInBatchMode() throws Exception {
         final StreamExecutionEnvironment env = buildBatchEnv();
@@ -182,6 +250,71 @@ public class SinkV2ITCase extends AbstractTestBase {
         env.setRuntimeMode(RuntimeExecutionMode.STREAMING);
         env.enableCheckpointing(100);
         return env;
+    }
+
+    private Configuration createConfigForScalingTest(File checkpointDir, int parallelism) {
+        final Configuration config = new Configuration();
+        config.set(CoreOptions.DEFAULT_PARALLELISM, parallelism);
+        config.set(StateBackendOptions.STATE_BACKEND, "hashmap");
+        config.set(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir.toURI().toString());
+        config.set(
+                CheckpointingOptions.EXTERNALIZED_CHECKPOINT_RETENTION,
+                ExternalizedCheckpointRetention.RETAIN_ON_CANCELLATION);
+        config.set(CheckpointingOptions.MAX_RETAINED_CHECKPOINTS, 2000);
+        config.set(RestartStrategyOptions.RESTART_STRATEGY, "disable");
+
+        return config;
+    }
+
+    private StreamExecutionEnvironment buildStreamEnvWithCheckpointDir(
+            Configuration config, int parallelism, MiniCluster miniCluster) {
+        final StreamExecutionEnvironment env =
+                new TestStreamEnvironment(
+                        miniCluster,
+                        config,
+                        parallelism,
+                        Collections.emptyList(),
+                        Collections.emptyList());
+        env.setRuntimeMode(RuntimeExecutionMode.STREAMING);
+        env.enableCheckpointing(100);
+
+        return env;
+    }
+
+    private JobID runStreamingWithScalingTest(
+            Configuration config,
+            int parallelism,
+            TrackingCommitter trackingCommitter,
+            boolean shouldMapperFail,
+            MiniCluster miniCluster,
+            ClusterClient<?> clusterClient)
+            throws Exception {
+        final StreamExecutionEnvironment env =
+                buildStreamEnvWithCheckpointDir(config, parallelism, miniCluster);
+        final Source<Integer, ?, ?> source = createStreamingSource();
+
+        env.fromSource(source, WatermarkStrategy.noWatermarks(), "source")
+                .map(
+                        new FailingCheckpointMapper(
+                                SHARED_OBJECTS.add(new AtomicBoolean(shouldMapperFail))))
+                .sinkTo(
+                        TestSinkV2.<Integer>newBuilder()
+                                .setCommitter(trackingCommitter, RecordSerializer::new)
+                                .build());
+
+        final JobID jobId = clusterClient.submitJob(env.getStreamGraph().getJobGraph()).get();
+        clusterClient.requestJobResult(jobId).get();
+
+        return jobId;
+    }
+
+    private String getCheckpointPath(MiniCluster miniCluster, JobID secondJobId)
+            throws InterruptedException, ExecutionException, FlinkJobNotFoundException {
+        final Optional<String> completedCheckpoint =
+                CommonTestUtils.getLatestCompletedCheckpointPath(secondJobId, miniCluster);
+
+        assertThat(completedCheckpoint).isPresent();
+        return completedCheckpoint.get();
     }
 
     private StreamExecutionEnvironment buildBatchEnv() {
@@ -244,5 +377,33 @@ public class SinkV2ITCase extends AbstractTestBase {
 
         @Override
         public void close() {}
+    }
+
+    private static class FailingCheckpointMapper
+            implements MapFunction<Integer, Integer>, CheckpointListener {
+
+        private final SharedReference<AtomicBoolean> failed;
+        private long lastCheckpointId = 0;
+        private int emittedBetweenCheckpoint = 0;
+
+        FailingCheckpointMapper(SharedReference<AtomicBoolean> failed) {
+            this.failed = failed;
+        }
+
+        @Override
+        public Integer map(Integer value) {
+            if (lastCheckpointId >= 1 && emittedBetweenCheckpoint > 0 && !failed.get().get()) {
+                failed.get().set(true);
+                throw new RuntimeException("Planned exception.");
+            }
+            emittedBetweenCheckpoint++;
+            return value;
+        }
+
+        @Override
+        public void notifyCheckpointComplete(long checkpointId) {
+            lastCheckpointId = checkpointId;
+            emittedBetweenCheckpoint = 0;
+        }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Fix the issue that GlobalCommitterOperator stuck when upstream operator - writer/committer is scaled up.


## Brief change log

Use the old subtask count from restored state instead of new subtask count.
When writer/committer operator is restored after scaling up, new tasks without restored state won't send CommittableSummary to downstream GlobalCommitterOperator. So if writer/committer sends subtasks of new run, GlobalCommitterOperator will stuck forever as it is looking for CommittableSummary for new tasks.

More details are describe here: https://issues.apache.org/jira/projects/FLINK/issues/FLINK-37747


## Verifying this change

Update existed UT case to cover the code change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: yes

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
