### PR TITLE
[FLINK-37750] Remove unused method FutureUtils.runIfNotDoneAndGet()

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/concurrent/FutureUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/concurrent/FutureUtils.java
@@ -39,7 +39,6 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ForkJoinPool;
-import java.util.concurrent.RunnableFuture;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -487,7 +486,7 @@ public class FutureUtils {
     // ------------------------------------------------------------------------
     //  Future actions
     // ------------------------------------------------------------------------
-    
+
     /**
      * Run the given action after the completion of the given future. The given future can be
      * completed normally or exceptionally. In case of an exceptional completion the, the action's


### PR DESCRIPTION
The runIfNotDoneAndGet function is no longer used in the codebase. Removing this function will reduce technical debt and improve code maintainability


## What is the purpose of the change

This change removes unused method runIfNotDoneAndGet() in FutureUtils class


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) not applicable
