### PR TITLE
[FLINK-37822][tests] Fix flaky test: OpenTelemetryMetricReporterITCase.testReport

### DIFF
--- a/flink-metrics/flink-metrics-otel/src/main/java/org/apache/flink/metrics/otel/OpenTelemetryMetricReporter.java
+++ b/flink-metrics/flink-metrics-otel/src/main/java/org/apache/flink/metrics/otel/OpenTelemetryMetricReporter.java
@@ -101,7 +101,7 @@ public class OpenTelemetryMetricReporter extends OpenTelemetryReporterBase
     @Override
     public void close() {
         exporter.flush();
-        lastResult.join(1, TimeUnit.MINUTES);
+        waitForLastReportToComplete();
         exporter.close();
     }
 
@@ -266,6 +266,13 @@ public class OpenTelemetryMetricReporter extends OpenTelemetryReporterBase
                     "Failed to call export for {} metrics using {}",
                     metricData.size(),
                     exporter.getClass().getName());
+        }
+    }
+
+    @VisibleForTesting
+    void waitForLastReportToComplete() {
+        if (lastResult != null) {
+            lastResult.join(1, TimeUnit.MINUTES);
         }
     }
 }

--- a/flink-metrics/flink-metrics-otel/src/test/java/org/apache/flink/metrics/otel/OpenTelemetryMetricReporterITCase.java
+++ b/flink-metrics/flink-metrics-otel/src/test/java/org/apache/flink/metrics/otel/OpenTelemetryMetricReporterITCase.java
@@ -80,6 +80,10 @@ public class OpenTelemetryMetricReporterITCase extends OpenTelemetryTestBase {
         reporter.notifyOfAddedMetric(gauge, "foo.gauge", group);
 
         reporter.report();
+        // Reporting is async, hence reports order is not deterministic.
+        // As test utils rely on verification of "last" report, we enforce report order
+        // for testing purposes.
+        reporter.waitForLastReportToComplete();
 
         MeterView meter = new MeterView(counter);
         reporter.notifyOfAddedMetric(meter, "foo.meter", group);


### PR DESCRIPTION
## What is the purpose of the change
Address flakiness of the test: `OpenTelemetryMetricReporterITCase.testReport`

## Brief change log
Adding `@VisibleForTesting OpenTelemetryMetricReporter#waitForLastReportToComplete` method to allow synchronous use of `OpenTelemetryMetricReporter#report` in tests.

## Verifying this change

This change is already covered by existing tests, such as `OpenTelemetryMetricReporterITCase`. 
To ensure it is not flaky, I have run it locally as `@RepeatedTest(100)` with no issues (previously, fail rate was around 30%).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation
  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
