### PR TITLE
[FLINK-37804][python] Limit Cython < 3

### DIFF
--- a/flink-python/pyproject.toml
+++ b/flink-python/pyproject.toml
@@ -22,7 +22,7 @@ requires = [
     "setuptools>=75.3",
     "wheel",
     "apache-beam>=2.54.0,<=2.61.0",
-    "cython>=0.29.24,<3.1.0",
+    "cython>=0.29.24,<3",
     "fastavro>=1.1.0,!=1.8.0"
 ]
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will limit Cython < 3 to workaound https://github.com/fastavro/fastavro/issues/701*


## Brief change log

  - *limit Cython < 3*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs)
