### PR TITLE
[FLINK-36166][table-planner] Make the test 'testJoinDisorderChangeLog' work again

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableSinkITCase.scala
@@ -28,7 +28,7 @@ import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.S
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension
 
 import org.assertj.core.api.Assertions.{assertThat, assertThatThrownBy}
-import org.junit.jupiter.api.{BeforeEach, Disabled, TestTemplate}
+import org.junit.jupiter.api.{BeforeEach, TestTemplate}
 import org.junit.jupiter.api.extension.ExtendWith
 
 import java.time.Duration
@@ -96,7 +96,6 @@ class TableSinkITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
                        |""".stripMargin)
   }
 
-  @Disabled("FLINK-36166")
   @TestTemplate
   def testJoinDisorderChangeLog(): Unit = {
     tEnv.executeSql("""


### PR DESCRIPTION
## What is the purpose of the change

The reason for this test failure is the same as the `testSinkDisorderChangeLog` in [FLINK-36167](https://issues.apache.org/jira/browse/FLINK-36167). Since we have already fixed the root cause in [pr](https://github.com/apache/flink/pull/25892), we can safely remove the Disabled tag.

## Brief change log

  - *Remove the tag `Disabled` in this test*

## Verifying this change

Existent tests can cover this fix.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? 
