### PR TITLE
[FLINK-37752][json] Make configuration 'json.decode.json-parser.enabled' take effect

### DIFF
--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonFormatFactory.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonFormatFactory.java
@@ -191,6 +191,7 @@ public class JsonFormatFactory implements DeserializationFormatFactory, Serializ
         options.add(MAP_NULL_KEY_LITERAL);
         options.add(ENCODE_DECIMAL_AS_PLAIN_NUMBER);
         options.add(ENCODE_IGNORE_NULL_FIELDS);
+        options.add(DECODE_JSON_PARSER_ENABLED);
         return options;
     }
 
@@ -202,6 +203,7 @@ public class JsonFormatFactory implements DeserializationFormatFactory, Serializ
         options.add(MAP_NULL_KEY_LITERAL);
         options.add(ENCODE_DECIMAL_AS_PLAIN_NUMBER);
         options.add(ENCODE_IGNORE_NULL_FIELDS);
+        options.add(DECODE_JSON_PARSER_ENABLED);
         return options;
     }
 }

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonFormatFactoryTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonFormatFactoryTest.java
@@ -125,6 +125,13 @@ class JsonFormatFactoryTest {
         testSchemaDeserializationSchema(tableOptions);
     }
 
+    @Test
+    void testDecodeJsonParseEnabled() {
+        testJsonParserConfiguration(true, JsonParserRowDataDeserializationSchema.class);
+
+        testJsonParserConfiguration(false, JsonRowDataDeserializationSchema.class);
+    }
+
     // ------------------------------------------------------------------------
     //  Utilities
     // ------------------------------------------------------------------------
@@ -229,6 +236,38 @@ class JsonFormatFactoryTest {
         options.put("json.map-null-key.literal", "null");
         options.put("json.encode.decimal-as-plain-number", "true");
         options.put("json.encode.ignore-null-fields", "true");
+        options.put("json.decode.json-parser.enabled", "true");
         return options;
+    }
+
+    private void testJsonParserConfiguration(boolean enabled, Class<?> expectedClass) {
+        Map<String, String> options =
+                getModifyOptions(
+                        opt -> opt.put("json.decode.json-parser.enabled", String.valueOf(enabled)));
+
+        DeserializationSchema<RowData> actualDeser =
+                createTableSource(options)
+                        .valueFormat
+                        .createRuntimeDecoder(
+                                ScanRuntimeProviderContext.INSTANCE,
+                                SCHEMA.toPhysicalRowDataType());
+
+        DeserializationSchema<RowData> expectedDeser =
+                enabled
+                        ? new JsonParserRowDataDeserializationSchema(
+                                PHYSICAL_TYPE,
+                                InternalTypeInfo.of(PHYSICAL_TYPE),
+                                false,
+                                true,
+                                TimestampFormat.ISO_8601)
+                        : new JsonRowDataDeserializationSchema(
+                                PHYSICAL_TYPE,
+                                InternalTypeInfo.of(PHYSICAL_TYPE),
+                                false,
+                                true,
+                                TimestampFormat.ISO_8601);
+
+        assertThat(actualDeser).isInstanceOf(expectedClass);
+        assertThat(actualDeser).isEqualTo(expectedDeser);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

- Make configuration 'json.decode.json-parser.enabled' take effect. The configuration 'json.decode.json-parser.enabled'  will never take effect, because of this configuration has not been added in `org.apache.flink.formats.json.JsonFormatFactory#optionalOptions`.



## Brief change log

- Make configuration 'json.decode.json-parser.enabled' take effect. 


## Verifying this change

This change added tests and can be verified as follows:
- Added test `JsonFormatFactoryTest#testDecodeJsonParseEnabled`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
