### PR TITLE
[BP-2.0][FLINK-37761][runtime] Fix unstable test testJobVertexUnFinishedAndOperatorCoordinatorNotSupportBatchSnapshot.

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/BatchJobRecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/BatchJobRecoveryTest.java
@@ -413,9 +413,12 @@ public class BatchJobRecoveryTest {
 
             // check middle task0 is CREATED because it's waiting source task0 finished.
             if (vertex.getParallelSubtaskIndex() == subtaskIndex) {
-                ExecutionState expectedState =
-                        isBlockingShuffle ? ExecutionState.CREATED : ExecutionState.DEPLOYING;
-                assertThat(vertex.getExecutionState()).isEqualTo(expectedState);
+                if (isBlockingShuffle) {
+                    assertThat(vertex.getExecutionState()).isEqualTo(ExecutionState.CREATED);
+                } else {
+                    assertThat(vertex.getExecutionState().ordinal())
+                            .isLessThanOrEqualTo(ExecutionState.DEPLOYING.ordinal());
+                }
                 continue;
             }
 


### PR DESCRIPTION
[FLINK-37761][runtime] Fix unstable test testJobVertexUnFinishedAndOperatorCoordinatorNotSupportBatchSnapshot.