### PR TITLE
[FLINK-37952] Skip compressing built python wheels by hand in Nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -116,10 +116,8 @@ jobs:
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair -w {dest_dir} {wheel}"
           # Skip repair on MacOS
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: ""
-      - name: "Tar python artifact"
-        run: tar -czvf python-wheel-${{ matrix.os_name }}.tar.gz -C flink-python/dist .
-      - name: "Upload python artifact"
+      - name: "Upload python wheels"
         uses: actions/upload-artifact@v4
         with:
           name: wheel_${{ matrix.os_name }}_${{ steps.stringify_workflow.outputs.stringified_value }}-${{ github.run_number }}
-          path: python-wheel-${{ matrix.os_name }}.tar.gz
+          path: flink-python/dist/**


### PR DESCRIPTION
## What is the purpose of the change

Skip manual tar compression step for built wheel files in the Nightly GH CI workflow, as the `upload-artifact` step zips what it uploads, so it is redundant and inconvenient during extraction.

## Brief change log
- Remove the tar step from the workflow.
- Specify any wheel files via wildcard in the `upload-artifact` action.

## Verifying this change

Modified workflow run on my fork: https://github.com/ferenc-csaky/flink/actions/runs/15619381218
Wheel build ran fine, and artifacts are downloadable.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
