### PR TITLE
[FLINK-37900][rocksdb] configurable jitter in rocksdb state uploader

### DIFF
--- a/docs/layouts/shortcodes/generated/expert_rocksdb_section.html
+++ b/docs/layouts/shortcodes/generated/expert_rocksdb_section.html
@@ -18,7 +18,7 @@
             <td><h5>state.backend.rocksdb.checkpoint.upload-jitter</h5></td>
             <td style="word-wrap: break-word;">0 ms</td>
             <td>Duration</td>
-            <td>The time interval used to create jitter for each checkpoint file upload.</td>
+            <td>The jitter time interval determines the amount of random delay introduced before uploading each checkpoint file. This jitter is applied to help stagger the upload times of state files, thereby introducing a small, randomized delay for each upload operation. The purpose of this mechanism is to avoid simultaneous upload bursts, which could otherwise overwhelm the remote storage system. By distributing the upload requests more evenly over time, jitter helps maintain system stability and prevents potential performance degradation during checkpoint completion. It is therefore recommended to configure the jitter interval at the seconds level, ensuring a balanced trade-off between randomness and upload efficiency.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.localdir</h5></td>

--- a/docs/layouts/shortcodes/generated/expert_rocksdb_section.html
+++ b/docs/layouts/shortcodes/generated/expert_rocksdb_section.html
@@ -15,6 +15,12 @@
             <td>The number of threads (per stateful operator) used to transfer (download and upload) files in RocksDBStateBackend.If negative, the common (TM) IO thread pool is used (see cluster.io-pool.size)</td>
         </tr>
         <tr>
+            <td><h5>state.backend.rocksdb.checkpoint.upload-jitter</h5></td>
+            <td style="word-wrap: break-word;">0 ms</td>
+            <td>Duration</td>
+            <td>The time interval used to create jitter for each checkpoint file upload.</td>
+        </tr>
+        <tr>
             <td><h5>state.backend.rocksdb.localdir</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/docs/layouts/shortcodes/generated/rocksdb_configuration.html
+++ b/docs/layouts/shortcodes/generated/rocksdb_configuration.html
@@ -18,7 +18,7 @@
             <td><h5>state.backend.rocksdb.checkpoint.upload-jitter</h5></td>
             <td style="word-wrap: break-word;">0 ms</td>
             <td>Duration</td>
-            <td>The time interval used to create jitter for each checkpoint file upload.</td>
+            <td>The jitter time interval determines the amount of random delay introduced before uploading each checkpoint file. This jitter is applied to help stagger the upload times of state files, thereby introducing a small, randomized delay for each upload operation. The purpose of this mechanism is to avoid simultaneous upload bursts, which could otherwise overwhelm the remote storage system. By distributing the upload requests more evenly over time, jitter helps maintain system stability and prevents potential performance degradation during checkpoint completion. It is therefore recommended to configure the jitter interval at the seconds level, ensuring a balanced trade-off between randomness and upload efficiency.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.localdir</h5></td>

--- a/docs/layouts/shortcodes/generated/rocksdb_configuration.html
+++ b/docs/layouts/shortcodes/generated/rocksdb_configuration.html
@@ -15,6 +15,12 @@
             <td>The number of threads (per stateful operator) used to transfer (download and upload) files in RocksDBStateBackend.If negative, the common (TM) IO thread pool is used (see cluster.io-pool.size)</td>
         </tr>
         <tr>
+            <td><h5>state.backend.rocksdb.checkpoint.upload-jitter</h5></td>
+            <td style="word-wrap: break-word;">0 ms</td>
+            <td>Duration</td>
+            <td>The time interval used to create jitter for each checkpoint file upload.</td>
+        </tr>
+        <tr>
             <td><h5>state.backend.rocksdb.localdir</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/state/rocksdb/EmbeddedRocksDBStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/state/rocksdb/EmbeddedRocksDBStateBackend.java
