### PR TITLE
[FLINK-35019] support convert show create model sql to operation

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/ShowCreateUtil.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/ShowCreateUtil.java
@@ -55,16 +55,25 @@ public class ShowCreateUtil {
             ResolvedCatalogModel model, ObjectIdentifier modelIdentifier, boolean isTemporary) {
         StringBuilder sb =
                 new StringBuilder()
-                        .append(buildCreateModelFormattedPrefix(modelIdentifier, isTemporary));
+                        .append(buildCreateFormattedPrefix("MODEL", isTemporary, modelIdentifier));
         extractFormattedColumns(model.getResolvedInputSchema())
                 .ifPresent(
                         c -> sb.append(String.format("INPUT (%s)%s", c, System.lineSeparator())));
         extractFormattedColumns(model.getResolvedOutputSchema())
                 .ifPresent(
                         c -> sb.append(String.format("OUTPUT (%s)%s", c, System.lineSeparator())));
-        extractComment(model).ifPresent(c -> sb.append(formatComment(c)).append("\n"));
+        extractComment(model)
+                .ifPresent(c -> sb.append(formatComment(c)).append(System.lineSeparator()));
         extractFormattedOptions(model.getOptions(), PRINT_INDENT)
-                .ifPresent(v -> sb.append("WITH (\n").append(v).append("\n)\n"));
+                .ifPresent(
+                        v ->
+                                sb.append(String.format("WITH (%s", System.lineSeparator()))
+                                        .append(v)
+                                        .append(
+                                                String.format(
+                                                        "%s)%s",
+                                                        System.lineSeparator(),
+                                                        System.lineSeparator())));
         return sb.toString();
     }
 
