### PR TITLE
[FLINK-37849][7/N] model provider factory discovery

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/ModelProviderFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/ModelProviderFactory.java
@@ -34,7 +34,7 @@ import org.apache.flink.table.ml.ModelProvider;
  * <p>See {@link Factory} for more information about the general design of a factory.
  */
 @PublicEvolving
-public interface ModelProviderFactory {
+public interface ModelProviderFactory extends Factory {
 
     /** Create ModelProvider based on provider. */
     ModelProvider createModelProvider(Context context);

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/FactoryUtilTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/FactoryUtilTest.java
@@ -22,17 +22,22 @@ import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.FlinkAssertions;
+import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.Catalog;
+import org.apache.flink.table.catalog.CatalogModel;
 import org.apache.flink.table.catalog.CatalogStore;
 import org.apache.flink.table.catalog.CommonCatalogOptions;
+import org.apache.flink.table.catalog.ResolvedCatalogModel;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.factories.TestDynamicTableFactory.DynamicTableSinkMock;
 import org.apache.flink.table.factories.TestDynamicTableFactory.DynamicTableSourceMock;
 import org.apache.flink.table.factories.TestFormatFactory.DecodingFormatMock;
 import org.apache.flink.table.factories.TestFormatFactory.EncodingFormatMock;
+import org.apache.flink.table.factories.TestModelProviderFactory.TestModelProviderMock;
 import org.apache.flink.table.factories.utils.FactoryMocks;
+import org.apache.flink.table.ml.ModelProvider;
 import org.apache.flink.testutils.ClassLoaderUtils;
 import org.apache.flink.util.FlinkUserCodeClassLoaders;
 import org.apache.flink.util.MutableURLClassLoader;
@@ -54,7 +59,9 @@ import java.util.Set;
 import java.util.function.Consumer;
 
 import static org.apache.flink.core.testutils.FlinkAssertions.anyCauseMatches;
+import static org.apache.flink.table.factories.utils.FactoryMocks.OUTPUT_SCHEMA;
 import static org.apache.flink.table.factories.utils.FactoryMocks.SCHEMA;
+import static org.apache.flink.table.factories.utils.FactoryMocks.createModelProvider;
 import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSink;
 import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSource;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -737,6 +744,122 @@ class FactoryUtilTest {
                                         + "configuration 'classloader.check-leaked-classloader'"));
     }
 
