### PR TITLE
[hotfix] Fix invalid comments in Committer

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/connector/sink2/Committer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/sink2/Committer.java
@@ -38,9 +38,9 @@ import java.util.Collection;
 @Public
 public interface Committer<CommT> extends AutoCloseable {
     /**
-     * Commit the given list of {@link CommT}.
+     * Commit the given collection of {@link CommitRequest}.
      *
-     * @param committables A list of commit requests staged by the sink writer.
+     * @param committables A collection of commit requests staged by the sink writer.
      * @throws IOException for reasons that may yield a complete restart of the job.
      */
     void commit(Collection<CommitRequest<CommT>> committables)
@@ -49,7 +49,7 @@ public interface Committer<CommT> extends AutoCloseable {
     /**
      * A request to commit a specific committable.
      *
-     * @param <CommT>
+     * @param <CommT> The type of information needed to commit the staged data
      */
     @Public
     interface CommitRequest<CommT> {


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to fix invalid comments in `Committer`.

- `CommT` is a generic parameters, we can't link it.
- `committables` is a collection but list.
- Add some missing comments.


## Brief change log

Fix invalid comments in `Committer`.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
