### PR TITLE
[hotfix] Remove unnecessary StateBackend

### DIFF
--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/AbstractChangelogStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/AbstractChangelogStateBackend.java
@@ -44,12 +44,11 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
- * An abstract base implementation of the {@link StateBackend} interface whose subclasses use
- * delegatedStateBackend and State changes to restore.
+ * An abstract base implementation of the {@link DelegatingStateBackend} interface whose subclasses
+ * use delegatedStateBackend and State changes to restore.
  */
 @Internal
-public abstract class AbstractChangelogStateBackend
-        implements DelegatingStateBackend, StateBackend {
+public abstract class AbstractChangelogStateBackend implements DelegatingStateBackend {
 
     private static final long serialVersionUID = 1000L;
 


### PR DESCRIPTION
## What is the purpose of the change

This PR proposes to remove unnecessary `StateBackend`.
Since `DelegatingStateBackend` already extends `StateBackend`.


## Brief change log

Remove unnecessary `StateBackend`.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
