### PR TITLE
[FLINK-37907][table] Allow to access memberExecNodes in BatchExecMultipleInput

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecMultipleInput.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecMultipleInput.java
@@ -262,6 +262,10 @@ public class BatchExecMultipleInput extends ExecNodeBase<RowData>
         return originalEdges;
     }
 
+    public List<ExecNode<?>> getMemberExecNodes() {
+        return memberExecNodes;
+    }
+
     @VisibleForTesting
     public ExecNode<?> getRootNode() {
         return rootNode;


### PR DESCRIPTION
## What is the purpose of the change

it is required access for downstream project

## Brief change log
Add a getter


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
