### PR TITLE
[hotfix][state] Remove duplicate comparing about intersect group range.

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/state/rocksdb/RocksDBIncrementalCheckpointUtils.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/state/rocksdb/RocksDBIncrementalCheckpointUtils.java
@@ -115,7 +115,6 @@ public class RocksDBIncrementalCheckpointUtils {
         public int compareTo(@Nullable Score other) {
             return Comparator.nullsFirst(
                             Comparator.comparing(Score::getIntersectGroupRange)
-                                    .thenComparing(Score::getIntersectGroupRange)
                                     .thenComparing(Score::getOverlapFraction))
                     .compare(this, other);
         }


### PR DESCRIPTION


## What is the purpose of the change

Remove duplicate comparing about intersect group range in Score of state handle.


## Brief change log

Fix the compareTo logic.


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
