### PR TITLE
[FLINK-37906][doc] Bump flink-connector-kafka to 4.0 for doc

### DIFF
--- a/docs/setup_docs.sh
+++ b/docs/setup_docs.sh
@@ -60,7 +60,7 @@ if [ "$SKIP_INTEGRATE_CONNECTOR_DOCS" = false ]; then
   integrate_connector_docs gcp-pubsub v3.0
   integrate_connector_docs mongodb v2.0
   integrate_connector_docs opensearch v1.2
-  integrate_connector_docs kafka v3.3
+  integrate_connector_docs kafka v4.0
   integrate_connector_docs hbase v4.0
   integrate_connector_docs prometheus v1.0
   integrate_connector_docs hive v3.0


### PR DESCRIPTION
## What is the purpose of the change

*[release-2.0 doc](https://nightlies.apache.org/flink/flink-docs-release-2.0/docs/connectors/datastream/kafka/) did not correctly display the artifactId for `4.0.0-2.0`. This pr bump kafka version to 4.0 for doc.*

*This should be also backport to `release-2.0` branch. Besides, we must also fix a parsing problem in connector repo(https://github.com/apache/flink-connector-kafka/pull/178).*


## Verifying this change

Build release-2.0 branch doc with fix locally:

![image](https://github.com/user-attachments/assets/bc016c08-9984-4348-aee8-33d025dc28e5)


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
