### PR TITLE
[FLINK-37779][2/N] extend catalog schema reader to get model

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/calcite/jdbc/SimpleCalciteSchema.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/calcite/jdbc/SimpleCalciteSchema.java
@@ -1,0 +1,305 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.jdbc;
+
+import org.apache.flink.table.planner.catalog.CatalogSchemaModel;
+import org.apache.flink.table.planner.catalog.FlinkSchema;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.ImmutableSortedSet;
+import org.apache.calcite.rel.type.RelProtoDataType;
+import org.apache.calcite.schema.Function;
+import org.apache.calcite.schema.Schema;
+import org.apache.calcite.schema.SchemaVersion;
+import org.apache.calcite.schema.Table;
+import org.apache.calcite.schema.TableMacro;
+import org.apache.calcite.util.NameMap;
+import org.apache.calcite.util.NameMultimap;
+import org.apache.calcite.util.NameSet;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * A concrete implementation of {@link org.apache.calcite.jdbc.CalciteSchema} that maintains minimal
+ * state. This is copied from {@link org.apache.calcite.jdbc.CalciteSchema} calcite and modified to
+ * support getModel operation.
+ */
+public class SimpleCalciteSchema extends CalciteSchema {
+
+    // ----- FLINK MODIFICATION START -----
+    public static class ModelEntry extends Entry {
+        private final CatalogSchemaModel model;
+
+        ModelEntry(CalciteSchema schema, String name, CatalogSchemaModel model) {
+            super(schema, name);
+            this.model = model;
+        }
+
+        public CatalogSchemaModel getModel() {
+            return model;
+        }
+    }
+
+    // ----- FLINK MODIFICATION END -----
+
+    /**
+     * Creates a SimpleCalciteSchema.
+     *
+     * <p>Use {@link CalciteSchema#createRootSchema(boolean)} or {@link #add(String, Schema)}.
+     */
+    SimpleCalciteSchema(@Nullable CalciteSchema parent, Schema schema, String name) {
+        this(parent, schema, name, null, null, null, null, null, null, null, null);
+    }
+
+    private SimpleCalciteSchema(
+            @Nullable CalciteSchema parent,
+            Schema schema,
+            String name,
+            @Nullable NameMap<CalciteSchema> subSchemaMap,
+            @Nullable NameMap<TableEntry> tableMap,
+            @Nullable NameMap<LatticeEntry> latticeMap,
+            @Nullable NameMap<TypeEntry> typeMap,
+            @Nullable NameMultimap<FunctionEntry> functionMap,
+            @Nullable NameSet functionNames,
+            @Nullable NameMap<FunctionEntry> nullaryFunctionMap,
+            @Nullable List<? extends List<String>> path) {
+        super(
+                parent,
+                schema,
+                name,
+                subSchemaMap,
+                tableMap,
+                latticeMap,
+                typeMap,
+                functionMap,
+                functionNames,
+                nullaryFunctionMap,
+                path);
+    }
+
+    @Override
+    public void setCache(boolean cache) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CalciteSchema add(String name, Schema schema) {
+        final CalciteSchema calciteSchema = new SimpleCalciteSchema(this, schema, name);
+        subSchemaMap.put(name, calciteSchema);
+        return calciteSchema;
+    }
+
+    private static @Nullable String caseInsensitiveLookup(Set<String> candidates, String name) {
+        // Exact string lookup
+        if (candidates.contains(name)) {
+            return name;
+        }
+        // Upper case string lookup
+        final String upperCaseName = name.toUpperCase(Locale.ROOT);
+        if (candidates.contains(upperCaseName)) {
+            return upperCaseName;
+        }
+        // Lower case string lookup
+        final String lowerCaseName = name.toLowerCase(Locale.ROOT);
+        if (candidates.contains(lowerCaseName)) {
+            return lowerCaseName;
+        }
+        // Fall through: Set iteration
+        for (String candidate : candidates) {
+            if (candidate.equalsIgnoreCase(name)) {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    protected @Nullable CalciteSchema getImplicitSubSchema(
+            String schemaName, boolean caseSensitive) {
+        // Check implicit schemas.
+        final String schemaName2 =
+                caseSensitive
+                        ? schemaName
+                        : caseInsensitiveLookup(schema.getSubSchemaNames(), schemaName);
+        if (schemaName2 == null) {
+            return null;
+        }
+        final Schema s = schema.getSubSchema(schemaName2);
+        if (s == null) {
+            return null;
+        }
+        return new SimpleCalciteSchema(this, s, schemaName2);
+    }
+
+    @Override
+    protected @Nullable TableEntry getImplicitTable(String tableName, boolean caseSensitive) {
+        // Check implicit tables.
+        final String tableName2 =
+                caseSensitive
+                        ? tableName
+                        : caseInsensitiveLookup(schema.getTableNames(), tableName);
+        if (tableName2 == null) {
+            return null;
+        }
+        final Table table = schema.getTable(tableName2);
+        if (table == null) {
+            return null;
+        }
+        return tableEntry(tableName2, table);
+    }
+
+    // ----- FLINK MODIFICATION START -----
+    public @Nullable ModelEntry getModel(String modelName, boolean caseSensitive) {
+        FlinkSchema flinkSchema = (FlinkSchema) schema;
+        final String modelName2 =
+                caseSensitive
+                        ? modelName
+                        : caseInsensitiveLookup(flinkSchema.getModelNames(), modelName);
+        if (modelName2 == null) {
+            return null;
+        }
+        final CatalogSchemaModel model = flinkSchema.getModel(modelName2);
+        if (model == null) {
+            return null;
+        }
+        return new ModelEntry(this, modelName2, model);
+    }
+
+    // ----- FLINK MODIFICATION END -----
+
+    @Override
+    protected @Nullable TypeEntry getImplicitType(String name, boolean caseSensitive) {
+        // Check implicit types.
+        final String name2 =
+                caseSensitive ? name : caseInsensitiveLookup(schema.getTypeNames(), name);
+        if (name2 == null) {
+            return null;
+        }
+        final RelProtoDataType type = schema.getType(name2);
+        if (type == null) {
+            return null;
+        }
+        return typeEntry(name2, type);
+    }
+
+    @Override
+    protected void addImplicitSubSchemaToBuilder(
+            ImmutableSortedMap.Builder<String, CalciteSchema> builder) {
+        ImmutableSortedMap<String, CalciteSchema> explicitSubSchemas = builder.build();
+        for (String schemaName : schema.getSubSchemaNames()) {
+            if (explicitSubSchemas.containsKey(schemaName)) {
+                // explicit subschema wins.
+                continue;
+            }
+            Schema s = schema.getSubSchema(schemaName);
+            if (s != null) {
+                CalciteSchema calciteSchema = new SimpleCalciteSchema(this, s, schemaName);
+                builder.put(schemaName, calciteSchema);
+            }
+        }
+    }
+
+    @Override
+    protected void addImplicitTableToBuilder(ImmutableSortedSet.Builder<String> builder) {
+        builder.addAll(schema.getTableNames());
+    }
+
+    @Override
+    protected void addImplicitFunctionsToBuilder(
+            ImmutableList.Builder<Function> builder, String name, boolean caseSensitive) {
+        Collection<Function> functions = schema.getFunctions(name);
+        if (functions != null) {
+            builder.addAll(functions);
+        }
+    }
+
+    @Override
+    protected void addImplicitFuncNamesToBuilder(ImmutableSortedSet.Builder<String> builder) {
+        builder.addAll(schema.getFunctionNames());
+    }
+
+    @Override
+    protected void addImplicitTypeNamesToBuilder(ImmutableSortedSet.Builder<String> builder) {
+        builder.addAll(schema.getTypeNames());
+    }
+
+    @Override
+    protected void addImplicitTablesBasedOnNullaryFunctionsToBuilder(
+            ImmutableSortedMap.Builder<String, Table> builder) {
+        ImmutableSortedMap<String, Table> explicitTables = builder.build();
+
+        for (String s : schema.getFunctionNames()) {
+            // explicit table wins.
+            if (explicitTables.containsKey(s)) {
+                continue;
+            }
+            for (Function function : schema.getFunctions(s)) {
+                if (function instanceof TableMacro && function.getParameters().isEmpty()) {
+                    final Table table = ((TableMacro) function).apply(ImmutableList.of());
+                    builder.put(s, table);
+                }
+            }
+        }
+    }
+
+    @Override
+    protected @Nullable TableEntry getImplicitTableBasedOnNullaryFunction(
+            String tableName, boolean caseSensitive) {
+        Collection<Function> functions = schema.getFunctions(tableName);
+        if (functions != null) {
+            for (Function function : functions) {
+                if (function instanceof TableMacro && function.getParameters().isEmpty()) {
+                    final Table table = ((TableMacro) function).apply(ImmutableList.of());
+                    return tableEntry(tableName, table);
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    protected CalciteSchema snapshot(@Nullable CalciteSchema parent, SchemaVersion version) {
+        CalciteSchema snapshot =
+                new SimpleCalciteSchema(
+                        parent,
+                        schema.snapshot(version),
+                        name,
+                        null,
+                        tableMap,
+                        latticeMap,
+                        typeMap,
+                        functionMap,
+                        functionNames,
+                        nullaryFunctionMap,
+                        getPath());
+        for (CalciteSchema subSchema : subSchemaMap.map().values()) {
+            CalciteSchema subSchemaSnapshot = subSchema.snapshot(snapshot, version);
+            snapshot.subSchemaMap.put(subSchema.name, subSchemaSnapshot);
+        }
+        return snapshot;
+    }
+
+    @Override
+    protected boolean isCacheEnabled() {
+        return false;
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/catalog/CatalogCalciteSchema.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/catalog/CatalogCalciteSchema.java
@@ -98,6 +98,11 @@ public class CatalogCalciteSchema extends FlinkSchema {
     }
 
     @Override
+    public CatalogSchemaModel getModel(String name) {
+        return null;
+    }
+
+    @Override
     public FlinkSchema copy() {
         return new CatalogCalciteSchema(catalogName, catalogManager, isStreamingMode);
     }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/catalog/CatalogManagerCalciteSchema.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/catalog/CatalogManagerCalciteSchema.java
@@ -91,6 +91,11 @@ public class CatalogManagerCalciteSchema extends FlinkSchema {
     }
 
     @Override
+    public CatalogSchemaModel getModel(String name) {
+        return null;
+    }
+
+    @Override
     public FlinkSchema copy() {
         return new CatalogManagerCalciteSchema(catalogManager, isStreamingMode);
     }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/catalog/CatalogSchemaModel.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/catalog/CatalogSchemaModel.java
@@ -79,28 +79,25 @@ public class CatalogSchemaModel {
         final FlinkTypeFactory flinkTypeFactory = (FlinkTypeFactory) typeFactory;
         final ResolvedSchema schema =
                 contextResolvedModel.getResolvedModel().getResolvedInputSchema();
-
-        final List<String> fieldNames = schema.getColumnNames();
-        final List<LogicalType> fieldTypes =
-                schema.getColumnDataTypes().stream()
-                        .map(DataType::getLogicalType)
-                        .map(PlannerTypeUtils::removeLegacyTypes)
-                        .collect(Collectors.toList());
-        return flinkTypeFactory.buildRelNodeRowType(fieldNames, fieldTypes);
+        return schemaToRelDataType(flinkTypeFactory, schema);
     }
 
     public RelDataType getOutputRowType(RelDataTypeFactory typeFactory) {
         final FlinkTypeFactory flinkTypeFactory = (FlinkTypeFactory) typeFactory;
         final ResolvedSchema schema =
                 contextResolvedModel.getResolvedModel().getResolvedOutputSchema();
+        return schemaToRelDataType(flinkTypeFactory, schema);
+    }
 
+    private static RelDataType schemaToRelDataType(
+            FlinkTypeFactory typeFactory, ResolvedSchema schema) {
         final List<String> fieldNames = schema.getColumnNames();
         final List<LogicalType> fieldTypes =
                 schema.getColumnDataTypes().stream()
                         .map(DataType::getLogicalType)
                         .map(PlannerTypeUtils::removeLegacyTypes)
                         .collect(Collectors.toList());
-        return flinkTypeFactory.buildRelNodeRowType(fieldNames, fieldTypes);
+        return typeFactory.buildRelNodeRowType(fieldNames, fieldTypes);
     }
 
     public FlinkStatistic getStatistic() {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/catalog/CatalogSchemaModel.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/catalog/CatalogSchemaModel.java
@@ -21,7 +21,6 @@ package org.apache.flink.table.planner.catalog;
 import org.apache.flink.table.catalog.ContextResolvedModel;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
-import org.apache.flink.table.planner.plan.stats.FlinkStatistic;
 import org.apache.flink.table.runtime.types.PlannerTypeUtils;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -40,8 +39,6 @@ public class CatalogSchemaModel {
     // ~ Instance fields --------------------------------------------------------
 
     private final ContextResolvedModel contextResolvedModel;
-    private final FlinkStatistic statistic;
-    private final boolean isStreamingMode;
 
     // ~ Constructors -----------------------------------------------------------
 
@@ -49,16 +46,9 @@ public class CatalogSchemaModel {
      * Create a CatalogSchemaModel instance.
      *
      * @param contextResolvedModel A result of catalog lookup
-     * @param statistic Model statistics
-     * @param isStreaming If the model is for streaming mode
      */
-    public CatalogSchemaModel(
-            ContextResolvedModel contextResolvedModel,
-            FlinkStatistic statistic,
-            boolean isStreaming) {
+    public CatalogSchemaModel(ContextResolvedModel contextResolvedModel) {
         this.contextResolvedModel = contextResolvedModel;
-        this.statistic = statistic;
-        this.isStreamingMode = isStreaming;
     }
 
     // ~ Methods ----------------------------------------------------------------
@@ -69,10 +59,6 @@ public class CatalogSchemaModel {
 
     public boolean isTemporary() {
         return contextResolvedModel.isTemporary();
-    }
-
-    public boolean isStreamingMode() {
-        return isStreamingMode;
     }
 
     public RelDataType getInputRowType(RelDataTypeFactory typeFactory) {
@@ -98,9 +84,5 @@ public class CatalogSchemaModel {
                         .map(PlannerTypeUtils::removeLegacyTypes)
                         .collect(Collectors.toList());
         return typeFactory.buildRelNodeRowType(fieldNames, fieldTypes);
-    }
-
-    public FlinkStatistic getStatistic() {
-        return statistic;
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/catalog/CatalogSchemaModel.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/catalog/CatalogSchemaModel.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.catalog;
+
+import org.apache.flink.table.catalog.ContextResolvedModel;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.planner.plan.stats.FlinkStatistic;
+import org.apache.flink.table.runtime.types.PlannerTypeUtils;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Represents a wrapper for {@link ContextResolvedModel} in {@link
+ * org.apache.calcite.schema.Schema}.
+ */
+public class CatalogSchemaModel {
+    // ~ Instance fields --------------------------------------------------------
+
+    private final ContextResolvedModel contextResolvedModel;
+    private final FlinkStatistic statistic;
+    private final boolean isStreamingMode;
+
+    // ~ Constructors -----------------------------------------------------------
+
+    /**
+     * Create a CatalogSchemaModel instance.
+     *
+     * @param contextResolvedModel A result of catalog lookup
+     * @param statistic Model statistics
+     * @param isStreaming If the model is for streaming mode
+     */
+    public CatalogSchemaModel(
+            ContextResolvedModel contextResolvedModel,
+            FlinkStatistic statistic,
+            boolean isStreaming) {
+        this.contextResolvedModel = contextResolvedModel;
+        this.statistic = statistic;
+        this.isStreamingMode = isStreaming;
+    }
+
+    // ~ Methods ----------------------------------------------------------------
+
+    public ContextResolvedModel getContextResolvedModel() {
+        return contextResolvedModel;
+    }
+
+    public boolean isTemporary() {
+        return contextResolvedModel.isTemporary();
+    }
+
+    public boolean isStreamingMode() {
+        return isStreamingMode;
+    }
+
+    public RelDataType getInputRowType(RelDataTypeFactory typeFactory) {
+        final FlinkTypeFactory flinkTypeFactory = (FlinkTypeFactory) typeFactory;
+        final ResolvedSchema schema =
+                contextResolvedModel.getResolvedModel().getResolvedInputSchema();
+
+        final List<String> fieldNames = schema.getColumnNames();
+        final List<LogicalType> fieldTypes =
+                schema.getColumnDataTypes().stream()
+                        .map(DataType::getLogicalType)
+                        .map(PlannerTypeUtils::removeLegacyTypes)
+                        .collect(Collectors.toList());
+        return flinkTypeFactory.buildRelNodeRowType(fieldNames, fieldTypes);
+    }
+
+    public RelDataType getOutputRowType(RelDataTypeFactory typeFactory) {
+        final FlinkTypeFactory flinkTypeFactory = (FlinkTypeFactory) typeFactory;
+        final ResolvedSchema schema =
+                contextResolvedModel.getResolvedModel().getResolvedOutputSchema();
+
+        final List<String> fieldNames = schema.getColumnNames();
+        final List<LogicalType> fieldTypes =
+                schema.getColumnDataTypes().stream()
+                        .map(DataType::getLogicalType)
+                        .map(PlannerTypeUtils::removeLegacyTypes)
+                        .collect(Collectors.toList());
+        return flinkTypeFactory.buildRelNodeRowType(fieldNames, fieldTypes);
+    }
+
+    public FlinkStatistic getStatistic() {
+        return statistic;
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/catalog/DatabaseCalciteSchema.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/catalog/DatabaseCalciteSchema.java
@@ -69,6 +69,21 @@ class DatabaseCalciteSchema extends FlinkSchema {
     }
 
     @Override
+    public CatalogSchemaModel getModel(String modelName) {
+        final ObjectIdentifier identifier =
+                ObjectIdentifier.of(catalogName, databaseName, modelName);
+        return catalogManager
+                .getModel(identifier)
+                .map(
+                        contextResolvedModel ->
+                                new CatalogSchemaModel(
+                                        contextResolvedModel,
+                                        FlinkStatistic.UNKNOWN(),
+                                        isStreamingMode))
+                .orElse(null);
+    }
+
+    @Override
     public Table getTable(String tableName) {
         final ObjectIdentifier identifier =
                 ObjectIdentifier.of(catalogName, databaseName, tableName);
@@ -133,6 +148,11 @@ class DatabaseCalciteSchema extends FlinkSchema {
                             tablePath.getObjectName()),
                     e);
         }
+    }
+
+    @Override
+    public Set<String> getModelNames() {
+        return catalogManager.listModels(catalogName, databaseName);
     }
 
     @Override

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/catalog/DatabaseCalciteSchema.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/catalog/DatabaseCalciteSchema.java
@@ -72,15 +72,7 @@ class DatabaseCalciteSchema extends FlinkSchema {
     public CatalogSchemaModel getModel(String modelName) {
         final ObjectIdentifier identifier =
                 ObjectIdentifier.of(catalogName, databaseName, modelName);
-        return catalogManager
-                .getModel(identifier)
-                .map(
-                        contextResolvedModel ->
-                                new CatalogSchemaModel(
-                                        contextResolvedModel,
-                                        FlinkStatistic.UNKNOWN(),
-                                        isStreamingMode))
-                .orElse(null);
+        return catalogManager.getModel(identifier).map(CatalogSchemaModel::new).orElse(null);
     }
 
     @Override

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/catalog/FlinkSchema.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/catalog/FlinkSchema.java
@@ -55,6 +55,12 @@ public abstract class FlinkSchema implements Schema {
         return Collections.emptySet();
     }
 
+    public abstract CatalogSchemaModel getModel(String name);
+
+    public Set<String> getModelNames() {
+        return Collections.emptySet();
+    }
+
     @Override
     public Schema snapshot(SchemaVersion version) {
         FlinkSchema schema = this.copy();

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/FlinkCalciteCatalogReader.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/FlinkCalciteCatalogReader.java
@@ -49,7 +49,8 @@ import org.apache.flink.table.planner.plan.schema.LegacyTableSourceTable;
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic;
 import org.apache.flink.table.utils.TableSchemaUtils;
 
-import com.google.common.collect.Iterables;
+import org.apache.flink.shaded.guava33.com.google.common.collect.Iterables;
+
 import org.apache.calcite.config.CalciteConnectionConfig;
 import org.apache.calcite.jdbc.CalciteSchema;
 import org.apache.calcite.plan.RelOptSchema;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/FlinkCalciteCatalogReader.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/FlinkCalciteCatalogReader.java
@@ -122,6 +122,10 @@ public class FlinkCalciteCatalogReader extends CalciteCatalogReader {
                 continue;
             }
 
+            if (!(schema.schema instanceof FlinkSchema)) {
+                throw new ValidationException("getModel() only supports FlinkSchema.");
+            }
+
             FlinkSchema flinkSchema = (FlinkSchema) schema.schema;
             CatalogSchemaModel model = flinkSchema.getModel(Util.last(names));
             if (model != null) {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/FlinkCalciteCatalogReaderTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/FlinkCalciteCatalogReaderTest.java
@@ -18,17 +18,25 @@
 
 package org.apache.flink.table.planner.plan;
 
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.CatalogModel;
 import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ConnectorCatalogTable;
+import org.apache.flink.table.catalog.ContextResolvedModel;
 import org.apache.flink.table.catalog.ContextResolvedTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.ResolvedCatalogModel;
 import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.expressions.DefaultSqlFactory;
 import org.apache.flink.table.legacy.api.TableSchema;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.planner.calcite.FlinkTypeSystem;
+import org.apache.flink.table.planner.catalog.CatalogSchemaModel;
 import org.apache.flink.table.planner.catalog.CatalogSchemaTable;
+import org.apache.flink.table.planner.catalog.FlinkSchema;
 import org.apache.flink.table.planner.plan.schema.FlinkPreparingTableBase;
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic;
 import org.apache.flink.table.planner.utils.TestTableSource;
@@ -37,17 +45,25 @@ import org.apache.flink.table.utils.CatalogManagerMocks;
 import org.apache.calcite.config.CalciteConnectionConfigImpl;
 import org.apache.calcite.config.CalciteConnectionProperty;
 import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.jdbc.CalciteSchemaBuilder;
+import org.apache.calcite.linq4j.tree.Expression;
 import org.apache.calcite.prepare.Prepare;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.schema.Schema;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.schema.Table;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -57,6 +73,7 @@ class FlinkCalciteCatalogReaderTest {
             new FlinkTypeFactory(
                     Thread.currentThread().getContextClassLoader(), FlinkTypeSystem.INSTANCE);
     private final String tableMockName = "ts";
+    private final String modelMockName = "ms";
 
     private SchemaPlus rootSchemaPlus;
     private FlinkCalciteCatalogReader catalogReader;
@@ -112,5 +129,116 @@ class FlinkCalciteCatalogReaderTest {
         Prepare.PreparingTable resultTable =
                 catalogReader.getTable(Collections.singletonList(tableMockName));
         assertThat(resultTable).isNotInstanceOf(FlinkPreparingTableBase.class);
+    }
+
+    @Test
+    void testGetCatalogSchemaModel() {
+        // Mock CatalogSchemaModel
+        final ResolvedCatalogModel resolvedCatalogModel = getModel();
+        CatalogSchemaModel mockModel =
+                new CatalogSchemaModel(
+                        ContextResolvedModel.permanent(
+                                ObjectIdentifier.of(modelMockName, "", ""),
+                                CatalogManagerMocks.createEmptyCatalog(),
+                                resolvedCatalogModel),
+                        FlinkStatistic.UNKNOWN(),
+                        true);
+
+        MockFlinkSchema mockFlinkSchema = new MockFlinkSchema();
+        mockFlinkSchema.addModel(modelMockName, mockModel);
+        catalogReader =
+                new FlinkCalciteCatalogReader(
+                        CalciteSchemaBuilder.asRootSchema(mockFlinkSchema),
+                        Collections.emptyList(),
+                        typeFactory,
+                        new CalciteConnectionConfigImpl(new Properties()));
+
+        CatalogSchemaModel model = catalogReader.getModel(Collections.singletonList(modelMockName));
+        assertThat(model).isInstanceOf(CatalogSchemaModel.class);
+    }
+
+    @Test
+    void testGetModelFromNonFlinkSchema() {
+        assertThatThrownBy(() -> catalogReader.getModel(Collections.singletonList(modelMockName)))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("getModel() only supports FlinkSchema.");
+    }
+
+    private static ResolvedCatalogModel getModel() {
+        final CatalogModel catalogModel =
+                CatalogModel.of(
+                        org.apache.flink.table.api.Schema.newBuilder()
+                                .column(
+                                        "f1",
+                                        DataTypes.INT().getLogicalType().asSerializableString())
+                                .build(),
+                        org.apache.flink.table.api.Schema.newBuilder()
+                                .column(
+                                        "label",
+                                        DataTypes.STRING().getLogicalType().asSerializableString())
+                                .build(),
+                        null,
+                        "some comment");
+
+        final Column f1 = Column.physical("f1", DataTypes.INT());
+        final Column label = Column.physical("label", DataTypes.STRING());
+        final ResolvedSchema inputSchema = ResolvedSchema.of(f1);
+        final ResolvedSchema outputSchema = ResolvedSchema.of(label);
+
+        return ResolvedCatalogModel.of(catalogModel, inputSchema, outputSchema);
+    }
+
+    private static class MockFlinkSchema extends FlinkSchema {
+
+        private final Map<String, CatalogSchemaModel> modelMap = new HashMap<>();
+
+        @Override
+        public Table getTable(String name) {
+            return null;
+        }
+
+        @Override
+        public Set<String> getTableNames() {
+            return Set.of();
+        }
+
+        @Override
+        public @Nullable Schema getSubSchema(String name) {
+            return null;
+        }
+
+        public void addModel(String name, CatalogSchemaModel model) {
+            modelMap.put(name, model);
+        }
+
+        @Override
+        public CatalogSchemaModel getModel(String name) {
+            return modelMap.get(name);
+        }
+
+        @Override
+        public Set<String> getModelNames() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public FlinkSchema copy() {
+            return null;
+        }
+
+        @Override
+        public Set<String> getSubSchemaNames() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public Expression getExpression(@Nullable SchemaPlus parentSchema, String name) {
+            return null;
+        }
+
+        @Override
+        public boolean isMutable() {
+            return false;
+        }
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/FlinkCalciteCatalogReaderTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/FlinkCalciteCatalogReaderTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.planner.plan;
 
 import org.apache.flink.table.api.DataTypes;
-import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.CatalogModel;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.Column;
@@ -176,8 +175,9 @@ class FlinkCalciteCatalogReaderTest {
     @Test
     void testGetModelFromNonFlinkSchema() {
         assertThatThrownBy(() -> catalogReader.getModel(Collections.singletonList(modelMockName)))
-                .isInstanceOf(ValidationException.class)
-                .hasMessageContaining("getModel() only supports FlinkSchema.");
+                .isInstanceOf(ClassCastException.class)
+                .hasMessageContaining(
+                        "class org.apache.calcite.jdbc.CalciteConnectionImpl$RootSchema cannot be cast to class org.apache.flink.table.planner.catalog.FlinkSchema");
     }
 
     private static ResolvedCatalogModel getModel() {


### PR DESCRIPTION
## What is the purpose of the change

Support `getModel` in `FlinkCalciteCatalogReader`


## Brief change log

* Introduce `CatalogSchemaModel`
* Add `getModel` in `FlinkSchema`
* Add `getModel` in `FlinkCalciteCatalogReader`
* Copy `SimpleCalciteSchema` from Calcite to support `getModel`


## Verifying this change

Unit test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
