### PR TITLE
[FLINK-37701][flink-runtime] Fix AdaptiveScheduler ignoring checkpoint states sizes for local recovery adjustment.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/JobAllocationsInformation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/JobAllocationsInformation.java
@@ -18,6 +18,7 @@
 package org.apache.flink.runtime.scheduler.adaptive.allocator;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
@@ -25,8 +26,6 @@ import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
-
-import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -47,11 +46,11 @@ public class JobAllocationsInformation {
         this.vertexAllocations = vertexAllocations;
     }
 
-    public static JobAllocationsInformation fromGraph(@Nullable ExecutionGraph graph) {
-        return graph == null
-                ? empty()
-                : new JobAllocationsInformation(
-                        calculateAllocations(graph, StateSizeEstimates.fromGraph(graph)));
+    public static JobAllocationsInformation fromGraphAndState(
+            final ExecutionGraph graph, final CompletedCheckpoint latestCheckpoint) {
+        return new JobAllocationsInformation(
+                calculateAllocations(
+                        graph, StateSizeEstimates.fromGraphAndState(graph, latestCheckpoint)));
     }
 
     public List<VertexAllocationInformation> getAllocations(JobVertexID jobVertexID) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/StateLocalitySlotAssigner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/StateLocalitySlotAssigner.java
@@ -196,14 +196,16 @@ public class StateLocalitySlotAssigner implements SlotAssigner {
     private static long estimateSize(
             KeyGroupRange newRange, VertexAllocationInformation allocation) {
         KeyGroupRange oldRange = allocation.getKeyGroupRange();
+        int numberOfKeyGroups = oldRange.getIntersection(newRange).getNumberOfKeyGroups();
         if (allocation.stateSizeInBytes * oldRange.getNumberOfKeyGroups() == 0) {
-            return 0L;
+            // As we want to maintain same allocation for local recovery, we should give positive
+            // score to allocations with the same key group range even when we have no state.
+            return numberOfKeyGroups > 0 ? 1 : 0;
         }
         // round up to 1
         long keyGroupSize =
                 allocation.stateSizeInBytes
                         / Math.min(allocation.stateSizeInBytes, oldRange.getNumberOfKeyGroups());
-        int numberOfKeyGroups = oldRange.getIntersection(newRange).getNumberOfKeyGroups();
         return numberOfKeyGroups * keyGroupSize;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/StateSizeEstimates.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/StateSizeEstimates.java
@@ -29,7 +29,7 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 
-import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -46,10 +46,6 @@ import static java.util.stream.Collectors.toMap;
 public class StateSizeEstimates {
     private final Map<ExecutionVertexID, Long> stateSizes;
 
-    public StateSizeEstimates() {
-        this(emptyMap());
-    }
-
     public StateSizeEstimates(Map<ExecutionVertexID, Long> stateSizes) {
         this.stateSizes = stateSizes;
     }
@@ -58,22 +54,13 @@ public class StateSizeEstimates {
         return Optional.ofNullable(stateSizes.get(jobVertexId));
     }
 
-    static StateSizeEstimates empty() {
-        return new StateSizeEstimates();
-    }
-
-    public static StateSizeEstimates fromGraph(@Nullable ExecutionGraph executionGraph) {
-        return Optional.ofNullable(executionGraph)
-                .flatMap(graph -> Optional.ofNullable(graph.getCheckpointCoordinator()))
-                .flatMap(coordinator -> Optional.ofNullable(coordinator.getCheckpointStore()))
-                .flatMap(store -> Optional.ofNullable(store.getLatestCheckpoint()))
-                .map(
-                        cp ->
-                                new StateSizeEstimates(
-                                        merge(
-                                                fromCompletedCheckpoint(cp),
-                                                mapVerticesToOperators(executionGraph))))
-                .orElse(empty());
+    public static StateSizeEstimates fromGraphAndState(
+            @NotNull final ExecutionGraph executionGraph,
+            @NotNull final CompletedCheckpoint latestCheckpoint) {
+        return new StateSizeEstimates(
+                merge(
+                        fromCompletedCheckpoint(latestCheckpoint),
+                        mapVerticesToOperators(executionGraph)));
     }
 
     /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.scheduler;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.blob.BlobWriter;
@@ -27,7 +28,9 @@ import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.CheckpointRetentionPolicy;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.runtime.checkpoint.PendingCheckpoint;
+import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.Execution;
@@ -47,6 +50,7 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobGraphBuilder;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
 import org.apache.flink.runtime.jobgraph.tasks.JobCheckpointingSettings;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
@@ -77,6 +81,7 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.finishJobVertex;
+import static org.apache.flink.runtime.testutils.CommonTestUtils.waitUntilCondition;
 import static org.apache.flink.runtime.util.JobVertexConnectionUtils.connectNewDataSetAsInput;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -85,6 +90,8 @@ import static org.assertj.core.api.Assertions.fail;
 public class SchedulerTestingUtils {
 
     private static final long DEFAULT_CHECKPOINT_TIMEOUT_MS = 10 * 60 * 1000;
+    private static final long RETRY_INTERVAL_MILLIS = 10L;
+    private static final int RETRY_ATTEMPTS = 6000;
 
     private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(300);
 
@@ -164,7 +171,7 @@ public class SchedulerTestingUtils {
     }
 
     public static Collection<ExecutionAttemptID> getAllCurrentExecutionAttempts(
-            DefaultScheduler scheduler) {
+            SchedulerNG scheduler) {
         return StreamSupport.stream(
                         scheduler
                                 .requestJob()
@@ -206,7 +213,7 @@ public class SchedulerTestingUtils {
         scheduler.updateTaskExecutionState(new TaskExecutionState(attemptID, executionState));
     }
 
-    public static void setAllExecutionsToRunning(final DefaultScheduler scheduler) {
+    public static void setAllExecutionsToRunning(final SchedulerNG scheduler) {
         getAllCurrentExecutionAttempts(scheduler)
                 .forEach(
                         (attemptId) -> {
@@ -238,6 +245,22 @@ public class SchedulerTestingUtils {
             checkpointCoordinator.receiveAcknowledgeMessage(
                     acknowledgeCheckpoint, "Unknown location");
         }
+    }
+
+    public static void acknowledgePendingCheckpoint(
+            final SchedulerNG scheduler,
+            final int checkpointId,
+            final Map<OperatorID, OperatorSubtaskState> subtaskStateMap) {
+        getAllCurrentExecutionAttempts(scheduler)
+                .forEach(
+                        (executionAttemptID) -> {
+                            scheduler.acknowledgeCheckpoint(
+                                    scheduler.requestJob().getJobId(),
+                                    executionAttemptID,
+                                    checkpointId,
+                                    new CheckpointMetrics(),
+                                    new TaskStateSnapshot(subtaskStateMap));
+                        });
     }
 
     public static CompletableFuture<CompletedCheckpoint> triggerCheckpoint(
@@ -279,27 +302,40 @@ public class SchedulerTestingUtils {
                                         null));
     }
 
-    public static CompletedCheckpoint takeCheckpoint(DefaultScheduler scheduler) throws Exception {
-        final CheckpointCoordinator checkpointCoordinator = getCheckpointCoordinator(scheduler);
-        checkpointCoordinator.triggerCheckpoint(false);
-
-        assertThat(checkpointCoordinator.getNumberOfPendingCheckpoints())
-                .as("test setup inconsistent")
-                .isOne();
-        final PendingCheckpoint checkpoint =
-                checkpointCoordinator.getPendingCheckpoints().values().iterator().next();
-        final CompletableFuture<CompletedCheckpoint> future = checkpoint.getCompletionFuture();
-
-        acknowledgePendingCheckpoint(scheduler, checkpoint.getCheckpointID());
-
-        CompletedCheckpoint completed = future.getNow(null);
-        assertThat(completed).withFailMessage("checkpoint not complete").isNotNull();
-        return completed;
-    }
-
     @SuppressWarnings("deprecation")
     public static CheckpointCoordinator getCheckpointCoordinator(SchedulerBase scheduler) {
         return scheduler.getCheckpointCoordinator();
+    }
+
+    public static void waitForJobStatusRunning(final SchedulerNG scheduler) throws Exception {
+        waitUntilCondition(
+                () -> scheduler.requestJobStatus() == JobStatus.RUNNING,
+                RETRY_INTERVAL_MILLIS,
+                RETRY_ATTEMPTS);
+    }
+
+    public static void waitForCheckpointInProgress(final SchedulerNG scheduler) throws Exception {
+        waitUntilCondition(
+                () ->
+                        scheduler
+                                        .requestCheckpointStats()
+                                        .getCounts()
+                                        .getNumberOfInProgressCheckpoints()
+                                > 0,
+                RETRY_INTERVAL_MILLIS,
+                RETRY_ATTEMPTS);
+    }
+
+    public static void waitForCompletedCheckpoint(final SchedulerNG scheduler) throws Exception {
+        waitUntilCondition(
+                () ->
+                        scheduler
+                                        .requestCheckpointStats()
+                                        .getCounts()
+                                        .getNumberOfCompletedCheckpoints()
+                                > 0,
+                RETRY_INTERVAL_MILLIS,
+                RETRY_ATTEMPTS);
     }
 
     private static ExecutionJobVertex getJobVertex(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
@@ -1074,9 +1074,16 @@ class ExecutingTest {
         MockExecutionJobVertex(
                 Function<ExecutionJobVertex, ExecutionVertex> executionVertexSupplier)
                 throws JobException {
+            this(executionVertexSupplier, new JobVertex("test"));
+        }
+
+        MockExecutionJobVertex(
+                final Function<ExecutionJobVertex, ExecutionVertex> executionVertexSupplier,
+                final JobVertex jobVertex)
+                throws JobException {
             super(
                     new MockInternalExecutionGraphAccessor(),
-                    new JobVertex("test"),
+                    jobVertex,
                     new DefaultVertexParallelismInfo(1, 1, max -> Optional.empty()),
                     new CoordinatorStoreImpl(),
                     UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/allocator/StateLocalitySlotAssignerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/allocator/StateLocalitySlotAssignerTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
 import org.apache.flink.runtime.scheduler.adaptive.JobSchedulingPlan.SlotAssignment;
 import org.apache.flink.runtime.scheduler.adaptive.allocator.JobAllocationsInformation.VertexAllocationInformation;
 import org.apache.flink.runtime.scheduler.adaptive.allocator.JobInformation.VertexInformation;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 
@@ -32,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -39,6 +41,7 @@ import java.util.stream.IntStream;
 
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 
@@ -72,6 +75,56 @@ class StateLocalitySlotAssignerTest {
                         allocations);
 
         verifyAssignments(assignments, newParallelism, allocationWith200bytes);
+    }
+
+    @Test
+    // In case of local recovery, we want to preserve slot allocations even if there is no
+    // keyed managed state available.
+    public void testSlotsPreservationWithNoStateSameParallelism() {
+        final int parallelism = 2;
+        final VertexInformation vertex = createVertex(parallelism);
+        final AllocationID allocationID1 = new AllocationID();
+        final AllocationID allocationID2 = new AllocationID();
+
+        final List<VertexAllocationInformation> previousAllocations =
+                Arrays.asList(
+                        new VertexAllocationInformation(
+                                allocationID1, vertex.getJobVertexID(), KeyGroupRange.of(0, 63), 0),
+                        new VertexAllocationInformation(
+                                allocationID2,
+                                vertex.getJobVertexID(),
+                                KeyGroupRange.of(64, 127),
+                                0));
+
+        final Collection<SlotAssignment> assignments =
+                assign(
+                        vertex,
+                        // Providing allocation IDs in reverse order to check that assigner fixes
+                        // the order based on previous allocations.
+                        Arrays.asList(allocationID2, allocationID1),
+                        previousAllocations);
+
+        // Extract allocation IDs from assignments sorted by subtask index.
+        final List<AllocationID> subtaskOrderedNewAllocations =
+                assignments.stream()
+                        .sorted(
+                                Comparator.comparingInt(
+                                        assignment ->
+                                                assignment
+                                                        .getTargetAs(
+                                                                SlotSharingSlotAllocator
+                                                                        .ExecutionSlotSharingGroup
+                                                                        .class)
+                                                        .getContainedExecutionVertices()
+                                                        .stream()
+                                                        .mapToInt(
+                                                                ExecutionVertexID::getSubtaskIndex)
+                                                        .findAny()
+                                                        .orElseThrow()))
+                        .map(assignment -> assignment.getSlotInfo().getAllocationId())
+                        .collect(Collectors.toList());
+
+        assertThat(subtaskOrderedNewAllocations).containsExactly(allocationID1, allocationID2);
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/allocator/TestingSlotAllocator.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/allocator/TestingSlotAllocator.java
@@ -21,9 +21,12 @@ package org.apache.flink.runtime.scheduler.adaptive.allocator;
 import org.apache.flink.runtime.jobmaster.SlotInfo;
 import org.apache.flink.runtime.scheduler.adaptive.JobSchedulingPlan;
 import org.apache.flink.runtime.util.ResourceCounter;
+import org.apache.flink.util.function.TriFunction;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 /** Testing implementation of {@link SlotAllocator}. */
@@ -32,14 +35,39 @@ public class TestingSlotAllocator implements SlotAllocator {
     private final Function<Iterable<JobInformation.VertexInformation>, ResourceCounter>
             calculateRequiredSlotsFunction;
 
-    private final Function<VertexParallelism, Optional<ReservedSlots>> tryReserveResourcesFunction;
+    private final Function<JobSchedulingPlan, Optional<ReservedSlots>> tryReserveResourcesFunction;
+
+    private final BiFunction<
+                    JobInformation, Collection<? extends SlotInfo>, Optional<VertexParallelism>>
+            determineParallelismFunction;
+
+    private final TriFunction<
+                    JobInformation,
+                    Collection<? extends SlotInfo>,
+                    JobAllocationsInformation,
+                    Optional<JobSchedulingPlan>>
+            determineParallelismAndCalculateAssignmentFunction;
 
     private TestingSlotAllocator(
             Function<Iterable<JobInformation.VertexInformation>, ResourceCounter>
                     calculateRequiredSlotsFunction,
-            Function<VertexParallelism, Optional<ReservedSlots>> tryReserveResourcesFunction) {
+            Function<JobSchedulingPlan, Optional<ReservedSlots>> tryReserveResourcesFunction,
+            final BiFunction<
+                            JobInformation,
+                            Collection<? extends SlotInfo>,
+                            Optional<VertexParallelism>>
+                    determineParallelismFunction,
+            final TriFunction<
+                            JobInformation,
+                            Collection<? extends SlotInfo>,
+                            JobAllocationsInformation,
+                            Optional<JobSchedulingPlan>>
+                    determineParallelismAndCalculateAssignmentFunction) {
         this.calculateRequiredSlotsFunction = calculateRequiredSlotsFunction;
         this.tryReserveResourcesFunction = tryReserveResourcesFunction;
+        this.determineParallelismFunction = determineParallelismFunction;
+        this.determineParallelismAndCalculateAssignmentFunction =
+                determineParallelismAndCalculateAssignmentFunction;
     }
 
     @Override
@@ -51,7 +79,7 @@ public class TestingSlotAllocator implements SlotAllocator {
     @Override
     public Optional<VertexParallelism> determineParallelism(
             JobInformation jobInformation, Collection<? extends SlotInfo> slots) {
-        return Optional.empty();
+        return determineParallelismFunction.apply(jobInformation, slots);
     }
 
     @Override
@@ -59,12 +87,13 @@ public class TestingSlotAllocator implements SlotAllocator {
             JobInformation jobInformation,
             Collection<? extends SlotInfo> slots,
             JobAllocationsInformation jobAllocationsInformation) {
-        return Optional.empty();
+        return determineParallelismAndCalculateAssignmentFunction.apply(
+                jobInformation, slots, jobAllocationsInformation);
     }
 
     @Override
     public Optional<ReservedSlots> tryReserveResources(JobSchedulingPlan jobSchedulingPlan) {
-        return tryReserveResourcesFunction.apply(jobSchedulingPlan.getVertexParallelism());
+        return tryReserveResourcesFunction.apply(jobSchedulingPlan);
     }
 
     public static Builder newBuilder() {
@@ -75,8 +104,20 @@ public class TestingSlotAllocator implements SlotAllocator {
     public static final class Builder {
         private Function<Iterable<JobInformation.VertexInformation>, ResourceCounter>
                 calculateRequiredSlotsFunction = ignored -> ResourceCounter.empty();
-        private Function<VertexParallelism, Optional<ReservedSlots>> tryReserveResourcesFunction =
+        private Function<JobSchedulingPlan, Optional<ReservedSlots>> tryReserveResourcesFunction =
                 ignored -> Optional.empty();
+
+        private BiFunction<
+                        JobInformation, Collection<? extends SlotInfo>, Optional<VertexParallelism>>
+                determineSlotsFunction = (jobInformation, slots) -> Optional.empty();
+
+        private TriFunction<
+                        JobInformation,
+                        Collection<? extends SlotInfo>,
+                        JobAllocationsInformation,
+                        Optional<JobSchedulingPlan>>
+                determineParallelismAndCalculateAssignmentFunction =
+                        (jobInformation, slots, jobAllocationsInformation) -> Optional.empty();
 
         public Builder setCalculateRequiredSlotsFunction(
                 Function<Iterable<JobInformation.VertexInformation>, ResourceCounter>
@@ -85,15 +126,56 @@ public class TestingSlotAllocator implements SlotAllocator {
             return this;
         }
 
+        public Builder setDetermineParallelismFunction(
+                BiFunction<
+                                JobInformation,
+                                Collection<? extends SlotInfo>,
+                                Optional<VertexParallelism>>
+                        determineParallelismFunction) {
+            this.determineSlotsFunction = determineParallelismFunction;
+            return this;
+        }
+
+        public Builder setDetermineParallelismAndCalculateAssignmentFunction(
+                TriFunction<
+                                JobInformation,
+                                Collection<? extends SlotInfo>,
+                                JobAllocationsInformation,
+                                Optional<JobSchedulingPlan>>
+                        determineParallelismAndCalculateAssignmentFunction) {
+            this.determineParallelismAndCalculateAssignmentFunction =
+                    determineParallelismAndCalculateAssignmentFunction;
+            return this;
+        }
+
         public Builder setTryReserveResourcesFunction(
-                Function<VertexParallelism, Optional<ReservedSlots>> tryReserveResourcesFunction) {
+                Function<JobSchedulingPlan, Optional<ReservedSlots>> tryReserveResourcesFunction) {
             this.tryReserveResourcesFunction = tryReserveResourcesFunction;
             return this;
         }
 
         public TestingSlotAllocator build() {
             return new TestingSlotAllocator(
-                    calculateRequiredSlotsFunction, tryReserveResourcesFunction);
+                    calculateRequiredSlotsFunction,
+                    tryReserveResourcesFunction,
+                    determineSlotsFunction,
+                    determineParallelismAndCalculateAssignmentFunction);
         }
+    }
+
+    public static TestingSlotAllocator getArgumentCapturingDelegatingSlotAllocator(
+            final SlotAllocator slotAllocator,
+            final List<JobAllocationsInformation> capturedAllocations) {
+        return TestingSlotAllocator.newBuilder()
+                .setCalculateRequiredSlotsFunction(slotAllocator::calculateRequiredSlots)
+                .setTryReserveResourcesFunction(slotAllocator::tryReserveResources)
+                .setDetermineParallelismFunction(slotAllocator::determineParallelism)
+                .setDetermineParallelismAndCalculateAssignmentFunction(
+                        (jobInformation, slotInfos, jobAllocationsInformation) -> {
+                            capturedAllocations.add(jobAllocationsInformation);
+                            return slotAllocator.determineParallelismAndCalculateAssignment(
+                                    jobInformation, slotInfos, jobAllocationsInformation);
+                        })
+                .build();
     }
 }

--- a/tools/maven/checkstyle.xml
+++ b/tools/maven/checkstyle.xml
@@ -61,7 +61,7 @@ This file is based on the checkstyle file of Apache Beam.
 	-->
 
 	<module name="FileLength">
-		<property name="max" value="3100"/>
+		<property name="max" value="3150"/>
 	</module>
 
 	<!-- All Java AST specific tests live under TreeWalker module. -->


### PR DESCRIPTION
## What is the purpose of the change

Address local recovery issues when Adaptive scheduler is enabled. 
1. Pass latest completed checkpoint in addition to execution graph to `StateSizeEstimates` (that is needed because execution graph goes through cancelling/cancelled state and checkpoint coordinator is `nulled` by the time we run calculations).
2. Assign positive priority score to allocations that have overlapping key groups even when state size is zero (currently we would only give priority score if `managedKeyedState` is present, but local recovery semantics doesn't `require` state presence).

**Context**: When job can be recovered locally, we should keep slot allocation after restart to maintain 

## Verifying this change

`LocalRecoveryITCase#testRecoverLocallyFromProcessCrashWithWorkingDirectory` now passes when `AdaptiveScheduler` is enabled. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
