### PR TITLE
[FLINK-37896][table-planner] Introduce a new trait derived from sink to source to check whether the downstream operators can accept duplicate data

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/optimize/StreamNonDeterministicUpdatePlanVisitor.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/optimize/StreamNonDeterministicUpdatePlanVisitor.java
@@ -475,6 +475,7 @@ public class StreamNonDeterministicUpdatePlanVisitor {
                                                 true,
                                                 false,
                                                 true,
+                                                false,
                                                 false);
                         throw new TableException(errorMsg);
                     }
@@ -899,6 +900,7 @@ public class StreamNonDeterministicUpdatePlanVisitor {
                                 true,
                                 false,
                                 true,
+                                false,
                                 false);
 
         throw new TableException(errorMsg);
@@ -941,6 +943,7 @@ public class StreamNonDeterministicUpdatePlanVisitor {
                                 true,
                                 false,
                                 true,
+                                false,
                                 false));
 
         throw new TableException(errorMsg.toString());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/DuplicateChangesInferRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/DuplicateChangesInferRule.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.physical.stream;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalCalcBase;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalDataStreamScan;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalDropUpdateBefore;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalExchange;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalIntermediateTableScan;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalLegacySink;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalLegacyTableSourceScan;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalMiniBatchAssigner;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalRel;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalSink;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalTableSourceScan;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalWatermarkAssigner;
