### PR TITLE
[FLINK-37923][sql] Introduce VARIANT type and PARSE_JSON to Flink SQL

### DIFF
--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/EnrichedRowData.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/EnrichedRowData.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.types.RowKind;
+import org.apache.flink.types.variant.Variant;
 
 import java.util.List;
 import java.util.Objects;
@@ -243,6 +244,16 @@ public class EnrichedRowData implements RowData {
             return mutableRow.getRow(index, numFields);
         } else {
             return fixedRow.getRow(-(index + 1), numFields);
+        }
+    }
+
+    @Override
+    public Variant getVariant(int pos) {
+        int index = indexMapping[pos];
+        if (index >= 0) {
+            return mutableRow.getVariant(index);
+        } else {
+            return fixedRow.getVariant(-(index + 1));
         }
     }
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/Types.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/Types.java
@@ -37,6 +37,7 @@ import org.apache.flink.api.java.typeutils.ValueTypeInfo;
 import org.apache.flink.types.Either;
 import org.apache.flink.types.Row;
 import org.apache.flink.types.Value;
+import org.apache.flink.types.variant.Variant;
 
 import java.lang.reflect.Field;
 import java.math.BigDecimal;
@@ -155,6 +156,8 @@ public class Types {
 
     /** Returns type information for {@link java.time.Instant}. Supports a null value. */
     public static final TypeInformation<Instant> INSTANT = BasicTypeInfo.INSTANT_TYPE_INFO;
+
+    public static final TypeInformation<Variant> VARIANT = VariantTypeInfo.INSTANCE;
 
     // CHECKSTYLE.OFF: MethodName
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/VariantTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/VariantTypeInfo.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.typeinfo;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.serialization.SerializerConfig;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.VariantSerializer;
+import org.apache.flink.types.variant.Variant;
+
+/** Type information for Variant. */
+@PublicEvolving
+public class VariantTypeInfo extends TypeInformation<Variant> {
+
+    public static final VariantTypeInfo INSTANCE = new VariantTypeInfo();
+
+    private VariantTypeInfo() {}
+
+    @Override
+    public boolean isBasicType() {
+        return false;
+    }
+
+    @Override
+    public boolean isTupleType() {
+        return false;
+    }
+
+    @Override
+    public int getArity() {
+        return 1;
+    }
+
+    @Override
+    public int getTotalFields() {
+        return 1;
+    }
+
+    @Override
+    public Class<Variant> getTypeClass() {
+        return Variant.class;
+    }
+
+    @Override
+    public boolean isKeyType() {
+        return true;
+    }
+
+    @Override
+    public TypeSerializer<Variant> createSerializer(SerializerConfig config) {
+        return VariantSerializer.INSTANCE;
+    }
+
+    @Override
+    public String toString() {
+        return Variant.class.getSimpleName();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof VariantTypeInfo) {
+            VariantTypeInfo other = (VariantTypeInfo) obj;
+            return other.canEqual(this);
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return VariantTypeInfo.class.hashCode();
+    }
+
+    @Override
+    public boolean canEqual(Object obj) {
+        return obj instanceof VariantTypeInfo;
+    }
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/VariantSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/VariantSerializer.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.typeutils.base;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.SimpleTypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.types.variant.BinaryVariant;
+import org.apache.flink.types.variant.Variant;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+/** Serializer for {@link Variant}. */
+@Internal
+public class VariantSerializer extends TypeSerializerSingleton<Variant> {
+
+    public static final VariantSerializer INSTANCE = new VariantSerializer();
+
+    @Override
+    public boolean isImmutableType() {
+        return false;
+    }
+
+    @Override
+    public Variant createInstance() {
+        return Variant.newBuilder().ofNull();
+    }
+
+    @Override
+    public Variant copy(Variant from) {
+        BinaryVariant binaryVariant = toBinaryVariant(from);
+        return new BinaryVariant(
+                Arrays.copyOf(binaryVariant.getValue(), binaryVariant.getValue().length),
+                Arrays.copyOf(binaryVariant.getMetadata(), binaryVariant.getMetadata().length));
+    }
+
+    @Override
+    public Variant copy(Variant from, Variant reuse) {
+        return copy(from);
+    }
+
+    @Override
+    public int getLength() {
+        return -1;
+    }
+
+    @Override
+    public void serialize(Variant record, DataOutputView target) throws IOException {
+
+        BinaryVariant binaryVariant = toBinaryVariant(record);
+
+        target.writeInt(binaryVariant.getValue().length);
+        target.writeInt(binaryVariant.getMetadata().length);
+        target.write(binaryVariant.getValue());
+        target.write(binaryVariant.getMetadata());
+    }
+
+    @Override
+    public Variant deserialize(DataInputView source) throws IOException {
+        int valueLength = source.readInt();
+        int metadataLength = source.readInt();
+        byte[] value = new byte[valueLength];
+        byte[] metaData = new byte[metadataLength];
+
+        source.read(value);
+        source.read(metaData);
+        return new BinaryVariant(value, metaData);
+    }
+
+    @Override
+    public Variant deserialize(Variant reuse, DataInputView source) throws IOException {
+        return this.deserialize(source);
+    }
+
+    @Override
+    public void copy(DataInputView source, DataOutputView target) throws IOException {
+        int valueLength = source.readInt();
+        int metadataLength = source.readInt();
+        target.writeInt(valueLength);
+        target.writeInt(metadataLength);
+        target.write(source, valueLength + metadataLength);
+    }
+
+    @Override
+    public TypeSerializerSnapshot<Variant> snapshotConfiguration() {
+        return new VariantSerializerSnapshot();
+    }
+
+    private BinaryVariant toBinaryVariant(Variant variant) {
+        if (variant instanceof BinaryVariant) {
+            return (BinaryVariant) variant;
+        }
+
+        throw new UnsupportedOperationException("Unsupported variant type: " + variant.getClass());
+    }
+
+    @Internal
+    public static final class VariantSerializerSnapshot
+            extends SimpleTypeSerializerSnapshot<Variant> {
+        /** Constructor to create snapshot from serializer (writing the snapshot). */
+        public VariantSerializerSnapshot() {
+            super(() -> INSTANCE);
+        }
+    }
+}

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
@@ -42,6 +42,7 @@ import org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInfoFactory;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.VariantTypeInfo;
 import org.apache.flink.api.common.typeutils.CompositeType;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple;
@@ -49,6 +50,7 @@ import org.apache.flink.api.java.tuple.Tuple0;
 import org.apache.flink.api.java.typeutils.TypeExtractionUtils.LambdaExecutable;
 import org.apache.flink.types.Row;
 import org.apache.flink.types.Value;
+import org.apache.flink.types.variant.Variant;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.Preconditions;
 
@@ -1968,6 +1970,11 @@ public class TypeExtractor {
         // check for Enums
         if (Enum.class.isAssignableFrom(clazz)) {
             return new EnumTypeInfo(clazz);
+        }
+
+        // check for Variant
+        if (Variant.class.isAssignableFrom(clazz)) {
+            return (TypeInformation<OUT>) VariantTypeInfo.INSTANCE;
         }
 
         // check for parameterized Collections, requirement:

--- a/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariant.java
+++ b/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariant.java
@@ -1,0 +1,490 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.types.variant;
+
+import org.apache.flink.annotation.Internal;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonFactory;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
+
+import java.io.CharArrayWriter;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Objects;
+
+import static org.apache.flink.types.variant.BinaryVariantUtil.BINARY_SEARCH_THRESHOLD;
+import static org.apache.flink.types.variant.BinaryVariantUtil.SIZE_LIMIT;
+import static org.apache.flink.types.variant.BinaryVariantUtil.TIMESTAMP_FORMATTER;
+import static org.apache.flink.types.variant.BinaryVariantUtil.TIMESTAMP_LTZ_FORMATTER;
+import static org.apache.flink.types.variant.BinaryVariantUtil.VERSION;
+import static org.apache.flink.types.variant.BinaryVariantUtil.VERSION_MASK;
+import static org.apache.flink.types.variant.BinaryVariantUtil.checkIndex;
+import static org.apache.flink.types.variant.BinaryVariantUtil.getMetadataKey;
+import static org.apache.flink.types.variant.BinaryVariantUtil.handleArray;
+import static org.apache.flink.types.variant.BinaryVariantUtil.handleObject;
+import static org.apache.flink.types.variant.BinaryVariantUtil.malformedVariant;
+import static org.apache.flink.types.variant.BinaryVariantUtil.readUnsigned;
+import static org.apache.flink.types.variant.BinaryVariantUtil.unexpectedType;
+import static org.apache.flink.types.variant.BinaryVariantUtil.valueSize;
+import static org.apache.flink.types.variant.BinaryVariantUtil.variantConstructorSizeLimit;
+
+/**
+ * A data structure that represents a semi-structured value. It consists of two binary values: value
+ * and metadata. The value encodes types and values, but not field names. The metadata currently
+ * contains a version flag and a list of field names. We can extend/modify the detailed binary
+ * format given the version flag.
+ *
+ * @see <a href="https://github.com/apache/parquet-format/blob/master/VariantEncoding.md">Variant
+ *     Binary Encoding</a> for the detail layout of the data structure.
+ */
+@Internal
+public final class BinaryVariant implements Variant {
+
+    private final byte[] value;
+    private final byte[] metadata;
+    // The variant value doesn't use the whole `value` binary, but starts from its `pos` index and
+    // spans a size of `valueSize(value, pos)`. This design avoids frequent copies of the value
+    // binary when reading a sub-variant in the array/object element.
+    private final int pos;
+
+    public BinaryVariant(byte[] value, byte[] metadata) {
+        this(value, metadata, 0);
+    }
+
+    private BinaryVariant(byte[] value, byte[] metadata, int pos) {
+        this.value = value;
+        this.metadata = metadata;
+        this.pos = pos;
+        // There is currently only one allowed version.
+        if (metadata.length < 1 || (metadata[0] & VERSION_MASK) != VERSION) {
+            throw malformedVariant();
+        }
+        // Don't attempt to use a Variant larger than 16 MiB. We'll never produce one, and it risks
+        // memory instability.
+        if (metadata.length > SIZE_LIMIT || value.length > SIZE_LIMIT) {
+            throw variantConstructorSizeLimit();
+        }
+    }
+
+    @Override
+    public boolean isPrimitive() {
+        return !isArray() && !isObject();
+    }
+
+    @Override
+    public boolean isArray() {
+        return getType() == Type.ARRAY;
+    }
+
+    @Override
+    public boolean isObject() {
+        return getType() == Type.OBJECT;
+    }
+
+    @Override
+    public boolean isNull() {
+        return getType() == Type.NULL;
+    }
+
+    @Override
+    public Type getType() {
+        return BinaryVariantUtil.getType(value, pos);
+    }
+
+    @Override
+    public boolean getBoolean() throws VariantTypeException {
+        checkType(Type.BOOLEAN, getType());
+        return BinaryVariantUtil.getBoolean(value, pos);
+    }
+
+    @Override
+    public byte getByte() throws VariantTypeException {
+        checkType(Type.TINYINT, getType());
+        return (byte) BinaryVariantUtil.getLong(value, pos);
+    }
+
+    @Override
+    public short getShort() throws VariantTypeException {
+        checkType(Type.SMALLINT, getType());
+        return (short) BinaryVariantUtil.getLong(value, pos);
+    }
+
+    @Override
+    public int getInt() throws VariantTypeException {
+        checkType(Type.INT, getType());
+        return (int) BinaryVariantUtil.getLong(value, pos);
+    }
+
+    @Override
+    public long getLong() throws VariantTypeException {
+        checkType(Type.BIGINT, getType());
+        return BinaryVariantUtil.getLong(value, pos);
+    }
+
+    @Override
+    public float getFloat() throws VariantTypeException {
+        checkType(Type.FLOAT, getType());
+        return BinaryVariantUtil.getFloat(value, pos);
+    }
+
+    @Override
+    public BigDecimal getDecimal() throws VariantTypeException {
+        checkType(Type.DECIMAL, getType());
+        return BinaryVariantUtil.getDecimal(value, pos);
+    }
+
+    @Override
+    public double getDouble() throws VariantTypeException {
+        checkType(Type.DOUBLE, getType());
+        return BinaryVariantUtil.getDouble(value, pos);
+    }
+
+    @Override
+    public String getString() throws VariantTypeException {
+        checkType(Type.STRING, getType());
+        return BinaryVariantUtil.getString(value, pos);
+    }
+
+    @Override
+    public LocalDate getDate() throws VariantTypeException {
+        checkType(Type.DATE, getType());
+        return LocalDate.ofEpochDay(BinaryVariantUtil.getLong(value, pos));
+    }
+
+    @Override
+    public LocalDateTime getDateTime() throws VariantTypeException {
+        checkType(Type.TIMESTAMP, getType());
+        return microsToInstant(BinaryVariantUtil.getLong(value, pos))
+                .atZone(ZoneOffset.UTC)
+                .toLocalDateTime();
+    }
+
+    @Override
+    public Instant getInstant() throws VariantTypeException {
+        checkType(Type.TIMESTAMP_LTZ, getType());
+        return microsToInstant(BinaryVariantUtil.getLong(value, pos));
+    }
+
+    @Override
+    public byte[] getBytes() throws VariantTypeException {
+        checkType(Type.BYTES, getType());
+        return BinaryVariantUtil.getBinary(value, pos);
+    }
+
+    @Override
+    public Object get() throws VariantTypeException {
+        switch (getType()) {
+            case NULL:
+                return null;
+            case BOOLEAN:
+                return getBoolean();
+            case TINYINT:
+                return getByte();
+            case SMALLINT:
+                return getShort();
+            case INT:
+                return getInt();
+            case BIGINT:
+                return getLong();
+            case FLOAT:
+                return getFloat();
+            case DOUBLE:
+                return getDouble();
+            case DECIMAL:
+                return getDecimal();
+            case STRING:
+                return getString();
+            case DATE:
+                return getDate();
+            case TIMESTAMP:
+                return getDateTime();
+            case TIMESTAMP_LTZ:
+                return getInstant();
+            case BYTES:
+                return getBytes();
+            default:
+                throw new VariantTypeException(
+                        String.format("Expecting a primitive variant but got %s", getType()));
+        }
+    }
+
+    @Override
+    public <T> T getAs() throws VariantTypeException {
+        return (T) get();
+    }
+
+    @Override
+    public Variant getElement(int index) throws VariantTypeException {
+        return getElementAtIndex(index);
+    }
+
+    @Override
+    public Variant getField(String fieldName) throws VariantTypeException {
+        return getFieldByKey(fieldName);
+    }
+
+    @Override
+    public String toJson() {
+        StringBuilder sb = new StringBuilder();
+        toJsonImpl(value, metadata, pos, sb, ZoneOffset.UTC);
+        return sb.toString();
+    }
+
+    public byte[] getValue() {
+        if (pos == 0) {
+            return value;
+        }
+        int size = valueSize(value, pos);
+        checkIndex(pos + size - 1, value.length);
+        return Arrays.copyOfRange(value, pos, pos + size);
+    }
+
+    public byte[] getMetadata() {
+        return metadata;
+    }
+
+    public int getPos() {
+        return pos;
+    }
+
+    private static void toJsonImpl(
+            byte[] value, byte[] metadata, int pos, StringBuilder sb, ZoneId zoneId) {
+        switch (BinaryVariantUtil.getType(value, pos)) {
+            case OBJECT:
+                handleObject(
+                        value,
+                        pos,
+                        (size, idSize, offsetSize, idStart, offsetStart, dataStart) -> {
+                            sb.append('{');
+                            for (int i = 0; i < size; ++i) {
+                                int id = readUnsigned(value, idStart + idSize * i, idSize);
+                                int offset =
+                                        readUnsigned(
+                                                value, offsetStart + offsetSize * i, offsetSize);
+                                int elementPos = dataStart + offset;
+                                if (i != 0) {
+                                    sb.append(',');
+                                }
+                                sb.append(escapeJson(getMetadataKey(metadata, id)));
+                                sb.append(':');
+                                toJsonImpl(value, metadata, elementPos, sb, zoneId);
+                            }
+                            sb.append('}');
+                            return null;
+                        });
+                break;
+            case ARRAY:
+                handleArray(
+                        value,
+                        pos,
+                        (size, offsetSize, offsetStart, dataStart) -> {
+                            sb.append('[');
+                            for (int i = 0; i < size; ++i) {
+                                int offset =
+                                        readUnsigned(
+                                                value, offsetStart + offsetSize * i, offsetSize);
+                                int elementPos = dataStart + offset;
+                                if (i != 0) {
+                                    sb.append(',');
+                                }
+                                toJsonImpl(value, metadata, elementPos, sb, zoneId);
+                            }
+                            sb.append(']');
+                            return null;
+                        });
+                break;
+            case NULL:
+                sb.append("null");
+                break;
+            case BOOLEAN:
+                sb.append(BinaryVariantUtil.getBoolean(value, pos));
+                break;
+            case TINYINT:
+            case SMALLINT:
+            case INT:
+            case BIGINT:
+                sb.append(BinaryVariantUtil.getLong(value, pos));
+                break;
+            case STRING:
+                sb.append(escapeJson(BinaryVariantUtil.getString(value, pos)));
+                break;
+            case DOUBLE:
+                sb.append(BinaryVariantUtil.getDouble(value, pos));
+                break;
+            case DECIMAL:
+                sb.append(BinaryVariantUtil.getDecimal(value, pos).toPlainString());
+                break;
+            case DATE:
+                appendQuoted(
+                        sb,
+                        LocalDate.ofEpochDay((int) BinaryVariantUtil.getLong(value, pos))
+                                .toString());
+                break;
+            case TIMESTAMP_LTZ:
+                appendQuoted(
+                        sb,
+                        TIMESTAMP_LTZ_FORMATTER.format(
+                                microsToInstant(BinaryVariantUtil.getLong(value, pos))
+                                        .atZone(zoneId)));
+                break;
+            case TIMESTAMP:
+                appendQuoted(
+                        sb,
+                        TIMESTAMP_FORMATTER.format(
+                                microsToInstant(BinaryVariantUtil.getLong(value, pos))
+                                        .atZone(ZoneOffset.UTC)));
+                break;
+            case FLOAT:
+                sb.append(BinaryVariantUtil.getFloat(value, pos));
+                break;
+            case BYTES:
+                appendQuoted(
+                        sb,
+                        Base64.getEncoder()
+                                .encodeToString(BinaryVariantUtil.getBinary(value, pos)));
+                break;
+            default:
+                throw unexpectedType(BinaryVariantUtil.getType(value, pos));
+        }
+    }
+
+    private static Instant microsToInstant(long timestamp) {
+        return Instant.EPOCH.plus(timestamp, ChronoUnit.MICROS);
+    }
+
+    private void checkType(Type expected, Type actual) {
+        if (expected != actual) {
+            throw new VariantTypeException(
+                    String.format("Expected type %s but got %s", expected, actual));
+        }
+    }
+
+    // Find the field value whose key is equal to `key`. Return null if the key is not found.
+    // It is only legal to call it when `getType()` is `Type.OBJECT`.
+    private BinaryVariant getFieldByKey(String key) {
+        return handleObject(
+                value,
+                pos,
+                (size, idSize, offsetSize, idStart, offsetStart, dataStart) -> {
+                    // Use linear search for a short list. Switch to binary search when the length
+                    // reaches `BINARY_SEARCH_THRESHOLD`.
+                    if (size < BINARY_SEARCH_THRESHOLD) {
+                        for (int i = 0; i < size; ++i) {
+                            int id = readUnsigned(value, idStart + idSize * i, idSize);
+                            if (key.equals(getMetadataKey(metadata, id))) {
+                                int offset =
+                                        readUnsigned(
+                                                value, offsetStart + offsetSize * i, offsetSize);
+                                return new BinaryVariant(value, metadata, dataStart + offset);
+                            }
+                        }
+                    } else {
+                        int low = 0;
+                        int high = size - 1;
+                        while (low <= high) {
+                            // Use unsigned right shift to compute the middle of `low` and `high`.
+                            // This is not only a performance optimization, because it can properly
+                            // handle the case where `low + high` overflows int.
+                            int mid = (low + high) >>> 1;
+                            int id = readUnsigned(value, idStart + idSize * mid, idSize);
+                            int cmp = getMetadataKey(metadata, id).compareTo(key);
+                            if (cmp < 0) {
+                                low = mid + 1;
+                            } else if (cmp > 0) {
+                                high = mid - 1;
+                            } else {
+                                int offset =
+                                        readUnsigned(
+                                                value, offsetStart + offsetSize * mid, offsetSize);
+                                return new BinaryVariant(value, metadata, dataStart + offset);
+                            }
+                        }
+                    }
+                    return null;
+                });
+    }
+
+    // Get the array element at the `index` slot. Return null if `index` is out of the bound of
+    // `[0, arraySize())`.
+    // It is only legal to call it when `getType()` is `Type.ARRAY`.
+    private BinaryVariant getElementAtIndex(int index) {
+        return handleArray(
+                value,
+                pos,
+                (size, offsetSize, offsetStart, dataStart) -> {
+                    if (index < 0 || index >= size) {
+                        return null;
+                    }
+                    int offset = readUnsigned(value, offsetStart + offsetSize * index, offsetSize);
+                    return new BinaryVariant(value, metadata, dataStart + offset);
+                });
+    }
+
+    // Escape a string so that it can be pasted into JSON structure.
+    // For example, if `str` only contains a new-line character, then the result content is "\n"
+    // (4 characters).
+    private static String escapeJson(String str) {
+        try (CharArrayWriter writer = new CharArrayWriter();
+                JsonGenerator gen = new JsonFactory().createGenerator(writer)) {
+            gen.writeString(str);
+            gen.flush();
+            return writer.toString();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void appendQuoted(StringBuilder sb, String str) {
+        sb.append('"');
+        sb.append(str);
+        sb.append('"');
+    }
+
+    @Override
+    public String toString() {
+        return toJson();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof BinaryVariant)) {
+            return false;
+        }
+        BinaryVariant variant = (BinaryVariant) o;
+        return getPos() == variant.getPos()
+                && Objects.deepEquals(getValue(), variant.getValue())
+                && Objects.deepEquals(getMetadata(), variant.getMetadata());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(Arrays.hashCode(value), Arrays.hashCode(metadata), pos);
+    }
+}

--- a/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariantBuilder.java
+++ b/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariantBuilder.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.types.variant;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+
+/** Builder for binary encoded variant. */
+@Internal
+public class BinaryVariantBuilder implements VariantBuilder {
+
+    @Override
+    public Variant of(byte b) {
+        BinaryVariantInternalBuilder builder = new BinaryVariantInternalBuilder(false);
+        builder.appendByte(b);
+        return builder.build();
+    }
+
+    @Override
+    public Variant of(short s) {
+        BinaryVariantInternalBuilder builder = new BinaryVariantInternalBuilder(false);
+        builder.appendShort(s);
+        return builder.build();
+    }
+
+    @Override
+    public Variant of(int i) {
+        BinaryVariantInternalBuilder builder = new BinaryVariantInternalBuilder(false);
+        builder.appendInt(i);
+        return builder.build();
+    }
+
+    @Override
+    public Variant of(long l) {
+        BinaryVariantInternalBuilder builder = new BinaryVariantInternalBuilder(false);
+        builder.appendLong(l);
+        return builder.build();
+    }
+
+    @Override
+    public Variant of(String s) {
+        BinaryVariantInternalBuilder builder = new BinaryVariantInternalBuilder(false);
+        builder.appendString(s);
+        return builder.build();
+    }
+
+    @Override
+    public Variant of(double d) {
+        BinaryVariantInternalBuilder builder = new BinaryVariantInternalBuilder(false);
+        builder.appendDouble(d);
+        return builder.build();
+    }
+
+    @Override
+    public Variant of(float f) {
+        BinaryVariantInternalBuilder builder = new BinaryVariantInternalBuilder(false);
+        builder.appendFloat(f);
+        return builder.build();
+    }
+
+    @Override
+    public Variant of(byte[] bytes) {
+        BinaryVariantInternalBuilder builder = new BinaryVariantInternalBuilder(false);
+        builder.appendBinary(bytes);
+        return builder.build();
+    }
+
+    @Override
+    public Variant of(boolean b) {
+        BinaryVariantInternalBuilder builder = new BinaryVariantInternalBuilder(false);
+        builder.appendBoolean(b);
+        return builder.build();
+    }
+
+    @Override
+    public Variant of(BigDecimal bigDecimal) {
+        BinaryVariantInternalBuilder builder = new BinaryVariantInternalBuilder(false);
+        builder.appendDecimal(bigDecimal);
+        return builder.build();
+    }
+
+    @Override
+    public Variant of(Instant instant) {
+        BinaryVariantInternalBuilder builder = new BinaryVariantInternalBuilder(false);
+        builder.appendTimestampLtz(ChronoUnit.MICROS.between(Instant.EPOCH, instant));
+        return builder.build();
+    }
+
+    @Override
+    public Variant of(LocalDate localDate) {
+        BinaryVariantInternalBuilder builder = new BinaryVariantInternalBuilder(false);
+        builder.appendDate((int) localDate.toEpochDay());
+        return builder.build();
+    }
+
+    @Override
+    public Variant of(LocalDateTime localDateTime) {
+        BinaryVariantInternalBuilder builder = new BinaryVariantInternalBuilder(false);
+        builder.appendTimestamp(
+                ChronoUnit.MICROS.between(Instant.EPOCH, localDateTime.toInstant(ZoneOffset.UTC)));
+        return builder.build();
+    }
+
+    @Override
+    public Variant ofNull() {
+        BinaryVariantInternalBuilder builder = new BinaryVariantInternalBuilder(false);
+        builder.appendNull();
+        return builder.build();
+    }
+
+    @Override
+    public VariantObjectBuilder object() {
+        return object(false);
+    }
+
+    @Override
+    public VariantObjectBuilder object(boolean allowDuplicateKeys) {
+        return new VariantObjectBuilder(allowDuplicateKeys);
+    }
+
+    /** Get the builder for a variant array. */
+    public VariantArrayBuilder array() {
+        return new VariantArrayBuilder();
+    }
+
+    /** Builder for a variant object. */
+    @PublicEvolving
+    public static class VariantObjectBuilder implements VariantBuilder.VariantObjectBuilder {
+        private final BinaryVariantInternalBuilder builder;
+        private final ArrayList<BinaryVariantInternalBuilder.FieldEntry> entries =
+                new ArrayList<>();
+
+        public VariantObjectBuilder(boolean allowDuplicateKeys) {
+            builder = new BinaryVariantInternalBuilder(allowDuplicateKeys);
+        }
+
+        @Override
+        public VariantObjectBuilder add(String key, Variant value) {
+            int id = builder.addKey(key);
+            entries.add(
+                    new BinaryVariantInternalBuilder.FieldEntry(key, id, builder.getWritePos()));
+            builder.appendVariant((BinaryVariant) value);
+            return this;
+        }
+
+        @Override
+        public Variant build() {
+            builder.finishWritingObject(0, entries);
+            return builder.build();
+        }
+    }
+
+    /** Builder for a variant array. */
+    @PublicEvolving
+    public static class VariantArrayBuilder implements VariantBuilder.VariantArrayBuilder {
+
+        private final BinaryVariantInternalBuilder builder;
+        private final ArrayList<Integer> offsets = new ArrayList<>();
+
+        public VariantArrayBuilder() {
+            builder = new BinaryVariantInternalBuilder(false);
+        }
+
+        @Override
+        public VariantArrayBuilder add(Variant value) {
+            offsets.add(builder.getWritePos());
+            builder.appendVariant((BinaryVariant) value);
+            return this;
+        }
+
+        @Override
+        public Variant build() {
+            builder.finishWritingArray(0, offsets);
+            return builder.build();
+        }
+    }
+}

--- a/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariantInternalBuilder.java
+++ b/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariantInternalBuilder.java
@@ -1,0 +1,655 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.types.variant;
+
+import org.apache.flink.annotation.Internal;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonFactory;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonParseException;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonParser;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonToken;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.exc.InputCoercionException;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+
+import static org.apache.flink.types.variant.BinaryVariantUtil.ARRAY;
+import static org.apache.flink.types.variant.BinaryVariantUtil.BASIC_TYPE_MASK;
+import static org.apache.flink.types.variant.BinaryVariantUtil.BINARY;
+import static org.apache.flink.types.variant.BinaryVariantUtil.DATE;
+import static org.apache.flink.types.variant.BinaryVariantUtil.DECIMAL16;
+import static org.apache.flink.types.variant.BinaryVariantUtil.DECIMAL4;
+import static org.apache.flink.types.variant.BinaryVariantUtil.DECIMAL8;
+import static org.apache.flink.types.variant.BinaryVariantUtil.DOUBLE;
+import static org.apache.flink.types.variant.BinaryVariantUtil.FALSE;
+import static org.apache.flink.types.variant.BinaryVariantUtil.FLOAT;
+import static org.apache.flink.types.variant.BinaryVariantUtil.INT1;
+import static org.apache.flink.types.variant.BinaryVariantUtil.INT2;
+import static org.apache.flink.types.variant.BinaryVariantUtil.INT4;
+import static org.apache.flink.types.variant.BinaryVariantUtil.INT8;
+import static org.apache.flink.types.variant.BinaryVariantUtil.LONG_STR;
+import static org.apache.flink.types.variant.BinaryVariantUtil.MAX_DECIMAL16_PRECISION;
+import static org.apache.flink.types.variant.BinaryVariantUtil.MAX_DECIMAL4_PRECISION;
+import static org.apache.flink.types.variant.BinaryVariantUtil.MAX_DECIMAL8_PRECISION;
+import static org.apache.flink.types.variant.BinaryVariantUtil.MAX_SHORT_STR_SIZE;
+import static org.apache.flink.types.variant.BinaryVariantUtil.NULL;
+import static org.apache.flink.types.variant.BinaryVariantUtil.OBJECT;
+import static org.apache.flink.types.variant.BinaryVariantUtil.SIZE_LIMIT;
+import static org.apache.flink.types.variant.BinaryVariantUtil.TIMESTAMP;
+import static org.apache.flink.types.variant.BinaryVariantUtil.TIMESTAMP_LTZ;
+import static org.apache.flink.types.variant.BinaryVariantUtil.TRUE;
+import static org.apache.flink.types.variant.BinaryVariantUtil.U16_MAX;
+import static org.apache.flink.types.variant.BinaryVariantUtil.U24_MAX;
+import static org.apache.flink.types.variant.BinaryVariantUtil.U24_SIZE;
+import static org.apache.flink.types.variant.BinaryVariantUtil.U32_SIZE;
+import static org.apache.flink.types.variant.BinaryVariantUtil.U8_MAX;
+import static org.apache.flink.types.variant.BinaryVariantUtil.VERSION;
+import static org.apache.flink.types.variant.BinaryVariantUtil.arrayHeader;
+import static org.apache.flink.types.variant.BinaryVariantUtil.checkIndex;
+import static org.apache.flink.types.variant.BinaryVariantUtil.getMetadataKey;
+import static org.apache.flink.types.variant.BinaryVariantUtil.handleArray;
+import static org.apache.flink.types.variant.BinaryVariantUtil.handleObject;
+import static org.apache.flink.types.variant.BinaryVariantUtil.objectHeader;
+import static org.apache.flink.types.variant.BinaryVariantUtil.primitiveHeader;
+import static org.apache.flink.types.variant.BinaryVariantUtil.readUnsigned;
+import static org.apache.flink.types.variant.BinaryVariantUtil.shortStrHeader;
+import static org.apache.flink.types.variant.BinaryVariantUtil.valueSize;
+import static org.apache.flink.types.variant.BinaryVariantUtil.writeLong;
+
+/* This file is based on source code from the Spark Project (http://spark.apache.org/), licensed by the Apache
+ * Software Foundation (ASF) under the Apache License, Version 2.0. See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership. */
+
+/** The internal builder for {@link BinaryVariant}. */
+@Internal
+public class BinaryVariantInternalBuilder {
+
+    public static final VariantTypeException VARIANT_SIZE_LIMIT_EXCEPTION =
+            new VariantTypeException("VARIANT_SIZE_LIMIT");
+    public static final VariantTypeException VARIANT_DUPLICATE_KEY_EXCEPTION =
+            new VariantTypeException("VARIANT_DUPLICATE_KEY");
+
+    public BinaryVariantInternalBuilder(boolean allowDuplicateKeys) {
+        this.allowDuplicateKeys = allowDuplicateKeys;
+    }
+
+    /**
+     * Parse a JSON string as a Variant value.
+     *
+     * @throws IOException if any JSON parsing error happens.
+     */
+    public static BinaryVariant parseJson(String json, boolean allowDuplicateKeys)
+            throws IOException {
+        try (JsonParser parser = new JsonFactory().createParser(json)) {
+            parser.nextToken();
+            return parseJson(parser, allowDuplicateKeys);
+        }
+    }
+
+    /**
+     * Similar {@link #parseJson(String, boolean)}, but takes a JSON parser instead of string input.
+     */
+    private static BinaryVariant parseJson(JsonParser parser, boolean allowDuplicateKeys)
+            throws IOException {
+        BinaryVariantInternalBuilder builder = new BinaryVariantInternalBuilder(allowDuplicateKeys);
+        builder.buildJson(parser);
+        return builder.build();
+    }
+
+    // Build the variant metadata from `dictionaryKeys` and return the variant result.
+    public BinaryVariant build() {
+        int numKeys = dictionaryKeys.size();
+        // Use long to avoid overflow in accumulating lengths.
+        long dictionaryStringSize = 0;
+        for (byte[] key : dictionaryKeys) {
+            dictionaryStringSize += key.length;
+        }
+        // Determine the number of bytes required per offset entry.
+        // The largest offset is the one-past-the-end value, which is total string size. It's very
+        // unlikely that the number of keys could be larger, but incorporate that into the
+        // calculation
+        // in case of pathological data.
+        long maxSize = Math.max(dictionaryStringSize, numKeys);
+        if (maxSize > SIZE_LIMIT) {
+            throw VARIANT_SIZE_LIMIT_EXCEPTION;
+        }
+        int offsetSize = getIntegerSize((int) maxSize);
+
+        int offsetStart = 1 + offsetSize;
+        int stringStart = offsetStart + (numKeys + 1) * offsetSize;
+        long metadataSize = stringStart + dictionaryStringSize;
+
+        if (metadataSize > SIZE_LIMIT) {
+            throw VARIANT_SIZE_LIMIT_EXCEPTION;
+        }
+        byte[] metadata = new byte[(int) metadataSize];
+        int headerByte = VERSION | ((offsetSize - 1) << 6);
+        writeLong(metadata, 0, headerByte, 1);
+        writeLong(metadata, 1, numKeys, offsetSize);
+        int currentOffset = 0;
+        for (int i = 0; i < numKeys; ++i) {
+            writeLong(metadata, offsetStart + i * offsetSize, currentOffset, offsetSize);
+            byte[] key = dictionaryKeys.get(i);
+            System.arraycopy(key, 0, metadata, stringStart + currentOffset, key.length);
+            currentOffset += key.length;
+        }
+        writeLong(metadata, offsetStart + numKeys * offsetSize, currentOffset, offsetSize);
+        return new BinaryVariant(Arrays.copyOfRange(writeBuffer, 0, writePos), metadata);
+    }
+
+    public void appendString(String str) {
+        byte[] text = str.getBytes(StandardCharsets.UTF_8);
+        boolean longStr = text.length > MAX_SHORT_STR_SIZE;
+        checkCapacity((longStr ? 1 + U32_SIZE : 1) + text.length);
+        if (longStr) {
+            writeBuffer[writePos++] = primitiveHeader(LONG_STR);
+            writeLong(writeBuffer, writePos, text.length, U32_SIZE);
+            writePos += U32_SIZE;
+        } else {
+            writeBuffer[writePos++] = shortStrHeader(text.length);
+        }
+        System.arraycopy(text, 0, writeBuffer, writePos, text.length);
+        writePos += text.length;
+    }
+
+    public void appendNull() {
+        checkCapacity(1);
+        writeBuffer[writePos++] = primitiveHeader(NULL);
+    }
+
+    public void appendBoolean(boolean b) {
+        checkCapacity(1);
+        writeBuffer[writePos++] = primitiveHeader(b ? TRUE : FALSE);
+    }
+
+    public void appendByte(byte b) {
+        checkCapacity(1 + 1);
+        writeBuffer[writePos++] = primitiveHeader(INT1);
+        writeLong(writeBuffer, writePos, b, 1);
+        writePos += 1;
+    }
+
+    public void appendShort(short s) {
+        checkCapacity(1 + 2);
+        writeBuffer[writePos++] = primitiveHeader(INT2);
+        writeLong(writeBuffer, writePos, s, 2);
+        writePos += 2;
+    }
+
+    public void appendInt(int i) {
+        checkCapacity(1 + 4);
+        writeBuffer[writePos++] = primitiveHeader(INT4);
+        writeLong(writeBuffer, writePos, i, 4);
+        writePos += 4;
+    }
+
+    public void appendLong(long l) {
+        checkCapacity(1 + 8);
+        writeBuffer[writePos++] = primitiveHeader(INT8);
+        writeLong(writeBuffer, writePos, l, 8);
+        writePos += 8;
+    }
+
+    public void appendNumeric(long l) {
+        if (l == (byte) l) {
+            appendByte((byte) l);
+        } else if (l == (short) l) {
+            appendShort((short) l);
+        } else if (l == (int) l) {
+            appendInt((int) l);
+        } else {
+            appendLong(l);
+        }
+    }
+
+    public void appendDouble(double d) {
+        checkCapacity(1 + 8);
+        writeBuffer[writePos++] = primitiveHeader(DOUBLE);
+        writeLong(writeBuffer, writePos, Double.doubleToLongBits(d), 8);
+        writePos += 8;
+    }
+
+    // Append a decimal value to the variant builder. The caller should guarantee that its precision
+    // and scale fit into `MAX_DECIMAL16_PRECISION`.
+    public void appendDecimal(BigDecimal d) {
+        checkCapacity(2 + 16);
+        BigInteger unscaled = d.unscaledValue();
+        if (d.scale() <= MAX_DECIMAL4_PRECISION && d.precision() <= MAX_DECIMAL4_PRECISION) {
+            writeBuffer[writePos++] = primitiveHeader(DECIMAL4);
+            writeBuffer[writePos++] = (byte) d.scale();
+            writeLong(writeBuffer, writePos, unscaled.intValueExact(), 4);
+            writePos += 4;
+        } else if (d.scale() <= MAX_DECIMAL8_PRECISION && d.precision() <= MAX_DECIMAL8_PRECISION) {
+            writeBuffer[writePos++] = primitiveHeader(DECIMAL8);
+            writeBuffer[writePos++] = (byte) d.scale();
+            writeLong(writeBuffer, writePos, unscaled.longValueExact(), 8);
+            writePos += 8;
+        } else {
+            assert d.scale() <= MAX_DECIMAL16_PRECISION && d.precision() <= MAX_DECIMAL16_PRECISION;
+            writeBuffer[writePos++] = primitiveHeader(DECIMAL16);
+            writeBuffer[writePos++] = (byte) d.scale();
+            // `toByteArray` returns a big-endian representation. We need to copy it reversely and
+            // sign
+            // extend it to 16 bytes.
+            byte[] bytes = unscaled.toByteArray();
+            for (int i = 0; i < bytes.length; ++i) {
+                writeBuffer[writePos + i] = bytes[bytes.length - 1 - i];
+            }
+            byte sign = (byte) (bytes[0] < 0 ? -1 : 0);
+            for (int i = bytes.length; i < 16; ++i) {
+                writeBuffer[writePos + i] = sign;
+            }
+            writePos += 16;
+        }
+    }
+
+    public void appendDate(int daysSinceEpoch) {
+        checkCapacity(1 + 4);
+        writeBuffer[writePos++] = primitiveHeader(DATE);
+        writeLong(writeBuffer, writePos, daysSinceEpoch, 4);
+        writePos += 4;
+    }
+
+    public void appendTimestampLtz(long microsSinceEpoch) {
+        checkCapacity(1 + 8);
+        writeBuffer[writePos++] = primitiveHeader(TIMESTAMP_LTZ);
+        writeLong(writeBuffer, writePos, microsSinceEpoch, 8);
+        writePos += 8;
+    }
+
+    public void appendTimestamp(long microsSinceEpoch) {
+        checkCapacity(1 + 8);
+        writeBuffer[writePos++] = primitiveHeader(TIMESTAMP);
+        writeLong(writeBuffer, writePos, microsSinceEpoch, 8);
+        writePos += 8;
+    }
+
+    public void appendFloat(float f) {
+        checkCapacity(1 + 4);
+        writeBuffer[writePos++] = primitiveHeader(FLOAT);
+        writeLong(writeBuffer, writePos, Float.floatToIntBits(f), 8);
+        writePos += 4;
+    }
+
+    public void appendBinary(byte[] binary) {
+        checkCapacity(1 + U32_SIZE + binary.length);
+        writeBuffer[writePos++] = primitiveHeader(BINARY);
+        writeLong(writeBuffer, writePos, binary.length, U32_SIZE);
+        writePos += U32_SIZE;
+        System.arraycopy(binary, 0, writeBuffer, writePos, binary.length);
+        writePos += binary.length;
+    }
+
+    // Add a key to the variant dictionary. If the key already exists, the dictionary is not
+    // modified.
+    // In either case, return the id of the key.
+    public int addKey(String key) {
+        int id;
+        if (dictionary.containsKey(key)) {
+            id = dictionary.get(key);
+        } else {
+            id = dictionaryKeys.size();
+            dictionary.put(key, id);
+            dictionaryKeys.add(key.getBytes(StandardCharsets.UTF_8));
+        }
+        return id;
+    }
+
+    // Return the current write position of the variant builder. It is used together with
+    // `finishWritingObject` or `finishWritingArray`.
+    public int getWritePos() {
+        return writePos;
+    }
+
+    // Finish writing a variant object after all of its fields have already been written. The
+    // process
+    // is as follows:
+    // 1. The caller calls `getWritePos` before writing any fields to obtain the `start` parameter.
+    // 2. The caller appends all the object fields to the builder. In the meantime, it should
+    // maintain
+    // the `fields` parameter. Before appending each field, it should append an entry to `fields` to
+    // record the offset of the field. The offset is computed as `getWritePos() - start`.
+    // 3. The caller calls `finishWritingObject` to finish writing a variant object.
+    //
+    // This function is responsible to sort the fields by key. If there are duplicate field keys:
+    // - when `allowDuplicateKeys` is true, the field with the greatest offset value (the last
+    // appended one) is kept.
+    // - otherwise, throw an exception.
+    public void finishWritingObject(int start, ArrayList<FieldEntry> fields) {
+        int size = fields.size();
+        Collections.sort(fields);
+        int maxId = size == 0 ? 0 : fields.get(0).id;
+        if (allowDuplicateKeys) {
+            int distinctPos = 0;
+            // Maintain a list of distinct keys in-place.
+            for (int i = 1; i < size; ++i) {
+                maxId = Math.max(maxId, fields.get(i).id);
+                if (fields.get(i).id == fields.get(i - 1).id) {
+                    // Found a duplicate key. Keep the field with a greater offset.
+                    if (fields.get(distinctPos).offset < fields.get(i).offset) {
+                        fields.set(
+                                distinctPos,
+                                fields.get(distinctPos).withNewOffset(fields.get(i).offset));
+                    }
+                } else {
+                    // Found a distinct key. Add the field to the list.
+                    ++distinctPos;
+                    fields.set(distinctPos, fields.get(i));
+                }
+            }
+            if (distinctPos + 1 < fields.size()) {
+                size = distinctPos + 1;
+                // Resize `fields` to `size`.
+                fields.subList(size, fields.size()).clear();
+                // Sort the fields by offsets so that we can move the value data of each field to
+                // the new
+                // offset without overwriting the fields after it.
+                fields.sort(Comparator.comparingInt(f -> f.offset));
+                int currentOffset = 0;
+                for (int i = 0; i < size; ++i) {
+                    int oldOffset = fields.get(i).offset;
+                    int fieldSize = valueSize(writeBuffer, start + oldOffset);
+                    System.arraycopy(
+                            writeBuffer,
+                            start + oldOffset,
+                            writeBuffer,
+                            start + currentOffset,
+                            fieldSize);
+                    fields.set(i, fields.get(i).withNewOffset(currentOffset));
+                    currentOffset += fieldSize;
+                }
+                writePos = start + currentOffset;
+                // Change back to the sort order by field keys to meet the variant spec.
+                Collections.sort(fields);
+            }
+        } else {
+            for (int i = 1; i < size; ++i) {
+                maxId = Math.max(maxId, fields.get(i).id);
+                String key = fields.get(i).key;
+                if (key.equals(fields.get(i - 1).key)) {
+                    throw VARIANT_DUPLICATE_KEY_EXCEPTION;
+                }
+            }
+        }
+        int dataSize = writePos - start;
+        boolean largeSize = size > U8_MAX;
+        int sizeBytes = largeSize ? U32_SIZE : 1;
+        int idSize = getIntegerSize(maxId);
+        int offsetSize = getIntegerSize(dataSize);
+        // The space for header byte, object size, id list, and offset list.
+        int headerSize = 1 + sizeBytes + size * idSize + (size + 1) * offsetSize;
+        checkCapacity(headerSize);
+        // Shift the just-written field data to make room for the object header section.
+        System.arraycopy(writeBuffer, start, writeBuffer, start + headerSize, dataSize);
+        writePos += headerSize;
+        writeBuffer[start] = objectHeader(largeSize, idSize, offsetSize);
+        writeLong(writeBuffer, start + 1, size, sizeBytes);
+        int idStart = start + 1 + sizeBytes;
+        int offsetStart = idStart + size * idSize;
+        for (int i = 0; i < size; ++i) {
+            writeLong(writeBuffer, idStart + i * idSize, fields.get(i).id, idSize);
+            writeLong(writeBuffer, offsetStart + i * offsetSize, fields.get(i).offset, offsetSize);
+        }
+        writeLong(writeBuffer, offsetStart + size * offsetSize, dataSize, offsetSize);
+    }
+
+    // Finish writing a variant array after all of its elements have already been written. The
+    // process
+    // is similar to that of `finishWritingObject`.
+    public void finishWritingArray(int start, ArrayList<Integer> offsets) {
+        int dataSize = writePos - start;
+        int size = offsets.size();
+        boolean largeSize = size > U8_MAX;
+        int sizeBytes = largeSize ? U32_SIZE : 1;
+        int offsetSize = getIntegerSize(dataSize);
+        // The space for header byte, object size, and offset list.
+        int headerSize = 1 + sizeBytes + (size + 1) * offsetSize;
+        checkCapacity(headerSize);
+        // Shift the just-written field data to make room for the header section.
+        System.arraycopy(writeBuffer, start, writeBuffer, start + headerSize, dataSize);
+        writePos += headerSize;
+        writeBuffer[start] = arrayHeader(largeSize, offsetSize);
+        writeLong(writeBuffer, start + 1, size, sizeBytes);
+        int offsetStart = start + 1 + sizeBytes;
+        for (int i = 0; i < size; ++i) {
+            writeLong(writeBuffer, offsetStart + i * offsetSize, offsets.get(i), offsetSize);
+        }
+        writeLong(writeBuffer, offsetStart + size * offsetSize, dataSize, offsetSize);
+    }
+
+    // Append a variant value to the variant builder. We need to insert the keys in the input
+    // variant
+    // into the current variant dictionary and rebuild it with new field ids. For scalar values in
+    // the
+    // input variant, we can directly copy the binary slice.
+    public void appendVariant(BinaryVariant v) {
+        appendVariantImpl(v.getValue(), v.getMetadata(), v.getPos());
+    }
+
+    private void appendVariantImpl(byte[] value, byte[] metadata, int pos) {
+        checkIndex(pos, value.length);
+        int basicType = value[pos] & BASIC_TYPE_MASK;
+        switch (basicType) {
+            case OBJECT:
+                handleObject(
+                        value,
+                        pos,
+                        (size, idSize, offsetSize, idStart, offsetStart, dataStart) -> {
+                            ArrayList<FieldEntry> fields = new ArrayList<>(size);
+                            int start = writePos;
+                            for (int i = 0; i < size; ++i) {
+                                int id = readUnsigned(value, idStart + idSize * i, idSize);
+                                int offset =
+                                        readUnsigned(
+                                                value, offsetStart + offsetSize * i, offsetSize);
+                                int elementPos = dataStart + offset;
+                                String key = getMetadataKey(metadata, id);
+                                int newId = addKey(key);
+                                fields.add(new FieldEntry(key, newId, writePos - start));
+                                appendVariantImpl(value, metadata, elementPos);
+                            }
+                            finishWritingObject(start, fields);
+                            return null;
+                        });
+                break;
+            case ARRAY:
+                handleArray(
+                        value,
+                        pos,
+                        (size, offsetSize, offsetStart, dataStart) -> {
+                            ArrayList<Integer> offsets = new ArrayList<>(size);
+                            int start = writePos;
+                            for (int i = 0; i < size; ++i) {
+                                int offset =
+                                        readUnsigned(
+                                                value, offsetStart + offsetSize * i, offsetSize);
+                                int elementPos = dataStart + offset;
+                                offsets.add(writePos - start);
+                                appendVariantImpl(value, metadata, elementPos);
+                            }
+                            finishWritingArray(start, offsets);
+                            return null;
+                        });
+                break;
+            default:
+                shallowAppendVariantImpl(value, pos);
+                break;
+        }
+    }
+
+    private void shallowAppendVariantImpl(byte[] value, int pos) {
+        int size = valueSize(value, pos);
+        checkIndex(pos + size - 1, value.length);
+        checkCapacity(size);
+        System.arraycopy(value, pos, writeBuffer, writePos, size);
+        writePos += size;
+    }
+
+    private void checkCapacity(int additional) {
+        int required = writePos + additional;
+        if (required > writeBuffer.length) {
+            // Allocate a new buffer with a capacity of the next power of 2 of `required`.
+            int newCapacity = Integer.highestOneBit(required);
+            newCapacity = newCapacity < required ? newCapacity * 2 : newCapacity;
+            if (newCapacity > SIZE_LIMIT) {
+                throw VARIANT_SIZE_LIMIT_EXCEPTION;
+            }
+            byte[] newValue = new byte[newCapacity];
+            System.arraycopy(writeBuffer, 0, newValue, 0, writePos);
+            writeBuffer = newValue;
+        }
+    }
+
+    // Temporarily store the information of a field. We need to collect all fields in an JSON
+    // object,
+    // sort them by their keys, and build the variant object in sorted order.
+    public static final class FieldEntry implements Comparable<FieldEntry> {
+        final String key;
+        final int id;
+        final int offset;
+
+        public FieldEntry(String key, int id, int offset) {
+            this.key = key;
+            this.id = id;
+            this.offset = offset;
+        }
+
+        FieldEntry withNewOffset(int newOffset) {
+            return new FieldEntry(key, id, newOffset);
+        }
+
+        @Override
+        public int compareTo(FieldEntry other) {
+            return key.compareTo(other.key);
+        }
+    }
+
+    private void buildJson(JsonParser parser) throws IOException {
+        JsonToken token = parser.currentToken();
+        if (token == null) {
+            throw new JsonParseException(parser, "Unexpected null token");
+        }
+        switch (token) {
+            case START_OBJECT:
+                {
+                    ArrayList<FieldEntry> fields = new ArrayList<>();
+                    int start = writePos;
+                    while (parser.nextToken() != JsonToken.END_OBJECT) {
+                        String key = parser.currentName();
+                        parser.nextToken();
+                        int id = addKey(key);
+                        fields.add(new FieldEntry(key, id, writePos - start));
+                        buildJson(parser);
+                    }
+                    finishWritingObject(start, fields);
+                    break;
+                }
+            case START_ARRAY:
+                {
+                    ArrayList<Integer> offsets = new ArrayList<>();
+                    int start = writePos;
+                    while (parser.nextToken() != JsonToken.END_ARRAY) {
+                        offsets.add(writePos - start);
+                        buildJson(parser);
+                    }
+                    finishWritingArray(start, offsets);
+                    break;
+                }
+            case VALUE_STRING:
+                appendString(parser.getText());
+                break;
+            case VALUE_NUMBER_INT:
+                try {
+                    appendNumeric(parser.getLongValue());
+                } catch (InputCoercionException ignored) {
+                    // If the value doesn't fit any integer type, parse it as decimal or floating
+                    // instead.
+                    parseFloatingPoint(parser);
+                }
+                break;
+            case VALUE_NUMBER_FLOAT:
+                parseFloatingPoint(parser);
+                break;
+            case VALUE_TRUE:
+                appendBoolean(true);
+                break;
+            case VALUE_FALSE:
+                appendBoolean(false);
+                break;
+            case VALUE_NULL:
+                appendNull();
+                break;
+            default:
+                throw new JsonParseException(parser, "Unexpected token " + token);
+        }
+    }
+
+    // Choose the smallest unsigned integer type that can store `value`. It must be within
+    // `[0, U24_MAX]`.
+    private int getIntegerSize(int value) {
+        assert value >= 0 && value <= U24_MAX;
+        if (value <= U8_MAX) {
+            return 1;
+        }
+        if (value <= U16_MAX) {
+            return 2;
+        }
+        return U24_SIZE;
+    }
+
+    private void parseFloatingPoint(JsonParser parser) throws IOException {
+        if (!tryParseDecimal(parser.getText())) {
+            appendDouble(parser.getDoubleValue());
+        }
+    }
+
+    // Try to parse a JSON number as a decimal. Return whether the parsing succeeds. The input must
+    // only use the decimal format (an integer value with an optional '.' in it) and must not use
+    // scientific notation. It also must fit into the precision limitation of decimal types.
+    private boolean tryParseDecimal(String input) {
+        for (int i = 0; i < input.length(); ++i) {
+            char ch = input.charAt(i);
+            if (ch != '-' && ch != '.' && !(ch >= '0' && ch <= '9')) {
+                return false;
+            }
+        }
+        BigDecimal d = new BigDecimal(input);
+        if (d.scale() <= MAX_DECIMAL16_PRECISION && d.precision() <= MAX_DECIMAL16_PRECISION) {
+            appendDecimal(d);
+            return true;
+        }
+        return false;
+    }
+
+    // The write buffer in building the variant value. Its first `writePos` bytes has been written.
+    private byte[] writeBuffer = new byte[128];
+    private int writePos = 0;
+    // Map keys to a monotonically increasing id.
+    private final HashMap<String, Integer> dictionary = new HashMap<>();
+    // Store all keys in `dictionary` in the order of id.
+    private final ArrayList<byte[]> dictionaryKeys = new ArrayList<>();
+    private final boolean allowDuplicateKeys;
+}

--- a/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariantUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariantUtil.java
@@ -1,0 +1,630 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.types.variant;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.types.variant.Variant.Type;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.util.Arrays;
+import java.util.Locale;
+
+/* This file is based on source code from the Spark Project (http://spark.apache.org/), licensed by the Apache
+ * Software Foundation (ASF) under the Apache License, Version 2.0. See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership. */
+
+/**
+ * This class defines constants related to the variant format and provides functions for
+ * manipulating variant binaries.
+ *
+ * <p>A variant is made up of 2 binaries: value and metadata. A variant value consists of a one-byte
+ * header and a number of content bytes (can be zero). The header byte is divided into upper 6 bits
+ * (called "type info") and lower 2 bits (called "basic type"). The content format is explained in
+ * the below constants for all possible basic type and type info values.
+ *
+ * <p>The variant metadata includes a version id and a dictionary of distinct strings
+ * (case-sensitive). Its binary format is: - Version: 1-byte unsigned integer. The only acceptable
+ * value is 1 currently. - Dictionary size: 4-byte little-endian unsigned integer. The number of
+ * keys in the dictionary. - Offsets: (size + 1) * 4-byte little-endian unsigned integers.
+ * `offsets[i]` represents the starting position of string i, counting starting from the address of
+ * `offsets[0]`. Strings must be stored contiguously, so we don’t need to store the string size,
+ * instead, we compute it with `offset[i + 1] - offset[i]`. - UTF-8 string data.
+ */
+@Internal
+public class BinaryVariantUtil {
+    public static final int BASIC_TYPE_BITS = 2;
+    public static final int BASIC_TYPE_MASK = 0x3;
+    public static final int TYPE_INFO_MASK = 0x3F;
+    // The inclusive maximum value of the type info value. It is the size limit of `SHORT_STR`.
+    public static final int MAX_SHORT_STR_SIZE = 0x3F;
+
+    // Below is all possible basic type values.
+    // Primitive value. The type info value must be one of the values in the below section.
+    public static final int PRIMITIVE = 0;
+    // Short string value. The type info value is the string size, which must be in `[0,
+    // kMaxShortStrSize]`.
+    // The string content bytes directly follow the header byte.
+    public static final int SHORT_STR = 1;
+    // Object value. The content contains a size, a list of field ids, a list of field offsets, and
+    // the actual field data. The length of the id list is `size`, while the length of the offset
+    // list is `size + 1`, where the last offset represent the total size of the field data. The
+    // fields in an object must be sorted by the field name in alphabetical order. Duplicate field
+    // names in one object are not allowed.
+    // We use 5 bits in the type info to specify the integer type of the object header: it should
+    // be 0_b4_b3b2_b1b0 (MSB is 0), where:
+    // - b4 specifies the type of size. When it is 0/1, `size` is a little-endian 1/4-byte
+    // unsigned integer.
+    // - b3b2/b1b0 specifies the integer type of id and offset. When the 2 bits are  0/1/2, the
+    // list contains 1/2/3-byte little-endian unsigned integers.
+    public static final int OBJECT = 2;
+    // Array value. The content contains a size, a list of field offsets, and the actual element
+    // data. It is similar to an object without the id list. The length of the offset list
+    // is `size + 1`, where the last offset represent the total size of the element data.
+    // Its type info should be: 000_b2_b1b0:
+    // - b2 specifies the type of size.
+    // - b1b0 specifies the integer type of offset.
+    public static final int ARRAY = 3;
+
+    // Below is all possible type info values for `PRIMITIVE`.
+    // JSON Null value. Empty content.
+    public static final int NULL = 0;
+    // True value. Empty content.
+    public static final int TRUE = 1;
+    // False value. Empty content.
+    public static final int FALSE = 2;
+    // 1-byte little-endian signed integer.
+    public static final int INT1 = 3;
+    // 2-byte little-endian signed integer.
+    public static final int INT2 = 4;
+    // 4-byte little-endian signed integer.
+    public static final int INT4 = 5;
+    // 4-byte little-endian signed integer.
+    public static final int INT8 = 6;
+    // 8-byte IEEE double.
+    public static final int DOUBLE = 7;
+    // 4-byte decimal. Content is 1-byte scale + 4-byte little-endian signed integer.
+    public static final int DECIMAL4 = 8;
+    // 8-byte decimal. Content is 1-byte scale + 8-byte little-endian signed integer.
+    public static final int DECIMAL8 = 9;
+    // 16-byte decimal. Content is 1-byte scale + 16-byte little-endian signed integer.
+    public static final int DECIMAL16 = 10;
+    // Date value. Content is 4-byte little-endian signed integer that represents the number of days
+    // from the Unix epoch.
+    public static final int DATE = 11;
+    // TimestampLTZ value. Content is 8-byte little-endian signed integer that represents the number
+    // of microseconds elapsed since the Unix epoch, 1970-01-01 00:00:00 UTC. It is displayed to
+    // users in their local time zones and may be displayed differently depending on the execution
+    // environment.
+    public static final int TIMESTAMP_LTZ = 12;
+    // Timestamp value. It has the same content as `TIMESTAMP` but should always be interpreted
+    // as if the local time zone is UTC.
+    public static final int TIMESTAMP = 13;
+    // 4-byte IEEE float.
+    public static final int FLOAT = 14;
+    // Binary value. The content is (4-byte little-endian unsigned integer representing the binary
+    // size) + (size bytes of binary content).
+    public static final int BINARY = 15;
+    // Long string value. The content is (4-byte little-endian unsigned integer representing the
+    // string size) + (size bytes of string content).
+    public static final int LONG_STR = 16;
+
+    public static final byte VERSION = 1;
+    // The lower 4 bits of the first metadata byte contain the version.
+    public static final byte VERSION_MASK = 0x0F;
+
+    public static final int U8_MAX = 0xFF;
+    public static final int U16_MAX = 0xFFFF;
+    public static final int U24_MAX = 0xFFFFFF;
+    public static final int U24_SIZE = 3;
+    public static final int U32_SIZE = 4;
+
+    // Both variant value and variant metadata need to be no longer than 16MiB.
+    public static final int SIZE_LIMIT = U24_MAX + 1;
+
+    public static final int MAX_DECIMAL4_PRECISION = 9;
+    public static final int MAX_DECIMAL8_PRECISION = 18;
+    public static final int MAX_DECIMAL16_PRECISION = 38;
+
+    public static final int BINARY_SEARCH_THRESHOLD = 32;
+
+    public static final DateTimeFormatter TIMESTAMP_FORMATTER =
+            new DateTimeFormatterBuilder()
+                    .append(DateTimeFormatter.ISO_LOCAL_DATE)
+                    .appendLiteral('T')
+                    .append(DateTimeFormatter.ISO_LOCAL_TIME)
+                    .toFormatter(Locale.US);
+
+    public static final DateTimeFormatter TIMESTAMP_LTZ_FORMATTER =
+            new DateTimeFormatterBuilder()
+                    .append(TIMESTAMP_FORMATTER)
+                    .appendOffset("+HH:MM", "+00:00")
+                    .toFormatter(Locale.US);
+
+    // Write the least significant `numBytes` bytes in `value` into `bytes[pos, pos + numBytes)` in
+    // little endian.
+    public static void writeLong(byte[] bytes, int pos, long value, int numBytes) {
+        for (int i = 0; i < numBytes; ++i) {
+            bytes[pos + i] = (byte) ((value >>> (8 * i)) & 0xFF);
+        }
+    }
+
+    public static byte primitiveHeader(int type) {
+        return (byte) (type << 2 | PRIMITIVE);
+    }
+
+    public static byte shortStrHeader(int size) {
+        return (byte) (size << 2 | SHORT_STR);
+    }
+
+    public static byte objectHeader(boolean largeSize, int idSize, int offsetSize) {
+        return (byte)
+                (((largeSize ? 1 : 0) << (BASIC_TYPE_BITS + 4))
+                        | ((idSize - 1) << (BASIC_TYPE_BITS + 2))
+                        | ((offsetSize - 1) << BASIC_TYPE_BITS)
+                        | OBJECT);
+    }
+
+    public static byte arrayHeader(boolean largeSize, int offsetSize) {
+        return (byte)
+                (((largeSize ? 1 : 0) << (BASIC_TYPE_BITS + 2))
+                        | ((offsetSize - 1) << BASIC_TYPE_BITS)
+                        | ARRAY);
+    }
+
+    // An exception indicating that the variant value or metadata doesn't
+    static VariantTypeException malformedVariant() {
+        return new VariantTypeException("MALFORMED_VARIANT");
+    }
+
+    static VariantTypeException unknownPrimitiveTypeInVariant(int id) {
+        return new VariantTypeException("UNKNOWN_PRIMITIVE_TYPE_IN_VARIANT, id: " + id);
+    }
+
+    // An exception indicating that an external caller tried to call the Variant constructor with
+    // value or metadata exceeding the 16MiB size limit. We will never construct a Variant this
+    // large,
+    // so it should only be possible to encounter this exception when reading a Variant produced by
+    // another tool.
+    static VariantTypeException variantConstructorSizeLimit() {
+        return new VariantTypeException("VARIANT_CONSTRUCTOR_SIZE_LIMIT");
+    }
+
+    // Check the validity of an array index `pos`. Throw `MALFORMED_VARIANT` if it is out of bound,
+    // meaning that the variant is malformed.
+    static void checkIndex(int pos, int length) {
+        if (pos < 0 || pos >= length) {
+            throw malformedVariant();
+        }
+    }
+
+    // Read a little-endian signed long value from `bytes[pos, pos + numBytes)`.
+    static long readLong(byte[] bytes, int pos, int numBytes) {
+        checkIndex(pos, bytes.length);
+        checkIndex(pos + numBytes - 1, bytes.length);
+        long result = 0;
+        // All bytes except the most significant byte should be unsign-extended and shifted (so we
+        // need `& 0xFF`). The most significant byte should be sign-extended and is handled after
+        // the loop.
+        for (int i = 0; i < numBytes - 1; ++i) {
+            long unsignedByteValue = bytes[pos + i] & 0xFF;
+            result |= unsignedByteValue << (8 * i);
+        }
+        long signedByteValue = bytes[pos + numBytes - 1];
+        result |= signedByteValue << (8 * (numBytes - 1));
+        return result;
+    }
+
+    // Read a little-endian unsigned int value from `bytes[pos, pos + numBytes)`. The value must fit
+    // into a non-negative int (`[0, Integer.MAX_VALUE]`).
+    static int readUnsigned(byte[] bytes, int pos, int numBytes) {
+        checkIndex(pos, bytes.length);
+        checkIndex(pos + numBytes - 1, bytes.length);
+        int result = 0;
+        // Similar to the `readLong` loop, but all bytes should be unsign-extended.
+        for (int i = 0; i < numBytes; ++i) {
+            int unsignedByteValue = bytes[pos + i] & 0xFF;
+            result |= unsignedByteValue << (8 * i);
+        }
+        if (result < 0) {
+            throw malformedVariant();
+        }
+        return result;
+    }
+
+    public static int getTypeInfo(byte[] value, int pos) {
+        checkIndex(pos, value.length);
+        return (value[pos] >> BASIC_TYPE_BITS) & TYPE_INFO_MASK;
+    }
+
+    // Get the value type of variant value `value[pos...]`. It is only legal to call `get*` if
+    // `getType` returns this type (for example, it is only legal to call `getLong` if `getType`
+    // returns `Type.Long`).
+    // Throw `MALFORMED_VARIANT` if the variant is malformed.
+    public static Type getType(byte[] value, int pos) {
+        checkIndex(pos, value.length);
+        int basicType = value[pos] & BASIC_TYPE_MASK;
+        int typeInfo = (value[pos] >> BASIC_TYPE_BITS) & TYPE_INFO_MASK;
+        switch (basicType) {
+            case SHORT_STR:
+                return Type.STRING;
+            case OBJECT:
+                return Type.OBJECT;
+            case ARRAY:
+                return Type.ARRAY;
+            default:
+                switch (typeInfo) {
+                    case NULL:
+                        return Type.NULL;
+                    case TRUE:
+                    case FALSE:
+                        return Type.BOOLEAN;
+                    case INT1:
+                        return Type.TINYINT;
+                    case INT2:
+                        return Type.SMALLINT;
+                    case INT4:
+                        return Type.INT;
+                    case INT8:
+                        return Type.BIGINT;
+                    case DOUBLE:
+                        return Type.DOUBLE;
+                    case DECIMAL4:
+                    case DECIMAL8:
+                    case DECIMAL16:
+                        return Type.DECIMAL;
+                    case DATE:
+                        return Type.DATE;
+                    case TIMESTAMP_LTZ:
+                        return Type.TIMESTAMP_LTZ;
+                    case TIMESTAMP:
+                        return Type.TIMESTAMP;
+                    case FLOAT:
+                        return Type.FLOAT;
+                    case BINARY:
+                        return Type.BYTES;
+                    case LONG_STR:
+                        return Type.STRING;
+                    default:
+                        throw unknownPrimitiveTypeInVariant(typeInfo);
+                }
+        }
+    }
+
+    // Compute the size in bytes of the variant value `value[pos...]`. `value.length - pos` is an
+    // upper bound of the size, but the actual size can be smaller.
+    // Throw `MALFORMED_VARIANT` if the variant is malformed.
+    public static int valueSize(byte[] value, int pos) {
+        checkIndex(pos, value.length);
+        int basicType = value[pos] & BASIC_TYPE_MASK;
+        int typeInfo = (value[pos] >> BASIC_TYPE_BITS) & TYPE_INFO_MASK;
+        switch (basicType) {
+            case SHORT_STR:
+                return 1 + typeInfo;
+            case OBJECT:
+                return handleObject(
+                        value,
+                        pos,
+                        (size, idSize, offsetSize, idStart, offsetStart, dataStart) ->
+                                dataStart
+                                        - pos
+                                        + readUnsigned(
+                                                value,
+                                                offsetStart + size * offsetSize,
+                                                offsetSize));
+            case ARRAY:
+                return handleArray(
+                        value,
+                        pos,
+                        (size, offsetSize, offsetStart, dataStart) ->
+                                dataStart
+                                        - pos
+                                        + readUnsigned(
+                                                value,
+                                                offsetStart + size * offsetSize,
+                                                offsetSize));
+            default:
+                switch (typeInfo) {
+                    case NULL:
+                    case TRUE:
+                    case FALSE:
+                        return 1;
+                    case INT1:
+                        return 2;
+                    case INT2:
+                        return 3;
+                    case INT4:
+                    case DATE:
+                    case FLOAT:
+                        return 5;
+                    case INT8:
+                    case DOUBLE:
+                    case TIMESTAMP_LTZ:
+                    case TIMESTAMP:
+                        return 9;
+                    case DECIMAL4:
+                        return 6;
+                    case DECIMAL8:
+                        return 10;
+                    case DECIMAL16:
+                        return 18;
+                    case BINARY:
+                    case LONG_STR:
+                        return 1 + U32_SIZE + readUnsigned(value, pos + 1, U32_SIZE);
+                    default:
+                        throw unknownPrimitiveTypeInVariant(typeInfo);
+                }
+        }
+    }
+
+    static VariantTypeException unexpectedType(Type type) {
+        return new VariantTypeException("Expect type to be " + type);
+    }
+
+    // Get a boolean value from variant value `value[pos...]`.
+    // Throw `MALFORMED_VARIANT` if the variant is malformed.
+    public static boolean getBoolean(byte[] value, int pos) {
+        checkIndex(pos, value.length);
+        int basicType = value[pos] & BASIC_TYPE_MASK;
+        int typeInfo = (value[pos] >> BASIC_TYPE_BITS) & TYPE_INFO_MASK;
+        if (basicType != PRIMITIVE || (typeInfo != TRUE && typeInfo != FALSE)) {
+            throw unexpectedType(Type.BOOLEAN);
+        }
+        return typeInfo == TRUE;
+    }
+
+    // Get a long value from variant value `value[pos...]`.
+    // It is only legal to call it if `getType` returns one of `Type.LONG/DATE/TIMESTAMP/
+    // TIMESTAMP_LTZ`. If the type is `DATE`, the return value is guaranteed to fit into an int and
+    // represents the number of days from the Unix epoch.
+    // If the type is `TIMESTAMP/TIMESTAMP_LTZ`, the return value represents the number of
+    // microseconds from the Unix epoch.
+    public static long getLong(byte[] value, int pos) {
+        checkIndex(pos, value.length);
+        int basicType = value[pos] & BASIC_TYPE_MASK;
+        int typeInfo = (value[pos] >> BASIC_TYPE_BITS) & TYPE_INFO_MASK;
+        String exceptionMessage = "Expect type to be LONG/DATE/TIMESTAMP/TIMESTAMP_LTZ";
+        if (basicType != PRIMITIVE) {
+            throw new IllegalStateException(exceptionMessage);
+        }
+        switch (typeInfo) {
+            case INT1:
+                return readLong(value, pos + 1, 1);
+            case INT2:
+                return readLong(value, pos + 1, 2);
+            case INT4:
+            case DATE:
+                return readLong(value, pos + 1, 4);
+            case INT8:
+            case TIMESTAMP_LTZ:
+            case TIMESTAMP:
+                return readLong(value, pos + 1, 8);
+            default:
+                throw new IllegalStateException(exceptionMessage);
+        }
+    }
+
+    // Get a double value from variant value `value[pos...]`.
+    // Throw `MALFORMED_VARIANT` if the variant is malformed.
+    public static double getDouble(byte[] value, int pos) {
+        checkIndex(pos, value.length);
+        int basicType = value[pos] & BASIC_TYPE_MASK;
+        int typeInfo = (value[pos] >> BASIC_TYPE_BITS) & TYPE_INFO_MASK;
+        if (basicType != PRIMITIVE || typeInfo != DOUBLE) {
+            throw unexpectedType(Type.DOUBLE);
+        }
+        return Double.longBitsToDouble(readLong(value, pos + 1, 8));
+    }
+
+    // Check whether the precision and scale of the decimal are within the limit.
+    private static void checkDecimal(BigDecimal d, int maxPrecision) {
+        if (d.precision() > maxPrecision || d.scale() > maxPrecision) {
+            throw malformedVariant();
+        }
+    }
+
+    // Get a decimal value from variant value `value[pos...]`.
+    // Throw `MALFORMED_VARIANT` if the variant is malformed.
+    public static BigDecimal getDecimalWithOriginalScale(byte[] value, int pos) {
+        checkIndex(pos, value.length);
+        int basicType = value[pos] & BASIC_TYPE_MASK;
+        int typeInfo = (value[pos] >> BASIC_TYPE_BITS) & TYPE_INFO_MASK;
+        if (basicType != PRIMITIVE) {
+            throw unexpectedType(Type.DECIMAL);
+        }
+        // Interpret the scale byte as unsigned. If it is a negative byte, the unsigned value must
+        // be greater than `MAX_DECIMAL16_PRECISION` and will trigger an error in `checkDecimal`.
+        int scale = value[pos + 1] & 0xFF;
+        BigDecimal result;
+        switch (typeInfo) {
+            case DECIMAL4:
+                result = BigDecimal.valueOf(readLong(value, pos + 2, 4), scale);
+                checkDecimal(result, MAX_DECIMAL4_PRECISION);
+                break;
+            case DECIMAL8:
+                result = BigDecimal.valueOf(readLong(value, pos + 2, 8), scale);
+                checkDecimal(result, MAX_DECIMAL8_PRECISION);
+                break;
+            case DECIMAL16:
+                checkIndex(pos + 17, value.length);
+                byte[] bytes = new byte[16];
+                // Copy the bytes reversely because the `BigInteger` constructor expects a
+                // big-endian representation.
+                for (int i = 0; i < 16; ++i) {
+                    bytes[i] = value[pos + 17 - i];
+                }
+                result = new BigDecimal(new BigInteger(bytes), scale);
+                checkDecimal(result, MAX_DECIMAL16_PRECISION);
+                break;
+            default:
+                throw unexpectedType(Type.DECIMAL);
+        }
+        return result;
+    }
+
+    public static BigDecimal getDecimal(byte[] value, int pos) {
+        return getDecimalWithOriginalScale(value, pos).stripTrailingZeros();
+    }
+
+    // Get a float value from variant value `value[pos...]`.
+    // Throw `MALFORMED_VARIANT` if the variant is malformed.
+    public static float getFloat(byte[] value, int pos) {
+        checkIndex(pos, value.length);
+        int basicType = value[pos] & BASIC_TYPE_MASK;
+        int typeInfo = (value[pos] >> BASIC_TYPE_BITS) & TYPE_INFO_MASK;
+        if (basicType != PRIMITIVE || typeInfo != FLOAT) {
+            throw unexpectedType(Type.FLOAT);
+        }
+        return Float.intBitsToFloat((int) readLong(value, pos + 1, 4));
+    }
+
+    // Get a binary value from variant value `value[pos...]`.
+    // Throw `MALFORMED_VARIANT` if the variant is malformed.
+    public static byte[] getBinary(byte[] value, int pos) {
+        checkIndex(pos, value.length);
+        int basicType = value[pos] & BASIC_TYPE_MASK;
+        int typeInfo = (value[pos] >> BASIC_TYPE_BITS) & TYPE_INFO_MASK;
+        if (basicType != PRIMITIVE || typeInfo != BINARY) {
+            throw unexpectedType(Type.BYTES);
+        }
+        int start = pos + 1 + U32_SIZE;
+        int length = readUnsigned(value, pos + 1, U32_SIZE);
+        checkIndex(start + length - 1, value.length);
+        return Arrays.copyOfRange(value, start, start + length);
+    }
+
+    // Get a string value from variant value `value[pos...]`.
+    // Throw `MALFORMED_VARIANT` if the variant is malformed.
+    public static String getString(byte[] value, int pos) {
+        checkIndex(pos, value.length);
+        int basicType = value[pos] & BASIC_TYPE_MASK;
+        int typeInfo = (value[pos] >> BASIC_TYPE_BITS) & TYPE_INFO_MASK;
+        if (basicType == SHORT_STR || (basicType == PRIMITIVE && typeInfo == LONG_STR)) {
+            int start;
+            int length;
+            if (basicType == SHORT_STR) {
+                start = pos + 1;
+                length = typeInfo;
+            } else {
+                start = pos + 1 + U32_SIZE;
+                length = readUnsigned(value, pos + 1, U32_SIZE);
+            }
+            checkIndex(start + length - 1, value.length);
+            return new String(value, start, length);
+        }
+        throw unexpectedType(Type.STRING);
+    }
+
+    /** 1. */
+    public interface ObjectHandler<T> {
+        /**
+         * @param size Number of object fields.
+         * @param idSize The integer size of the field id list.
+         * @param offsetSize The integer size of the offset list.
+         * @param idStart The starting index of the field id list in the variant value array.
+         * @param offsetStart The starting index of the offset list in the variant value array.
+         * @param dataStart The starting index of field data in the variant value array.
+         */
+        T apply(int size, int idSize, int offsetSize, int idStart, int offsetStart, int dataStart);
+    }
+
+    // A helper function to access a variant object. It provides `handler` with its required
+    // parameters and returns what it returns.
+    public static <T> T handleObject(byte[] value, int pos, ObjectHandler<T> handler) {
+        checkIndex(pos, value.length);
+        int basicType = value[pos] & BASIC_TYPE_MASK;
+        int typeInfo = (value[pos] >> BASIC_TYPE_BITS) & TYPE_INFO_MASK;
+        if (basicType != OBJECT) {
+            throw unexpectedType(Type.OBJECT);
+        }
+        // Refer to the comment of the `OBJECT` constant for the details of the object header
+        // encoding. Suppose `typeInfo` has a bit representation of 0_b4_b3b2_b1b0, the following
+        // line extracts b4 to determine whether the object uses a 1/4-byte size.
+        boolean largeSize = ((typeInfo >> 4) & 0x1) != 0;
+        int sizeBytes = (largeSize ? U32_SIZE : 1);
+        int size = readUnsigned(value, pos + 1, sizeBytes);
+        // Extracts b3b2 to determine the integer size of the field id list.
+        int idSize = ((typeInfo >> 2) & 0x3) + 1;
+        // Extracts b1b0 to determine the integer size of the offset list.
+        int offsetSize = (typeInfo & 0x3) + 1;
+        int idStart = pos + 1 + sizeBytes;
+        int offsetStart = idStart + size * idSize;
+        int dataStart = offsetStart + (size + 1) * offsetSize;
+        return handler.apply(size, idSize, offsetSize, idStart, offsetStart, dataStart);
+    }
+
+    /** 1. */
+    public interface ArrayHandler<T> {
+        /**
+         * @param size Number of array elements.
+         * @param offsetSize The integer size of the offset list.
+         * @param offsetStart The starting index of the offset list in the variant value array.
+         * @param dataStart The starting index of element data in the variant value array.
+         */
+        T apply(int size, int offsetSize, int offsetStart, int dataStart);
+    }
+
+    // A helper function to access a variant array.
+    public static <T> T handleArray(byte[] value, int pos, ArrayHandler<T> handler) {
+        checkIndex(pos, value.length);
+        int basicType = value[pos] & BASIC_TYPE_MASK;
+        int typeInfo = (value[pos] >> BASIC_TYPE_BITS) & TYPE_INFO_MASK;
+        if (basicType != ARRAY) {
+            throw unexpectedType(Type.ARRAY);
+        }
+        // Refer to the comment of the `ARRAY` constant for the details of the object header
+        // encoding.
+        // Suppose `typeInfo` has a bit representation of 000_b2_b1b0, the following line extracts
+        // b2 to determine whether the object uses a 1/4-byte size.
+        boolean largeSize = ((typeInfo >> 2) & 0x1) != 0;
+        int sizeBytes = (largeSize ? U32_SIZE : 1);
+        int size = readUnsigned(value, pos + 1, sizeBytes);
+        // Extracts b1b0 to determine the integer size of the offset list.
+        int offsetSize = (typeInfo & 0x3) + 1;
+        int offsetStart = pos + 1 + sizeBytes;
+        int dataStart = offsetStart + (size + 1) * offsetSize;
+        return handler.apply(size, offsetSize, offsetStart, dataStart);
+    }
+
+    // Get a key at `id` in the variant metadata.
+    // Throw `MALFORMED_VARIANT` if the variant is malformed. An out-of-bound `id` is also
+    // considered a malformed variant because it is read from the corresponding variant value.
+    public static String getMetadataKey(byte[] metadata, int id) {
+        checkIndex(0, metadata.length);
+        // Extracts the highest 2 bits in the metadata header to determine the integer size of the
+        // offset list.
+        int offsetSize = ((metadata[0] >> 6) & 0x3) + 1;
+        int dictSize = readUnsigned(metadata, 1, offsetSize);
+        if (id >= dictSize) {
+            throw malformedVariant();
+        }
+        // There are a header byte, a `dictSize` with `offsetSize` bytes, and `(dictSize + 1)`
+        // offsets before the string data.
+        int stringStart = 1 + (dictSize + 2) * offsetSize;
+        int offset = readUnsigned(metadata, 1 + (id + 1) * offsetSize, offsetSize);
+        int nextOffset = readUnsigned(metadata, 1 + (id + 2) * offsetSize, offsetSize);
+        if (offset > nextOffset) {
+            throw malformedVariant();
+        }
+        checkIndex(stringStart + nextOffset - 1, metadata.length);
+        return new String(metadata, stringStart + offset, nextOffset - offset);
+    }
+}

--- a/flink-core/src/main/java/org/apache/flink/types/variant/Variant.java
+++ b/flink-core/src/main/java/org/apache/flink/types/variant/Variant.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.types.variant;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/** Variant represent a semi-structured data. */
+@PublicEvolving
+public interface Variant {
+
+    /** Returns true if the variant is a primitive typed value, such as INT, DOUBLE, STRING, etc. */
+    boolean isPrimitive();
+
+    /** Returns true if this variant is an Array, false otherwise. */
+    boolean isArray();
+
+    /** Returns true if this variant is an Object, false otherwise. */
+    boolean isObject();
+
+    /** Check If this variant is null. */
+    boolean isNull();
+
+    /** Get the type of variant. */
+    Type getType();
+
+    /**
+     * Get the scalar value of variant as boolean, if the variant type is {@link Type#BOOLEAN}.
+     *
+     * @throws VariantTypeException If this variant is not a scalar value or is not {@link
+     *     Type#BOOLEAN}.
+     */
+    boolean getBoolean() throws VariantTypeException;
+
+    /**
+     * Get the scalar value of variant as byte, if the variant type is {@link Type#TINYINT}.
+     *
+     * @throws VariantTypeException If this variant is not a scalar value or is not {@link
+     *     Type#TINYINT}.
+     */
+    byte getByte() throws VariantTypeException;
+
+    /**
+     * Get the scalar value of variant as short, if the variant type is {@link Type#SMALLINT}.
+     *
+     * @throws VariantTypeException If this variant is not a scalar value or is not {@link
+     *     Type#SMALLINT}.
+     */
+    short getShort() throws VariantTypeException;
+
+    /**
+     * Get the scalar value of variant as int, if the variant type is {@link Type#INT}.
+     *
+     * @throws VariantTypeException if this variant is not a scalar value or is not {@link
+     *     Type#INT}.
+     */
+    int getInt() throws VariantTypeException;
+
+    /**
+     * Get the scalar value of variant as long, if the variant type is {@link Type#BIGINT}.
+     *
+     * @throws VariantTypeException If this variant is not a scalar value or is not {@link
+     *     Type#BIGINT}.
+     */
+    long getLong() throws VariantTypeException;
+
+    /**
+     * Get the scalar value of variant as float, if the variant type is {@link Type#FLOAT}.
+     *
+     * @throws VariantTypeException If this variant is not a scalar value or is not {@link
+     *     Type#FLOAT}.
+     */
+    float getFloat() throws VariantTypeException;
+
+    /**
+     * Get the scalar value of variant as BigDecimal, if the variant type is {@link Type#DECIMAL}.
+     *
+     * @throws VariantTypeException If this variant is not a scalar value or is not {@link
+     *     Type#DECIMAL}.
+     */
+    BigDecimal getDecimal() throws VariantTypeException;
+
+    /**
+     * Get the scalar value of variant as double, if the variant type is {@link Type#DOUBLE}.
+     *
+     * @throws VariantTypeException If this variant is not a scalar value or is not {@link
+     *     Type#DOUBLE}.
+     */
+    double getDouble() throws VariantTypeException;
+
+    /**
+     * Get the scalar value of variant as string, if the variant type is {@link Type#STRING}.
+     *
+     * @throws VariantTypeException If this variant is not a scalar value or is not {@link
+     *     Type#STRING}.
+     */
+    String getString() throws VariantTypeException;
+
+    /**
+     * Get the scalar value of variant as LocalDate, if the variant type is {@link Type#DATE}.
+     *
+     * @throws VariantTypeException If this variant is not a scalar value or is not {@link
+     *     Type#DATE}.
+     */
+    LocalDate getDate() throws VariantTypeException;
+
+    /**
+     * Get the scalar value of variant as LocalDateTime, if the variant type is {@link
+     * Type#TIMESTAMP}.
+     *
+     * @throws VariantTypeException If this variant is not a scalar value or is not {@link
+     *     Type#TIMESTAMP}.
+     */
+    LocalDateTime getDateTime() throws VariantTypeException;
+
+    /**
+     * Get the scalar value of variant as Instant, if the variant type is {@link Type#TIMESTAMP}.
+     *
+     * @throws VariantTypeException If this variant is not a scalar value or is not {@link
+     *     Type#TIMESTAMP}.
+     */
+    Instant getInstant() throws VariantTypeException;
+
+    /**
+     * Get the scalar value of variant as byte array, if the variant type is {@link Type#BYTES}.
+     *
+     * @throws VariantTypeException If this variant is not a scalar value or is not {@link
+     *     Type#BYTES}.
+     */
+    byte[] getBytes() throws VariantTypeException;
+
+    /**
+     * Get the scalar value of variant.
+     *
+     * @throws VariantTypeException If this variant is not a scalar value.
+     */
+    Object get() throws VariantTypeException;
+
+    /**
+     * Get the scalar value of variant.
+     *
+     * @throws VariantTypeException If this variant is not a scalar value.
+     */
+    <T> T getAs() throws VariantTypeException;
+
+    /**
+     * Access value of the specified element of an array variant. If index is out of range, null is
+     * returned.
+     *
+     * <p>NOTE: if the element value has been explicitly set as <code>null</code> (which is
+     * different from removal!), a variant that @{@link Variant#isNull()} returns true will be
+     * returned, not null.
+     *
+     * @throws VariantTypeException If this variant is not an array.
+     */
+    Variant getElement(int index) throws VariantTypeException;
+
+    /**
+     * Access value of the specified field of an object variant. If there is no field with the
+     * specified name, null is returned.
+     *
+     * <p>NOTE: if the property value has been explicitly set as <code>null</code>, a variant
+     * that @{@link Variant#isNull()} returns true will be returned, not null.
+     *
+     * @throws VariantTypeException If this variant is not an object.
+     */
+    Variant getField(String fieldName) throws VariantTypeException;
+
+    /** Parses the variant to json. */
+    String toJson();
+
+    /** The type of variant. */
+    @PublicEvolving
+    enum Type {
+        OBJECT,
+        ARRAY,
+        NULL,
+        BOOLEAN,
+        TINYINT,
+        SMALLINT,
+        INT,
+        BIGINT,
+        FLOAT,
+        DOUBLE,
+        DECIMAL,
+        STRING,
+        DATE,
+        TIMESTAMP,
+        TIMESTAMP_LTZ,
+        BYTES
+    }
+
+    static VariantBuilder newBuilder() {
+        return new BinaryVariantBuilder();
+    }
+}

--- a/flink-core/src/main/java/org/apache/flink/types/variant/VariantBuilder.java
+++ b/flink-core/src/main/java/org/apache/flink/types/variant/VariantBuilder.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.types.variant;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/** Builder for variants. */
+@PublicEvolving
+public interface VariantBuilder {
+
+    /** Create a variant from a byte. */
+    Variant of(byte b);
+
+    /** Create a variant from a short. */
+    Variant of(short s);
+
+    /** Create a variant from a int. */
+    Variant of(int i);
+
+    /** Create a variant from a long. */
+    Variant of(long l);
+
+    /** Create a variant from a string. */
+    Variant of(String s);
+
+    /** Create a variant from a double. */
+    Variant of(double d);
+
+    /** Create a variant from a float. */
+    Variant of(float f);
+
+    /** Create a variant from a byte array. */
+    Variant of(byte[] bytes);
+
+    /** Create a variant from a boolean. */
+    Variant of(boolean b);
+
+    /** Create a variant from a BigDecimal. */
+    Variant of(BigDecimal bigDecimal);
+
+    /** Create a variant from an Instant. */
+    Variant of(Instant instant);
+
+    /** Create a variant from a LocalDate. */
+    Variant of(LocalDate localDate);
+
+    /** Create a variant from a LocalDateTime. */
+    Variant of(LocalDateTime localDateTime);
+
+    /** Create a variant of null. */
+    Variant ofNull();
+
+    /** Get the builder of a variant object. */
+    VariantObjectBuilder object();
+
+    /** Get the builder of a variant object. */
+    VariantObjectBuilder object(boolean allowDuplicateKeys);
+
+    /** Get the builder for a variant array. */
+    VariantArrayBuilder array();
+
+    /** Builder for a variant object. */
+    @PublicEvolving
+    interface VariantObjectBuilder {
+
+        /** Add a field to the object. */
+        VariantObjectBuilder add(String key, Variant value);
+
+        /** Build the variant object. */
+        Variant build();
+    }
+
+    /** Builder for a variant array. */
+    @PublicEvolving
+    interface VariantArrayBuilder {
+
+        /** Add a value to the array. */
+        VariantArrayBuilder add(Variant value);
+
+        /** Build the variant array. */
+        Variant build();
+    }
+}

--- a/flink-core/src/main/java/org/apache/flink/types/variant/VariantTypeException.java
+++ b/flink-core/src/main/java/org/apache/flink/types/variant/VariantTypeException.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.types.variant;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/** Exception thrown when a variant value is not of the expected type. */
+@PublicEvolving
+public class VariantTypeException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    public VariantTypeException(String message) {
+        super(message);
+    }
+}

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeinfo/VariantTypeInfoTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeinfo/VariantTypeInfoTest.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.typeinfo;
+
+import org.apache.flink.api.common.typeutils.TypeInformationTestBase;
+
+/** Test for {@link VariantTypeInfo}. */
+class VariantTypeInfoTest extends TypeInformationTestBase<VariantTypeInfo> {
+
+    @Override
+    protected VariantTypeInfo[] getTestData() {
+        return new VariantTypeInfo[] {VariantTypeInfo.INSTANCE};
+    }
+}

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/VariantSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/VariantSerializerTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.typeutils.base;
+
+import org.apache.flink.api.common.typeutils.SerializerTestBase;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.types.variant.Variant;
+import org.apache.flink.types.variant.VariantBuilder;
+
+class VariantSerializerTest extends SerializerTestBase<Variant> {
+
+    @Override
+    protected TypeSerializer<Variant> createSerializer() {
+        return VariantSerializer.INSTANCE;
+    }
+
+    @Override
+    protected int getLength() {
+        return -1;
+    }
+
+    @Override
+    protected Class<Variant> getTypeClass() {
+        return Variant.class;
+    }
+
+    @Override
+    protected Variant[] getTestData() {
+        VariantBuilder builder = Variant.newBuilder();
+        return new Variant[] {
+            builder.of(1),
+            builder.object()
+                    .add("k", builder.of(1))
+                    .add("object", builder.object().add("k", builder.of("hello")).build())
+                    .add(
+                            "array",
+                            builder.array()
+                                    .add(builder.of(1))
+                                    .add(builder.of(2))
+                                    .add(builder.object().add("kk", builder.of(1.123f)).build())
+                                    .build())
+                    .build(),
+            builder.array()
+                    .add(builder.object().add("k", builder.of(1)).build())
+                    .add(builder.of("hello"))
+                    .add(builder.object().add("k", builder.of(2)).build())
+                    .build()
+        };
+    }
+}

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/VariantSerializerUpgradeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/VariantSerializerUpgradeTest.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.typeutils.base;
+
+import org.apache.flink.FlinkVersion;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerConditions;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
+import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
+import org.apache.flink.api.common.typeutils.base.VariantSerializer.VariantSerializerSnapshot;
+import org.apache.flink.test.util.MigrationTest;
+import org.apache.flink.types.variant.Variant;
+import org.apache.flink.types.variant.VariantBuilder;
+
+import org.assertj.core.api.Condition;
+import org.junit.jupiter.api.Disabled;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * A {@link TypeSerializerUpgradeTestBase} for {@link VariantSerializerSnapshot}. The test is
+ * disabled because Variant is introduced in Flink 2.1. We should restore the test when there is a
+ * Flink 2.2 which should test compatibility with Flink 2.1
+ */
+@Disabled("FLINK-37951")
+class VariantSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Variant, Variant> {
+
+    private static final String SPEC_NAME = "variant-serializer";
+
+    @Override
+    public Collection<TestSpecification<?, ?>> createTestSpecifications(FlinkVersion currentVersion)
+            throws Exception {
+        ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
+        testSpecifications.add(
+                new TestSpecification<>(
+                        SPEC_NAME,
+                        currentVersion,
+                        VariantSerializerSetup.class,
+                        VariantSerializerVerifier.class));
+
+        return testSpecifications;
+    }
+
+    @Override
+    public Collection<FlinkVersion> getMigrationVersions() {
+        return FlinkVersion.rangeOf(
+                FlinkVersion.v2_1, MigrationTest.getMostRecentlyPublishedVersion());
+    }
+
+    // ----------------------------------------------------------------------------------------------
+    //  Specification for "variant-serializer"
+    // ----------------------------------------------------------------------------------------------
+
+    /**
+     * This class is only public to work with {@link
+     * org.apache.flink.api.common.typeutils.ClassRelocator}.
+     */
+    public static final class VariantSerializerSetup implements PreUpgradeSetup<Variant> {
+        @Override
+        public TypeSerializer<Variant> createPriorSerializer() {
+            return VariantSerializer.INSTANCE;
+        }
+
+        @Override
+        public Variant createTestData() {
+            VariantBuilder builder = Variant.newBuilder();
+            return builder.object()
+                    .add("k", builder.of(1))
+                    .add("object", builder.object().add("k", builder.of("hello")).build())
+                    .add(
+                            "array",
+                            builder.array()
+                                    .add(builder.of(1))
+                                    .add(builder.of(2))
+                                    .add(builder.object().add("kk", builder.of(1.123f)).build())
+                                    .build())
+                    .build();
+        }
+    }
+
+    /**
+     * This class is only public to work with {@link
+     * org.apache.flink.api.common.typeutils.ClassRelocator}.
+     */
+    public static final class VariantSerializerVerifier implements UpgradeVerifier<Variant> {
+        @Override
+        public TypeSerializer<Variant> createUpgradedSerializer() {
+            return VariantSerializer.INSTANCE;
+        }
+
+        @Override
+        public Condition<Variant> testDataCondition() {
+            VariantBuilder builder = Variant.newBuilder();
+            Variant data =
+                    builder.object()
+                            .add("k", builder.of(1))
+                            .add("object", builder.object().add("k", builder.of("hello")).build())
+                            .add(
+                                    "array",
+                                    builder.array()
+                                            .add(builder.of(1))
+                                            .add(builder.of(2))
+                                            .add(
+                                                    builder.object()
+                                                            .add("kk", builder.of(1.123f))
+                                                            .build())
+                                            .build())
+                            .build();
+            return new Condition<>(data::equals, "value is " + data);
+        }
+
+        @Override
+        public Condition<TypeSerializerSchemaCompatibility<Variant>> schemaCompatibilityCondition(
+                FlinkVersion version) {
+            return TypeSerializerConditions.isCompatibleAsIs();
+        }
+    }
+}

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/TypeExtractorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/TypeExtractorTest.java
@@ -38,6 +38,7 @@ import org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeHint;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.common.typeinfo.VariantTypeInfo;
 import org.apache.flink.api.common.typeutils.CompositeType.FlatFieldDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
@@ -53,6 +54,8 @@ import org.apache.flink.types.IntValue;
 import org.apache.flink.types.Row;
 import org.apache.flink.types.StringValue;
 import org.apache.flink.types.Value;
+import org.apache.flink.types.variant.BinaryVariant;
+import org.apache.flink.types.variant.Variant;
 import org.apache.flink.util.Collector;
 
 import org.junit.jupiter.api.Test;
@@ -2103,6 +2106,13 @@ public class TypeExtractorTest {
                 TypeExtractor.getMapReturnTypes((MapFunction) mf, new EnumTypeInfo(MyEnum.class));
         assertThat(ti).isInstanceOf(EnumTypeInfo.class);
         assertThat(ti.getTypeClass()).isEqualTo(MyEnum.class);
+    }
+
+    @Test
+    void testVariantType() {
+        assertThat(TypeExtractor.createTypeInfo(Variant.class)).isEqualTo(VariantTypeInfo.INSTANCE);
+        assertThat(TypeExtractor.createTypeInfo(BinaryVariant.class))
+                .isEqualTo(VariantTypeInfo.INSTANCE);
     }
 
     public static class MapperWithMultiDimGenericArray<T>

--- a/flink-core/src/test/java/org/apache/flink/types/variant/BinaryVariantInternalBuilderTest.java
+++ b/flink-core/src/test/java/org/apache/flink/types/variant/BinaryVariantInternalBuilderTest.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.types.variant;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class BinaryVariantInternalBuilderTest {
+
+    @Test
+    void testParseScalarJson() throws IOException {
+        assertThat(BinaryVariantInternalBuilder.parseJson("1", false).getByte())
+                .isEqualTo((byte) 1);
+        short s = (short) (Byte.MAX_VALUE + 1L);
+        assertThat(BinaryVariantInternalBuilder.parseJson(String.valueOf(s), false).getShort())
+                .isEqualTo(s);
+        int i = (int) (Short.MAX_VALUE + 1L);
+        assertThat(BinaryVariantInternalBuilder.parseJson(String.valueOf(i), false).getInt())
+                .isEqualTo(i);
+        long l = Integer.MAX_VALUE + 1L;
+        assertThat(BinaryVariantInternalBuilder.parseJson(String.valueOf(l), false).getLong())
+                .isEqualTo(l);
+
+        BigDecimal bigDecimal = BigDecimal.valueOf(Long.MAX_VALUE).add(BigDecimal.ONE);
+        assertThat(
+                        BinaryVariantInternalBuilder.parseJson(bigDecimal.toPlainString(), false)
+                                .getDecimal())
+                .isEqualTo(bigDecimal);
+
+        assertThat(BinaryVariantInternalBuilder.parseJson("1.123", false).getDecimal())
+                .isEqualTo(BigDecimal.valueOf(1.123));
+        assertThat(
+                        BinaryVariantInternalBuilder.parseJson(
+                                        String.valueOf(Double.MAX_VALUE), false)
+                                .getDouble())
+                .isEqualTo(Double.MAX_VALUE);
+
+        assertThat(BinaryVariantInternalBuilder.parseJson("\"hello\"", false).getString())
+                .isEqualTo("hello");
+
+        assertThat(BinaryVariantInternalBuilder.parseJson("true", false).getBoolean()).isTrue();
+
+        assertThat(BinaryVariantInternalBuilder.parseJson("false", false).getBoolean()).isFalse();
+
+        assertThat(BinaryVariantInternalBuilder.parseJson("null", false).isNull()).isTrue();
+    }
+
+    @Test
+    void testParseJsonArray() throws IOException {
+        BinaryVariant variant = BinaryVariantInternalBuilder.parseJson("[]", false);
+        assertThat(variant.getElement(0)).isNull();
+
+        variant = BinaryVariantInternalBuilder.parseJson("[1,\"hello\",3.1, null]", false);
+        assertThat(variant.getElement(0).getByte()).isEqualTo((byte) 1);
+        assertThat(variant.getElement(1).getString()).isEqualTo("hello");
+        assertThat(variant.getElement(2).getDecimal()).isEqualTo(BigDecimal.valueOf(3.1));
+        assertThat(variant.getElement(3).isNull()).isTrue();
+
+        variant = BinaryVariantInternalBuilder.parseJson("[1,[\"hello\",[3.1]]]", false);
+        assertThat(variant.getElement(0).getByte()).isEqualTo((byte) 1);
+        assertThat(variant.getElement(1).getElement(0).getString()).isEqualTo("hello");
+        assertThat(variant.getElement(1).getElement(1).getElement(0).getDecimal())
+                .isEqualTo(BigDecimal.valueOf(3.1));
+    }
+
+    @Test
+    void testParseJsonObject() throws IOException {
+        BinaryVariant variant = BinaryVariantInternalBuilder.parseJson("{}", false);
+        assertThat(variant.getField("a")).isNull();
+
+        variant =
+                BinaryVariantInternalBuilder.parseJson(
+                        "{\"a\":1,\"b\":\"hello\",\"c\":3.1}", false);
+
+        assertThat(variant.getField("a").getByte()).isEqualTo((byte) 1);
+        assertThat(variant.getField("b").getString()).isEqualTo("hello");
+        assertThat(variant.getField("c").getDecimal()).isEqualTo(BigDecimal.valueOf(3.1));
+
+        variant =
+                BinaryVariantInternalBuilder.parseJson(
+                        "{\"a\":1,\"b\":{\"c\":\"hello\",\"d\":[3.1]}}", false);
+        assertThat(variant.getField("a").getByte()).isEqualTo((byte) 1);
+        assertThat(variant.getField("b").getField("c").getString()).isEqualTo("hello");
+        assertThat(variant.getField("b").getField("d").getElement(0).getDecimal())
+                .isEqualTo(BigDecimal.valueOf(3.1));
+
+        assertThatThrownBy(
+                        () ->
+                                BinaryVariantInternalBuilder.parseJson(
+                                        "{\"k1\":1,\"k1\":2,\"k2\":1.5}", false))
+                .isInstanceOf(VariantTypeException.class)
+                .hasMessage("VARIANT_DUPLICATE_KEY");
+
+        variant = BinaryVariantInternalBuilder.parseJson("{\"k1\":1,\"k1\":2,\"k2\":1.5}", true);
+        assertThat(variant.getField("k1").getByte()).isEqualTo((byte) 2);
+        assertThat(variant.getField("k2").getDecimal()).isEqualTo(BigDecimal.valueOf(1.5));
+    }
+}

--- a/flink-core/src/test/java/org/apache/flink/types/variant/BinaryVariantTest.java
+++ b/flink-core/src/test/java/org/apache/flink/types/variant/BinaryVariantTest.java
@@ -1,0 +1,265 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.types.variant;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class BinaryVariantTest {
+
+    private BinaryVariantBuilder builder;
+
+    @BeforeEach
+    void setUp() {
+        builder = new BinaryVariantBuilder();
+    }
+
+    @Test
+    void testScalarVariant() {
+
+        assertThat(builder.of((byte) 10).isPrimitive()).isTrue();
+        assertThat(builder.of((byte) 10).isNull()).isFalse();
+        assertThat(builder.of((byte) 10).isArray()).isFalse();
+        assertThat(builder.of((byte) 10).isObject()).isFalse();
+        assertThat(builder.of((byte) 10).getType()).isEqualTo(Variant.Type.TINYINT);
+
+        assertThat(builder.of((byte) 10).getByte()).isEqualTo((byte) 10);
+        assertThat(builder.of((byte) 10).get()).isEqualTo((byte) 10);
+        assertThat((byte) builder.of((byte) 10).getAs()).isEqualTo((byte) 10);
+
+        assertThat(builder.of((short) 10).getShort()).isEqualTo((short) 10);
+        assertThat(builder.of((short) 10).get()).isEqualTo((short) 10);
+
+        assertThat(builder.of(10).getInt()).isEqualTo(10);
+        assertThat(builder.of(10).get()).isEqualTo(10);
+
+        assertThat(builder.of(10L).getLong()).isEqualTo(10L);
+        assertThat(builder.of(10L).get()).isEqualTo(10L);
+
+        assertThat(builder.of(10.0).getDouble()).isEqualTo(10.0d);
+        assertThat(builder.of(10.0).get()).isEqualTo(10.0d);
+
+        assertThat(builder.of(10.0f).getFloat()).isEqualTo(10.0f);
+        assertThat(builder.of(10.0f).get()).isEqualTo(10.0f);
+
+        assertThat(builder.of("hello").getString()).isEqualTo("hello");
+        assertThat(builder.of("hello").get()).isEqualTo("hello");
+
+        assertThat(builder.of("hello".getBytes()).getBytes()).isEqualTo("hello".getBytes());
+        assertThat(builder.of("hello".getBytes()).get()).isEqualTo("hello".getBytes());
+
+        assertThat(builder.of(true).getBoolean()).isTrue();
+        assertThat(builder.of(true).get()).isEqualTo(true);
+
+        assertThat(builder.of(BigDecimal.valueOf(100)).getDecimal())
+                .isEqualByComparingTo(BigDecimal.valueOf(100));
+        assertThat((BigDecimal) builder.of(BigDecimal.valueOf(100)).get())
+                .isEqualByComparingTo(BigDecimal.valueOf(100));
+
+        Instant instant = Instant.now().truncatedTo(ChronoUnit.MICROS);
+        assertThat(builder.of(instant).getInstant()).isEqualTo(instant);
+        assertThat(builder.of(instant).get()).isEqualTo(instant);
+
+        LocalDateTime localDateTime = LocalDateTime.now().truncatedTo(ChronoUnit.MICROS);
+        assertThat(builder.of(localDateTime).getDateTime()).isEqualTo(localDateTime);
+        assertThat(builder.of(localDateTime).get()).isEqualTo(localDateTime);
+
+        LocalDate localDate = LocalDate.now();
+        assertThat(builder.of(localDate).getDate()).isEqualTo(localDate);
+        assertThat(builder.of(localDate).get()).isEqualTo(localDate);
+
+        assertThat(builder.ofNull().get()).isEqualTo(null);
+        assertThat(builder.ofNull().isNull()).isTrue();
+    }
+
+    @Test
+    void testArrayVariant() {
+        Instant now = Instant.now().truncatedTo(ChronoUnit.MICROS);
+        Variant variant =
+                builder.array()
+                        .add(builder.of(1))
+                        .add(builder.of("hello"))
+                        .add(builder.of(now))
+                        .add(builder.array().add(builder.of("hello2")).add(builder.of(10f)).build())
+                        .add(builder.ofNull())
+                        .build();
+
+        assertThat(variant.isArray()).isTrue();
+        assertThat(variant.isPrimitive()).isFalse();
+        assertThat(variant.isObject()).isFalse();
+        assertThat(variant.getType()).isEqualTo(Variant.Type.ARRAY);
+
+        assertThat(variant.getElement(-1)).isNull();
+        assertThat(variant.getElement(0).getInt()).isEqualTo(1);
+        assertThat(variant.getElement(1).getString()).isEqualTo("hello");
+        assertThat(variant.getElement(2).getInstant()).isEqualTo(now);
+        assertThat(variant.getElement(3).getElement(0).getString()).isEqualTo("hello2");
+        assertThat(variant.getElement(3).getElement(1).getFloat()).isEqualTo(10f);
+        assertThat(variant.getElement(4).isNull()).isTrue();
+        assertThat(variant.getElement(5)).isNull();
+    }
+
+    @Test
+    void testObjectVariant() {
+        Variant variant =
+                builder.object()
+                        .add(
+                                "list",
+                                builder.array().add(builder.of("hello")).add(builder.of(1)).build())
+                        .add(
+                                "object",
+                                builder.object()
+                                        .add("ss", builder.of((short) 1))
+                                        .add("ff", builder.of(10.0f))
+                                        .build())
+                        .add("bb", builder.of((byte) 10))
+                        .build();
+
+        assertThat(variant.isArray()).isFalse();
+        assertThat(variant.isPrimitive()).isFalse();
+        assertThat(variant.isObject()).isTrue();
+        assertThat(variant.getType()).isEqualTo(Variant.Type.OBJECT);
+
+        assertThat(variant.getField("list").isArray()).isTrue();
+        assertThat(variant.getField("list").getElement(0).getString()).isEqualTo("hello");
+        assertThat(variant.getField("list").getElement(1).getInt()).isEqualTo(1);
+
+        assertThat(variant.getField("object").isObject()).isTrue();
+        assertThat(variant.getField("object").getField("ss").getShort()).isEqualTo((short) 1);
+        assertThat(variant.getField("object").getField("ff").getFloat()).isEqualTo((10.0f));
+
+        assertThat(variant.getField("bb").getByte()).isEqualTo((byte) 10);
+        assertThat(variant.getField("non_exist")).isNull();
+
+        BinaryVariantBuilder.VariantObjectBuilder objectBuilder = builder.object();
+
+        for (int i = 0; i < 100; i++) {
+            objectBuilder.add(String.valueOf(i), builder.of(i));
+        }
+        variant = objectBuilder.build();
+        for (int i = 0; i < 100; i++) {
+            assertThat(variant.getField(String.valueOf(i)).getInt()).isEqualTo(i);
+        }
+    }
+
+    @Test
+    void testDuplicatedKeyObjectVariant() {
+        assertThatThrownBy(
+                        () ->
+                                builder.object(false)
+                                        .add("k", builder.of((byte) 10))
+                                        .add("k", builder.of("hello"))
+                                        .build())
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("VARIANT_DUPLICATE_KEY");
+
+        Variant variant =
+                builder.object(true)
+                        .add("k", builder.of((byte) 10))
+                        .add("k", builder.of("hello"))
+                        .add("k1", builder.of(10))
+                        .build();
+
+        assertThat(variant.getField("k").getString()).isEqualTo("hello");
+        assertThat(variant.getField("k1").getInt()).isEqualTo(10);
+    }
+
+    @Test
+    void testToJsonScalar() {
+        Instant instant = Instant.EPOCH;
+        LocalDateTime localDateTime = LocalDateTime.of(2000, 1, 1, 0, 0);
+        LocalDate localDate = LocalDate.of(2000, 1, 1);
+
+        assertThat(builder.of((byte) 1).toJson()).isEqualTo("1");
+        assertThat(builder.of((short) 1).toJson()).isEqualTo("1");
+        assertThat(builder.of(1L).toJson()).isEqualTo("1");
+        assertThat(builder.of(1).toJson()).isEqualTo("1");
+        assertThat(builder.of("hello").toJson()).isEqualTo("\"hello\"");
+        assertThat(builder.of(true).toJson()).isEqualTo("true");
+        assertThat(builder.of(10.0f).toJson()).isEqualTo("10.0");
+        assertThat(builder.of(10.0d).toJson()).isEqualTo("10.0");
+        assertThat(builder.of(BigDecimal.valueOf(100)).toJson()).isEqualTo("100");
+        assertThat(builder.of(instant).toJson()).isEqualTo("\"1970-01-01T00:00:00+00:00\"");
+        assertThat(builder.of(localDateTime).toJson()).isEqualTo("\"2000-01-01T00:00:00\"");
+        assertThat(builder.of(localDate).toJson()).isEqualTo("\"2000-01-01\"");
+        assertThat(builder.of("hello".getBytes()).toJson()).isEqualTo("\"aGVsbG8=\"");
+        assertThat(builder.ofNull().toJson()).isEqualTo("null");
+    }
+
+    @Test
+    void testToJsonNested() {
+        Variant variant =
+                builder.object()
+                        .add(
+                                "list",
+                                builder.array().add(builder.of("hello")).add(builder.of(1)).build())
+                        .add(
+                                "object",
+                                builder.object()
+                                        .add("ss", builder.of((short) 1))
+                                        .add("ff", builder.of(10.0f))
+                                        .build())
+                        .build();
+
+        String json = variant.toJson();
+        assertThat(json)
+                .isEqualTo("{" + "\"list\":[\"hello\",1]," + "\"object\":{\"ff\":10.0,\"ss\":1}}");
+    }
+
+    @Test
+    void testVariantException() {
+        assertThatThrownBy(() -> new BinaryVariant(new byte[0], new byte[0]))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("MALFORMED_VARIANT");
+
+        byte[] meta = new byte[1];
+        meta[0] = (byte) 0x02;
+        assertThatThrownBy(() -> new BinaryVariant(new byte[1], meta))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("MALFORMED_VARIANT");
+
+        byte[] oversize = new byte[0xFFFFFF + 2];
+        meta[0] = (byte) 0x01;
+        oversize[0] = (byte) 0x01;
+        assertThatThrownBy(() -> new BinaryVariant(oversize, meta))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("VARIANT_CONSTRUCTOR_SIZE_LIMIT");
+
+        assertThatThrownBy(() -> new BinaryVariant(new byte[1], oversize))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("VARIANT_CONSTRUCTOR_SIZE_LIMIT");
+    }
+
+    @Test
+    void testGetThrowException() {
+        Variant variant = builder.of(10f);
+        assertThatThrownBy(variant::getDouble)
+                .isInstanceOf(VariantTypeException.class)
+                .hasMessage("Expected type DOUBLE but got FLOAT");
+    }
+}

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/serde/LogicalTypeJsonDeserializer.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/serde/LogicalTypeJsonDeserializer.java
@@ -47,6 +47,7 @@ import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.table.types.logical.VariantType;
 import org.apache.flink.table.types.logical.YearMonthIntervalType;
 import org.apache.flink.table.types.logical.ZonedTimestampType;
 
@@ -159,6 +160,8 @@ public final class LogicalTypeJsonDeserializer extends StdDeserializer<LogicalTy
                 return deserializeRow(logicalTypeNode).copy(isNullable);
             case RAW:
                 return deserializeRaw(logicalTypeNode).copy(isNullable);
+            case VARIANT:
+                return new VariantType(isNullable);
             default:
                 throw new UnsupportedOperationException(
                         String.format(

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/serde/LogicalTypeJsonSerializer.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/serde/LogicalTypeJsonSerializer.java
@@ -128,6 +128,7 @@ public final class LogicalTypeJsonSerializer extends StdSerializer<LogicalType> 
             case FLOAT:
             case DOUBLE:
             case DATE:
+            case VARIANT:
                 break;
             case CHAR:
                 jsonGenerator.writeNumberField(

--- a/flink-table/flink-sql-parser/src/main/codegen/templates/Parser.jj
+++ b/flink-table/flink-sql-parser/src/main/codegen/templates/Parser.jj
@@ -5680,6 +5680,8 @@ SqlTypeNameSpec SqlTypeName1(Span s) :
         [ <PRECISION> ] { sqlTypeName = SqlTypeName.DOUBLE; }
     |
         <FLOAT> { s.add(this); sqlTypeName = SqlTypeName.FLOAT; }
+    |
+        <VARIANT> { s.add(this); sqlTypeName = SqlTypeName.VARIANT; }
     )
     {
         return new SqlBasicTypeNameSpec(sqlTypeName, s.end(this));
@@ -8369,6 +8371,7 @@ SqlPostfixOperator PostfixRowOperator() :
 |   < VAR_SAMP: "VAR_SAMP" >
 |   < VARBINARY: "VARBINARY" >
 |   < VARCHAR: "VARCHAR" >
+|   < VARIANT: "VARIANT" >
 |   < VARYING: "VARYING" >
 |   < VERSION: "VERSION" >
 |   < VERSIONING: "VERSIONING" >

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/calcite/sql/type/SqlTypeFamily.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/calcite/sql/type/SqlTypeFamily.java
@@ -1,0 +1,280 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.type;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.calcite.avatica.util.TimeUnit;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeFamily;
+import org.apache.calcite.sql.SqlIntervalQualifier;
+import org.apache.calcite.sql.SqlWindow;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.sql.Types;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * SqlTypeFamily provides SQL type categorization.
+ *
+ * <p>The <em>primary</em> family categorization is a complete disjoint partitioning of SQL types
+ * into families, where two types are members of the same primary family iff instances of the two
+ * types can be the operands of an SQL equality predicate such as <code>WHERE v1 = v2</code>.
+ * Primary families are returned by RelDataType.getFamily().
+ *
+ * <p>There is also a <em>secondary</em> family categorization which overlaps with the primary
+ * categorization. It is used in type strategies for more specific or more general categorization
+ * than the primary families. Secondary families are never returned by RelDataType.getFamily().
+ *
+ * <p>This class was copied over from Calcite to support variant type(CALCITE-4918). When upgrading
+ * to Calcite 1.39.0 version, please remove the entire class.
+ */
+public enum SqlTypeFamily implements RelDataTypeFamily {
+    // Primary families.
+    CHARACTER,
+    BINARY,
+    NUMERIC,
+    DATE,
+    TIME,
+    TIMESTAMP,
+    BOOLEAN,
+    INTERVAL_YEAR_MONTH,
+    INTERVAL_DAY_TIME,
+
+    // Secondary families.
+
+    STRING,
+    APPROXIMATE_NUMERIC,
+    EXACT_NUMERIC,
+    DECIMAL,
+    INTEGER,
+    DATETIME,
+    DATETIME_INTERVAL,
+    MULTISET,
+    ARRAY,
+    MAP,
+    NULL,
+    ANY,
+    CURSOR,
+    COLUMN_LIST,
+    GEO,
+    VARIANT,
+    /** Like ANY, but do not even validate the operand. It may not be an expression. */
+    IGNORE;
+
+    private static final Map<Integer, SqlTypeFamily> JDBC_TYPE_TO_FAMILY =
+            ImmutableMap.<Integer, SqlTypeFamily>builder()
+                    // Not present:
+                    // SqlTypeName.MULTISET shares Types.ARRAY with SqlTypeName.ARRAY;
+                    // SqlTypeName.MAP has no corresponding JDBC type
+                    // SqlTypeName.COLUMN_LIST has no corresponding JDBC type
+                    .put(Types.BIT, NUMERIC)
+                    .put(Types.TINYINT, NUMERIC)
+                    .put(Types.SMALLINT, NUMERIC)
+                    .put(Types.BIGINT, NUMERIC)
+                    .put(Types.INTEGER, NUMERIC)
+                    .put(Types.NUMERIC, NUMERIC)
+                    .put(Types.DECIMAL, NUMERIC)
+                    .put(Types.FLOAT, NUMERIC)
+                    .put(Types.REAL, NUMERIC)
+                    .put(Types.DOUBLE, NUMERIC)
+                    .put(Types.CHAR, CHARACTER)
+                    .put(Types.VARCHAR, CHARACTER)
+                    .put(Types.LONGVARCHAR, CHARACTER)
+                    .put(Types.CLOB, CHARACTER)
+                    .put(Types.BINARY, BINARY)
+                    .put(Types.VARBINARY, BINARY)
+                    .put(Types.LONGVARBINARY, BINARY)
+                    .put(Types.BLOB, BINARY)
+                    .put(Types.DATE, DATE)
+                    .put(Types.TIME, TIME)
+                    .put(ExtraSqlTypes.TIME_WITH_TIMEZONE, TIME)
+                    .put(Types.TIMESTAMP, TIMESTAMP)
+                    .put(ExtraSqlTypes.TIMESTAMP_WITH_TIMEZONE, TIMESTAMP)
+                    .put(Types.BOOLEAN, BOOLEAN)
+                    .put(ExtraSqlTypes.REF_CURSOR, CURSOR)
+                    .put(Types.ARRAY, ARRAY)
+                    .put(Types.JAVA_OBJECT, VARIANT)
+                    .build();
+
+    /**
+     * Gets the primary family containing a JDBC type.
+     *
+     * @param jdbcType the JDBC type of interest
+     * @return containing family
+     */
+    public static @Nullable SqlTypeFamily getFamilyForJdbcType(int jdbcType) {
+        return JDBC_TYPE_TO_FAMILY.get(jdbcType);
+    }
+
+    /**
+     * For this type family, returns the allow types of the difference between two values of this
+     * family.
+     *
+     * <p>Equivalently, given an {@code ORDER BY} expression with one key, returns the allowable
+     * type families of the difference between two keys.
+     *
+     * <p>Example 1. For {@code ORDER BY empno}, a NUMERIC, the difference between two {@code empno}
+     * values is also NUMERIC.
+     *
+     * <p>Example 2. For {@code ORDER BY hireDate}, a DATE, the difference between two {@code
+     * hireDate} values might be an INTERVAL_DAY_TIME or INTERVAL_YEAR_MONTH.
+     *
+     * <p>The result determines whether a {@link SqlWindow} with a {@code RANGE} is valid (for
+     * example, {@code OVER (ORDER BY empno RANGE 10} is valid because {@code 10} is numeric); and
+     * whether a call to {@link org.apache.calcite.sql.fun.SqlStdOperatorTable#PERCENTILE_CONT
+     * PERCENTILE_CONT} is valid (for example, {@code PERCENTILE_CONT(0.25)} ORDER BY (hireDate)} is
+     * valid because {@code hireDate} values may be interpolated by adding values of type {@code
+     * INTERVAL_DAY_TIME}.
+     */
+    public List<SqlTypeFamily> allowableDifferenceTypes() {
+        switch (this) {
+            case NUMERIC:
+                return ImmutableList.of(NUMERIC);
+            case DATE:
+            case TIME:
+            case TIMESTAMP:
+                return ImmutableList.of(INTERVAL_DAY_TIME, INTERVAL_YEAR_MONTH);
+            default:
+                return ImmutableList.of();
+        }
+    }
+
+    /** Returns the collection of {@link SqlTypeName}s included in this family. */
+    public Collection<SqlTypeName> getTypeNames() {
+        switch (this) {
+            case CHARACTER:
+                return SqlTypeName.CHAR_TYPES;
+            case BINARY:
+                return SqlTypeName.BINARY_TYPES;
+            case NUMERIC:
+                return SqlTypeName.NUMERIC_TYPES;
+            case DECIMAL:
+                return ImmutableList.of(SqlTypeName.DECIMAL);
+            case DATE:
+                return ImmutableList.of(SqlTypeName.DATE);
+            case TIME:
+                return ImmutableList.of(SqlTypeName.TIME, SqlTypeName.TIME_WITH_LOCAL_TIME_ZONE);
+            case TIMESTAMP:
+                return ImmutableList.of(
+                        SqlTypeName.TIMESTAMP, SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE);
+            case BOOLEAN:
+                return SqlTypeName.BOOLEAN_TYPES;
+            case INTERVAL_YEAR_MONTH:
+                return SqlTypeName.YEAR_INTERVAL_TYPES;
+            case INTERVAL_DAY_TIME:
+                return SqlTypeName.DAY_INTERVAL_TYPES;
+            case STRING:
+                return SqlTypeName.STRING_TYPES;
+            case APPROXIMATE_NUMERIC:
+                return SqlTypeName.APPROX_TYPES;
+            case EXACT_NUMERIC:
+                return SqlTypeName.EXACT_TYPES;
+            case INTEGER:
+                return SqlTypeName.INT_TYPES;
+            case DATETIME:
+                return SqlTypeName.DATETIME_TYPES;
+            case DATETIME_INTERVAL:
+                return SqlTypeName.INTERVAL_TYPES;
+            case GEO:
+                return SqlTypeName.GEOMETRY_TYPES;
+            case MULTISET:
+                return ImmutableList.of(SqlTypeName.MULTISET);
+            case ARRAY:
+                return ImmutableList.of(SqlTypeName.ARRAY);
+            case MAP:
+                return ImmutableList.of(SqlTypeName.MAP);
+            case NULL:
+                return ImmutableList.of(SqlTypeName.NULL);
+            case ANY:
+                return SqlTypeName.ALL_TYPES;
+            case CURSOR:
+                return ImmutableList.of(SqlTypeName.CURSOR);
+            case COLUMN_LIST:
+                return ImmutableList.of(SqlTypeName.COLUMN_LIST);
+            case VARIANT:
+                return ImmutableList.of(SqlTypeName.VARIANT);
+            default:
+                throw new IllegalArgumentException();
+        }
+    }
+
+    /** Return the default {@link RelDataType} that belongs to this family. */
+    public @Nullable RelDataType getDefaultConcreteType(RelDataTypeFactory factory) {
+        switch (this) {
+            case CHARACTER:
+                return factory.createSqlType(SqlTypeName.VARCHAR);
+            case BINARY:
+                return factory.createSqlType(SqlTypeName.VARBINARY);
+            case NUMERIC:
+                return SqlTypeUtil.getMaxPrecisionScaleDecimal(factory);
+            case DATE:
+                return factory.createSqlType(SqlTypeName.DATE);
+            case TIME:
+                return factory.createSqlType(SqlTypeName.TIME);
+            case TIMESTAMP:
+                return factory.createSqlType(SqlTypeName.TIMESTAMP);
+            case BOOLEAN:
+                return factory.createSqlType(SqlTypeName.BOOLEAN);
+            case STRING:
+                return factory.createSqlType(SqlTypeName.VARCHAR);
+            case APPROXIMATE_NUMERIC:
+                return factory.createSqlType(SqlTypeName.DOUBLE);
+            case EXACT_NUMERIC:
+                return SqlTypeUtil.getMaxPrecisionScaleDecimal(factory);
+            case INTEGER:
+                return factory.createSqlType(SqlTypeName.BIGINT);
+            case DECIMAL:
+                return factory.createSqlType(SqlTypeName.DECIMAL);
+            case DATETIME:
+                return factory.createSqlType(SqlTypeName.TIMESTAMP);
+            case INTERVAL_DAY_TIME:
+                return factory.createSqlIntervalType(
+                        new SqlIntervalQualifier(TimeUnit.DAY, TimeUnit.SECOND, SqlParserPos.ZERO));
+            case INTERVAL_YEAR_MONTH:
+                return factory.createSqlIntervalType(
+                        new SqlIntervalQualifier(TimeUnit.YEAR, TimeUnit.MONTH, SqlParserPos.ZERO));
+            case GEO:
+                return factory.createSqlType(SqlTypeName.GEOMETRY);
+            case MULTISET:
+                return factory.createMultisetType(factory.createSqlType(SqlTypeName.ANY), -1);
+            case ARRAY:
+                return factory.createArrayType(factory.createSqlType(SqlTypeName.ANY), -1);
+            case MAP:
+                return factory.createMapType(
+                        factory.createSqlType(SqlTypeName.ANY),
+                        factory.createSqlType(SqlTypeName.ANY));
+            case NULL:
+                return factory.createSqlType(SqlTypeName.NULL);
+            case CURSOR:
+                return factory.createSqlType(SqlTypeName.CURSOR);
+            case COLUMN_LIST:
+                return factory.createSqlType(SqlTypeName.COLUMN_LIST);
+            default:
+                return null;
+        }
+    }
+
+    public boolean contains(RelDataType type) {
+        return SqlTypeUtil.isOfSameTypeName(getTypeNames(), type);
+    }
+}

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/calcite/sql/type/SqlTypeName.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/calcite/sql/type/SqlTypeName.java
@@ -1,0 +1,1055 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.type;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
+import org.apache.calcite.avatica.util.TimeUnit;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.DateString;
+import org.apache.calcite.util.TimeString;
+import org.apache.calcite.util.TimestampString;
+import org.apache.calcite.util.Util;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.math.BigDecimal;
+import java.sql.Types;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Enumeration of the type names which can be used to construct a SQL type. Rationale for this
+ * class's existence (instead of just using the standard java.sql.Type ordinals):
+ *
+ * <ul>
+ *   <li>{@link Types} does not include all SQL2003 data-types;
+ *   <li>SqlTypeName provides a type-safe enumeration;
+ *   <li>SqlTypeName provides a place to hang extra information such as whether the type carries
+ *       precision and scale.
+ * </ul>
+ *
+ * <p>This class was copied over from Calcite to support variant type(CALCITE-4918). When upgrading
+ * to Calcite 1.39.0 version, please remove the entire class.
+ */
+public enum SqlTypeName {
+    BOOLEAN(PrecScale.NO_NO, false, Types.BOOLEAN, SqlTypeFamily.BOOLEAN),
+    TINYINT(PrecScale.NO_NO, false, Types.TINYINT, SqlTypeFamily.NUMERIC),
+    SMALLINT(PrecScale.NO_NO, false, Types.SMALLINT, SqlTypeFamily.NUMERIC),
+    INTEGER(PrecScale.NO_NO, false, Types.INTEGER, SqlTypeFamily.NUMERIC),
+    BIGINT(PrecScale.NO_NO, false, Types.BIGINT, SqlTypeFamily.NUMERIC),
+    DECIMAL(
+            PrecScale.NO_NO | PrecScale.YES_NO | PrecScale.YES_YES,
+            false,
+            Types.DECIMAL,
+            SqlTypeFamily.NUMERIC),
+    FLOAT(PrecScale.NO_NO, false, Types.FLOAT, SqlTypeFamily.NUMERIC),
+    REAL(PrecScale.NO_NO, false, Types.REAL, SqlTypeFamily.NUMERIC),
+    DOUBLE(PrecScale.NO_NO, false, Types.DOUBLE, SqlTypeFamily.NUMERIC),
+    DATE(PrecScale.NO_NO, false, Types.DATE, SqlTypeFamily.DATE),
+    TIME(PrecScale.NO_NO | PrecScale.YES_NO, false, Types.TIME, SqlTypeFamily.TIME),
+    TIME_WITH_LOCAL_TIME_ZONE(
+            PrecScale.NO_NO | PrecScale.YES_NO, false, Types.OTHER, SqlTypeFamily.TIME),
+    TIMESTAMP(PrecScale.NO_NO | PrecScale.YES_NO, false, Types.TIMESTAMP, SqlTypeFamily.TIMESTAMP),
+    TIMESTAMP_WITH_LOCAL_TIME_ZONE(
+            PrecScale.NO_NO | PrecScale.YES_NO, false, Types.TIMESTAMP, SqlTypeFamily.TIMESTAMP),
+    INTERVAL_YEAR(PrecScale.NO_NO, false, Types.OTHER, SqlTypeFamily.INTERVAL_YEAR_MONTH),
+    INTERVAL_YEAR_MONTH(PrecScale.NO_NO, false, Types.OTHER, SqlTypeFamily.INTERVAL_YEAR_MONTH),
+    INTERVAL_MONTH(PrecScale.NO_NO, false, Types.OTHER, SqlTypeFamily.INTERVAL_YEAR_MONTH),
+    INTERVAL_DAY(
+            PrecScale.NO_NO | PrecScale.YES_NO | PrecScale.YES_YES,
+            false,
+            Types.OTHER,
+            SqlTypeFamily.INTERVAL_DAY_TIME),
+    INTERVAL_DAY_HOUR(
+            PrecScale.NO_NO | PrecScale.YES_NO | PrecScale.YES_YES,
+            false,
+            Types.OTHER,
+            SqlTypeFamily.INTERVAL_DAY_TIME),
+    INTERVAL_DAY_MINUTE(
+            PrecScale.NO_NO | PrecScale.YES_NO | PrecScale.YES_YES,
+            false,
+            Types.OTHER,
+            SqlTypeFamily.INTERVAL_DAY_TIME),
+    INTERVAL_DAY_SECOND(
+            PrecScale.NO_NO | PrecScale.YES_NO | PrecScale.YES_YES,
+            false,
+            Types.OTHER,
+            SqlTypeFamily.INTERVAL_DAY_TIME),
+    INTERVAL_HOUR(
+            PrecScale.NO_NO | PrecScale.YES_NO | PrecScale.YES_YES,
+            false,
+            Types.OTHER,
+            SqlTypeFamily.INTERVAL_DAY_TIME),
+    INTERVAL_HOUR_MINUTE(
+            PrecScale.NO_NO | PrecScale.YES_NO | PrecScale.YES_YES,
+            false,
+            Types.OTHER,
+            SqlTypeFamily.INTERVAL_DAY_TIME),
+    INTERVAL_HOUR_SECOND(
+            PrecScale.NO_NO | PrecScale.YES_NO | PrecScale.YES_YES,
+            false,
+            Types.OTHER,
+            SqlTypeFamily.INTERVAL_DAY_TIME),
+    INTERVAL_MINUTE(
+            PrecScale.NO_NO | PrecScale.YES_NO | PrecScale.YES_YES,
+            false,
+            Types.OTHER,
+            SqlTypeFamily.INTERVAL_DAY_TIME),
+    INTERVAL_MINUTE_SECOND(
+            PrecScale.NO_NO | PrecScale.YES_NO | PrecScale.YES_YES,
+            false,
+            Types.OTHER,
+            SqlTypeFamily.INTERVAL_DAY_TIME),
+    INTERVAL_SECOND(
+            PrecScale.NO_NO | PrecScale.YES_NO | PrecScale.YES_YES,
+            false,
+            Types.OTHER,
+            SqlTypeFamily.INTERVAL_DAY_TIME),
+    CHAR(PrecScale.NO_NO | PrecScale.YES_NO, false, Types.CHAR, SqlTypeFamily.CHARACTER),
+    VARCHAR(PrecScale.NO_NO | PrecScale.YES_NO, false, Types.VARCHAR, SqlTypeFamily.CHARACTER),
+    BINARY(PrecScale.NO_NO | PrecScale.YES_NO, false, Types.BINARY, SqlTypeFamily.BINARY),
+    VARBINARY(PrecScale.NO_NO | PrecScale.YES_NO, false, Types.VARBINARY, SqlTypeFamily.BINARY),
+    NULL(PrecScale.NO_NO, true, Types.NULL, SqlTypeFamily.NULL),
+    UNKNOWN(PrecScale.NO_NO, true, Types.NULL, SqlTypeFamily.NULL),
+    ANY(
+            PrecScale.NO_NO | PrecScale.YES_NO | PrecScale.YES_YES,
+            true,
+            Types.JAVA_OBJECT,
+            SqlTypeFamily.ANY),
+    SYMBOL(PrecScale.NO_NO, true, Types.OTHER, null),
+    MULTISET(PrecScale.NO_NO, false, Types.ARRAY, SqlTypeFamily.MULTISET),
+    ARRAY(PrecScale.NO_NO, false, Types.ARRAY, SqlTypeFamily.ARRAY),
+    MAP(PrecScale.NO_NO, false, Types.OTHER, SqlTypeFamily.MAP),
+    DISTINCT(PrecScale.NO_NO, false, Types.DISTINCT, null),
+    STRUCTURED(PrecScale.NO_NO, false, Types.STRUCT, null),
+    ROW(PrecScale.NO_NO, false, Types.STRUCT, null),
+    OTHER(PrecScale.NO_NO, false, Types.OTHER, null),
+    CURSOR(PrecScale.NO_NO, false, ExtraSqlTypes.REF_CURSOR, SqlTypeFamily.CURSOR),
+    COLUMN_LIST(PrecScale.NO_NO, false, Types.OTHER + 2, SqlTypeFamily.COLUMN_LIST),
+    DYNAMIC_STAR(
+            PrecScale.NO_NO | PrecScale.YES_NO | PrecScale.YES_YES,
+            true,
+            Types.JAVA_OBJECT,
+            SqlTypeFamily.ANY),
+    /**
+     * Spatial type. Though not standard, it is common to several DBs, so we do not flag it
+     * 'special' (internal).
+     */
+    GEOMETRY(PrecScale.NO_NO, false, ExtraSqlTypes.GEOMETRY, SqlTypeFamily.GEO),
+    MEASURE(PrecScale.NO_NO, true, Types.OTHER, SqlTypeFamily.ANY),
+    SARG(PrecScale.NO_NO, true, Types.OTHER, SqlTypeFamily.ANY),
+    /**
+     * VARIANT data type, a dynamically-typed value that can have at runtime any of the other data
+     * types in this table.
+     */
+    VARIANT(PrecScale.NO_NO, false, Types.OTHER, SqlTypeFamily.VARIANT);
+
+    public static final int MAX_DATETIME_PRECISION = 3;
+
+    // Minimum and default interval precisions are  defined by SQL2003
+    // Maximum interval precisions are implementation dependent,
+    //  but must be at least the default value
+    public static final int DEFAULT_INTERVAL_START_PRECISION = 2;
+    public static final int DEFAULT_INTERVAL_FRACTIONAL_SECOND_PRECISION = 6;
+    public static final int MIN_INTERVAL_START_PRECISION = 1;
+    public static final int MIN_INTERVAL_FRACTIONAL_SECOND_PRECISION = 1;
+    public static final int MAX_INTERVAL_START_PRECISION = 10;
+    public static final int MAX_INTERVAL_FRACTIONAL_SECOND_PRECISION = 9;
+
+    // Cached map of enum values
+    private static final Map<String, SqlTypeName> VALUES_MAP =
+            Util.enumConstants(SqlTypeName.class);
+
+    // categorizations used by SqlTypeFamily definitions
+
+    // you probably want to use JDK 1.5 support for treating enumeration
+    // as collection instead; this is only here to support
+    // SqlTypeFamily.ANY
+    public static final List<SqlTypeName> ALL_TYPES =
+            ImmutableList.of(
+                    BOOLEAN,
+                    INTEGER,
+                    VARCHAR,
+                    DATE,
+                    TIME,
+                    TIMESTAMP,
+                    NULL,
+                    DECIMAL,
+                    ANY,
+                    CHAR,
+                    BINARY,
+                    VARBINARY,
+                    TINYINT,
+                    SMALLINT,
+                    BIGINT,
+                    REAL,
+                    DOUBLE,
+                    SYMBOL,
+                    INTERVAL_YEAR,
+                    INTERVAL_YEAR_MONTH,
+                    INTERVAL_MONTH,
+                    INTERVAL_DAY,
+                    INTERVAL_DAY_HOUR,
+                    INTERVAL_DAY_MINUTE,
+                    INTERVAL_DAY_SECOND,
+                    INTERVAL_HOUR,
+                    INTERVAL_HOUR_MINUTE,
+                    INTERVAL_HOUR_SECOND,
+                    INTERVAL_MINUTE,
+                    INTERVAL_MINUTE_SECOND,
+                    INTERVAL_SECOND,
+                    TIME_WITH_LOCAL_TIME_ZONE,
+                    TIMESTAMP_WITH_LOCAL_TIME_ZONE,
+                    FLOAT,
+                    MULTISET,
+                    DISTINCT,
+                    STRUCTURED,
+                    ROW,
+                    CURSOR,
+                    COLUMN_LIST,
+                    VARIANT);
+
+    public static final List<SqlTypeName> BOOLEAN_TYPES = ImmutableList.of(BOOLEAN);
+
+    public static final List<SqlTypeName> BINARY_TYPES = ImmutableList.of(BINARY, VARBINARY);
+
+    public static final List<SqlTypeName> INT_TYPES =
+            ImmutableList.of(TINYINT, SMALLINT, INTEGER, BIGINT);
+
+    public static final List<SqlTypeName> EXACT_TYPES =
+            combine(INT_TYPES, ImmutableList.of(DECIMAL));
+
+    public static final List<SqlTypeName> APPROX_TYPES = ImmutableList.of(FLOAT, REAL, DOUBLE);
+
+    public static final List<SqlTypeName> NUMERIC_TYPES = combine(EXACT_TYPES, APPROX_TYPES);
+
+    public static final List<SqlTypeName> FRACTIONAL_TYPES =
+            combine(APPROX_TYPES, ImmutableList.of(DECIMAL));
+
+    public static final List<SqlTypeName> CHAR_TYPES = ImmutableList.of(CHAR, VARCHAR);
+
+    public static final List<SqlTypeName> STRING_TYPES = combine(CHAR_TYPES, BINARY_TYPES);
+
+    public static final List<SqlTypeName> GEOMETRY_TYPES = ImmutableList.of(GEOMETRY);
+
+    public static final List<SqlTypeName> DATETIME_TYPES =
+            ImmutableList.of(
+                    DATE,
+                    TIME,
+                    TIME_WITH_LOCAL_TIME_ZONE,
+                    TIMESTAMP,
+                    TIMESTAMP_WITH_LOCAL_TIME_ZONE);
+
+    public static final Set<SqlTypeName> YEAR_INTERVAL_TYPES =
+            Sets.immutableEnumSet(
+                    SqlTypeName.INTERVAL_YEAR,
+                    SqlTypeName.INTERVAL_YEAR_MONTH,
+                    SqlTypeName.INTERVAL_MONTH);
+
+    public static final Set<SqlTypeName> DAY_INTERVAL_TYPES =
+            Sets.immutableEnumSet(
+                    SqlTypeName.INTERVAL_DAY,
+                    SqlTypeName.INTERVAL_DAY_HOUR,
+                    SqlTypeName.INTERVAL_DAY_MINUTE,
+                    SqlTypeName.INTERVAL_DAY_SECOND,
+                    SqlTypeName.INTERVAL_HOUR,
+                    SqlTypeName.INTERVAL_HOUR_MINUTE,
+                    SqlTypeName.INTERVAL_HOUR_SECOND,
+                    SqlTypeName.INTERVAL_MINUTE,
+                    SqlTypeName.INTERVAL_MINUTE_SECOND,
+                    SqlTypeName.INTERVAL_SECOND);
+
+    public static final Set<SqlTypeName> INTERVAL_TYPES =
+            Sets.immutableEnumSet(Iterables.concat(YEAR_INTERVAL_TYPES, DAY_INTERVAL_TYPES));
+
+    /** The possible types of a time frame argument to a function such as {@code TIMESTAMP_DIFF}. */
+    public static final Set<SqlTypeName> TIME_FRAME_TYPES =
+            Sets.immutableEnumSet(Iterables.concat(INTERVAL_TYPES, ImmutableList.of(SYMBOL)));
+
+    private static final Map<Integer, SqlTypeName> JDBC_TYPE_TO_NAME =
+            ImmutableMap.<Integer, SqlTypeName>builder()
+                    .put(Types.TINYINT, TINYINT)
+                    .put(Types.SMALLINT, SMALLINT)
+                    .put(Types.BIGINT, BIGINT)
+                    .put(Types.INTEGER, INTEGER)
+                    .put(Types.NUMERIC, DECIMAL) // REVIEW
+                    .put(Types.DECIMAL, DECIMAL)
+                    .put(Types.FLOAT, FLOAT)
+                    .put(Types.REAL, REAL)
+                    .put(Types.DOUBLE, DOUBLE)
+                    .put(Types.CHAR, CHAR)
+                    .put(Types.VARCHAR, VARCHAR)
+
+                    // TODO: provide real support for these eventually
+                    .put(ExtraSqlTypes.NCHAR, CHAR)
+                    .put(ExtraSqlTypes.NVARCHAR, VARCHAR)
+
+                    // TODO: additional types not yet supported. See ExtraSqlTypes.
+                    // .put(Types.LONGVARCHAR, Longvarchar)
+                    // .put(Types.CLOB, Clob)
+                    // .put(Types.LONGVARBINARY, Longvarbinary)
+                    // .put(Types.BLOB, Blob)
+                    // .put(Types.LONGNVARCHAR, Longnvarchar)
+                    // .put(Types.NCLOB, Nclob)
+                    // .put(Types.ROWID, Rowid)
+                    // .put(Types.SQLXML, Sqlxml)
+
+                    .put(Types.BINARY, BINARY)
+                    .put(Types.VARBINARY, VARBINARY)
+                    .put(Types.DATE, DATE)
+                    .put(Types.TIME, TIME)
+                    .put(Types.TIMESTAMP, TIMESTAMP)
+                    .put(Types.BIT, BOOLEAN)
+                    .put(Types.BOOLEAN, BOOLEAN)
+                    .put(Types.DISTINCT, DISTINCT)
+                    .put(Types.STRUCT, STRUCTURED)
+                    .put(Types.ARRAY, ARRAY)
+                    .build();
+
+    /** Bitwise-or of flags indicating allowable precision/scale combinations. */
+    private final int signatures;
+
+    /**
+     * Returns true if not of a "pure" standard sql type. "Inpure" types are {@link #ANY}, {@link
+     * #NULL} and {@link #SYMBOL}
+     */
+    private final boolean special;
+
+    private final int jdbcOrdinal;
+    private final @Nullable SqlTypeFamily family;
+
+    SqlTypeName(int signatures, boolean special, int jdbcType, @Nullable SqlTypeFamily family) {
+        this.signatures = signatures;
+        this.special = special;
+        this.jdbcOrdinal = jdbcType;
+        this.family = family;
+    }
+
+    /**
+     * Looks up a type name from its name.
+     *
+     * @return Type name, or null if not found
+     */
+    public static @Nullable SqlTypeName get(String name) {
+        if (false) {
+            // The following code works OK, but the spurious exceptions are
+            // annoying.
+            try {
+                return SqlTypeName.valueOf(name);
+            } catch (IllegalArgumentException e) {
+                return null;
+            }
+        }
+        return VALUES_MAP.get(name);
+    }
+
+    /**
+     * Returns the SqlTypeName value whose name or {@link #getSpaceName()} matches the given name,
+     * or throws {@link IllegalArgumentException}; never returns null.
+     */
+    public static SqlTypeName lookup(String tag) {
+        String tag2 = tag.replace(' ', '_');
+        return valueOf(tag2);
+    }
+
+    public boolean allowsNoPrecNoScale() {
+        return (signatures & PrecScale.NO_NO) != 0;
+    }
+
+    public boolean allowsPrecNoScale() {
+        return (signatures & PrecScale.YES_NO) != 0;
+    }
+
+    public boolean allowsPrec() {
+        return allowsPrecScale(true, true) || allowsPrecScale(true, false);
+    }
+
+    public boolean allowsScale() {
+        return allowsPrecScale(true, true);
+    }
+
+    /**
+     * Returns whether this type can be specified with a given combination of precision and scale.
+     * For example,
+     *
+     * <ul>
+     *   <li><code>Varchar.allowsPrecScale(true, false)</code> returns <code>
+     * true</code>, because the VARCHAR type allows a precision parameter, as in <code>VARCHAR(10)
+     *       </code>.
+     *   <li><code>Varchar.allowsPrecScale(true, true)</code> returns <code>
+     * true</code>, because the VARCHAR type does not allow a precision and a scale parameter, as in
+     *       <code>VARCHAR(10, 4)</code>.
+     *   <li><code>allowsPrecScale(false, true)</code> returns <code>false</code> for every type.
+     * </ul>
+     *
+     * @param precision Whether the precision/length field is part of the type specification
+     * @param scale Whether the scale field is part of the type specification
+     * @return Whether this combination of precision/scale is valid
+     */
+    public boolean allowsPrecScale(boolean precision, boolean scale) {
+        int mask =
+                precision
+                        ? (scale ? PrecScale.YES_YES : PrecScale.YES_NO)
+                        : (scale ? 0 : PrecScale.NO_NO);
+        return (signatures & mask) != 0;
+    }
+
+    public boolean isSpecial() {
+        return special;
+    }
+
+    /** Returns the ordinal from {@link Types} corresponding to this SqlTypeName. */
+    public int getJdbcOrdinal() {
+        return jdbcOrdinal;
+    }
+
+    private static List<SqlTypeName> combine(List<SqlTypeName> list0, List<SqlTypeName> list1) {
+        return ImmutableList.<SqlTypeName>builder().addAll(list0).addAll(list1).build();
+    }
+
+    /**
+     * Returns the default scale for this type if supported, otherwise -1 if scale is either
+     * unsupported or must be specified explicitly.
+     */
+    public int getDefaultScale() {
+        switch (this) {
+            case DECIMAL:
+                return 0;
+            case INTERVAL_YEAR:
+            case INTERVAL_YEAR_MONTH:
+            case INTERVAL_MONTH:
+            case INTERVAL_DAY:
+            case INTERVAL_DAY_HOUR:
+            case INTERVAL_DAY_MINUTE:
+            case INTERVAL_DAY_SECOND:
+            case INTERVAL_HOUR:
+            case INTERVAL_HOUR_MINUTE:
+            case INTERVAL_HOUR_SECOND:
+            case INTERVAL_MINUTE:
+            case INTERVAL_MINUTE_SECOND:
+            case INTERVAL_SECOND:
+                return DEFAULT_INTERVAL_FRACTIONAL_SECOND_PRECISION;
+            default:
+                return -1;
+        }
+    }
+
+    /**
+     * Gets the SqlTypeFamily containing this SqlTypeName.
+     *
+     * @return containing family, or null for none (SYMBOL, DISTINCT, STRUCTURED, ROW, OTHER)
+     */
+    public @Nullable SqlTypeFamily getFamily() {
+        return family;
+    }
+
+    /**
+     * Gets the SqlTypeName corresponding to a JDBC type.
+     *
+     * @param jdbcType the JDBC type of interest
+     * @return corresponding SqlTypeName, or null if the type is not known
+     */
+    public static @Nullable SqlTypeName getNameForJdbcType(int jdbcType) {
+        return JDBC_TYPE_TO_NAME.get(jdbcType);
+    }
+
+    /**
+     * Returns the limit of this datatype. For example,
+     *
+     * <table border="1">
+     * <caption>Datatype limits</caption>
+     * <tr>
+     * <th>Datatype</th>
+     * <th>sign</th>
+     * <th>limit</th>
+     * <th>beyond</th>
+     * <th>precision</th>
+     * <th>scale</th>
+     * <th>Returns</th>
+     * </tr>
+     * <tr>
+     * <td>Integer</td>
+     * <td>true</td>
+     * <td>true</td>
+     * <td>false</td>
+     * <td>-1</td>
+     * <td>-1</td>
+     * <td>2147483647 (2 ^ 31 -1 = MAXINT)</td>
+     * </tr>
+     * <tr>
+     * <td>Integer</td>
+     * <td>true</td>
+     * <td>true</td>
+     * <td>true</td>
+     * <td>-1</td>
+     * <td>-1</td>
+     * <td>2147483648 (2 ^ 31 = MAXINT + 1)</td>
+     * </tr>
+     * <tr>
+     * <td>Integer</td>
+     * <td>false</td>
+     * <td>true</td>
+     * <td>false</td>
+     * <td>-1</td>
+     * <td>-1</td>
+     * <td>-2147483648 (-2 ^ 31 = MININT)</td>
+     * </tr>
+     * <tr>
+     * <td>Boolean</td>
+     * <td>true</td>
+     * <td>true</td>
+     * <td>false</td>
+     * <td>-1</td>
+     * <td>-1</td>
+     * <td>TRUE</td>
+     * </tr>
+     * <tr>
+     * <td>Varchar</td>
+     * <td>true</td>
+     * <td>true</td>
+     * <td>false</td>
+     * <td>10</td>
+     * <td>-1</td>
+     * <td>'ZZZZZZZZZZ'</td>
+     * </tr>
+     * </table>
+     *
+     * @param sign If true, returns upper limit, otherwise lower limit
+     * @param limit If true, returns value at or near to overflow; otherwise value at or near to
+     *     underflow
+     * @param beyond If true, returns the value just beyond the limit, otherwise the value at the
+     *     limit
+     * @param precision Precision, or -1 if not applicable
+     * @param scale Scale, or -1 if not applicable
+     * @return Limit value
+     */
+    public @Nullable Object getLimit(
+            boolean sign, Limit limit, boolean beyond, int precision, int scale) {
+        assert allowsPrecScale(precision != -1, scale != -1) : this;
+        if (limit == Limit.ZERO) {
+            if (beyond) {
+                return null;
+            }
+            sign = true;
+        }
+        Calendar calendar;
+
+        switch (this) {
+            case BOOLEAN:
+                switch (limit) {
+                    case ZERO:
+                        return false;
+                    case UNDERFLOW:
+                        return null;
+                    case OVERFLOW:
+                        if (beyond || !sign) {
+                            return null;
+                        } else {
+                            return true;
+                        }
+                    default:
+                        throw Util.unexpected(limit);
+                }
+
+            case TINYINT:
+                return getNumericLimit(2, 8, sign, limit, beyond);
+
+            case SMALLINT:
+                return getNumericLimit(2, 16, sign, limit, beyond);
+
+            case INTEGER:
+                return getNumericLimit(2, 32, sign, limit, beyond);
+
+            case BIGINT:
+                return getNumericLimit(2, 64, sign, limit, beyond);
+
+            case DECIMAL:
+                BigDecimal decimal = getNumericLimit(10, precision, sign, limit, beyond);
+                if (decimal == null) {
+                    return null;
+                }
+
+                // Decimal values must fit into 64 bits. So, the maximum value of
+                // a DECIMAL(19, 0) is 2^63 - 1, not 10^19 - 1.
+                switch (limit) {
+                    case OVERFLOW:
+                        final BigDecimal other =
+                                (BigDecimal) BIGINT.getLimit(sign, limit, beyond, -1, -1);
+                        if (other != null && decimal.compareTo(other) == (sign ? 1 : -1)) {
+                            decimal = other;
+                        }
+                        break;
+                    default:
+                        break;
+                }
+
+                // Apply scale.
+                if (scale == 0) {
+                    // do nothing
+                } else if (scale > 0) {
+                    decimal = decimal.divide(BigDecimal.TEN.pow(scale));
+                } else {
+                    decimal = decimal.multiply(BigDecimal.TEN.pow(-scale));
+                }
+                return decimal;
+
+            case CHAR:
+            case VARCHAR:
+                if (!sign) {
+                    return null; // this type does not have negative values
+                }
+                StringBuilder buf = new StringBuilder();
+                switch (limit) {
+                    case ZERO:
+                        break;
+                    case UNDERFLOW:
+                        if (beyond) {
+                            // There is no value between the empty string and the
+                            // smallest non-empty string.
+                            return null;
+                        }
+                        buf.append("a");
+                        break;
+                    case OVERFLOW:
+                        for (int i = 0; i < precision; ++i) {
+                            buf.append("Z");
+                        }
+                        if (beyond) {
+                            buf.append("Z");
+                        }
+                        break;
+                    default:
+                        break;
+                }
+                return buf.toString();
+
+            case BINARY:
+            case VARBINARY:
+                if (!sign) {
+                    return null; // this type does not have negative values
+                }
+                byte[] bytes;
+                switch (limit) {
+                    case ZERO:
+                        bytes = new byte[0];
+                        break;
+                    case UNDERFLOW:
+                        if (beyond) {
+                            // There is no value between the empty string and the
+                            // smallest value.
+                            return null;
+                        }
+                        bytes = new byte[] {0x00};
+                        break;
+                    case OVERFLOW:
+                        bytes = new byte[precision + (beyond ? 1 : 0)];
+                        Arrays.fill(bytes, (byte) 0xff);
+                        break;
+                    default:
+                        throw Util.unexpected(limit);
+                }
+                return bytes;
+
+            case DATE:
+                calendar = Util.calendar();
+                switch (limit) {
+                    case ZERO:
+                        // The epoch.
+                        calendar.set(Calendar.YEAR, 1970);
+                        calendar.set(Calendar.MONTH, 0);
+                        calendar.set(Calendar.DAY_OF_MONTH, 1);
+                        break;
+                    case UNDERFLOW:
+                        return null;
+                    case OVERFLOW:
+                        if (beyond) {
+                            // It is impossible to represent an invalid year as a date
+                            // literal. SQL dates are represented as 'yyyy-mm-dd', and
+                            // 1 <= yyyy <= 9999 is valid. There is no year 0: the year
+                            // before 1AD is 1BC, so SimpleDateFormat renders the day
+                            // before 0001-01-01 (AD) as 0001-12-31 (BC), which looks
+                            // like a valid date.
+                            return null;
+                        }
+
+                        // "SQL:2003 6.1 <data type> Access Rules 6" says that year is
+                        // between 1 and 9999, and days/months are the valid Gregorian
+                        // calendar values for these years.
+                        if (sign) {
+                            calendar.set(Calendar.YEAR, 9999);
+                            calendar.set(Calendar.MONTH, 11);
+                            calendar.set(Calendar.DAY_OF_MONTH, 31);
+                        } else {
+                            calendar.set(Calendar.YEAR, 1);
+                            calendar.set(Calendar.MONTH, 0);
+                            calendar.set(Calendar.DAY_OF_MONTH, 1);
+                        }
+                        break;
+                    default:
+                        break;
+                }
+                calendar.set(Calendar.HOUR_OF_DAY, 0);
+                calendar.set(Calendar.MINUTE, 0);
+                calendar.set(Calendar.SECOND, 0);
+                return calendar;
+
+            case TIME:
+                if (!sign) {
+                    return null; // this type does not have negative values
+                }
+                if (beyond) {
+                    return null; // invalid values are impossible to represent
+                }
+                calendar = Util.calendar();
+                switch (limit) {
+                    case ZERO:
+
+                        // The epoch.
+                        calendar.set(Calendar.HOUR_OF_DAY, 0);
+                        calendar.set(Calendar.MINUTE, 0);
+                        calendar.set(Calendar.SECOND, 0);
+                        calendar.set(Calendar.MILLISECOND, 0);
+                        break;
+                    case UNDERFLOW:
+                        return null;
+                    case OVERFLOW:
+                        calendar.set(Calendar.HOUR_OF_DAY, 23);
+                        calendar.set(Calendar.MINUTE, 59);
+                        calendar.set(Calendar.SECOND, 59);
+                        int millis =
+                                (precision >= 3)
+                                        ? 999
+                                        : ((precision == 2) ? 990 : ((precision == 1) ? 900 : 0));
+                        calendar.set(Calendar.MILLISECOND, millis);
+                        break;
+                    default:
+                        break;
+                }
+                return calendar;
+
+            case TIMESTAMP:
+                calendar = Util.calendar();
+                switch (limit) {
+                    case ZERO:
+                        // The epoch.
+                        calendar.set(Calendar.YEAR, 1970);
+                        calendar.set(Calendar.MONTH, 0);
+                        calendar.set(Calendar.DAY_OF_MONTH, 1);
+                        calendar.set(Calendar.HOUR_OF_DAY, 0);
+                        calendar.set(Calendar.MINUTE, 0);
+                        calendar.set(Calendar.SECOND, 0);
+                        calendar.set(Calendar.MILLISECOND, 0);
+                        break;
+                    case UNDERFLOW:
+                        return null;
+                    case OVERFLOW:
+                        if (beyond) {
+                            // It is impossible to represent an invalid year as a date
+                            // literal. SQL dates are represented as 'yyyy-mm-dd', and
+                            // 1 <= yyyy <= 9999 is valid. There is no year 0: the year
+                            // before 1AD is 1BC, so SimpleDateFormat renders the day
+                            // before 0001-01-01 (AD) as 0001-12-31 (BC), which looks
+                            // like a valid date.
+                            return null;
+                        }
+
+                        // "SQL:2003 6.1 <data type> Access Rules 6" says that year is
+                        // between 1 and 9999, and days/months are the valid Gregorian
+                        // calendar values for these years.
+                        if (sign) {
+                            calendar.set(Calendar.YEAR, 9999);
+                            calendar.set(Calendar.MONTH, 11);
+                            calendar.set(Calendar.DAY_OF_MONTH, 31);
+                            calendar.set(Calendar.HOUR_OF_DAY, 23);
+                            calendar.set(Calendar.MINUTE, 59);
+                            calendar.set(Calendar.SECOND, 59);
+                            int millis =
+                                    (precision >= 3)
+                                            ? 999
+                                            : ((precision == 2)
+                                                    ? 990
+                                                    : ((precision == 1) ? 900 : 0));
+                            calendar.set(Calendar.MILLISECOND, millis);
+                        } else {
+                            calendar.set(Calendar.YEAR, 1);
+                            calendar.set(Calendar.MONTH, 0);
+                            calendar.set(Calendar.DAY_OF_MONTH, 1);
+                            calendar.set(Calendar.HOUR_OF_DAY, 0);
+                            calendar.set(Calendar.MINUTE, 0);
+                            calendar.set(Calendar.SECOND, 0);
+                            calendar.set(Calendar.MILLISECOND, 0);
+                        }
+                        break;
+                    default:
+                        break;
+                }
+                return calendar;
+
+            default:
+                throw Util.unexpected(this);
+        }
+    }
+
+    /**
+     * Returns the minimum precision (or length) allowed for this type, or -1 if precision/length
+     * are not applicable for this type.
+     *
+     * @return Minimum allowed precision
+     */
+    public int getMinPrecision() {
+        switch (this) {
+            case DECIMAL:
+            case VARCHAR:
+            case CHAR:
+            case VARBINARY:
+            case BINARY:
+            case TIME:
+            case TIME_WITH_LOCAL_TIME_ZONE:
+            case TIMESTAMP:
+            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                return 1;
+            case INTERVAL_YEAR:
+            case INTERVAL_YEAR_MONTH:
+            case INTERVAL_MONTH:
+            case INTERVAL_DAY:
+            case INTERVAL_DAY_HOUR:
+            case INTERVAL_DAY_MINUTE:
+            case INTERVAL_DAY_SECOND:
+            case INTERVAL_HOUR:
+            case INTERVAL_HOUR_MINUTE:
+            case INTERVAL_HOUR_SECOND:
+            case INTERVAL_MINUTE:
+            case INTERVAL_MINUTE_SECOND:
+            case INTERVAL_SECOND:
+                return MIN_INTERVAL_START_PRECISION;
+            default:
+                return -1;
+        }
+    }
+
+    /**
+     * Returns the minimum scale (or fractional second precision in the case of intervals) allowed
+     * for this type, or -1 if precision/length are not applicable for this type.
+     *
+     * @return Minimum allowed scale
+     */
+    public int getMinScale() {
+        switch (this) {
+                // TODO: Minimum numeric scale for decimal
+            case INTERVAL_YEAR:
+            case INTERVAL_YEAR_MONTH:
+            case INTERVAL_MONTH:
+            case INTERVAL_DAY:
+            case INTERVAL_DAY_HOUR:
+            case INTERVAL_DAY_MINUTE:
+            case INTERVAL_DAY_SECOND:
+            case INTERVAL_HOUR:
+            case INTERVAL_HOUR_MINUTE:
+            case INTERVAL_HOUR_SECOND:
+            case INTERVAL_MINUTE:
+            case INTERVAL_MINUTE_SECOND:
+            case INTERVAL_SECOND:
+                return MIN_INTERVAL_FRACTIONAL_SECOND_PRECISION;
+            default:
+                return -1;
+        }
+    }
+
+    /**
+     * Returns {@code HOUR} for {@code HOUR TO SECOND} and {@code HOUR}, {@code SECOND} for {@code
+     * SECOND}.
+     */
+    public TimeUnit getStartUnit() {
+        switch (this) {
+            case INTERVAL_YEAR:
+            case INTERVAL_YEAR_MONTH:
+                return TimeUnit.YEAR;
+            case INTERVAL_MONTH:
+                return TimeUnit.MONTH;
+            case INTERVAL_DAY:
+            case INTERVAL_DAY_HOUR:
+            case INTERVAL_DAY_MINUTE:
+            case INTERVAL_DAY_SECOND:
+                return TimeUnit.DAY;
+            case INTERVAL_HOUR:
+            case INTERVAL_HOUR_MINUTE:
+            case INTERVAL_HOUR_SECOND:
+                return TimeUnit.HOUR;
+            case INTERVAL_MINUTE:
+            case INTERVAL_MINUTE_SECOND:
+                return TimeUnit.MINUTE;
+            case INTERVAL_SECOND:
+                return TimeUnit.SECOND;
+            default:
+                throw new AssertionError(this);
+        }
+    }
+
+    /** Returns {@code SECOND} for both {@code HOUR TO SECOND} and {@code SECOND}. */
+    public TimeUnit getEndUnit() {
+        switch (this) {
+            case INTERVAL_YEAR:
+                return TimeUnit.YEAR;
+            case INTERVAL_YEAR_MONTH:
+            case INTERVAL_MONTH:
+                return TimeUnit.MONTH;
+            case INTERVAL_DAY:
+                return TimeUnit.DAY;
+            case INTERVAL_DAY_HOUR:
+            case INTERVAL_HOUR:
+                return TimeUnit.HOUR;
+            case INTERVAL_DAY_MINUTE:
+            case INTERVAL_HOUR_MINUTE:
+            case INTERVAL_MINUTE:
+                return TimeUnit.MINUTE;
+            case INTERVAL_DAY_SECOND:
+            case INTERVAL_HOUR_SECOND:
+            case INTERVAL_MINUTE_SECOND:
+            case INTERVAL_SECOND:
+                return TimeUnit.SECOND;
+            default:
+                throw new AssertionError(this);
+        }
+    }
+
+    public boolean isYearMonth() {
+        switch (this) {
+            case INTERVAL_YEAR:
+            case INTERVAL_YEAR_MONTH:
+            case INTERVAL_MONTH:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    /** Limit. */
+    public enum Limit {
+        ZERO,
+        UNDERFLOW,
+        OVERFLOW
+    }
+
+    private static @Nullable BigDecimal getNumericLimit(
+            int radix, int exponent, boolean sign, Limit limit, boolean beyond) {
+        switch (limit) {
+            case OVERFLOW:
+
+                // 2-based schemes run from -2^(N-1) to 2^(N-1)-1 e.g. -128 to +127
+                // 10-based schemas run from -(10^N-1) to 10^N-1 e.g. -99 to +99
+                final BigDecimal bigRadix = BigDecimal.valueOf(radix);
+                if (radix == 2) {
+                    --exponent;
+                }
+                BigDecimal decimal = bigRadix.pow(exponent);
+                if (sign || (radix != 2)) {
+                    decimal = decimal.subtract(BigDecimal.ONE);
+                }
+                if (beyond) {
+                    decimal = decimal.add(BigDecimal.ONE);
+                }
+                if (!sign) {
+                    decimal = decimal.negate();
+                }
+                return decimal;
+            case UNDERFLOW:
+                return beyond ? null : (sign ? BigDecimal.ONE : BigDecimal.ONE.negate());
+            case ZERO:
+                return BigDecimal.ZERO;
+            default:
+                throw Util.unexpected(limit);
+        }
+    }
+
+    public SqlLiteral createLiteral(Object o, SqlParserPos pos) {
+        switch (this) {
+            case BOOLEAN:
+                return SqlLiteral.createBoolean((Boolean) o, pos);
+            case TINYINT:
+            case SMALLINT:
+            case INTEGER:
+            case BIGINT:
+            case DECIMAL:
+                return SqlLiteral.createExactNumeric(o.toString(), pos);
+            case VARCHAR:
+            case CHAR:
+                return SqlLiteral.createCharString((String) o, pos);
+            case VARBINARY:
+            case BINARY:
+                return SqlLiteral.createBinaryString((byte[]) o, pos);
+            case DATE:
+                return SqlLiteral.createDate(
+                        o instanceof Calendar
+                                ? DateString.fromCalendarFields((Calendar) o)
+                                : (DateString) o,
+                        pos);
+            case TIME:
+                return SqlLiteral.createTime(
+                        o instanceof Calendar
+                                ? TimeString.fromCalendarFields((Calendar) o)
+                                : (TimeString) o,
+                        0 /* todo */,
+                        pos);
+            case TIMESTAMP:
+                return SqlLiteral.createTimestamp(
+                        this,
+                        o instanceof Calendar
+                                ? TimestampString.fromCalendarFields((Calendar) o)
+                                : (TimestampString) o,
+                        0 /* todo */,
+                        pos);
+            default:
+                throw Util.unexpected(this);
+        }
+    }
+
+    /** Returns the name of this type. */
+    public String getName() {
+        return name();
+    }
+
+    /**
+     * Returns the name of this type, with underscores converted to spaces, for example "TIMESTAMP
+     * WITH LOCAL TIME ZONE", "DATE".
+     */
+    public String getSpaceName() {
+        return name().replace('_', ' ');
+    }
+
+    /**
+     * Flags indicating precision/scale combinations.
+     *
+     * <p>Note: for intervals:
+     *
+     * <ul>
+     *   <li>precision = start (leading field) precision
+     *   <li>scale = fractional second precision
+     * </ul>
+     */
+    private interface PrecScale {
+        int NO_NO = 1;
+        int YES_NO = 2;
+        int YES_YES = 4;
+    }
+}

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/calcite/sql/type/SqlTypeName.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/calcite/sql/type/SqlTypeName.java
@@ -856,7 +856,7 @@ public enum SqlTypeName {
      */
     public int getMinScale() {
         switch (this) {
-                // TODO: Minimum numeric scale for decimal
+            // TODO: Minimum numeric scale for decimal
             case INTERVAL_YEAR:
             case INTERVAL_YEAR_MONTH:
             case INTERVAL_MONTH:

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -3457,6 +3457,15 @@ class FlinkSqlParserImplTest extends SqlParserTest {
                 .fails("(?s).*Encountered \"\\)\" at .*");
     }
 
+    @Test
+    void testVariantType() {
+        sql("CREATE TABLE t (\n" + "v variant" + "\n)")
+                .ok("CREATE TABLE `T` (\n" + "  `V` VARIANT\n" + ")");
+
+        sql("CREATE TABLE t (\n" + "v VARIANT NOT NULL" + "\n)")
+                .ok("CREATE TABLE `T` (\n" + "  `V` VARIANT NOT NULL\n" + ")");
+    }
+
     /** Matcher that invokes the #validate() of the {@link ExtendedSqlNode} instance. * */
     private static class ValidationMatcher extends BaseMatcher<SqlNode> {
         private String expectedColumnSql;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/DataTypes.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/DataTypes.java
@@ -60,6 +60,7 @@ import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.table.types.logical.VariantType;
 import org.apache.flink.table.types.logical.YearMonthIntervalType;
 import org.apache.flink.table.types.logical.YearMonthIntervalType.YearMonthResolution;
 import org.apache.flink.table.types.logical.ZonedTimestampType;
@@ -1026,6 +1027,18 @@ public final class DataTypes {
                 Stream.of(fields).map(DataTypes.Field::getDataType).collect(Collectors.toList());
         return new FieldsDataType(
                 structuredType, structuredType.getDefaultConversion(), fieldDataTypes);
+    }
+
+    /**
+     * Data type of semi-structured data.
+     *
+     * <p>The type supports storing any semi-structured data, including ARRAY, MAP, and primitive
+     * types. VARIANT can only store MAP types with keys of type STRING.
+     *
+     * @see VariantType
+     */
+    public static DataType VARIANT() {
+        return new AtomicDataType(new VariantType());
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/ArrayData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/ArrayData.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.DistinctType;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.types.variant.Variant;
 
 import javax.annotation.Nullable;
 
@@ -95,6 +96,9 @@ public interface ArrayData {
 
     /** Returns the raw value at the given position. */
     <T> RawValueData<T> getRawValue(int pos);
+
+    /** Returns the Variant value at the given position. */
+    Variant getVariant(int i);
 
     /** Returns the binary value at the given position. */
     byte[] getBinary(int pos);
@@ -207,6 +211,9 @@ public interface ArrayData {
                 break;
             case RAW:
                 elementGetter = ArrayData::getRawValue;
+                break;
+            case VARIANT:
+                elementGetter = ArrayData::getVariant;
                 break;
             case NULL:
             case SYMBOL:

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/GenericArrayData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/GenericArrayData.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.data;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.types.variant.Variant;
 
 import org.apache.commons.lang3.ArrayUtils;
 
@@ -236,6 +237,11 @@ public final class GenericArrayData implements ArrayData {
     @Override
     public <T> RawValueData<T> getRawValue(int pos) {
         return (RawValueData<T>) getObject(pos);
+    }
+
+    @Override
+    public Variant getVariant(int pos) {
+        return (Variant) getObject(pos);
     }
 
     @Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/GenericRowData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/GenericRowData.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.StructuredType;
 import org.apache.flink.types.RowKind;
+import org.apache.flink.types.variant.Variant;
 import org.apache.flink.util.StringUtils;
 
 import java.util.Arrays;
@@ -203,6 +204,11 @@ public final class GenericRowData implements RowData {
     @Override
     public RowData getRow(int pos, int numFields) {
         return (RowData) this.fields[pos];
+    }
+
+    @Override
+    public Variant getVariant(int pos) {
+        return (Variant) this.fields[pos];
     }
 
     @Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/RowData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/RowData.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.StructuredType;
 import org.apache.flink.types.RowKind;
+import org.apache.flink.types.variant.Variant;
 
 import javax.annotation.Nullable;
 
@@ -201,6 +202,9 @@ public interface RowData {
      */
     RowData getRow(int pos, int numFields);
 
+    /** Returns the variant value at the given position. */
+    Variant getVariant(int pos);
+
     // ------------------------------------------------------------------------------------------
     // Access Utilities
     // ------------------------------------------------------------------------------------------
@@ -279,6 +283,9 @@ public interface RowData {
                 break;
             case RAW:
                 fieldGetter = row -> row.getRawValue(fieldPos);
+                break;
+            case VARIANT:
+                fieldGetter = row -> row.getVariant(fieldPos);
                 break;
             case NULL:
             case SYMBOL:

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/BinaryArrayData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/BinaryArrayData.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.types.logical.DistinctType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.utils.LogicalTypeUtils;
+import org.apache.flink.types.variant.Variant;
 
 import java.lang.reflect.Array;
 
@@ -91,6 +92,7 @@ public final class BinaryArrayData extends BinarySection implements ArrayData, T
             case ROW:
             case STRUCTURED_TYPE:
             case RAW:
+            case VARIANT:
                 // long and double are 8 bytes;
                 // otherwise it stores the length and offset of the variable-length part for types
                 // such as is string, map, etc.
@@ -247,6 +249,14 @@ public final class BinaryArrayData extends BinarySection implements ArrayData, T
         int fieldOffset = getElementOffset(pos, 8);
         final long offsetAndSize = BinarySegmentUtils.getLong(segments, fieldOffset);
         return BinarySegmentUtils.readRawValueData(segments, offset, offsetAndSize);
+    }
+
+    @Override
+    public Variant getVariant(int pos) {
+        assertIndexIsValid(pos);
+        int fieldOffset = getElementOffset(pos, 8);
+        final long offsetAndSize = BinarySegmentUtils.getLong(segments, fieldOffset);
+        return BinarySegmentUtils.readVariant(segments, offset, offsetAndSize);
     }
 
     @Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/BinaryRowData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/BinaryRowData.java
@@ -33,6 +33,7 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.types.RowKind;
+import org.apache.flink.types.variant.BinaryVariant;
 
 import java.nio.ByteOrder;
 
@@ -386,6 +387,12 @@ public final class BinaryRowData extends BinarySection
     public RowData getRow(int pos, int numFields) {
         assertIndexIsValid(pos);
         return BinarySegmentUtils.readRowData(segments, numFields, offset, getLong(pos));
+    }
+
+    @Override
+    public BinaryVariant getVariant(int pos) {
+        assertIndexIsValid(pos);
+        return BinarySegmentUtils.readVariant(segments, offset, getLong(pos));
     }
 
     /** The bit is 1 when the field is null. Default is 0. */

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/NestedRowData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/NestedRowData.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.types.RowKind;
+import org.apache.flink.types.variant.Variant;
 
 import static org.apache.flink.table.data.binary.BinaryRowData.calculateBitSetWidthInBytes;
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -296,6 +297,12 @@ public final class NestedRowData extends BinarySection implements RowData, Typed
     public RowData getRow(int pos, int numFields) {
         assertIndexIsValid(pos);
         return BinarySegmentUtils.readRowData(segments, numFields, offset, getLong(pos));
+    }
+
+    @Override
+    public Variant getVariant(int pos) {
+        assertIndexIsValid(pos);
+        return BinarySegmentUtils.readVariant(segments, offset, getLong(pos));
     }
 
     @Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/columnar/ColumnarArrayData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/columnar/ColumnarArrayData.java
@@ -41,6 +41,7 @@ import org.apache.flink.table.data.columnar.vector.MapColumnVector;
 import org.apache.flink.table.data.columnar.vector.RowColumnVector;
 import org.apache.flink.table.data.columnar.vector.ShortColumnVector;
 import org.apache.flink.table.data.columnar.vector.TimestampColumnVector;
+import org.apache.flink.types.variant.Variant;
 
 import java.util.Arrays;
 
@@ -127,6 +128,11 @@ public final class ColumnarArrayData implements ArrayData, TypedSetters {
     @Override
     public <T> RawValueData<T> getRawValue(int pos) {
         throw new UnsupportedOperationException("RawValueData is not supported.");
+    }
+
+    @Override
+    public Variant getVariant(int i) {
+        throw new UnsupportedOperationException("Variant is not supported yet.");
     }
 
     @Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/columnar/ColumnarRowData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/columnar/ColumnarRowData.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.data.binary.TypedSetters;
 import org.apache.flink.table.data.columnar.vector.BytesColumnVector.Bytes;
 import org.apache.flink.table.data.columnar.vector.VectorizedColumnBatch;
 import org.apache.flink.types.RowKind;
+import org.apache.flink.types.variant.Variant;
 
 /**
  * Columnar row to support access to vector column data. It is a row view in {@link
@@ -153,6 +154,11 @@ public final class ColumnarRowData implements RowData, TypedSetters {
     @Override
     public RowData getRow(int pos, int numFields) {
         return vectorizedColumnBatch.getRow(rowId, pos);
+    }
+
+    @Override
+    public Variant getVariant(int pos) {
+        return vectorizedColumnBatch.getVariant(rowId, pos);
     }
 
     @Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/columnar/vector/VectorizedColumnBatch.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/columnar/vector/VectorizedColumnBatch.java
@@ -24,7 +24,9 @@ import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.data.columnar.ColumnarRowData;
 import org.apache.flink.table.data.columnar.vector.BytesColumnVector.Bytes;
+import org.apache.flink.types.variant.BinaryVariant;
 
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
@@ -132,5 +134,10 @@ public class VectorizedColumnBatch implements Serializable {
 
     public MapData getMap(int rowId, int colId) {
         return ((MapColumnVector) columns[colId]).getMap(rowId);
+    }
+
+    public BinaryVariant getVariant(int rowId, int colId) {
+        ColumnarRowData valueAndMeta = ((RowColumnVector) columns[colId]).getRow(rowId);
+        return new BinaryVariant(valueAndMeta.getBinary(0), valueAndMeta.getBinary(1));
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/utils/JoinedRowData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/utils/JoinedRowData.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.types.RowKind;
+import org.apache.flink.types.variant.Variant;
 
 import javax.annotation.Nullable;
 
@@ -246,6 +247,15 @@ public class JoinedRowData implements RowData {
             return row1.getRow(pos, numFields);
         } else {
             return row2.getRow(pos - row1.getArity(), numFields);
+        }
+    }
+
+    @Override
+    public Variant getVariant(int pos) {
+        if (pos < row1.getArity()) {
+            return row1.getVariant(pos);
+        } else {
+            return row2.getVariant(pos - row1.getArity());
         }
     }
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/utils/ProjectedRowData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/utils/ProjectedRowData.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.types.RowKind;
+import org.apache.flink.types.variant.Variant;
 
 import java.util.Arrays;
 
@@ -157,6 +158,11 @@ public class ProjectedRowData implements RowData {
     @Override
     public RowData getRow(int pos, int numFields) {
         return row.getRow(indexMapping[pos], numFields);
+    }
+
+    @Override
+    public Variant getVariant(int pos) {
+        return row.getVariant(indexMapping[pos]);
     }
 
     @Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -2850,6 +2850,40 @@ public final class BuiltInFunctionDefinitions {
                     .build();
 
     // --------------------------------------------------------------------------------------------
+    // Variant functions
+    // --------------------------------------------------------------------------------------------
+
+    public static final BuiltInFunctionDefinition PARSE_JSON =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("PARSE_JSON")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            or(
+                                    sequence(logical(LogicalTypeFamily.CHARACTER_STRING)),
+                                    sequence(
+                                            logical(LogicalTypeFamily.CHARACTER_STRING),
+                                            logical(LogicalTypeRoot.BOOLEAN))))
+                    .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.VARIANT())))
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.scalar.ParseJsonFunction")
+                    .build();
+
+    public static final BuiltInFunctionDefinition TRY_PARSE_JSON =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("TRY_PARSE_JSON")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            or(
+                                    sequence(logical(LogicalTypeFamily.CHARACTER_STRING)),
+                                    sequence(
+                                            logical(LogicalTypeFamily.CHARACTER_STRING),
+                                            logical(LogicalTypeRoot.BOOLEAN))))
+                    .outputTypeStrategy(forceNullable(explicit(DataTypes.VARIANT())))
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.scalar.TryParseJsonFunction")
+                    .build();
+
+    // --------------------------------------------------------------------------------------------
     // Other functions
     // --------------------------------------------------------------------------------------------
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeRoot.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeRoot.java
@@ -141,7 +141,9 @@ public enum LogicalTypeRoot {
 
     UNRESOLVED(LogicalTypeFamily.EXTENSION),
 
-    DESCRIPTOR(LogicalTypeFamily.DESCRIPTOR);
+    DESCRIPTOR(LogicalTypeFamily.DESCRIPTOR),
+
+    VARIANT(LogicalTypeFamily.EXTENSION);
 
     private final Set<LogicalTypeFamily> families;
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
@@ -93,5 +93,9 @@ public interface LogicalTypeVisitor<R> {
         return visit((LogicalType) descriptorType);
     }
 
+    default R visit(VariantType variantType) {
+        return visit((LogicalType) variantType);
+    }
+
     R visit(LogicalType other);
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/VariantType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/VariantType.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.types.variant.BinaryVariant;
+import org.apache.flink.types.variant.Variant;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Data type of semi-structured data.
+ *
+ * <p>The type supports storing any semi-structured data, including ARRAY, MAP, and scalar types.
+ * VARIANT can only store MAP types with keys of type STRING. The data type of the fields are stored
+ * in the data structure, which is close to the semantics of JSON. Compared to ROW and STRUCTURED
+ * type, VARIANT type has the flexibility that supports highly nested and evolving schema.
+ *
+ * <p>The serializable string representation of this type is {@code VARIANT}.
+ */
+@PublicEvolving
+public final class VariantType extends LogicalType {
+
+    private static final Set<String> INPUT_OUTPUT_CONVERSION =
+            conversionSet(Variant.class.getName(), BinaryVariant.class.getName());
+
+    public VariantType(boolean isNullable) {
+        super(isNullable, LogicalTypeRoot.VARIANT);
+    }
+
+    public VariantType() {
+        this(true);
+    }
+
+    @Override
+    public LogicalType copy(boolean isNullable) {
+        return new VariantType(isNullable);
+    }
+
+    @Override
+    public String asSerializableString() {
+        return withNullability("VARIANT");
+    }
+
+    @Override
+    public boolean supportsInputConversion(Class<?> clazz) {
+        return INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+    }
+
+    @Override
+    public boolean supportsOutputConversion(Class<?> clazz) {
+        return INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+    }
+
+    @Override
+    public Class<?> getDefaultConversion() {
+        return Variant.class;
+    }
+
+    @Override
+    public List<LogicalType> getChildren() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public <R> R accept(LogicalTypeVisitor<R> visitor) {
+        return visitor.visit(this);
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeParser.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeParser.java
@@ -55,6 +55,7 @@ import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.UnresolvedUserDefinedType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.table.types.logical.VariantType;
 import org.apache.flink.table.types.logical.YearMonthIntervalType;
 import org.apache.flink.table.types.logical.YearMonthIntervalType.YearMonthResolution;
 import org.apache.flink.table.types.logical.ZonedTimestampType;
@@ -332,7 +333,8 @@ public final class LogicalTypeParser {
         LEGACY,
         NOT,
         DESCRIPTOR,
-        STRUCTURED
+        STRUCTURED,
+        VARIANT
     }
 
     private static final Set<String> KEYWORDS =
@@ -578,6 +580,8 @@ public final class LogicalTypeParser {
                     return parseLegacyType();
                 case DESCRIPTOR:
                     return new DescriptorType();
+                case VARIANT:
+                    return new VariantType();
                 default:
                     throw parsingError("Unsupported type: " + token().value);
             }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeUtils.java
@@ -35,6 +35,7 @@ import org.apache.flink.table.types.logical.StructuredType;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.ZonedTimestampType;
 import org.apache.flink.types.ColumnList;
+import org.apache.flink.types.variant.Variant;
 import org.apache.flink.util.Preconditions;
 
 import java.util.List;
@@ -109,6 +110,8 @@ public final class LogicalTypeUtils {
                 return Object.class;
             case DESCRIPTOR:
                 return ColumnList.class;
+            case VARIANT:
+                return Variant.class;
             case SYMBOL:
             case UNRESOLVED:
             default:

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/ClassDataTypeConverter.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/ClassDataTypeConverter.java
@@ -28,6 +28,8 @@ import org.apache.flink.table.types.extraction.DataTypeExtractor;
 import org.apache.flink.table.types.logical.SymbolType;
 import org.apache.flink.types.ColumnList;
 import org.apache.flink.types.Row;
+import org.apache.flink.types.variant.BinaryVariant;
+import org.apache.flink.types.variant.Variant;
 
 import java.math.BigDecimal;
 import java.util.HashMap;
@@ -76,6 +78,8 @@ public final class ClassDataTypeConverter {
         addDefaultDataType(
                 java.time.Period.class, DataTypes.INTERVAL(DataTypes.YEAR(4), DataTypes.MONTH()));
         addDefaultDataType(ColumnList.class, DataTypes.DESCRIPTOR());
+        addDefaultDataType(BinaryVariant.class, DataTypes.VARIANT());
+        addDefaultDataType(Variant.class, DataTypes.VARIANT());
     }
 
     private static void addDefaultDataType(Class<?> clazz, DataType rootType) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/LegacyTypeInfoDataTypeConverter.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/LegacyTypeInfoDataTypeConverter.java
@@ -74,6 +74,7 @@ import static org.apache.flink.table.types.logical.LogicalTypeRoot.TIMESTAMP_WIT
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.TIME_WITHOUT_TIME_ZONE;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.VARCHAR;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.VARIANT;
 import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.isRowtimeAttribute;
 
 /**
@@ -225,6 +226,8 @@ public final class LegacyTypeInfoDataTypeConverter {
             return Types.STRING;
         } else if (logicalType.is(VARCHAR)) {
             return Types.STRING;
+        } else if (logicalType.is(VARIANT)) {
+            return Types.VARIANT;
         }
 
         // relax the precision constraint as Timestamp can store the highest precision

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/TypeInfoDataTypeConverter.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/TypeInfoDataTypeConverter.java
@@ -43,6 +43,7 @@ import org.apache.flink.table.types.logical.RawType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.StructuredType;
 import org.apache.flink.types.Row;
+import org.apache.flink.types.variant.Variant;
 
 import javax.annotation.Nullable;
 
@@ -147,6 +148,7 @@ public final class TypeInfoDataTypeConverter {
                 PrimitiveArrayTypeInfo.DOUBLE_PRIMITIVE_ARRAY_TYPE_INFO,
                 DataTypes.ARRAY(DataTypes.DOUBLE().notNull().bridgedTo(double.class))
                         .bridgedTo(double[].class));
+        conversionMap.put(Types.VARIANT, DataTypes.VARIANT().bridgedTo(Variant.class));
     }
 
     /** Converts the given {@link TypeInformation} into {@link DataType}. */

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/ValueDataTypeConverter.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/ValueDataTypeConverter.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.BinaryType;
 import org.apache.flink.table.types.logical.CharType;
 import org.apache.flink.table.types.logical.LogicalTypeFamily;
+import org.apache.flink.types.variant.Variant;
 
 import java.math.BigDecimal;
 import java.util.Objects;
@@ -90,6 +91,8 @@ public final class ValueDataTypeConverter {
             // don't let the class-based extraction kick in if array elements differ
             return convertToArrayType((Object[]) value)
                     .map(dt -> dt.notNull().bridgedTo(value.getClass()));
+        } else if (value instanceof Variant) {
+            convertedDataType = DataTypes.VARIANT();
         }
 
         final Optional<DataType> resultType;

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/ClassDataTypeConverterTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/ClassDataTypeConverterTest.java
@@ -23,6 +23,8 @@ import org.apache.flink.table.expressions.TimeIntervalUnit;
 import org.apache.flink.table.types.logical.SymbolType;
 import org.apache.flink.table.types.utils.ClassDataTypeConverter;
 import org.apache.flink.types.Row;
+import org.apache.flink.types.variant.BinaryVariant;
+import org.apache.flink.types.variant.Variant;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -90,7 +92,9 @@ class ClassDataTypeConverterTest {
                 of(
                         TimeIntervalUnit.class,
                         new AtomicDataType(new SymbolType<>()).bridgedTo(TimeIntervalUnit.class)),
-                of(Row.class, null));
+                of(Row.class, null),
+                of(Variant.class, DataTypes.VARIANT()),
+                of(BinaryVariant.class, DataTypes.VARIANT().bridgedTo(BinaryVariant.class)));
     }
 
     @ParameterizedTest(name = "[{index}] class: {0} type: {1}")

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/DataTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/DataTypesTest.java
@@ -45,12 +45,14 @@ import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.table.types.logical.VariantType;
 import org.apache.flink.table.types.logical.YearMonthIntervalType;
 import org.apache.flink.table.types.logical.YearMonthIntervalType.YearMonthResolution;
 import org.apache.flink.table.types.logical.ZonedTimestampType;
 import org.apache.flink.table.types.utils.DataTypeFactoryMock;
 import org.apache.flink.table.types.utils.LogicalTypeDataTypeConverter;
 import org.apache.flink.types.Row;
+import org.apache.flink.types.variant.Variant;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -96,6 +98,7 @@ import static org.apache.flink.table.api.DataTypes.TIMESTAMP_WITH_TIME_ZONE;
 import static org.apache.flink.table.api.DataTypes.TINYINT;
 import static org.apache.flink.table.api.DataTypes.VARBINARY;
 import static org.apache.flink.table.api.DataTypes.VARCHAR;
+import static org.apache.flink.table.api.DataTypes.VARIANT;
 import static org.apache.flink.table.test.TableAssertions.assertThat;
 import static org.apache.flink.table.types.logical.DayTimeIntervalType.DEFAULT_DAY_PRECISION;
 import static org.apache.flink.table.types.logical.DayTimeIntervalType.DayTimeResolution.MINUTE_TO_SECOND;
@@ -218,6 +221,9 @@ class DataTypesTest {
                 TestSpec.forDataType(RAW(Void.class, VoidSerializer.INSTANCE))
                         .expectLogicalType(new RawType<>(Void.class, VoidSerializer.INSTANCE))
                         .expectConversionClass(Void.class),
+                TestSpec.forDataType(VARIANT())
+                        .expectLogicalType(new VariantType())
+                        .expectConversionClass(Variant.class),
                 TestSpec.forUnresolvedDataType(RAW(Types.VOID))
                         .expectUnresolvedString("[RAW('java.lang.Void', '?')]")
                         .lookupReturns(dummyRaw(Void.class))
@@ -287,7 +293,10 @@ class DataTypesTest {
                 TestSpec.forUnresolvedDataType(DataTypes.of(Types.ENUM(DayOfWeek.class)))
                         .expectUnresolvedString("['EnumTypeInfo<java.time.DayOfWeek>']")
                         .lookupReturns(dummyRaw(DayOfWeek.class))
-                        .expectResolvedDataType(dummyRaw(DayOfWeek.class)));
+                        .expectResolvedDataType(dummyRaw(DayOfWeek.class)),
+                TestSpec.forUnresolvedDataType(DataTypes.of(Variant.class))
+                        .expectUnresolvedString("['org.apache.flink.types.variant.Variant']")
+                        .expectResolvedDataType(VARIANT()));
     }
 
     @ParameterizedTest(name = "{index}: {0}")

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeParserTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeParserTest.java
@@ -56,6 +56,7 @@ import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.UnresolvedUserDefinedType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.table.types.logical.VariantType;
 import org.apache.flink.table.types.logical.YearMonthIntervalType;
 import org.apache.flink.table.types.logical.YearMonthIntervalType.YearMonthResolution;
 import org.apache.flink.table.types.logical.ZonedTimestampType;
@@ -303,6 +304,8 @@ public class LogicalTypeParserTest {
                 TestSpec.forString(
                                 "LEGACY('RAW', 'ANY<org.apache.flink.table.types.LogicalTypeParserTest>')")
                         .expectType(createGenericLegacyType()),
+                TestSpec.forString("VARIANT").expectType(new VariantType()),
+                TestSpec.forString("VARIANT NOT NULL").expectType(new VariantType(false)),
 
                 // error message testing
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
@@ -58,9 +58,12 @@ import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.UnresolvedUserDefinedType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.table.types.logical.VariantType;
 import org.apache.flink.table.types.logical.YearMonthIntervalType;
 import org.apache.flink.table.types.logical.ZonedTimestampType;
 import org.apache.flink.types.Row;
+import org.apache.flink.types.variant.BinaryVariant;
+import org.apache.flink.types.variant.Variant;
 
 import org.assertj.core.api.ThrowingConsumer;
 import org.junit.jupiter.api.Test;
@@ -595,6 +598,18 @@ public class LogicalTypesTest {
                 .supportsOutputConversion(Object.class)
                 .supportsOutputConversion(Integer.class)
                 .doesNotSupportOutputConversion(int.class);
+    }
+
+    @Test
+    void testVariantType() {
+        assertThat(new VariantType())
+                .isJavaSerializable()
+                .hasSerializableString("VARIANT")
+                .hasSummaryString("VARIANT")
+                .supportsOutputConversion(Variant.class)
+                .supportsOutputConversion(BinaryVariant.class)
+                .supportsInputConversion(Variant.class)
+                .supportsInputConversion(BinaryVariant.class);
     }
 
     @Test

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/TypeInfoDataTypeConverterTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/TypeInfoDataTypeConverterTest.java
@@ -109,7 +109,8 @@ class TypeInfoDataTypeConverterTest {
                 TestSpec.forType(new QueryableTypeInfo()).expectDataType(DataTypes.BYTES()),
                 TestSpec.forType(Types.ENUM(DayOfWeek.class))
                         .lookupExpects(DayOfWeek.class)
-                        .expectDataType(dummyRaw(DayOfWeek.class)));
+                        .expectDataType(dummyRaw(DayOfWeek.class)),
+                TestSpec.forType(Types.VARIANT).expectDataType(DataTypes.VARIANT()));
     }
 
     @ParameterizedTest(name = "{index}: {0}")

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/ValueDataTypeConverterTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/ValueDataTypeConverterTest.java
@@ -24,6 +24,8 @@ import org.apache.flink.table.types.logical.BinaryType;
 import org.apache.flink.table.types.logical.CharType;
 import org.apache.flink.table.types.logical.SymbolType;
 import org.apache.flink.table.types.utils.ValueDataTypeConverter;
+import org.apache.flink.types.variant.BinaryVariant;
+import org.apache.flink.types.variant.Variant;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -107,7 +109,10 @@ class ValueDataTypeConverterTest {
                         },
                         DataTypes.ARRAY(DataTypes.ARRAY(DataTypes.INT()))),
                 of(TimePointUnit.HOUR, new AtomicDataType(new SymbolType<>(), TimePointUnit.class)),
-                of(new BigDecimal[0], null));
+                of(new BigDecimal[0], null),
+                of(
+                        Variant.newBuilder().of("hello"),
+                        DataTypes.VARIANT().bridgedTo(BinaryVariant.class)));
     }
 
     @ParameterizedTest(name = "[{index}] value: {0} type: {1}")

--- a/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql/fun/SqlCastFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql/fun/SqlCastFunction.java
@@ -161,12 +161,19 @@ public class SqlCastFunction extends SqlFunction {
 
     private boolean canCastFrom(RelDataType toType, RelDataType fromType) {
         SqlTypeName fromTypeName = fromType.getSqlTypeName();
+
+        // Cast to Variant is not support at the moment.
+        // TODO: Support cast to variant (FLINK-37925，FLINK-37926)
+        if (toType.getSqlTypeName() == SqlTypeName.VARIANT) {
+            return false;
+        }
         switch (fromTypeName) {
             case ARRAY:
             case MAP:
             case MULTISET:
             case STRUCTURED:
             case ROW:
+            case VARIANT:
             case OTHER:
                 // We use our casting checker logic only for these types,
                 //  as the differences with calcite casting checker logic generates issues

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/CastRuleProvider.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/CastRuleProvider.java
@@ -92,6 +92,8 @@ public class CastRuleProvider {
                 .addRule(ArrayToArrayCastRule.INSTANCE)
                 .addRule(MapToMapAndMultisetToMultisetCastRule.INSTANCE)
                 .addRule(RowToRowCastRule.INSTANCE)
+                // Variant rules
+                .addRule(VariantToStringCastRule.INSTANCE)
                 // Special rules
                 .addRule(CharVarCharTrimPadCastRule.INSTANCE)
                 .addRule(NullToStringCastRule.INSTANCE)

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/VariantToStringCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/VariantToStringCastRule.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions.casting;
+
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeFamily;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.types.variant.Variant;
+
+import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.methodCall;
+import static org.apache.flink.table.types.logical.VarCharType.STRING_TYPE;
+
+/** {@link LogicalTypeRoot#VARIANT} to {@link LogicalTypeFamily#CHARACTER_STRING} cast rule. */
+class VariantToStringCastRule extends AbstractCharacterFamilyTargetRule<Variant> {
+
+    static final VariantToStringCastRule INSTANCE = new VariantToStringCastRule();
+
+    private VariantToStringCastRule() {
+        super(
+                CastRulePredicate.builder()
+                        .input(LogicalTypeRoot.VARIANT)
+                        .target(STRING_TYPE)
+                        .build());
+    }
+
+    @Override
+    public String generateStringExpression(
+            CodeGeneratorCastRule.Context context,
+            String inputTerm,
+            LogicalType inputLogicalType,
+            LogicalType targetLogicalType) {
+        return methodCall(inputTerm, "toString");
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
@@ -1333,6 +1333,20 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
     public static final SqlPostfixOperator IS_NOT_JSON_SCALAR =
             SqlStdOperatorTable.IS_NOT_JSON_SCALAR;
 
+    // VARIANT FUNCTIONS
+    public static final SqlFunction TRY_PARSE_JSON =
+            new SqlFunction(
+                    "TRY_PARSE_JSON",
+                    SqlKind.OTHER_FUNCTION,
+                    ReturnTypes.cascade(
+                            ReturnTypes.explicit(SqlTypeName.VARIANT),
+                            SqlTypeTransforms.FORCE_NULLABLE),
+                    null,
+                    OperandTypes.or(
+                            OperandTypes.family(SqlTypeFamily.STRING),
+                            OperandTypes.family(SqlTypeFamily.STRING, SqlTypeFamily.BOOLEAN)),
+                    SqlFunctionCategory.SYSTEM);
+
     // WINDOW TABLE FUNCTIONS
     // use the definitions in Flink, because we have different return types
     // and special check on the time attribute.

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/FlinkTypeFactory.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/FlinkTypeFactory.scala
@@ -156,6 +156,9 @@ class FlinkTypeFactory(
       case LogicalTypeRoot.DESCRIPTOR =>
         createSqlType(SqlTypeName.COLUMN_LIST)
 
+      case LogicalTypeRoot.VARIANT =>
+        createSqlType(SqlTypeName.VARIANT)
+
       case _ @t =>
         throw new TableException(s"Type is not supported: $t")
     }
@@ -677,6 +680,8 @@ object FlinkTypeFactory {
 
       // CURSOR for UDTF case, whose type info will never be used, just a placeholder
       case CURSOR => new TypeInformationRawType[Nothing](new NothingTypeInfo)
+
+      case VARIANT => new VariantType()
 
       case OTHER if relDataType.isInstanceOf[RawRelDataType] =>
         relDataType.asInstanceOf[RawRelDataType].getRawType

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
@@ -44,6 +44,7 @@ import org.apache.flink.table.types.logical.utils.LogicalTypeUtils.toInternalCon
 import org.apache.flink.table.types.utils.DataTypeUtils.isInternal
 import org.apache.flink.table.utils.EncodingUtils
 import org.apache.flink.types.{ColumnList, Row, RowKind}
+import org.apache.flink.types.variant.Variant
 
 import java.lang.{Boolean => JBoolean, Byte => JByte, Double => JDouble, Float => JFloat, Integer => JInt, Long => JLong, Object => JObject, Short => JShort}
 import java.lang.reflect.Method
@@ -273,6 +274,7 @@ object CodeGenUtils {
     case NULL => className[JObject] // special case for untyped null literals
     case RAW => className[BinaryRawValueData[_]]
     case DESCRIPTOR => className[ColumnList]
+    case VARIANT => className[Variant]
     case SYMBOL | UNRESOLVED =>
       throw new IllegalArgumentException("Illegal type: " + t)
   }
@@ -525,6 +527,8 @@ object CodeGenUtils {
         rowFieldReadAccess(indexTerm, rowTerm, t.asInstanceOf[DistinctType].getSourceType)
       case RAW =>
         s"(($BINARY_RAW_VALUE) $rowTerm.getRawValue($indexTerm))"
+      case VARIANT =>
+        s"$rowTerm.getVariant($indexTerm)"
       case NULL | SYMBOL | UNRESOLVED =>
         throw new IllegalArgumentException("Illegal type: " + t)
     }
@@ -818,6 +822,8 @@ object CodeGenUtils {
     case RAW =>
       val ser = addSerializer(t)
       s"$writerTerm.writeRawValue($indexTerm, $fieldValTerm, $ser)"
+    case VARIANT =>
+      s"$writerTerm.writeVariant($indexTerm, $fieldValTerm)"
     case NULL | SYMBOL | UNRESOLVED =>
       throw new IllegalArgumentException("Illegal type: " + t);
   }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ExpressionReducer.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ExpressionReducer.scala
@@ -146,7 +146,8 @@ class ExpressionReducer(
             unreduced.getType.getSqlTypeName match {
               // we insert the original expression for object literals
               case SqlTypeName.ANY | SqlTypeName.OTHER | SqlTypeName.ROW | SqlTypeName.STRUCTURED |
-                  SqlTypeName.ARRAY | SqlTypeName.MAP | SqlTypeName.MULTISET =>
+                  SqlTypeName.ARRAY | SqlTypeName.MAP | SqlTypeName.MULTISET |
+                  SqlTypeName.VARIANT =>
                 reducedValues.add(unreduced)
               case SqlTypeName.VARCHAR | SqlTypeName.CHAR =>
                 val escapeVarchar = BinaryStringDataUtil.safeToString(

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
@@ -633,7 +633,7 @@ object GenerateUtils {
     case TINYINT | SMALLINT | INTEGER | BIGINT | FLOAT | DOUBLE | DATE | TIME_WITHOUT_TIME_ZONE |
         INTERVAL_YEAR_MONTH | INTERVAL_DAY_TIME =>
       s"($leftTerm > $rightTerm ? 1 : $leftTerm < $rightTerm ? -1 : 0)"
-    case TIMESTAMP_WITH_TIME_ZONE | MULTISET | MAP =>
+    case TIMESTAMP_WITH_TIME_ZONE | MULTISET | MAP | VARIANT =>
       throw new UnsupportedOperationException(
         s"Type($t) is not an orderable data type, " +
           s"it is not supported as a ORDER_BY/GROUP_BY/JOIN_EQUAL field.")

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdSize.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdSize.scala
@@ -435,7 +435,8 @@ object FlinkRelMdSize {
         SqlTypeName.DATE =>
       12d
     case SqlTypeName.ANY | SqlTypeName.OTHER => 128d // 128 is an arbitrary estimate
-    case SqlTypeName.BINARY | SqlTypeName.VARBINARY => 16d // 16 is an arbitrary estimate
+    case SqlTypeName.BINARY | SqlTypeName.VARBINARY | SqlTypeName.VARIANT =>
+      16d // 16 is an arbitrary estimate
     case _ => throw new TableException(s"Unsupported data type encountered: $sqlType")
   }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/AggFunctionFactory.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/AggFunctionFactory.scala
@@ -569,7 +569,8 @@ class AggFunctionFactory(
     val valueType = argTypes(0)
     if (aggCallNeedRetractions(index)) {
       valueType.getTypeRoot match {
-        case TINYINT | SMALLINT | INTEGER | BIGINT | FLOAT | DOUBLE | BOOLEAN | VARCHAR | DECIMAL =>
+        case TINYINT | SMALLINT | INTEGER | BIGINT | FLOAT | DOUBLE | BOOLEAN | VARCHAR | DECIMAL |
+            VARIANT =>
           new FirstValueWithRetractAggFunction(valueType)
         case t =>
           throw new TableException(
@@ -578,7 +579,8 @@ class AggFunctionFactory(
       }
     } else {
       valueType.getTypeRoot match {
-        case TINYINT | SMALLINT | INTEGER | BIGINT | FLOAT | DOUBLE | BOOLEAN | VARCHAR | DECIMAL =>
+        case TINYINT | SMALLINT | INTEGER | BIGINT | FLOAT | DOUBLE | BOOLEAN | VARCHAR | DECIMAL |
+            VARIANT =>
           new FirstValueAggFunction(valueType)
         case t =>
           throw new TableException(
@@ -594,7 +596,8 @@ class AggFunctionFactory(
     val valueType = argTypes(0)
     if (aggCallNeedRetractions(index)) {
       valueType.getTypeRoot match {
-        case TINYINT | SMALLINT | INTEGER | BIGINT | FLOAT | DOUBLE | BOOLEAN | VARCHAR | DECIMAL =>
+        case TINYINT | SMALLINT | INTEGER | BIGINT | FLOAT | DOUBLE | BOOLEAN | VARCHAR | DECIMAL |
+            VARIANT =>
           new LastValueWithRetractAggFunction(valueType)
         case t =>
           throw new TableException(
@@ -603,7 +606,8 @@ class AggFunctionFactory(
       }
     } else {
       valueType.getTypeRoot match {
-        case TINYINT | SMALLINT | INTEGER | BIGINT | FLOAT | DOUBLE | BOOLEAN | VARCHAR | DECIMAL =>
+        case TINYINT | SMALLINT | INTEGER | BIGINT | FLOAT | DOUBLE | BOOLEAN | VARCHAR | DECIMAL |
+            VARIANT =>
           new LastValueAggFunction(valueType)
         case t =>
           throw new TableException(

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/AggregateUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/AggregateUtil.scala
@@ -912,7 +912,8 @@ object AggregateUtil extends Enumeration {
         // ordered by type root definition
         case CHAR | VARCHAR | BOOLEAN | DECIMAL | TINYINT | SMALLINT | INTEGER | BIGINT | FLOAT |
             DOUBLE | DATE | TIME_WITHOUT_TIME_ZONE | TIMESTAMP_WITHOUT_TIME_ZONE |
-            TIMESTAMP_WITH_LOCAL_TIME_ZONE | INTERVAL_YEAR_MONTH | INTERVAL_DAY_TIME | ARRAY =>
+            TIMESTAMP_WITH_LOCAL_TIME_ZONE | INTERVAL_YEAR_MONTH | INTERVAL_DAY_TIME | ARRAY |
+            VARIANT =>
           argTypes(0)
         case t =>
           throw new TableException(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/VariantSemanticTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/VariantSemanticTest.java
@@ -1,0 +1,304 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.stream;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableRuntimeException;
+import org.apache.flink.table.functions.AggregateFunction;
+import org.apache.flink.table.functions.ScalarFunction;
+import org.apache.flink.table.planner.plan.nodes.exec.testutils.SemanticTestBase;
+import org.apache.flink.table.test.program.SinkTestStep;
+import org.apache.flink.table.test.program.SourceTestStep;
+import org.apache.flink.table.test.program.TableTestProgram;
+import org.apache.flink.types.Row;
+import org.apache.flink.types.RowKind;
+import org.apache.flink.types.variant.Variant;
+import org.apache.flink.types.variant.VariantBuilder;
+
+import java.util.List;
+
+/** Semantic tests for {@link DataTypes#VARIANT()} type. */
+public class VariantSemanticTest extends SemanticTestBase {
+
+    static final VariantBuilder BUILDER = Variant.newBuilder();
+
+    static final TableTestProgram PARSE_JSON_OF_NULL =
+            TableTestProgram.of(
+                            "parse-json-of-null", "validates PARSE_JSON handle null value properly")
+                    .setupTableSource(
+                            SourceTestStep.newBuilder("t")
+                                    .addSchema("v STRING")
+                                    .producedValues(Row.of("1"), new Row(1))
+                                    .build())
+                    .setupTableSink(
+                            SinkTestStep.newBuilder("sink_t")
+                                    .addSchema("v VARIANT")
+                                    .consumedValues(Row.of(BUILDER.of((byte) 1)), new Row(1))
+                                    .build())
+                    .runSql("INSERT INTO sink_t SELECT PARSE_JSON(v) FROM t")
+                    .build();
+
+    static final TableTestProgram TRY_PARSE_JSON_OF_NULL =
+            TableTestProgram.of(
+                            "try-parse-json-of-null",
+                            "validates TRY_PARSE_JSON handle null value properly")
+                    .setupTableSource(
+                            SourceTestStep.newBuilder("t")
+                                    .addSchema("v STRING")
+                                    .producedValues(Row.of("1"), new Row(1))
+                                    .build())
+                    .setupTableSink(
+                            SinkTestStep.newBuilder("sink_t")
+                                    .addSchema("v VARIANT")
+                                    .consumedValues(Row.of(BUILDER.of((byte) 1)), new Row(1))
+                                    .build())
+                    .runSql("INSERT INTO sink_t SELECT TRY_PARSE_JSON(v) FROM t")
+                    .build();
+
+    static final TableTestProgram PARSE_JSON_FAIL_MALFORMED_JSON =
+            TableTestProgram.of(
+                            "parse-json-fail-malformed-json",
+                            "validates PARSE_JSON throw exception on malformed json")
+                    .setupTableSource(
+                            SourceTestStep.newBuilder("t")
+                                    .addSchema("v STRING")
+                                    .producedValues(Row.of("1"), Row.of("{"))
+                                    .build())
+                    .setupTableSink(
+                            SinkTestStep.newBuilder("sink_t")
+                                    .addSchema("v VARIANT")
+                                    .consumedValues(Row.of(BUILDER.of((byte) 1)))
+                                    .build())
+                    .runFailingSql(
+                            "INSERT INTO sink_t SELECT PARSE_JSON(v) FROM t",
+                            TableRuntimeException.class,
+                            "Failed to parse json string")
+                    .build();
+
+    static final TableTestProgram TRY_PARSE_JSON_HANDLE_MALFORMED_JSON =
+            TableTestProgram.of(
+                            "try-parse-json-handle-malformed-json",
+                            "validates TRY_PARSE_JSON handle malformed json properly")
+                    .setupTableSource(
+                            SourceTestStep.newBuilder("t")
+                                    .addSchema("v STRING")
+                                    .producedValues(Row.of("1"), Row.of("{"))
+                                    .build())
+                    .setupTableSink(
+                            SinkTestStep.newBuilder("sink_t")
+                                    .addSchema("v VARIANT")
+                                    .consumedValues(Row.of(BUILDER.of((byte) 1)), new Row(1))
+                                    .build())
+                    .runSql("INSERT INTO sink_t SELECT TRY_PARSE_JSON(v) FROM t")
+                    .build();
+
+    static final TableTestProgram BUILTIN_AGG_WITH_RETRACTION;
+
+    static final TableTestProgram BUILTIN_AGG;
+
+    static {
+        Variant v1 = BUILDER.of(1);
+        Variant v2 = BUILDER.of(2);
+
+        BUILTIN_AGG =
+                TableTestProgram.of("builtin-agg", "validates builtin agg")
+                        .setupTableSource(
+                                SourceTestStep.newBuilder("t")
+                                        .addSchema("v VARIANT")
+                                        .producedValues(Row.of(v1), Row.of(v2), Row.of(v2))
+                                        .build())
+                        .setupTableSink(
+                                SinkTestStep.newBuilder("sink_t")
+                                        .addSchema(
+                                                "fv VARIANT", "lv VARIANT", "c BIGINT", "dc BIGINT")
+                                        .consumedValues(
+                                                Row.of(v1, v1, 1, 1),
+                                                Row.ofKind(RowKind.UPDATE_BEFORE, v1, v1, 1, 1),
+                                                Row.ofKind(RowKind.UPDATE_AFTER, v1, v2, 2, 2),
+                                                Row.ofKind(RowKind.UPDATE_BEFORE, v1, v2, 2, 2),
+                                                Row.ofKind(RowKind.UPDATE_AFTER, v1, v2, 3, 2))
+                                        .build())
+                        .runSql(
+                                "INSERT INTO sink_t SELECT FIRST_VALUE(v), LAST_VALUE(v), COUNT(v), COUNT(DISTINCT v) FROM t")
+                        .build();
+
+        BUILTIN_AGG_WITH_RETRACTION =
+                TableTestProgram.of(
+                                "builtin-agg-with-retraction",
+                                "validates builtin agg with retraction")
+                        .setupTableSource(
+                                SourceTestStep.newBuilder("t")
+                                        .addSchema("v VARIANT")
+                                        .addOption("changelog-mode", "I,UB,UA,D")
+                                        .producedValues(
+                                                Row.of(v1),
+                                                Row.of(v2),
+                                                Row.of(v2),
+                                                Row.ofKind(RowKind.DELETE, v1))
+                                        .build())
+                        .setupTableSink(
+                                SinkTestStep.newBuilder("sink_t")
+                                        .addSchema(
+                                                "fv VARIANT", "lv VARIANT", "c BIGINT", "dc BIGINT")
+                                        .consumedValues(
+                                                Row.of(v1, v1, 1, 1),
+                                                Row.ofKind(RowKind.UPDATE_BEFORE, v1, v1, 1, 1),
+                                                Row.ofKind(RowKind.UPDATE_AFTER, v1, v2, 2, 2),
+                                                Row.ofKind(RowKind.UPDATE_BEFORE, v1, v2, 2, 2),
+                                                Row.ofKind(RowKind.UPDATE_AFTER, v1, v2, 3, 2),
+                                                Row.ofKind(RowKind.UPDATE_BEFORE, v1, v2, 3, 2),
+                                                Row.ofKind(RowKind.UPDATE_AFTER, v2, v2, 2, 1))
+                                        .build())
+                        .runSql(
+                                "INSERT INTO sink_t SELECT FIRST_VALUE(v), LAST_VALUE(v), COUNT(v), COUNT(DISTINCT v) FROM t")
+                        .build();
+    }
+
+    static final TableTestProgram VARIANT_AS_UDF_ARG =
+            TableTestProgram.of("variant-as-udf-arg", "validates variant as udf argument")
+                    .setupTemporarySystemFunction("udf", MyUdf.class)
+                    .setupTableSource(
+                            SourceTestStep.newBuilder("t")
+                                    .addSchema("v VARIANT")
+                                    .producedValues(
+                                            Row.of(
+                                                    BUILDER.object()
+                                                            .add("k", BUILDER.of(1))
+                                                            .build()),
+                                            Row.of(
+                                                    BUILDER.object()
+                                                            .add("k", BUILDER.of(2))
+                                                            .build()),
+                                            Row.of(
+                                                    BUILDER.object()
+                                                            .add("k", BUILDER.ofNull())
+                                                            .build()),
+                                            new Row(1))
+                                    .build())
+                    .setupTableSink(
+                            SinkTestStep.newBuilder("sink_t")
+                                    .addSchema("v INTEGER")
+                                    .consumedValues(Row.of(1), Row.of(2), new Row(1), new Row(1))
+                                    .build())
+                    .runSql("INSERT INTO sink_t SELECT udf(v) FROM t")
+                    .build();
+
+    static final TableTestProgram VARIANT_AS_UDAF_ARG =
+            TableTestProgram.of("variant-as-udaf-arg", "validates variant as udaf argument")
+                    .setupTemporarySystemFunction("udf", MyAggFunc.class)
+                    .setupTableSource(
+                            SourceTestStep.newBuilder("t")
+                                    .addSchema("v VARIANT")
+                                    .producedValues(
+                                            Row.of(
+                                                    BUILDER.object()
+                                                            .add("k", BUILDER.of(1))
+                                                            .build()),
+                                            Row.of(
+                                                    BUILDER.object()
+                                                            .add("k", BUILDER.of(2))
+                                                            .build()),
+                                            Row.of(
+                                                    BUILDER.object()
+                                                            .add("k", BUILDER.ofNull())
+                                                            .build()),
+                                            new Row(1))
+                                    .build())
+                    .setupTableSink(
+                            SinkTestStep.newBuilder("sink_t")
+                                    .addSchema("v BIGINT")
+                                    .consumedValues(
+                                            Row.of(1),
+                                            Row.ofKind(RowKind.UPDATE_BEFORE, 1),
+                                            Row.ofKind(RowKind.UPDATE_AFTER, 3))
+                                    .build())
+                    .runSql("INSERT INTO sink_t SELECT udf(v) FROM t")
+                    .build();
+
+    static final TableTestProgram VARIANT_AS_AGG_KEY =
+            TableTestProgram.of("variant-as-agg-key", "validates variant as agg key")
+                    .setupTableSource(
+                            SourceTestStep.newBuilder("t")
+                                    .addSchema("k VARIANT", "v INTEGER")
+                                    .producedValues(
+                                            Row.of(BUILDER.of(1), 1),
+                                            Row.of(BUILDER.of(2), 2),
+                                            Row.of(BUILDER.of(1), 2))
+                                    .build())
+                    .setupTableSink(
+                            SinkTestStep.newBuilder("sink_t")
+                                    .addSchema("k VARIANT", "total INTEGER")
+                                    .consumedValues(
+                                            Row.of(1, 1),
+                                            Row.of(2, 2),
+                                            Row.ofKind(RowKind.UPDATE_BEFORE, 1, 1),
+                                            Row.ofKind(RowKind.UPDATE_AFTER, 1, 3))
+                                    .build())
+                    .runSql("INSERT INTO sink_t SELECT k, SUM(v) AS total FROM t GROUP BY k")
+                    .build();
+
+    @Override
+    public List<TableTestProgram> programs() {
+        return List.of(
+                TRY_PARSE_JSON_OF_NULL,
+                PARSE_JSON_OF_NULL,
+                PARSE_JSON_FAIL_MALFORMED_JSON,
+                TRY_PARSE_JSON_HANDLE_MALFORMED_JSON,
+                BUILTIN_AGG,
+                BUILTIN_AGG_WITH_RETRACTION,
+                VARIANT_AS_UDF_ARG,
+                VARIANT_AS_UDAF_ARG,
+                VARIANT_AS_AGG_KEY);
+    }
+
+    public static class MyUdf extends ScalarFunction {
+
+        public Integer eval(Variant v) {
+            if (v == null) {
+                return null;
+            }
+            Variant k = v.getField("k");
+            if (k.isNull()) {
+                return null;
+            }
+            return k.getInt();
+        }
+    }
+
+    public static class MyAggFunc extends AggregateFunction<Long, List<Long>> {
+        public Long getValue(List<Long> accumulator) {
+            return accumulator.get(0);
+        }
+
+        public List<Long> createAccumulator() {
+            return List.of(0L);
+        }
+
+        public void accumulate(List<Long> accumulator, Variant v) {
+            if (v == null) {
+                return;
+            }
+            Variant variant = v.getField("k");
+            if (variant == null || variant.isNull()) {
+                return;
+            }
+            accumulator.set(0, accumulator.get(0) + variant.getInt());
+        }
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/BoxedWrapperRowData.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/BoxedWrapperRowData.java
@@ -27,6 +27,7 @@ import org.apache.flink.types.IntValue;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.types.RowKind;
 import org.apache.flink.types.ShortValue;
+import org.apache.flink.types.variant.Variant;
 import org.apache.flink.util.StringUtils;
 
 import java.util.Arrays;
@@ -140,6 +141,11 @@ public class BoxedWrapperRowData implements RowData, TypedSetters {
     @Override
     public RowData getRow(int pos, int numFields) {
         return (RowData) this.fields[pos];
+    }
+
+    @Override
+    public Variant getVariant(int pos) {
+        return (Variant) this.fields[pos];
     }
 
     @Override

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/UpdatableRowData.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/UpdatableRowData.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.data;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.data.binary.TypedSetters;
 import org.apache.flink.types.RowKind;
+import org.apache.flink.types.variant.Variant;
 
 import java.util.BitSet;
 
@@ -128,6 +129,11 @@ public final class UpdatableRowData implements RowData, TypedSetters {
     @Override
     public RowData getRow(int pos, int numFields) {
         return updated.get(pos) ? (RowData) fields[pos] : row.getRow(pos, numFields);
+    }
+
+    @Override
+    public Variant getVariant(int pos) {
+        return updated.get(pos) ? (Variant) fields[pos] : row.getVariant(pos);
     }
 
     @Override

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/conversion/DataStructureConverters.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/conversion/DataStructureConverters.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.types.Row;
+import org.apache.flink.types.variant.Variant;
 
 import java.math.BigDecimal;
 import java.time.Duration;
@@ -194,6 +195,7 @@ public final class DataStructureConverters {
         putConverter(LogicalTypeRoot.STRUCTURED_TYPE, RowData.class, identity());
         putConverter(LogicalTypeRoot.RAW, byte[].class, RawByteArrayConverter::create);
         putConverter(LogicalTypeRoot.RAW, RawValueData.class, identity());
+        putConverter(LogicalTypeRoot.VARIANT, Variant.class, identity());
     }
 
     /** Returns a converter for the given {@link DataType}. */

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/util/DataFormatConverters.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/util/DataFormatConverters.java
@@ -67,6 +67,7 @@ import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.utils.TypeConversions;
 import org.apache.flink.table.utils.DateTimeUtils;
 import org.apache.flink.types.Row;
+import org.apache.flink.types.variant.Variant;
 
 import org.apache.commons.lang3.ArrayUtils;
 
@@ -347,7 +348,10 @@ public class DataFormatConverters {
 
                 if (clazz == RawValueData.class) {
                     return RawValueDataConverter.INSTANCE;
+                } else if (clazz == Variant.class) {
+                    return VariantConverter.INSTANCE;
                 }
+
                 return new GenericConverter(typeInfo.createSerializer(new SerializerConfigImpl()));
             default:
                 throw new RuntimeException("Not support dataType: " + dataType);
@@ -724,6 +728,20 @@ public class DataFormatConverters {
         @Override
         T toExternalImpl(RowData row, int column) {
             return (T) toExternalImpl(row.getRawValue(column));
+        }
+    }
+
+    public static final class VariantConverter extends IdentityConverter<Variant> {
+
+        private static final long serialVersionUID = 1L;
+
+        public static final VariantConverter INSTANCE = new VariantConverter();
+
+        private VariantConverter() {}
+
+        @Override
+        Variant toExternalImpl(RowData row, int column) {
+            return row.getVariant(column);
         }
     }
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/writer/BinaryArrayWriter.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/writer/BinaryArrayWriter.java
@@ -245,6 +245,7 @@ public final class BinaryArrayWriter extends AbstractBinaryWriter {
             case ROW:
             case STRUCTURED_TYPE:
             case RAW:
+            case VARIANT:
                 return BinaryArrayWriter::setNullLong;
             case BOOLEAN:
                 return BinaryArrayWriter::setNullBoolean;

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/writer/BinaryWriter.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/writer/BinaryWriter.java
@@ -36,6 +36,7 @@ import org.apache.flink.table.types.logical.DistinctType;
 import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.types.variant.Variant;
 
 import java.io.Serializable;
 
@@ -84,6 +85,8 @@ public interface BinaryWriter {
     void writeRow(int pos, RowData value, RowDataSerializer serializer);
 
     void writeRawValue(int pos, RawValueData<?> value, RawValueDataSerializer<?> serializer);
+
+    void writeVariant(int pos, Variant variant);
 
     /** Finally, complete write to set real size to binary. */
     void complete();
@@ -162,6 +165,9 @@ public interface BinaryWriter {
             case VARBINARY:
                 writer.writeBinary(pos, (byte[]) o);
                 break;
+            case VARIANT:
+                writer.writeVariant(pos, (Variant) o);
+                break;
             default:
                 throw new UnsupportedOperationException("Not support type: " + type);
         }
@@ -237,6 +243,8 @@ public interface BinaryWriter {
                                 pos,
                                 (RawValueData<?>) value,
                                 (RawValueDataSerializer<?>) rawSerializer);
+            case VARIANT:
+                return (writer, pos, value) -> writer.writeVariant(pos, (Variant) value);
             case NULL:
             case SYMBOL:
             case UNRESOLVED:

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ParseJsonFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ParseJsonFunction.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.table.api.TableRuntimeException;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction;
+import org.apache.flink.types.variant.BinaryVariantInternalBuilder;
+import org.apache.flink.types.variant.Variant;
+
+import javax.annotation.Nullable;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#PARSE_JSON}. */
+public class ParseJsonFunction extends BuiltInScalarFunction {
+
+    public ParseJsonFunction(SpecializedFunction.SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.PARSE_JSON, context);
+    }
+
+    public @Nullable Variant eval(@Nullable StringData jsonStr) {
+        return eval(jsonStr, false);
+    }
+
+    public @Nullable Variant eval(@Nullable StringData jsonStr, boolean allowDuplicateKeys) {
+        if (jsonStr == null) {
+            return null;
+        }
+
+        try {
+            return BinaryVariantInternalBuilder.parseJson(jsonStr.toString(), allowDuplicateKeys);
+        } catch (Throwable e) {
+            throw new TableRuntimeException(
+                    String.format("Failed to parse json string: %s", jsonStr), e);
+        }
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/TryParseJsonFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/TryParseJsonFunction.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction;
+import org.apache.flink.types.variant.BinaryVariantInternalBuilder;
+import org.apache.flink.types.variant.Variant;
+
+import javax.annotation.Nullable;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#TRY_PARSE_JSON}. */
+public class TryParseJsonFunction extends BuiltInScalarFunction {
+
+    public TryParseJsonFunction(SpecializedFunction.SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.TRY_PARSE_JSON, context);
+    }
+
+    public @Nullable Variant eval(@Nullable StringData jsonStr) {
+        return eval(jsonStr, false);
+    }
+
+    public @Nullable Variant eval(@Nullable StringData jsonStr, boolean allowDuplicateKeys) {
+        if (jsonStr == null) {
+            return null;
+        }
+
+        try {
+            return BinaryVariantInternalBuilder.parseJson(jsonStr.toString(), allowDuplicateKeys);
+        } catch (Throwable e) {
+            return null;
+        }
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/process/RepeatedRowData.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/process/RepeatedRowData.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.types.RowKind;
+import org.apache.flink.types.variant.Variant;
 
 /** A row that repeats the columns of a given row by the given count. */
 public class RepeatedRowData implements RowData {
@@ -141,5 +142,10 @@ public class RepeatedRowData implements RowData {
     @Override
     public RowData getRow(int pos, int numFields) {
         return row.getRow(pos / count, numFields);
+    }
+
+    @Override
+    public Variant getVariant(int pos) {
+        return row.getVariant(pos / count);
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/InternalSerializers.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/InternalSerializers.java
@@ -28,6 +28,7 @@ import org.apache.flink.api.common.typeutils.base.FloatSerializer;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.api.common.typeutils.base.ShortSerializer;
+import org.apache.flink.api.common.typeutils.base.VariantSerializer;
 import org.apache.flink.api.common.typeutils.base.array.BytePrimitiveArraySerializer;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.legacy.types.logical.TypeInformationRawType;
@@ -123,6 +124,8 @@ public final class InternalSerializers {
                 throw new ValidationException(
                         "The DESCRIPTOR data type is intended for parameters of PTFs. "
                                 + "Any other use is unsupported.");
+            case VARIANT:
+                return VariantSerializer.INSTANCE;
             case NULL:
             case SYMBOL:
             case UNRESOLVED:

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/TypeCheckUtils.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/TypeCheckUtils.java
@@ -37,6 +37,7 @@ import static org.apache.flink.table.types.logical.LogicalTypeRoot.ROW;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.STRUCTURED_TYPE;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.VARIANT;
 import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.isRowtimeAttribute;
 
 /** Utils for type. */
@@ -131,13 +132,18 @@ public class TypeCheckUtils {
         return type.getTypeRoot() == STRUCTURED_TYPE;
     }
 
+    private static boolean isVariantType(LogicalType type) {
+        return type.getTypeRoot() == VARIANT;
+    }
+
     public static boolean isComparable(LogicalType type) {
         return !isRaw(type)
                 && !isMap(type)
                 && !isMultiset(type)
                 && !isRow(type)
                 && !isArray(type)
-                && !isStructuredType(type);
+                && !isStructuredType(type)
+                && !isVariantType(type);
     }
 
     public static boolean isMutable(LogicalType type) {

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/BinaryArrayDataTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/BinaryArrayDataTest.java
@@ -35,6 +35,7 @@ import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.types.variant.Variant;
 
 import org.junit.jupiter.api.Test;
 
@@ -309,6 +310,24 @@ class BinaryArrayDataTest {
             BinaryArrayData newArray = splitArray(array);
             assertThat(newArray.isNullAt(0)).isTrue();
             assertThat(newArray.getString(1)).isEqualTo(fromString("jaja"));
+        }
+
+        {
+            // test variant
+            Variant variant = Variant.newBuilder().of(1);
+
+            BinaryArrayData array = new BinaryArrayData();
+            BinaryArrayWriter writer = new BinaryArrayWriter(array, 2, 8);
+            writer.setNullAt(0);
+            writer.writeVariant(1, variant);
+            writer.complete();
+
+            assertThat(array.isNullAt(0)).isTrue();
+            assertThat(array.getVariant(1)).isEqualTo(variant);
+
+            BinaryArrayData newArray = splitArray(array);
+            assertThat(newArray.isNullAt(0)).isTrue();
+            assertThat(newArray.getVariant(1)).isEqualTo(variant);
         }
 
         BinaryArrayData subArray = new BinaryArrayData();

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/BinaryRowDataTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/BinaryRowDataTest.java
@@ -52,6 +52,8 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.types.RowKind;
+import org.apache.flink.types.variant.Variant;
+import org.apache.flink.types.variant.VariantBuilder;
 
 import org.junit.jupiter.api.Test;
 
@@ -1128,5 +1130,22 @@ class BinaryRowDataTest {
 
         assertThat(nestedBinaryRow.getRow(1, 2)).isEqualTo(innerBinaryRow);
         assertThat(innerBinaryRow).isEqualTo(nestedBinaryRow.getRow(1, 2));
+    }
+
+    @Test
+    public void testVariant() {
+        BinaryRowData row = new BinaryRowData(2);
+        BinaryRowWriter writer = new BinaryRowWriter(row);
+
+        VariantBuilder builder = Variant.newBuilder();
+
+        Variant v1 = builder.object().add("k", builder.of(1)).build();
+        Variant v2 = builder.array().add(builder.of(1)).build();
+        writer.writeVariant(0, v1);
+        writer.writeVariant(1, v2);
+        writer.complete();
+
+        assertThat(row.getVariant(0)).isEqualTo(v1);
+        assertThat(row.getVariant(1)).isEqualTo(v2);
     }
 }

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/DataStructureConvertersTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/DataStructureConvertersTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.utils.DataTypeFactoryMock;
 import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
+import org.apache.flink.types.variant.Variant;
 import org.apache.flink.util.InstantiationUtil;
 
 import org.junit.jupiter.params.ParameterizedTest;
@@ -356,6 +357,8 @@ class DataStructureConvertersTest {
                                 DataTypes.STRUCTURED(GenericPojo.class, FIELD("value", DATE())))
                         .convertedTo(
                                 GenericPojo.class, new GenericPojo<>(LocalDate.ofEpochDay(123))),
+                TestSpec.forDataType(DataTypes.VARIANT())
+                        .convertedTo(Variant.class, Variant.newBuilder().of("hello")),
 
                 // partial delete messages
                 TestSpec.forDataType(


### PR DESCRIPTION
## What is the purpose of the change

This pull request introduces the Variant data structure to represent semi-structured data, a new SQL type variant, and a builtin method to parse json string to the variant type.


## Brief change log

- Patch calcite to support variant type
- Introduce `Variant` and `BinaryVariant`
- Introduce variant type and `PARSE_JSON` to Flink SQL

## Verifying this change

This change added tests and can be verified.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
