### PR TITLE
[FLINK-37845][table] Remove FlinkRexBuilder#makeIn

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/FlinkRexBuilder.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/FlinkRexBuilder.java
@@ -18,26 +18,12 @@
 
 package org.apache.flink.table.planner.calcite;
 
-import org.apache.flink.shaded.guava33.com.google.common.collect.ImmutableList;
-
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexBuilder;
-import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
-import org.apache.calcite.rex.RexUtil;
-import org.apache.calcite.runtime.FlatLists;
-import org.apache.calcite.sql.fun.SqlStdOperatorTable;
-import org.apache.calcite.sql.type.SqlTypeUtil;
-import org.apache.calcite.tools.RelBuilder;
-import org.apache.calcite.util.Sarg;
 import org.apache.calcite.util.TimestampString;
-import org.apache.calcite.util.Util;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
 
 /** A slim extension over a {@link RexBuilder}. See the overridden methods for more explanation. */
 public final class FlinkRexBuilder extends RexBuilder {
@@ -108,122 +94,6 @@ public final class FlinkRexBuilder extends RexBuilder {
                 return makeLiteral(new TimestampString(1970, 1, 1, 0, 0, 0), type);
             default:
                 return super.makeZeroLiteral(type);
-        }
-    }
-
-    /**
-     * Convert the conditions into the {@code IN} and fix [CALCITE-4888]: Unexpected {@link RexNode}
-     * when call {@link RelBuilder#in} to create an {@code IN} predicate with a list of varchar
-     * literals which have different length in {@link RexBuilder#makeIn}.
-     *
-     * <p>The bug is because the origin implementation doesn't take {@link
-     * FlinkTypeSystem#shouldConvertRaggedUnionTypesToVarying} into consideration. When this is
-     * true, the behaviour should not padding char. Please see
-     * https://issues.apache.org/jira/browse/CALCITE-4590 and
-     * https://issues.apache.org/jira/browse/CALCITE-2321. Please refer to {@code
-     * org.apache.calcite.rex.RexSimplify.RexSargBuilder#getType} for the correct behaviour.
-     *
-     * <p>Once CALCITE-4888 is fixed, this method (and related methods) should be removed.
-     */
-    @Override
-    @SuppressWarnings("unchecked")
-    public RexNode makeIn(RexNode arg, List<? extends RexNode> ranges) {
-        if (areAssignable(arg, ranges)) {
-            // Fix calcite doesn't check literal whether is NULL here
-            List<RexNode> rangeWithoutNull = new ArrayList<>();
-            boolean containsNull = false;
-            for (RexNode node : ranges) {
-                if (isNull(node)) {
-                    containsNull = true;
-                } else {
-                    rangeWithoutNull.add(node);
-                }
-            }
-            final Sarg sarg = toSarg(Comparable.class, rangeWithoutNull, containsNull);
-            if (sarg != null) {
-                List<RelDataType> distinctTypes =
-                        Util.distinctList(
-                                ranges.stream().map(RexNode::getType).collect(Collectors.toList()));
-                RelDataType commonType = getTypeFactory().leastRestrictive(distinctTypes);
-                return makeCall(
-                        SqlStdOperatorTable.SEARCH,
-                        arg,
-                        makeSearchArgumentLiteral(sarg, commonType));
-            }
-        }
-        return RexUtil.composeDisjunction(
-                this,
-                ranges.stream()
-                        .map(r -> makeCall(SqlStdOperatorTable.EQUALS, arg, r))
-                        .collect(Util.toImmutableList()));
-    }
-
-    private boolean isNull(RexNode node) {
-        if (node instanceof RexLiteral) {
-            return ((RexLiteral) node).isNull();
-        }
-        return false;
-    }
-
-    /** Copied from the {@link RexBuilder} to fix the {@link RexBuilder#makeIn}. */
-    private boolean areAssignable(RexNode arg, List<? extends RexNode> bounds) {
-        for (RexNode bound : bounds) {
-            if (!SqlTypeUtil.inSameFamily(arg.getType(), bound.getType())
-                    && !(arg.getType().isStruct() && bound.getType().isStruct())) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    /**
-     * Converts a list of expressions to a search argument, or returns null if not possible.
-     *
-     * <p>Copied from the {@link RexBuilder} to fix the {@link RexBuilder#makeIn}.
-     */
-    @SuppressWarnings("UnstableApiUsage")
-    private static <C extends Comparable<C>> Sarg<C> toSarg(
-            Class<C> clazz, List<? extends RexNode> ranges, boolean containsNull) {
-        if (ranges.isEmpty()) {
-            // Cannot convert an empty list to a Sarg (by this interface, at least)
-            // because we use the type of the first element.
-            return null;
-        }
-        final com.google.common.collect.RangeSet<C> rangeSet =
-                com.google.common.collect.TreeRangeSet.create();
-        for (RexNode range : ranges) {
-            final C value = toComparable(clazz, range);
-            if (value == null) {
-                return null;
-            }
-            rangeSet.add(com.google.common.collect.Range.singleton(value));
-        }
-        return Sarg.of(containsNull, rangeSet);
-    }
-
-    /** Copied from the {@link RexBuilder} to fix the {@link RexBuilder#makeIn}. */
-    @SuppressWarnings("rawtypes")
-    private static <C extends Comparable<C>> C toComparable(Class<C> clazz, RexNode point) {
-        switch (point.getKind()) {
-            case LITERAL:
-                final RexLiteral literal = (RexLiteral) point;
-                return literal.getValueAs(clazz);
-
-            case ROW:
-                final RexCall call = (RexCall) point;
-                final ImmutableList.Builder<Comparable> b = ImmutableList.builder();
-                for (RexNode operand : call.operands) {
-                    //noinspection unchecked
-                    final Comparable value = toComparable(Comparable.class, operand);
-                    if (value == null) {
-                        return null; // not a constant value
-                    }
-                    b.add(value);
-                }
-                return clazz.cast(FlatLists.ofComparable(b.build()));
-
-            default:
-                return null; // not a constant value
         }
     }
 }

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/ConvertToNotInOrInRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/ConvertToNotInOrInRuleTest.xml
@@ -497,7 +497,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4])
     <Resource name="optimized rel plan">
       <![CDATA[
 LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4])
-+- LogicalFilter(condition=[SEARCH($4, Sarg[_UTF-16LE'HELLO WORLD!':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", _UTF-16LE'a':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", _UTF-16LE'b':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", _UTF-16LE'c':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", _UTF-16LE'd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", _UTF-16LE'e':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", _UTF-16LE'f':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"; NULL AS TRUE]:VARCHAR(2147483647) CHARACTER SET "UTF-16LE")])
++- LogicalFilter(condition=[OR(=($4, _UTF-16LE'a'), =($4, _UTF-16LE'b'), =($4, _UTF-16LE'c'), =($4, _UTF-16LE'd'), =($4, _UTF-16LE'e'), =($4, _UTF-16LE'f'), =($4, null), =($4, _UTF-16LE'HELLO WORLD!'))])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
 ]]>
     </Resource>


### PR DESCRIPTION

## What is the purpose of the change

Removes `FlinkRexBuilder#makeIn` since CALCITE-4888 and CALCITE-4632 are done/closed with 1.33


## Verifying this change

existing tests and `ConvertToNotInOrInRuleTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