+import org.apache.flink.table.planner.plan.trait.DuplicateChanges;
+import org.apache.flink.table.planner.plan.trait.DuplicateChangesTrait;
+import org.apache.flink.table.planner.plan.trait.DuplicateChangesTraitDef;
+import org.apache.flink.table.planner.plan.utils.DuplicateChangesUtils;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.plan.hep.HepRelVertex;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rex.RexProgram;
+import org.apache.calcite.rex.RexUtil;
+import org.immutables.value.Value;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * A rule that infers the {@link DuplicateChanges} for each {@link StreamPhysicalRel} node.
+ *
+ * <p>Notes: This rule only supports HepPlanner with TOP_DOWN match order.
+ */
+@Internal
+@Value.Enclosing
+public class DuplicateChangesInferRule extends RelRule<DuplicateChangesInferRule.Config> {
+
+    public static final DuplicateChangesInferRule INSTANCE =
+            DuplicateChangesInferRule.Config.DEFAULT.toRule();
+
+    protected DuplicateChangesInferRule(Config config) {
+        super(config);
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+        StreamPhysicalRel rel = call.rel(0);
+        DuplicateChangesTrait parentTrait =
+                rel.getTraitSet().getTrait(DuplicateChangesTraitDef.INSTANCE);
+        Preconditions.checkState(parentTrait != null);
+
+        DuplicateChangesTrait requiredTrait;
+        if (rel instanceof StreamPhysicalSink) {
+            boolean canConsumeDuplicateChanges =
+                    canConsumeDuplicateChanges((StreamPhysicalSink) rel);
+            boolean isMaterialized = ((StreamPhysicalSink) rel).upsertMaterialize();
+            requiredTrait =
+                    canConsumeDuplicateChanges && !isMaterialized
+                            ? DuplicateChangesTrait.ALLOW
+                            : DuplicateChangesTrait.DISALLOW;
+        } else if (rel instanceof StreamPhysicalLegacySink) {
+            boolean canConsumeDuplicateChanges =
+                    canConsumeDuplicateChanges((StreamPhysicalLegacySink<?>) rel);
+            requiredTrait =
+                    canConsumeDuplicateChanges
+                            ? DuplicateChangesTrait.ALLOW
+                            : DuplicateChangesTrait.DISALLOW;
+        } else if (rel instanceof StreamPhysicalCalcBase) {
+            // if the calc contains non-deterministic fields, we should not allow duplicate
+            if (existNonDeterministicFiltersOrProjections((StreamPhysicalCalcBase) rel)) {
+                requiredTrait = DuplicateChangesTrait.DISALLOW;
+            } else {
+                requiredTrait = parentTrait;
+            }
+        } else if (rel instanceof StreamPhysicalExchange
+                || rel instanceof StreamPhysicalMiniBatchAssigner
+                || rel instanceof StreamPhysicalWatermarkAssigner
+                || rel instanceof StreamPhysicalDropUpdateBefore
+                || rel instanceof StreamPhysicalTableSourceScan
+                || rel instanceof StreamPhysicalDataStreamScan
+                || rel instanceof StreamPhysicalLegacyTableSourceScan
+                || rel instanceof StreamPhysicalIntermediateTableScan) {
+            // forward parent requirement
+            requiredTrait = parentTrait;
+        } else {
+            // if not explicitly supported, all operators should not accept duplicate changes
+            // TODO consider more operators to support consuming duplicate changes
+            requiredTrait = DuplicateChangesTrait.DISALLOW;
+        }
+
+        boolean anyInputUpdated = false;
+        List<RelNode> inputs = getInputs(rel);
+        List<RelNode> newInputs = new ArrayList<>();
+        for (RelNode input : inputs) {
+            DuplicateChangesTrait inputOriginalTrait =
+                    input.getTraitSet().getTrait(DuplicateChangesTraitDef.INSTANCE);
+            if (!requiredTrait.equals(inputOriginalTrait)) {
+                DuplicateChangesTrait mergedTrait =
+                        getMergedDuplicateChangesTrait(inputOriginalTrait, requiredTrait);
+                RelNode newInput =
+                        input.copy(input.getTraitSet().plus(mergedTrait), input.getInputs());
+                newInputs.add(newInput);
+                anyInputUpdated = true;
+            } else {
+                newInputs.add(input);
+            }
+        }
+        // update parent if a child was updated
+        if (anyInputUpdated) {
+            RelNode newRel = rel.copy(rel.getTraitSet(), newInputs);
+            call.transformTo(newRel);
+        }
+    }
+
+    private static DuplicateChangesTrait getMergedDuplicateChangesTrait(
+            DuplicateChangesTrait inputOriginalTrait, DuplicateChangesTrait newRequiredTrait) {
+        DuplicateChangesTrait mergedTrait;
+        if (inputOriginalTrait == null) {
+            mergedTrait = newRequiredTrait;
+        } else {
+            DuplicateChanges mergedDuplicateChanges =
+                    DuplicateChangesUtils.mergeDuplicateChanges(
+                            inputOriginalTrait.getDuplicateChanges(),
+                            newRequiredTrait.getDuplicateChanges());
+            mergedTrait = new DuplicateChangesTrait(mergedDuplicateChanges);
+        }
+        return mergedTrait;
+    }
+
+    private boolean existNonDeterministicFiltersOrProjections(StreamPhysicalCalcBase calc) {
+        RexProgram calcProgram = calc.getProgram();
+        // all projections and conditions should be expanded and checked
+        return !calcProgram.getExprList().stream().allMatch(RexUtil::isDeterministic);
+    }
+
+    private List<DuplicateChangesTrait> getRequireDuplicateChangeTraits(
+            boolean allowDuplicateChanges) {
+        List<DuplicateChangesTrait> requireDuplicateChangeTraits = new ArrayList<>();
+        if (allowDuplicateChanges) {
+            requireDuplicateChangeTraits.add(DuplicateChangesTrait.ALLOW);
+        }
+        requireDuplicateChangeTraits.add(DuplicateChangesTrait.DISALLOW);
+        return requireDuplicateChangeTraits;
+    }
+
+    private boolean canConsumeDuplicateChanges(StreamPhysicalSink sink) {
+        return sink.contextResolvedTable().getResolvedSchema().getPrimaryKey().isPresent();
+    }
+
+    private boolean canConsumeDuplicateChanges(StreamPhysicalLegacySink<?> sink) {
+        return sink.sink().getTableSchema().getPrimaryKey().isPresent();
+    }
+
+    private List<RelNode> getInputs(RelNode parent) {
+        return parent.getInputs().stream()
+                .map(
+                        rel -> {
+                            if (rel instanceof HepRelVertex) {
+                                return ((HepRelVertex) rel).getCurrentRel();
+                            } else {
+                                return rel;
+                            }
+                        })
+                .collect(Collectors.toList());
+    }
+
+    /** Configuration for {@link DuplicateChangesInferRule}. */
+    @Value.Immutable(singleton = false)
+    public interface Config extends RelRule.Config {
+
+        Config DEFAULT =
+                ImmutableDuplicateChangesInferRule.Config.builder()
+                        .build()
+                        .withOperandSupplier(b0 -> b0.operand(StreamPhysicalRel.class).anyInputs())
+                        .withDescription("DuplicateChangesInferRule")
+                        .as(Config.class);
+
+        @Override
+        default DuplicateChangesInferRule toRule() {
+            return new DuplicateChangesInferRule(this);
+        }
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/FlinkDuplicateChangesTraitInitProgram.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/FlinkDuplicateChangesTraitInitProgram.java
@@ -29,7 +29,7 @@ import org.apache.calcite.rel.RelNode;
 
 /**
  * A {@link FlinkOptimizeProgram} that does some initialization for {@link DuplicateChanges}
- * inferences.
+ * inference.
  */
 public class FlinkDuplicateChangesTraitInitProgram
         implements FlinkOptimizeProgram<StreamOptimizeContext> {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/FlinkDuplicateChangesTraitInitProgram.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/FlinkDuplicateChangesTraitInitProgram.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.physical.stream;
+
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalLegacySink;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalSink;
+import org.apache.flink.table.planner.plan.optimize.program.FlinkOptimizeProgram;
+import org.apache.flink.table.planner.plan.optimize.program.StreamOptimizeContext;
+import org.apache.flink.table.planner.plan.trait.DuplicateChanges;
+import org.apache.flink.table.planner.plan.trait.DuplicateChangesTrait;
+
+import org.apache.calcite.rel.RelNode;
+
+/**
+ * A {@link FlinkOptimizeProgram} that does some initialization for {@link DuplicateChanges}
+ * inferences.
+ */
+public class FlinkDuplicateChangesTraitInitProgram
+        implements FlinkOptimizeProgram<StreamOptimizeContext> {
+
+    @Override
+    public RelNode optimize(RelNode root, StreamOptimizeContext context) {
+        DuplicateChangesTrait trait;
+        if (isSink(root)) {
+            trait = DuplicateChangesTrait.NONE;
+        } else if (context.isAllowDuplicateChanges()) {
+            trait = DuplicateChangesTrait.ALLOW;
+        } else {
+            trait = DuplicateChangesTrait.DISALLOW;
+        }
+        return root.copy(root.getTraitSet().plus(trait), root.getInputs());
+    }
+
+    private boolean isSink(RelNode root) {
+        return root instanceof StreamPhysicalSink || root instanceof StreamPhysicalLegacySink;
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/trait/DuplicateChanges.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/trait/DuplicateChanges.java
@@ -15,23 +15,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.flink.table.planner.plan.optimize.program
 
-import org.apache.flink.table.planner.plan.`trait`.MiniBatchInterval
+package org.apache.flink.table.planner.plan.trait;
 
-/** A OptimizeContext allows to obtain stream table environment information when optimizing. */
-trait StreamOptimizeContext extends FlinkOptimizeContext {
+/**
+ * Lists all kinds of all behaviors that handle consume redundant data produced by upstream
+ * operators.
+ */
+public enum DuplicateChanges {
 
-  /**
-   * Returns true if the root is required to send UPDATE_BEFORE message with UPDATE_AFTER message
-   * together for update changes.
-   */
-  def isUpdateBeforeRequired: Boolean
+    /** Allow to produce duplicated data for downstream operators to consume. */
+    ALLOW,
 
-  /** Returns the mini-batch interval that sink requests. */
-  def getMiniBatchInterval: MiniBatchInterval
+    /** Disallow to produce duplicated data for downstream operators to consume. */
+    DISALLOW,
 
-  /** Returns true if the root can output duplicate changes. */
-  def isAllowDuplicateChanges: Boolean
+    /** There are no operators downstream of the operator like sink. */
+    NONE,
 
+    /** The {@link DuplicateChanges} is not inferred yet. */
+    UNKNOWN
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/trait/DuplicateChanges.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/trait/DuplicateChanges.java
@@ -19,7 +19,7 @@
 package org.apache.flink.table.planner.plan.trait;
 
 /**
- * Lists all kinds of all behaviors to describe whether the node can produce duplicated changes for
+ * Lists all kinds of behaviors to describe whether the node can produce duplicated changes for
  * downstream operators to consume.
  *
  * <p>The trait in each operator is determined by its downstream operators, meaning that downstream

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/trait/DuplicateChanges.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/trait/DuplicateChanges.java
@@ -19,8 +19,11 @@
 package org.apache.flink.table.planner.plan.trait;
 
 /**
- * Lists all kinds of all behaviors that handle consume redundant data produced by upstream
- * operators.
+ * Lists all kinds of all behaviors to describe whether the node can produce duplicated changes for
+ * downstream operators to consume.
+ *
+ * <p>The trait in each operator is determined by its downstream operators, meaning that downstream
+ * defines whether the operator is allowed to output duplicate changes.
  */
 public enum DuplicateChanges {
 
@@ -30,9 +33,9 @@ public enum DuplicateChanges {
     /** Disallow to produce duplicated data for downstream operators to consume. */
     DISALLOW,
 
-    /** There are no operators downstream of the operator like sink. */
-    NONE,
-
-    /** The {@link DuplicateChanges} is not inferred yet. */
-    UNKNOWN
+    /**
+     * The {@link DuplicateChanges} is not inferred yet or there are no operators downstream of the
+     * operator like sink.
+     */
+    NONE
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/trait/DuplicateChangesTrait.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/trait/DuplicateChangesTrait.java
@@ -28,9 +28,6 @@ import org.apache.calcite.plan.RelTraitDef;
  */
 public class DuplicateChangesTrait implements RelTrait {
 
-    public static final DuplicateChangesTrait UNKNOWN =
-            new DuplicateChangesTrait(DuplicateChanges.UNKNOWN);
-
     public static final DuplicateChangesTrait ALLOW =
             new DuplicateChangesTrait(DuplicateChanges.ALLOW);
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/trait/DuplicateChangesTrait.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/trait/DuplicateChangesTrait.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.trait;
+
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.plan.RelTrait;
+import org.apache.calcite.plan.RelTraitDef;
+
+/**
+ * This trait is used to describe whether the node can produce duplicated changes for downstream
+ * operators to consume.
+ */
+public class DuplicateChangesTrait implements RelTrait {
+
+    public static final DuplicateChangesTrait UNKNOWN =
+            new DuplicateChangesTrait(DuplicateChanges.UNKNOWN);
+
+    public static final DuplicateChangesTrait ALLOW =
+            new DuplicateChangesTrait(DuplicateChanges.ALLOW);
+
+    public static final DuplicateChangesTrait NONE =
+            new DuplicateChangesTrait(DuplicateChanges.NONE);
+
+    public static final DuplicateChangesTrait DISALLOW =
+            new DuplicateChangesTrait(DuplicateChanges.DISALLOW);
+
+    private final DuplicateChanges duplicateChanges;
+
+    public DuplicateChangesTrait(DuplicateChanges duplicateChanges) {
+        this.duplicateChanges = duplicateChanges;
+    }
+
+    public DuplicateChanges getDuplicateChanges() {
+        return duplicateChanges;
+    }
+
+    @Override
+    public boolean satisfies(RelTrait relTrait) {
+        // should totally match
+        if (relTrait instanceof DuplicateChangesTrait) {
+            return this.duplicateChanges.equals(
+                    ((DuplicateChangesTrait) relTrait).duplicateChanges);
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public RelTraitDef<DuplicateChangesTrait> getTraitDef() {
+        return DuplicateChangesTraitDef.INSTANCE;
+    }
+
+    @Override
+    public int hashCode() {
+        return duplicateChanges.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DuplicateChangesTrait that = (DuplicateChangesTrait) o;
+        return duplicateChanges == that.duplicateChanges;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("[%s]", duplicateChanges);
+    }
+
+    @Override
+    public void register(RelOptPlanner relOptPlanner) {}
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/trait/DuplicateChangesTraitDef.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/trait/DuplicateChangesTraitDef.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.trait;
+
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.plan.RelTraitDef;
+import org.apache.calcite.rel.RelNode;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/** A {@link RelTraitDef} for {@link DuplicateChangesTrait}. */
+public class DuplicateChangesTraitDef extends RelTraitDef<DuplicateChangesTrait> {
+
+    public static final DuplicateChangesTraitDef INSTANCE = new DuplicateChangesTraitDef();
+
+    @Override
+    public Class<DuplicateChangesTrait> getTraitClass() {
+        return DuplicateChangesTrait.class;
+    }
+
+    @Override
+    public String getSimpleName() {
+        return this.getClass().getSimpleName();
+    }
+
+    @Override
+    public @Nullable RelNode convert(
+            RelOptPlanner planner,
+            RelNode rel,
+            DuplicateChangesTrait toTrait,
+            boolean allowInfiniteCostConverters) {
+        return rel.copy(rel.getTraitSet().plus(toTrait), rel.getInputs());
+    }
+
+    @Override
+    public boolean canConvert(
+            RelOptPlanner relOptPlanner,
+            DuplicateChangesTrait duplicateChangesTrait,
+            DuplicateChangesTrait t1) {
+        return true;
+    }
+
+    @Override
+    public DuplicateChangesTrait getDefault() {
+        return DuplicateChangesTrait.UNKNOWN;
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/trait/DuplicateChangesTraitDef.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/trait/DuplicateChangesTraitDef.java
@@ -57,6 +57,6 @@ public class DuplicateChangesTraitDef extends RelTraitDef<DuplicateChangesTrait>
 
     @Override
     public DuplicateChangesTrait getDefault() {
-        return DuplicateChangesTrait.UNKNOWN;
+        return DuplicateChangesTrait.NONE;
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/utils/DuplicateChangesUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/utils/DuplicateChangesUtils.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.utils;
+
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalRel;
+import org.apache.flink.table.planner.plan.trait.DuplicateChanges;
+import org.apache.flink.table.planner.plan.trait.DuplicateChangesTrait;
+import org.apache.flink.table.planner.plan.trait.DuplicateChangesTraitDef;
+
+import java.util.Optional;
+
+/** Utils for {@link DuplicateChanges}. */
+public class DuplicateChangesUtils {
+
+    private DuplicateChangesUtils() {}
+
+    /**
+     * Get an optional {@link DuplicateChanges} from the given {@link StreamPhysicalRel}.
+     *
+     * <p>The {@link DuplicateChanges} is inferred from {@link DuplicateChangesTrait}.
+     */
+    public static Optional<DuplicateChanges> getDuplicateChanges(StreamPhysicalRel rel) {
+        Optional<DuplicateChangesTrait> duplicateChangesTraitOp =
+                Optional.ofNullable(rel.getTraitSet().getTrait(DuplicateChangesTraitDef.INSTANCE));
+        return duplicateChangesTraitOp.stream()
+                .map(DuplicateChangesTrait::getDuplicateChanges)
+                .findFirst();
+    }
+
+    /**
+     * Merge the given two {@link DuplicateChanges} as a new one.
+     *
+     * <p>The logic matrix is following:
+     *
+     * <p>ANY`(xxx) means any duplicate changes except xxx.
+     *
+     * <pre>
+     *       +-------------+-------------+---------------+
+     *       | origin_1    | origin_2    | merge result  |
+     *       +-------------+-------------+---------------+
+     *       | UNKNOWN     | `ANY`       |   `ANY`       |
+     *       | `ANY`       |  UNKNOWN    |   `ANY`       |
+     *       | NONE        | `ANY`       |   `NONE`      |
+     *       | `ANY`       |  NONE       |   `NONE`      |
+     *       | DISALLOW    | `ANY`(NONE) |   DISALLOW    |
+     *       | `ANY`(NONE) |  DISALLOW   |   DISALLOW    |
+     *       | ALLOW       | ALLOW       |   ALLOW       |
+     *       +-------------+-------------+--------------+
+     * </pre>
+     */
+    public static DuplicateChanges mergeDuplicateChanges(
+            DuplicateChanges duplicateChanges1, DuplicateChanges duplicateChanges2) {
+        if (duplicateChanges1 == DuplicateChanges.UNKNOWN
+                || duplicateChanges2 == DuplicateChanges.UNKNOWN) {
+            return duplicateChanges1 == DuplicateChanges.UNKNOWN
+                    ? duplicateChanges2
+                    : duplicateChanges1;
+        }
+        if (duplicateChanges1 == DuplicateChanges.NONE
+                || duplicateChanges2 == DuplicateChanges.NONE) {
+            return DuplicateChanges.NONE;
+        }
+        if (duplicateChanges1 == DuplicateChanges.DISALLOW
+                || duplicateChanges2 == DuplicateChanges.DISALLOW) {
+            return DuplicateChanges.DISALLOW;
+        }
+
+        return DuplicateChanges.ALLOW;
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/utils/DuplicateChangesUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/utils/DuplicateChangesUtils.java
@@ -48,33 +48,25 @@ public class DuplicateChangesUtils {
      *
      * <p>The logic matrix is following:
      *
-     * <p>ANY`(xxx) means any duplicate changes except xxx.
-     *
      * <pre>
      *       +-------------+-------------+---------------+
      *       | origin_1    | origin_2    | merge result  |
      *       +-------------+-------------+---------------+
-     *       | UNKNOWN     | `ANY`       |   `ANY`       |
-     *       | `ANY`       |  UNKNOWN    |   `ANY`       |
-     *       | NONE        | `ANY`       |   `NONE`      |
-     *       | `ANY`       |  NONE       |   `NONE`      |
-     *       | DISALLOW    | `ANY`(NONE) |   DISALLOW    |
-     *       | `ANY`(NONE) |  DISALLOW   |   DISALLOW    |
-     *       | ALLOW       | ALLOW       |   ALLOW       |
+     *       | NONE        | `ANY`       |   `ANY`      |
+     *       | `ANY`       |  NONE       |   `ANY`      |
+     *       | DISALLOW    | `ANY`       |   DISALLOW   |
+     *       | `ANY`       |  DISALLOW   |   DISALLOW   |
+     *       | ALLOW       | ALLOW       |   ALLOW      |
      *       +-------------+-------------+--------------+
      * </pre>
      */
     public static DuplicateChanges mergeDuplicateChanges(
             DuplicateChanges duplicateChanges1, DuplicateChanges duplicateChanges2) {
-        if (duplicateChanges1 == DuplicateChanges.UNKNOWN
-                || duplicateChanges2 == DuplicateChanges.UNKNOWN) {
-            return duplicateChanges1 == DuplicateChanges.UNKNOWN
-                    ? duplicateChanges2
-                    : duplicateChanges1;
-        }
         if (duplicateChanges1 == DuplicateChanges.NONE
                 || duplicateChanges2 == DuplicateChanges.NONE) {
-            return DuplicateChanges.NONE;
+            return duplicateChanges1 == DuplicateChanges.NONE
+                    ? duplicateChanges2
+                    : duplicateChanges1;
         }
         if (duplicateChanges1 == DuplicateChanges.DISALLOW
                 || duplicateChanges2 == DuplicateChanges.DISALLOW) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/utils/DuplicateChangesUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/utils/DuplicateChangesUtils.java
@@ -52,12 +52,12 @@ public class DuplicateChangesUtils {
      *       +-------------+-------------+---------------+
      *       | origin_1    | origin_2    | merge result  |
      *       +-------------+-------------+---------------+
-     *       | NONE        | `ANY`       |   `ANY`      |
-     *       | `ANY`       |  NONE       |   `ANY`      |
-     *       | DISALLOW    | `ANY`       |   DISALLOW   |
-     *       | `ANY`       |  DISALLOW   |   DISALLOW   |
-     *       | ALLOW       | ALLOW       |   ALLOW      |
-     *       +-------------+-------------+--------------+
+     *       | NONE        |   *         |     *         |
+     *       | `ANY`       |  NONE       |   `ANY`       |
+     *       | DISALLOW    |   *         |   DISALLOW    |
+     *       |   *         |  DISALLOW   |   DISALLOW    |
+     *       | ALLOW       | ALLOW       |   ALLOW       |
+     *       +-------------+-------------+---------------+
      * </pre>
      */
     public static DuplicateChanges mergeDuplicateChanges(

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/StreamPlanner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/StreamPlanner.scala
@@ -20,19 +20,16 @@ package org.apache.flink.table.planner.delegation
 import org.apache.flink.api.common.RuntimeExecutionMode
 import org.apache.flink.api.dag.Transformation
 import org.apache.flink.configuration.ExecutionOptions
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectReader
 import org.apache.flink.streaming.api.graph.StreamGraph
 import org.apache.flink.table.api._
-import org.apache.flink.table.api.PlanReference.{FilePlanReference, JsonContentPlanReference, ResourcePlanReference}
 import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog}
 import org.apache.flink.table.delegation.{Executor, InternalPlan}
 import org.apache.flink.table.module.ModuleManager
-import org.apache.flink.table.operations.{ModifyOperation, Operation}
+import org.apache.flink.table.operations.Operation
 import org.apache.flink.table.planner.plan.`trait`._
 import org.apache.flink.table.planner.plan.ExecNodeGraphInternalPlan
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeGraph
 import org.apache.flink.table.planner.plan.nodes.exec.processor.ExecNodeGraphProcessor
-import org.apache.flink.table.planner.plan.nodes.exec.serde.CompiledPlanSerdeUtil
 import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecNode
 import org.apache.flink.table.planner.plan.nodes.exec.utils.ExecNodePlanDumper
 import org.apache.flink.table.planner.plan.optimize.{Optimizer, StreamCommonSubGraphBasedOptimizer}
@@ -43,7 +40,6 @@ import _root_.scala.collection.JavaConversions._
 import org.apache.calcite.plan.{ConventionTraitDef, RelTrait, RelTraitDef}
 import org.apache.calcite.sql.SqlExplainLevel
 
-import java.io.{File, IOException}
 import java.util
 
 import scala.collection.mutable
@@ -70,7 +66,8 @@ class StreamPlanner(
       FlinkRelDistributionTraitDef.INSTANCE,
       MiniBatchIntervalTraitDef.INSTANCE,
       ModifyKindSetTraitDef.INSTANCE,
-      UpdateKindTraitDef.INSTANCE
+      UpdateKindTraitDef.INSTANCE,
+      DuplicateChangesTraitDef.INSTANCE
     )
   }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/RelNodeBlock.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/RelNodeBlock.scala
@@ -105,7 +105,7 @@ class RelNodeBlock(val outputNode: RelNode) {
 
   private var miniBatchInterval: MiniBatchInterval = MiniBatchInterval.NONE
 
-  private var allowDuplicateChanges: Boolean = true
+  private var allowDuplicateChanges: Option[Boolean] = None
 
   def addChild(block: RelNodeBlock): Unit = childBlocks += block
 
@@ -141,15 +141,21 @@ class RelNodeBlock(val outputNode: RelNode) {
 
   def getMiniBatchInterval: MiniBatchInterval = miniBatchInterval
 
-  def setAllowDuplicateChanges(allowDuplicateChanges: Boolean): Unit = {
+  def mergeAllowDuplicateChanges(allowDuplicateChanges: Boolean): Unit = {
     // a child block may have multiple parents (outputs), if one of the parents could not
     // accept duplicated changes, then this child block doesn't allow to produce duplicate changes
-    if (this.allowDuplicateChanges) {
-      this.allowDuplicateChanges = allowDuplicateChanges
+    if (this.allowDuplicateChanges.isEmpty || this.allowDuplicateChanges.get) {
+      this.allowDuplicateChanges = Option.apply(allowDuplicateChanges)
     }
   }
 
-  def isAllowDuplicateChanges: Boolean = allowDuplicateChanges
+  def isDuplicateChangesAllowed: Boolean = {
+    if (allowDuplicateChanges.isEmpty) {
+      // disallow to produce duplicate changes by default
+      return false
+    }
+    allowDuplicateChanges.get
+  }
 
   def getChildBlock(node: RelNode): Option[RelNodeBlock] = {
     val find = children.filter(_.outputNode.equals(node))

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/RelNodeBlock.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/RelNodeBlock.scala
@@ -105,6 +105,8 @@ class RelNodeBlock(val outputNode: RelNode) {
 
   private var miniBatchInterval: MiniBatchInterval = MiniBatchInterval.NONE
 
+  private var allowDuplicateChanges: Boolean = true
+
   def addChild(block: RelNodeBlock): Unit = childBlocks += block
 
   def children: Seq[RelNodeBlock] = childBlocks.toSeq
@@ -138,6 +140,16 @@ class RelNodeBlock(val outputNode: RelNode) {
   }
 
   def getMiniBatchInterval: MiniBatchInterval = miniBatchInterval
+
+  def setAllowDuplicateChanges(allowDuplicateChanges: Boolean): Unit = {
+    // a child block may have multiple parents (outputs), if one of the parents could not
+    // accept duplicated changes, then this child block doesn't allow to produce duplicate changes
+    if (this.allowDuplicateChanges) {
+      this.allowDuplicateChanges = allowDuplicateChanges
+    }
+  }
+
+  def isAllowDuplicateChanges: Boolean = allowDuplicateChanges
 
   def getChildBlock(node: RelNode): Option[RelNodeBlock] = {
     val find = children.filter(_.outputNode.equals(node))

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/StreamCommonSubGraphBasedOptimizer.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/StreamCommonSubGraphBasedOptimizer.scala
@@ -304,8 +304,6 @@ class StreamCommonSubGraphBasedOptimizer(planner: StreamPlanner)
         case DuplicateChanges.ALLOW => true
         case DuplicateChanges.DISALLOW => false
         case DuplicateChanges.NONE => true
-        case DuplicateChanges.UNKNOWN =>
-          throw new IllegalStateException("The duplicateChanges is not inferred")
         case _ =>
           throw new IllegalStateException(
             s"Unknown duplicateChanges: ${duplicateChangesTrait.getDuplicateChanges}"

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkStreamProgram.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkStreamProgram.scala
@@ -22,6 +22,7 @@ import org.apache.flink.table.api.config.OptimizerConfigOptions
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.rules.FlinkStreamRuleSets
 import org.apache.flink.table.planner.plan.rules.logical.EventTimeTemporalJoinRewriteRule
+import org.apache.flink.table.planner.plan.rules.physical.stream.FlinkDuplicateChangesTraitInitProgram
 
 import org.apache.calcite.plan.hep.HepMatchOrder
 
@@ -314,6 +315,17 @@ object FlinkStreamProgram {
             .add(FlinkStreamRuleSets.MINI_BATCH_RULES)
             .build(),
           "mini-batch interval rules"
+        )
+        .addProgram(
+          new FlinkDuplicateChangesTraitInitProgram,
+          "initialization for duplicate changes inference")
+        .addProgram(
+          FlinkHepRuleSetProgramBuilder.newBuilder
+            .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_SEQUENCE)
+            .setHepMatchOrder(HepMatchOrder.TOP_DOWN)
+            .add(FlinkStreamRuleSets.DUPLICATE_CHANGES_RULES)
+            .build(),
+          "duplicate changes rules"
         )
         .addProgram(
           FlinkHepRuleSetProgramBuilder.newBuilder

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -508,6 +508,11 @@ object FlinkStreamRuleSets {
     MiniBatchIntervalInferRule.INSTANCE
   )
 
+  val DUPLICATE_CHANGES_RULES: RuleSet = RuleSets.ofList(
+    // duplicate changes infer rule
+    DuplicateChangesInferRule.INSTANCE
+  )
+
   /** RuleSet to optimize plans after stream exec execution. */
   val PHYSICAL_REWRITE: RuleSet = RuleSets.ofList(
     // optimize agg rule
@@ -516,6 +521,8 @@ object FlinkStreamRuleSets {
     IncrementalAggregateRule.INSTANCE,
     // optimize window agg rule
     TwoStageOptimizedWindowAggregateRule.INSTANCE
+    // delta join redundant data acceptable infer rule
+
   )
 
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -521,8 +521,6 @@ object FlinkStreamRuleSets {
     IncrementalAggregateRule.INSTANCE,
     // optimize window agg rule
     TwoStageOptimizedWindowAggregateRule.INSTANCE
-    // delta join redundant data acceptable infer rule
-
   )
 
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/FlinkRelOptUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/FlinkRelOptUtil.scala
@@ -77,7 +77,8 @@ object FlinkRelOptUtil {
       withChangelogTraits: Boolean = false,
       withRowType: Boolean = false,
       withUpsertKey: Boolean = false,
-      withQueryBlockAlias: Boolean = false): String = {
+      withQueryBlockAlias: Boolean = false,
+      withDuplicateChangesTrait: Boolean = false): String = {
     if (rel == null) {
       return null
     }
@@ -91,7 +92,8 @@ object FlinkRelOptUtil {
       withTreeStyle = true,
       withUpsertKey,
       withQueryHint = true,
-      withQueryBlockAlias)
+      withQueryBlockAlias,
+      withDuplicateChangesTrait = withDuplicateChangesTrait)
     rel.explain(planWriter)
     sw.toString
   }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/RelTreeWriterImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/RelTreeWriterImpl.scala
@@ -187,13 +187,9 @@ class RelTreeWriterImpl(
       rel match {
         case streamRel: StreamPhysicalRel =>
           val duplicateChanges = DuplicateChangesUtils.getDuplicateChanges(streamRel)
-          val stringifyDuplicateChanges: String =
-            if (duplicateChanges.isEmpty) {
-              "EMPTY"
-            } else {
-              duplicateChanges.get().toString
-            }
-          printValues.add(Pair.of("duplicateChanges", stringifyDuplicateChanges))
+          if (duplicateChanges.isPresent) {
+            printValues.add(Pair.of("duplicateChanges", duplicateChanges.get().toString))
+          }
         case _ => // ignore
       }
     }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/RelTreeWriterImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/RelTreeWriterImpl.scala
@@ -48,7 +48,8 @@ class RelTreeWriterImpl(
     withQueryHint: Boolean = true,
     withQueryBlockAlias: Boolean = false,
     statementNum: Integer = 1,
-    withAdvice: Boolean = false)
+    withAdvice: Boolean = false,
+    withDuplicateChangesTrait: Boolean = false)
   extends RelWriterImpl(pw, explainLevel, withIdPrefix) {
 
   val NODE_LEVEL_ADVICE = new util.HashMap[Integer, util.List[PlanAdvice]]()
@@ -178,6 +179,21 @@ class RelTreeWriterImpl(
                   Pair.of("hints", RelExplainUtil.hintsToString(queryBlockAliasHints)))
               }
           }
+        case _ => // ignore
+      }
+    }
+
+    if (withDuplicateChangesTrait) {
+      rel match {
+        case streamRel: StreamPhysicalRel =>
+          val duplicateChanges = DuplicateChangesUtils.getDuplicateChanges(streamRel)
+          val stringifyDuplicateChanges: String =
+            if (duplicateChanges.isEmpty) {
+              "EMPTY"
+            } else {
+              duplicateChanges.get().toString
+            }
+          printValues.add(Pair.of("duplicateChanges", stringifyDuplicateChanges))
         case _ => // ignore
       }
     }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/analyze/GroupAggregationAnalyzerTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/analyze/GroupAggregationAnalyzerTest.java
@@ -150,6 +150,7 @@ class GroupAggregationAnalyzerTest extends TableTestBase {
                 false,
                 new Enumeration.Value[] {PlanKind.OPT_REL_WITH_ADVICE()},
                 () -> UNIT,
+                false,
                 false);
     }
 
@@ -198,6 +199,7 @@ class GroupAggregationAnalyzerTest extends TableTestBase {
                 false,
                 new Enumeration.Value[] {PlanKind.OPT_REL_WITH_ADVICE()},
                 () -> UNIT,
+                false,
                 false);
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/analyze/NonDeterministicUpdateAnalyzerTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/analyze/NonDeterministicUpdateAnalyzerTest.java
@@ -352,6 +352,7 @@ class NonDeterministicUpdateAnalyzerTest extends TableTestBase {
                 false,
                 new Enumeration.Value[] {PlanKind.OPT_REL_WITH_ADVICE()},
                 () -> UNIT,
+                false,
                 false);
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/hint/ClearQueryHintsWithInvalidPropagationShuttleTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/hint/ClearQueryHintsWithInvalidPropagationShuttleTestBase.java
@@ -130,7 +130,14 @@ abstract class ClearQueryHintsWithInvalidPropagationShuttleTestBase extends Tabl
     protected String buildRelPlanWithQueryBlockAlias(RelNode node) {
         return System.lineSeparator()
                 + FlinkRelOptUtil.toString(
-                        node, SqlExplainLevel.EXPPLAN_ATTRIBUTES, false, false, true, false, true);
+                        node,
+                        SqlExplainLevel.EXPPLAN_ATTRIBUTES,
+                        false,
+                        false,
+                        true,
+                        false,
+                        true,
+                        false);
     }
 
     protected void verifyRelPlan(RelNode node) {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/hints/batch/JoinHintTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/hints/batch/JoinHintTestBase.java
@@ -124,7 +124,8 @@ public abstract class JoinHintTestBase extends TableTestBase {
                 false,
                 new Enumeration.Value[] {PlanKind.AST(), PlanKind.OPT_REL()},
                 () -> UNIT,
-                true);
+                true,
+                false);
     }
 
     protected List<String> getOtherJoinHints() {
@@ -896,7 +897,8 @@ public abstract class JoinHintTestBase extends TableTestBase {
                                                 false,
                                                 true,
                                                 false,
-                                                true)));
+                                                true,
+                                                false)));
         return astBuilder.toString();
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/physical/stream/DuplicateChangesInferRuleTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/physical/stream/DuplicateChangesInferRuleTest.java
@@ -445,13 +445,14 @@ public class DuplicateChangesInferRuleTest extends TableTestBase {
                         true);
 
         util.tableEnv().executeSql("CREATE VIEW my_view as select a, b, c+1 as c from append_src1");
-
+        util.tableEnv().executeSql("CREATE TABLE pk_snk2 LIKE pk_snk");
         // left: allow
         // right: disallow
         // merged: disallow
         StatementSet stmtSet = util.tableEnv().createStatementSet();
         stmtSet.addInsertSql("insert into pk_snk select a, b, c/2 from my_view");
-        stmtSet.addInsertSql("insert into pk_snk select a, max(b), sum(c) from my_view group by a");
+        stmtSet.addInsertSql(
+                "insert into pk_snk2 select a, max(b), sum(c) from my_view group by a");
         verifyRelPlanInsert(stmtSet);
     }
 
@@ -466,13 +467,14 @@ public class DuplicateChangesInferRuleTest extends TableTestBase {
                         true);
 
         util.tableEnv().executeSql("CREATE VIEW my_view as select a, b, c+1 as c from append_src1");
+        util.tableEnv().executeSql("CREATE TABLE pk_snk2 LIKE pk_snk");
 
         // left: disallow
         // right: allow
         // merged: disallow
         StatementSet stmtSet = util.tableEnv().createStatementSet();
         stmtSet.addInsertSql("insert into pk_snk select a, max(b), sum(c) from my_view group by a");
-        stmtSet.addInsertSql("insert into pk_snk select a, b, c/2 from my_view");
+        stmtSet.addInsertSql("insert into pk_snk2 select a, b, c/2 from my_view");
         verifyRelPlanInsert(stmtSet);
     }
 
@@ -487,13 +489,14 @@ public class DuplicateChangesInferRuleTest extends TableTestBase {
                         true);
 
         util.tableEnv().executeSql("CREATE VIEW my_view as select a, b, c+1 as c from append_src1");
+        util.tableEnv().executeSql("CREATE TABLE pk_snk2 LIKE pk_snk");
 
         // left: allow
         // right: allow
         // merged: allow
         StatementSet stmtSet = util.tableEnv().createStatementSet();
         stmtSet.addInsertSql("insert into pk_snk select a, b, c/3 from my_view");
-        stmtSet.addInsertSql("insert into pk_snk select a, b, c/2 from my_view");
+        stmtSet.addInsertSql("insert into pk_snk2 select a, b, c/2 from my_view");
         verifyRelPlanInsert(stmtSet);
     }
 
@@ -508,13 +511,15 @@ public class DuplicateChangesInferRuleTest extends TableTestBase {
                         true);
 
         util.tableEnv().executeSql("CREATE VIEW my_view as select a, b, c+1 as c from append_src1");
+        util.tableEnv().executeSql("CREATE TABLE pk_snk2 LIKE pk_snk");
 
         // left: disallow
         // right: disallow
         // merged: disallow
         StatementSet stmtSet = util.tableEnv().createStatementSet();
         stmtSet.addInsertSql("insert into pk_snk select a, max(b), sum(c) from my_view group by a");
-        stmtSet.addInsertSql("insert into pk_snk select a, min(b), max(c) from my_view group by a");
+        stmtSet.addInsertSql(
+                "insert into pk_snk2 select a, min(b), max(c) from my_view group by a");
         verifyRelPlanInsert(stmtSet);
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/physical/stream/DuplicateChangesInferRuleTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/physical/stream/DuplicateChangesInferRuleTest.java
@@ -1,0 +1,549 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.physical.stream;
+
+import org.apache.flink.table.api.ExplainDetail;
+import org.apache.flink.table.api.StatementSet;
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.config.AggregatePhaseStrategy;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
+import org.apache.flink.table.api.config.OptimizerConfigOptions;
+import org.apache.flink.table.planner.utils.PlanKind;
+import org.apache.flink.table.planner.utils.StreamTableTestUtil;
+import org.apache.flink.table.planner.utils.TableTestBase;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+
+import scala.Enumeration;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static scala.runtime.BoxedUnit.UNIT;
+
+/** Tests for {@link DuplicateChangesInferRule}. */
+@ExtendWith(ParameterizedTestExtension.class)
+public class DuplicateChangesInferRuleTest extends TableTestBase {
+
+    private final StreamTableTestUtil util = streamTestUtil(TableConfig.getDefault());
+
+    private final boolean testSinkWithPk;
+
+    public DuplicateChangesInferRuleTest(boolean testSinkWithPk) {
+        this.testSinkWithPk = testSinkWithPk;
+    }
+
+    @Parameters(name = "testSinkWithPk = {0}")
+    private static Collection<Boolean[]> params() {
+        return Arrays.asList(new Boolean[] {false}, new Boolean[] {true});
+    }
+
+    @BeforeEach
+    void setup() {
+        util.tableEnv()
+                .executeSql(
+                        "CREATE TABLE append_src1 (\n"
+                                + "   a int not null,\n"
+                                + "   b string not null,\n"
+                                + "   c bigint not null,\n"
+                                + "   rt timestamp(3),\n"
+                                + "   watermark for rt as rt - INTERVAL '1' SECOND)\n"
+                                + " with (\n"
+                                + "   'connector' = 'values',\n"
+                                + "   'changelog-mode' = 'I'\n"
+                                + ")");
+
+        util.tableEnv().executeSql("CREATE TABLE append_src2 LIKE append_src1");
+
+        util.tableEnv()
+                .executeSql(
+                        "CREATE TABLE retract_src (\n"
+                                + "   primary key (a) not enforced\n"
+                                + ") WITH (\n"
+                                + "   'changelog-mode' = 'I,UA,UB,D'\n"
+                                + ") LIKE append_src1 (\n"
+                                + "   OVERWRITING OPTIONS\n"
+                                + ")");
+
+        util.tableEnv()
+                .executeSql(
+                        "CREATE TABLE upsert_src (\n"
+                                + "   primary key (a) not enforced\n"
+                                + ") WITH (\n"
+                                + "   'changelog-mode' = 'I,UA,D'\n"
+                                + ") LIKE append_src1 (\n"
+                                + "   OVERWRITING OPTIONS\n"
+                                + ")");
+
+        util.tableEnv()
+                .executeSql(
+                        "CREATE TABLE no_pk_snk (\n"
+                                + "   a int not null,\n"
+                                + "   b string not null,\n"
+                                + "   c bigint not null)\n"
+                                + " with (\n"
+                                + "   'connector' = 'values',\n"
+                                + "   'sink-insert-only' = 'true'\n"
+                                + ")");
+
+        util.tableEnv()
+                .executeSql(
+                        "CREATE TABLE pk_snk (\n"
+                                + "   a int not null,\n"
+                                + "   b string not null,\n"
+                                + "   c bigint not null,\n"
+                                + "   primary key (a) not enforced\n"
+                                + ")\n"
+                                + " with (\n"
+                                + "   'connector' = 'values',\n"
+                                + "   'sink-insert-only' = 'false',\n"
+                                + "   'sink-changelog-mode-enforced' = 'I,UA,UB,D'\n"
+                                + ")");
+    }
+
+    @TestTemplate
+    void testCalc() {
+        String sql =
+                String.format("insert into %s select a,b,c from append_src1", getSinkTableName());
+        verifyRelPlanInsert(sql);
+    }
+
+    @TestTemplate
+    void testCalcWithNonDeterministicFilter1() {
+        String sql =
+                String.format(
+                        "insert into %s select a,b,c from append_src1 where c < cast(now() as bigint)",
+                        getSinkTableName());
+        verifyRelPlanInsert(sql);
+    }
+
+    @TestTemplate
+    void testCalcWithNonDeterministicFilter2() {
+        String sql =
+                String.format(
+                        "insert into %s select a,b,c from append_src1 where a <> 1 and c < cast(now() as bigint)",
+                        getSinkTableName());
+        verifyRelPlanInsert(sql);
+    }
+
+    @TestTemplate
+    void testCalcWithNestedNonDeterministicFilter() {
+        String sql =
+                String.format(
+                        "insert into %s select a,b,c from append_src1 where c < cast(cast(now() as int) as bigint)",
+                        getSinkTableName());
+        verifyRelPlanInsert(sql);
+    }
+
+    @TestTemplate
+    void testCalcWithNonDeterministicProjection() {
+        String sql =
+                String.format(
+                        "insert into %s select a, b, cast(now() as bigint) from append_src1",
+                        getSinkTableName());
+        verifyRelPlanInsert(sql);
+    }
+
+    @TestTemplate
+    void testCalcWithNestedNonDeterministicProjection() {
+        String sql =
+                String.format(
+                        "insert into %s select a, b, cast(cast(now() as int) as bigint) from append_src1",
+                        getSinkTableName());
+        verifyRelPlanInsert(sql);
+    }
+
+    @TestTemplate
+    void testAggregate() {
+        assumeTrue(testSinkWithPk);
+        String sql = "insert into pk_snk select a,max(b),sum(c) from append_src1 group by a";
+        verifyRelPlanInsert(sql);
+    }
+
+    @TestTemplate
+    void testOneStageWindowAggregate() {
+        util.tableConfig()
+                .set(
+                        OptimizerConfigOptions.TABLE_OPTIMIZER_AGG_PHASE_STRATEGY,
+                        AggregatePhaseStrategy.ONE_PHASE);
+        testWindowAggregate();
+    }
+
+    @TestTemplate
+    void testTwoStageWindowAggregate() {
+        util.tableConfig()
+                .set(
+                        OptimizerConfigOptions.TABLE_OPTIMIZER_AGG_PHASE_STRATEGY,
+                        AggregatePhaseStrategy.TWO_PHASE);
+        testWindowAggregate();
+    }
+
+    private void testWindowAggregate() {
+        String sql =
+                String.format(
+                        "insert into %s select a, max(b), max(c) "
+                                + "from TABLE(TUMBLE(TABLE append_src1, DESCRIPTOR(rt), INTERVAL '1' MINUTE)) "
+                                + "group by a, window_start, window_end",
+                        getSinkTableName());
+        verifyRelPlanInsert(sql);
+    }
+
+    @TestTemplate
+    void testWindowTVF() {
+        assumeTrue(testSinkWithPk);
+
+        util.tableEnv()
+                .executeSql(
+                        "CREATE TABLE pk_snk_with_time_col (\n"
+                                + "  w_start timestamp(3),\n"
+                                + "  w_end timestamp(3)\n"
+                                + ") LIKE pk_snk");
+        String sql =
+                "insert into pk_snk_with_time_col select a, b, c, window_start, window_end "
+                        + "from TABLE(TUMBLE(TABLE append_src1, DESCRIPTOR(rt), INTERVAL '1' MINUTE))";
+        verifyRelPlanInsert(sql);
+    }
+
+    @TestTemplate
+    void testRank() {
+        assumeTrue(testSinkWithPk);
+
+        String sql =
+                "insert into pk_snk select a, b, c "
+                        + "from ( "
+                        + "  select a, b, c, "
+                        + "    ROW_NUMBER() OVER (PARTITION BY a ORDER BY c DESC) as rank_num "
+                        + "  from append_src1) "
+                        + "where rank_num <= 1";
+        verifyRelPlanInsert(sql);
+    }
+
+    @TestTemplate
+    void testWindowRank() {
+        assumeTrue(testSinkWithPk);
+
+        util.tableEnv()
+                .executeSql(
+                        "CREATE TABLE pk_snk_with_time_col (\n"
+                                + "  w_start timestamp(3),\n"
+                                + "  w_end timestamp(3)\n"
+                                + ") LIKE pk_snk");
+        String sql =
+                "insert into pk_snk_with_time_col select a, b, c, window_start, window_end "
+                        + "from ( "
+                        + "  select a, b, c, window_start, window_end, "
+                        + "    ROW_NUMBER() OVER (PARTITION BY a, window_start, window_end ORDER BY c DESC) as rank_num "
+                        + "  from TABLE(TUMBLE(TABLE append_src1, DESCRIPTOR(rt), INTERVAL '1' MINUTE))) "
+                        + "where rank_num <= 1";
+        verifyRelPlanInsert(sql);
+    }
+
+    @TestTemplate
+    void testMiniBatchTwoStageAggregate() {
+        assumeTrue(testSinkWithPk);
+
+        enableMiniBatch();
+
+        String sql = "insert into pk_snk select a,max(b),sum(c) from append_src1 group by a";
+        verifyRelPlanInsert(sql);
+    }
+
+    @TestTemplate
+    void testExpandAndIncrementalAggregate() {
+        assumeTrue(testSinkWithPk);
+
+        enableMiniBatch();
+        util.tableConfig()
+                .set(
+                        OptimizerConfigOptions.TABLE_OPTIMIZER_AGG_PHASE_STRATEGY,
+                        AggregatePhaseStrategy.TWO_PHASE);
+        util.tableConfig()
+                .set(OptimizerConfigOptions.TABLE_OPTIMIZER_DISTINCT_AGG_SPLIT_ENABLED, true);
+
+        String sql =
+                "insert into pk_snk select a, max(b), count(distinct c) from append_src1 group by a";
+        verifyRelPlanInsert(sql);
+    }
+
+    @TestTemplate
+    void testDropUpdateBefore() {
+        assumeTrue(testSinkWithPk);
+
+        util.tableEnv()
+                .executeSql(
+                        "CREATE TABLE upsert_snk WITH (\n"
+                                + "  'sink-changelog-mode-enforced' = 'I,UA,D'"
+                                + ") LIKE pk_snk (\n"
+                                + "  OVERWRITING OPTIONS\n"
+                                + ")");
+
+        String sql = "insert into pk_snk select a,b,c from retract_src";
+        verifyRelPlanInsert(sql);
+    }
+
+    @TestTemplate
+    void testSinkWithMaterialize() {
+        assumeTrue(testSinkWithPk);
+
+        util.tableEnv()
+                .executeSql(
+                        "CREATE TABLE another_pk_snk (\n"
+                                + "  primary key (b) not enforced\n"
+                                + ") LIKE pk_snk (\n"
+                                + "  EXCLUDING CONSTRAINTS\n"
+                                + ")");
+
+        String sql = "insert into another_pk_snk select a,b,c from retract_src";
+        verifyRelPlanInsert(sql);
+    }
+
+    @TestTemplate
+    void testChangelogNormalize() {
+        assumeTrue(testSinkWithPk);
+
+        String sql = "insert into pk_snk select a,b,c from upsert_src";
+        verifyRelPlanInsert(sql);
+    }
+
+    @TestTemplate
+    void testJoin() {
+        String sql =
+                String.format(
+                        "insert into %s select T1.a, T2.b, T1.c "
+                                + "from append_src1 T1 join append_src2 T2 "
+                                + "on T1.a = T2.a",
+                        getSinkTableName());
+        verifyRelPlanInsert(sql);
+    }
+
+    @TestTemplate
+    void testWindowJoin() {
+        assumeTrue(testSinkWithPk);
+
+        String sql =
+                String.format(
+                        "insert into %s select T1.a, T2.b, T1.c "
+                                + "from ("
+                                + "   select * from TABLE(TUMBLE(TABLE append_src1, DESCRIPTOR(rt), INTERVAL '1' MINUTES))"
+                                + ") T1 join ("
+                                + "   select * from TABLE(TUMBLE(TABLE append_src2, DESCRIPTOR(rt), INTERVAL '1' MINUTES))"
+                                + ") T2 "
+                                + "on T1.a = T2.a and T1.window_start = T2.window_start and T1.window_end = T2.window_end",
+                        getSinkTableName());
+        verifyRelPlanInsert(sql);
+    }
+
+    @TestTemplate
+    void testIntervalJoin() {
+        assumeTrue(testSinkWithPk);
+
+        String sql =
+                String.format(
+                        "insert into %s select T1.a, T2.b, T1.c "
+                                + "from append_src1 T1 join append_src2 T2 "
+                                + "on T1.a = T2.a and "
+                                + "  T1.rt > T2.rt - INTERVAL '1' MINUTES and "
+                                + "  T1.rt < T2.rt + INTERVAL '1' MINUTES",
+                        getSinkTableName());
+        verifyRelPlanInsert(sql);
+    }
+
+    @TestTemplate
+    void testLimit() {
+        String sql =
+                String.format(
+                        "insert into %s select a,b,c from append_src1 limit 10",
+                        getSinkTableName());
+        verifyRelPlanInsert(sql);
+    }
+
+    @TestTemplate
+    void testTemporalJoin() {
+        util.tableEnv()
+                .executeSql(
+                        "CREATE TABLE dim_src (\n"
+                                + "   primary key (a) not enforced\n"
+                                + ") WITH (\n"
+                                + "   'disable-lookup' = 'true'\n"
+                                + ") LIKE append_src1 (\n"
+                                + "   OVERWRITING OPTIONS\n"
+                                + ")");
+
+        String sql =
+                String.format(
+                        "insert into %s select T1.a, T1.b, T1.c from ( "
+                                + "   select *, proctime() as pt from append_src1 "
+                                + ") T1 "
+                                + "join dim_src FOR SYSTEM_TIME AS OF T1.pt AS T2 "
+                                + "on T1.a = T2.a",
+                        getSinkTableName());
+        verifyRelPlanInsert(sql);
+    }
+
+    @TestTemplate
+    void testLookupJoin() {
+        util.tableEnv()
+                .executeSql(
+                        "CREATE TABLE dim_src (\n"
+                                + "   primary key (a) not enforced\n"
+                                + ") LIKE append_src1 (\n"
+                                + "   OVERWRITING OPTIONS\n"
+                                + "   EXCLUDING WATERMARKS\n"
+                                + ")");
+
+        String sql =
+                String.format(
+                        "insert into %s select T1.a, T1.b, T1.c from ( "
+                                + "   select *, proctime() as pt from append_src1 "
+                                + ") T1 "
+                                + "join dim_src FOR SYSTEM_TIME AS OF T1.pt AS T2 "
+                                + "on T1.a = T2.a",
+                        getSinkTableName());
+        verifyRelPlanInsert(sql);
+    }
+
+    @TestTemplate
+    void testUnion() {
+        String sql =
+                String.format(
+                        "insert into %s select a,b,c from append_src1 union all select a,b,c from append_src2",
+                        getSinkTableName());
+        verifyRelPlanInsert(sql);
+    }
+
+    @TestTemplate
+    void testMultiSink1() {
+        assumeTrue(testSinkWithPk);
+
+        util.tableConfig()
+                .set(
+                        OptimizerConfigOptions
+                                .TABLE_OPTIMIZER_REUSE_OPTIMIZE_BLOCK_WITH_DIGEST_ENABLED,
+                        true);
+
+        util.tableEnv().executeSql("CREATE VIEW my_view as select a, b, c+1 as c from append_src1");
+
+        // left: allow
+        // right: disallow
+        // merged: disallow
+        StatementSet stmtSet = util.tableEnv().createStatementSet();
+        stmtSet.addInsertSql("insert into pk_snk select a, b, c/2 from my_view");
+        stmtSet.addInsertSql("insert into pk_snk select a, max(b), sum(c) from my_view group by a");
+        verifyRelPlanInsert(stmtSet);
+    }
+
+    @TestTemplate
+    void testMultiSink2() {
+        assumeTrue(testSinkWithPk);
+
+        util.tableConfig()
+                .set(
+                        OptimizerConfigOptions
+                                .TABLE_OPTIMIZER_REUSE_OPTIMIZE_BLOCK_WITH_DIGEST_ENABLED,
+                        true);
+
+        util.tableEnv().executeSql("CREATE VIEW my_view as select a, b, c+1 as c from append_src1");
+
+        // left: disallow
+        // right: allow
+        // merged: disallow
+        StatementSet stmtSet = util.tableEnv().createStatementSet();
+        stmtSet.addInsertSql("insert into pk_snk select a, max(b), sum(c) from my_view group by a");
+        stmtSet.addInsertSql("insert into pk_snk select a, b, c/2 from my_view");
+        verifyRelPlanInsert(stmtSet);
+    }
+
+    @TestTemplate
+    void testMultiSink3() {
+        assumeTrue(testSinkWithPk);
+
+        util.tableConfig()
+                .set(
+                        OptimizerConfigOptions
+                                .TABLE_OPTIMIZER_REUSE_OPTIMIZE_BLOCK_WITH_DIGEST_ENABLED,
+                        true);
+
+        util.tableEnv().executeSql("CREATE VIEW my_view as select a, b, c+1 as c from append_src1");
+
+        // left: allow
+        // right: allow
+        // merged: allow
+        StatementSet stmtSet = util.tableEnv().createStatementSet();
+        stmtSet.addInsertSql("insert into pk_snk select a, b, c/3 from my_view");
+        stmtSet.addInsertSql("insert into pk_snk select a, b, c/2 from my_view");
+        verifyRelPlanInsert(stmtSet);
+    }
+
+    @TestTemplate
+    void testMultiSink4() {
+        assumeTrue(testSinkWithPk);
+
+        util.tableConfig()
+                .set(
+                        OptimizerConfigOptions
+                                .TABLE_OPTIMIZER_REUSE_OPTIMIZE_BLOCK_WITH_DIGEST_ENABLED,
+                        true);
+
+        util.tableEnv().executeSql("CREATE VIEW my_view as select a, b, c+1 as c from append_src1");
+
+        // left: disallow
+        // right: disallow
+        // merged: disallow
+        StatementSet stmtSet = util.tableEnv().createStatementSet();
+        stmtSet.addInsertSql("insert into pk_snk select a, max(b), sum(c) from my_view group by a");
+        stmtSet.addInsertSql("insert into pk_snk select a, min(b), max(c) from my_view group by a");
+        verifyRelPlanInsert(stmtSet);
+    }
+
+    private void verifyRelPlanInsert(String insert) {
+        StatementSet stmtSet = util.tableEnv().createStatementSet();
+        stmtSet.addInsertSql(insert);
+        verifyRelPlanInsert(stmtSet);
+    }
+
+    private void verifyRelPlanInsert(StatementSet stmtSet) {
+        util.doVerifyPlan(
+                stmtSet,
+                new ExplainDetail[] {},
+                false,
+                new Enumeration.Value[] {PlanKind.AST(), PlanKind.OPT_REL()},
+                () -> UNIT,
+                false,
+                true);
+    }
+
+    private String getSinkTableName() {
+        return testSinkWithPk ? "pk_snk" : "no_pk_snk";
+    }
+
+    private void enableMiniBatch() {
+        util.tableConfig().set(ExecutionConfigOptions.TABLE_EXEC_MINIBATCH_ENABLED, true);
+        util.tableConfig()
+                .set(
+                        ExecutionConfigOptions.TABLE_EXEC_MINIBATCH_ALLOW_LATENCY,
+                        Duration.ofSeconds(1));
+        util.tableEnv().getConfig().set(ExecutionConfigOptions.TABLE_EXEC_MINIBATCH_SIZE, 10L);
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/utils/DuplicateChangesUtilsTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/utils/DuplicateChangesUtilsTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.utils;
+
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.table.planner.plan.trait.DuplicateChanges;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.apache.flink.table.planner.plan.trait.DuplicateChanges.ALLOW;
+import static org.apache.flink.table.planner.plan.trait.DuplicateChanges.DISALLOW;
+import static org.apache.flink.table.planner.plan.trait.DuplicateChanges.NONE;
+import static org.apache.flink.table.planner.plan.trait.DuplicateChanges.UNKNOWN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link DuplicateChangesUtils}. */
+class DuplicateChangesUtilsTest {
+
+    @ParameterizedTest
+    @MethodSource("testMergingMatrix")
+    void testMergeDuplicateChanges(
+            Tuple3<DuplicateChanges, DuplicateChanges, DuplicateChanges> testData) {
+        DuplicateChanges actual =
+                DuplicateChangesUtils.mergeDuplicateChanges(testData.f0, testData.f1);
+        assertThat(actual).isEqualTo(testData.f2);
+    }
+
+    private static Stream<Tuple3<DuplicateChanges, DuplicateChanges, DuplicateChanges>>
+            testMergingMatrix() {
+        // input1, input2, expected_merged_result
+        return Stream.of(
+                // -------------------------------------
+                Tuple3.of(ALLOW, ALLOW, ALLOW),
+                Tuple3.of(ALLOW, DISALLOW, DISALLOW),
+                Tuple3.of(ALLOW, NONE, NONE),
+                Tuple3.of(ALLOW, UNKNOWN, ALLOW),
+                // -------------------------------------
+                Tuple3.of(DISALLOW, ALLOW, DISALLOW),
+                Tuple3.of(DISALLOW, DISALLOW, DISALLOW),
+                Tuple3.of(DISALLOW, NONE, NONE),
+                Tuple3.of(DISALLOW, UNKNOWN, DISALLOW),
+                // -------------------------------------
+                Tuple3.of(NONE, ALLOW, NONE),
+                Tuple3.of(NONE, DISALLOW, NONE),
+                Tuple3.of(NONE, NONE, NONE),
+                Tuple3.of(NONE, UNKNOWN, NONE),
+                // -------------------------------------
+                Tuple3.of(UNKNOWN, ALLOW, ALLOW),
+                Tuple3.of(UNKNOWN, DISALLOW, DISALLOW),
+                Tuple3.of(UNKNOWN, NONE, NONE),
+                Tuple3.of(UNKNOWN, UNKNOWN, UNKNOWN));
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/utils/DuplicateChangesUtilsTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/utils/DuplicateChangesUtilsTest.java
@@ -29,7 +29,6 @@ import java.util.stream.Stream;
 import static org.apache.flink.table.planner.plan.trait.DuplicateChanges.ALLOW;
 import static org.apache.flink.table.planner.plan.trait.DuplicateChanges.DISALLOW;
 import static org.apache.flink.table.planner.plan.trait.DuplicateChanges.NONE;
-import static org.apache.flink.table.planner.plan.trait.DuplicateChanges.UNKNOWN;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link DuplicateChangesUtils}. */
@@ -51,22 +50,14 @@ class DuplicateChangesUtilsTest {
                 // -------------------------------------
                 Tuple3.of(ALLOW, ALLOW, ALLOW),
                 Tuple3.of(ALLOW, DISALLOW, DISALLOW),
-                Tuple3.of(ALLOW, NONE, NONE),
-                Tuple3.of(ALLOW, UNKNOWN, ALLOW),
+                Tuple3.of(ALLOW, NONE, ALLOW),
                 // -------------------------------------
                 Tuple3.of(DISALLOW, ALLOW, DISALLOW),
                 Tuple3.of(DISALLOW, DISALLOW, DISALLOW),
-                Tuple3.of(DISALLOW, NONE, NONE),
-                Tuple3.of(DISALLOW, UNKNOWN, DISALLOW),
+                Tuple3.of(DISALLOW, NONE, DISALLOW),
                 // -------------------------------------
-                Tuple3.of(NONE, ALLOW, NONE),
-                Tuple3.of(NONE, DISALLOW, NONE),
-                Tuple3.of(NONE, NONE, NONE),
-                Tuple3.of(NONE, UNKNOWN, NONE),
-                // -------------------------------------
-                Tuple3.of(UNKNOWN, ALLOW, ALLOW),
-                Tuple3.of(UNKNOWN, DISALLOW, DISALLOW),
-                Tuple3.of(UNKNOWN, NONE, NONE),
-                Tuple3.of(UNKNOWN, UNKNOWN, UNKNOWN));
+                Tuple3.of(NONE, ALLOW, ALLOW),
+                Tuple3.of(NONE, DISALLOW, DISALLOW),
+                Tuple3.of(NONE, NONE, NONE));
     }
 }

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/physical/stream/DuplicateChangesInferRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/physical/stream/DuplicateChangesInferRuleTest.xml
@@ -37,6 +37,24 @@ Sink(table=[default_catalog.default_database.pk_snk], fields=[a, EXPR$1, EXPR$2]
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testAppendOnlySinkWithPk[testSinkWithPk = false]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.append_only_sink_with_pk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$2])
+   +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.append_only_sink_with_pk], fields=[a, b, c], duplicateChanges=[NONE])
++- Calc(select=[a, b, c], duplicateChanges=[DISALLOW])
+   +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+      +- TableSourceScan(table=[[default_catalog, default_database, append_src1]], fields=[a, b, c, rt], duplicateChanges=[DISALLOW])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testCalc[testSinkWithPk = false]">
     <Resource name="ast">
       <![CDATA[

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/physical/stream/DuplicateChangesInferRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/physical/stream/DuplicateChangesInferRuleTest.xml
@@ -549,7 +549,7 @@ LogicalSink(table=[default_catalog.default_database.pk_snk], fields=[a, b, EXPR$
       +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
          +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
 
-LogicalSink(table=[default_catalog.default_database.pk_snk], fields=[a, EXPR$1, EXPR$2])
+LogicalSink(table=[default_catalog.default_database.pk_snk2], fields=[a, EXPR$1, EXPR$2])
 +- LogicalAggregate(group=[{0}], EXPR$1=[MAX($1)], EXPR$2=[SUM($2)])
    +- LogicalProject(a=[$0], b=[$1], c=[+($2, 1)])
       +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
@@ -564,7 +564,7 @@ Sink(table=[default_catalog.default_database.pk_snk], fields=[a, b, EXPR$2], dup
       +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
          +- TableSourceScan(table=[[default_catalog, default_database, append_src1]], fields=[a, b, c, rt], duplicateChanges=[DISALLOW])
 
-Sink(table=[default_catalog.default_database.pk_snk], fields=[a, EXPR$1, EXPR$2], duplicateChanges=[NONE])
+Sink(table=[default_catalog.default_database.pk_snk2], fields=[a, EXPR$1, EXPR$2], duplicateChanges=[NONE])
 +- GroupAggregate(groupBy=[a], select=[a, MAX(b) AS EXPR$1, SUM(c) AS EXPR$2], duplicateChanges=[ALLOW])
    +- Exchange(distribution=[hash[a]], duplicateChanges=[DISALLOW])
       +- Calc(select=[a, b, +(c, 1) AS c], duplicateChanges=[DISALLOW])
@@ -582,7 +582,7 @@ LogicalSink(table=[default_catalog.default_database.pk_snk], fields=[a, EXPR$1, 
       +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
          +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
 
-LogicalSink(table=[default_catalog.default_database.pk_snk], fields=[a, b, EXPR$2])
+LogicalSink(table=[default_catalog.default_database.pk_snk2], fields=[a, b, EXPR$2])
 +- LogicalProject(a=[$0], b=[$1], EXPR$2=[/($2, 2)])
    +- LogicalProject(a=[$0], b=[$1], c=[+($2, 1)])
       +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
@@ -598,7 +598,7 @@ Sink(table=[default_catalog.default_database.pk_snk], fields=[a, EXPR$1, EXPR$2]
          +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
             +- TableSourceScan(table=[[default_catalog, default_database, append_src1]], fields=[a, b, c, rt], duplicateChanges=[DISALLOW])
 
-Sink(table=[default_catalog.default_database.pk_snk], fields=[a, b, EXPR$2], duplicateChanges=[NONE])
+Sink(table=[default_catalog.default_database.pk_snk2], fields=[a, b, EXPR$2], duplicateChanges=[NONE])
 +- Calc(select=[a, b, /(c, 2) AS EXPR$2], duplicateChanges=[ALLOW])
    +- Calc(select=[a, b, +(c, 1) AS c], duplicateChanges=[DISALLOW])
       +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
@@ -615,7 +615,7 @@ LogicalSink(table=[default_catalog.default_database.pk_snk], fields=[a, b, EXPR$
       +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
          +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
 
-LogicalSink(table=[default_catalog.default_database.pk_snk], fields=[a, b, EXPR$2])
+LogicalSink(table=[default_catalog.default_database.pk_snk2], fields=[a, b, EXPR$2])
 +- LogicalProject(a=[$0], b=[$1], EXPR$2=[/($2, 2)])
    +- LogicalProject(a=[$0], b=[$1], c=[+($2, 1)])
       +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
@@ -630,7 +630,7 @@ Sink(table=[default_catalog.default_database.pk_snk], fields=[a, b, EXPR$2], dup
       +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[ALLOW])
          +- TableSourceScan(table=[[default_catalog, default_database, append_src1]], fields=[a, b, c, rt], duplicateChanges=[ALLOW])
 
-Sink(table=[default_catalog.default_database.pk_snk], fields=[a, b, EXPR$2], duplicateChanges=[NONE])
+Sink(table=[default_catalog.default_database.pk_snk2], fields=[a, b, EXPR$2], duplicateChanges=[NONE])
 +- Calc(select=[a, b, /(c, 2) AS EXPR$2], duplicateChanges=[ALLOW])
    +- Calc(select=[a, b, +(c, 1) AS c], duplicateChanges=[ALLOW])
       +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[ALLOW])
@@ -647,7 +647,7 @@ LogicalSink(table=[default_catalog.default_database.pk_snk], fields=[a, EXPR$1, 
       +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
          +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
 
-LogicalSink(table=[default_catalog.default_database.pk_snk], fields=[a, EXPR$1, EXPR$2])
+LogicalSink(table=[default_catalog.default_database.pk_snk2], fields=[a, EXPR$1, EXPR$2])
 +- LogicalAggregate(group=[{0}], EXPR$1=[MIN($1)], EXPR$2=[MAX($2)])
    +- LogicalProject(a=[$0], b=[$1], c=[+($2, 1)])
       +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
@@ -663,7 +663,7 @@ Sink(table=[default_catalog.default_database.pk_snk], fields=[a, EXPR$1, EXPR$2]
          +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
             +- TableSourceScan(table=[[default_catalog, default_database, append_src1]], fields=[a, b, c, rt], duplicateChanges=[DISALLOW])
 
-Sink(table=[default_catalog.default_database.pk_snk], fields=[a, EXPR$1, EXPR$2], duplicateChanges=[NONE])
+Sink(table=[default_catalog.default_database.pk_snk2], fields=[a, EXPR$1, EXPR$2], duplicateChanges=[NONE])
 +- GroupAggregate(groupBy=[a], select=[a, MIN(b) AS EXPR$1, MAX(c) AS EXPR$2], duplicateChanges=[ALLOW])
    +- Exchange(distribution=[hash[a]], duplicateChanges=[DISALLOW])
       +- Calc(select=[a, b, +(c, 1) AS c], duplicateChanges=[DISALLOW])

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/physical/stream/DuplicateChangesInferRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/physical/stream/DuplicateChangesInferRuleTest.xml
@@ -1,0 +1,991 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testAggregate[testSinkWithPk = true]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.pk_snk], fields=[a, EXPR$1, EXPR$2])
++- LogicalAggregate(group=[{0}], EXPR$1=[MAX($1)], EXPR$2=[SUM($2)])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2])
+      +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.pk_snk], fields=[a, EXPR$1, EXPR$2], duplicateChanges=[NONE])
++- GroupAggregate(groupBy=[a], select=[a, MAX(b) AS EXPR$1, SUM(c) AS EXPR$2], duplicateChanges=[ALLOW])
+   +- Exchange(distribution=[hash[a]], duplicateChanges=[DISALLOW])
+      +- Calc(select=[a, b, c], duplicateChanges=[DISALLOW])
+         +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+            +- TableSourceScan(table=[[default_catalog, default_database, append_src1]], fields=[a, b, c, rt], duplicateChanges=[DISALLOW])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCalc[testSinkWithPk = false]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.no_pk_snk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$2])
+   +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.no_pk_snk], fields=[a, b, c], duplicateChanges=[NONE])
++- Calc(select=[a, b, c], duplicateChanges=[DISALLOW])
+   +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+      +- TableSourceScan(table=[[default_catalog, default_database, append_src1]], fields=[a, b, c, rt], duplicateChanges=[DISALLOW])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCalc[testSinkWithPk = true]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.pk_snk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$2])
+   +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.pk_snk], fields=[a, b, c], duplicateChanges=[NONE])
++- Calc(select=[a, b, c], duplicateChanges=[ALLOW])
+   +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[ALLOW])
+      +- TableSourceScan(table=[[default_catalog, default_database, append_src1]], fields=[a, b, c, rt], duplicateChanges=[ALLOW])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCalcWithNestedNonDeterministicFilter[testSinkWithPk = false]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.no_pk_snk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$2])
+   +- LogicalFilter(condition=[<($2, CAST(CAST(NOW()):INTEGER NOT NULL):BIGINT NOT NULL)])
+      +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.no_pk_snk], fields=[a, b, c], duplicateChanges=[NONE])
++- Calc(select=[a, b, c], where=[<(c, CAST(CAST(NOW() AS INTEGER) AS BIGINT))], duplicateChanges=[DISALLOW])
+   +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+      +- TableSourceScan(table=[[default_catalog, default_database, append_src1]], fields=[a, b, c, rt], duplicateChanges=[DISALLOW])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCalcWithNestedNonDeterministicFilter[testSinkWithPk = true]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.pk_snk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$2])
+   +- LogicalFilter(condition=[<($2, CAST(CAST(NOW()):INTEGER NOT NULL):BIGINT NOT NULL)])
+      +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.pk_snk], fields=[a, b, c], duplicateChanges=[NONE])
++- Calc(select=[a, b, c], where=[<(c, CAST(CAST(NOW() AS INTEGER) AS BIGINT))], duplicateChanges=[ALLOW])
+   +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+      +- TableSourceScan(table=[[default_catalog, default_database, append_src1]], fields=[a, b, c, rt], duplicateChanges=[DISALLOW])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCalcWithNestedNonDeterministicProjection[testSinkWithPk = false]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.no_pk_snk], fields=[a, b, EXPR$2])
++- LogicalProject(a=[$0], b=[$1], EXPR$2=[CAST(CAST(NOW()):INTEGER NOT NULL):BIGINT NOT NULL])
+   +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.no_pk_snk], fields=[a, b, EXPR$2], duplicateChanges=[NONE])
++- Calc(select=[a, b, CAST(CAST(NOW() AS INTEGER) AS BIGINT) AS EXPR$2], duplicateChanges=[DISALLOW])
+   +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+      +- TableSourceScan(table=[[default_catalog, default_database, append_src1, project=[a, b, rt], metadata=[]]], fields=[a, b, rt], duplicateChanges=[DISALLOW])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCalcWithNestedNonDeterministicProjection[testSinkWithPk = true]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.pk_snk], fields=[a, b, EXPR$2])
++- LogicalProject(a=[$0], b=[$1], EXPR$2=[CAST(CAST(NOW()):INTEGER NOT NULL):BIGINT NOT NULL])
+   +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.pk_snk], fields=[a, b, EXPR$2], duplicateChanges=[NONE])
++- Calc(select=[a, b, CAST(CAST(NOW() AS INTEGER) AS BIGINT) AS EXPR$2], duplicateChanges=[ALLOW])
+   +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+      +- TableSourceScan(table=[[default_catalog, default_database, append_src1, project=[a, b, rt], metadata=[]]], fields=[a, b, rt], duplicateChanges=[DISALLOW])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCalcWithNonDeterministicFilter1[testSinkWithPk = false]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.no_pk_snk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$2])
+   +- LogicalFilter(condition=[<($2, CAST(NOW()):BIGINT NOT NULL)])
+      +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.no_pk_snk], fields=[a, b, c], duplicateChanges=[NONE])
++- Calc(select=[a, b, c], where=[<(c, CAST(NOW() AS BIGINT))], duplicateChanges=[DISALLOW])
+   +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+      +- TableSourceScan(table=[[default_catalog, default_database, append_src1]], fields=[a, b, c, rt], duplicateChanges=[DISALLOW])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCalcWithNonDeterministicFilter1[testSinkWithPk = true]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.pk_snk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$2])
+   +- LogicalFilter(condition=[<($2, CAST(NOW()):BIGINT NOT NULL)])
+      +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.pk_snk], fields=[a, b, c], duplicateChanges=[NONE])
++- Calc(select=[a, b, c], where=[<(c, CAST(NOW() AS BIGINT))], duplicateChanges=[ALLOW])
+   +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+      +- TableSourceScan(table=[[default_catalog, default_database, append_src1]], fields=[a, b, c, rt], duplicateChanges=[DISALLOW])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCalcWithNonDeterministicFilter2[testSinkWithPk = false]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.no_pk_snk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$2])
+   +- LogicalFilter(condition=[AND(<>($0, 1), <($2, CAST(NOW()):BIGINT NOT NULL))])
+      +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.no_pk_snk], fields=[a, b, c], duplicateChanges=[NONE])
++- Calc(select=[a, b, c], where=[AND(<>(a, 1), <(c, CAST(NOW() AS BIGINT)))], duplicateChanges=[DISALLOW])
+   +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+      +- TableSourceScan(table=[[default_catalog, default_database, append_src1]], fields=[a, b, c, rt], duplicateChanges=[DISALLOW])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCalcWithNonDeterministicFilter2[testSinkWithPk = true]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.pk_snk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$2])
+   +- LogicalFilter(condition=[AND(<>($0, 1), <($2, CAST(NOW()):BIGINT NOT NULL))])
+      +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.pk_snk], fields=[a, b, c], duplicateChanges=[NONE])
++- Calc(select=[a, b, c], where=[AND(<>(a, 1), <(c, CAST(NOW() AS BIGINT)))], duplicateChanges=[ALLOW])
+   +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+      +- TableSourceScan(table=[[default_catalog, default_database, append_src1]], fields=[a, b, c, rt], duplicateChanges=[DISALLOW])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCalcWithNonDeterministicProjection[testSinkWithPk = false]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.no_pk_snk], fields=[a, b, EXPR$2])
++- LogicalProject(a=[$0], b=[$1], EXPR$2=[CAST(NOW()):BIGINT NOT NULL])
+   +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.no_pk_snk], fields=[a, b, EXPR$2], duplicateChanges=[NONE])
++- Calc(select=[a, b, CAST(NOW() AS BIGINT) AS EXPR$2], duplicateChanges=[DISALLOW])
+   +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+      +- TableSourceScan(table=[[default_catalog, default_database, append_src1, project=[a, b, rt], metadata=[]]], fields=[a, b, rt], duplicateChanges=[DISALLOW])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCalcWithNonDeterministicProjection[testSinkWithPk = true]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.pk_snk], fields=[a, b, EXPR$2])
++- LogicalProject(a=[$0], b=[$1], EXPR$2=[CAST(NOW()):BIGINT NOT NULL])
+   +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.pk_snk], fields=[a, b, EXPR$2], duplicateChanges=[NONE])
++- Calc(select=[a, b, CAST(NOW() AS BIGINT) AS EXPR$2], duplicateChanges=[ALLOW])
+   +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+      +- TableSourceScan(table=[[default_catalog, default_database, append_src1, project=[a, b, rt], metadata=[]]], fields=[a, b, rt], duplicateChanges=[DISALLOW])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testChangelogNormalize[testSinkWithPk = true]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.pk_snk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$2])
+   +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, upsert_src]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.pk_snk], fields=[a, b, c], duplicateChanges=[NONE])
++- ChangelogNormalize(key=[a], duplicateChanges=[ALLOW])
+   +- Exchange(distribution=[hash[a]], duplicateChanges=[DISALLOW])
+      +- Calc(select=[a, b, c], duplicateChanges=[DISALLOW])
+         +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+            +- TableSourceScan(table=[[default_catalog, default_database, upsert_src]], fields=[a, b, c, rt], duplicateChanges=[DISALLOW])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testDropUpdateBefore[testSinkWithPk = true]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.pk_snk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$2])
+   +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, retract_src]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.pk_snk], fields=[a, b, c], duplicateChanges=[NONE])
++- Calc(select=[a, b, c], duplicateChanges=[ALLOW])
+   +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[ALLOW])
+      +- TableSourceScan(table=[[default_catalog, default_database, retract_src]], fields=[a, b, c, rt], duplicateChanges=[ALLOW])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testExpandAndIncrementalAggregate[testSinkWithPk = true]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.pk_snk], fields=[a, EXPR$1, EXPR$2])
++- LogicalAggregate(group=[{0}], EXPR$1=[MAX($1)], EXPR$2=[COUNT(DISTINCT $2)])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2])
+      +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.pk_snk], fields=[a, $f1, $f2], duplicateChanges=[NONE])
++- Calc(select=[a, CAST($f1 AS VARCHAR(2147483647)) AS $f1, $f2], duplicateChanges=[ALLOW])
+   +- GlobalGroupAggregate(groupBy=[a], partialFinalType=[FINAL], select=[a, MAX(max$0) AS $f1, $SUM0(count$1) AS $f2], duplicateChanges=[ALLOW])
+      +- Exchange(distribution=[hash[a]], duplicateChanges=[DISALLOW])
+         +- IncrementalGroupAggregate(partialAggGrouping=[a, $f3, $f4], finalAggGrouping=[a], select=[a, MAX(max$0) AS max$0, COUNT(distinct$0 count$1) AS count$1], duplicateChanges=[DISALLOW])
+            +- Exchange(distribution=[hash[a, $f3, $f4]], duplicateChanges=[DISALLOW])
+               +- LocalGroupAggregate(groupBy=[a, $f3, $f4], partialFinalType=[PARTIAL], select=[a, $f3, $f4, MAX(b) FILTER $g_1 AS max$0, COUNT(distinct$0 c) FILTER $g_2 AS count$1, DISTINCT(c) AS distinct$0], duplicateChanges=[DISALLOW])
+                  +- Calc(select=[a, b, c, $f3, $f4, =($e, 1) AS $g_1, =($e, 2) AS $g_2], duplicateChanges=[DISALLOW])
+                     +- Expand(projects=[{a, b, c, $f3, null AS $f4, 1 AS $e}, {a, b, c, null AS $f3, $f4, 2 AS $e}], duplicateChanges=[DISALLOW])
+                        +- Calc(select=[a, b, c, MOD(HASH_CODE(b), 1024) AS $f3, MOD(HASH_CODE(c), 1024) AS $f4], duplicateChanges=[DISALLOW])
+                           +- MiniBatchAssigner(interval=[1000ms], mode=[ProcTime], duplicateChanges=[DISALLOW])
+                              +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+                                 +- TableSourceScan(table=[[default_catalog, default_database, append_src1]], fields=[a, b, c, rt], duplicateChanges=[DISALLOW])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testIntervalJoin[testSinkWithPk = true]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.pk_snk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$5], c=[$2])
+   +- LogicalJoin(condition=[AND(=($0, $4), >($3, -($7, 60000:INTERVAL MINUTE)), <($3, +($7, 60000:INTERVAL MINUTE)))], joinType=[inner])
+      :- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+      +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, append_src2]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.pk_snk], fields=[a, b, c], duplicateChanges=[NONE])
++- Calc(select=[a, b, c], duplicateChanges=[ALLOW])
+   +- IntervalJoin(joinType=[InnerJoin], windowBounds=[isRowTime=true, leftLowerBound=-59999, leftUpperBound=59999, leftTimeIndex=2, rightTimeIndex=2], where=[AND(=(a, a0), >(rt, -(rt0, 60000:INTERVAL MINUTE)), <(rt, +(rt0, 60000:INTERVAL MINUTE)))], select=[a, c, rt, a0, b, rt0], duplicateChanges=[ALLOW])
+      :- Exchange(distribution=[hash[a]], duplicateChanges=[DISALLOW])
+      :  +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+      :     +- TableSourceScan(table=[[default_catalog, default_database, append_src1, project=[a, c, rt], metadata=[]]], fields=[a, c, rt], duplicateChanges=[DISALLOW])
+      +- Exchange(distribution=[hash[a]], duplicateChanges=[DISALLOW])
+         +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+            +- TableSourceScan(table=[[default_catalog, default_database, append_src2, project=[a, b, rt], metadata=[]]], fields=[a, b, rt], duplicateChanges=[DISALLOW])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoin[testSinkWithPk = false]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.no_pk_snk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$5], c=[$2])
+   +- LogicalJoin(condition=[=($0, $4)], joinType=[inner])
+      :- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+      +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, append_src2]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.no_pk_snk], fields=[a, b, c], duplicateChanges=[NONE])
++- Calc(select=[a, b, c], duplicateChanges=[DISALLOW])
+   +- Join(joinType=[InnerJoin], where=[=(a, a0)], select=[a, c, a0, b], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey], duplicateChanges=[DISALLOW])
+      :- Exchange(distribution=[hash[a]], duplicateChanges=[DISALLOW])
+      :  +- Calc(select=[a, c], duplicateChanges=[DISALLOW])
+      :     +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+      :        +- TableSourceScan(table=[[default_catalog, default_database, append_src1, project=[a, c, rt], metadata=[]]], fields=[a, c, rt], duplicateChanges=[DISALLOW])
+      +- Exchange(distribution=[hash[a]], duplicateChanges=[DISALLOW])
+         +- Calc(select=[a, b], duplicateChanges=[DISALLOW])
+            +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+               +- TableSourceScan(table=[[default_catalog, default_database, append_src2, project=[a, b, rt], metadata=[]]], fields=[a, b, rt], duplicateChanges=[DISALLOW])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoin[testSinkWithPk = true]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.pk_snk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$5], c=[$2])
+   +- LogicalJoin(condition=[=($0, $4)], joinType=[inner])
+      :- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+      +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, append_src2]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.pk_snk], fields=[a, b, c], duplicateChanges=[NONE])
++- Calc(select=[a, b, c], duplicateChanges=[ALLOW])
+   +- Join(joinType=[InnerJoin], where=[=(a, a0)], select=[a, c, a0, b], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey], duplicateChanges=[ALLOW])
+      :- Exchange(distribution=[hash[a]], duplicateChanges=[DISALLOW])
+      :  +- Calc(select=[a, c], duplicateChanges=[DISALLOW])
+      :     +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+      :        +- TableSourceScan(table=[[default_catalog, default_database, append_src1, project=[a, c, rt], metadata=[]]], fields=[a, c, rt], duplicateChanges=[DISALLOW])
+      +- Exchange(distribution=[hash[a]], duplicateChanges=[DISALLOW])
+         +- Calc(select=[a, b], duplicateChanges=[DISALLOW])
+            +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+               +- TableSourceScan(table=[[default_catalog, default_database, append_src2, project=[a, b, rt], metadata=[]]], fields=[a, b, rt], duplicateChanges=[DISALLOW])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLimit[testSinkWithPk = false]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.no_pk_snk], fields=[a, b, c])
++- LogicalSort(fetch=[10])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2])
+      +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.no_pk_snk], fields=[a, b, c], duplicateChanges=[NONE])
++- Calc(select=[a, b, c], duplicateChanges=[DISALLOW])
+   +- Limit(offset=[0], fetch=[10], duplicateChanges=[DISALLOW])
+      +- Exchange(distribution=[single], duplicateChanges=[DISALLOW])
+         +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+            +- TableSourceScan(table=[[default_catalog, default_database, append_src1]], fields=[a, b, c, rt], duplicateChanges=[DISALLOW])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLimit[testSinkWithPk = true]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.pk_snk], fields=[a, b, c])
++- LogicalSort(fetch=[10])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2])
+      +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.pk_snk], fields=[a, b, c], duplicateChanges=[NONE])
++- Calc(select=[a, b, c], duplicateChanges=[ALLOW])
+   +- Limit(offset=[0], fetch=[10], duplicateChanges=[ALLOW])
+      +- Exchange(distribution=[single], duplicateChanges=[DISALLOW])
+         +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+            +- TableSourceScan(table=[[default_catalog, default_database, append_src1]], fields=[a, b, c, rt], duplicateChanges=[DISALLOW])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLookupJoin[testSinkWithPk = false]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.no_pk_snk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$2])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 4}])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], rt=[$3], pt=[PROCTIME()])
+      :  +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+      :     +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+      +- LogicalFilter(condition=[=($cor0.a, $0)])
+         +- LogicalSnapshot(period=[$cor0.pt])
+            +- LogicalTableScan(table=[[default_catalog, default_database, dim_src]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.no_pk_snk], fields=[a, b, c], duplicateChanges=[NONE])
++- Calc(select=[a, b, c], duplicateChanges=[DISALLOW])
+   +- LookupJoin(table=[default_catalog.default_database.dim_src], joinType=[InnerJoin], lookup=[a=a], select=[a, b, c, a0], duplicateChanges=[DISALLOW])
+      +- Calc(select=[a, b, c], duplicateChanges=[DISALLOW])
+         +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+            +- TableSourceScan(table=[[default_catalog, default_database, append_src1]], fields=[a, b, c, rt], duplicateChanges=[DISALLOW])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLookupJoin[testSinkWithPk = true]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.pk_snk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$2])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 4}])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], rt=[$3], pt=[PROCTIME()])
+      :  +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+      :     +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+      +- LogicalFilter(condition=[=($cor0.a, $0)])
+         +- LogicalSnapshot(period=[$cor0.pt])
+            +- LogicalTableScan(table=[[default_catalog, default_database, dim_src]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.pk_snk], fields=[a, b, c], duplicateChanges=[NONE])
++- Calc(select=[a, b, c], duplicateChanges=[ALLOW])
+   +- LookupJoin(table=[default_catalog.default_database.dim_src], joinType=[InnerJoin], lookup=[a=a], select=[a, b, c, a0], duplicateChanges=[ALLOW])
+      +- Calc(select=[a, b, c], duplicateChanges=[DISALLOW])
+         +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+            +- TableSourceScan(table=[[default_catalog, default_database, append_src1]], fields=[a, b, c, rt], duplicateChanges=[DISALLOW])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMiniBatchTwoStageAggregate[testSinkWithPk = true]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.pk_snk], fields=[a, EXPR$1, EXPR$2])
++- LogicalAggregate(group=[{0}], EXPR$1=[MAX($1)], EXPR$2=[SUM($2)])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2])
+      +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.pk_snk], fields=[a, EXPR$1, EXPR$2], duplicateChanges=[NONE])
++- GlobalGroupAggregate(groupBy=[a], select=[a, MAX(max$0) AS EXPR$1, SUM(sum$1) AS EXPR$2], duplicateChanges=[ALLOW])
+   +- Exchange(distribution=[hash[a]], duplicateChanges=[DISALLOW])
+      +- LocalGroupAggregate(groupBy=[a], select=[a, MAX(b) AS max$0, SUM(c) AS sum$1], duplicateChanges=[DISALLOW])
+         +- Calc(select=[a, b, c], duplicateChanges=[DISALLOW])
+            +- MiniBatchAssigner(interval=[1000ms], mode=[ProcTime], duplicateChanges=[DISALLOW])
+               +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+                  +- TableSourceScan(table=[[default_catalog, default_database, append_src1]], fields=[a, b, c, rt], duplicateChanges=[DISALLOW])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMultiSink1[testSinkWithPk = true]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.pk_snk], fields=[a, b, EXPR$2])
++- LogicalProject(a=[$0], b=[$1], EXPR$2=[/($2, 2)])
+   +- LogicalProject(a=[$0], b=[$1], c=[+($2, 1)])
+      +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+
+LogicalSink(table=[default_catalog.default_database.pk_snk], fields=[a, EXPR$1, EXPR$2])
++- LogicalAggregate(group=[{0}], EXPR$1=[MAX($1)], EXPR$2=[SUM($2)])
+   +- LogicalProject(a=[$0], b=[$1], c=[+($2, 1)])
+      +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.pk_snk], fields=[a, b, EXPR$2], duplicateChanges=[NONE])
++- Calc(select=[a, b, /(c, 2) AS EXPR$2], duplicateChanges=[ALLOW])
+   +- Calc(select=[a, b, +(c, 1) AS c], duplicateChanges=[DISALLOW])
+      +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+         +- TableSourceScan(table=[[default_catalog, default_database, append_src1]], fields=[a, b, c, rt], duplicateChanges=[DISALLOW])
+
+Sink(table=[default_catalog.default_database.pk_snk], fields=[a, EXPR$1, EXPR$2], duplicateChanges=[NONE])
++- GroupAggregate(groupBy=[a], select=[a, MAX(b) AS EXPR$1, SUM(c) AS EXPR$2], duplicateChanges=[ALLOW])
+   +- Exchange(distribution=[hash[a]], duplicateChanges=[DISALLOW])
+      +- Calc(select=[a, b, +(c, 1) AS c], duplicateChanges=[DISALLOW])
+         +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+            +- TableSourceScan(table=[[default_catalog, default_database, append_src1]], fields=[a, b, c, rt], duplicateChanges=[DISALLOW])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMultiSink2[testSinkWithPk = true]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.pk_snk], fields=[a, EXPR$1, EXPR$2])
++- LogicalAggregate(group=[{0}], EXPR$1=[MAX($1)], EXPR$2=[SUM($2)])
+   +- LogicalProject(a=[$0], b=[$1], c=[+($2, 1)])
+      +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+
+LogicalSink(table=[default_catalog.default_database.pk_snk], fields=[a, b, EXPR$2])
++- LogicalProject(a=[$0], b=[$1], EXPR$2=[/($2, 2)])
+   +- LogicalProject(a=[$0], b=[$1], c=[+($2, 1)])
+      +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.pk_snk], fields=[a, EXPR$1, EXPR$2], duplicateChanges=[NONE])
++- GroupAggregate(groupBy=[a], select=[a, MAX(b) AS EXPR$1, SUM(c) AS EXPR$2], duplicateChanges=[ALLOW])
+   +- Exchange(distribution=[hash[a]], duplicateChanges=[DISALLOW])
+      +- Calc(select=[a, b, +(c, 1) AS c], duplicateChanges=[DISALLOW])
+         +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+            +- TableSourceScan(table=[[default_catalog, default_database, append_src1]], fields=[a, b, c, rt], duplicateChanges=[DISALLOW])
+
+Sink(table=[default_catalog.default_database.pk_snk], fields=[a, b, EXPR$2], duplicateChanges=[NONE])
++- Calc(select=[a, b, /(c, 2) AS EXPR$2], duplicateChanges=[ALLOW])
+   +- Calc(select=[a, b, +(c, 1) AS c], duplicateChanges=[DISALLOW])
+      +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+         +- TableSourceScan(table=[[default_catalog, default_database, append_src1]], fields=[a, b, c, rt], duplicateChanges=[DISALLOW])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMultiSink3[testSinkWithPk = true]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.pk_snk], fields=[a, b, EXPR$2])
++- LogicalProject(a=[$0], b=[$1], EXPR$2=[/($2, 3)])
+   +- LogicalProject(a=[$0], b=[$1], c=[+($2, 1)])
+      +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+
+LogicalSink(table=[default_catalog.default_database.pk_snk], fields=[a, b, EXPR$2])
++- LogicalProject(a=[$0], b=[$1], EXPR$2=[/($2, 2)])
+   +- LogicalProject(a=[$0], b=[$1], c=[+($2, 1)])
+      +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.pk_snk], fields=[a, b, EXPR$2], duplicateChanges=[NONE])
++- Calc(select=[a, b, /(c, 3) AS EXPR$2], duplicateChanges=[ALLOW])
+   +- Calc(select=[a, b, +(c, 1) AS c], duplicateChanges=[ALLOW])
+      +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[ALLOW])
+         +- TableSourceScan(table=[[default_catalog, default_database, append_src1]], fields=[a, b, c, rt], duplicateChanges=[ALLOW])
+
+Sink(table=[default_catalog.default_database.pk_snk], fields=[a, b, EXPR$2], duplicateChanges=[NONE])
++- Calc(select=[a, b, /(c, 2) AS EXPR$2], duplicateChanges=[ALLOW])
+   +- Calc(select=[a, b, +(c, 1) AS c], duplicateChanges=[ALLOW])
+      +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[ALLOW])
+         +- TableSourceScan(table=[[default_catalog, default_database, append_src1]], fields=[a, b, c, rt], duplicateChanges=[ALLOW])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMultiSink4[testSinkWithPk = true]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.pk_snk], fields=[a, EXPR$1, EXPR$2])
++- LogicalAggregate(group=[{0}], EXPR$1=[MAX($1)], EXPR$2=[SUM($2)])
+   +- LogicalProject(a=[$0], b=[$1], c=[+($2, 1)])
+      +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+
+LogicalSink(table=[default_catalog.default_database.pk_snk], fields=[a, EXPR$1, EXPR$2])
++- LogicalAggregate(group=[{0}], EXPR$1=[MIN($1)], EXPR$2=[MAX($2)])
+   +- LogicalProject(a=[$0], b=[$1], c=[+($2, 1)])
+      +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.pk_snk], fields=[a, EXPR$1, EXPR$2], duplicateChanges=[NONE])
++- GroupAggregate(groupBy=[a], select=[a, MAX(b) AS EXPR$1, SUM(c) AS EXPR$2], duplicateChanges=[ALLOW])
+   +- Exchange(distribution=[hash[a]], duplicateChanges=[DISALLOW])
+      +- Calc(select=[a, b, +(c, 1) AS c], duplicateChanges=[DISALLOW])
+         +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+            +- TableSourceScan(table=[[default_catalog, default_database, append_src1]], fields=[a, b, c, rt], duplicateChanges=[DISALLOW])
+
+Sink(table=[default_catalog.default_database.pk_snk], fields=[a, EXPR$1, EXPR$2], duplicateChanges=[NONE])
++- GroupAggregate(groupBy=[a], select=[a, MIN(b) AS EXPR$1, MAX(c) AS EXPR$2], duplicateChanges=[ALLOW])
+   +- Exchange(distribution=[hash[a]], duplicateChanges=[DISALLOW])
+      +- Calc(select=[a, b, +(c, 1) AS c], duplicateChanges=[DISALLOW])
+         +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+            +- TableSourceScan(table=[[default_catalog, default_database, append_src1]], fields=[a, b, c, rt], duplicateChanges=[DISALLOW])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testOneStageWindowAggregate[testSinkWithPk = false]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.no_pk_snk], fields=[a, EXPR$1, EXPR$2])
++- LogicalProject(a=[$0], EXPR$1=[$3], EXPR$2=[$4])
+   +- LogicalAggregate(group=[{0, 1, 2}], EXPR$1=[MAX($3)], EXPR$2=[MAX($4)])
+      +- LogicalProject(a=[$0], window_start=[$4], window_end=[$5], b=[$1], c=[$2])
+         +- LogicalTableFunctionScan(invocation=[TUMBLE(TABLE(#0), DESCRIPTOR(_UTF-16LE'rt'), 60000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, VARCHAR(2147483647) b, BIGINT c, TIMESTAMP(3) *ROWTIME* rt, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP(3) *ROWTIME* window_time)])
+            +- LogicalProject(a=[$0], b=[$1], c=[$2], rt=[$3])
+               +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+                  +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.no_pk_snk], fields=[a, EXPR$1, EXPR$2], duplicateChanges=[NONE])
++- Calc(select=[a, EXPR$1, EXPR$2], duplicateChanges=[DISALLOW])
+   +- WindowAggregate(groupBy=[a], window=[TUMBLE(time_col=[rt], size=[1 min])], select=[a, MAX(b) AS EXPR$1, MAX(c) AS EXPR$2, start('w$) AS window_start, end('w$) AS window_end], duplicateChanges=[DISALLOW])
+      +- Exchange(distribution=[hash[a]], duplicateChanges=[DISALLOW])
+         +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+            +- TableSourceScan(table=[[default_catalog, default_database, append_src1]], fields=[a, b, c, rt], duplicateChanges=[DISALLOW])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testOneStageWindowAggregate[testSinkWithPk = true]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.pk_snk], fields=[a, EXPR$1, EXPR$2])
++- LogicalProject(a=[$0], EXPR$1=[$3], EXPR$2=[$4])
+   +- LogicalAggregate(group=[{0, 1, 2}], EXPR$1=[MAX($3)], EXPR$2=[MAX($4)])
+      +- LogicalProject(a=[$0], window_start=[$4], window_end=[$5], b=[$1], c=[$2])
+         +- LogicalTableFunctionScan(invocation=[TUMBLE(TABLE(#0), DESCRIPTOR(_UTF-16LE'rt'), 60000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, VARCHAR(2147483647) b, BIGINT c, TIMESTAMP(3) *ROWTIME* rt, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP(3) *ROWTIME* window_time)])
+            +- LogicalProject(a=[$0], b=[$1], c=[$2], rt=[$3])
+               +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+                  +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.pk_snk], fields=[a, EXPR$1, EXPR$2], duplicateChanges=[NONE])
++- Calc(select=[a, EXPR$1, EXPR$2], duplicateChanges=[ALLOW])
+   +- WindowAggregate(groupBy=[a], window=[TUMBLE(time_col=[rt], size=[1 min])], select=[a, MAX(b) AS EXPR$1, MAX(c) AS EXPR$2, start('w$) AS window_start, end('w$) AS window_end], duplicateChanges=[ALLOW])
+      +- Exchange(distribution=[hash[a]], duplicateChanges=[DISALLOW])
+         +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+            +- TableSourceScan(table=[[default_catalog, default_database, append_src1]], fields=[a, b, c, rt], duplicateChanges=[DISALLOW])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testRank[testSinkWithPk = true]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.pk_snk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$2])
+   +- LogicalFilter(condition=[<=($3, 1)])
+      +- LogicalProject(a=[$0], b=[$1], c=[$2], rank_num=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $2 DESC NULLS LAST)])
+         +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+            +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.pk_snk], fields=[a, b, c], duplicateChanges=[NONE])
++- Rank(strategy=[AppendFastStrategy], rankType=[ROW_NUMBER], rankRange=[rankStart=1, rankEnd=1], partitionBy=[a], orderBy=[c DESC], select=[a, b, c], duplicateChanges=[ALLOW])
+   +- Exchange(distribution=[hash[a]], duplicateChanges=[DISALLOW])
+      +- Calc(select=[a, b, c], duplicateChanges=[DISALLOW])
+         +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+            +- TableSourceScan(table=[[default_catalog, default_database, append_src1]], fields=[a, b, c, rt], duplicateChanges=[DISALLOW])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSinkWithMaterialize[testSinkWithPk = true]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.another_pk_snk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$2])
+   +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, retract_src]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.another_pk_snk], fields=[a, b, c], upsertMaterialize=[true], duplicateChanges=[NONE])
++- Calc(select=[a, b, c], duplicateChanges=[DISALLOW])
+   +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+      +- TableSourceScan(table=[[default_catalog, default_database, retract_src]], fields=[a, b, c, rt], duplicateChanges=[DISALLOW])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testTemporalJoin[testSinkWithPk = false]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.no_pk_snk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$2])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 4}])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], rt=[$3], pt=[PROCTIME()])
+      :  +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+      :     +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+      +- LogicalFilter(condition=[=($cor0.a, $0)])
+         +- LogicalSnapshot(period=[$cor0.pt])
+            +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+               +- LogicalTableScan(table=[[default_catalog, default_database, dim_src]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.no_pk_snk], fields=[a, b, c], duplicateChanges=[NONE])
++- Calc(select=[a, b, c], duplicateChanges=[DISALLOW])
+   +- TemporalJoin(joinType=[InnerJoin], where=[AND(=(a, a0), __TEMPORAL_JOIN_CONDITION(pt, __TEMPORAL_JOIN_CONDITION_PRIMARY_KEY(a0), __TEMPORAL_JOIN_LEFT_KEY(a), __TEMPORAL_JOIN_RIGHT_KEY(a0)))], select=[a, b, c, pt, a0], duplicateChanges=[DISALLOW])
+      :- Exchange(distribution=[hash[a]], duplicateChanges=[DISALLOW])
+      :  +- Calc(select=[a, b, c, PROCTIME() AS pt], duplicateChanges=[DISALLOW])
+      :     +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+      :        +- TableSourceScan(table=[[default_catalog, default_database, append_src1]], fields=[a, b, c, rt], duplicateChanges=[DISALLOW])
+      +- Exchange(distribution=[hash[a]], duplicateChanges=[DISALLOW])
+         +- Calc(select=[a], duplicateChanges=[DISALLOW])
+            +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+               +- TableSourceScan(table=[[default_catalog, default_database, dim_src, project=[a, rt], metadata=[]]], fields=[a, rt], duplicateChanges=[DISALLOW])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testTemporalJoin[testSinkWithPk = true]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.pk_snk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$2])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 4}])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], rt=[$3], pt=[PROCTIME()])
+      :  +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+      :     +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+      +- LogicalFilter(condition=[=($cor0.a, $0)])
+         +- LogicalSnapshot(period=[$cor0.pt])
+            +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+               +- LogicalTableScan(table=[[default_catalog, default_database, dim_src]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.pk_snk], fields=[a, b, c], duplicateChanges=[NONE])
++- Calc(select=[a, b, c], duplicateChanges=[ALLOW])
+   +- TemporalJoin(joinType=[InnerJoin], where=[AND(=(a, a0), __TEMPORAL_JOIN_CONDITION(pt, __TEMPORAL_JOIN_CONDITION_PRIMARY_KEY(a0), __TEMPORAL_JOIN_LEFT_KEY(a), __TEMPORAL_JOIN_RIGHT_KEY(a0)))], select=[a, b, c, pt, a0], duplicateChanges=[ALLOW])
+      :- Exchange(distribution=[hash[a]], duplicateChanges=[DISALLOW])
+      :  +- Calc(select=[a, b, c, PROCTIME() AS pt], duplicateChanges=[DISALLOW])
+      :     +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+      :        +- TableSourceScan(table=[[default_catalog, default_database, append_src1]], fields=[a, b, c, rt], duplicateChanges=[DISALLOW])
+      +- Exchange(distribution=[hash[a]], duplicateChanges=[DISALLOW])
+         +- Calc(select=[a], duplicateChanges=[DISALLOW])
+            +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+               +- TableSourceScan(table=[[default_catalog, default_database, dim_src, project=[a, rt], metadata=[]]], fields=[a, rt], duplicateChanges=[DISALLOW])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testTwoStageWindowAggregate[testSinkWithPk = false]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.no_pk_snk], fields=[a, EXPR$1, EXPR$2])
++- LogicalProject(a=[$0], EXPR$1=[$3], EXPR$2=[$4])
+   +- LogicalAggregate(group=[{0, 1, 2}], EXPR$1=[MAX($3)], EXPR$2=[MAX($4)])
+      +- LogicalProject(a=[$0], window_start=[$4], window_end=[$5], b=[$1], c=[$2])
+         +- LogicalTableFunctionScan(invocation=[TUMBLE(TABLE(#0), DESCRIPTOR(_UTF-16LE'rt'), 60000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, VARCHAR(2147483647) b, BIGINT c, TIMESTAMP(3) *ROWTIME* rt, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP(3) *ROWTIME* window_time)])
+            +- LogicalProject(a=[$0], b=[$1], c=[$2], rt=[$3])
+               +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+                  +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.no_pk_snk], fields=[a, EXPR$1, EXPR$2], duplicateChanges=[NONE])
++- Calc(select=[a, EXPR$1, EXPR$2], duplicateChanges=[DISALLOW])
+   +- GlobalWindowAggregate(groupBy=[a], window=[TUMBLE(slice_end=[$slice_end], size=[1 min])], select=[a, MAX(max$0) AS EXPR$1, MAX(max$1) AS EXPR$2, start('w$) AS window_start, end('w$) AS window_end], duplicateChanges=[DISALLOW])
+      +- Exchange(distribution=[hash[a]], duplicateChanges=[DISALLOW])
+         +- LocalWindowAggregate(groupBy=[a], window=[TUMBLE(time_col=[rt], size=[1 min])], select=[a, MAX(b) AS max$0, MAX(c) AS max$1, slice_end('w$) AS $slice_end], duplicateChanges=[DISALLOW])
+            +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+               +- TableSourceScan(table=[[default_catalog, default_database, append_src1]], fields=[a, b, c, rt], duplicateChanges=[DISALLOW])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testTwoStageWindowAggregate[testSinkWithPk = true]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.pk_snk], fields=[a, EXPR$1, EXPR$2])
++- LogicalProject(a=[$0], EXPR$1=[$3], EXPR$2=[$4])
+   +- LogicalAggregate(group=[{0, 1, 2}], EXPR$1=[MAX($3)], EXPR$2=[MAX($4)])
+      +- LogicalProject(a=[$0], window_start=[$4], window_end=[$5], b=[$1], c=[$2])
+         +- LogicalTableFunctionScan(invocation=[TUMBLE(TABLE(#0), DESCRIPTOR(_UTF-16LE'rt'), 60000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, VARCHAR(2147483647) b, BIGINT c, TIMESTAMP(3) *ROWTIME* rt, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP(3) *ROWTIME* window_time)])
+            +- LogicalProject(a=[$0], b=[$1], c=[$2], rt=[$3])
+               +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+                  +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.pk_snk], fields=[a, EXPR$1, EXPR$2], duplicateChanges=[NONE])
++- Calc(select=[a, EXPR$1, EXPR$2], duplicateChanges=[ALLOW])
+   +- GlobalWindowAggregate(groupBy=[a], window=[TUMBLE(slice_end=[$slice_end], size=[1 min])], select=[a, MAX(max$0) AS EXPR$1, MAX(max$1) AS EXPR$2, start('w$) AS window_start, end('w$) AS window_end], duplicateChanges=[ALLOW])
+      +- Exchange(distribution=[hash[a]], duplicateChanges=[DISALLOW])
+         +- LocalWindowAggregate(groupBy=[a], window=[TUMBLE(time_col=[rt], size=[1 min])], select=[a, MAX(b) AS max$0, MAX(c) AS max$1, slice_end('w$) AS $slice_end], duplicateChanges=[DISALLOW])
+            +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+               +- TableSourceScan(table=[[default_catalog, default_database, append_src1]], fields=[a, b, c, rt], duplicateChanges=[DISALLOW])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUnion[testSinkWithPk = false]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.no_pk_snk], fields=[a, b, c])
++- LogicalUnion(all=[true])
+   :- LogicalProject(a=[$0], b=[$1], c=[$2])
+   :  +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2])
+      +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, append_src2]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.no_pk_snk], fields=[a, b, c], duplicateChanges=[NONE])
++- Union(all=[true], union=[a, b, c], duplicateChanges=[DISALLOW])
+   :- Calc(select=[a, b, c], duplicateChanges=[DISALLOW])
+   :  +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+   :     +- TableSourceScan(table=[[default_catalog, default_database, append_src1]], fields=[a, b, c, rt], duplicateChanges=[DISALLOW])
+   +- Calc(select=[a, b, c], duplicateChanges=[DISALLOW])
+      +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+         +- TableSourceScan(table=[[default_catalog, default_database, append_src2]], fields=[a, b, c, rt], duplicateChanges=[DISALLOW])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUnion[testSinkWithPk = true]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.pk_snk], fields=[a, b, c])
++- LogicalUnion(all=[true])
+   :- LogicalProject(a=[$0], b=[$1], c=[$2])
+   :  +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2])
+      +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, append_src2]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.pk_snk], fields=[a, b, c], duplicateChanges=[NONE])
++- Union(all=[true], union=[a, b, c], duplicateChanges=[ALLOW])
+   :- Calc(select=[a, b, c], duplicateChanges=[DISALLOW])
+   :  +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+   :     +- TableSourceScan(table=[[default_catalog, default_database, append_src1]], fields=[a, b, c, rt], duplicateChanges=[DISALLOW])
+   +- Calc(select=[a, b, c], duplicateChanges=[DISALLOW])
+      +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+         +- TableSourceScan(table=[[default_catalog, default_database, append_src2]], fields=[a, b, c, rt], duplicateChanges=[DISALLOW])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testWindowTVF[testSinkWithPk = true]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.pk_snk_with_time_col], fields=[a, b, c, window_start, window_end])
++- LogicalProject(a=[$0], b=[$1], c=[$2], window_start=[$4], window_end=[$5])
+   +- LogicalTableFunctionScan(invocation=[TUMBLE(TABLE(#0), DESCRIPTOR(_UTF-16LE'rt'), 60000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, VARCHAR(2147483647) b, BIGINT c, TIMESTAMP(3) *ROWTIME* rt, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP(3) *ROWTIME* window_time)])
+      +- LogicalProject(a=[$0], b=[$1], c=[$2], rt=[$3])
+         +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+            +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.pk_snk_with_time_col], fields=[a, b, c, window_start, window_end], duplicateChanges=[NONE])
++- Calc(select=[a, b, c, window_start, window_end], duplicateChanges=[ALLOW])
+   +- WindowTableFunction(window=[TUMBLE(time_col=[rt], size=[1 min])], duplicateChanges=[ALLOW])
+      +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+         +- TableSourceScan(table=[[default_catalog, default_database, append_src1]], fields=[a, b, c, rt], duplicateChanges=[DISALLOW])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testWindowJoin[testSinkWithPk = true]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.pk_snk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$8], c=[$2])
+   +- LogicalJoin(condition=[AND(=($0, $7), =($4, $11), =($5, $12))], joinType=[inner])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], rt=[$3], window_start=[$4], window_end=[$5], window_time=[$6])
+      :  +- LogicalTableFunctionScan(invocation=[TUMBLE(TABLE(#0), DESCRIPTOR(_UTF-16LE'rt'), 60000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, VARCHAR(2147483647) b, BIGINT c, TIMESTAMP(3) *ROWTIME* rt, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP(3) *ROWTIME* window_time)])
+      :     +- LogicalProject(a=[$0], b=[$1], c=[$2], rt=[$3])
+      :        +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+      :           +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+      +- LogicalProject(a=[$0], b=[$1], c=[$2], rt=[$3], window_start=[$4], window_end=[$5], window_time=[$6])
+         +- LogicalTableFunctionScan(invocation=[TUMBLE(TABLE(#0), DESCRIPTOR(_UTF-16LE'rt'), 60000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, VARCHAR(2147483647) b, BIGINT c, TIMESTAMP(3) *ROWTIME* rt, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP(3) *ROWTIME* window_time)])
+            +- LogicalProject(a=[$0], b=[$1], c=[$2], rt=[$3])
+               +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+                  +- LogicalTableScan(table=[[default_catalog, default_database, append_src2]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.pk_snk], fields=[a, b, c], duplicateChanges=[NONE])
++- Calc(select=[a, b, c], duplicateChanges=[ALLOW])
+   +- WindowJoin(leftWindow=[TUMBLE(win_start=[window_start], win_end=[window_end], size=[1 min])], rightWindow=[TUMBLE(win_start=[window_start], win_end=[window_end], size=[1 min])], joinType=[InnerJoin], where=[=(a, a0)], select=[a, c, window_start, window_end, a0, b, window_start0, window_end0], duplicateChanges=[ALLOW])
+      :- Exchange(distribution=[hash[a]], duplicateChanges=[DISALLOW])
+      :  +- Calc(select=[a, c, window_start, window_end], duplicateChanges=[DISALLOW])
+      :     +- WindowTableFunction(window=[TUMBLE(time_col=[rt], size=[1 min])], duplicateChanges=[DISALLOW])
+      :        +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+      :           +- TableSourceScan(table=[[default_catalog, default_database, append_src1, project=[a, c, rt], metadata=[]]], fields=[a, c, rt], duplicateChanges=[DISALLOW])
+      +- Exchange(distribution=[hash[a]], duplicateChanges=[DISALLOW])
+         +- Calc(select=[a, b, window_start, window_end], duplicateChanges=[DISALLOW])
+            +- WindowTableFunction(window=[TUMBLE(time_col=[rt], size=[1 min])], duplicateChanges=[DISALLOW])
+               +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+                  +- TableSourceScan(table=[[default_catalog, default_database, append_src2, project=[a, b, rt], metadata=[]]], fields=[a, b, rt], duplicateChanges=[DISALLOW])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testWindowRank[testSinkWithPk = true]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.pk_snk_with_time_col], fields=[a, b, c, window_start, window_end])
++- LogicalProject(a=[$0], b=[$1], c=[$2], window_start=[$3], window_end=[$4])
+   +- LogicalFilter(condition=[<=($5, 1)])
+      +- LogicalProject(a=[$0], b=[$1], c=[$2], window_start=[$4], window_end=[$5], rank_num=[ROW_NUMBER() OVER (PARTITION BY $0, $4, $5 ORDER BY $2 DESC NULLS LAST)])
+         +- LogicalTableFunctionScan(invocation=[TUMBLE(TABLE(#0), DESCRIPTOR(_UTF-16LE'rt'), 60000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, VARCHAR(2147483647) b, BIGINT c, TIMESTAMP(3) *ROWTIME* rt, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP(3) *ROWTIME* window_time)])
+            +- LogicalProject(a=[$0], b=[$1], c=[$2], rt=[$3])
+               +- LogicalWatermarkAssigner(rowtime=[rt], watermark=[-($3, 1000:INTERVAL SECOND)])
+                  +- LogicalTableScan(table=[[default_catalog, default_database, append_src1]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.pk_snk_with_time_col], fields=[a, b, c, window_start, window_end], duplicateChanges=[NONE])
++- WindowRank(window=[TUMBLE(win_start=[window_start], win_end=[window_end], size=[1 min])], rankType=[ROW_NUMBER], rankRange=[rankStart=1, rankEnd=1], partitionBy=[a], orderBy=[c DESC], select=[a, b, c, window_start, window_end], duplicateChanges=[ALLOW])
+   +- Exchange(distribution=[hash[a]], duplicateChanges=[DISALLOW])
+      +- Calc(select=[a, b, c, window_start, window_end], duplicateChanges=[DISALLOW])
+         +- WindowTableFunction(window=[TUMBLE(time_col=[rt], size=[1 min])], duplicateChanges=[DISALLOW])
+            +- WatermarkAssigner(rowtime=[rt], watermark=[-(rt, 1000:INTERVAL SECOND)], duplicateChanges=[DISALLOW])
+               +- TableSourceScan(table=[[default_catalog, default_database, append_src1]], fields=[a, b, c, rt], duplicateChanges=[DISALLOW])
+]]>
+    </Resource>
+  </TestCase>
+</Root>


### PR DESCRIPTION
## What is the purpose of the change

Introduce a new trait derived from sink to source to check whether the downstream operators can accept duplicate data produced by upstream nodes.

## Brief change log

  - *Introduce a new trait and inference rules about it.*
  - *Add tests for all stream physical nodes*

## Verifying this change

Tests are added to verify this pr.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? 
