### PR TITLE
[hotfix][ci] Ensure presence of Python.h headers in Github Actions runners

### DIFF
--- a/.github/workflows/template.flink-ci.yml
+++ b/.github/workflows/template.flink-ci.yml
@@ -215,6 +215,10 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: "Install Python header files"
+        if: matrix.module == 'python'
+        run: sudo apt-get update && sudo apt-get -y install python3-dev
+
       - name: "Set coredump pattern"
         working-directory: ${{ env.CONTAINER_LOCAL_WORKING_DIR }}
         run: sudo sysctl -w kernel.core_pattern=core.%p


### PR DESCRIPTION
## What is the purpose of the change

I saw that the Python tests on GHA are failing occasionally with `fatal error: Python.h: No such file or directory`. This might be due to an inconsistent state of the underlying runners, some having the headers or some not - in either case, this PR adds a step to ensure their presence in the container.

## Brief change log

- Explicitly install Python.h headers when running Python tests in Github Actions.