### PR TITLE
[hotfix] Use correct `FlinkVersion.v2_1`

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecMLPredictTableFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecMLPredictTableFunction.java
@@ -81,8 +81,8 @@ import java.util.Optional;
         name = "stream-exec-ml-predict-table-function",
         version = 1,
         producedTransformations = StreamExecMLPredictTableFunction.ML_PREDICT_TRANSFORMATION,
-        minPlanVersion = FlinkVersion.V2_1,
-        minStateVersion = FlinkVersion.V2_1)
+        minPlanVersion = FlinkVersion.v2_1,
+        minStateVersion = FlinkVersion.v2_1)
 public class StreamExecMLPredictTableFunction extends ExecNodeBase<RowData>
         implements MultipleTransformationTranslator<RowData>, StreamExecNode<RowData> {
 


### PR DESCRIPTION
## What is the purpose of the change

The PR is to fix the build after 
https://github.com/apache/flink/commit/ed9aebe1680be720e23d6321623253f66b2032d4



## Verifying this change

existing tests
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
