### PR TITLE
[hotfix] Remove unnecessary java.io.Serializable

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractStateBackend.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  * users.
  */
 @PublicEvolving
-public abstract class AbstractStateBackend implements StateBackend, java.io.Serializable {
+public abstract class AbstractStateBackend implements StateBackend {
 
     private static final long serialVersionUID = 4620415814639230247L;
 


### PR DESCRIPTION
## What is the purpose of the change

This PR proposes to remove unnecessary `java.io.Serializable`.
Since `StateBackend` already extends `java.io.Serializable`.


## Brief change log

Remove unnecessary `java.io.Serializable`.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
