### PR TITLE
[FLINK-37862][table] Support inline structured types in SQL

### DIFF
--- a/docs/content.zh/docs/dev/table/types.md
+++ b/docs/content.zh/docs/dev/table/types.md
@@ -1232,34 +1232,46 @@ equivalent to `ROW<myField INT, myOtherField BOOLEAN>`.
 
 ### User-Defined Data Types
 
-{{< tabs "udf" >}}
+#### `STRUCTURED`
+
+Data type for a user-defined object.
+
+Compared to `ROW`, which may also be considered a "struct-like" type, structured types are distinguishable even if they
+contain the same set of fields. For example, `Visit(amount DOUBLE)` is distinct from `Interaction(amount DOUBLE)` due
+its identifier.
+
+Similar to classes in object-oriented programming languages, structured types are identified by a class name and contain
+zero, one or more attributes. Each attribute consists of a name and a type. A type cannot be defined in such a way that
+one of its attribute types (transitively) refers to itself.
+
+Structured types are internally converted by the system into suitable data structures. Serialization and equality checks
+are managed by the system based on the logical type.
+
+{{< tabs "udt" >}}
+{{< tab "SQL" >}}
+```sql
+STRUCTURED<'c', n0 t0, n1 t1, ...>
+STRUCTURED<'c', n0 t0, n1 t1 'd1', ...>
+```
+The type can be declared using `STRUCTURED<'c', n0 t0 'd0', n1 t1 'd1', ...>` where `c` is the class name, `n` is the
+unique name of a field, `t` is the logical type of a field, `d` is the description of a field.
+{{< /tab >}}
+
 {{< tab "Java/Scala" >}}
-<span class="label label-danger">Attention</span> User-defined data types are not fully supported yet. They are
-currently (as of Flink 1.11) only exposed as unregistered structured types in parameters and return types of functions.
+Usually structured types are defined **inline** and can be reflectively extracted from a corresponding implementation class.
+For example, in the signature of an `eval()` method for functions. This is useful when programmatically defining a table
+program. They enable reusing existing JVM classes without manually defining the schema of a data type again.
 
-A structured type is similar to an object in an object-oriented programming language. It contains
-zero, one or more attributes. Each attribute consists of a name and a type.
+If the class name matches a class in the classpath, the system will convert a structured object to a JVM object at the edges
+of the table ecosystem (e.g. when bridging to a function or connector). The implementation class must provide either a
+zero-argument constructor or a full constructor that assigns all attributes.
 
-There are two kinds of structured types:
+But the class name does not need to be resolvable in the classpath, it may be used solely to distinguish between objects with
+identical attribute sets. However, in Table API and UDF calls, the system will attempt to resolve the class name to an
+actual implementation class. If resolution fails, `Row` is used as a fallback.
 
-- Types that are stored in a catalog and are identified by a _catalog identifier_ (like `cat.db.MyType`). Those
-are equal to the SQL standard definition of structured types.
-
-- Anonymously defined, unregistered types (usually reflectively extracted) that are identified by
-an _implementation class_ (like `com.myorg.model.MyType`). Those are useful when programmatically
-defining a table program. They enable reusing existing JVM classes without manually defining the
-schema of a data type again.
-
-#### Registered Structured Types
-
-Currently, registered structured types are not supported. Thus, they cannot be stored in a catalog
-or referenced in a `CREATE TABLE` DDL.
-
-#### Unregistered Structured Types
-
-Unregistered structured types can be created from regular POJOs (Plain Old Java Objects) using automatic reflective extraction.
-
-The implementation class of a structured type must meet the following requirements:
+Inline structured types can be created from regular POJOs (Plain Old Java Objects) if the implementation class meets the
+following requirements:
 - The class must be globally accessible which means it must be declared `public`, `static`, and not `abstract`.
 - The class must offer a default constructor with zero arguments or a full constructor that assigns all
 fields.
@@ -1281,15 +1293,51 @@ For some classes an annotation is required in order to map the class to a data t
 to assign a fixed precision and scale for `java.math.BigDecimal`).
 {{< /tab >}}
 {{< tab "Python" >}}
+```python
+Not supported.
+```
 {{< /tab >}}
 {{< /tabs >}}
 
 **Declaration**
 
 {{< tabs "c5e5527b-b09d-4dc5-9549-8fd2bfc7cc2a" >}}
-{{< tab "Java" >}}
+{{< tab "Java/Scala" >}}
+Structured types are usually declared via their implementation classes:
+
 ```java
-class User {
+// A simple POJO that qualifies as a structured type.
+// Note: Without a fully assigning constructor, the order of fields will be alphabetical.
+// The final data type will be:
+// STRUCTURED<'com.myorg.Customer', active BOOLEAN, id INT NOT NULL, name STRING, properties MAP<STRING, STRING>>
+class Customer {
+  public int id;
+  public String name;
+  public Map<String, String> properties;
+  public boolean active;
+}
+
+// A POJO with a fully assigning constructor defining the field order.
+// The final data type will be:
+// STRUCTURED<'com.myorg.Customer', id INT NOT NULL, name STRING, properties MAP<STRING, STRING>, active BOOLEAN>
+class Customer {
+  public int id;
+  public String name;
+  public Map<String, String> properties;
+  public boolean active;
+
+  public Customer(int id, String name, Map<String, String> properties, boolean active) {
+    this.id = id;
+    this.name = name;
+    this.properties = properties;
+    this.active = active;
+  }
+}
+
+// A POJO that uses the @DataTypeHint annotations for supporting the reflective extraction.
+// The final data type will be:
+// STRUCTURED<'com.myorg.Customer', age INT NOT NULL, modelClass RAW(...), name STRING, totalBalance DECIMAL(10, 2)>
+class Customer {
 
     // extract fields automatically
     public int age;
@@ -1301,35 +1349,27 @@ class User {
     // enrich the extraction with forcing using RAW types
     public @DataTypeHint("RAW") Class<?> modelClass;
 }
-
-DataTypes.of(User.class);
 ```
 
-**Bridging to JVM Types**
+Or via explicit declaration:
+```java
+DataTypes.STRUCTURED(Class, DataTypes.FIELD(n0, t0), DataTypes.FIELD(n1, t1), ...);
+DataTypes.STRUCTURED(String, DataTypes.FIELD(n0, t0), DataTypes.FIELD(n1, t1), ...);
 
-| Java Type                            | Input | Output | Remarks                                 |
-|:-------------------------------------|:-----:|:------:|:----------------------------------------|
-|*class*                               | X     | X      | Originating class or subclasses (for input) or <br>superclasses (for output). *Default* |
-|`org.apache.flink.types.Row`          | X     | X      | Represent the structured type as a row. |
-|`org.apache.flink.table.data.RowData` | X     | X      | Internal data structure.                |
+// For example:
+DataTypes.STRUCTURED(
+  Customer.class,
+  DataTypes.FIELD("age", DataTypes.INT().notNull()),
+  DataTypes.FIELD("name", DataTypes.STRING())
+);
+```
 
-{{< /tab >}}
-{{< tab "Scala" >}}
-```scala
-case class User(
+Or via explicit extraction:
+```java
+DataTypes.of(Class);
 
-    // extract fields automatically
-    age: Int,
-    name: String,
-
-    // enrich the extraction with precision information
-    @DataTypeHint("DECIMAL(10, 2)") totalBalance: java.math.BigDecimal,
-
-    // enrich the extraction with forcing using a RAW type
-    @DataTypeHint("RAW") modelClass: Class[_]
-)
-
-DataTypes.of(classOf[User])
+// For example:
+DataTypes.of(Customer.class);
 ```
 
 **Bridging to JVM Types**

--- a/docs/content.zh/docs/dev/table/types.md
+++ b/docs/content.zh/docs/dev/table/types.md
@@ -1241,8 +1241,8 @@ contain the same set of fields. For example, `Visit(amount DOUBLE)` is distinct 
 its identifier.
 
 Similar to classes in object-oriented programming languages, structured types are identified by a class name and contain
-zero, one or more attributes. Each attribute consists of a name and a type. A type cannot be defined in such a way that
-one of its attribute types (transitively) refers to itself.
+zero, one or more attributes. Each attribute has a name, a type, and an optional description. A type cannot be defined
+in such a way that one of its attribute types (transitively) refers to itself.
 
 Structured types are internally converted by the system into suitable data structures. Serialization and equality checks
 are managed by the system based on the logical type.
@@ -1254,7 +1254,7 @@ STRUCTURED<'c', n0 t0, n1 t1, ...>
 STRUCTURED<'c', n0 t0, n1 t1 'd1', ...>
 ```
 The type can be declared using `STRUCTURED<'c', n0 t0 'd0', n1 t1 'd1', ...>` where `c` is the class name, `n` is the
-unique name of a field, `t` is the logical type of a field, `d` is the description of a field.
+unique name of a field, `t` is the logical type of a field, `d` is the optional description of a field.
 {{< /tab >}}
 
 {{< tab "Java/Scala" >}}
