### PR TITLE
[Flink-37703][hadoop] Add more log info to locate the root cause of failed HadoopRecoverableWriterTest#testRecoverFromIntermWithoutAdditionalState in azure cron pipeline

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/core/fs/AbstractRecoverableWriterTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/AbstractRecoverableWriterTest.java
@@ -25,6 +25,8 @@ import org.apache.flink.util.StringUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -41,6 +43,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * filesystem specific writer.
  */
 public abstract class AbstractRecoverableWriterTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractRecoverableWriterTest.class);
 
     private static final Random RND = new Random();
 
@@ -196,16 +200,29 @@ public abstract class AbstractRecoverableWriterTest {
         final Map<String, RecoverableWriter.ResumeRecoverable> recoverables = new HashMap<>(4);
         RecoverableFsDataOutputStream stream = null;
         try {
-            stream = initWriter.open(path);
-            recoverables.put(INIT_EMPTY_PERSIST, stream.persist());
+            // This is just for locate  the root cause:
+            // https://issues.apache.org/jira/browse/FLINK-37703
+            // After the fix, this logic should be reverted.
+            int times = 0;
+            try {
+                times++;
+                stream = initWriter.open(path);
+                recoverables.put(INIT_EMPTY_PERSIST, stream.persist());
 
-            stream.write(testData1.getBytes(StandardCharsets.UTF_8));
+                times++;
+                stream.write(testData1.getBytes(StandardCharsets.UTF_8));
 
-            recoverables.put(INTERM_WITH_STATE_PERSIST, stream.persist());
-            recoverables.put(INTERM_WITH_NO_ADDITIONAL_STATE_PERSIST, stream.persist());
+                recoverables.put(INTERM_WITH_STATE_PERSIST, stream.persist());
+                recoverables.put(INTERM_WITH_NO_ADDITIONAL_STATE_PERSIST, stream.persist());
 
-            // and write some more data
-            stream.write(testData2.getBytes(StandardCharsets.UTF_8));
+                // and write some more data
+                times++;
+                stream.write(testData2.getBytes(StandardCharsets.UTF_8));
+
+            } catch (IOException e) {
+                LOG.warn("{} execution failed, err message{}: ", times, e.getMessage());
+                throw e;
+            }
 
             recoverables.put(FINAL_WITH_EXTRA_STATE, stream.persist());
         } finally {
@@ -236,9 +253,13 @@ public abstract class AbstractRecoverableWriterTest {
                 assertThat(fileContents.getKey().getName()).startsWith(".part-0.inprogress.");
                 assertThat(fileContents.getValue()).isEqualTo(expectedPostRecoveryContents);
             }
-
-            recoveredStream.write(testData3.getBytes(StandardCharsets.UTF_8));
-            recoveredStream.closeForCommit().commit();
+            try {
+                recoveredStream.write(testData3.getBytes(StandardCharsets.UTF_8));
+                recoveredStream.closeForCommit().commit();
+            } catch (IOException e) {
+                LOG.warn("Final write failed: {}", e.getMessage());
+                throw e;
+            }
 
             files = getFileContentByPath(testDir);
             assertThat(files).hasSize(1);

--- a/flink-core/src/test/java/org/apache/flink/core/fs/AbstractRecoverableWriterTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/AbstractRecoverableWriterTest.java
@@ -200,7 +200,7 @@ public abstract class AbstractRecoverableWriterTest {
         final Map<String, RecoverableWriter.ResumeRecoverable> recoverables = new HashMap<>(4);
         RecoverableFsDataOutputStream stream = null;
         try {
-            // This is just for locate  the root cause:
+            // This is just to provide diagnostics to locate the root cause:
             // https://issues.apache.org/jira/browse/FLINK-37703
             // After the fix, this logic should be reverted.
             int times = 0;

--- a/flink-filesystems/flink-hadoop-fs/src/test/resources/log4j2-test.properties
+++ b/flink-filesystems/flink-hadoop-fs/src/test/resources/log4j2-test.properties
@@ -18,7 +18,11 @@
 
 # Set root logger level to OFF to not flood build logs
 # set manually to INFO for debugging purposes
-rootLogger.level = OFF
+# ----------------------
+# This is just for locate  the root cause:
+# https://issues.apache.org/jira/browse/FLINK-37703
+# After the fix, this logic should be reverted.
+rootLogger.level = WARN
 rootLogger.appenderRef.test.ref = TestLogger
 
 appender.testlogger.name = TestLogger
@@ -26,3 +30,7 @@ appender.testlogger.type = CONSOLE
 appender.testlogger.target = SYSTEM_ERR
 appender.testlogger.layout.type = PatternLayout
 appender.testlogger.layout.pattern = %-4r [%t] %-5p %c %x - %m%n
+
+logger.DataStreamer.name = org.apache.hadoop.hdfs.DataStreamer
+logger.DataStreamer.level = DEBUG
+


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This PR is to find out what makes the hadoop-fs UT unstable.


## Brief change log

  - *add some log in file `AbstractRecoverableWriterTest.java`*


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
