### PR TITLE
[FLINK-37935][table] Allow to read WindowingStrategy by downstream projects

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPhysicalWindowTableFunction.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPhysicalWindowTableFunction.scala
@@ -67,4 +67,8 @@ abstract class CommonPhysicalWindowTableFunction(
       null.asInstanceOf[Double]
     }
   }
+
+  def getWindowingStrategy: TimeAttributeWindowingStrategy = {
+    windowing
+  }
 }


### PR DESCRIPTION

## What is the purpose of the change

it allows to read  `WindowingStrategy` by downstream projects from `CommonPhysicalWindowTableFunction`


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
