### PR TITLE
[BP-2.0][FLINK-37906][doc] Bump flink-connector-kafka to 4.0 for doc

### DIFF
--- a/docs/setup_docs.sh
+++ b/docs/setup_docs.sh
@@ -60,7 +60,7 @@ if [ "$SKIP_INTEGRATE_CONNECTOR_DOCS" = false ]; then
   integrate_connector_docs gcp-pubsub v3.0
   integrate_connector_docs mongodb v1.2
   integrate_connector_docs opensearch v1.2
-  integrate_connector_docs kafka v3.3
+  integrate_connector_docs kafka v4.0
   integrate_connector_docs hbase v4.0
   integrate_connector_docs prometheus v1.0
 


### PR DESCRIPTION
Backport FLINK-37906 to `release-2.0` branch.

See https://github.com/apache/flink/pull/26635 for reviewing.