### PR TITLE
[FLINK-37804][python][build] Fix build mac wheels error on Python3.8 in GHA

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -99,9 +99,7 @@ jobs:
       - name: "Setup Python"
         uses: actions/setup-python@v5
         with:
-          # pinning to 3.8.x to avoid issues with cibuildwheel for macOS with python 3.8 wheel,
-          # if drop support of 3.8,  change to 3.x
-          python-version: '3.8'
+          python-version: '3.x'
       - name: "Install cibuildwheel"
         run: python -m pip install cibuildwheel==2.16.5
       - name: "Build python wheels for ${{ matrix.os_name }}"

--- a/flink-python/pyproject.toml
+++ b/flink-python/pyproject.toml
@@ -21,6 +21,8 @@ requires = [
     "packaging>=20.5; platform_machine=='arm64'",  # macos M1
     "setuptools>=75.3",
     "wheel",
+    "cython>=0.29.24,<3; sys_platform == 'darwin' and python_version == '3.8'",
+    "fastavro==1.7.4; sys_platform == 'darwin' and python_version == '3.8'",
     "apache-beam>=2.54.0,<=2.61.0",
     "cython>=0.29.24"
 ]

--- a/tools/azure-pipelines/build-python-wheels.yml
+++ b/tools/azure-pipelines/build-python-wheels.yml
@@ -36,9 +36,7 @@ jobs:
     steps:
       - task: UsePythonVersion@0
         inputs:
-          # pinning to 3.8.x to avoid issues with cibuildwheel for macOS with python 3.8 wheel,
-          # if drop support of 3.8,  change to 3.x
-          versionSpec: '3.8'
+          versionSpec: '3.12'
       - script: |
           cd flink-python
           python -m pip install --upgrade pip


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will fix build mac wheels error on Python3.8 in GHA*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
