### PR TITLE
[FLINK-37870][checkpoint] Fix the bug that unaligned checkpoint is disabled for all connections unexpectedly

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/SinkTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/SinkTransformationTranslator.java
@@ -225,7 +225,9 @@ public class SinkTransformationTranslator<Input, Output>
 
             // check all transformation after the writer and recursively disable UC for all inputs
             // up to the writer
-            Set<Integer> seen = new HashSet<>(writer.getId());
+            Set<Integer> seen = new HashSet<>(sinkTransformations.size() * 2);
+            seen.add(writer.getId());
+
             Queue<Transformation<?>> pending =
                     new ArrayDeque<>(
                             sinkTransformations.subList(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/SinkTransformationTranslatorITCaseBase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/SinkTransformationTranslatorITCaseBase.java
@@ -117,6 +117,7 @@ abstract class SinkTransformationTranslatorITCaseBase<SinkT> {
 
         assertThat(streamGraph.getStreamNodes()).hasSize(3);
         assertNoUnalignedOutput(writerNode);
+        assertUnalignedOutput(sourceNode);
 
         validateTopology(
                 writerNode,
@@ -279,6 +280,10 @@ abstract class SinkTransformationTranslatorITCaseBase<SinkT> {
 
     protected static void assertNoUnalignedOutput(StreamNode src) {
         assertThat(src.getOutEdges()).allMatch(e -> !e.supportsUnalignedCheckpoints());
+    }
+
+    protected static void assertUnalignedOutput(StreamNode src) {
+        assertThat(src.getOutEdges()).allMatch(StreamEdge::supportsUnalignedCheckpoints);
     }
 
     StreamGraph buildGraph(SinkT sink, RuntimeExecutionMode runtimeExecutionMode) {


### PR DESCRIPTION
Backport https://github.com/apache/flink/pull/26619
