### PR TITLE
[FLINK-37545][metrics] Fix StackOverflowError when using MetricGroup in custom WatermarkStrategy (1.20)

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/TimestampsAndWatermarksOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/TimestampsAndWatermarksOperator.java
@@ -97,7 +97,8 @@ public class TimestampsAndWatermarksOperator<T> extends AbstractStreamOperator<T
                                 new WatermarkGeneratorSupplier.Context() {
                                     @Override
                                     public MetricGroup getMetricGroup() {
-                                        return this.getMetricGroup();
+                                        return TimestampsAndWatermarksOperator.this
+                                                .getMetricGroup();
                                     }
 
                                     @Override


### PR DESCRIPTION
backport of https://github.com/apache/flink/pull/26539 to 2.0