### PR TITLE
[FLINK-37294][state] Support state migration between disabling and enabling ttl in HeapKeyedStateBackend

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendMigrationTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendMigrationTestBase.java
@@ -1203,6 +1203,47 @@ public abstract class StateBackendMigrationTestBase<B extends StateBackend> {
     }
 
     @TestTemplate
+    protected void testStateMigrationAfterChangingTTLFromDisablingToEnabling() throws Exception {
+        final String stateName = "test-ttl";
+
+        ValueStateDescriptor<TestType> initialAccessDescriptor =
+                new ValueStateDescriptor<>(stateName, new TestType.V1TestTypeSerializer());
+        ValueStateDescriptor<TestType> newAccessDescriptorAfterRestore =
+                new ValueStateDescriptor<>(
+                        stateName,
+                        // restore with a V2 serializer that has a different schema
+                        new TestType.V2TestTypeSerializer());
+        newAccessDescriptorAfterRestore.enableTimeToLive(
+                StateTtlConfig.newBuilder(Duration.ofDays(1)).build());
+
+        ListStateDescriptor<TestType> initialAccessListDescriptor =
+                new ListStateDescriptor<>(stateName, new TestType.V1TestTypeSerializer());
+        ListStateDescriptor<TestType> newAccessListDescriptorAfterRestore =
+                new ListStateDescriptor<>(
+                        stateName,
+                        // restore with a V2 serializer that has a different schema
+                        new TestType.V2TestTypeSerializer());
+        newAccessListDescriptorAfterRestore.enableTimeToLive(
+                StateTtlConfig.newBuilder(Duration.ofDays(1)).build());
+
+        MapStateDescriptor<Integer, TestType> initialAccessMapDescriptor =
+                new MapStateDescriptor<>(
+                        stateName, IntSerializer.INSTANCE, new TestType.V1TestTypeSerializer());
+        MapStateDescriptor<Integer, TestType> newAccessMapDescriptorAfterRestore =
+                new MapStateDescriptor<>(
+                        stateName,
+                        IntSerializer.INSTANCE,
+                        // restore with a V2 serializer that has a different schema
+                        new TestType.V2TestTypeSerializer());
+        newAccessMapDescriptorAfterRestore.enableTimeToLive(
+                StateTtlConfig.newBuilder(Duration.ofDays(1)).build());
+
+        testKeyedValueStateUpgrade(initialAccessDescriptor, newAccessDescriptorAfterRestore);
+        testKeyedListStateUpgrade(initialAccessListDescriptor, newAccessListDescriptorAfterRestore);
+        testKeyedMapStateUpgrade(initialAccessMapDescriptor, newAccessMapDescriptorAfterRestore);
+    }
+
+    @TestTemplate
     protected void testStateMigrationAfterChangingTTLFromEnablingToDisabling() throws Exception {
         final String stateName = "test-ttl";
 
@@ -1210,37 +1251,37 @@ public abstract class StateBackendMigrationTestBase<B extends StateBackend> {
                 new ValueStateDescriptor<>(stateName, new TestType.V1TestTypeSerializer());
         initialAccessDescriptor.enableTimeToLive(
                 StateTtlConfig.newBuilder(Duration.ofDays(1)).build());
-
         ValueStateDescriptor<TestType> newAccessDescriptorAfterRestore =
-                new ValueStateDescriptor<>(stateName, new TestType.V2TestTypeSerializer());
+                new ValueStateDescriptor<>(
+                        stateName,
+                        // restore with a V2 serializer that has a different schema
+                        new TestType.V2TestTypeSerializer());
 
-        assertThatThrownBy(
-                        () ->
-                                testKeyedValueStateUpgrade(
-                                        initialAccessDescriptor, newAccessDescriptorAfterRestore))
-                .satisfiesAnyOf(
-                        e -> assertThat(e).isInstanceOf(StateMigrationException.class),
-                        e -> assertThat(e).hasCauseInstanceOf(StateMigrationException.class));
-    }
-
-    @TestTemplate
-    protected void testStateMigrationAfterChangingTTLFromDisablingToEnabling() throws Exception {
-        final String stateName = "test-ttl";
-
-        ValueStateDescriptor<TestType> initialAccessDescriptor =
-                new ValueStateDescriptor<>(stateName, new TestType.V1TestTypeSerializer());
-        ValueStateDescriptor<TestType> newAccessDescriptorAfterRestore =
-                new ValueStateDescriptor<>(stateName, new TestType.V2TestTypeSerializer());
-        newAccessDescriptorAfterRestore.enableTimeToLive(
+        ListStateDescriptor<TestType> initialAccessListDescriptor =
+                new ListStateDescriptor<>(stateName, new TestType.V1TestTypeSerializer());
+        initialAccessListDescriptor.enableTimeToLive(
                 StateTtlConfig.newBuilder(Duration.ofDays(1)).build());
+        ListStateDescriptor<TestType> newAccessListDescriptorAfterRestore =
+                new ListStateDescriptor<>(
+                        stateName,
+                        // restore with a V2 serializer that has a different schema
+                        new TestType.V2TestTypeSerializer());
 
-        assertThatThrownBy(
-                        () ->
-                                testKeyedValueStateUpgrade(
-                                        initialAccessDescriptor, newAccessDescriptorAfterRestore))
-                .satisfiesAnyOf(
-                        e -> assertThat(e).isInstanceOf(StateMigrationException.class),
-                        e -> assertThat(e).hasCauseInstanceOf(StateMigrationException.class));
+        MapStateDescriptor<Integer, TestType> initialAccessMapDescriptor =
+                new MapStateDescriptor<>(
+                        stateName, IntSerializer.INSTANCE, new TestType.V1TestTypeSerializer());
+        initialAccessMapDescriptor.enableTimeToLive(
+                StateTtlConfig.newBuilder(Duration.ofDays(1)).build());
+        MapStateDescriptor<Integer, TestType> newAccessMapDescriptorAfterRestore =
+                new MapStateDescriptor<>(
+                        stateName,
+                        IntSerializer.INSTANCE,
+                        // restore with a V2 serializer that has a different schema
+                        new TestType.V2TestTypeSerializer());
+
+        testKeyedValueStateUpgrade(initialAccessDescriptor, newAccessDescriptorAfterRestore);
+        testKeyedListStateUpgrade(initialAccessListDescriptor, newAccessListDescriptorAfterRestore);
+        testKeyedMapStateUpgrade(initialAccessMapDescriptor, newAccessMapDescriptorAfterRestore);
     }
 
     // -------------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlStateTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlStateTestBase.java
@@ -31,7 +31,6 @@ import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
 import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 import org.apache.flink.util.Preconditions;
-import org.apache.flink.util.StateMigrationException;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -46,7 +45,6 @@ import java.util.function.Consumer;
 
 import static org.apache.flink.runtime.state.ttl.StateBackendTestContext.NUMBER_OF_KEY_GROUPS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 /** State TTL base test suite. */
@@ -508,8 +506,7 @@ public abstract class TtlStateTestBase {
         sbetc.createAndRestoreKeyedStateBackend(snapshot);
 
         sbetc.setCurrentKey("defaultKey");
-        assertThatThrownBy(() -> sbetc.createState(ctx().createStateDescriptor(), ""))
-                .isInstanceOf(StateMigrationException.class);
+        sbetc.createState(ctx().createStateDescriptor(), "");
     }
 
     @TestTemplate

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateBackendMigrationTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateBackendMigrationTest.java
@@ -64,18 +64,4 @@ public class ChangelogStateBackendMigrationTest
         // TODO support checking key serializer
         return false;
     }
-
-    @Override
-    protected void testStateMigrationAfterChangingTTLFromDisablingToEnabling() throws Exception {
-        if (!(this.delegatedStateBackendSupplier.get() instanceof EmbeddedRocksDBStateBackend)) {
-            super.testStateMigrationAfterChangingTTLFromDisablingToEnabling();
-        }
-    }
-
-    @Override
-    protected void testStateMigrationAfterChangingTTLFromEnablingToDisabling() throws Exception {
-        if (!(this.delegatedStateBackendSupplier.get() instanceof EmbeddedRocksDBStateBackend)) {
-            super.testStateMigrationAfterChangingTTLFromEnablingToDisabling();
-        }
-    }
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/state/rocksdb/EmbeddedRocksDBStateBackendMigrationTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/state/rocksdb/EmbeddedRocksDBStateBackendMigrationTest.java
@@ -18,29 +18,21 @@
 
 package org.apache.flink.state.rocksdb;
 
-import org.apache.flink.api.common.state.ListStateDescriptor;
-import org.apache.flink.api.common.state.MapStateDescriptor;
-import org.apache.flink.api.common.state.StateTtlConfig;
-import org.apache.flink.api.common.state.ValueStateDescriptor;
-import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.StateBackendMigrationTestBase;
 import org.apache.flink.runtime.state.storage.FileSystemCheckpointStorage;
 import org.apache.flink.runtime.state.storage.JobManagerCheckpointStorage;
-import org.apache.flink.runtime.testutils.statemigration.TestType;
 import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
 import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 import org.apache.flink.testutils.junit.utils.TempDirUtils;
 import org.apache.flink.util.function.SupplierWithException;
 
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 
@@ -86,89 +78,5 @@ public class EmbeddedRocksDBStateBackendMigrationTest
     @Override
     protected CheckpointStorage getCheckpointStorage() throws Exception {
         return storageSupplier.get();
-    }
-
-    /// Todo: Move to StateBackendMigrationTestBase when all backends support ttl state migration
-    @TestTemplate
-    protected void testStateMigrationAfterChangingTTLFromDisablingToEnabling() throws Exception {
-        final String stateName = "test-ttl";
-
-        ValueStateDescriptor<TestType> initialAccessDescriptor =
-                new ValueStateDescriptor<>(stateName, new TestType.V1TestTypeSerializer());
-        ValueStateDescriptor<TestType> newAccessDescriptorAfterRestore =
-                new ValueStateDescriptor<>(
-                        stateName,
-                        // restore with a V2 serializer that has a different schema
-                        new TestType.V2TestTypeSerializer());
-        newAccessDescriptorAfterRestore.enableTimeToLive(
-                StateTtlConfig.newBuilder(Duration.ofDays(1)).build());
-
-        ListStateDescriptor<TestType> initialAccessListDescriptor =
-                new ListStateDescriptor<>(stateName, new TestType.V1TestTypeSerializer());
-        ListStateDescriptor<TestType> newAccessListDescriptorAfterRestore =
-                new ListStateDescriptor<>(
-                        stateName,
-                        // restore with a V2 serializer that has a different schema
-                        new TestType.V2TestTypeSerializer());
-        newAccessListDescriptorAfterRestore.enableTimeToLive(
-                StateTtlConfig.newBuilder(Duration.ofDays(1)).build());
-
-        MapStateDescriptor<Integer, TestType> initialAccessMapDescriptor =
-                new MapStateDescriptor<>(
-                        stateName, IntSerializer.INSTANCE, new TestType.V1TestTypeSerializer());
-        MapStateDescriptor<Integer, TestType> newAccessMapDescriptorAfterRestore =
-                new MapStateDescriptor<>(
-                        stateName,
-                        IntSerializer.INSTANCE,
-                        // restore with a V2 serializer that has a different schema
-                        new TestType.V2TestTypeSerializer());
-        newAccessMapDescriptorAfterRestore.enableTimeToLive(
-                StateTtlConfig.newBuilder(Duration.ofDays(1)).build());
-
-        testKeyedValueStateUpgrade(initialAccessDescriptor, newAccessDescriptorAfterRestore);
-        testKeyedListStateUpgrade(initialAccessListDescriptor, newAccessListDescriptorAfterRestore);
-        testKeyedMapStateUpgrade(initialAccessMapDescriptor, newAccessMapDescriptorAfterRestore);
-    }
-
-    /// Todo: Move to StateBackendMigrationTestBase when all backends support ttl state migration
-    @TestTemplate
-    protected void testStateMigrationAfterChangingTTLFromEnablingToDisabling() throws Exception {
-        final String stateName = "test-ttl";
-
-        ValueStateDescriptor<TestType> initialAccessDescriptor =
-                new ValueStateDescriptor<>(stateName, new TestType.V1TestTypeSerializer());
-        initialAccessDescriptor.enableTimeToLive(
-                StateTtlConfig.newBuilder(Duration.ofDays(1)).build());
-        ValueStateDescriptor<TestType> newAccessDescriptorAfterRestore =
-                new ValueStateDescriptor<>(
-                        stateName,
-                        // restore with a V2 serializer that has a different schema
-                        new TestType.V2TestTypeSerializer());
-
-        ListStateDescriptor<TestType> initialAccessListDescriptor =
-                new ListStateDescriptor<>(stateName, new TestType.V1TestTypeSerializer());
-        initialAccessListDescriptor.enableTimeToLive(
-                StateTtlConfig.newBuilder(Duration.ofDays(1)).build());
-        ListStateDescriptor<TestType> newAccessListDescriptorAfterRestore =
-                new ListStateDescriptor<>(
-                        stateName,
-                        // restore with a V2 serializer that has a different schema
-                        new TestType.V2TestTypeSerializer());
-
-        MapStateDescriptor<Integer, TestType> initialAccessMapDescriptor =
-                new MapStateDescriptor<>(
-                        stateName, IntSerializer.INSTANCE, new TestType.V1TestTypeSerializer());
-        initialAccessMapDescriptor.enableTimeToLive(
-                StateTtlConfig.newBuilder(Duration.ofDays(1)).build());
-        MapStateDescriptor<Integer, TestType> newAccessMapDescriptorAfterRestore =
-                new MapStateDescriptor<>(
-                        stateName,
-                        IntSerializer.INSTANCE,
-                        // restore with a V2 serializer that has a different schema
-                        new TestType.V2TestTypeSerializer());
-
-        testKeyedValueStateUpgrade(initialAccessDescriptor, newAccessDescriptorAfterRestore);
-        testKeyedListStateUpgrade(initialAccessListDescriptor, newAccessListDescriptorAfterRestore);
-        testKeyedMapStateUpgrade(initialAccessMapDescriptor, newAccessMapDescriptorAfterRestore);
     }
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/state/rocksdb/RocksDBStateBackendMigrationTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/state/rocksdb/RocksDBStateBackendMigrationTest.java
@@ -18,27 +18,19 @@
 
 package org.apache.flink.state.rocksdb;
 
-import org.apache.flink.api.common.state.ListStateDescriptor;
-import org.apache.flink.api.common.state.MapStateDescriptor;
-import org.apache.flink.api.common.state.StateTtlConfig;
-import org.apache.flink.api.common.state.ValueStateDescriptor;
-import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.StateBackendMigrationTestBase;
 import org.apache.flink.runtime.state.storage.FileSystemCheckpointStorage;
-import org.apache.flink.runtime.testutils.statemigration.TestType;
 import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
 import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 import org.apache.flink.testutils.junit.utils.TempDirUtils;
 import org.apache.flink.util.TernaryBoolean;
 
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -77,89 +69,5 @@ public class RocksDBStateBackendMigrationTest
     protected CheckpointStorage getCheckpointStorage() throws Exception {
         String checkpointPath = TempDirUtils.newFolder(tempFolder).toURI().toString();
         return new FileSystemCheckpointStorage(checkpointPath);
-    }
-
-    /// Todo: Move to StateBackendMigrationTestBase when all backends support ttl state migration
-    @TestTemplate
-    protected void testStateMigrationAfterChangingTTLFromDisablingToEnabling() throws Exception {
-        final String stateName = "test-ttl";
-
-        ValueStateDescriptor<TestType> initialAccessDescriptor =
-                new ValueStateDescriptor<>(stateName, new TestType.V1TestTypeSerializer());
-        ValueStateDescriptor<TestType> newAccessDescriptorAfterRestore =
-                new ValueStateDescriptor<>(
-                        stateName,
-                        // restore with a V2 serializer that has a different schema
-                        new TestType.V2TestTypeSerializer());
-        newAccessDescriptorAfterRestore.enableTimeToLive(
-                StateTtlConfig.newBuilder(Duration.ofDays(1)).build());
-
-        ListStateDescriptor<TestType> initialAccessListDescriptor =
-                new ListStateDescriptor<>(stateName, new TestType.V1TestTypeSerializer());
-        ListStateDescriptor<TestType> newAccessListDescriptorAfterRestore =
-                new ListStateDescriptor<>(
-                        stateName,
-                        // restore with a V2 serializer that has a different schema
-                        new TestType.V2TestTypeSerializer());
-        newAccessListDescriptorAfterRestore.enableTimeToLive(
-                StateTtlConfig.newBuilder(Duration.ofDays(1)).build());
-
-        MapStateDescriptor<Integer, TestType> initialAccessMapDescriptor =
-                new MapStateDescriptor<>(
-                        stateName, IntSerializer.INSTANCE, new TestType.V1TestTypeSerializer());
-        MapStateDescriptor<Integer, TestType> newAccessMapDescriptorAfterRestore =
-                new MapStateDescriptor<>(
-                        stateName,
-                        IntSerializer.INSTANCE,
-                        // restore with a V2 serializer that has a different schema
-                        new TestType.V2TestTypeSerializer());
-        newAccessMapDescriptorAfterRestore.enableTimeToLive(
-                StateTtlConfig.newBuilder(Duration.ofDays(1)).build());
-
-        testKeyedValueStateUpgrade(initialAccessDescriptor, newAccessDescriptorAfterRestore);
-        testKeyedListStateUpgrade(initialAccessListDescriptor, newAccessListDescriptorAfterRestore);
-        testKeyedMapStateUpgrade(initialAccessMapDescriptor, newAccessMapDescriptorAfterRestore);
-    }
-
-    /// Todo: Move to StateBackendMigrationTestBase when all backends support ttl state migration
-    @TestTemplate
-    protected void testStateMigrationAfterChangingTTLFromEnablingToDisabling() throws Exception {
-        final String stateName = "test-ttl";
-
-        ValueStateDescriptor<TestType> initialAccessDescriptor =
-                new ValueStateDescriptor<>(stateName, new TestType.V1TestTypeSerializer());
-        initialAccessDescriptor.enableTimeToLive(
-                StateTtlConfig.newBuilder(Duration.ofDays(1)).build());
-        ValueStateDescriptor<TestType> newAccessDescriptorAfterRestore =
-                new ValueStateDescriptor<>(
-                        stateName,
-                        // restore with a V2 serializer that has a different schema
-                        new TestType.V2TestTypeSerializer());
-
-        ListStateDescriptor<TestType> initialAccessListDescriptor =
-                new ListStateDescriptor<>(stateName, new TestType.V1TestTypeSerializer());
-        initialAccessListDescriptor.enableTimeToLive(
-                StateTtlConfig.newBuilder(Duration.ofDays(1)).build());
-        ListStateDescriptor<TestType> newAccessListDescriptorAfterRestore =
-                new ListStateDescriptor<>(
-                        stateName,
-                        // restore with a V2 serializer that has a different schema
-                        new TestType.V2TestTypeSerializer());
-
-        MapStateDescriptor<Integer, TestType> initialAccessMapDescriptor =
-                new MapStateDescriptor<>(
-                        stateName, IntSerializer.INSTANCE, new TestType.V1TestTypeSerializer());
-        initialAccessMapDescriptor.enableTimeToLive(
-                StateTtlConfig.newBuilder(Duration.ofDays(1)).build());
-        MapStateDescriptor<Integer, TestType> newAccessMapDescriptorAfterRestore =
-                new MapStateDescriptor<>(
-                        stateName,
-                        IntSerializer.INSTANCE,
-                        // restore with a V2 serializer that has a different schema
-                        new TestType.V2TestTypeSerializer());
-
-        testKeyedValueStateUpgrade(initialAccessDescriptor, newAccessDescriptorAfterRestore);
-        testKeyedListStateUpgrade(initialAccessListDescriptor, newAccessListDescriptorAfterRestore);
-        testKeyedMapStateUpgrade(initialAccessMapDescriptor, newAccessMapDescriptorAfterRestore);
     }
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/state/rocksdb/ttl/RocksDBTtlStateTestBase.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/state/rocksdb/ttl/RocksDBTtlStateTestBase.java
@@ -22,10 +22,8 @@ import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.state.StateTtlConfig;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.state.CheckpointStorage;
-import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.storage.FileSystemCheckpointStorage;
-import org.apache.flink.runtime.state.ttl.MockTtlStateTest;
 import org.apache.flink.runtime.state.ttl.StateBackendTestContext;
 import org.apache.flink.runtime.state.ttl.TtlStateTestBase;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
@@ -43,7 +41,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assumptions.assumeThat;
 
 /** Base test suite for rocksdb state TTL. */
 public abstract class RocksDBTtlStateTestBase extends TtlStateTestBase {
@@ -90,24 +87,6 @@ public abstract class RocksDBTtlStateTestBase extends TtlStateTestBase {
     @TestTemplate
     public void testCompactFilter() throws Exception {
         testCompactFilter(false, false);
-    }
-
-    /// Todo: Move to TtlStateTestBase when all backends support ttl state migration
-    @TestTemplate
-    @Override
-    protected void testRestoreTtlAndRegisterNonTtlStateCompatFailure() throws Exception {
-        assumeThat(this).isNotInstanceOf(MockTtlStateTest.class);
-
-        initTest();
-
-        timeProvider.time = 0;
-        ctx().update(ctx().updateEmpty);
-
-        KeyedStateHandle snapshot = sbetc.takeSnapshot();
-        sbetc.createAndRestoreKeyedStateBackend(snapshot);
-
-        sbetc.setCurrentKey("defaultKey");
-        sbetc.createState(ctx().createStateDescriptor(), "");
     }
 
     @TestTemplate


### PR DESCRIPTION
## What is the purpose of the change

Support state migration between disabling and enabling ttl in HeapKeyedStateBackend



## Brief change log

Add migrateTtlAwareStateValues in AbstractHeapState. When the state TTL switch changes, trigger the migration of state data.


## Verifying this change

This change is already covered by existing tests, such as StateBackendMigrationTestBase#testStateMigrationAfterChangingTTLFromEnablingToDisabling and StateBackendMigrationTestBase#testStateMigrationAfterChangingTTLFromDisablingToEnabling.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? 
