### PR TITLE
[FLINK-34094] Adds documentation for AsyncScalarFunction

### DIFF
--- a/docs/content.zh/docs/dev/table/functions/udfs.md
+++ b/docs/content.zh/docs/dev/table/functions/udfs.md
@@ -1013,7 +1013,7 @@ import static org.apache.flink.table.api.Expressions.*;
  * Since such lookups are often slow, we use an AsyncScalarFunction.
  */
 public static class BeverageNameLookupFunction extends AsyncScalarFunction {
-    private Executor executor;
+    private transient Executor executor;
 
     @Override
     public void open(FunctionContext context) {
@@ -1024,7 +1024,7 @@ public static class BeverageNameLookupFunction extends AsyncScalarFunction {
     // The eval method takes a future for the result and the beverage ID to lookup.
     public void eval(CompletableFuture<String> future, Integer beverageId) {
         // Submit a task to the thread pool. We don't want to block this main 
-        // thread since would prevent concurrent execution. The future can be 
+        // thread since that would prevent concurrent execution. The future can be 
         // completed from another thread when the lookup is done.
         executor.execute(() -> {
             // Simulate a database lookup by sleeping for 1s.

--- a/docs/content.zh/docs/dev/table/functions/udfs.md
+++ b/docs/content.zh/docs/dev/table/functions/udfs.md
@@ -995,20 +995,7 @@ In order to define an asynchronous scalar function, extend the base class `Async
 
 The number of outstanding calls to `eval` may be configured by [`table.exec.async-scalar.max-concurrent-operations`]({{< ref "docs/dev/table/config#table-exec-async-scalar-max-concurrent-operations" >}}).
 
-#### Asynchronous Semantics
-While calls to an `AsyncScalarFunction` may be completed out of the original input order, to maintain correct semantics, the outputs of the function are guaranteed to maintain that input order to downstream components of the query. The data itself could reveal completion order (e.g. by containing fetch timestamps), so the user should consider whether this is acceptable for their use-case.
-
-#### Error Handling
-The primary way for a user to indicate an error is to call `completableFuture.completeExceptionally(throwable)`. Similarly, if an exception is encountered by the system when invoking `eval`, that will also result in an error. When an error occurs, the system will consider the retry strategy, configured by [`table.exec.async-scalar.retry-strategy`]({{< ref "docs/dev/table/config#table-exec-async-scalar-retry-strategy" >}}). If this is `NO_RETRY`, the job is failed. If it is set to `FIXED_DELAY`, a period of [`table.exec.async-scalar.retry-delay`]({{< ref "docs/dev/table/config#table-exec-async-scalar-retry-delay" >}}) will be waited, and the function call will be retried. If there have been [`table.exec.async-scalar.max-attempts`]({{< ref "docs/dev/table/config#table-exec-async-scalar-max-attempts" >}}) failed attempts or if the timeout [`table.exec.async-scalar.timeout`]({{< ref "docs/dev/table/config#table-exec-async-scalar-timeout" >}}) expires (including all retry attempts), the job will fail.
-
-#### Is AsyncScalarFunction Required?
-One thing to consider is if the UDF contains CPU intensive logic with no blocking calls.  If so, it likely doesn't require asynchronous functionality and could use a `ScalarFunction`. If the logic involves waiting for things like network or background operations (e.g. database lookups, RPCs, or REST calls), this may be a useful way to speed things up.
-
-
 The following example shows how to do work on a thread pool in the background, though any libraries exposing an async interface may be directly used to complete the `CompletableFuture` from a callback. See the [Implementation Guide](#implementation-guide) for more details.
-
-{{< tabs "a385387e-d64b-44b3-9b65-fd42f0820e99" >}}
-{{< tab "Java" >}}
 
 ```java
 import org.apache.flink.table.api.*;
@@ -1021,22 +1008,44 @@ import java.util.concurrent.Executors;
 
 import static org.apache.flink.table.api.Expressions.*;
 
-public static class BackgroundFunction extends AsyncScalarFunction {
+/**
+ * A function which simulates looking up a beverage name from a database.
+ * Since such lookups are often slow, we use an AsyncScalarFunction.
+ */
+public static class BeverageNameLookupFunction extends AsyncScalarFunction {
     private Executor executor;
 
     @Override
     public void open(FunctionContext context) {
+        // Create a thread pool for executing the background lookup.
         executor = Executors.newFixedThreadPool(10);
     }
 
-    // take any data type and return INT
-    public void eval(CompletableFuture<Long> future, Integer waitMax) {
+    // The eval method takes a future for the result and the beverage ID to lookup.
+    public void eval(CompletableFuture<String> future, Integer beverageId) {
+        // Submit a task to the thread pool. We don't want to block this main 
+        // thread since would prevent concurrent execution. The future can be 
+        // completed from another thread when the lookup is done.
         executor.execute(() -> {
-            long sleepTime = new Random().nextInt(waitMax);
+            // Simulate a database lookup by sleeping for 1s.
             try {
-                Thread.sleep(sleepTime);
+                Thread.sleep(1000);
             } catch (InterruptedException e) {}
-            future.complete(sleepTime);
+            // Complete the future with the right beverage name.
+            switch (beverageId) {
+                case 0:
+                    future.complete("Latte");
+                    break;
+                case 1:
+                    future.complete("Cappuccino");
+                    break;
+                case 2:
+                    future.complete("Espresso");
+                    break;
+                default:
+                    // In the exceptional case, return an error.
+                    future.completeExceptionally(new IllegalArgumentException("Bad beverageId: " + beverageId));
+            }
         });
     }
 }
@@ -1046,66 +1055,27 @@ env.getConfig().set("table.exec.async-scalar.max-concurrent-operations", "5");
 env.getConfig().set("table.exec.async-scalar.timeout", "1m");
 
 // call function "inline" without registration in Table API
-env.from("MyTable").select(call(BackgroundFunction.class, $("myField")));
+env.from("Beverages").select(call(BeverageNameLookupFunction.class, $("beverageId")));
 
 // register function
-env.createTemporarySystemFunction("BackgroundFunction", BackgroundFunction.class);
+env.createTemporarySystemFunction("GetBeverageName", BeverageNameLookupFunction.class);
 
 // call registered function in Table API
-env.from("MyTable").select(call("BackgroundFunction", $("myField")));
+env.from("Beverages").select(call("GetBeverageName", $("beverageId")));
 
 // call registered function in SQL
-env.sqlQuery("SELECT BackgroundFunction(myField) FROM MyTable");
+env.sqlQuery("SELECT GetBeverageName(beverageId) FROM Beverages");
 
 ```
-{{< /tab >}}
-{{< tab "Scala" >}}
-```scala
-import org.apache.flink.table.api._
-import org.apache.flink.table.functions.{AsyncScalarFunction, FunctionContext}
 
-import java.util.Random
-import java.util.concurrent.{CompletableFuture, Executor, Executors}
+#### Asynchronous Semantics
+While calls to an `AsyncScalarFunction` may be completed out of the original input order, to maintain correct semantics, the outputs of the function are guaranteed to maintain that input order to downstream components of the query. The data itself could reveal completion order (e.g. by containing fetch timestamps), so the user should consider whether this is acceptable for their use-case.
 
-class BackgroundFunc extends AsyncScalarFunction {
+#### Error Handling
+The primary way for a user to indicate an error is to call `CompletableFuture.completeExceptionally(Throwable)`. Similarly, if an exception is encountered by the system when invoking `eval`, that will also result in an error. When an error occurs, the system will consider the retry strategy, configured by [`table.exec.async-scalar.retry-strategy`]({{< ref "docs/dev/table/config#table-exec-async-scalar-retry-strategy" >}}). If this is `NO_RETRY`, the job is failed. If it is set to `FIXED_DELAY`, a period of [`table.exec.async-scalar.retry-delay`]({{< ref "docs/dev/table/config#table-exec-async-scalar-retry-delay" >}}) will be waited, and the function call will be retried. If there have been [`table.exec.async-scalar.max-attempts`]({{< ref "docs/dev/table/config#table-exec-async-scalar-max-attempts" >}}) failed attempts or if the timeout [`table.exec.async-scalar.timeout`]({{< ref "docs/dev/table/config#table-exec-async-scalar-timeout" >}}) expires (including all retry attempts), the job will fail.
 
-  private var executor: Executor = null
-
-  override def open(context: FunctionContext): Unit = {
-    executor = Executors.newFixedThreadPool(10)
-  }
-
-  def eval(future: CompletableFuture[java.lang.Long], waitMax: Integer): Unit = {
-    executor.execute(() => {
-      val sleepTime = new Random().nextInt(waitMax)
-      try Thread.sleep(sleepTime)
-      catch {
-        case e: InterruptedException =>
-      }
-      future.complete(sleepTime)
-    })
-  }
-}
-
-val env = TableEnvironment.create(...)
-env.getConfig.set("table.exec.async-scalar.max-concurrent-operations", "5")
-env.getConfig.set("table.exec.async-scalar.timeout", "1m")
-
-// call function "inline" without registration in Table API
-env.from("MyTable").select(call(classOf[BackgroundFunc], $"myField"))
-
-// register function
-env.createTemporarySystemFunction("BackgroundFunc", classOf[BackgroundFunc])
-
-// call registered function in Table API
-env.from("MyTable").select(call("BackgroundFunc", $"myField"))
-
-// call registered function in SQL
-env.sqlQuery("SELECT BackgroundFunc(myField) FROM MyTable")
-
-```
-{{< /tab >}}
-{{< /tabs >}}
+#### AsyncScalarFunction vs. ScalarFunction
+One thing to consider is if the UDF contains CPU intensive logic with no blocking calls. If so, it likely doesn't require asynchronous functionality and could use a `ScalarFunction`. If the logic involves waiting for things like network or background operations (e.g. database lookups, RPCs, or REST calls), this may be a useful way to speed things up. There are also some queries that don't support `AsyncScalarFunction`, so when in doubt, `ScalarFunction` should be used.
 
 {{< top >}}
 

--- a/docs/content.zh/docs/dev/table/functions/udfs.md
+++ b/docs/content.zh/docs/dev/table/functions/udfs.md
@@ -976,7 +976,6 @@ env.sqlQuery("SELECT HashFunction(myField) FROM MyTable")
 
 {{< top >}}
 
-
 Asynchronous Scalar Functions
 ----------------
 
@@ -994,13 +993,13 @@ A user-defined asynchronous scalar function maps zero, one, or multiple scalar v
 
 In order to define an asynchronous scalar function, extend the base class `AsyncScalarFunction` in `org.apache.flink.table.functions` and implement one or more evaluation methods named `eval(...)`.  The first argument must be a `CompletableFuture<...>` which is used to return the result, with subsequent arguments being the parameters passed to the function.
 
-The number of outstanding calls to `eval` may be configured by `table.exec.async-scalar.max-concurrent-operations`.
+The number of outstanding calls to `eval` may be configured by [`table.exec.async-scalar.max-concurrent-operations`]({{< ref "docs/dev/table/config#table-exec-async-scalar-max-concurrent-operations" >}}).
 
 #### Asynchronous Semantics
 While calls to an `AsyncScalarFunction` may be completed out of the original input order, to maintain correct semantics, the outputs of the function are guaranteed to maintain that input order to downstream components of the query. The data itself could reveal completion order (e.g. by containing fetch timestamps), so the user should consider whether this is acceptable for their use-case.
 
 #### Error Handling
-The primary way for a user to indicate an error is to call `completableFuture.completeExceptionally(throwable)`. Similarly, if an exception is encountered by the system when invoking `eval`, that will also result in an error. When an error occurs, the system will consider the retry strategy, configured by `table.exec.async-scalar.retry-strategy`. If this is `NO_RETRY`, the job is failed. If it is set to `FIXED_DELAY`, a period of `table.exec.async-scalar.retry-delay` will be waited, and the function call will be retried. If there have been `table.exec.async-scalar.max-attempts` failed attempts or if the timeout `table.exec.async-scalar.timeout` expires (including all retry attempts), the job will fail.
+The primary way for a user to indicate an error is to call `completableFuture.completeExceptionally(throwable)`. Similarly, if an exception is encountered by the system when invoking `eval`, that will also result in an error. When an error occurs, the system will consider the retry strategy, configured by [`table.exec.async-scalar.retry-strategy`]({{< ref "docs/dev/table/config#table-exec-async-scalar-retry-strategy" >}}). If this is `NO_RETRY`, the job is failed. If it is set to `FIXED_DELAY`, a period of [`table.exec.async-scalar.retry-delay`]({{< ref "docs/dev/table/config#table-exec-async-scalar-retry-delay" >}}) will be waited, and the function call will be retried. If there have been [`table.exec.async-scalar.max-attempts`]({{< ref "docs/dev/table/config#table-exec-async-scalar-max-attempts" >}}) failed attempts or if the timeout [`table.exec.async-scalar.timeout`]({{< ref "docs/dev/table/config#table-exec-async-scalar-timeout" >}}) expires (including all retry attempts), the job will fail.
 
 #### Is AsyncScalarFunction Required?
 One thing to consider is if the UDF contains CPU intensive logic with no blocking calls.  If so, it likely doesn't require asynchronous functionality and could use a `ScalarFunction`. If the logic involves waiting for things like network or background operations (e.g. database lookups, RPCs, or REST calls), this may be a useful way to speed things up.

--- a/docs/content/docs/dev/table/functions/udfs.md
+++ b/docs/content/docs/dev/table/functions/udfs.md
@@ -40,7 +40,7 @@ Overview
 Currently, Flink distinguishes between the following kinds of functions:
 
 - *Scalar functions* map scalar values to a new scalar value.
-  - *Asynchronous scalar functions* asynchronously map scalar values to a new scalar value.
+- *Asynchronous scalar functions* asynchronously map scalar values to a new scalar value.
 - *Table functions* map scalar values to new rows.
 - *Aggregate functions* map scalar values of multiple rows to a new scalar value.
 - *Table aggregate functions* map scalar values of multiple rows to new rows.

--- a/docs/content/docs/dev/table/functions/udfs.md
+++ b/docs/content/docs/dev/table/functions/udfs.md
@@ -1021,13 +1021,29 @@ If you intend to implement or call functions in Python, please refer to the [Pyt
 Asynchronous Scalar Functions
 ----------------
 
+When interacting with external systems (for example when enriching stream events with data stored in a database), one needs to take care that network or other latency does not dominate the streaming application’s running time.
+
+Naively accessing data in the external database, for example using a `ScalarFunction`, typically means **synchronous** interaction: A request is sent to the database and the `ScalarFunction` waits until the response has been received. In many cases, this waiting makes up the vast majority of the function’s time.
+
+Asynchronous interaction with the database means that a single function instance can handle many requests concurrently and receive the responses concurrently. That way, the waiting time can be overlaid with sending other requests and receiving responses. At the very least, the waiting time is amortized over multiple requests. This leads in most cased to much higher streaming throughput.
+
+{{< img src="/fig/async_io.svg" width="50%" >}}
+
+#### Defining an AsyncScalarFunction
+
 A user-defined asynchronous scalar function maps zero, one, or multiple scalar values to a new scalar value, but does it asynchronously. Any data type listed in the [data types section]({{< ref "docs/dev/table/types" >}}) can be used as a parameter or return type of an evaluation method.
 
 In order to define an asynchronous scalar function, one has to extend the base class `AsyncScalarFunction` in `org.apache.flink.table.functions` and implement one or more evaluation methods named `eval(...)`.  The first argument must be a `CompletableFuture<...>` which is used to return the result, with subsequent arguments being the parameters passed to the function.
 
-The following example shows how to do work on a thread pool in the background, though any libraries exposing an async interface may be directly used to complete the `CompletableFuture` from a callback. See the [Implementation Guide](#implementation-guide) for more details.
+The number of outstanding calls to `eval` may be configured by `table.exec.async-scalar.buffer-capacity`.
 
-Also, see the configurations under `table.exec.async-scalar.*` for setting the number of outstanding calls, timeouts, and other parameters.
+#### Asynchronous Semantics
+While calls to an `AsyncScalarFunction` may be completed out of the original input order, to maintain correct semantics, the outputs of the function are guaranteed to maintain that input order to downstream components of the query. The data itself could reveal completion order (e.g. by containing fetch timestamps), so the user should consider whether this is acceptable for the use-case. 
+
+#### Error Handling
+The primary way for a user to indicate an error is to call `completableFuture.completeExceptionally(throwable)`. Similarly, if an exception is encountered by the system when invoking `eval`, that will also result in an error. When an error occurs, the system will consider the retry strategy, configured by `table.exec.async-scalar.retry-strategy`. If this is `NO_RETRY`, it will fail the job immediately. If it is set to `FIXED_DELAY`, a period of `table.exec.async-scalar.retry-delay` will be waited, and the function call will be retried and given another attempt to succeed. If the number of retries exceeds `table.exec.async-scalar.max-attempts` or if the timeout `table.exec.async-scalar.timeout` expires (including all retry attempts), the job will fail.
+
+The following example shows how to do work on a thread pool in the background, though any libraries exposing an async interface may be directly used to complete the `CompletableFuture` from a callback. See the [Implementation Guide](#implementation-guide) for more details.
 
 {{< tabs "a385387e-d64b-44b3-9b65-fd42f0820e99" >}}
 {{< tab "Java" >}}

--- a/docs/content/docs/dev/table/functions/udfs.md
+++ b/docs/content/docs/dev/table/functions/udfs.md
@@ -1035,7 +1035,7 @@ A user-defined asynchronous scalar function maps zero, one, or multiple scalar v
 
 In order to define an asynchronous scalar function, one has to extend the base class `AsyncScalarFunction` in `org.apache.flink.table.functions` and implement one or more evaluation methods named `eval(...)`.  The first argument must be a `CompletableFuture<...>` which is used to return the result, with subsequent arguments being the parameters passed to the function.
 
-The number of outstanding calls to `eval` may be configured by `table.exec.async-scalar.buffer-capacity`.
+The number of outstanding calls to `eval` may be configured by `table.exec.async-scalar.max-concurrent-operations`.
 
 #### Asynchronous Semantics
 While calls to an `AsyncScalarFunction` may be completed out of the original input order, to maintain correct semantics, the outputs of the function are guaranteed to maintain that input order to downstream components of the query. The data itself could reveal completion order (e.g. by containing fetch timestamps), so the user should consider whether this is acceptable for the use-case. 
@@ -1084,7 +1084,7 @@ public static class BackgroundFunction extends AsyncScalarFunction {
 }
 
 TableEnvironment env = TableEnvironment.create(...);
-env.getConfig().set("table.exec.async-scalar.buffer-capacity", "5");
+env.getConfig().set("table.exec.async-scalar.max-concurrent-operations", "5");
 env.getConfig().set("table.exec.async-scalar.timeout", "1m");
 
 // call function "inline" without registration in Table API
@@ -1130,7 +1130,7 @@ class BackgroundFunc extends AsyncScalarFunction {
 }
 
 val env = TableEnvironment.create(...)
-env.getConfig.set("table.exec.async-scalar.buffer-capacity", "5")
+env.getConfig.set("table.exec.async-scalar.max-concurrent-operations", "5")
 env.getConfig.set("table.exec.async-scalar.timeout", "1m")
 
 // call function "inline" without registration in Table API

--- a/docs/content/docs/dev/table/functions/udfs.md
+++ b/docs/content/docs/dev/table/functions/udfs.md
@@ -1083,9 +1083,11 @@ env.sqlQuery("SELECT BackgroundFunction(myField) FROM MyTable");
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-import org.apache.flink.table.annotation.InputGroup
 import org.apache.flink.table.api._
-import org.apache.flink.table.functions.AsyncScalarFunction
+import org.apache.flink.table.functions.{AsyncScalarFunction, FunctionContext}
+
+import java.util.Random
+import java.util.concurrent.{CompletableFuture, Executor, Executors}
 
 class BackgroundFunc extends AsyncScalarFunction {
 

--- a/docs/content/docs/dev/table/functions/udfs.md
+++ b/docs/content/docs/dev/table/functions/udfs.md
@@ -1055,7 +1055,7 @@ import static org.apache.flink.table.api.Expressions.*;
  * Since such lookups are often slow, we use an AsyncScalarFunction.
  */
 public static class BeverageNameLookupFunction extends AsyncScalarFunction {
-    private Executor executor;
+    private transient Executor executor;
 
     @Override
     public void open(FunctionContext context) {
@@ -1066,7 +1066,7 @@ public static class BeverageNameLookupFunction extends AsyncScalarFunction {
     // The eval method takes a future for the result and the beverage ID to lookup.
     public void eval(CompletableFuture<String> future, Integer beverageId) {
         // Submit a task to the thread pool. We don't want to block this main 
-        // thread since would prevent concurrent execution. The future can be 
+        // thread since that would prevent concurrent execution. The future can be 
         // completed from another thread when the lookup is done.
         executor.execute(() -> {
             // Simulate a database lookup by sleeping for 1s.

--- a/docs/content/docs/dev/table/functions/udfs.md
+++ b/docs/content/docs/dev/table/functions/udfs.md
@@ -1025,7 +1025,7 @@ When interacting with external systems (for example when enriching stream events
 
 Naively accessing data in the external database, for example using a `ScalarFunction`, typically means **synchronous** interaction: A request is sent to the database and the `ScalarFunction` waits until the response has been received. In many cases, this waiting makes up the vast majority of the function’s time.
 
-Asynchronous interaction with the database means that a single function instance can handle many requests concurrently and receive the responses concurrently. That way, the waiting time can be overlaid with sending other requests and receiving responses. At the very least, the waiting time is amortized over multiple requests. This leads in most cased to much higher streaming throughput.
+To address this inefficiency, there is an `AsyncScalarFunction`. Asynchronous interaction with the database means that a single function instance can handle many requests concurrently and receive the responses concurrently. That way, the waiting time can be overlaid with sending other requests and receiving responses. At the very least, the waiting time is amortized over multiple requests. This leads in most cased to much higher streaming throughput.
 
 {{< img src="/fig/async_io.svg" width="50%" >}}
 

--- a/docs/content/docs/dev/table/functions/udfs.md
+++ b/docs/content/docs/dev/table/functions/udfs.md
@@ -1043,6 +1043,10 @@ While calls to an `AsyncScalarFunction` may be completed out of the original inp
 #### Error Handling
 The primary way for a user to indicate an error is to call `completableFuture.completeExceptionally(throwable)`. Similarly, if an exception is encountered by the system when invoking `eval`, that will also result in an error. When an error occurs, the system will consider the retry strategy, configured by `table.exec.async-scalar.retry-strategy`. If this is `NO_RETRY`, it will fail the job immediately. If it is set to `FIXED_DELAY`, a period of `table.exec.async-scalar.retry-delay` will be waited, and the function call will be retried and given another attempt to succeed. If the number of retries exceeds `table.exec.async-scalar.max-attempts` or if the timeout `table.exec.async-scalar.timeout` expires (including all retry attempts), the job will fail.
 
+#### Is AsyncScalarFunction Required?
+One thing to consider is if the UDF contains CPU intensive logic with no blocking calls.  If so, it likely doesn't require asynchronous functionality and could use a `ScalarFunction`. If the logic involves waiting for things like network or background operations (e.g. database lookups, RPCs, or REST calls), this may be a useful way to speed things up. 
+
+
 The following example shows how to do work on a thread pool in the background, though any libraries exposing an async interface may be directly used to complete the `CompletableFuture` from a callback. See the [Implementation Guide](#implementation-guide) for more details.
 
 {{< tabs "a385387e-d64b-44b3-9b65-fd42f0820e99" >}}

--- a/docs/content/docs/dev/table/functions/udfs.md
+++ b/docs/content/docs/dev/table/functions/udfs.md
@@ -40,6 +40,7 @@ Overview
 Currently, Flink distinguishes between the following kinds of functions:
 
 - *Scalar functions* map scalar values to a new scalar value.
+  - *Asynchronous scalar functions* asynchronously map scalar values to a new scalar value.
 - *Table functions* map scalar values to new rows.
 - *Aggregate functions* map scalar values of multiple rows to a new scalar value.
 - *Table aggregate functions* map scalar values of multiple rows to new rows.
@@ -1014,6 +1015,117 @@ env.sqlQuery("SELECT HashFunction(myField) FROM MyTable")
 {{< /tabs >}}
 
 If you intend to implement or call functions in Python, please refer to the [Python Scalar Functions]({{< ref "docs/dev/python/table/udfs/python_udfs" >}}#scalar-functions) documentation for more details.
+
+{{< top >}}
+
+Asynchronous Scalar Functions
+----------------
+
+A user-defined asynchronous scalar function maps zero, one, or multiple scalar values to a new scalar value, but does it asynchronously. Any data type listed in the [data types section]({{< ref "docs/dev/table/types" >}}) can be used as a parameter or return type of an evaluation method.
+
+In order to define an asynchronous scalar function, one has to extend the base class `AsyncScalarFunction` in `org.apache.flink.table.functions` and implement one or more evaluation methods named `eval(...)`.  The first argument must be a `CompletableFuture<...>` which is used to return the result, with subsequent arguments being the parameters passed to the function.
+
+The following example shows how to do work on a thread pool in the background, though any libraries exposing an async interface may be directly used to complete the `CompletableFuture` from a callback. See the [Implementation Guide](#implementation-guide) for more details.
+
+Also, see the configurations under `table.exec.async-scalar.*` for setting the number of outstanding calls, timeouts, and other parameters.
+
+{{< tabs "a385387e-d64b-44b3-9b65-fd42f0820e99" >}}
+{{< tab "Java" >}}
+
+```java
+import org.apache.flink.table.api.*;
+import org.apache.flink.table.functions.AsyncScalarFunction;
+
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+import static org.apache.flink.table.api.Expressions.*;
+
+public static class BackgroundFunction extends AsyncScalarFunction {
+    private Executor executor;
+
+    @Override
+    public void open(FunctionContext context) {
+        executor = Executors.newFixedThreadPool(10);
+    }
+
+    // take any data type and return INT
+    public void eval(CompletableFuture<Long> future, Integer waitMax) {
+        executor.execute(() -> {
+            long sleepTime = new Random().nextInt(waitMax);
+            try {
+                Thread.sleep(sleepTime);
+            } catch (InterruptedException e) {}
+            future.complete(sleepTime);
+        });
+    }
+}
+
+TableEnvironment env = TableEnvironment.create(...);
+env.getConfig().set("table.exec.async-scalar.buffer-capacity", "5");
+env.getConfig().set("table.exec.async-scalar.timeout", "1m");
+
+// call function "inline" without registration in Table API
+env.from("MyTable").select(call(BackgroundFunction.class, $("myField")));
+
+// register function
+env.createTemporarySystemFunction("BackgroundFunction", BackgroundFunction.class);
+
+// call registered function in Table API
+env.from("MyTable").select(call("BackgroundFunction", $("myField")));
+
+// call registered function in SQL
+env.sqlQuery("SELECT BackgroundFunction(myField) FROM MyTable");
+
+```
+{{< /tab >}}
+{{< tab "Scala" >}}
+```scala
+import org.apache.flink.table.annotation.InputGroup
+import org.apache.flink.table.api._
+import org.apache.flink.table.functions.AsyncScalarFunction
+
+class BackgroundFunc extends AsyncScalarFunction {
+
+  private var executor: Executor = null
+
+  override def open(context: FunctionContext): Unit = {
+    executor = Executors.newFixedThreadPool(10)
+  }
+
+  def eval(future: CompletableFuture[java.lang.Long], waitMax: Integer): Unit = {
+    executor.execute(() => {
+      val sleepTime = new Random().nextInt(waitMax)
+      try Thread.sleep(sleepTime)
+      catch {
+        case e: InterruptedException =>
+      }
+      future.complete(sleepTime)
+    })
+  }
+}
+
+val env = TableEnvironment.create(...)
+env.getConfig.set("table.exec.async-scalar.buffer-capacity", "5")
+env.getConfig.set("table.exec.async-scalar.timeout", "1m")
+
+// call function "inline" without registration in Table API
+env.from("MyTable").select(call(classOf[BackgroundFunc], $"myField"))
+
+// register function
+env.createTemporarySystemFunction("BackgroundFunc", classOf[BackgroundFunc])
+
+// call registered function in Table API
+env.from("MyTable").select(call("BackgroundFunc", $"myField"))
+
+// call registered function in SQL
+env.sqlQuery("SELECT BackgroundFunc(myField) FROM MyTable")
+
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 {{< top >}}
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Adds documentation for AsyncScalarFunction.

## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
