### PR TITLE
[FLINK-37804][python][build] Fix build mac wheels error in GHA

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -99,7 +99,9 @@ jobs:
       - name: "Setup Python"
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          # pinning to 3.8.x to avoid issues with cibuildwheel for macOS with python 3.8 wheel,
+          # if drop support of 3.8,  change to 3.x
+          python-version: '3.8'
       - name: "Install cibuildwheel"
         run: python -m pip install cibuildwheel==2.16.5
       - name: "Build python wheels for ${{ matrix.os_name }}"

--- a/flink-python/dev/dev-requirements.txt
+++ b/flink-python/dev/dev-requirements.txt
@@ -16,7 +16,7 @@ pip>=20.3
 setuptools>=75.3
 wheel
 apache-beam>=2.54.0,<=2.61.0
-cython>=0.29.24,<3.1.0
+cython>=0.29.24
 py4j==0.10.9.7
 python-dateutil>=2.8.0,<3
 cloudpickle~=2.2.0

--- a/flink-python/pyproject.toml
+++ b/flink-python/pyproject.toml
@@ -22,8 +22,7 @@ requires = [
     "setuptools>=75.3",
     "wheel",
     "apache-beam>=2.54.0,<=2.61.0",
-    "cython>=0.29.24,<3.1.0",
-    "fastavro>=1.1.0,!=1.8.0"
+    "cython>=0.29.24"
 ]
 
 [tool.cibuildwheel]


### PR DESCRIPTION
## What is the purpose of the change

*This pull request makes will fix build mac wheels error in GHA*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
