### PR TITLE
[hotfix] Removed Extraneous Semicolon

### DIFF
--- a/flink-end-to-end-tests/flink-file-sink-test/src/main/java/org/apache/flink/connector/file/sink/FileSinkProgram.java
+++ b/flink-end-to-end-tests/flink-file-sink-test/src/main/java/org/apache/flink/connector/file/sink/FileSinkProgram.java
@@ -55,7 +55,6 @@ import java.util.Collections;
  * a complete sequence from 0 (inclusive) to 60000 (exclusive).
  */
 public enum FileSinkProgram {
-    ;
 
     public static void main(final String[] args) throws Exception {
         final ParameterTool params = ParameterTool.fromArgs(args);


### PR DESCRIPTION
## What is the purpose of the change

This pull request removes a unnecessary semicolon present within the `FileSinkProgram` example application for the File Sink Connector to _hopefully_ not confuse potentially new users when exploring the repository and related connector.

## Brief change log
Removed a single line with a single semicolon prior to the remainder of the logic within the `FileSinkProgram` class.


## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