+    @Test
+    public void testMissingModelProvider() {
+        assertCreateModelProviderWithOptionModifier(
+                options -> options.remove("provider"),
+                "Model options do not contain an option key 'provider' for discovering a provider.");
+    }
+
+    @Test
+    void testInvalidModelProvider() {
+        assertCreateModelProviderWithOptionModifier(
+                options -> options.put("provider", "FAIL"),
+                "Could not find any factory for identifier 'FAIL' that implements '"
+                        + ModelProviderFactory.class.getName()
+                        + "' in the classpath.\n\n"
+                        + "Available factory identifiers are:\n\n"
+                        + "conflicting-model\n"
+                        + "test-model");
+    }
+
+    @Test
+    void testMissingModelProviderOption() {
+        assertCreateModelProviderWithOptionModifier(
+                options -> options.remove("endpoint"),
+                "One or more required options are missing.\n\n"
+                        + "Missing required options are:\n\n"
+                        + "endpoint");
+    }
+
+    @Test
+    void testInvalidModelProviderOption() {
+        assertCreateModelProviderWithOptionModifier(
+                options -> options.put("version", "FAIL"), "Invalid value for option 'version'.");
+    }
+
+    @Test
+    void testUnconsumedModelOption() {
+        assertCreateModelProviderWithOptionModifier(
+                options -> {
+                    options.put("this-is-not-consumed", "42");
+                    options.put("this-is-also-not-consumed", "true");
+                },
+                "Unsupported options found for 'test-model'.\n\n"
+                        + "Unsupported options:\n\n"
+                        + "this-is-also-not-consumed\n"
+                        + "this-is-not-consumed\n\n"
+                        + "Supported options:\n\n"
+                        + "endpoint\n"
+                        + "property-version\n"
+                        + "provider\n"
+                        + "task\n"
+                        + "version");
+    }
+
+    @Test
+    void testAllModelOptions() {
+        final Map<String, String> options = createAllModelOptions();
+        final ModelProvider actualProvider = createModelProvider(SCHEMA, OUTPUT_SCHEMA, options);
+        final ModelProvider expectedProvider =
+                new TestModelProviderMock(
+                        ResolvedCatalogModel.of(
+                                CatalogModel.of(
+                                        Schema.newBuilder().fromResolvedSchema(SCHEMA).build(),
+                                        Schema.newBuilder()
+                                                .fromResolvedSchema(OUTPUT_SCHEMA)
+                                                .build(),
+                                        options,
+                                        "mock model"),
+                                SCHEMA,
+                                OUTPUT_SCHEMA));
+        assertThat(actualProvider).isEqualTo(expectedProvider);
+    }
+
+    @Test
+    void testModelProviderFactoryHelper() {
+        final Map<String, String> options = new HashMap<>();
+        options.put("endpoint", "https://openai.com");
+        options.put("task", "text_generation");
+
+        final FactoryUtil.ModelProviderFactoryHelper helper =
+                FactoryUtil.createModelProviderFactoryHelper(
+                        new TestModelProviderFactory(),
+                        FactoryMocks.createModelContext(SCHEMA, OUTPUT_SCHEMA, options));
+
+        // No error
+        helper.validate();
+
+        final Map<String, String> invalidOptions = new HashMap<>(options);
+        invalidOptions.put("invalid-option", "value");
+
+        final FactoryUtil.ModelProviderFactoryHelper invalidHelper =
+                FactoryUtil.createModelProviderFactoryHelper(
+                        new TestModelProviderFactory(),
+                        FactoryMocks.createModelContext(SCHEMA, OUTPUT_SCHEMA, invalidOptions));
+
+        assertThatThrownBy(invalidHelper::validate)
+                .satisfies(
+                        anyCauseMatches(
+                                ValidationException.class,
+                                "Unsupported options found for 'test-model'"));
+    }
+
+    @Test
+    void testConflictingModelProvider() {
+        assertCreateModelProviderWithOptionModifier(
+                options -> options.put("provider", TestConflictingModelProviderFactory1.IDENTIFIER),
+                "Multiple factories for identifier 'conflicting-model' that implement '"
+                        + ModelProviderFactory.class.getName()
+                        + "' found in the classpath.\n"
+                        + "\n"
+                        + "Ambiguous factory classes are:\n"
+                        + "\n"
+                        + TestConflictingModelProviderFactory1.class.getName()
+                        + "\n"
+                        + TestConflictingModelProviderFactory2.class.getName());
+    }
+
     // --------------------------------------------------------------------------------------------
     // Helper methods
     // --------------------------------------------------------------------------------------------
