### PR TITLE
[hotfix][python] Enable parallel builds for python API docs

### DIFF
--- a/flink-python/docs/Makefile
+++ b/flink-python/docs/Makefile
@@ -52,7 +52,7 @@ BUILDDIR     ?= _build
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -d _build/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
+ALLSPHINXOPTS   = -j auto -d _build/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
 .PHONY: help clean html dirhtml pickle json htmlhelp qthelp latex changes linkcheck doctest
 


### PR DESCRIPTION
## What is the purpose of the change

I noticed that building the Flink Python API docs by running `make html` in `flink-python/docs` can take longer than I expected - often well over 1 minute, which can be a little disruptive when working on the docs. This PR adds `-j auto` to the sphinx build options, which makes Sphinx distribute the build over N processes in parallel, where N is the number of CPUs available, which is better when building on multiprocessor machines. With this enabled fresh Sphinx builds take less than 20 seconds, on my personal machine.

Edit - Just to see in CI:
- [Before](https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=67394&view=logs&j=9cada3cb-c1d3-5621-16da-0f718fb86602&t=c67e71ed-6451-5d26-8920-5a8cf9651901): 1m 32s
- [This PR](https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=67438&view=logs&j=9cada3cb-c1d3-5621-16da-0f718fb86602&t=c67e71ed-6451-5d26-8920-5a8cf9651901): 35s

## Brief change log

- *Enabled parallel builds for Sphinx when building Python API docs*
