### PR TITLE
[hotfix][javadoc] Correct the default value of chaining strategy

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/ChainingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/ChainingStrategy.java
@@ -24,9 +24,8 @@ import org.apache.flink.annotation.PublicEvolving;
  * Defines the chaining scheme for the operator. When an operator is chained to the predecessor, it
  * means that they run in the same thread. They become one operator consisting of multiple steps.
  *
- * <p>The default value used by the StreamOperator is {@link #HEAD}, which means that the operator
- * is not chained to its predecessor. Most operators override this with {@link #ALWAYS}, meaning
- * they will be chained to predecessors whenever possible.
+ * <p>The default value used by the StreamOperator is {@link #ALWAYS}, which means that the operator
+ * will be chained to predecessors whenever possible.
  */
 @PublicEvolving
 public enum ChainingStrategy {


### PR DESCRIPTION
## What is the purpose of the change

This hotfix corrects the default value of chaining strategy in the javadocs.


## Brief change log

Correct the description of javadocs in `ChainingStrategy.java`


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
