### PR TITLE
[FLINK-37545][metrics] Fix StackOverflowError when using MetricGroup in custom WatermarkStrategy (2.0)

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/TimestampsAndWatermarksOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/TimestampsAndWatermarksOperator.java
@@ -99,7 +99,8 @@ public class TimestampsAndWatermarksOperator<T> extends AbstractStreamOperator<T
                                 new WatermarkGeneratorSupplier.Context() {
                                     @Override
                                     public MetricGroup getMetricGroup() {
-                                        return this.getMetricGroup();
+                                        return TimestampsAndWatermarksOperator.this
+                                                .getMetricGroup();
                                     }
 
                                     @Override


### PR DESCRIPTION
backport of https://github.com/apache/flink/pull/26539 to 2.0