@@ -143,7 +143,7 @@ public class EmbeddedRocksDBStateBackend extends AbstractManagedMemoryStateBacke
     private int numberOfTransferThreads;
 
     /** The max duration of checkpoint uploader jitter. */
-    private Duration checkpointUploadJitter;
+    private final Duration checkpointUploadJitter;
 
     /** The configuration for memory settings (pool sizes, etc.). */
     private final RocksDBMemoryConfiguration memoryConfiguration;

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/state/rocksdb/RocksDBOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/state/rocksdb/RocksDBOptions.java
@@ -100,7 +100,13 @@ public class RocksDBOptions {
                     .durationType()
                     .defaultValue(Duration.ZERO)
                     .withDescription(
-                            "The time interval used to create jitter for each checkpoint file upload.");
+                            "The jitter time interval determines the amount of random delay introduced before uploading each checkpoint file. "
+                                    + "This jitter is applied to help stagger the upload times of state files, thereby introducing a small, "
+                                    + "randomized delay for each upload operation. The purpose of this mechanism is to avoid simultaneous upload bursts, "
+                                    + "which could otherwise overwhelm the remote storage system. By distributing the upload requests more evenly over time, "
+                                    + "jitter helps maintain system stability and prevents potential performance degradation during checkpoint completion. "
+                                    + "It is therefore recommended to configure the jitter interval at the seconds level, ensuring a balanced trade-off "
+                                    + "between randomness and upload efficiency.");
 
     /** The predefined settings for RocksDB DBOptions and ColumnFamilyOptions by Flink community. */
     @Documentation.Section(Documentation.Sections.EXPERT_ROCKSDB)

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/state/rocksdb/RocksDBOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/state/rocksdb/RocksDBOptions.java
@@ -27,6 +27,8 @@ import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.description.Description;
 import org.apache.flink.configuration.description.TextElement;
 
+import java.time.Duration;
+
 import static org.apache.flink.configuration.ClusterOptions.CLUSTER_IO_EXECUTOR_POOL_SIZE;
 import static org.apache.flink.state.rocksdb.EmbeddedRocksDBStateBackend.PriorityQueueStateType.ROCKSDB;
 import static org.apache.flink.state.rocksdb.PredefinedOptions.DEFAULT;
@@ -90,6 +92,15 @@ public class RocksDBOptions {
                                     + "If negative, the common (TM) IO thread pool is used (see "
                                     + CLUSTER_IO_EXECUTOR_POOL_SIZE.key()
                                     + ")");
+
+    /** The time interval used to create jitter for each checkpoint file upload. */
+    @Documentation.Section(Documentation.Sections.EXPERT_ROCKSDB)
+    public static final ConfigOption<Duration> CHECKPOINT_UPLOAD_JITTER =
+            ConfigOptions.key("state.backend.rocksdb.checkpoint.upload-jitter")
+                    .durationType()
+                    .defaultValue(Duration.ZERO)
+                    .withDescription(
+                            "The time interval used to create jitter for each checkpoint file upload.");
 
     /** The predefined settings for RocksDB DBOptions and ColumnFamilyOptions by Flink community. */
     @Documentation.Section(Documentation.Sections.EXPERT_ROCKSDB)

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/state/rocksdb/RocksDBStateUploader.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/state/rocksdb/RocksDBStateUploader.java
@@ -32,6 +32,9 @@ import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.concurrent.FutureUtils;
 import org.apache.flink.util.function.CheckedSupplier;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.annotation.Nonnull;
 
 import java.io.Closeable;
