### PR TITLE
[FLINK-37702][ci] Ensure Python setup/headers for Python tests

### DIFF
--- a/tools/azure-pipelines/jobs-template.yml
+++ b/tools/azure-pipelines/jobs-template.yml
@@ -108,6 +108,13 @@ jobs:
     condition: not(eq('${{parameters.test_pool_definition.name}}', 'Default'))
     displayName: Free up disk space
 
+  # Ensure Python devel headers for Python tests
+  - script: |
+      sudo apt-get update
+      sudo apt-get install -y python3-dev
+    condition: eq(variables['module'], 'python')
+    displayName: Install Python development headers
+
   # download artifact from compile stage
   - task: DownloadPipelineArtifact@2
     inputs:


### PR DESCRIPTION
## What is the purpose of the change

This change ensures that Python installation (Python.h headers, etc) are available during tests, regardless of whether the underlying CI machine has Python installed or not. We already do this in the [e2e template](https://github.com/apache/flink/blob/master/tools/azure-pipelines/e2e-template.yml#L51:L53) .

## Brief change log

- *Added `UsePythonVersion` step for Azure Pipelines Python tests*