### PR TITLE
[FLINK-37795] rewrite ml_evaluate to ml_predict and aggregate function

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/ml/TaskType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/ml/TaskType.java
@@ -19,8 +19,11 @@
 package org.apache.flink.table.ml;
 
 import org.apache.flink.annotation.Experimental;
+import org.apache.flink.table.api.ValidationException;
 
 import java.util.Arrays;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Enum representing different types of machine learning tasks. Each task type has a corresponding
@@ -48,10 +51,31 @@ public enum TaskType {
         return Arrays.stream(values())
                 .filter(taskType -> taskType.name.equals(name))
                 .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("Unknown task type: " + name));
+                .orElseThrow(() -> new ValidationException("Unknown task type: " + name + "."));
     }
 
     public static boolean isValidTaskType(String name) {
         return Arrays.stream(values()).anyMatch(taskType -> taskType.name.equals(name));
+    }
+
+    public static Optional<RuntimeException> throwOrReturnInvalidTaskType(
+            String task, boolean throwException) {
+        if (!isValidTaskType(task)) {
+            ValidationException exception =
+                    new ValidationException(
+                            "Invalid task type: '"
+                                    + task
+                                    + "'. Supported task types are: "
+                                    + Arrays.stream(TaskType.values())
+                                            .map(TaskType::getName)
+                                            .collect(Collectors.toList())
+                                    + ".");
+            if (throwException) {
+                throw exception;
+            } else {
+                return Optional.of(exception);
+            }
+        }
+        return Optional.empty();
     }
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestModelProviderFactory.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestModelProviderFactory.java
@@ -68,7 +68,6 @@ public final class TestModelProviderFactory implements ModelProviderFactory {
     @Override
     public Set<ConfigOption<?>> requiredOptions() {
         final Set<ConfigOption<?>> options = new HashSet<>();
-        options.add(TASK);
         options.add(ENDPOINT);
         return options;
     }
@@ -77,6 +76,7 @@ public final class TestModelProviderFactory implements ModelProviderFactory {
     public Set<ConfigOption<?>> optionalOptions() {
         Set<ConfigOption<?>> options = new HashSet<>();
         options.add(MODEL_VERSION);
+        options.add(TASK);
         return options;
     }
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/ml/TaskTypeTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/ml/TaskTypeTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.table.ml;
 
+import org.apache.flink.table.api.ValidationException;
+
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -57,7 +59,8 @@ public class TaskTypeTest {
     @Test
     public void testFromNameWithInvalidName() {
         assertThatThrownBy(() -> TaskType.fromName("invalid_task_type"))
-                .isInstanceOf(IllegalArgumentException.class);
+                .isInstanceOf(ValidationException.class)
+                .hasMessage("Unknown task type: invalid_task_type.");
     }
 
     @Test

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/catalog/CatalogSchemaModel.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/catalog/CatalogSchemaModel.java
@@ -96,7 +96,7 @@ public class CatalogSchemaModel {
         FlinkContext context = ShortcutUtils.unwrapContext(cluster);
         ModelProvider modelProvider = createModelProvider(context, contextResolvedModel);
         return new RexModelCall(
-                getInputRowType(validator.getTypeFactory()), contextResolvedModel, modelProvider);
+                getOutputRowType(validator.getTypeFactory()), contextResolvedModel, modelProvider);
     }
 
     private static RelDataType schemaToRelDataType(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/ml/MLEvaluationAggregationFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/ml/MLEvaluationAggregationFunction.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions.sql.ml;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.catalog.DataTypeFactory;
+import org.apache.flink.table.functions.AggregateFunction;
+import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.ml.TaskType;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.ArgumentCount;
+import org.apache.flink.table.types.inference.CallContext;
+import org.apache.flink.table.types.inference.InputTypeStrategy;
+import org.apache.flink.table.types.inference.Signature;
+import org.apache.flink.table.types.inference.TypeInference;
+import org.apache.flink.types.Row;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/** Aggregation function for evaluating models based on task type. */
+@Internal
+public class MLEvaluationAggregationFunction extends AggregateFunction<Row, Object> {
+
+    public static final Map<String, DataType> TASK_TYPE_MAP =
+            Map.of(
+                    TaskType.TEXT_GENERATION.getName(),
+                    DataTypes.STRING(),
+                    TaskType.CLUSTERING.getName(),
+                    DataTypes.DOUBLE(),
+                    TaskType.EMBEDDING.getName(),
+                    DataTypes.ARRAY(DataTypes.FLOAT()),
+                    TaskType.CLASSIFICATION.getName(),
+                    DataTypes.DOUBLE(),
+                    TaskType.REGRESSION.getName(),
+                    DataTypes.DOUBLE());
+
+    private final String task;
+
+    public MLEvaluationAggregationFunction(String task) {
+        TaskType.throwOrReturnInvalidTaskType(task, true);
+        this.task = task;
+    }
+
+    private TypeInference typeInference() {
+        return TypeInference.newBuilder()
+                .inputTypeStrategy(
+                        new InputTypeStrategy() {
+                            @Override
+                            public ArgumentCount getArgumentCount() {
+                                return new ArgumentCount() {
+                                    @Override
+                                    public boolean isValidCount(int count) {
+                                        return count == 2;
+                                    }
+
+                                    @Override
+                                    public Optional<Integer> getMinCount() {
+                                        return Optional.of(2);
+                                    }
+
+                                    @Override
+                                    public Optional<Integer> getMaxCount() {
+                                        return Optional.of(2);
+                                    }
+                                };
+                            }
+
+                            @Override
+                            public Optional<List<DataType>> inferInputTypes(
+                                    CallContext callContext, boolean throwOnFailure) {
+                                DataType argumentType = TASK_TYPE_MAP.get(task.toLowerCase());
+                                final List<DataType> args = List.of(argumentType, argumentType);
+                                return Optional.of(args);
+                            }
+
+                            @Override
+                            public List<Signature> getExpectedSignatures(
+                                    FunctionDefinition definition) {
+                                final List<Signature.Argument> arguments = new ArrayList<>();
+                                arguments.add(Signature.Argument.of("label"));
+                                arguments.add(Signature.Argument.of("prediction"));
+                                return Collections.singletonList(Signature.of(arguments));
+                            }
+                        })
+                .outputTypeStrategy(
+                        callContext ->
+                                Optional.of(
+                                        DataTypes.MAP(
+                                                        DataTypes.STRING().notNull(),
+                                                        DataTypes.DOUBLE().notNull())
+                                                .notNull()
+                                                .bridgedTo(Map.class)))
+                .accumulatorTypeStrategy(callContext -> Optional.of(DataTypes.DOUBLE()))
+                .build();
+    }
+
+    /** Creates a new accumulator based on the model task type. */
+    @Override
+    public Object createAccumulator() {
+        // TODO
+        return null;
+    }
+
+    @Override
+    public TypeInference getTypeInference(DataTypeFactory typeFactory) {
+        return typeInference();
+    }
+
+    /**
+     * Accumulates input values for evaluation. The first argument is the model path, followed by
+     * input features, and the last argument is the actual value (ground truth).
+     */
+    public void accumulate(Object acc, Object... values) {
+        // TODO
+    }
+
+    /** Retracts the input values from evaluation. */
+    public void retract(Object acc, Object... values) {
+        // TODO
+    }
+
+    public void merge(Object acc, Iterable<Object> its) {
+        // TODO
+    }
+
+    public void resetAccumulator(Object acc) {
+        // TODO
+    }
+
+    @Override
+    public Row getValue(Object accumulator) {
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return "MLEvaluationAggregationFunction{" + "task='" + task + "}";
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/ml/SqlMLEvaluateTableFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/ml/SqlMLEvaluateTableFunction.java
@@ -40,7 +40,6 @@ import org.apache.calcite.sql.validate.SqlNameMatcher;
 import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.util.NlsString;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -181,16 +180,7 @@ public class SqlMLEvaluateTableFunction extends SqlMLTableFunction {
             }
 
             String task = ((SqlCharStringLiteral) node).getValueAs(NlsString.class).getValue();
-            if (!TaskType.isValidTaskType(task)) {
-                return Optional.of(
-                        new ValidationException(
-                                "Unsupported task: "
-                                        + task
-                                        + ". Supported tasks are: "
-                                        + Arrays.toString(TaskType.values())
-                                        + "."));
-            }
-            return Optional.empty();
+            return TaskType.throwOrReturnInvalidTaskType(task, false);
         }
 
         private static Optional<RuntimeException> checkModelOutputType(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/ExpandMLEvaluateTableFunctionRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/ExpandMLEvaluateTableFunctionRule.java
@@ -1,0 +1,263 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.logical;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.ContextResolvedFunction;
+import org.apache.flink.table.functions.FunctionIdentifier;
+import org.apache.flink.table.ml.AsyncPredictRuntimeProvider;
+import org.apache.flink.table.ml.PredictRuntimeProvider;
+import org.apache.flink.table.ml.TaskType;
+import org.apache.flink.table.planner.calcite.FlinkContext;
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.planner.calcite.RexModelCall;
+import org.apache.flink.table.planner.functions.bridging.BridgingSqlAggFunction;
+import org.apache.flink.table.planner.functions.sql.ml.MLEvaluationAggregationFunction;
+import org.apache.flink.table.planner.functions.sql.ml.SqlMLEvaluateTableFunction;
+import org.apache.flink.table.planner.functions.sql.ml.SqlMLPredictTableFunction;
+import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableFunctionScan;
+import org.apache.flink.table.planner.utils.ShortcutUtils;
+
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.rel.RelCollations;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.logical.LogicalTableFunctionScan;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexCallBinding;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.util.NlsString;
+import org.immutables.value.Value;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Rule that expands ML evaluation table function calls.
+ *
+ * <p>This rule matches {@link FlinkLogicalTableFunctionScan} with a {@link
+ * SqlMLEvaluateTableFunction} call and expands it into ml predict table function and an aggregation
+ * function following it.
+ */
+@Internal
+@Value.Enclosing
+public class ExpandMLEvaluateTableFunctionRule
+        extends RelRule<ExpandMLEvaluateTableFunctionRule.Config> {
+
+    public static final RelOptRule INSTANCE = new ExpandMLEvaluateTableFunctionRule(Config.DEFAULT);
+
+    public ExpandMLEvaluateTableFunctionRule(Config config) {
+        super(config);
+    }
+
+    private static RexCall getConfigMap(RexCall rexCall) {
+        if (rexCall.getOperands().size() > 5) {
+            return (RexCall) rexCall.getOperands().get(5);
+        }
+        if (rexCall.getOperands().size() > 4) {
+            RexNode node = rexCall.getOperands().get(4);
+            if (node instanceof RexCall
+                    && ((RexCall) node).getOperator().getKind() == SqlKind.MAP_VALUE_CONSTRUCTOR) {
+                return (RexCall) node;
+            }
+        }
+        return null;
+    }
+
+    private static String getTask(RexCall rexCall) {
+        final RexModelCall modelCall = (RexModelCall) rexCall.getOperands().get(1);
+        final RexNode taskNode = rexCall.getOperands().get(4);
+        String task = null;
+        if (taskNode instanceof RexLiteral) {
+            task = ((RexLiteral) taskNode).getValueAs(NlsString.class).getValue();
+            if (task == null || task.isEmpty()) {
+                task = null;
+            }
+        }
+        if (task == null) {
+            throw new ValidationException(
+                    "Task type must be specified in the model options or as a parameter to the ML_EVALUATE function.");
+        }
+        TaskType.throwOrReturnInvalidTaskType(task, true);
+        return task;
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+        final LogicalTableFunctionScan scan = call.rel(0);
+        final RelDataType resultType = scan.getRowType();
+        final RelBuilder relBuilder = call.builder().push(scan.getInput(0));
+
+        final RexCall rexCall = (RexCall) scan.getCall();
+
+        RelDataType predictOutputType = addPredictTableFunction(relBuilder, rexCall);
+        addProjection(relBuilder, rexCall, predictOutputType);
+        addAggregate(relBuilder, rexCall, resultType);
+
+        call.transformTo(relBuilder.build());
+    }
+
+    private void addAggregate(RelBuilder relBuilder, RexCall rexCall, RelDataType resultType) {
+        final String task = getTask(rexCall);
+        final MLEvaluationAggregationFunction aggregationFunction =
+                new MLEvaluationAggregationFunction(task);
+        final FlinkContext context = ShortcutUtils.unwrapContext(relBuilder.getCluster());
+        final FlinkTypeFactory typeFactory =
+                ShortcutUtils.unwrapTypeFactory(relBuilder.getCluster());
+        relBuilder.aggregate(
+                relBuilder.groupKey(),
+                List.of(
+                        AggregateCall.create(
+                                BridgingSqlAggFunction.of(
+                                        context,
+                                        typeFactory,
+                                        ContextResolvedFunction.temporary(
+                                                FunctionIdentifier.of("ml_evaluate"),
+                                                aggregationFunction)),
+                                false,
+                                false,
+                                false,
+                                List.of(0, 1),
+                                -1,
+                                null,
+                                RelCollations.EMPTY,
+                                resultType.getFieldList().get(0).getType(),
+                                "result")));
+    }
+
+    private void addProjection(
+            RelBuilder relBuilder, RexCall rexCall, RelDataType predictOutputType) {
+        final RexCall labelDescriptor = (RexCall) rexCall.getOperands().get(2);
+        final String labelCol =
+                ((RexLiteral) labelDescriptor.getOperands().get(0))
+                        .getValueAs(NlsString.class)
+                        .getValue();
+
+        // Project the label column and the last column (prediction). Only one label and prediction
+        // column is expected. Validation is done in SqlMLEvaluateTableFunction.
+        final List<RexNode> projectFields =
+                predictOutputType.getFieldList().stream()
+                        .filter(
+                                field ->
+                                        field.getName().equals(labelCol)
+                                                || field.getIndex()
+                                                        == predictOutputType.getFieldCount() - 1)
+                        .map(field -> relBuilder.field(field.getIndex()))
+                        .collect(Collectors.toList());
+        relBuilder.project(projectFields);
+    }
+
+    private RelDataType addPredictTableFunction(RelBuilder relBuilder, RexCall rexCall) {
+        final RexCall tableArg = (RexCall) rexCall.getOperands().get(0);
+        final RexCall modelCall = (RexCall) rexCall.getOperands().get(1);
+        final RexCall featuresDescriptor = (RexCall) rexCall.getOperands().get(3);
+
+        // Get optional config map if present
+        final RexCall configMap = getConfigMap(rexCall);
+
+        final List<RexNode> predictOperands = new ArrayList<>();
+        predictOperands.add(tableArg);
+        predictOperands.add(modelCall);
+        predictOperands.add(featuresDescriptor);
+        if (configMap != null) {
+            predictOperands.add(configMap);
+        }
+
+        final RexCall predictCall =
+                (RexCall)
+                        relBuilder
+                                .getRexBuilder()
+                                .makeCall(new SqlMLPredictTableFunction(), predictOperands);
+
+        RexCallBinding callBinding =
+                new RexCallBinding(
+                        relBuilder.getTypeFactory(),
+                        predictCall.getOperator(),
+                        predictOperands,
+                        List.of());
+
+        RelDataType predictReturnType =
+                ((SqlMLPredictTableFunction) predictCall.getOperator())
+                        .getRowTypeInference()
+                        .inferReturnType(callBinding);
+
+        relBuilder.push(
+                LogicalTableFunctionScan.create(
+                        relBuilder.getCluster(),
+                        List.of(relBuilder.build()),
+                        predictCall,
+                        null,
+                        predictReturnType,
+                        Collections.emptySet()));
+
+        return predictReturnType;
+    }
+
+    /** Rule configuration. */
+    @Value.Immutable(singleton = false)
+    public interface Config extends RelRule.Config {
+        Config DEFAULT =
+                ImmutableExpandMLEvaluateTableFunctionRule.Config.builder()
+                        .build()
+                        .withDescription("ExpandMLEvaluateTableFunctionRule")
+                        .as(Config.class)
+                        .onMLEvaluateFunction();
+
+        @Override
+        default RelOptRule toRule() {
+            return new ExpandMLEvaluateTableFunctionRule(this);
+        }
+
+        default Config onMLEvaluateFunction() {
+            final RelRule.OperandTransform scanTransform =
+                    operandBuilder ->
+                            operandBuilder
+                                    .operand(LogicalTableFunctionScan.class)
+                                    .predicate(
+                                            scan -> {
+                                                if (!(scan.getCall() instanceof RexCall)) {
+                                                    return false;
+                                                }
+                                                RexCall call = (RexCall) scan.getCall();
+                                                if (!(call.getOperator()
+                                                        instanceof SqlMLEvaluateTableFunction)) {
+                                                    return false;
+                                                }
+                                                final RexModelCall modelCall =
+                                                        (RexModelCall) call.getOperands().get(1);
+                                                return modelCall.getModelProvider()
+                                                                instanceof PredictRuntimeProvider
+                                                        || modelCall.getModelProvider()
+                                                                instanceof
+                                                                AsyncPredictRuntimeProvider;
+                                            })
+                                    .anyInputs();
+
+            return withOperandSupplier(scanTransform).as(Config.class);
+        }
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/ExpandMLEvaluateTableFunctionRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/ExpandMLEvaluateTableFunctionRule.java
@@ -74,38 +74,6 @@ public class ExpandMLEvaluateTableFunctionRule
         super(config);
     }
 
-    private static RexCall getConfigMap(RexCall rexCall) {
-        if (rexCall.getOperands().size() > 5) {
-            return (RexCall) rexCall.getOperands().get(5);
-        }
-        if (rexCall.getOperands().size() > 4) {
-            RexNode node = rexCall.getOperands().get(4);
-            if (node instanceof RexCall
-                    && ((RexCall) node).getOperator().getKind() == SqlKind.MAP_VALUE_CONSTRUCTOR) {
-                return (RexCall) node;
-            }
-        }
-        return null;
-    }
-
-    private static String getTask(RexCall rexCall) {
-        final RexModelCall modelCall = (RexModelCall) rexCall.getOperands().get(1);
-        final RexNode taskNode = rexCall.getOperands().get(4);
-        String task = null;
-        if (taskNode instanceof RexLiteral) {
-            task = ((RexLiteral) taskNode).getValueAs(NlsString.class).getValue();
-            if (task == null || task.isEmpty()) {
-                task = null;
-            }
-        }
-        if (task == null) {
-            throw new ValidationException(
-                    "Task type must be specified in the model options or as a parameter to the ML_EVALUATE function.");
-        }
-        TaskType.throwOrReturnInvalidTaskType(task, true);
-        return task;
-    }
-
     @Override
     public void onMatch(RelOptRuleCall call) {
         final LogicalTableFunctionScan scan = call.rel(0);
@@ -215,6 +183,37 @@ public class ExpandMLEvaluateTableFunctionRule
                         Collections.emptySet()));
 
         return predictReturnType;
+    }
+
+    private static RexCall getConfigMap(RexCall rexCall) {
+        if (rexCall.getOperands().size() > 5) {
+            return (RexCall) rexCall.getOperands().get(5);
+        }
+        if (rexCall.getOperands().size() > 4) {
+            RexNode node = rexCall.getOperands().get(4);
+            if (node instanceof RexCall
+                    && ((RexCall) node).getOperator().getKind() == SqlKind.MAP_VALUE_CONSTRUCTOR) {
+                return (RexCall) node;
+            }
+        }
+        return null;
+    }
+
+    private static String getTask(RexCall rexCall) {
+        final RexNode taskNode = rexCall.getOperands().get(4);
+        String task = null;
+        if (taskNode instanceof RexLiteral) {
+            task = ((RexLiteral) taskNode).getValueAs(NlsString.class).getValue();
+            if (task == null || task.isEmpty()) {
+                task = null;
+            }
+        }
+        if (task == null) {
+            throw new ValidationException(
+                    "Task type must be specified as a parameter to the ML_EVALUATE function.");
+        }
+        TaskType.throwOrReturnInvalidTaskType(task, true);
+        return task;
     }
 
     /** Rule configuration. */

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -131,7 +131,9 @@ object FlinkStreamRuleSets {
           // rewrite constant table function scan to correlate
           JoinTableFunctionScanToCorrelateRule.INSTANCE,
           // Wrap arguments for JSON aggregate functions
-          WrapJsonAggFunctionArgumentsRule.INSTANCE
+          WrapJsonAggFunctionArgumentsRule.INSTANCE,
+          // Expand MLEvaluate to MLPredict and Aggregate
+          ExpandMLEvaluateTableFunctionRule.INSTANCE
         )
     ).asJava)
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/sql/ml/MLEvaluationAggregationFunctionTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/sql/ml/MLEvaluationAggregationFunctionTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions.sql.ml;
+
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.ml.TaskType;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link MLEvaluationAggregationFunction}. */
+public class MLEvaluationAggregationFunctionTest {
+
+    @Test
+    public void testTaskMapConsistency() {
+        assertThat(MLEvaluationAggregationFunction.TASK_TYPE_MAP.size())
+                .isEqualTo(TaskType.values().length);
+        for (TaskType taskType : TaskType.values()) {
+            assertThat(MLEvaluationAggregationFunction.TASK_TYPE_MAP)
+                    .containsKey(taskType.getName());
+        }
+    }
+
+    @Test
+    public void testInvalidTaskInConstructor() {
+        assertThatThrownBy(() -> new MLEvaluationAggregationFunction("invalid_task"))
+                .isInstanceOf(ValidationException.class)
+                .hasMessage(
+                        "Invalid task type: 'invalid_task'. Supported task types are: [regression, clustering, classification, embedding, text_generation].");
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/MLEvaluateTableFunctionTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/MLEvaluateTableFunctionTest.java
@@ -26,7 +26,6 @@ import org.apache.flink.table.planner.utils.TableTestBase;
 import org.apache.flink.table.planner.utils.TableTestUtil;
 
 import org.apache.calcite.sql.type.SqlOperandTypeChecker;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -78,7 +77,6 @@ public class MLEvaluateTableFunctionTest extends TableTestBase {
 
     @Test
     public void testNamedArguments() {
-        Assertions.setMaxStackTraceElementsDisplayed(100);
         String sql =
                 "SELECT *\n"
                         + "FROM TABLE(ML_EVALUATE("

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/MLEvaluateTableFunctionTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/MLEvaluateTableFunctionTest.xml
@@ -1,0 +1,656 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testCompatibleInputTypes[[10] DECIMAL(10,2), DOUBLE]">
+    <Resource name="sql">
+      <![CDATA[SELECT *
+FROM TABLE(ML_EVALUATE(TABLE TypeTable, MODEL TypeModel, DESCRIPTOR(label), DESCRIPTOR(col), 'classification'))]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(result=[$0])
++- LogicalTableFunctionScan(invocation=[ML_EVALUATE(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'label'), DESCRIPTOR(_UTF-16LE'col'), _UTF-16LE'classification')], rowType=[RecordType((VARCHAR(2147483647), DOUBLE) MAP result)])
+   +- LogicalProject(col=[$0], label=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, TypeTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+GroupAggregate(select=[ml_evaluate(label, prediction) AS result])
++- Exchange(distribution=[single])
+   +- Calc(select=[label, prediction])
+      +- MLPredictTableFunction(invocation=[ML_PREDICT(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'col'))], rowType=[RecordType(DECIMAL(10, 2) col, DOUBLE label, DOUBLE prediction)])
+         +- TableSourceScan(table=[[default_catalog, default_database, TypeTable]], fields=[col, label])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCompatibleInputTypes[[11] FLOAT, DOUBLE]">
+    <Resource name="sql">
+      <![CDATA[SELECT *
+FROM TABLE(ML_EVALUATE(TABLE TypeTable, MODEL TypeModel, DESCRIPTOR(label), DESCRIPTOR(col), 'classification'))]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(result=[$0])
++- LogicalTableFunctionScan(invocation=[ML_EVALUATE(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'label'), DESCRIPTOR(_UTF-16LE'col'), _UTF-16LE'classification')], rowType=[RecordType((VARCHAR(2147483647), DOUBLE) MAP result)])
+   +- LogicalProject(col=[$0], label=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, TypeTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+GroupAggregate(select=[ml_evaluate(label, prediction) AS result])
++- Exchange(distribution=[single])
+   +- Calc(select=[label, prediction])
+      +- MLPredictTableFunction(invocation=[ML_PREDICT(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'col'))], rowType=[RecordType(FLOAT col, DOUBLE label, DOUBLE prediction)])
+         +- TableSourceScan(table=[[default_catalog, default_database, TypeTable]], fields=[col, label])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCompatibleInputTypes[[12] CHAR(10), STRING]">
+    <Resource name="sql">
+      <![CDATA[SELECT *
+FROM TABLE(ML_EVALUATE(TABLE TypeTable, MODEL TypeModel, DESCRIPTOR(label), DESCRIPTOR(col), 'classification'))]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(result=[$0])
++- LogicalTableFunctionScan(invocation=[ML_EVALUATE(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'label'), DESCRIPTOR(_UTF-16LE'col'), _UTF-16LE'classification')], rowType=[RecordType((VARCHAR(2147483647), DOUBLE) MAP result)])
+   +- LogicalProject(col=[$0], label=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, TypeTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+GroupAggregate(select=[ml_evaluate(label, prediction) AS result])
++- Exchange(distribution=[single])
+   +- Calc(select=[label, prediction])
+      +- MLPredictTableFunction(invocation=[ML_PREDICT(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'col'))], rowType=[RecordType(CHAR(10) col, DOUBLE label, DOUBLE prediction)])
+         +- TableSourceScan(table=[[default_catalog, default_database, TypeTable]], fields=[col, label])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCompatibleInputTypes[[13] VARCHAR(10), STRING]">
+    <Resource name="sql">
+      <![CDATA[SELECT *
+FROM TABLE(ML_EVALUATE(TABLE TypeTable, MODEL TypeModel, DESCRIPTOR(label), DESCRIPTOR(col), 'classification'))]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(result=[$0])
++- LogicalTableFunctionScan(invocation=[ML_EVALUATE(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'label'), DESCRIPTOR(_UTF-16LE'col'), _UTF-16LE'classification')], rowType=[RecordType((VARCHAR(2147483647), DOUBLE) MAP result)])
+   +- LogicalProject(col=[$0], label=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, TypeTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+GroupAggregate(select=[ml_evaluate(label, prediction) AS result])
++- Exchange(distribution=[single])
+   +- Calc(select=[label, prediction])
+      +- MLPredictTableFunction(invocation=[ML_PREDICT(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'col'))], rowType=[RecordType(VARCHAR(10) col, DOUBLE label, DOUBLE prediction)])
+         +- TableSourceScan(table=[[default_catalog, default_database, TypeTable]], fields=[col, label])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCompatibleInputTypes[[14] STRING, STRING]">
+    <Resource name="sql">
+      <![CDATA[SELECT *
+FROM TABLE(ML_EVALUATE(TABLE TypeTable, MODEL TypeModel, DESCRIPTOR(label), DESCRIPTOR(col), 'classification'))]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(result=[$0])
++- LogicalTableFunctionScan(invocation=[ML_EVALUATE(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'label'), DESCRIPTOR(_UTF-16LE'col'), _UTF-16LE'classification')], rowType=[RecordType((VARCHAR(2147483647), DOUBLE) MAP result)])
+   +- LogicalProject(col=[$0], label=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, TypeTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+GroupAggregate(select=[ml_evaluate(label, prediction) AS result])
++- Exchange(distribution=[single])
+   +- Calc(select=[label, prediction])
+      +- MLPredictTableFunction(invocation=[ML_PREDICT(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'col'))], rowType=[RecordType(VARCHAR(2147483647) col, DOUBLE label, DOUBLE prediction)])
+         +- TableSourceScan(table=[[default_catalog, default_database, TypeTable]], fields=[col, label])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCompatibleInputTypes[[1] INT, INT]">
+    <Resource name="sql">
+      <![CDATA[SELECT *
+FROM TABLE(ML_EVALUATE(TABLE TypeTable, MODEL TypeModel, DESCRIPTOR(label), DESCRIPTOR(col), 'classification'))]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(result=[$0])
++- LogicalTableFunctionScan(invocation=[ML_EVALUATE(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'label'), DESCRIPTOR(_UTF-16LE'col'), _UTF-16LE'classification')], rowType=[RecordType((VARCHAR(2147483647), DOUBLE) MAP result)])
+   +- LogicalProject(col=[$0], label=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, TypeTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+GroupAggregate(select=[ml_evaluate(label, prediction) AS result])
++- Exchange(distribution=[single])
+   +- Calc(select=[label, prediction])
+      +- MLPredictTableFunction(invocation=[ML_PREDICT(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'col'))], rowType=[RecordType(INTEGER col, DOUBLE label, DOUBLE prediction)])
+         +- TableSourceScan(table=[[default_catalog, default_database, TypeTable]], fields=[col, label])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCompatibleInputTypes[[2] BIGINT, BIGINT]">
+    <Resource name="sql">
+      <![CDATA[SELECT *
+FROM TABLE(ML_EVALUATE(TABLE TypeTable, MODEL TypeModel, DESCRIPTOR(label), DESCRIPTOR(col), 'classification'))]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(result=[$0])
++- LogicalTableFunctionScan(invocation=[ML_EVALUATE(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'label'), DESCRIPTOR(_UTF-16LE'col'), _UTF-16LE'classification')], rowType=[RecordType((VARCHAR(2147483647), DOUBLE) MAP result)])
+   +- LogicalProject(col=[$0], label=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, TypeTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+GroupAggregate(select=[ml_evaluate(label, prediction) AS result])
++- Exchange(distribution=[single])
+   +- Calc(select=[label, prediction])
+      +- MLPredictTableFunction(invocation=[ML_PREDICT(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'col'))], rowType=[RecordType(BIGINT col, DOUBLE label, DOUBLE prediction)])
+         +- TableSourceScan(table=[[default_catalog, default_database, TypeTable]], fields=[col, label])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCompatibleInputTypes[[3] DOUBLE, DOUBLE]">
+    <Resource name="sql">
+      <![CDATA[SELECT *
+FROM TABLE(ML_EVALUATE(TABLE TypeTable, MODEL TypeModel, DESCRIPTOR(label), DESCRIPTOR(col), 'classification'))]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(result=[$0])
++- LogicalTableFunctionScan(invocation=[ML_EVALUATE(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'label'), DESCRIPTOR(_UTF-16LE'col'), _UTF-16LE'classification')], rowType=[RecordType((VARCHAR(2147483647), DOUBLE) MAP result)])
+   +- LogicalProject(col=[$0], label=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, TypeTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+GroupAggregate(select=[ml_evaluate(label, prediction) AS result])
++- Exchange(distribution=[single])
+   +- Calc(select=[label, prediction])
+      +- MLPredictTableFunction(invocation=[ML_PREDICT(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'col'))], rowType=[RecordType(DOUBLE col, DOUBLE label, DOUBLE prediction)])
+         +- TableSourceScan(table=[[default_catalog, default_database, TypeTable]], fields=[col, label])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCompatibleInputTypes[[4] STRING, STRING]">
+    <Resource name="sql">
+      <![CDATA[SELECT *
+FROM TABLE(ML_EVALUATE(TABLE TypeTable, MODEL TypeModel, DESCRIPTOR(label), DESCRIPTOR(col), 'classification'))]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(result=[$0])
++- LogicalTableFunctionScan(invocation=[ML_EVALUATE(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'label'), DESCRIPTOR(_UTF-16LE'col'), _UTF-16LE'classification')], rowType=[RecordType((VARCHAR(2147483647), DOUBLE) MAP result)])
+   +- LogicalProject(col=[$0], label=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, TypeTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+GroupAggregate(select=[ml_evaluate(label, prediction) AS result])
++- Exchange(distribution=[single])
+   +- Calc(select=[label, prediction])
+      +- MLPredictTableFunction(invocation=[ML_PREDICT(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'col'))], rowType=[RecordType(VARCHAR(2147483647) col, DOUBLE label, DOUBLE prediction)])
+         +- TableSourceScan(table=[[default_catalog, default_database, TypeTable]], fields=[col, label])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCompatibleInputTypes[[5] BOOLEAN, BOOLEAN]">
+    <Resource name="sql">
+      <![CDATA[SELECT *
+FROM TABLE(ML_EVALUATE(TABLE TypeTable, MODEL TypeModel, DESCRIPTOR(label), DESCRIPTOR(col), 'classification'))]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(result=[$0])
++- LogicalTableFunctionScan(invocation=[ML_EVALUATE(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'label'), DESCRIPTOR(_UTF-16LE'col'), _UTF-16LE'classification')], rowType=[RecordType((VARCHAR(2147483647), DOUBLE) MAP result)])
+   +- LogicalProject(col=[$0], label=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, TypeTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+GroupAggregate(select=[ml_evaluate(label, prediction) AS result])
++- Exchange(distribution=[single])
+   +- Calc(select=[label, prediction])
+      +- MLPredictTableFunction(invocation=[ML_PREDICT(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'col'))], rowType=[RecordType(BOOLEAN col, DOUBLE label, DOUBLE prediction)])
+         +- TableSourceScan(table=[[default_catalog, default_database, TypeTable]], fields=[col, label])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCompatibleInputTypes[[6] TINYINT, SMALLINT]">
+    <Resource name="sql">
+      <![CDATA[SELECT *
+FROM TABLE(ML_EVALUATE(TABLE TypeTable, MODEL TypeModel, DESCRIPTOR(label), DESCRIPTOR(col), 'classification'))]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(result=[$0])
++- LogicalTableFunctionScan(invocation=[ML_EVALUATE(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'label'), DESCRIPTOR(_UTF-16LE'col'), _UTF-16LE'classification')], rowType=[RecordType((VARCHAR(2147483647), DOUBLE) MAP result)])
+   +- LogicalProject(col=[$0], label=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, TypeTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+GroupAggregate(select=[ml_evaluate(label, prediction) AS result])
++- Exchange(distribution=[single])
+   +- Calc(select=[label, prediction])
+      +- MLPredictTableFunction(invocation=[ML_PREDICT(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'col'))], rowType=[RecordType(TINYINT col, DOUBLE label, DOUBLE prediction)])
+         +- TableSourceScan(table=[[default_catalog, default_database, TypeTable]], fields=[col, label])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCompatibleInputTypes[[7] SMALLINT, INT]">
+    <Resource name="sql">
+      <![CDATA[SELECT *
+FROM TABLE(ML_EVALUATE(TABLE TypeTable, MODEL TypeModel, DESCRIPTOR(label), DESCRIPTOR(col), 'classification'))]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(result=[$0])
++- LogicalTableFunctionScan(invocation=[ML_EVALUATE(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'label'), DESCRIPTOR(_UTF-16LE'col'), _UTF-16LE'classification')], rowType=[RecordType((VARCHAR(2147483647), DOUBLE) MAP result)])
+   +- LogicalProject(col=[$0], label=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, TypeTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+GroupAggregate(select=[ml_evaluate(label, prediction) AS result])
++- Exchange(distribution=[single])
+   +- Calc(select=[label, prediction])
+      +- MLPredictTableFunction(invocation=[ML_PREDICT(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'col'))], rowType=[RecordType(SMALLINT col, DOUBLE label, DOUBLE prediction)])
+         +- TableSourceScan(table=[[default_catalog, default_database, TypeTable]], fields=[col, label])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCompatibleInputTypes[[8] INT, BIGINT]">
+    <Resource name="sql">
+      <![CDATA[SELECT *
+FROM TABLE(ML_EVALUATE(TABLE TypeTable, MODEL TypeModel, DESCRIPTOR(label), DESCRIPTOR(col), 'classification'))]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(result=[$0])
++- LogicalTableFunctionScan(invocation=[ML_EVALUATE(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'label'), DESCRIPTOR(_UTF-16LE'col'), _UTF-16LE'classification')], rowType=[RecordType((VARCHAR(2147483647), DOUBLE) MAP result)])
+   +- LogicalProject(col=[$0], label=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, TypeTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+GroupAggregate(select=[ml_evaluate(label, prediction) AS result])
++- Exchange(distribution=[single])
+   +- Calc(select=[label, prediction])
+      +- MLPredictTableFunction(invocation=[ML_PREDICT(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'col'))], rowType=[RecordType(INTEGER col, DOUBLE label, DOUBLE prediction)])
+         +- TableSourceScan(table=[[default_catalog, default_database, TypeTable]], fields=[col, label])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCompatibleInputTypes[[9] BIGINT, DECIMAL(19,0)]">
+    <Resource name="sql">
+      <![CDATA[SELECT *
+FROM TABLE(ML_EVALUATE(TABLE TypeTable, MODEL TypeModel, DESCRIPTOR(label), DESCRIPTOR(col), 'classification'))]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(result=[$0])
++- LogicalTableFunctionScan(invocation=[ML_EVALUATE(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'label'), DESCRIPTOR(_UTF-16LE'col'), _UTF-16LE'classification')], rowType=[RecordType((VARCHAR(2147483647), DOUBLE) MAP result)])
+   +- LogicalProject(col=[$0], label=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, TypeTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+GroupAggregate(select=[ml_evaluate(label, prediction) AS result])
++- Exchange(distribution=[single])
+   +- Calc(select=[label, prediction])
+      +- MLPredictTableFunction(invocation=[ML_PREDICT(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'col'))], rowType=[RecordType(BIGINT col, DOUBLE label, DOUBLE prediction)])
+         +- TableSourceScan(table=[[default_catalog, default_database, TypeTable]], fields=[col, label])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCompatibleOutputTypes[[1] INT, INT]">
+    <Resource name="sql">
+      <![CDATA[SELECT *
+FROM TABLE(ML_EVALUATE(TABLE TypeTable, MODEL TypeModel, DESCRIPTOR(label), DESCRIPTOR(col), 'classification'))]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(result=[$0])
++- LogicalTableFunctionScan(invocation=[ML_EVALUATE(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'label'), DESCRIPTOR(_UTF-16LE'col'), _UTF-16LE'classification')], rowType=[RecordType((VARCHAR(2147483647), DOUBLE) MAP result)])
+   +- LogicalProject(col=[$0], label=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, TypeTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+GroupAggregate(select=[ml_evaluate(label, prediction) AS result])
++- Exchange(distribution=[single])
+   +- Calc(select=[label, prediction])
+      +- MLPredictTableFunction(invocation=[ML_PREDICT(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'col'))], rowType=[RecordType(INTEGER col, INTEGER label, INTEGER prediction)])
+         +- TableSourceScan(table=[[default_catalog, default_database, TypeTable]], fields=[col, label])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCompatibleOutputTypes[[2] BIGINT, BIGINT]">
+    <Resource name="sql">
+      <![CDATA[SELECT *
+FROM TABLE(ML_EVALUATE(TABLE TypeTable, MODEL TypeModel, DESCRIPTOR(label), DESCRIPTOR(col), 'classification'))]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(result=[$0])
++- LogicalTableFunctionScan(invocation=[ML_EVALUATE(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'label'), DESCRIPTOR(_UTF-16LE'col'), _UTF-16LE'classification')], rowType=[RecordType((VARCHAR(2147483647), DOUBLE) MAP result)])
+   +- LogicalProject(col=[$0], label=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, TypeTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+GroupAggregate(select=[ml_evaluate(label, prediction) AS result])
++- Exchange(distribution=[single])
+   +- Calc(select=[label, prediction])
+      +- MLPredictTableFunction(invocation=[ML_PREDICT(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'col'))], rowType=[RecordType(INTEGER col, BIGINT label, BIGINT prediction)])
+         +- TableSourceScan(table=[[default_catalog, default_database, TypeTable]], fields=[col, label])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCompatibleOutputTypes[[3] DOUBLE, DOUBLE]">
+    <Resource name="sql">
+      <![CDATA[SELECT *
+FROM TABLE(ML_EVALUATE(TABLE TypeTable, MODEL TypeModel, DESCRIPTOR(label), DESCRIPTOR(col), 'classification'))]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(result=[$0])
++- LogicalTableFunctionScan(invocation=[ML_EVALUATE(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'label'), DESCRIPTOR(_UTF-16LE'col'), _UTF-16LE'classification')], rowType=[RecordType((VARCHAR(2147483647), DOUBLE) MAP result)])
+   +- LogicalProject(col=[$0], label=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, TypeTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+GroupAggregate(select=[ml_evaluate(label, prediction) AS result])
++- Exchange(distribution=[single])
+   +- Calc(select=[label, prediction])
+      +- MLPredictTableFunction(invocation=[ML_PREDICT(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'col'))], rowType=[RecordType(INTEGER col, DOUBLE label, DOUBLE prediction)])
+         +- TableSourceScan(table=[[default_catalog, default_database, TypeTable]], fields=[col, label])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCompatibleOutputTypes[[4] TINYINT, SMALLINT]">
+    <Resource name="sql">
+      <![CDATA[SELECT *
+FROM TABLE(ML_EVALUATE(TABLE TypeTable, MODEL TypeModel, DESCRIPTOR(label), DESCRIPTOR(col), 'classification'))]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(result=[$0])
++- LogicalTableFunctionScan(invocation=[ML_EVALUATE(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'label'), DESCRIPTOR(_UTF-16LE'col'), _UTF-16LE'classification')], rowType=[RecordType((VARCHAR(2147483647), DOUBLE) MAP result)])
+   +- LogicalProject(col=[$0], label=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, TypeTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+GroupAggregate(select=[ml_evaluate(label, prediction) AS result])
++- Exchange(distribution=[single])
+   +- Calc(select=[label, prediction])
+      +- MLPredictTableFunction(invocation=[ML_PREDICT(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'col'))], rowType=[RecordType(INTEGER col, TINYINT label, SMALLINT prediction)])
+         +- TableSourceScan(table=[[default_catalog, default_database, TypeTable]], fields=[col, label])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCompatibleOutputTypes[[5] SMALLINT, INT]">
+    <Resource name="sql">
+      <![CDATA[SELECT *
+FROM TABLE(ML_EVALUATE(TABLE TypeTable, MODEL TypeModel, DESCRIPTOR(label), DESCRIPTOR(col), 'classification'))]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(result=[$0])
++- LogicalTableFunctionScan(invocation=[ML_EVALUATE(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'label'), DESCRIPTOR(_UTF-16LE'col'), _UTF-16LE'classification')], rowType=[RecordType((VARCHAR(2147483647), DOUBLE) MAP result)])
+   +- LogicalProject(col=[$0], label=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, TypeTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+GroupAggregate(select=[ml_evaluate(label, prediction) AS result])
++- Exchange(distribution=[single])
+   +- Calc(select=[label, prediction])
+      +- MLPredictTableFunction(invocation=[ML_PREDICT(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'col'))], rowType=[RecordType(INTEGER col, SMALLINT label, INTEGER prediction)])
+         +- TableSourceScan(table=[[default_catalog, default_database, TypeTable]], fields=[col, label])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCompatibleOutputTypes[[6] INT, BIGINT]">
+    <Resource name="sql">
+      <![CDATA[SELECT *
+FROM TABLE(ML_EVALUATE(TABLE TypeTable, MODEL TypeModel, DESCRIPTOR(label), DESCRIPTOR(col), 'classification'))]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(result=[$0])
++- LogicalTableFunctionScan(invocation=[ML_EVALUATE(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'label'), DESCRIPTOR(_UTF-16LE'col'), _UTF-16LE'classification')], rowType=[RecordType((VARCHAR(2147483647), DOUBLE) MAP result)])
+   +- LogicalProject(col=[$0], label=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, TypeTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+GroupAggregate(select=[ml_evaluate(label, prediction) AS result])
++- Exchange(distribution=[single])
+   +- Calc(select=[label, prediction])
+      +- MLPredictTableFunction(invocation=[ML_PREDICT(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'col'))], rowType=[RecordType(INTEGER col, INTEGER label, BIGINT prediction)])
+         +- TableSourceScan(table=[[default_catalog, default_database, TypeTable]], fields=[col, label])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCompatibleOutputTypes[[7] BIGINT, DECIMAL(19,0)]">
+    <Resource name="sql">
+      <![CDATA[SELECT *
+FROM TABLE(ML_EVALUATE(TABLE TypeTable, MODEL TypeModel, DESCRIPTOR(label), DESCRIPTOR(col), 'classification'))]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(result=[$0])
++- LogicalTableFunctionScan(invocation=[ML_EVALUATE(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'label'), DESCRIPTOR(_UTF-16LE'col'), _UTF-16LE'classification')], rowType=[RecordType((VARCHAR(2147483647), DOUBLE) MAP result)])
+   +- LogicalProject(col=[$0], label=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, TypeTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+GroupAggregate(select=[ml_evaluate(label, prediction) AS result])
++- Exchange(distribution=[single])
+   +- Calc(select=[label, prediction])
+      +- MLPredictTableFunction(invocation=[ML_PREDICT(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'col'))], rowType=[RecordType(INTEGER col, BIGINT label, DECIMAL(19, 0) prediction)])
+         +- TableSourceScan(table=[[default_catalog, default_database, TypeTable]], fields=[col, label])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCompatibleOutputTypes[[8] DECIMAL(10,2), DOUBLE]">
+    <Resource name="sql">
+      <![CDATA[SELECT *
+FROM TABLE(ML_EVALUATE(TABLE TypeTable, MODEL TypeModel, DESCRIPTOR(label), DESCRIPTOR(col), 'classification'))]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(result=[$0])
++- LogicalTableFunctionScan(invocation=[ML_EVALUATE(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'label'), DESCRIPTOR(_UTF-16LE'col'), _UTF-16LE'classification')], rowType=[RecordType((VARCHAR(2147483647), DOUBLE) MAP result)])
+   +- LogicalProject(col=[$0], label=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, TypeTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+GroupAggregate(select=[ml_evaluate(label, prediction) AS result])
++- Exchange(distribution=[single])
+   +- Calc(select=[label, prediction])
+      +- MLPredictTableFunction(invocation=[ML_PREDICT(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'col'))], rowType=[RecordType(INTEGER col, DECIMAL(10, 2) label, DOUBLE prediction)])
+         +- TableSourceScan(table=[[default_catalog, default_database, TypeTable]], fields=[col, label])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCompatibleOutputTypes[[9] FLOAT, DOUBLE]">
+    <Resource name="sql">
+      <![CDATA[SELECT *
+FROM TABLE(ML_EVALUATE(TABLE TypeTable, MODEL TypeModel, DESCRIPTOR(label), DESCRIPTOR(col), 'classification'))]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(result=[$0])
++- LogicalTableFunctionScan(invocation=[ML_EVALUATE(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'label'), DESCRIPTOR(_UTF-16LE'col'), _UTF-16LE'classification')], rowType=[RecordType((VARCHAR(2147483647), DOUBLE) MAP result)])
+   +- LogicalProject(col=[$0], label=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, TypeTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+GroupAggregate(select=[ml_evaluate(label, prediction) AS result])
++- Exchange(distribution=[single])
+   +- Calc(select=[label, prediction])
+      +- MLPredictTableFunction(invocation=[ML_PREDICT(TABLE(#0), Model(MODEL default_catalog.default_database.TypeModel), DESCRIPTOR(_UTF-16LE'col'))], rowType=[RecordType(INTEGER col, FLOAT label, DOUBLE prediction)])
+         +- TableSourceScan(table=[[default_catalog, default_database, TypeTable]], fields=[col, label])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testNamedArguments">
+    <Resource name="sql">
+      <![CDATA[SELECT *
+FROM TABLE(ML_EVALUATE(INPUT => TABLE MyTable, MODEL => MODEL MyModel, LABEL => DESCRIPTOR(label), TASK => 'classification', ARGS => DESCRIPTOR(a, b)))]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(result=[$0])
++- LogicalTableFunctionScan(invocation=[ML_EVALUATE(TABLE(#0), Model(MODEL default_catalog.default_database.MyModel), DESCRIPTOR(_UTF-16LE'label'), DESCRIPTOR(_UTF-16LE'a', _UTF-16LE'b'), _UTF-16LE'classification')], rowType=[RecordType((VARCHAR(2147483647), DOUBLE) MAP result)])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], label=[$4], rowtime=[$5], proctime=[$6])
+      +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($5, 1000:INTERVAL SECOND)])
+         +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], label=[$4], rowtime=[$5], proctime=[PROCTIME()])
+            +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+GroupAggregate(select=[ml_evaluate(label, prediction) AS result])
++- Exchange(distribution=[single])
+   +- Calc(select=[label, prediction])
+      +- MLPredictTableFunction(invocation=[ML_PREDICT(TABLE(#0), Model(MODEL default_catalog.default_database.MyModel), DESCRIPTOR(_UTF-16LE'a', _UTF-16LE'b'))], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, FLOAT label, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, DOUBLE prediction)])
+         +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
+            +- Calc(select=[a, b, c, d, label, rowtime, PROCTIME() AS proctime])
+               +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, label, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testOptionalNamedArgumentsWithTask">
+    <Resource name="sql">
+      <![CDATA[SELECT *
+FROM TABLE(ML_EVALUATE(INPUT => TABLE MyTable, MODEL => MODEL MyModel, LABEL => DESCRIPTOR(label), ARGS => DESCRIPTOR(a, b), TASK => 'classification'))]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(result=[$0])
++- LogicalTableFunctionScan(invocation=[ML_EVALUATE(TABLE(#0), Model(MODEL default_catalog.default_database.MyModel), DESCRIPTOR(_UTF-16LE'label'), DESCRIPTOR(_UTF-16LE'a', _UTF-16LE'b'), _UTF-16LE'classification')], rowType=[RecordType((VARCHAR(2147483647), DOUBLE) MAP result)])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], label=[$4], rowtime=[$5], proctime=[$6])
+      +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($5, 1000:INTERVAL SECOND)])
+         +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], label=[$4], rowtime=[$5], proctime=[PROCTIME()])
+            +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+GroupAggregate(select=[ml_evaluate(label, prediction) AS result])
++- Exchange(distribution=[single])
+   +- Calc(select=[label, prediction])
+      +- MLPredictTableFunction(invocation=[ML_PREDICT(TABLE(#0), Model(MODEL default_catalog.default_database.MyModel), DESCRIPTOR(_UTF-16LE'a', _UTF-16LE'b'))], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, FLOAT label, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, DOUBLE prediction)])
+         +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
+            +- Calc(select=[a, b, c, d, label, rowtime, PROCTIME() AS proctime])
+               +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, label, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testOptionalNamedArgumentsWithTaskAndConfig">
+    <Resource name="sql">
+      <![CDATA[SELECT *
+FROM TABLE(ML_EVALUATE(INPUT => TABLE MyTable, MODEL => MODEL MyModel, LABEL => DESCRIPTOR(label), ARGS => DESCRIPTOR(a, b), TASK => 'classification', CONFIG => MAP['metrics', 'accuracy,f1']))]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(result=[$0])
++- LogicalTableFunctionScan(invocation=[ML_EVALUATE(TABLE(#0), Model(MODEL default_catalog.default_database.MyModel), DESCRIPTOR(_UTF-16LE'label'), DESCRIPTOR(_UTF-16LE'a', _UTF-16LE'b'), _UTF-16LE'classification', MAP(_UTF-16LE'metrics', _UTF-16LE'accuracy,f1'))], rowType=[RecordType((VARCHAR(2147483647), DOUBLE) MAP result)])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], label=[$4], rowtime=[$5], proctime=[$6])
+      +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($5, 1000:INTERVAL SECOND)])
+         +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], label=[$4], rowtime=[$5], proctime=[PROCTIME()])
+            +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+GroupAggregate(select=[ml_evaluate(label, prediction) AS result])
++- Exchange(distribution=[single])
+   +- Calc(select=[label, prediction])
+      +- MLPredictTableFunction(invocation=[ML_PREDICT(TABLE(#0), Model(MODEL default_catalog.default_database.MyModel), DESCRIPTOR(_UTF-16LE'a', _UTF-16LE'b'), MAP(_UTF-16LE'metrics', _UTF-16LE'accuracy,f1'))], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, FLOAT label, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, DOUBLE prediction)])
+         +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
+            +- Calc(select=[a, b, c, d, label, rowtime, PROCTIME() AS proctime])
+               +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, label, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSimple">
+    <Resource name="sql">
+      <![CDATA[SELECT *
+FROM TABLE(ML_EVALUATE(TABLE MyTable, MODEL MyModel, DESCRIPTOR(label), DESCRIPTOR(a, b), 'classification'))]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(result=[$0])
++- LogicalTableFunctionScan(invocation=[ML_EVALUATE(TABLE(#0), Model(MODEL default_catalog.default_database.MyModel), DESCRIPTOR(_UTF-16LE'label'), DESCRIPTOR(_UTF-16LE'a', _UTF-16LE'b'), _UTF-16LE'classification')], rowType=[RecordType((VARCHAR(2147483647), DOUBLE) MAP result)])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], label=[$4], rowtime=[$5], proctime=[$6])
+      +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($5, 1000:INTERVAL SECOND)])
+         +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], label=[$4], rowtime=[$5], proctime=[PROCTIME()])
+            +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+GroupAggregate(select=[ml_evaluate(label, prediction) AS result])
++- Exchange(distribution=[single])
+   +- Calc(select=[label, prediction])
+      +- MLPredictTableFunction(invocation=[ML_PREDICT(TABLE(#0), Model(MODEL default_catalog.default_database.MyModel), DESCRIPTOR(_UTF-16LE'a', _UTF-16LE'b'))], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, FLOAT label, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, DOUBLE prediction)])
+         +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
+            +- Calc(select=[a, b, c, d, label, rowtime, PROCTIME() AS proctime])
+               +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, label, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+</Root>


### PR DESCRIPTION
## What is the purpose of the change

Rewrite `ml_evaluate` table function scan to `ml_predict` table function scan and `LogicalAggreate`


## Brief change log

Rewrite `ml_evaluate` table function scan to `ml_predict` table function scan and `LogicalAggreate`


## Verifying this change

Unit test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