@@ -141,21 +150,14 @@ public class ShowCreateUtil {
     }
 
     static String buildCreateFormattedPrefix(
-            String tableType, boolean isTemporary, ObjectIdentifier identifier) {
+            String type, boolean isTemporary, ObjectIdentifier identifier) {
+        String postName = "model".equalsIgnoreCase(type) ? "" : " (";
         return String.format(
-                "CREATE %s%s %s (%s",
+                "CREATE %s%s %s%s%s",
                 isTemporary ? "TEMPORARY " : "",
-                tableType,
+                type,
                 identifier.asSerializableString(),
-                System.lineSeparator());
-    }
-
-    static String buildCreateModelFormattedPrefix(
-            ObjectIdentifier modelIdentifier, boolean isTemporary) {
-        return String.format(
-                "CREATE %sMODEL %s%s",
-                isTemporary ? "TEMPORARY " : "",
-                modelIdentifier.asSerializableString(),
+                postName,
                 System.lineSeparator());
     }
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowCreateModelOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowCreateModelOperation.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.internal.ShowCreateUtil;
+import org.apache.flink.table.api.internal.TableResultInternal;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.ResolvedCatalogModel;
+
+import static org.apache.flink.table.api.internal.TableResultUtils.buildStringArrayResult;
+
+/** Operation to describe a SHOW CREATE MODEL statement. */
+@Internal
+public class ShowCreateModelOperation implements ShowOperation {
+
+    private final ObjectIdentifier modelIdentifier;
+    private final ResolvedCatalogModel model;
+    private final boolean isTemporary;
+
+    public ShowCreateModelOperation(
+            ObjectIdentifier sqlIdentifier, ResolvedCatalogModel model, boolean isTemporary) {
+        this.modelIdentifier = sqlIdentifier;
+        this.model = model;
+        this.isTemporary = isTemporary;
+    }
+
+    public ResolvedCatalogModel getModel() {
+        return model;
+    }
+
+    @Override
+    public String asSummaryString() {
+        return String.format("SHOW CREATE MODEL %s", modelIdentifier.asSummaryString());
+    }
+
+    @Override
+    public TableResultInternal execute(Context ctx) {
+        String resultRow =
+                ShowCreateUtil.buildShowCreateModelRow(model, modelIdentifier, isTemporary);
+        return buildStringArrayResult("result", new String[] {resultRow});
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverters.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverters.java
@@ -53,6 +53,7 @@ public class SqlNodeConverters {
         register(new SqlTruncateTableConverter());
         register(new SqlShowFunctionsConverter());
         register(new SqlShowModelsConverter());
+        register(new SqlShowCreateModelConverter());
         register(new SqlShowProcedureConverter());
         register(new SqlReplaceTableAsConverter());
         register(new SqlProcedureCallConverter());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlShowCreateModelConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlShowCreateModelConverter.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.table.planner.operations.converters;
 
 import org.apache.flink.sql.parser.dql.SqlShowCreateModel;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlShowCreateModelConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlShowCreateModelConverter.java
@@ -1,0 +1,34 @@
+package org.apache.flink.table.planner.operations.converters;
+
+import org.apache.flink.sql.parser.dql.SqlShowCreateModel;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.ContextResolvedModel;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.UnresolvedIdentifier;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.ShowCreateModelOperation;
+
+import java.util.Optional;
+
+/** A converter for {@link org.apache.flink.sql.parser.dql.SqlShowCreateModel}. */
+public class SqlShowCreateModelConverter implements SqlNodeConverter<SqlShowCreateModel> {
+
+    @Override
+    public Operation convertSqlNode(SqlShowCreateModel showCreateModel, ConvertContext context) {
+        UnresolvedIdentifier unresolvedIdentifier =
+                UnresolvedIdentifier.of(showCreateModel.getFullModelName());
+        ObjectIdentifier identifier =
+                context.getCatalogManager().qualifyIdentifier(unresolvedIdentifier);
+        Optional<ContextResolvedModel> model = context.getCatalogManager().getModel(identifier);
+
+        if (model.isEmpty()) {
+            throw new ValidationException(
+                    String.format(
+                            "Could not execute SHOW CREATE MODEL. Model with identifier %s does not exist.",
+                            identifier.asSerializableString()));
+        }
+
+        return new ShowCreateModelOperation(
+                identifier, model.get().getResolvedModel(), model.get().isTemporary());
+    }
+}

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
@@ -2990,6 +2990,47 @@ class TableEnvironmentTest {
   }
 
   @Test
+  def testShowCreateModelComplexTypes(): Unit = {
+    val sourceDDL =
+      """
+        |CREATE MODEL M1
+        |  INPUT(
+        |    f0 ARRAY<INT>,
+        |    f1 MAP<STRING, INT>,
+        |    f2 ROW<name STRING, age INT>,
+        |    f3 ROW<name STRING, address ROW<street STRING, city STRING>>,
+        |    f4 ARRAY<ROW<id INT, details ROW<color STRING, size INT>>>
+        |  )
+        |  OUTPUT(
+        |    f5 ARRAY<MAP<STRING, INT>>,
+        |    f6 ARRAY<ARRAY<STRING>>
+        |  )
+        |COMMENT 'this is a model'
+        |with (
+        |  'task' = 'clustering',
+        |  'provider' = 'openai',
+        |  'openai.endpoint' = 'some-endpoint'
+        |)
+      """.stripMargin
+
+    tableEnv.executeSql(sourceDDL)
+
+    val expectedDDL =
+      """|CREATE MODEL `default_catalog`.`default_database`.`M1`
+         |INPUT (`f0` ARRAY<INT>, `f1` MAP<VARCHAR(2147483647), INT>, `f2` ROW<`name` VARCHAR(2147483647), `age` INT>, `f3` ROW<`name` VARCHAR(2147483647), `address` ROW<`street` VARCHAR(2147483647), `city` VARCHAR(2147483647)>>, `f4` ARRAY<ROW<`id` INT, `details` ROW<`color` VARCHAR(2147483647), `size` INT>>>)
+         |OUTPUT (`f5` ARRAY<MAP<VARCHAR(2147483647), INT>>, `f6` ARRAY<ARRAY<VARCHAR(2147483647)>>)
+         |COMMENT 'this is a model'
+         |WITH (
+         |  'openai.endpoint' = 'some-endpoint',
+         |  'provider' = 'openai',
+         |  'task' = 'clustering'
+         |)
+         |""".stripMargin
+    val row = tableEnv.executeSql("SHOW CREATE MODEL M1").collect().next()
+    assertEquals(expectedDDL, row.getField(0))
+  }
+
+  @Test
   def testShowCreateTemporaryModel(): Unit = {
     val sourceDDL =
       """

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
@@ -2985,7 +2985,7 @@ class TableEnvironmentTest {
          |  'task' = 'clustering'
          |)
          |""".stripMargin
-    val row = tableEnv.executeSql("show create MODEL M1").collect().next()
+    val row = tableEnv.executeSql("SHOW CREATE MODEL M1").collect().next()
     assertEquals(expectedDDL, row.getField(0))
   }
 
@@ -3017,7 +3017,7 @@ class TableEnvironmentTest {
          |  'task' = 'clustering'
          |)
          |""".stripMargin
-    val row = tableEnv.executeSql("show create MODEL M1").collect().next()
+    val row = tableEnv.executeSql("SHOW CREATE MODEL M1").collect().next()
     assertEquals(expectedDDL, row.getField(0))
   }
 
@@ -3025,7 +3025,7 @@ class TableEnvironmentTest {
   def testShowCreateNonExistModel(): Unit = {
     assertThatThrownBy(() => tableEnv.executeSql("SHOW CREATE MODEL M1"))
       .isInstanceOf(classOf[ValidationException])
-      .hasMessageContaining(
+      .hasMessage(
         "Could not execute SHOW CREATE MODEL. Model with identifier `default_catalog`.`default_database`.`M1` does not exist.")
   }
 
@@ -3053,7 +3053,7 @@ class TableEnvironmentTest {
          |  'task' = 'clustering'
          |)
          |""".stripMargin
-    val row = tableEnv.executeSql("show create MODEL M1").collect().next()
+    val row = tableEnv.executeSql("SHOW CREATE MODEL M1").collect().next()
     assertEquals(expectedDDL, row.getField(0))
   }
 
@@ -3083,7 +3083,7 @@ class TableEnvironmentTest {
          |  'task' = 'clustering'
          |)
          |""".stripMargin
-    val row = tableEnv.executeSql("show create MODEL M1").collect().next()
+    val row = tableEnv.executeSql("SHOW CREATE MODEL M1").collect().next()
     assertEquals(expectedDDL, row.getField(0))
   }
 


### PR DESCRIPTION
## What is the purpose of the change

support convert `show create model` sql to operation.


## Brief change log

* Add converter to convert `show create model` sql to operation.


## Verifying this change

Unit test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