@@ -1353,10 +1353,13 @@ class Customer {
 
 Or via explicit declaration:
 ```java
-DataTypes.STRUCTURED(Class, DataTypes.FIELD(n0, t0), DataTypes.FIELD(n1, t1), ...);
-DataTypes.STRUCTURED(String, DataTypes.FIELD(n0, t0), DataTypes.FIELD(n1, t1), ...);
+// Provide an implementation class
+DataTypes.STRUCTURED(MyPojo.class, DataTypes.FIELD(n0, t0), DataTypes.FIELD(n1, t1), ...);
 
-// For example:
+// Provide a class name only, the class is resolved only if available in the classpath
+DataTypes.STRUCTURED("com.myorg.MyPojo", DataTypes.FIELD(n0, t0), DataTypes.FIELD(n1, t1), ...);
+
+// Full example
 DataTypes.STRUCTURED(
   Customer.class,
   DataTypes.FIELD("age", DataTypes.INT().notNull()),

--- a/docs/content/docs/dev/table/types.md
+++ b/docs/content/docs/dev/table/types.md
@@ -1241,34 +1241,46 @@ equivalent to `ROW<myField INT, myOtherField BOOLEAN>`.
 
 ### User-Defined Data Types
 
-{{< tabs "udf" >}}
+#### `STRUCTURED`
+
+Data type for a user-defined object.
+
+Compared to `ROW`, which may also be considered a "struct-like" type, structured types are distinguishable even if they
+contain the same set of fields. For example, `Visit(amount DOUBLE)` is distinct from `Interaction(amount DOUBLE)` due
+its identifier.
+
+Similar to classes in object-oriented programming languages, structured types are identified by a class name and contain
+zero, one or more attributes. Each attribute consists of a name and a type. A type cannot be defined in such a way that
+one of its attribute types (transitively) refers to itself.
+
+Structured types are internally converted by the system into suitable data structures. Serialization and equality checks
+are managed by the system based on the logical type.
+
+{{< tabs "udt" >}}
+{{< tab "SQL" >}}
+```sql
+STRUCTURED<'c', n0 t0, n1 t1, ...>
+STRUCTURED<'c', n0 t0, n1 t1 'd1', ...>
+```
+The type can be declared using `STRUCTURED<'c', n0 t0 'd0', n1 t1 'd1', ...>` where `c` is the class name, `n` is the
+unique name of a field, `t` is the logical type of a field, `d` is the description of a field.
+{{< /tab >}}
+
 {{< tab "Java/Scala" >}}
-<span class="label label-danger">Attention</span> User-defined data types are not fully supported yet. They are
-currently (as of Flink 1.11) only exposed as unregistered structured types in parameters and return types of functions.
+Usually structured types are defined **inline** and can be reflectively extracted from a corresponding implementation class.
+For example, in the signature of an `eval()` method for functions. This is useful when programmatically defining a table
+program. They enable reusing existing JVM classes without manually defining the schema of a data type again.
 
-A structured type is similar to an object in an object-oriented programming language. It contains
-zero, one or more attributes. Each attribute consists of a name and a type.
+If the class name matches a class in the classpath, the system will convert a structured object to a JVM object at the edges
+of the table ecosystem (e.g. when bridging to a function or connector). The implementation class must provide either a
+zero-argument constructor or a full constructor that assigns all attributes.
 
-There are two kinds of structured types:
+But the class name does not need to be resolvable in the classpath, it may be used solely to distinguish between objects with
+identical attribute sets. However, in Table API and UDF calls, the system will attempt to resolve the class name to an
+actual implementation class. If resolution fails, `Row` is used as a fallback.
 
-- Types that are stored in a catalog and are identified by a _catalog identifier_ (like `cat.db.MyType`). Those
-are equal to the SQL standard definition of structured types.
-
-- Anonymously defined, unregistered types (usually reflectively extracted) that are identified by
-an _implementation class_ (like `com.myorg.model.MyType`). Those are useful when programmatically
-defining a table program. They enable reusing existing JVM classes without manually defining the
-schema of a data type again.
-
-#### Registered Structured Types
-
-Currently, registered structured types are not supported. Thus, they cannot be stored in a catalog
-or referenced in a `CREATE TABLE` DDL.
-
-#### Unregistered Structured Types
-
-Unregistered structured types can be created from regular POJOs (Plain Old Java Objects) using automatic reflective extraction.
-
-The implementation class of a structured type must meet the following requirements:
+Inline structured types can be created from regular POJOs (Plain Old Java Objects) if the implementation class meets the
+following requirements:
 - The class must be globally accessible which means it must be declared `public`, `static`, and not `abstract`.
 - The class must offer a default constructor with zero arguments or a full constructor that assigns all
 fields.
@@ -1290,15 +1302,51 @@ For some classes an annotation is required in order to map the class to a data t
 to assign a fixed precision and scale for `java.math.BigDecimal`).
 {{< /tab >}}
 {{< tab "Python" >}}
+```python
+Not supported.
+```
 {{< /tab >}}
 {{< /tabs >}}
 
 **Declaration**
 
 {{< tabs "c5e5527b-b09d-4dc5-9549-8fd2bfc7cc2a" >}}
-{{< tab "Java" >}}
+{{< tab "Java/Scala" >}}
+Structured types are usually declared via their implementation classes:
+
 ```java
-class User {
+// A simple POJO that qualifies as a structured type.
+// Note: Without a fully assigning constructor, the order of fields will be alphabetical.
+// The final data type will be:
+// STRUCTURED<'com.myorg.Customer', active BOOLEAN, id INT NOT NULL, name STRING, properties MAP<STRING, STRING>>
+class Customer {
+  public int id;
+  public String name;
+  public Map<String, String> properties;
+  public boolean active;
+}
+
+// A POJO with a fully assigning constructor defining the field order.
+// The final data type will be:
+// STRUCTURED<'com.myorg.Customer', id INT NOT NULL, name STRING, properties MAP<STRING, STRING>, active BOOLEAN>
+class Customer {
+  public int id;
+  public String name;
+  public Map<String, String> properties;
+  public boolean active;
+
+  public Customer(int id, String name, Map<String, String> properties, boolean active) {
+    this.id = id;
+    this.name = name;
+    this.properties = properties;
+    this.active = active;
+  }
+}
+
+// A POJO that uses the @DataTypeHint annotations for supporting the reflective extraction.
+// The final data type will be:
+// STRUCTURED<'com.myorg.Customer', age INT NOT NULL, modelClass RAW(...), name STRING, totalBalance DECIMAL(10, 2)>
+class Customer {
 
     // extract fields automatically
     public int age;
@@ -1310,35 +1358,27 @@ class User {
     // enrich the extraction with forcing using RAW types
     public @DataTypeHint("RAW") Class<?> modelClass;
 }
-
-DataTypes.of(User.class);
 ```
 
-**Bridging to JVM Types**
+Or via explicit declaration:
+```java
+DataTypes.STRUCTURED(Class, DataTypes.FIELD(n0, t0), DataTypes.FIELD(n1, t1), ...);
+DataTypes.STRUCTURED(String, DataTypes.FIELD(n0, t0), DataTypes.FIELD(n1, t1), ...);
 
-| Java Type                            | Input | Output | Remarks                                 |
-|:-------------------------------------|:-----:|:------:|:----------------------------------------|
-|*class*                               | X     | X      | Originating class or subclasses (for input) or <br>superclasses (for output). *Default* |
-|`org.apache.flink.types.Row`          | X     | X      | Represent the structured type as a row. |
-|`org.apache.flink.table.data.RowData` | X     | X      | Internal data structure.                |
+// For example:
+DataTypes.STRUCTURED(
+  Customer.class,
+  DataTypes.FIELD("age", DataTypes.INT().notNull()),
+  DataTypes.FIELD("name", DataTypes.STRING())
+);
+```
 
-{{< /tab >}}
-{{< tab "Scala" >}}
-```scala
-case class User(
+Or via explicit extraction:
+```java
+DataTypes.of(Class);
 
-    // extract fields automatically
-    age: Int,
-    name: String,
-
-    // enrich the extraction with precision information
-    @DataTypeHint("DECIMAL(10, 2)") totalBalance: java.math.BigDecimal,
-
-    // enrich the extraction with forcing using a RAW type
-    @DataTypeHint("RAW") modelClass: Class[_]
-)
-
-DataTypes.of(classOf[User])
+// For example:
+DataTypes.of(Customer.class);
 ```
 
 **Bridging to JVM Types**

--- a/docs/content/docs/dev/table/types.md
+++ b/docs/content/docs/dev/table/types.md
@@ -1250,8 +1250,8 @@ contain the same set of fields. For example, `Visit(amount DOUBLE)` is distinct 
 its identifier.
 
 Similar to classes in object-oriented programming languages, structured types are identified by a class name and contain
-zero, one or more attributes. Each attribute consists of a name and a type. A type cannot be defined in such a way that
-one of its attribute types (transitively) refers to itself.
+zero, one or more attributes. Each attribute has a name, a type, and an optional description. A type cannot be defined
+in such a way that one of its attribute types (transitively) refers to itself.
 
 Structured types are internally converted by the system into suitable data structures. Serialization and equality checks
 are managed by the system based on the logical type.
@@ -1263,7 +1263,7 @@ STRUCTURED<'c', n0 t0, n1 t1, ...>
 STRUCTURED<'c', n0 t0, n1 t1 'd1', ...>
 ```
 The type can be declared using `STRUCTURED<'c', n0 t0 'd0', n1 t1 'd1', ...>` where `c` is the class name, `n` is the
-unique name of a field, `t` is the logical type of a field, `d` is the description of a field.
+unique name of a field, `t` is the logical type of a field, `d` is the optional description of a field.
 {{< /tab >}}
 
 {{< tab "Java/Scala" >}}
@@ -1362,10 +1362,13 @@ class Customer {
 
 Or via explicit declaration:
 ```java
-DataTypes.STRUCTURED(Class, DataTypes.FIELD(n0, t0), DataTypes.FIELD(n1, t1), ...);
-DataTypes.STRUCTURED(String, DataTypes.FIELD(n0, t0), DataTypes.FIELD(n1, t1), ...);
+// Provide an implementation class
+DataTypes.STRUCTURED(MyPojo.class, DataTypes.FIELD(n0, t0), DataTypes.FIELD(n1, t1), ...);
 
-// For example:
+// Provide a class name only, the class is resolved only if available in the classpath
+DataTypes.STRUCTURED("com.myorg.MyPojo", DataTypes.FIELD(n0, t0), DataTypes.FIELD(n1, t1), ...);
+
+// Full example
 DataTypes.STRUCTURED(
   Customer.class,
   DataTypes.FIELD("age", DataTypes.INT().notNull()),

--- a/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
@@ -150,6 +150,7 @@
     "org.apache.flink.sql.parser.type.ExtendedSqlRowTypeNameSpec"
     "org.apache.flink.sql.parser.type.SqlMapTypeNameSpec"
     "org.apache.flink.sql.parser.type.SqlRawTypeNameSpec"
+    "org.apache.flink.sql.parser.type.SqlStructuredTypeNameSpec"
     "org.apache.flink.sql.parser.type.SqlTimestampLtzTypeNameSpec"
     "org.apache.flink.sql.parser.utils.ParserResource"
     "org.apache.flink.sql.parser.validate.FlinkSqlConformance"
@@ -219,6 +220,7 @@
     "STATISTICS"
     "STOP"
     "STRING"
+    "STRUCTURED"
     "SUSPEND"
     "REFRESH"
     "RESUME"
@@ -661,6 +663,7 @@
     "SqlMapTypeName()"
     "SqlRawTypeName()"
     "ExtendedSqlRowTypeName()"
+    "SqlStructuredTypeName()"
   ]
 
   # List of methods for parsing builtin function calls.

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -2490,6 +2490,34 @@ SqlTypeNameSpec ExtendedSqlRowTypeName() :
 }
 
 /**
+ * Parse inline structured type such as STRUCTURED&lt;'className', name1 type1 'comment', name2 type2&gt;.
+ */
+SqlTypeNameSpec SqlStructuredTypeName() :
+{
+    final SqlNode className;
+    final List<SqlIdentifier> fieldNames = new ArrayList<SqlIdentifier>();
+    final List<SqlDataTypeSpec> fieldTypes = new ArrayList<SqlDataTypeSpec>();
+    final List<SqlCharStringLiteral> comments = new ArrayList<SqlCharStringLiteral>();
+}
+{
+    <STRUCTURED>
+    <LT>
+        className = StringLiteral()
+        [
+            <COMMA>ExtendedFieldNameTypeCommaList(fieldNames, fieldTypes, comments)
+        ]
+    <GT>
+    {
+        return new SqlStructuredTypeNameSpec(
+            getPos(),
+            className,
+            fieldNames,
+            fieldTypes,
+            comments);
+    }
+}
+
+/**
  * Those methods should not be used in SQL. They are good for parsing identifiers
  * in Table API. The difference between those identifiers and CompoundIdentifer is
  * that the Table API identifiers ignore any keywords. They are also strictly limited

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/type/SqlRawTypeNameSpec.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/type/SqlRawTypeNameSpec.java
@@ -32,8 +32,6 @@ import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.util.Litmus;
 import org.apache.calcite.util.NlsString;
 
-import java.util.Objects;
-
 /**
  * Represents a raw type such as {@code RAW('org.my.Class', 'sW3Djsds...')}.
  *
@@ -55,6 +53,7 @@ public final class SqlRawTypeNameSpec extends SqlTypeNameSpec {
     }
 
     @Override
+    @SuppressWarnings("DataFlowIssue")
     public RelDataType deriveType(SqlValidator validator) {
         return ((ExtendedRelTypeFactory) validator.getTypeFactory())
                 .createRawType(
@@ -79,10 +78,10 @@ public final class SqlRawTypeNameSpec extends SqlTypeNameSpec {
             return litmus.fail("{} != {}", this, spec);
         }
         SqlRawTypeNameSpec that = (SqlRawTypeNameSpec) spec;
-        if (!Objects.equals(this.className, that.className)) {
+        if (!className.equalsDeep(that.className, litmus)) {
             return litmus.fail("{} != {}", this, spec);
         }
-        if (!Objects.equals(this.serializerString, that.serializerString)) {
+        if (!serializerString.equalsDeep(that.serializerString, litmus)) {
             return litmus.fail("{} != {}", this, spec);
         }
         return litmus.succeed();

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/table/calcite/ExtendedRelTypeFactory.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/table/calcite/ExtendedRelTypeFactory.java
@@ -23,6 +23,8 @@ import org.apache.flink.annotation.Internal;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 
+import java.util.List;
+
 /**
  * A factory for creating {@link RelDataType} instances including Flink-specific extensions.
  *
@@ -33,4 +35,10 @@ public interface ExtendedRelTypeFactory extends RelDataTypeFactory {
 
     /** Creates a RAW type such as {@code RAW('org.my.Class', 'sW3Djsds...')}. */
     RelDataType createRawType(String className, String serializerString);
+
+    /**
+     * Creates a STRUCTURED type such as {@code STRUCTURED('org.my.Class', name STRING, age INT)}.
+     */
+    RelDataType createStructuredType(
+            String className, List<RelDataType> typeList, List<String> fieldNameList);
 }

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/Fixture.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/Fixture.java
@@ -29,6 +29,7 @@ public class Fixture {
 
     static final String RAW_TYPE_INT_CLASS = "java.lang.Integer";
     static final String RAW_TYPE_INT_SERIALIZER_STRING = "<Serializer Snapshot>";
+    static final String STRUCTURED_TYPE_NAME = "org.apache.flink.MyStructuredType";
 
     final RelDataType char1Type;
     final RelDataType char33Type;
@@ -112,8 +113,9 @@ public class Fixture {
         return typeFactory.createStructType(keyTypes, names);
     }
 
-    public RelDataType createRawType(String className, String serializerString) {
-        return typeFactory.createRawType(className, serializerString);
+    public RelDataType createStructuredType(
+            String className, List<RelDataType> typeList, List<String> fieldNameList) {
+        return typeFactory.createStructuredType(className, typeList, fieldNameList);
     }
 
     public RelDataType nullable(RelDataType type) {

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkDDLDataTypeTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkDDLDataTypeTest.java
@@ -61,6 +61,7 @@ import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -292,6 +293,36 @@ class FlinkDDLDataTypeTest {
                                 Fixture.RAW_TYPE_INT_SERIALIZER_STRING.substring(1)
                                 + "') NOT NULL",
                         FIXTURE.rawTypeOfInteger),
+                createArgumentsTestItem(
+                        "STRUCTURED<'"
+                                + Fixture.STRUCTURED_TYPE_NAME
+                                + "', age INT, `updated` BOOLEAN NOT NULL>",
+                        nullable(
+                                FIXTURE.createStructuredType(
+                                        Fixture.STRUCTURED_TYPE_NAME,
+                                        List.of(nullable(FIXTURE.intType), FIXTURE.booleanType),
+                                        List.of("age", "updated"))),
+                        "STRUCTURED< '"
+                                + Fixture.STRUCTURED_TYPE_NAME
+                                + "', `age` INTEGER, `updated` BOOLEAN NOT NULL >"),
+                createArgumentsTestItem(
+                        "STRUCTURED<'" + Fixture.STRUCTURED_TYPE_NAME + "'>",
+                        nullable(
+                                FIXTURE.createStructuredType(
+                                        Fixture.STRUCTURED_TYPE_NAME, List.of(), List.of())),
+                        "STRUCTURED< '" + Fixture.STRUCTURED_TYPE_NAME + "' >"),
+                createArgumentsTestItem(
+                        "STRUCTURED<'"
+                                + Fixture.STRUCTURED_TYPE_NAME
+                                + "', age INT 'This is comment', `updated` BOOLEAN NOT NULL 'This as well'>",
+                        nullable(
+                                FIXTURE.createStructuredType(
+                                        Fixture.STRUCTURED_TYPE_NAME,
+                                        List.of(nullable(FIXTURE.intType), FIXTURE.booleanType),
+                                        List.of("age", "updated"))),
+                        "STRUCTURED< '"
+                                + Fixture.STRUCTURED_TYPE_NAME
+                                + "', `age` INTEGER 'This is comment', `updated` BOOLEAN NOT NULL 'This as well' >"),
 
                 // Test parse throws error.
                 createArgumentsTestItem(

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/DataTypes.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/DataTypes.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.table.annotation.DataTypeHint;
 import org.apache.flink.table.catalog.DataTypeFactory;
-import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.functions.ProcessTableFunction;
 import org.apache.flink.table.types.AbstractDataType;
 import org.apache.flink.table.types.AtomicDataType;
@@ -66,6 +65,7 @@ import org.apache.flink.table.types.logical.YearMonthIntervalType.YearMonthResol
 import org.apache.flink.table.types.logical.ZonedTimestampType;
 import org.apache.flink.table.types.utils.TypeConversions;
 import org.apache.flink.table.types.utils.TypeInfoDataTypeConverter;
+import org.apache.flink.types.Row;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
@@ -928,28 +928,37 @@ public final class DataTypes {
     }
 
     /**
-     * Data type of a user-defined object structured type. Structured types contain zero, one or
-     * more attributes. Each attribute consists of a name and a type. A type cannot be defined so
-     * that one of its attribute types (transitively) uses itself.
+     * Data type of a user-defined object structured type. Structured types are identified by a
+     * class name and contain zero, one or more attributes. Each attribute consists of a name and a
+     * type. A type cannot be defined in such a way that one of its attribute types (transitively)
+     * refers to itself.
      *
-     * <p>There are two kinds of structured types. Types that are stored in a catalog and are
-     * identified by an {@link ObjectIdentifier} or anonymously defined, unregistered types (usually
-     * reflectively extracted) that are identified by an implementation {@link Class}.
+     * <p>Compared to {@link #ROW(Field...)}, which may also be considered a "struct-like" type,
+     * structured types are distinguishable even if they contain the same set of fields. For
+     * example, "Visit(amount DOUBLE)" is distinct from "Interaction(amount DOUBLE)" due its
+     * identifier.
      *
-     * <p>This method helps in manually constructing anonymous, unregistered types. This is useful
-     * in cases where the reflective extraction using {@link DataTypes#of(Class)} is not applicable.
-     * However, {@link DataTypes#of(Class)} is the recommended way of creating inline structured
-     * types as it also considers {@link DataTypeHint}s.
+     * <p>This method allows for manually constructing an inline structured type. This is useful in
+     * cases where the reflective extraction using {@link DataTypes#of(Class)} is not applicable.
+     * However, {@link DataTypes#of(Class)} is the recommended approach for creating inline
+     * structured types, as it also considers {@link DataTypeHint}s.
      *
-     * <p>Structured types are converted to internal data structures by the runtime. The given
-     * implementation class is only used at the edges of the table ecosystem (e.g. when bridging to
-     * a function or connector). Serialization and equality ({@code hashCode/equals}) are handled by
-     * the runtime based on the logical type. An implementation class must offer a default
-     * constructor with zero arguments or a full constructor that assigns all attributes.
+     * <p>Structured types are internally converted by the system into suitable data structures.
+     * Serialization and equality checks (e.g. {@code hashCode/equals}) are managed by the system
+     * based on the logical type.
      *
-     * <p>Note: A caller of this method must make sure that the {@link
-     * DataType#getConversionClass()} of the given fields matches with the attributes of the given
-     * implementation class, otherwise an exception might be thrown during runtime.
+     * <p>If an optional implementation class is provided, the system will convert a structured
+     * object to a JVM object at the edges of the table ecosystem (e.g. when bridging to a function
+     * or connector). The implementation class must provide either a zero-argument constructor or a
+     * full constructor that assigns all attributes. The class name does not need to be resolvable
+     * in the classpath; it may be used solely to distinguish between objects with identical
+     * attribute sets. However, in Table API and UDF calls, the system will attempt to resolve the
+     * class name to an actual implementation class. If resolution fails, {@link Row} is used as a
+     * fallback.
+     *
+     * <p>Note: The caller of this method must ensure that the {@link DataType#getConversionClass()}
+     * of each field matches the corresponding attribute in the implementation class. Otherwise, a
+     * runtime exception may be thrown.
      *
      * @see DataTypes#of(Class)
      * @see StructuredType
@@ -957,8 +966,50 @@ public final class DataTypes {
     public static <T> DataType STRUCTURED(Class<T> implementationClass, Field... fields) {
         // some basic validation of the class to prevent common mistakes
         validateStructuredClass(implementationClass);
+        return buildStructuredType(StructuredType.newBuilder(implementationClass), fields);
+    }
 
-        final StructuredType.Builder builder = StructuredType.newBuilder(implementationClass);
+    /**
+     * Data type of a user-defined object structured type. Structured types are identified by a
+     * class name and contain zero, one or more attributes. Each attribute consists of a name and a
+     * type. A type cannot be defined in such a way that one of its attribute types (transitively)
+     * refers to itself.
+     *
+     * <p>Compared to {@link #ROW(Field...)}, which may also be considered a "struct-like" type,
+     * structured types are distinguishable even if they contain the same set of fields. For
+     * example, "Visit(amount DOUBLE)" is distinct from "Interaction(amount DOUBLE)" due its
+     * identifier.
+     *
+     * <p>This method allows for manually constructing an inline structured type. This is useful in
+     * cases where the reflective extraction using {@link DataTypes#of(Class)} is not applicable.
+     * However, {@link DataTypes#of(Class)} is the recommended approach for creating inline
+     * structured types, as it also considers {@link DataTypeHint}s.
+     *
+     * <p>Structured types are internally converted by the system into suitable data structures.
+     * Serialization and equality checks (e.g. {@code hashCode/equals}) are managed by the system
+     * based on the logical type.
+     *
+     * <p>If an optional implementation class is provided, the system will convert a structured
+     * object to a JVM object at the edges of the table ecosystem (e.g. when bridging to a function
+     * or connector). The implementation class must provide either a zero-argument constructor or a
+     * full constructor that assigns all attributes. The class name does not need to be resolvable
+     * in the classpath; it may be used solely to distinguish between objects with identical
+     * attribute sets. However, in Table API and UDF calls, the system will attempt to resolve the
+     * class name to an actual implementation class. If resolution fails, {@link Row} is used as a
+     * fallback.
+     *
+     * <p>Note: The caller of this method must ensure that the {@link DataType#getConversionClass()}
+     * of each field matches the corresponding attribute in the implementation class. Otherwise, a
+     * runtime exception may be thrown.
+     *
+     * @see DataTypes#of(Class)
+     * @see StructuredType
+     */
+    public static <T> DataType STRUCTURED(String className, Field... fields) {
+        return buildStructuredType(StructuredType.newBuilder(className), fields);
+    }
+
+    private static DataType buildStructuredType(StructuredType.Builder builder, Field... fields) {
         final List<StructuredAttribute> attributes =
                 Stream.of(fields)
                         .map(
@@ -969,11 +1020,12 @@ public final class DataTypes {
                                                 f.getDescription().orElse(null)))
                         .collect(Collectors.toList());
         builder.attributes(attributes);
-        builder.setFinal(true);
-        builder.setInstantiable(true);
+        final StructuredType structuredType = builder.build();
+
         final List<DataType> fieldDataTypes =
                 Stream.of(fields).map(DataTypes.Field::getDataType).collect(Collectors.toList());
-        return new FieldsDataType(builder.build(), implementationClass, fieldDataTypes);
+        return new FieldsDataType(
+                structuredType, structuredType.getDefaultConversion(), fieldDataTypes);
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/DataTypes.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/DataTypes.java
@@ -929,9 +929,9 @@ public final class DataTypes {
 
     /**
      * Data type of a user-defined object structured type. Structured types are identified by a
-     * class name and contain zero, one or more attributes. Each attribute consists of a name and a
-     * type. A type cannot be defined in such a way that one of its attribute types (transitively)
-     * refers to itself.
+     * class name and contain zero, one or more attributes. Each attribute has a name, a type, and
+     * an optional description. A type cannot be defined in such a way that one of its attribute
+     * types (transitively) refers to itself.
      *
      * <p>Compared to {@link #ROW(Field...)}, which may also be considered a "struct-like" type,
      * structured types are distinguishable even if they contain the same set of fields. For
@@ -971,9 +971,9 @@ public final class DataTypes {
 
     /**
      * Data type of a user-defined object structured type. Structured types are identified by a
-     * class name and contain zero, one or more attributes. Each attribute consists of a name and a
-     * type. A type cannot be defined in such a way that one of its attribute types (transitively)
-     * refers to itself.
+     * class name and contain zero, one or more attributes. Each attribute has a name, a type, and
+     * an optional description. A type cannot be defined in such a way that one of its attribute
+     * types (transitively) refers to itself.
      *
      * <p>Compared to {@link #ROW(Field...)}, which may also be considered a "struct-like" type,
      * structured types are distinguishable even if they contain the same set of fields. For

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificInputTypeStrategies.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificInputTypeStrategies.java
@@ -27,7 +27,6 @@ import org.apache.flink.table.types.inference.InputTypeStrategies;
 import org.apache.flink.table.types.inference.InputTypeStrategy;
 import org.apache.flink.table.types.logical.LogicalTypeFamily;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
-import org.apache.flink.table.types.logical.StructuredType;
 import org.apache.flink.table.types.logical.TimestampKind;
 
 import static org.apache.flink.table.types.inference.InputTypeStrategies.LITERAL;
@@ -155,14 +154,14 @@ public final class SpecificInputTypeStrategies {
      * arguments.
      */
     public static final InputTypeStrategy TWO_FULLY_COMPARABLE =
-            comparable(ConstantArgumentCount.of(2), StructuredType.StructuredComparison.FULL);
+            comparable(ConstantArgumentCount.of(2), StructuredComparison.FULL);
 
     /**
      * Strategy that checks all types are equals comparable with each other. Requires exactly two
      * arguments.
      */
     public static final InputTypeStrategy TWO_EQUALS_COMPARABLE =
-            comparable(ConstantArgumentCount.of(2), StructuredType.StructuredComparison.EQUALS);
+            comparable(ConstantArgumentCount.of(2), StructuredComparison.EQUALS);
 
     /** Type strategy specific for {@link BuiltInFunctionDefinitions#IN}. */
     public static final InputTypeStrategy IN = new SubQueryInputTypeStrategy();

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/DistinctType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/DistinctType.java
@@ -29,10 +29,13 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * Logical type of a user-defined distinct type. A distinct type specifies an identifier and is
- * backed by a source type. A distinct type has the same internal representation as a source type,
- * but is considered to be a separate and incompatible data type for most operations. Compared to
- * the SQL standard, every non-user-defined type can be used as a source type.
+ * Logical type of a user-defined distinct type. This type is currently not fully supported in the
+ * planner and remains future work.
+ *
+ * <p>A distinct type specifies an identifier and is backed by a source type. A distinct type has
+ * the same internal representation as the source type, but is considered to be a separate and
+ * incompatible data type for most operations. Compared to the SQL standard, every non-user-defined
+ * type can be used as a source type.
  *
  * <p>A distinct type can always be cast to its source type and vice versa.
  *
@@ -115,6 +118,14 @@ public final class DistinctType extends UserDefinedType {
                 getObjectIdentifier().orElseThrow(IllegalStateException::new),
                 sourceType.copy(isNullable),
                 getDescription().orElse(null));
+    }
+
+    @Override
+    public String asSerializableString() {
+        return withNullability(
+                getObjectIdentifier()
+                        .orElseThrow(IllegalStateException::new)
+                        .asSerializableString());
     }
 
     @Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/StructuredType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/StructuredType.java
@@ -19,17 +19,20 @@
 package org.apache.flink.table.types.logical;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.utils.EncodingUtils;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
+import javax.lang.model.SourceVersion;
 
+import java.io.ObjectStreamException;
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -41,38 +44,61 @@ import static org.apache.flink.table.utils.EncodingUtils.escapeSingleQuotes;
 
 /**
  * Logical type of a user-defined object structured type. Structured types contain zero, one or more
- * attributes. Each attribute consists of a name and a type. A type cannot be defined so that one of
- * its attribute types (transitively) uses itself.
+ * attributes. Each attribute consists of a name and a type. A type cannot be defined in such a way
+ * that one of its attribute types (transitively) refers to itself.
  *
- * <p>There are two kinds of structured types. Types that are stored in a catalog and are identified
- * by an {@link ObjectIdentifier} or anonymously defined, unregistered types (usually reflectively
- * extracted) that are identified by an implementation {@link Class}.
+ * <p>Compared to {@link RowType}, which may also be considered a "struct-like" type, structured
+ * types are distinguishable even if they contain the same set of fields. For example, "Visit(amount
+ * DOUBLE)" is distinct from "Interaction(amount DOUBLE)" due its identifier.
  *
- * <h1>Logical properties</h1>
+ * <p>There are two kinds of structured types:
  *
- * <p>A structured type can declare a super type and allows single inheritance for more complex type
- * hierarchies, similar to JVM-based languages.
+ * <h1>Catalog Structured Types</h1>
  *
- * <p>A structured type can be declared {@code final} for preventing further inheritance (default
- * behavior) or {@code not final} for allowing subtypes.
+ * <strong>This type is currently not fully supported in the planner and is future work.</strong>
  *
- * <p>A structured type can be declared {@code not instantiable} if a more specific type is required
- * or {@code instantiable} if instances can be created from this type (default behavior).
+ * <p>Types that are stored in a catalog and are identified by an {@link ObjectIdentifier}. Some
+ * logical properties that align with the SQL standard have been prepared already but are currently
+ * not used by the planner:
  *
- * <p>A structured type declares comparison properties of either {@code none} (no equality), {@code
- * equals} (only equality and inequality), or {@code full} (greater, equals, less).
+ * <ul>
+ *   <li>super type and single inheritance for more complex type hierarchies, similar to JVM-based
+ *       languages.
+ *   <li>{@code final} for preventing further inheritance (default behavior) or {@code not final}
+ *       for allowing subtypes.
+ *   <li>{@code not instantiable} if a more specific type is required or {@code instantiable} if
+ *       instances can be created from this type (default behavior).
+ *   <li>comparison properties of either {@code none} (no equality), {@code equals} (only equality
+ *       and inequality), or {@code full} (greater, equals, less).
+ * </ul>
  *
  * <p>NOTE: Compared to the SQL standard, this class is incomplete. We might add new features such
  * as method declarations in the future. Also ordering is not supported yet.
  *
- * <h1>Physical properties</h1>
+ * <p>The serialized string representation is {@code `cat`.`db`.`t`} where {@code cat} is the
+ * catalog name, {@code db} is the database name, and {@code t} the user-defined type name.
  *
- * <p>A structured type can be defined fully logically (e.g. by using a {@code CREATE TYPE} DDL).
- * The implementation class is optional and only used at the edges of the table ecosystem (e.g. when
- * bridging to a function or connector). Serialization and equality ({@code hashCode/equals}) are
- * handled by the runtime based on the logical type. In other words: {@code hashCode/equals} of an
- * implementation class are not used. Custom equality, casting logic, and further overloaded
- * operators will be supported once we allow defining methods on structured types.
+ * <h1>Inline Structured Types</h1>
+ *
+ * <p>Types that are unregistered (i.e. declared inline) and are identified by a class name.
+ *
+ * <p>The class name does not have to be resolvable in the classpath. It can be used purely to
+ * distinguish between two objects containing the same set of attributes. However, in Table API and
+ * UDF calls an attempt is being made to resolve the class name to an implementation class. If that
+ * fails, {@link Row} is used as the {@link #getDefaultConversion()}.
+ *
+ * <p>The serialized string representation is {@code STRUCTURED<'c', n0 t0 'd0', n1 t1 'd1', ...>}
+ * where {@code c} is the class name, {@code n} is the unique name of a field, {@code t} is the
+ * logical type of a field, {@code d} is the description of a field.
+ *
+ * <h1>Implementation Class</h1>
+ *
+ * <p>A structured type can be defined fully logically. The implementation class is optional and
+ * only used at the edges of the table ecosystem (e.g. when bridging to a function or collecting
+ * results). Serialization and equality ({@code hashCode/equals}) are handled by the runtime based
+ * on the logical type. In other words: {@code hashCode/equals} of an implementation class are not
+ * used. Custom equality, casting logic, and further overloaded operators will be supported once we
+ * allow defining methods on structured types.
  *
  * <p>An implementation class must offer a default constructor with zero arguments or a full
  * constructor that assigns all attributes. Other physical properties such as the conversion classes
@@ -82,7 +108,8 @@ import static org.apache.flink.table.utils.EncodingUtils.escapeSingleQuotes;
 public final class StructuredType extends UserDefinedType {
     private static final long serialVersionUID = 1L;
 
-    public static final String FORMAT = "*%s<%s>*";
+    public static final String CATALOG_FORMAT = "%s";
+    public static final String INLINE_FORMAT = "STRUCTURED<'%s', %s>";
 
     private static final Set<String> INPUT_OUTPUT_CONVERSION =
             conversionSet(Row.class.getName(), RowData.class.getName());
@@ -95,13 +122,10 @@ public final class StructuredType extends UserDefinedType {
         private static final long serialVersionUID = 1L;
 
         public static final String FIELD_FORMAT_WITH_DESCRIPTION = "%s %s '%s'";
-
         public static final String FIELD_FORMAT_NO_DESCRIPTION = "%s %s";
 
         private final String name;
-
         private final LogicalType type;
-
         private final @Nullable String description;
 
         public StructuredAttribute(String name, LogicalType type, @Nullable String description) {
@@ -132,6 +156,10 @@ public final class StructuredType extends UserDefinedType {
 
         public String asSummaryString() {
             return formatString(type.asSummaryString(), true);
+        }
+
+        public String asSerializableString() {
+            return formatString(type.asSerializableString(), false);
         }
 
         @Override
@@ -198,34 +226,36 @@ public final class StructuredType extends UserDefinedType {
     public static final class Builder {
 
         private final @Nullable ObjectIdentifier objectIdentifier;
-
+        private final @Nullable String className;
         private final @Nullable Class<?> implementationClass;
 
         private List<StructuredAttribute> attributes = new ArrayList<>();
-
         private boolean isNullable = true;
-
         private boolean isFinal = true;
-
         private boolean isInstantiable = true;
-
-        private StructuredComparison comparison = StructuredComparison.NONE;
-
+        private StructuredComparison comparison = StructuredComparison.EQUALS;
         private @Nullable StructuredType superType;
-
         private @Nullable String description;
+
+        public Builder(String className) {
+            this.objectIdentifier = null;
+            this.className = Preconditions.checkNotNull(className, "Class name must not be null.");
+            this.implementationClass = null;
+        }
 
         public Builder(Class<?> implementationClass) {
             this.objectIdentifier = null;
             this.implementationClass =
                     Preconditions.checkNotNull(
                             implementationClass, "Implementation class must not be null.");
+            this.className = implementationClass.getName();
         }
 
         public Builder(ObjectIdentifier objectIdentifier) {
             this.objectIdentifier =
                     Preconditions.checkNotNull(
                             objectIdentifier, "Object identifier must not be null.");
+            this.className = null;
             this.implementationClass = null;
         }
 
@@ -236,14 +266,13 @@ public final class StructuredType extends UserDefinedType {
             this.implementationClass =
                     Preconditions.checkNotNull(
                             implementationClass, "Implementation class must not be null.");
+            this.className = implementationClass.getName();
         }
 
         public Builder attributes(List<StructuredAttribute> attributes) {
             this.attributes =
-                    Collections.unmodifiableList(
-                            new ArrayList<>(
-                                    Preconditions.checkNotNull(
-                                            attributes, "Attributes must not be null.")));
+                    List.copyOf(
+                            Preconditions.checkNotNull(attributes, "Attributes must not be null."));
             return this;
         }
 
@@ -289,19 +318,17 @@ public final class StructuredType extends UserDefinedType {
                     comparison,
                     superType,
                     description,
+                    className,
                     implementationClass);
         }
     }
 
     private final List<StructuredAttribute> attributes;
-
     private final boolean isInstantiable;
-
     private final StructuredComparison comparison;
-
     private final @Nullable StructuredType superType;
-
     private final @Nullable Class<?> implementationClass;
+    private @Nullable String className;
 
     private StructuredType(
             boolean isNullable,
@@ -312,32 +339,32 @@ public final class StructuredType extends UserDefinedType {
             StructuredComparison comparison,
             @Nullable StructuredType superType,
             @Nullable String description,
+            @Nullable String className,
             @Nullable Class<?> implementationClass) {
         super(isNullable, LogicalTypeRoot.STRUCTURED_TYPE, objectIdentifier, isFinal, description);
 
         Preconditions.checkArgument(
-                objectIdentifier != null || implementationClass != null,
-                "An identifier is missing.");
+                objectIdentifier != null || className != null, "An identifier is missing.");
 
         this.attributes = attributes;
         this.isInstantiable = isInstantiable;
         this.comparison = comparison;
         this.superType = superType;
+        this.className = checkClassName(className);
         this.implementationClass = implementationClass;
     }
 
     /**
-     * Creates a builder for a {@link StructuredType} that has been stored in a catalog and is
-     * identified by an {@link ObjectIdentifier}.
+     * Creates a builder for a {@link StructuredType} that is identified by an {@link
+     * ObjectIdentifier}.
      */
     public static StructuredType.Builder newBuilder(ObjectIdentifier objectIdentifier) {
         return new StructuredType.Builder(objectIdentifier);
     }
 
     /**
-     * Creates a builder for a {@link StructuredType} that has been stored in a catalog and is
-     * identified by an {@link ObjectIdentifier}. The optional implementation class defines
-     * supported conversions.
+     * Creates a builder for a {@link StructuredType} that identified by an {@link ObjectIdentifier}
+     * but with a resolved implementation class.
      */
     public static StructuredType.Builder newBuilder(
             ObjectIdentifier objectIdentifier, Class<?> implementationClass) {
@@ -345,11 +372,19 @@ public final class StructuredType extends UserDefinedType {
     }
 
     /**
-     * Creates a builder for a {@link StructuredType} that is not stored in a catalog and is
-     * identified by an implementation {@link Class}.
+     * Creates a builder for a {@link StructuredType} that is identified by a class name derived
+     * from the given implementation class.
      */
     public static StructuredType.Builder newBuilder(Class<?> implementationClass) {
         return new StructuredType.Builder(implementationClass);
+    }
+
+    /**
+     * Creates a builder for a {@link StructuredType} that is identified by a class name but without
+     * a resolved implementation class (i.e. eventually using {@link #FALLBACK_CONVERSION}).
+     */
+    public static StructuredType.Builder newBuilder(String className) {
+        return new StructuredType.Builder(className);
     }
 
     public List<StructuredAttribute> getAttributes() {
@@ -368,6 +403,10 @@ public final class StructuredType extends UserDefinedType {
         return Optional.ofNullable(superType);
     }
 
+    public Optional<String> getClassName() {
+        return Optional.ofNullable(className);
+    }
+
     public Optional<Class<?>> getImplementationClass() {
         return Optional.ofNullable(implementationClass);
     }
@@ -383,6 +422,7 @@ public final class StructuredType extends UserDefinedType {
                 comparison,
                 superType == null ? null : (StructuredType) superType.copy(),
                 getDescription().orElse(null),
+                className,
                 implementationClass);
     }
 
@@ -391,14 +431,29 @@ public final class StructuredType extends UserDefinedType {
         if (getObjectIdentifier().isPresent()) {
             return asSerializableString();
         }
-        assert implementationClass != null;
-        // we use *class<...>* to make it visible that this type is unregistered and not confuse it
-        // with catalog types
+        assert className != null;
         return withNullability(
-                FORMAT,
-                implementationClass.getName(),
+                INLINE_FORMAT,
+                className,
                 getAllAttributes().stream()
                         .map(StructuredAttribute::asSummaryString)
+                        .collect(Collectors.joining(", ")));
+    }
+
+    @Override
+    public String asSerializableString() {
+        final String identifier =
+                getObjectIdentifier().map(ObjectIdentifier::asSerializableString).orElse(null);
+        if (identifier != null) {
+            return withNullability(CATALOG_FORMAT, identifier);
+        }
+
+        assert className != null;
+        return withNullability(
+                INLINE_FORMAT,
+                EncodingUtils.escapeSingleQuotes(className),
+                getAllAttributes().stream()
+                        .map(StructuredAttribute::asSerializableString)
                         .collect(Collectors.joining(", ")));
     }
 
@@ -449,25 +504,38 @@ public final class StructuredType extends UserDefinedType {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        if (!super.equals(o)) {
-            return false;
-        }
-        StructuredType that = (StructuredType) o;
-        return isInstantiable == that.isInstantiable
-                && attributes.equals(that.attributes)
-                && comparison == that.comparison
-                && Objects.equals(superType, that.superType)
-                && Objects.equals(implementationClass, that.implementationClass);
+        final StructuredType that = (StructuredType) o;
+        // Builder defaults might change once the planner supports more structured type properties
+        // (i.e. full comparison). Comparing the reference (object identifier or class name) and
+        // attributes should be sufficient.
+        return Objects.equals(getReference(), that.getReference())
+                && Objects.equals(attributes, that.attributes);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(
-                super.hashCode(),
+        // Builder defaults might change once the planner supports more structured type properties
+        // (i.e. full comparison). Comparing the reference (object identifier or class name) and
+        // attributes should be sufficient.
+        return Objects.hash(getReference(), attributes);
+    }
+
+    private Object readResolve() throws ObjectStreamException {
+        // Before Flink 2.1 the implementation class was used as a reference.
+        // This restores the old behavior for backwards compatibility.
+        if (getReference() != null) {
+            return this;
+        }
+        return new StructuredType(
+                isNullable(),
+                getObjectIdentifier().orElse(null),
                 attributes,
+                isFinal(),
                 isInstantiable,
                 comparison,
                 superType,
+                getDescription().orElse(null),
+                implementationClass != null ? implementationClass.getName() : className,
                 implementationClass);
     }
 
@@ -480,5 +548,42 @@ public final class StructuredType extends UserDefinedType {
         // then specific fields
         allAttributes.addAll(attributes);
         return allAttributes;
+    }
+
+    /** Unified method for referring to both catalog or inline structured types. */
+    private Object getReference() {
+        return getObjectIdentifier().map(Object.class::cast).orElse(className);
+    }
+
+    private static @Nullable String checkClassName(@Nullable String className) {
+        if (className != null && !SourceVersion.isName(className)) {
+            throw new ValidationException(
+                    String.format(
+                            "Invalid class name '%s'. The class name must comply with JVM identifier rules.",
+                            className));
+        }
+        return className;
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Shared helpers
+    // --------------------------------------------------------------------------------------------
+
+    /**
+     * Restores an implementation class from the class name component of a serialized string
+     * representation.
+     *
+     * <p>Note: This method does not perform any kind of validation. The logical type system should
+     * not be destabilized by incorrectly implemented classes. This is also why classes won't get
+     * initialized. At this stage, only the class existence (i.e. metadata) in classloader matters.
+     */
+    public static Optional<Class<?>> resolveClass(ClassLoader classLoader, String className) {
+        checkClassName(className);
+        try {
+            // Initialization is deferred until first instantiation
+            return Optional.of(Class.forName(className, false, classLoader));
+        } catch (Throwable t) {
+            return Optional.empty();
+        }
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/StructuredType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/StructuredType.java
@@ -44,8 +44,8 @@ import static org.apache.flink.table.utils.EncodingUtils.escapeSingleQuotes;
 
 /**
  * Logical type of a user-defined object structured type. Structured types contain zero, one or more
- * attributes. Each attribute consists of a name and a type. A type cannot be defined in such a way
- * that one of its attribute types (transitively) refers to itself.
+ * attributes. Each attribute has a name, a type, and an optional description. A type cannot be
+ * defined in such a way that one of its attribute types (transitively) refers to itself.
  *
  * <p>Compared to {@link RowType}, which may also be considered a "struct-like" type, structured
  * types are distinguishable even if they contain the same set of fields. For example, "Visit(amount
@@ -89,7 +89,7 @@ import static org.apache.flink.table.utils.EncodingUtils.escapeSingleQuotes;
  *
  * <p>The serialized string representation is {@code STRUCTURED<'c', n0 t0 'd0', n1 t1 'd1', ...>}
  * where {@code c} is the class name, {@code n} is the unique name of a field, {@code t} is the
- * logical type of a field, {@code d} is the description of a field.
+ * logical type of a field, {@code d} is the optional description of a field.
  *
  * <h1>Implementation Class</h1>
  *

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/UserDefinedType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/UserDefinedType.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.types.logical;
 
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 
 import javax.annotation.Nullable;
@@ -31,13 +30,11 @@ import java.util.Optional;
  * Logical type of a user-defined representation for one or more built-in types. A user-defined type
  * is either a distinct type or a structured type.
  *
- * <p>A {@link UserDefinedType} instance is the result of a catalog lookup or an anonymous, inline
- * definition (for structured types only). Therefore, the serialized string representation is a
- * unique {@link ObjectIdentifier} (if registered) or a representation does not exist (if
- * unregistered).
+ * <p>A {@link UserDefinedType} instance is the result of a catalog lookup or an inline definition
+ * (for structured types only).
  *
- * <p>NOTE: Compared to the SQL standard, this class and subclasses are incomplete. We might add new
- * features such as method declarations in the future.
+ * <p>NOTE: Compared to the SQL standard, this class and subclasses have extensions and are
+ * incomplete. We might add new features such as method declarations in the future.
  *
  * @see DistinctType
  * @see StructuredType
@@ -74,15 +71,6 @@ public abstract class UserDefinedType extends LogicalType {
 
     public Optional<String> getDescription() {
         return Optional.ofNullable(description);
-    }
-
-    @Override
-    public String asSerializableString() {
-        if (objectIdentifier == null) {
-            throw new TableException(
-                    "An unregistered user-defined type has no serializable string representation.");
-        }
-        return withNullability(objectIdentifier.asSerializableString());
     }
 
     @Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/DataTypeUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/DataTypeUtils.java
@@ -526,16 +526,19 @@ public final class DataTypeUtils {
         // ----------------------------------------------------------------------------------------
 
         private StructuredType.Builder createStructuredBuilder(StructuredType structuredType) {
-            final Optional<ObjectIdentifier> identifier = structuredType.getObjectIdentifier();
-            final Optional<Class<?>> implementationClass = structuredType.getImplementationClass();
-            if (identifier.isPresent() && implementationClass.isPresent()) {
-                return StructuredType.newBuilder(identifier.get(), implementationClass.get());
-            } else if (identifier.isPresent()) {
-                return StructuredType.newBuilder(identifier.get());
-            } else if (implementationClass.isPresent()) {
-                return StructuredType.newBuilder(implementationClass.get());
+            final ObjectIdentifier identifier = structuredType.getObjectIdentifier().orElse(null);
+            final String className = structuredType.getClassName().orElse(null);
+            final Class<?> implementationClass =
+                    structuredType.getImplementationClass().orElse(null);
+
+            if (identifier != null && implementationClass != null) {
+                return StructuredType.newBuilder(identifier, implementationClass);
+            } else if (identifier != null) {
+                return StructuredType.newBuilder(identifier);
+            } else if (implementationClass != null) {
+                return StructuredType.newBuilder(implementationClass);
             } else {
-                throw new IllegalArgumentException("Invalid structured type.");
+                return StructuredType.newBuilder(className);
             }
         }
     }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalTypeJsonDeserializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalTypeJsonDeserializer.java
@@ -333,14 +333,15 @@ final class LogicalTypeJsonDeserializer extends StdDeserializer<LogicalType> {
             identifier = null;
         }
 
+        final String className;
         final Class<?> implementationClass;
         if (logicalTypeNode.has(FIELD_NAME_IMPLEMENTATION_CLASS)) {
+            className = logicalTypeNode.get(FIELD_NAME_IMPLEMENTATION_CLASS).asText();
             implementationClass =
-                    loadClass(
-                            logicalTypeNode.get(FIELD_NAME_IMPLEMENTATION_CLASS).asText(),
-                            serdeContext,
-                            "structured type");
+                    StructuredType.resolveClass(serdeContext.getClassLoader(), className)
+                            .orElse(null);
         } else {
+            className = null;
             implementationClass = null;
         }
 
@@ -349,8 +350,10 @@ final class LogicalTypeJsonDeserializer extends StdDeserializer<LogicalType> {
             builder = StructuredType.newBuilder(identifier, implementationClass);
         } else if (identifier != null) {
             builder = StructuredType.newBuilder(identifier);
-        } else {
+        } else if (implementationClass != null) {
             builder = StructuredType.newBuilder(implementationClass);
+        } else {
+            builder = StructuredType.newBuilder(className);
         }
 
         if (logicalTypeNode.has(FIELD_NAME_DESCRIPTION)) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/schema/StructuredRelDataType.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/schema/StructuredRelDataType.java
@@ -36,21 +36,17 @@ import org.apache.calcite.sql.type.SqlTypeName;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * The {@link RelDataType} representation of a {@link StructuredType}.
  *
- * <p>It extends {@link ObjectSqlType} for preserving the original logical type (including an
- * optional implementation class) and supporting anonymous/unregistered structured types from Table
- * API.
+ * <p>It extends {@link ObjectSqlType} for by inline structured types and an optional implementation
+ * class.
  */
 @Internal
 public final class StructuredRelDataType extends ObjectSqlType {
 
     private static final String IDENTIFIER_FORMAT = "*%s*";
-
-    private static final String DIGEST_FORMAT = "*%s(%s)*%s";
 
     private final StructuredType structuredType;
 
@@ -108,25 +104,7 @@ public final class StructuredRelDataType extends ObjectSqlType {
             return;
         }
         if (withDetail) {
-            if (structuredType.getObjectIdentifier().isPresent()) {
-                sb.append(structuredType.asSerializableString());
-            }
-            // in case of inline structured types we are using a temporary digest
-            // that includes both the implementation class plus its children for cases with classes
-            // that use generics
-            else {
-                sb.append(
-                        String.format(
-                                DIGEST_FORMAT,
-                                structuredType
-                                        .getImplementationClass()
-                                        .map(Class::getName)
-                                        .orElseThrow(IllegalStateException::new),
-                                fieldList.stream()
-                                        .map(field -> field.getType().getFullTypeString())
-                                        .collect(Collectors.joining(", ")),
-                                structuredType.isNullable() ? "" : " NOT NULL"));
-            }
+            sb.append(structuredType.asSerializableString());
         } else {
             sb.append(structuredType.asSummaryString());
         }
@@ -149,8 +127,7 @@ public final class StructuredRelDataType extends ObjectSqlType {
                                         String.format(
                                                 IDENTIFIER_FORMAT,
                                                 structuredType
-                                                        .getImplementationClass()
-                                                        .map(Class::getName)
+                                                        .getClassName()
                                                         .orElseThrow(IllegalStateException::new)),
                                         SqlParserPos.ZERO));
     }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StructuredFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StructuredFunctionsITCase.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.ScalarFunction;
+import org.apache.flink.table.types.logical.StructuredType;
+
+import java.util.stream.Stream;
+
+/** Tests for functions dealing with {@link StructuredType}. */
+public class StructuredFunctionsITCase extends BuiltInFunctionTestBase {
+
+    @Override
+    Stream<TestSetSpec> getTestSetSpecs() {
+        return Stream.of(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.EQUALS)
+                        .onFieldsWithData(14, "Bob")
+                        .andDataTypes(DataTypes.INT(), DataTypes.STRING())
+                        .withFunction(Type1.Type1Constructor.class)
+                        .withFunction(Type2.Type2Constructor.class)
+                        // Same value from function
+                        .testSqlResult(
+                                "Type1Constructor(f0, f1) = Type1Constructor(14, 'Bob')",
+                                true,
+                                DataTypes.BOOLEAN())
+                        // Same value from CAST
+                        .testSqlResult(
+                                "Type1Constructor(f0, f1) = CAST((14, 'Bob') AS "
+                                        + Type1.TYPE
+                                        + ")",
+                                true,
+                                DataTypes.BOOLEAN())
+                        // Different value from function
+                        .testSqlResult(
+                                "Type1Constructor(f0, f1) = Type1Constructor(15, 'Alice')",
+                                false,
+                                DataTypes.BOOLEAN())
+                        // Different value from CAST
+                        .testSqlResult(
+                                "Type1Constructor(f0, f1) = CAST((15, 'Alice') AS "
+                                        + Type1.TYPE
+                                        + ")",
+                                false,
+                                DataTypes.BOOLEAN())
+                        // Different class name from function
+                        .testSqlValidationError(
+                                "Type1Constructor(f0, f1) = Type2Constructor(14, 'Bob')",
+                                "Incompatible structured types")
+                        // Different class name from CAST
+                        .testSqlValidationError(
+                                "Type1Constructor(f0, f1) = CAST((14, 'Bob') AS "
+                                        + Type2.TYPE
+                                        + ")",
+                                "Incompatible structured types")
+                        // Same class name but different fields
+                        .testSqlValidationError(
+                                "Type1Constructor(f0, f1) = CAST((14, 'Bob') AS STRUCTURED<'"
+                                        + Type1.class.getName()
+                                        + "', a BOOLEAN, b BOOLEAN>)",
+                                "Cannot apply '=' to arguments"));
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Helpers
+    // --------------------------------------------------------------------------------------------
+
+    /** Structured type Type1. */
+    public static class Type1 {
+        public static final String TYPE =
+                "STRUCTURED<'" + Type1.class.getName() + "', a INT, b STRING>";
+
+        public Integer a;
+        public String b;
+
+        public static class Type1Constructor extends ScalarFunction {
+            public Type1 eval(Integer a, String b) {
+                final Type1 t = new Type1();
+                t.a = a;
+                t.b = b;
+                return t;
+            }
+        }
+    }
+
+    /** Structured type Type2. */
+    public static class Type2 {
+        public static final String TYPE =
+                "STRUCTURED<'" + Type2.class.getName() + "', a INT, b STRING>";
+
+        public Integer a;
+        public String b;
+
+        public static class Type2Constructor extends ScalarFunction {
+            public Type2 eval(Integer a, String b) {
+                final Type2 t = new Type2();
+                t.a = a;
+                t.b = b;
+                return t;
+            }
+        }
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlNodeToCallOperationTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlNodeToCallOperationTest.java
@@ -130,7 +130,7 @@ public class SqlNodeToCallOperationTest extends SqlNodeToOperationConversionTest
                 "CALL PROCEDURE:"
                         + " (procedureIdentifier: [`p1`.`system`.`pojo_result`],"
                         + " inputTypes: [STRING, BIGINT NOT NULL],"
-                        + " outputTypes: [*org.apache.flink.table.planner.operations.SqlNodeToCallOperationTest$MyPojo<`name` STRING, `id` BIGINT NOT NULL>*],"
+                        + " outputTypes: [STRUCTURED<'org.apache.flink.table.planner.operations.SqlNodeToCallOperationTest$MyPojo', `name` STRING, `id` BIGINT NOT NULL>],"
                         + " arguments: [name, 1])");
 
         // test call the procedure with timestamp as arguments

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/typeutils/LogicalRelDataTypeConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/typeutils/LogicalRelDataTypeConverterTest.java
@@ -41,6 +41,7 @@ import org.apache.flink.table.types.logical.RawType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.SmallIntType;
 import org.apache.flink.table.types.logical.StructuredType;
+import org.apache.flink.table.types.logical.StructuredType.StructuredAttribute;
 import org.apache.flink.table.types.logical.SymbolType;
 import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampKind;
@@ -56,7 +57,6 @@ import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
@@ -69,7 +69,7 @@ public class LogicalRelDataTypeConverterTest {
 
     @ParameterizedTest
     @MethodSource("testConversion")
-    public void testConversion(LogicalType logicalType) throws IOException {
+    public void testConversion(LogicalType logicalType) {
         final RelDataTypeFactory typeFactory =
                 new FlinkTypeFactory(
                         LogicalRelDataTypeConverterTest.class.getClassLoader(),
@@ -167,17 +167,24 @@ public class LogicalRelDataTypeConverterTest {
                         VarCharType.ofEmptyLiteral(),
                         BinaryType.ofEmptyLiteral(),
                         VarBinaryType.ofEmptyLiteral()),
-                // registered structured type
+                // catalog structured type
                 PojoClass.TYPE_WITH_IDENTIFIER,
-                // unregistered structured type
+                // inline structured type
+                StructuredType.newBuilder("MyPojo")
+                        .attributes(
+                                Arrays.asList(
+                                        new StructuredAttribute("f0", new IntType(true)),
+                                        new StructuredAttribute("f1", new BigIntType(true)),
+                                        new StructuredAttribute(
+                                                "f2", new VarCharType(200), "desc")))
+                        .build(),
+                // inline structured type with resolved class
                 StructuredType.newBuilder(PojoClass.class)
                         .attributes(
                                 Arrays.asList(
-                                        new StructuredType.StructuredAttribute(
-                                                "f0", new IntType(true)),
-                                        new StructuredType.StructuredAttribute(
-                                                "f1", new BigIntType(true)),
-                                        new StructuredType.StructuredAttribute(
+                                        new StructuredAttribute("f0", new IntType(true)),
+                                        new StructuredAttribute("f1", new BigIntType(true)),
+                                        new StructuredAttribute(
                                                 "f2", new VarCharType(200), "desc")))
                         .build(),
                 // custom RawType
@@ -196,11 +203,9 @@ public class LogicalRelDataTypeConverterTest {
                                 ObjectIdentifier.of("cat", "db", "structuredType"), PojoClass.class)
                         .attributes(
                                 Arrays.asList(
-                                        new StructuredType.StructuredAttribute(
-                                                "f0", new IntType(true)),
-                                        new StructuredType.StructuredAttribute(
-                                                "f1", new BigIntType(true)),
-                                        new StructuredType.StructuredAttribute(
+                                        new StructuredAttribute("f0", new IntType(true)),
+                                        new StructuredAttribute("f1", new BigIntType(true)),
+                                        new StructuredAttribute(
                                                 "f2", new VarCharType(200), "desc")))
                         .comparison(StructuredType.StructuredComparison.FULL)
                         .setFinal(false)
@@ -210,7 +215,7 @@ public class LogicalRelDataTypeConverterTest {
                                                 ObjectIdentifier.of("cat", "db", "structuredType2"))
                                         .attributes(
                                                 Collections.singletonList(
-                                                        new StructuredType.StructuredAttribute(
+                                                        new StructuredAttribute(
                                                                 "f0", new BigIntType(false))))
                                         .build())
                         .description("description for StructuredType")


### PR DESCRIPTION
## What is the purpose of the change

This adds support for inline structured types in Flink SQL. Inline structured types are not a completely new type. They have been added as part of FLIP-37 when reworking the Flink table type system. However, mostly Table API users were able to use them properly. For SQL, there was no type DDL to cast or declare the type.

This PR improves handling inline structured types by supporting the type declaration:
```
STRUCTURED<'c', n0 t0 'd0', n1 t1 'd1', ...>
```
where `c` is the class name, `n` is the unique name of a field, `t` is the logical type of a field, `d` is the description of a field.

## Brief change log

- Support `STRUCTURED<>` in SQL parser and logical type parser
- Decouple structured types from the hard requirement of a class being present in the classpath
- Support equality between types for testing structured types with different class name
- Improve various JavaDocs and docs to highlight the benefits and shortcomings of structured types

## Verifying this change

This change is already covered by existing tests such as `LogicalTypeParserTest`, `LogicalTypeTest` and others.

It adds casting and equality tests as well as a new `StructuredFunctionITCase` for testing functions dealing with structured types in the future.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: yes
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