@@ -39,25 +42,34 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 /** Help class for uploading RocksDB state files. */
 public class RocksDBStateUploader implements Closeable {
+    private static final Logger LOG = LoggerFactory.getLogger(RocksDBStateUploader.class);
     private static final int READ_BUFFER_SIZE = 16 * 1024;
-
+    private final Duration uploadJitter;
+    private final Random random;
     private final RocksDBStateDataTransferHelper transfer;
 
     @VisibleForTesting
-    public RocksDBStateUploader(int numberOfSnapshottingThreads) {
-        this(RocksDBStateDataTransferHelper.forThreadNum(numberOfSnapshottingThreads));
+    public RocksDBStateUploader(int numberOfSnapshottingThreads, Duration uploadJitter) {
+        this(
+                RocksDBStateDataTransferHelper.forThreadNum(numberOfSnapshottingThreads),
+                uploadJitter);
     }
 
-    public RocksDBStateUploader(RocksDBStateDataTransferHelper transfer) {
+    public RocksDBStateUploader(RocksDBStateDataTransferHelper transfer, Duration uploadJitter) {
         this.transfer = transfer;
+        this.uploadJitter = uploadJitter;
+        this.random = new Random();
     }
 
     /**
@@ -133,12 +145,14 @@ public class RocksDBStateUploader implements Closeable {
             CheckpointedStateScope stateScope,
             CloseableRegistry closeableRegistry,
             CloseableRegistry tmpResourcesRegistry)
-            throws IOException {
+            throws IOException, InterruptedException {
 
         InputStream inputStream = null;
         CheckpointStateOutputStream outputStream = null;
 
         try {
+            // add a random jitter
+            applyJitter(new JitterConsumer());
             final byte[] buffer = new byte[READ_BUFFER_SIZE];
 
             inputStream = Files.newInputStream(filePath);
@@ -176,6 +190,28 @@ public class RocksDBStateUploader implements Closeable {
 
             if (closeableRegistry.unregisterCloseable(outputStream)) {
                 IOUtils.closeQuietly(outputStream);
+            }
+        }
+    }
+
+    @VisibleForTesting
+    void applyJitter(Consumer<Long> consumer) {
+        if (uploadJitter.isZero()) {
+            return;
+        }
+
+        long milliseconds = random.nextLong(0, uploadJitter.toMillis() + 1);
+        consumer.accept(milliseconds);
+    }
+
+    static class JitterConsumer implements Consumer<Long> {
+
+        @Override
+        public void accept(Long milliseconds) {
+            try {
+                Thread.sleep(milliseconds);
+            } catch (InterruptedException e) {
+                LOG.error("Fail to apply jitter in RocksDBStateUploader.", e);
             }
         }
     }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/state/rocksdb/EmbeddedRocksDBStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/state/rocksdb/EmbeddedRocksDBStateBackendTest.java
@@ -282,7 +282,8 @@ public class EmbeddedRocksDBStateBackendTest
             rocksDBStateUploader =
                     spy(
                             new RocksDBStateUploader(
-                                    RocksDBOptions.CHECKPOINT_TRANSFER_THREAD_NUM.defaultValue()));
+                                    RocksDBOptions.CHECKPOINT_TRANSFER_THREAD_NUM.defaultValue(),
+                                    RocksDBOptions.CHECKPOINT_UPLOAD_JITTER.defaultValue()));
             keyedStateBackendBuilder.setRocksDBStateUploader(rocksDBStateUploader);
         }
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/state/rocksdb/snapshot/RocksIncrementalSnapshotStrategyTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/state/rocksdb/snapshot/RocksIncrementalSnapshotStrategyTest.java
@@ -114,7 +114,8 @@ class RocksIncrementalSnapshotStrategyTest {
 
         RocksDBStateUploader rocksDBStateUploader =
                 new RocksDBStateUploader(
-                        RocksDBOptions.CHECKPOINT_TRANSFER_THREAD_NUM.defaultValue());
+                        RocksDBOptions.CHECKPOINT_TRANSFER_THREAD_NUM.defaultValue(),
+                        RocksDBOptions.CHECKPOINT_UPLOAD_JITTER.defaultValue());
 
         int keyGroupPrefixBytes =
                 CompositeKeySerializationUtils.computeRequiredBytesInKeyGroupPrefix(2);


### PR DESCRIPTION
## What is the purpose of the change
Support configurable jitter in rocksdb state uploader


## Brief change log
  - Add a configurable jitter for rocksdb state uploader 

## Verifying this change
  - *Added testJitterApply in RocksDBStateUploaderTest.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
