### PR TITLE
[FLINK-37778][1/N] introduce MODEL keyword for model as argument

### DIFF
--- a/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
@@ -666,6 +666,7 @@
   # Example: DateFunctionCall().
   builtinFunctionCallMethods: [
     "TryCastFunctionCall()"
+    "ExplicitModel()"
   ]
 
   # List of methods for parsing extensions to "ALTER <scope>" calls.

--- a/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
@@ -158,6 +158,7 @@
     "org.apache.calcite.sql.SqlAlienSystemTypeNameSpec"
     "org.apache.calcite.sql.SqlCreate"
     "org.apache.calcite.sql.SqlDrop"
+    "org.apache.calcite.sql.SqlExplicitModelOperator"
     "org.apache.calcite.sql.SqlIntervalLiteral"
     "java.util.ArrayList"
     "java.util.Collections"

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -3090,6 +3090,22 @@ SqlNode TryCastFunctionCall() :
 }
 
 /**
+ * Parses an explicit Model m reference.
+ */
+SqlNode ExplicitModel() :
+{
+    SqlNode modelRef;
+    final Span s;
+}
+{
+    <MODEL> modelRef = CompoundIdentifier()
+    {
+        s = span();
+        return new SqlExplicitModelOperator(2, null, null, null).createCall(s.pos(), modelRef);
+    }
+}
+
+/**
 * Parses a partition key/value,
 * e.g. p or p = '10'.
 */

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -3101,7 +3101,7 @@ SqlNode ExplicitModel() :
     <MODEL> modelRef = CompoundIdentifier()
     {
         s = span();
-        return new SqlExplicitModelOperator(2, null, null, null).createCall(s.pos(), modelRef);
+        return new SqlExplicitModelOperator(2).createCall(s.pos(), modelRef);
     }
 }
 

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/calcite/sql/SqlExplicitModelCall.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/calcite/sql/SqlExplicitModelCall.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.calcite.sql;
+
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.List;
+
+/** SqlExplicitModelCall is a SQL call that represents an explicit model. */
+public class SqlExplicitModelCall extends SqlBasicCall {
+
+    public SqlExplicitModelCall(
+            SqlOperator operator,
+            List<? extends @Nullable SqlNode> operandList,
+            SqlParserPos pos,
+            @Nullable SqlLiteral functionQualifier) {
+        super(operator, operandList, pos, functionQualifier);
+    }
+}

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/calcite/sql/SqlExplicitModelOperator.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/calcite/sql/SqlExplicitModelOperator.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.calcite.sql;
+
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.type.SqlOperandTypeChecker;
+import org.apache.calcite.sql.type.SqlOperandTypeInference;
+import org.apache.calcite.sql.type.SqlReturnTypeInference;
+import org.apache.calcite.util.ImmutableNullableList;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/** SqlExplicitModelOperator is a SQL operator that represents an explicit model. */
+public class SqlExplicitModelOperator extends SqlPrefixOperator {
+
+    public SqlExplicitModelOperator(
+            int prec,
+            @Nullable SqlReturnTypeInference returnTypeInference,
+            @Nullable SqlOperandTypeInference operandTypeInference,
+            @Nullable SqlOperandTypeChecker operandTypeChecker) {
+        super(
+                "MODEL",
+                SqlKind.OTHER_FUNCTION,
+                prec,
+                returnTypeInference,
+                operandTypeInference,
+                operandTypeChecker);
+    }
+
+    @Override
+    public SqlCall createCall(
+            @Nullable SqlLiteral functionQualifier,
+            SqlParserPos pos,
+            @Nullable SqlNode... operands) {
+        pos = pos.plusAll(operands);
+        return new SqlExplicitModelCall(
+                this, ImmutableNullableList.copyOf(operands), pos, functionQualifier);
+    }
+}

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/calcite/sql/SqlExplicitModelOperator.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/calcite/sql/SqlExplicitModelOperator.java
@@ -18,27 +18,14 @@
 package org.apache.calcite.sql;
 
 import org.apache.calcite.sql.parser.SqlParserPos;
-import org.apache.calcite.sql.type.SqlOperandTypeChecker;
-import org.apache.calcite.sql.type.SqlOperandTypeInference;
-import org.apache.calcite.sql.type.SqlReturnTypeInference;
 import org.apache.calcite.util.ImmutableNullableList;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /** SqlExplicitModelOperator is a SQL operator that represents an explicit model. */
 public class SqlExplicitModelOperator extends SqlPrefixOperator {
 
-    public SqlExplicitModelOperator(
-            int prec,
-            @Nullable SqlReturnTypeInference returnTypeInference,
-            @Nullable SqlOperandTypeInference operandTypeInference,
-            @Nullable SqlOperandTypeChecker operandTypeChecker) {
-        super(
-                "MODEL",
-                SqlKind.OTHER_FUNCTION,
-                prec,
-                returnTypeInference,
-                operandTypeInference,
-                operandTypeChecker);
+    public SqlExplicitModelOperator(int prec) {
+        super("MODEL", SqlKind.OTHER_FUNCTION, prec, null, null, null);
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -3360,6 +3360,22 @@ class FlinkSqlParserImplTest extends SqlParserTest {
                                         "CREATE MODEL AS SELECT syntax does not support to specify explicit output columns."));
     }
 
+    @Test
+    void testModelInFunction() {
+        sql("select * from table(ml_predict(TABLE my_table, MODEL my_model))")
+                .ok(
+                        "SELECT *\n"
+                                + "FROM TABLE(`ML_PREDICT`((TABLE `MY_TABLE`), MODEL `MY_MODEL`))");
+    }
+
+    @Test
+    void testModelInFunctionWithoutTable() {
+        sql("select * from func(TABLE my_table, MODEL cat.db.my_model)")
+                .ok(
+                        "SELECT *\n"
+                                + "FROM TABLE(`FUNC`((TABLE `MY_TABLE`), MODEL `CAT`.`DB`.`MY_MODEL`))");
+    }
+
     /*
      * This test was backported from Calcite 1.38 (CALCITE-6266).
      * Remove it together with upgrade to Calcite 1.38.


### PR DESCRIPTION
## What is the purpose of the change

Parse `MODEL` keyword in function argument and convert it to `SqlExplicitModelCall` with `SqlExplicitModelOperator`.

## Brief change log

* Parser changes to support `MODEL` keyword in function argument.
* `SqlExplicitModelCall` sql node for model argument
* `SqlExplicitModelOperator` sql operator

## Verifying this change

Added unit test for parser changes

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