@@ -754,6 +877,30 @@ class FactoryUtilTest {
         for (String message : messages) {
             assertion.satisfies(anyCauseMatches(ValidationException.class, message));
         }
+    }
+
+    private static void assertCreateModelProviderWithOptionModifier(
+            Consumer<Map<String, String>> optionModifier, String... messages) {
+        AbstractThrowableAssert<?, ? extends Throwable> assertion =
+                assertThatThrownBy(
+                        () -> {
+                            final Map<String, String> options = createAllModelOptions();
+                            optionModifier.accept(options);
+                            createModelProvider(SCHEMA, OUTPUT_SCHEMA, options);
+                        });
+
+        for (String message : messages) {
+            assertion.satisfies(anyCauseMatches(ValidationException.class, message));
+        }
+    }
+
+    private static Map<String, String> createAllModelOptions() {
+        final Map<String, String> options = new HashMap<>();
+        options.put("provider", TestModelProviderFactory.IDENTIFIER);
+        options.put("endpoint", "https://openai.com");
+        options.put("task", "text_generation");
+        options.put("version", "1");
+        return options;
     }
 
     private static Map<String, String> createAllOptions() {

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestConflictingModelProviderFactory1.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestConflictingModelProviderFactory1.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.factories;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.table.ml.ModelProvider;
+
+import java.util.Collections;
+import java.util.Set;
+
+/** First test implementation for conflicting {@link ModelProviderFactory}. */
+public class TestConflictingModelProviderFactory1 implements ModelProviderFactory {
+
+    public static final String IDENTIFIER = "conflicting-model";
+
+    @Override
+    public ModelProvider createModelProvider(Context context) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String factoryIdentifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        return Collections.emptySet();
+    }
+}

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestConflictingModelProviderFactory2.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestConflictingModelProviderFactory2.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.factories;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.table.ml.ModelProvider;
+
+import java.util.Collections;
+import java.util.Set;
+
+/** Second test implementation for conflicting {@link ModelProviderFactory}. */
+public class TestConflictingModelProviderFactory2 implements ModelProviderFactory {
+
+    @Override
+    public ModelProvider createModelProvider(Context context) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String factoryIdentifier() {
+        return TestConflictingModelProviderFactory1.IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        return Collections.emptySet();
+    }
+}

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestModelProviderFactory.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestModelProviderFactory.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.factories;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.table.catalog.ResolvedCatalogModel;
+import org.apache.flink.table.factories.FactoryUtil.ModelProviderFactoryHelper;
+import org.apache.flink.table.ml.ModelProvider;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/** Test implementation for {@link ModelProviderFactory}. */
+public final class TestModelProviderFactory implements ModelProviderFactory {
+
+    public static final String IDENTIFIER = "test-model";
+
+    public static final ConfigOption<String> TASK =
+            ConfigOptions.key("task")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Task of the test model.");
+
+    public static final ConfigOption<String> ENDPOINT =
+            ConfigOptions.key("endpoint")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Endpoint of the test model.");
+
+    public static final ConfigOption<Integer> MODEL_VERSION =
+            ConfigOptions.key("version")
+                    .intType()
+                    .defaultValue(1)
+                    .withDescription("Version of the test model.");
+
+    @Override
+    public ModelProvider createModelProvider(Context context) {
+        final ModelProviderFactoryHelper helper =
+                FactoryUtil.createModelProviderFactoryHelper(this, context);
+        helper.validate();
+        return new TestModelProviderMock(context.getCatalogModel());
+    }
+
+    @Override
+    public String factoryIdentifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        final Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(TASK);
+        options.add(ENDPOINT);
+        return options;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(MODEL_VERSION);
+        return options;
+    }
+
+    /** Test implementation of {@link ModelProvider} for testing purposes. */
+    public static class TestModelProviderMock implements ModelProvider {
+
+        private final ResolvedCatalogModel catalogModel;
+
+        public TestModelProviderMock(ResolvedCatalogModel catalogModel) {
+            this.catalogModel = catalogModel;
+        }
+
+        @Override
+        public ModelProvider copy() {
+            return new TestModelProviderMock(catalogModel);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            return catalogModel.equals(((TestModelProviderMock) o).catalogModel);
+        }
+    }
+}

--- a/flink-table/flink-table-common/src/test/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink-table/flink-table-common/src/test/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -23,5 +23,8 @@ org.apache.flink.table.factories.TestConflictingDynamicTableFactory1
 org.apache.flink.table.factories.TestConflictingDynamicTableFactory2
 org.apache.flink.table.factories.TestCatalogFactory
 org.apache.flink.table.factories.TestCatalogStoreFactory
+org.apache.flink.table.factories.TestModelProviderFactory
+org.apache.flink.table.factories.TestConflictingModelProviderFactory1
+org.apache.flink.table.factories.TestConflictingModelProviderFactory2
 org.apache.flink.table.factories.module.DummyModuleFactory
 org.apache.flink.table.factories.workflow.TestWorkflowSchedulerFactory


### PR DESCRIPTION
## What is the purpose of the change

Add function in `FactoryUtils` to discover `ModelProviderFactory`


## Brief change log
Add function in `FactoryUtils` to discover `ModelProviderFactory`


## Verifying this change

Unit test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
