### PR TITLE
[FLINK-37827][table] Fix use `SHOW CREATE TABLE` for MATERIALIZED_TABLE

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/ShowCreateUtil.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/ShowCreateUtil.java
@@ -22,11 +22,13 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.CatalogDescriptor;
+import org.apache.flink.table.catalog.CatalogMaterializedTable;
 import org.apache.flink.table.catalog.CatalogView;
 import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.QueryOperationCatalogView;
 import org.apache.flink.table.catalog.ResolvedCatalogBaseTable;
+import org.apache.flink.table.catalog.ResolvedCatalogMaterializedTable;
 import org.apache.flink.table.catalog.ResolvedCatalogModel;
 import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.ResolvedSchema;
@@ -87,6 +89,9 @@ public class ShowCreateUtil {
                     String.format(
                             "SHOW CREATE TABLE is only supported for tables, but %s is a view. Please use SHOW CREATE VIEW instead.",
                             tableIdentifier.asSerializableString()));
+        } else if (table.getTableKind() == CatalogBaseTable.TableKind.MATERIALIZED_TABLE) {
+            return buildShowCreateMaterializedTableRow(
+                    (ResolvedCatalogMaterializedTable) table, tableIdentifier, isTemporary);
         }
         StringBuilder sb =
                 new StringBuilder()
@@ -107,6 +112,37 @@ public class ShowCreateUtil {
                                         .append(")\n"));
         extractFormattedOptions(table.getOptions(), PRINT_INDENT)
                 .ifPresent(v -> sb.append("WITH (\n").append(v).append("\n)\n"));
+        return sb.toString();
+    }
+
+    private static String buildShowCreateMaterializedTableRow(
+            ResolvedCatalogMaterializedTable table,
+            ObjectIdentifier tableIdentifier,
+            boolean isTemporary) {
+        StringBuilder sb =
+                new StringBuilder()
+                        .append(
+                                buildCreateMaterializedTableFormattedPrefix(
+                                        isTemporary, tableIdentifier));
+        extractFormattedPrimaryKey(table, PRINT_INDENT)
+                .ifPresent(pk -> sb.append(" (").append(pk).append(")\n"));
+
+        extractComment(table).ifPresent(c -> sb.append(formatComment(c)).append("\n"));
+
+        extractFormattedPartitionedInfo(table)
+                .ifPresent(
+                        partitionedInfoFormatted ->
+                                sb.append("PARTITIONED BY (")
+                                        .append(partitionedInfoFormatted)
+                                        .append(")\n"));
+
+        extractFormattedOptions(table.getOptions(), PRINT_INDENT)
+                .ifPresent(v -> sb.append("WITH (\n").append(v).append("\n)\n"));
+
+        sb.append(extractMaterializedTablefreshNess(table)).append("\n");
+        extractMaterializedTableRefreshMode(table).ifPresent(mode -> sb.append(mode).append("\n"));
+
+        sb.append("AS ").append(table.getDefinitionQuery());
         return sb.toString();
     }
 
@@ -158,6 +194,15 @@ public class ShowCreateUtil {
                 type,
                 identifier.asSerializableString(),
                 postName,
+                System.lineSeparator());
+    }
+
+    static String buildCreateMaterializedTableFormattedPrefix(
+            boolean isTemporary, ObjectIdentifier identifier) {
+        return String.format(
+                "CREATE %sMATERIALIZED TABLE %s %s",
+                isTemporary ? "TEMPORARY " : "",
+                identifier.asSerializableString(),
                 System.lineSeparator());
     }
 
@@ -267,6 +312,31 @@ public class ShowCreateUtil {
                 catalogTable.getPartitionKeys().stream()
                         .map(EncodingUtils::escapeIdentifier)
                         .collect(Collectors.joining(", ")));
+    }
+
+    static Optional<String> extractFormattedPartitionedInfo(
+            ResolvedCatalogMaterializedTable catalogTable) {
+        if (!catalogTable.isPartitioned()) {
+            return Optional.empty();
+        }
+        return Optional.of(
+                catalogTable.getPartitionKeys().stream()
+                        .map(EncodingUtils::escapeIdentifier)
+                        .collect(Collectors.joining(", ")));
+    }
+
+    static String extractMaterializedTablefreshNess(ResolvedCatalogMaterializedTable table) {
+        return String.format("FRESHNESS = %s ", table.getDefinitionFreshness().toString());
+    }
+
+    static Optional<String> extractMaterializedTableRefreshMode(
+            ResolvedCatalogMaterializedTable table) {
+        CatalogMaterializedTable.LogicalRefreshMode logicalRefreshMode =
+                table.getLogicalRefreshMode();
+        if (logicalRefreshMode == CatalogMaterializedTable.LogicalRefreshMode.AUTOMATIC) {
+            return Optional.empty();
+        }
+        return Optional.of(String.format("REFRESH_MODE = %s", table.getRefreshMode().name()));
     }
 
     static Optional<String> extractFormattedOptions(Map<String, String> conf, String printIndent) {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
