### PR TITLE
[BP-1.20][FLINK-37810] Update log4j to 2.24.3

### DIFF
--- a/docs/content.zh/docs/dev/configuration/overview.md
+++ b/docs/content.zh/docs/dev/configuration/overview.md
@@ -108,7 +108,7 @@ ext {
     flinkVersion = '{{< version >}}'
     scalaBinaryVersion = '{{< scala_version >}}'
     slf4jVersion = '1.7.36'
-    log4jVersion = '2.17.1'
+    log4jVersion = '2.24.3'
 }
 sourceCompatibility = javaVersion
 targetCompatibility = javaVersion

--- a/docs/content/docs/dev/configuration/overview.md
+++ b/docs/content/docs/dev/configuration/overview.md
@@ -110,7 +110,7 @@ ext {
     flinkVersion = '{{< version >}}'
     scalaBinaryVersion = '{{< scala_version >}}'
     slf4jVersion = '1.7.36'
-    log4jVersion = '2.17.1'
+    log4jVersion = '2.24.3'
 }
 sourceCompatibility = javaVersion
 targetCompatibility = javaVersion

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@ under the License.
 		<flink.markBundledAsOptional>true</flink.markBundledAsOptional>
 		<target.java.version>1.8</target.java.version>
 		<slf4j.version>1.7.36</slf4j.version>
-		<log4j.version>2.17.1</log4j.version>
+		<log4j.version>2.24.3</log4j.version>
 		<!-- Overwrite default values from parent pom.
 			 IntelliJ IDEA is (sometimes?) using those values to choose target language level
 			 and thus is changing back to java 1.6 on each maven re-import -->

--- a/tools/releasing/NOTICE-binary_PREAMBLE.txt
+++ b/tools/releasing/NOTICE-binary_PREAMBLE.txt
@@ -8,10 +8,10 @@ Copyright 2014-2024 The Apache Software Foundation
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- org.apache.logging.log4j:log4j-api:2.17.1
-- org.apache.logging.log4j:log4j-core:2.17.1
-- org.apache.logging.log4j:log4j-slf4j-impl:2.17.1
-- org.apache.logging.log4j:log4j-1.2-api:2.17.1
+- org.apache.logging.log4j:log4j-api:2.24.3
+- org.apache.logging.log4j:log4j-core:2.24.3
+- org.apache.logging.log4j:log4j-slf4j-impl:2.24.3
+- org.apache.logging.log4j:log4j-1.2-api:2.24.3
 
 This project bundles the following dependencies under the BSD license.
 See bundled license files for details.


### PR DESCRIPTION
release-1.20 backport of https://github.com/apache/flink/pull/26570