### PR TITLE
[FLINK-37897][table-planner] Support converting a regular join to a delta join for the simplest pattern in planner

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/OptimizerConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/OptimizerConfigOptions.java
@@ -373,6 +373,17 @@ public class OptimizerConfigOptions {
                                     + "requires reserving network buffers, which impacts memory usage. For this reason, "
                                     + "the number of input tables is limited to 20.");
 
+    @Documentation.TableOption(execMode = Documentation.ExecMode.STREAMING)
+    public static final ConfigOption<DeltaJoinStrategy> TABLE_OPTIMIZER_DELTA_JOIN_STRATEGY =
+            key("table.optimizer.delta-join.strategy")
+                    .enumType(DeltaJoinStrategy.class)
+                    .defaultValue(DeltaJoinStrategy.NONE)
+                    .withDescription(
+                            "Whether to enable delta join strategy. Only AUTO, FORCE or NONE can be set.\n"
+                                    + "AUTO: Optimizer will try to use delta join first. If it fails, it will fallback to the regular join.\n"
+                                    + "FORCE: Use the delta join. If it fails, an exception will be thrown.\n"
+                                    + "NONE: Don't try to use delta join.");
+
     /** Strategy for handling non-deterministic updates. */
     @PublicEvolving
     public enum NonDeterministicUpdateStrategy {
@@ -440,6 +451,28 @@ public class OptimizerConfigOptions {
         @Override
         public String toString() {
             return value;
+        }
+
+        @Override
+        public InlineElement getDescription() {
+            return description;
+        }
+    }
+
+    /** Strategy for delta join. */
+    @PublicEvolving
+    public enum DeltaJoinStrategy implements DescribedEnum {
+        AUTO(
+                text(
+                        "Optimizer will try to use delta join first. "
+                                + "If it fails, it will fallback to the regular join.")),
+        FORCE(text("Use the delta join. If it fails, an exception will be thrown.")),
+        NONE(text("Don't try to use delta join."));
+
+        private final InlineElement description;
+
+        DeltaJoinStrategy(InlineElement description) {
+            this.description = description;
         }
 
         @Override

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/DeltaJoinSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/DeltaJoinSpec.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.spec;
+
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalDeltaJoin;
+import org.apache.flink.table.planner.plan.utils.FunctionCallUtils;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.apache.calcite.rex.RexNode;
+
+import javax.annotation.Nullable;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * DeltaJoinSpec describes one side lookup the dim table on the other side.
+ *
+ * <p>This class corresponds to {@link StreamPhysicalDeltaJoin}.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DeltaJoinSpec {
+
+    public static final String FIELD_NAME_LOOKUP_TABLE = "lookupTable";
+    public static final String FIELD_NAME_LOOKUP_KEYS = "lookupKeys";
+    public static final String FIELD_NAME_REMAINING_CONDITION = "remainingCondition";
+
+    @JsonProperty(FIELD_NAME_LOOKUP_TABLE)
+    private final TemporalTableSourceSpec lookupTable;
+
+    // <lookup column index of the dim table, stream side's related key>
+    @JsonProperty(FIELD_NAME_LOOKUP_KEYS)
+    private final Map<Integer, FunctionCallUtils.FunctionParam> lookupKeyMap;
+
+    /** join condition except equi-conditions extracted as lookup keys. */
+    @JsonProperty(FIELD_NAME_REMAINING_CONDITION)
+    private final @Nullable RexNode remainingCondition;
+
+    @JsonCreator
+    public DeltaJoinSpec(
+            @JsonProperty(FIELD_NAME_LOOKUP_TABLE) TemporalTableSourceSpec lookupTable,
+            @JsonProperty(FIELD_NAME_LOOKUP_KEYS)
+                    Map<Integer, FunctionCallUtils.FunctionParam> lookupKeyMap,
+            @JsonProperty(FIELD_NAME_REMAINING_CONDITION) @Nullable RexNode remainingCondition) {
+        this.lookupKeyMap = lookupKeyMap;
+        this.lookupTable = lookupTable;
+        this.remainingCondition = remainingCondition;
+    }
+
+    @JsonIgnore
+    public TemporalTableSourceSpec getLookupTable() {
+        return lookupTable;
+    }
+
+    @JsonIgnore
+    public Map<Integer, FunctionCallUtils.FunctionParam> getLookupKeyMap() {
+        return lookupKeyMap;
+    }
+
+    @JsonIgnore
+    public Optional<RexNode> getRemainingCondition() {
+        return Optional.ofNullable(remainingCondition);
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalDeltaJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalDeltaJoin.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.physical.stream;
+
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
+import org.apache.flink.table.planner.plan.nodes.exec.spec.DeltaJoinSpec;
+import org.apache.flink.table.planner.plan.utils.RelExplainUtil;
+import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
+import org.apache.flink.table.runtime.operators.join.FlinkJoinType;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.BiRel;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelWriter;
+import org.apache.calcite.rel.hint.Hintable;
+import org.apache.calcite.rel.hint.RelHint;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexNode;
+
+import java.util.List;
+import java.util.Optional;
+
+/** Stream physical RelNode for delta join. */
+public class StreamPhysicalDeltaJoin extends BiRel implements StreamPhysicalRel, Hintable {
+
+    private final FlinkJoinType joinType;
+
+    private final RexNode originalJoinCondition;
+
+    private final com.google.common.collect.ImmutableList<RelHint> hints;
+
+    private final RelDataType rowType;
+
+    // treat right side as lookup table
+    private final DeltaJoinSpec leftDeltaJoinSpec;
+
+    // treat left side as lookup table
+    private final DeltaJoinSpec rightDeltaJoinSpec;
+
+    public StreamPhysicalDeltaJoin(
+            RelOptCluster cluster,
+            RelTraitSet traitSet,
+            List<RelHint> hints,
+            RelNode left,
+            RelNode right,
+            FlinkJoinType joinType,
+            RexNode originalJoinCondition,
+            DeltaJoinSpec leftDeltaJoinSpec,
+            DeltaJoinSpec rightDeltaJoinSpec,
+            RelDataType rowType) {
+        super(cluster, traitSet, left, right);
+        this.hints = com.google.common.collect.ImmutableList.copyOf(hints);
+        this.joinType = joinType;
+        this.originalJoinCondition = originalJoinCondition;
+        this.leftDeltaJoinSpec = leftDeltaJoinSpec;
+        this.rightDeltaJoinSpec = rightDeltaJoinSpec;
+        this.rowType = rowType;
+    }
+
+    @Override
+    public ExecNode<?> translateToExecNode() {
+        throw new UnsupportedOperationException("Introduce delta join in runtime later");
+    }
+
+    @Override
+    public boolean requireWatermark() {
+        return false;
+    }
+
+    @Override
+    public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
+        assert inputs.size() == 2;
+        return new StreamPhysicalDeltaJoin(
+                getCluster(),
+                traitSet,
+                hints,
+                inputs.get(0),
+                inputs.get(1),
+                joinType,
+                originalJoinCondition,
+                leftDeltaJoinSpec,
+                rightDeltaJoinSpec,
+                rowType);
+    }
+
+    @Override
+    protected RelDataType deriveRowType() {
+        return rowType;
+    }
+
+    @Override
+    public com.google.common.collect.ImmutableList<RelHint> getHints() {
+        return hints;
+    }
+
+    @Override
+    public RelWriter explainTerms(RelWriter pw) {
+        return super.explainTerms(pw)
+                .item("joinType", joinType.toString())
+                .item(
+                        "where",
+                        getExpressionString(
+                                originalJoinCondition,
+                                JavaScalaConversionUtil.toScala(this.getRowType().getFieldNames())
+                                        .toList(),
+                                JavaScalaConversionUtil.toScala(Optional.empty()),
+                                RelExplainUtil.preferExpressionFormat(pw),
+                                RelExplainUtil.preferExpressionDetail(pw)))
+                .item("select", String.join(", ", rowType.getFieldNames()));
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/optimize/StreamPhysicalDeltaJoinForceValidator.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/optimize/StreamPhysicalDeltaJoinForceValidator.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.optimize;
+
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.api.config.OptimizerConfigOptions;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalDeltaJoin;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalJoin;
+import org.apache.flink.table.planner.plan.utils.FlinkRelOptUtil;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelVisitor;
+import org.apache.calcite.sql.SqlExplainLevel;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * A validator to check whether there is at least one {@link StreamPhysicalDeltaJoin} when {@link
+ * OptimizerConfigOptions#TABLE_OPTIMIZER_DELTA_JOIN_STRATEGY} is set to {@link
+ * OptimizerConfigOptions.DeltaJoinStrategy#FORCE}.
+ *
+ * <p>If there is a {@link StreamPhysicalJoin} but no {@link StreamPhysicalDeltaJoin}, an exception
+ * will be thrown.
+ */
+public class StreamPhysicalDeltaJoinForceValidator {
+
+    /** Validate the roots if there is at least one {@link StreamPhysicalDeltaJoin}. */
+    public static List<RelNode> validatePhysicalPlan(List<RelNode> roots, TableConfig tableConfig) {
+        OptimizerConfigOptions.DeltaJoinStrategy deltaJoinStrategy =
+                tableConfig.get(OptimizerConfigOptions.TABLE_OPTIMIZER_DELTA_JOIN_STRATEGY);
+        if (OptimizerConfigOptions.DeltaJoinStrategy.FORCE != deltaJoinStrategy) {
+            return roots;
+        }
+
+        DeltaJoinFinder finder = new DeltaJoinFinder();
+        roots.forEach(finder::go);
+
+        if (!finder.regularJoinExists && !finder.deltaJoinExists) {
+            return roots;
+        }
+        if (finder.deltaJoinExists) {
+            return roots;
+        }
+
+        // TODO FLINK-37954 full the exception message
+        throw new ValidationException(
+                String.format(
+                        "The current sql doesn't support to do delta join optimization. The plan is:\n\n%s",
+                        roots.stream()
+                                .map(StreamPhysicalDeltaJoinForceValidator::getPlanAsString)
+                                .collect(Collectors.joining("\n"))));
+    }
+
+    private static String getPlanAsString(RelNode root) {
+        return FlinkRelOptUtil.toString(
+                root,
+                SqlExplainLevel.DIGEST_ATTRIBUTES,
+                false, // withIdPrefix
+                true, // withChangelogTraits
+                false, // withRowType
+                false, // withUpsertKey
+                false, // withQueryBlockAlias
+                true // withDuplicateChangesTrait
+                );
+    }
+
+    private static class DeltaJoinFinder extends RelVisitor {
+
+        private boolean deltaJoinExists = false;
+        private boolean regularJoinExists = false;
+
+        @Override
+        public void visit(RelNode node, int ordinal, @Nullable RelNode parent) {
+            if (node instanceof StreamPhysicalJoin) {
+                regularJoinExists = true;
+            } else if (node instanceof StreamPhysicalDeltaJoin) {
+                deltaJoinExists = true;
+            }
+            super.visit(node, ordinal, parent);
+        }
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/DeltaJoinRewriteRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/DeltaJoinRewriteRule.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.physical.stream;
+
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.config.OptimizerConfigOptions;
+import org.apache.flink.table.connector.source.LookupTableSource;
+import org.apache.flink.table.planner.plan.nodes.exec.spec.DeltaJoinSpec;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalDeltaJoin;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalJoin;
+import org.apache.flink.table.planner.plan.utils.DeltaJoinUtil;
+import org.apache.flink.table.planner.plan.utils.JoinTypeUtil;
+
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelRule;
+import org.immutables.value.Value;
+
+import static org.apache.flink.table.planner.utils.ShortcutUtils.unwrapTableConfig;
+
+/**
+ * A rule that converts a {@link StreamPhysicalJoin} to a {@link StreamPhysicalDeltaJoin} if all
+ * conditions are matched.
+ *
+ * <p>Currently, only {@link StreamPhysicalJoin} satisfied the following requirements can be
+ * converted to {@link StreamPhysicalDeltaJoin}.
+ *
+ * <ol>
+ *   <li>The join is INNER join.
+ *   <li>There is at least one join key pair in the join.
+ *   <li>The downstream nodes of this join can accept duplicate changes.
+ *   <li>All join inputs are insert only streams.
+ *   <li>All downstream nodes of this join are in {@code
+ *       DeltaJoinUtil#ALL_SUPPORTED_DELTA_JOIN_UPSTREAM_NODES}
+ *   <li>The join keys include at least one complete index in each the source table in join inputs.
+ *   <li>All table scans in this join inputs support async {@link LookupTableSource}.
+ * </ol>
+ *
+ * <p>See more at {@link DeltaJoinUtil#canConvertToDeltaJoin}.
+ */
+@Value.Enclosing
+public class DeltaJoinRewriteRule extends RelRule<DeltaJoinRewriteRule.Config> {
+
+    public static final DeltaJoinRewriteRule INSTANCE =
+            DeltaJoinRewriteRule.Config.DEFAULT.toRule();
+
+    private DeltaJoinRewriteRule(Config config) {
+        super(config);
+    }
+
+    @Override
+    public boolean matches(RelOptRuleCall call) {
+        TableConfig tableConfig = unwrapTableConfig(call);
+        OptimizerConfigOptions.DeltaJoinStrategy deltaJoinStrategy =
+                tableConfig.get(OptimizerConfigOptions.TABLE_OPTIMIZER_DELTA_JOIN_STRATEGY);
+        if (OptimizerConfigOptions.DeltaJoinStrategy.NONE == deltaJoinStrategy) {
+            return false;
+        }
+
+        StreamPhysicalJoin join = call.rel(0);
+        return DeltaJoinUtil.canConvertToDeltaJoin(join);
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+        StreamPhysicalJoin join = call.rel(0);
+        StreamPhysicalDeltaJoin deltaJoin = convertToDeltaJoin(join);
+        call.transformTo(deltaJoin);
+    }
+
+    private StreamPhysicalDeltaJoin convertToDeltaJoin(StreamPhysicalJoin join) {
+        DeltaJoinSpec lookupRightJoinSpec = DeltaJoinUtil.getDeltaJoinSpec(join, true);
+        DeltaJoinSpec lookupLeftJoinSpec = DeltaJoinUtil.getDeltaJoinSpec(join, false);
+        return new StreamPhysicalDeltaJoin(
+                join.getCluster(),
+                join.getTraitSet(),
+                join.getHints(),
+                join.getLeft(),
+                join.getRight(),
+                JoinTypeUtil.getFlinkJoinType(join.getJoinType()),
+                join.getCondition(),
+                lookupLeftJoinSpec,
+                lookupRightJoinSpec,
+                join.getRowType());
+    }
+
+    /** Rule configuration. */
+    @Value.Immutable(singleton = false)
+    public interface Config extends RelRule.Config {
+        DeltaJoinRewriteRule.Config DEFAULT =
+                ImmutableDeltaJoinRewriteRule.Config.builder()
+                        .build()
+                        .withOperandSupplier(b0 -> b0.operand(StreamPhysicalJoin.class).anyInputs())
+                        .withDescription("DeltaJoinRewriteRule");
+
+        @Override
+        default DeltaJoinRewriteRule toRule() {
+            return new DeltaJoinRewriteRule(this);
+        }
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/utils/DeltaJoinUtil.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/utils/DeltaJoinUtil.java
@@ -1,0 +1,325 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.utils;
+
+import org.apache.flink.table.catalog.Index;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.LookupTableSource;
+import org.apache.flink.table.planner.plan.nodes.exec.spec.DeltaJoinSpec;
+import org.apache.flink.table.planner.plan.nodes.exec.spec.TemporalTableSourceSpec;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalDeltaJoin;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalExchange;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalIntermediateTableScan;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalJoin;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalRel;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalTableSourceScan;
+import org.apache.flink.table.planner.plan.schema.IntermediateRelTable;
+import org.apache.flink.table.planner.plan.schema.TableSourceTable;
+import org.apache.flink.table.planner.plan.trait.DuplicateChanges;
+import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
+import org.apache.flink.types.RowKind;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.flink.shaded.guava33.com.google.common.collect.Sets;
+
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.plan.hep.HepRelVertex;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.JoinInfo;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexUtil;
+import org.apache.calcite.util.mapping.IntPair;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/** Utils for delta joins. */
+public class DeltaJoinUtil {
+
+    /**
+     * All supported delta join upstream nodes. Only the following nodes are allowed to exist
+     * between the delta join and the source. Otherwise, the regular join will not be optimized into
+     * the delta join.
+     *
+     * <p>More physical nodes can be added to support more patterns for delta join.
+     */
+    private static final Set<Class<?>> ALL_SUPPORTED_DELTA_JOIN_UPSTREAM_NODES =
+            Sets.newHashSet(StreamPhysicalTableSourceScan.class, StreamPhysicalExchange.class);
+
+    private DeltaJoinUtil() {}
+
+    /** Check whether the {@link StreamPhysicalJoin} can be optimized into a delta join. */
+    public static boolean canConvertToDeltaJoin(StreamPhysicalJoin join) {
+        if (!isJoinTypeSupported(join)) {
+            return false;
+        }
+
+        if (!areJoinConditionsSupported(join)) {
+            return false;
+        }
+
+        // delta join with eventual consistency will send duplicate changes to downstream nodes
+        if (!canJoinOutputDuplicateChanges(join)) {
+            return false;
+        }
+
+        // currently, only join with append-only inputs is supported
+        if (!areAllInputsInsertOnly(join)) {
+            return false;
+        }
+
+        if (!areAllJoinInputsInWhiteList(join)) {
+            return false;
+        }
+
+        return areAllJoinTableScansSupported(join);
+    }
+
+    /**
+     * Get the {@link RelOptTable} from the {@link TableScan} recursively on the input of this node.
+     */
+    public static RelOptTable getTableScanRelOptTable(RelNode node) {
+        return getTableScan(node).getTable();
+    }
+
+    /**
+     * Extract the delta join spec used for {@link StreamPhysicalDeltaJoin} from {@link
+     * StreamPhysicalJoin}.
+     */
+    public static DeltaJoinSpec getDeltaJoinSpec(
+            StreamPhysicalJoin join, boolean treatRightAsLookupSide) {
+        JoinInfo joinInfo = join.analyzeCondition();
+        RexBuilder rexBuilder = join.getCluster().getRexBuilder();
+
+        RexNode condition = RexUtil.composeConjunction(rexBuilder, joinInfo.nonEquiConditions);
+        Optional<RexNode> remainingCondition =
+                condition.isAlwaysTrue() ? Optional.empty() : Optional.of(condition);
+
+        final RelOptTable lookupRelOptTable;
+        List<IntPair> streamToLookupJoinKeys = joinInfo.pairs();
+        if (treatRightAsLookupSide) {
+            lookupRelOptTable = DeltaJoinUtil.getTableScanRelOptTable(join.getRight());
+        } else {
+            streamToLookupJoinKeys = reverseIntPairs(streamToLookupJoinKeys);
+            lookupRelOptTable = DeltaJoinUtil.getTableScanRelOptTable(join.getLeft());
+        }
+        Preconditions.checkState(lookupRelOptTable instanceof TableSourceTable);
+        final TableSourceTable lookupTable = (TableSourceTable) lookupRelOptTable;
+
+        Map<Integer, FunctionCallUtils.FunctionParam> allLookupKeys =
+                analyzerDeltaJoinLookupKeys(streamToLookupJoinKeys);
+
+        return new DeltaJoinSpec(
+                new TemporalTableSourceSpec(lookupTable),
+                allLookupKeys,
+                remainingCondition.orElse(null));
+    }
+
+    /**
+     * get the lookup key from the join keys.
+     *
+     * <p>Different with {@see CommonPhysicalLookupJoin#analyzeLookupKeys}, we have not supported
+     * calc between delta join and source yet.
+     *
+     * @param streamToLookupJoinKeys the join keys from stream side to lookup side
+     */
+    private static Map<Integer, FunctionCallUtils.FunctionParam> analyzerDeltaJoinLookupKeys(
+            List<IntPair> streamToLookupJoinKeys) {
+        Map<Integer, FunctionCallUtils.FunctionParam> allFieldRefLookupKeys = new LinkedHashMap<>();
+        for (IntPair intPair : streamToLookupJoinKeys) {
+            allFieldRefLookupKeys.put(
+                    intPair.target, new FunctionCallUtils.FieldRef(intPair.source));
+        }
+        return allFieldRefLookupKeys;
+    }
+
+    private static List<IntPair> reverseIntPairs(List<IntPair> intPairs) {
+        return intPairs.stream()
+                .map(pair -> new IntPair(pair.target, pair.source))
+                .collect(Collectors.toList());
+    }
+
+    private static int[][] getColumnIndicesOfAllTableIndexes(TableSourceTable tableSourceTable) {
+        List<List<String>> columnsOfIndexes = getAllIndexesColumnsOfTable(tableSourceTable);
+        int[][] results = new int[columnsOfIndexes.size()][];
+        for (int i = 0; i < columnsOfIndexes.size(); i++) {
+            List<String> fieldNames = tableSourceTable.getRowType().getFieldNames();
+            results[i] = columnsOfIndexes.get(i).stream().mapToInt(fieldNames::indexOf).toArray();
+        }
+
+        return results;
+    }
+
+    private static List<List<String>> getAllIndexesColumnsOfTable(
+            TableSourceTable tableSourceTable) {
+        ResolvedSchema schema = tableSourceTable.contextResolvedTable().getResolvedSchema();
+        List<Index> indexes = schema.getIndexes();
+        return indexes.stream().map(Index::getColumns).collect(Collectors.toList());
+    }
+
+    private static boolean areJoinConditionsSupported(StreamPhysicalJoin join) {
+        JoinInfo joinInfo = join.analyzeCondition();
+        // there must be one pair of join key
+        return !joinInfo.pairs().isEmpty();
+    }
+
+    private static boolean areAllJoinTableScansSupported(StreamPhysicalJoin join) {
+        return isTableScanSupported(getTableScan(join.getLeft()), join.joinSpec().getLeftKeys())
+                && isTableScanSupported(
+                        getTableScan(join.getRight()), join.joinSpec().getRightKeys());
+    }
+
+    private static boolean isTableScanSupported(TableScan tableScan, int[] lookupKeys) {
+        // legacy source and data stream source are not supported yet
+        if (!(tableScan instanceof StreamPhysicalTableSourceScan)) {
+            return false;
+        }
+
+        TableSourceTable tableSourceTable =
+                ((StreamPhysicalTableSourceScan) tableScan).tableSourceTable();
+
+        // source with ability specs are not supported yet
+        if (tableSourceTable.abilitySpecs().length != 0) {
+            return false;
+        }
+
+        DynamicTableSource source = tableSourceTable.tableSource();
+        // the source must also be a lookup source
+        if (!(source instanceof LookupTableSource)) {
+            return false;
+        }
+
+        int[][] idxsOfAllIndexes = getColumnIndicesOfAllTableIndexes(tableSourceTable);
+        if (idxsOfAllIndexes.length == 0) {
+            return false;
+        }
+        // the source must have at least one index, and the join key contains one index
+        Set<Integer> lookupKeysSet = Arrays.stream(lookupKeys).boxed().collect(Collectors.toSet());
+
+        for (int[] idxsOfIndex : idxsOfAllIndexes) {
+            Preconditions.checkState(idxsOfIndex.length > 0);
+
+            // ignore the field order of the index
+            boolean containsIndex = Arrays.stream(idxsOfIndex).allMatch(lookupKeysSet::contains);
+            if (!containsIndex) {
+                return false;
+            }
+        }
+
+        // the lookup source must support async lookup
+        return LookupJoinUtil.isAsyncLookup(
+                tableSourceTable,
+                lookupKeysSet,
+                null, // hint
+                false, // upsertMaterialize
+                false // preferCustomShuffle
+                );
+    }
+
+    private static TableScan getTableScan(RelNode node) {
+        node = unwrapNode(node, true);
+        // support to get table across more nodes if we support more nodes in
+        // `ALL_SUPPORTED_DELTA_JOIN_UPSTREAM_NODES`
+        if (node instanceof StreamPhysicalExchange) {
+            return getTableScan(((StreamPhysicalExchange) node).getInput());
+        }
+
+        Preconditions.checkState(node instanceof TableScan);
+        return (TableScan) node;
+    }
+
+    private static boolean isJoinTypeSupported(StreamPhysicalJoin join) {
+        // currently, only inner join is supported
+        return JoinRelType.INNER == join.getJoinType();
+    }
+
+    private static boolean areAllJoinInputsInWhiteList(RelNode node) {
+        for (RelNode input : node.getInputs()) {
+            input = unwrapNode(input, true);
+            if (!isTheNodeInWhiteList(input)) {
+                return false;
+            }
+            if (!areAllJoinInputsInWhiteList(input)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isTheNodeInWhiteList(RelNode node) {
+        Class<?> nodeClazz = node.getClass();
+        return ALL_SUPPORTED_DELTA_JOIN_UPSTREAM_NODES.contains(nodeClazz);
+    }
+
+    private static boolean canJoinOutputDuplicateChanges(StreamPhysicalJoin join) {
+        DuplicateChanges duplicateChanges =
+                DuplicateChangesUtils.getDuplicateChanges(join)
+                        .orElseThrow(
+                                () ->
+                                        new IllegalStateException(
+                                                String.format(
+                                                        "Unable to derive changelog mode from node %s. This is a bug.",
+                                                        join)));
+
+        return DuplicateChanges.ALLOW.equals(duplicateChanges);
+    }
+
+    private static boolean areAllInputsInsertOnly(StreamPhysicalJoin join) {
+        for (RelNode input : join.getInputs()) {
+            if (!isInsertOnly(unwrapNode(input, false))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isInsertOnly(StreamPhysicalRel node) {
+        ChangelogMode changelogMode =
+                JavaScalaConversionUtil.toJava(ChangelogPlanUtils.getChangelogMode(node))
+                        .orElseThrow(
+                                () ->
+                                        new IllegalStateException(
+                                                String.format(
+                                                        "Unable to derive changelog mode from node %s. This is a bug.",
+                                                        node)));
+        return changelogMode.containsOnly(RowKind.INSERT);
+    }
+
+    private static StreamPhysicalRel unwrapNode(RelNode node, boolean transposeToChildBlock) {
+        if (node instanceof HepRelVertex) {
+            node = ((HepRelVertex) node).getCurrentRel();
+        }
+        if (node instanceof StreamPhysicalIntermediateTableScan && transposeToChildBlock) {
+            IntermediateRelTable inputBlockOptimizedTree = (IntermediateRelTable) node.getTable();
+            Preconditions.checkState(inputBlockOptimizedTree != null);
+            node = inputBlockOptimizedTree.relNode();
+        }
+        return (StreamPhysicalRel) node;
+    }
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/StreamCommonSubGraphBasedOptimizer.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/StreamCommonSubGraphBasedOptimizer.scala
@@ -373,6 +373,9 @@ class StreamCommonSubGraphBasedOptimizer(planner: StreamPlanner)
   }
 
   override protected def postOptimize(expanded: Seq[RelNode]): Seq[RelNode] = {
-    StreamNonDeterministicPhysicalPlanResolver.resolvePhysicalPlan(expanded, planner.getTableConfig)
+    val tableConfig = planner.getTableConfig
+    val newRoots =
+      StreamNonDeterministicPhysicalPlanResolver.resolvePhysicalPlan(expanded, tableConfig)
+    StreamPhysicalDeltaJoinForceValidator.validatePhysicalPlan(newRoots, tableConfig)
   }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -520,7 +520,9 @@ object FlinkStreamRuleSets {
     // incremental agg rule
     IncrementalAggregateRule.INSTANCE,
     // optimize window agg rule
-    TwoStageOptimizedWindowAggregateRule.INSTANCE
+    TwoStageOptimizedWindowAggregateRule.INSTANCE,
+    // delta join redundant data acceptable infer rule
+    DeltaJoinRewriteRule.INSTANCE
   )
 
 }

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/DeltaJoinTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/DeltaJoinTest.xml
@@ -1,0 +1,720 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testCdcSource">
+    <Resource name="sql">
+      <![CDATA[insert into snk select * from src1 join cdc_src on src1.a1 = cdc_src.b1 and src1.a2 = cdc_src.b2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1])
++- LogicalProject(a0=[$0], a1=[$1], a2=[$2], a3=[$3], b0=[$4], b2=[$5], b1=[$6])
+   +- LogicalJoin(condition=[AND(=($1, $6), =($2, $5))], joinType=[inner])
+      :- LogicalTableScan(table=[[default_catalog, default_database, src1]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, cdc_src]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1], upsertMaterialize=[true])
++- Join(joinType=[InnerJoin], where=[AND(=(a1, b1), =(a2, b2))], select=[a0, a1, a2, a3, b0, b2, b1], leftInputSpec=[HasUniqueKey], rightInputSpec=[HasUniqueKey])
+   :- Exchange(distribution=[hash[a1, a2]])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, src1]], fields=[a0, a1, a2, a3])
+   +- Exchange(distribution=[hash[b1, b2]])
+      +- TableSourceScan(table=[[default_catalog, default_database, cdc_src]], fields=[b0, b2, b1])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testComputeIndexKeyOnJoinCondition">
+    <Resource name="sql">
+      <![CDATA[insert into snk select * from src1 join src2 on src1.a1 = src2.b1 and src1.a2 = TRIM(src2.b2)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1])
++- LogicalProject(a0=[$0], a1=[$1], a2=[$2], a3=[$3], b0=[$4], b2=[$5], b1=[$6])
+   +- LogicalProject(a0=[$0], a1=[$1], a2=[$2], a3=[$3], b0=[$4], b2=[$5], b1=[$6])
+      +- LogicalJoin(condition=[AND(=($1, $6), =($2, $7))], joinType=[inner])
+         :- LogicalTableScan(table=[[default_catalog, default_database, src1]])
+         +- LogicalProject(b0=[$0], b2=[$1], b1=[$2], $f3=[TRIM(FLAG(BOTH), _UTF-16LE' ', $1)])
+            +- LogicalTableScan(table=[[default_catalog, default_database, src2]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1])
++- Calc(select=[a0, a1, a2, a3, b0, b2, b1])
+   +- Join(joinType=[InnerJoin], where=[AND(=(a1, b1), =(a2, $f3))], select=[a0, a1, a2, a3, b0, b2, b1, $f3], leftInputSpec=[HasUniqueKey], rightInputSpec=[HasUniqueKey])
+      :- Exchange(distribution=[hash[a1, a2]])
+      :  +- TableSourceScan(table=[[default_catalog, default_database, src1]], fields=[a0, a1, a2, a3])
+      +- Exchange(distribution=[hash[b1, $f3]])
+         +- Calc(select=[b0, b2, b1, TRIM(BOTH, ' ', b2) AS $f3])
+            +- TableSourceScan(table=[[default_catalog, default_database, src2]], fields=[b0, b2, b1])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testConstantConditionInIndex">
+    <Resource name="sql">
+      <![CDATA[insert into snk select * from src1 join src2 on src1.a1 = 1.1 and src1.a2 = src2.b2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1])
++- LogicalProject(a0=[$0], a1=[$1], a2=[$2], a3=[$3], b0=[$4], b2=[$5], b1=[$6])
+   +- LogicalJoin(condition=[AND(=($1, 1.1), =($2, $5))], joinType=[inner])
+      :- LogicalTableScan(table=[[default_catalog, default_database, src1]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, src2]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1])
++- Calc(select=[a0, 1.1000000000000000888E0 AS a1, a2, a3, b0, b2, b1])
+   +- Join(joinType=[InnerJoin], where=[=(a2, b2)], select=[a0, a2, a3, b0, b2, b1], leftInputSpec=[HasUniqueKey], rightInputSpec=[HasUniqueKey])
+      :- Exchange(distribution=[hash[a2]])
+      :  +- Calc(select=[a0, a2, a3], where=[=(a1, 1.1E0)])
+      :     +- TableSourceScan(table=[[default_catalog, default_database, src1, filter=[]]], fields=[a0, a1, a2, a3])
+      +- Exchange(distribution=[hash[b2]])
+         +- TableSourceScan(table=[[default_catalog, default_database, src2]], fields=[b0, b2, b1])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testDeltaJoinStrategyWithForce">
+    <Resource name="sql">
+      <![CDATA[insert into snk select * from src1 join src2 on src1.a1 = src2.b1 and src1.a2 = src2.b2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1])
++- LogicalProject(a0=[$0], a1=[$1], a2=[$2], a3=[$3], b0=[$4], b2=[$5], b1=[$6])
+   +- LogicalJoin(condition=[AND(=($1, $6), =($2, $5))], joinType=[inner])
+      :- LogicalTableScan(table=[[default_catalog, default_database, src1]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, src2]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1])
++- DeltaJoin(joinType=[InnerJoin], where=[AND(=(a1, b1), =(a2, b2))], select=[a0, a1, a2, a3, b0, b2, b1])
+   :- Exchange(distribution=[hash[a1, a2]])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, src1]], fields=[a0, a1, a2, a3])
+   +- Exchange(distribution=[hash[b1, b2]])
+      +- TableSourceScan(table=[[default_catalog, default_database, src2]], fields=[b0, b2, b1])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testDeltaJoinStrategyWithForce3">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1])
++- LogicalProject(a0=[$0], a1=[$1], a2=[$2], a3=[$3], b0=[$4], b2=[$5], b1=[$6])
+   +- LogicalJoin(condition=[AND(=($1, $6), =($2, $5))], joinType=[inner])
+      :- LogicalTableScan(table=[[default_catalog, default_database, src1]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, src2]])
+
+LogicalSink(table=[default_catalog.default_database.snk2], fields=[a0, a1, a2, a3, b0, b2, b1])
++- LogicalProject(a0=[$0], a1=[$1], a2=[$2], a3=[$3], b0=[$4], b2=[$5], b1=[$6])
+   +- LogicalJoin(condition=[AND(=($1, $6), =($2, $5))], joinType=[inner])
+      :- LogicalTableScan(table=[[default_catalog, default_database, src1]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, src2]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1])
++- DeltaJoin(joinType=[InnerJoin], where=[AND(=(a1, b1), =(a2, b2))], select=[a0, a1, a2, a3, b0, b2, b1])
+   :- Exchange(distribution=[hash[a1, a2]])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, src1]], fields=[a0, a1, a2, a3])
+   +- Exchange(distribution=[hash[b1, b2]])
+      +- TableSourceScan(table=[[default_catalog, default_database, src2]], fields=[b0, b2, b1])
+
+Sink(table=[default_catalog.default_database.snk2], fields=[a0, a1, a2, a3, b0, b2, b1])
++- Join(joinType=[InnerJoin], where=[AND(=(a1, b1), =(a2, b2))], select=[a0, a1, a2, a3, b0, b2, b1], leftInputSpec=[HasUniqueKey], rightInputSpec=[HasUniqueKey])
+   :- Exchange(distribution=[hash[a1, a2]])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, src1]], fields=[a0, a1, a2, a3])
+   +- Exchange(distribution=[hash[b1, b2]])
+      +- TableSourceScan(table=[[default_catalog, default_database, src2]], fields=[b0, b2, b1])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testDeltaJoinStrategyWithForce4">
+    <Resource name="sql">
+      <![CDATA[insert into tmp_snk select a0, a1 from src1]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.tmp_snk], fields=[a0, a1])
++- LogicalProject(a0=[$0], a1=[$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, src1]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.tmp_snk], fields=[a0, a1])
++- TableSourceScan(table=[[default_catalog, default_database, src1, project=[a0, a1], metadata=[]]], fields=[a0, a1])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testDeltaJoinStrategyWithNone">
+    <Resource name="sql">
+      <![CDATA[insert into snk select * from src1 join src2 on src1.a1 = src2.b1 and src1.a2 = src2.b2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1])
++- LogicalProject(a0=[$0], a1=[$1], a2=[$2], a3=[$3], b0=[$4], b2=[$5], b1=[$6])
+   +- LogicalJoin(condition=[AND(=($1, $6), =($2, $5))], joinType=[inner])
+      :- LogicalTableScan(table=[[default_catalog, default_database, src1]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, src2]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1])
++- Join(joinType=[InnerJoin], where=[AND(=(a1, b1), =(a2, b2))], select=[a0, a1, a2, a3, b0, b2, b1], leftInputSpec=[HasUniqueKey], rightInputSpec=[HasUniqueKey])
+   :- Exchange(distribution=[hash[a1, a2]])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, src1]], fields=[a0, a1, a2, a3])
+   +- Exchange(distribution=[hash[b1, b2]])
+      +- TableSourceScan(table=[[default_catalog, default_database, src2]], fields=[b0, b2, b1])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testFilterProjectFieldsAfterJoin">
+    <Resource name="sql">
+      <![CDATA[insert into snk(l0, l1, r0) select a0, a1, b0 from src1 join src2 on src1.a1 = src2.b1 and src1.a2 = src2.b2 where a3 > b0]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.snk], targetColumns=[[0],[1],[4]], fields=[a0, a1, EXPR$2, EXPR$3, b0, EXPR$5, EXPR$6])
++- LogicalProject(a0=[$0], a1=[$1], EXPR$2=[null:VARCHAR(2147483647) CHARACTER SET "UTF-16LE"], EXPR$3=[null:INTEGER], b0=[$4], EXPR$5=[null:VARCHAR(2147483647) CHARACTER SET "UTF-16LE"], EXPR$6=[null:DOUBLE])
+   +- LogicalFilter(condition=[>($3, $4)])
+      +- LogicalJoin(condition=[AND(=($1, $6), =($2, $5))], joinType=[inner])
+         :- LogicalTableScan(table=[[default_catalog, default_database, src1]])
+         +- LogicalTableScan(table=[[default_catalog, default_database, src2]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.snk], targetColumns=[[0],[1],[4]], fields=[a0, a1, EXPR$2, EXPR$3, b0, EXPR$5, EXPR$6])
++- Calc(select=[a0, a1, null:VARCHAR(2147483647) AS EXPR$2, null:INTEGER AS EXPR$3, b0, null:VARCHAR(2147483647) AS EXPR$5, null:DOUBLE AS EXPR$6])
+   +- DeltaJoin(joinType=[InnerJoin], where=[AND(=(a1, b1), =(a2, b2), >(a3, b0))], select=[a0, a1, a2, a3, b0, b2, b1])
+      :- Exchange(distribution=[hash[a1, a2]])
+      :  +- TableSourceScan(table=[[default_catalog, default_database, src1]], fields=[a0, a1, a2, a3])
+      +- Exchange(distribution=[hash[b1, b2]])
+         +- TableSourceScan(table=[[default_catalog, default_database, src2]], fields=[b0, b2, b1])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinKeysContainIndexOnBothSide">
+    <Resource name="sql">
+      <![CDATA[insert into snk select * from src1 join src2 on src1.a1 = src2.b1 and src1.a2 = src2.b2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1])
++- LogicalProject(a0=[$0], a1=[$1], a2=[$2], a3=[$3], b0=[$4], b2=[$5], b1=[$6])
+   +- LogicalJoin(condition=[AND(=($1, $6), =($2, $5))], joinType=[inner])
+      :- LogicalTableScan(table=[[default_catalog, default_database, src1]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, src2]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1])
++- DeltaJoin(joinType=[InnerJoin], where=[AND(=(a1, b1), =(a2, b2))], select=[a0, a1, a2, a3, b0, b2, b1])
+   :- Exchange(distribution=[hash[a1, a2]])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, src1]], fields=[a0, a1, a2, a3])
+   +- Exchange(distribution=[hash[b1, b2]])
+      +- TableSourceScan(table=[[default_catalog, default_database, src2]], fields=[b0, b2, b1])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinKeysContainIndexOnBothSide2">
+    <Resource name="sql">
+      <![CDATA[insert into snk select * from src1 join src2 on src1.a1 = src2.b1 and src1.a2 = src2.b2 and src1.a3 = src2.b0]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1])
++- LogicalProject(a0=[$0], a1=[$1], a2=[$2], a3=[$3], b0=[$4], b2=[$5], b1=[$6])
+   +- LogicalJoin(condition=[AND(=($1, $6), =($2, $5), =($3, $4))], joinType=[inner])
+      :- LogicalTableScan(table=[[default_catalog, default_database, src1]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, src2]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1])
++- DeltaJoin(joinType=[InnerJoin], where=[AND(=(a1, b1), =(a2, b2), =(a3, b0))], select=[a0, a1, a2, a3, b0, b2, b1])
+   :- Exchange(distribution=[hash[a1, a2, a3]])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, src1]], fields=[a0, a1, a2, a3])
+   +- Exchange(distribution=[hash[b1, b2, b0]])
+      +- TableSourceScan(table=[[default_catalog, default_database, src2]], fields=[b0, b2, b1])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinKeysNotContainIndexOnOneSide">
+    <Resource name="sql">
+      <![CDATA[insert into snk select * from src1 join src2 on src1.a2 = src2.b2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1])
++- LogicalProject(a0=[$0], a1=[$1], a2=[$2], a3=[$3], b0=[$4], b2=[$5], b1=[$6])
+   +- LogicalJoin(condition=[=($2, $5)], joinType=[inner])
+      :- LogicalTableScan(table=[[default_catalog, default_database, src1]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, src2]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1])
++- Join(joinType=[InnerJoin], where=[=(a2, b2)], select=[a0, a1, a2, a3, b0, b2, b1], leftInputSpec=[HasUniqueKey], rightInputSpec=[HasUniqueKey])
+   :- Exchange(distribution=[hash[a2]])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, src1]], fields=[a0, a1, a2, a3])
+   +- Exchange(distribution=[hash[b2]])
+      +- TableSourceScan(table=[[default_catalog, default_database, src2]], fields=[b0, b2, b1])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMultiRootsWithoutReusingDeltaJoin">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1])
++- LogicalProject(a0=[$0], a1=[$1], a2=[$2], a3=[$3], b0=[$4], b2=[$5], b1=[$6])
+   +- LogicalJoin(condition=[AND(=($1, $6), =($2, $5))], joinType=[inner])
+      :- LogicalTableScan(table=[[default_catalog, default_database, src1]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, src2]])
+
+LogicalSink(table=[default_catalog.default_database.snk2], fields=[a0, a1, a2, a3, b0, b2, b1])
++- LogicalProject(a0=[$0], a1=[$1], a2=[$2], a3=[$3], b0=[$4], b2=[$5], b1=[$6])
+   +- LogicalJoin(condition=[AND(=($1, $6), =($2, $5))], joinType=[inner])
+      :- LogicalTableScan(table=[[default_catalog, default_database, src1]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, src2]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1])
++- DeltaJoin(joinType=[InnerJoin], where=[AND(=(a1, b1), =(a2, b2))], select=[a0, a1, a2, a3, b0, b2, b1])
+   :- Exchange(distribution=[hash[a1, a2]])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, src1]], fields=[a0, a1, a2, a3])
+   +- Exchange(distribution=[hash[b1, b2]])
+      +- TableSourceScan(table=[[default_catalog, default_database, src2]], fields=[b0, b2, b1])
+
+Sink(table=[default_catalog.default_database.snk2], fields=[a0, a1, a2, a3, b0, b2, b1])
++- Join(joinType=[InnerJoin], where=[AND(=(a1, b1), =(a2, b2))], select=[a0, a1, a2, a3, b0, b2, b1], leftInputSpec=[HasUniqueKey], rightInputSpec=[HasUniqueKey])
+   :- Exchange(distribution=[hash[a1, a2]])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, src1]], fields=[a0, a1, a2, a3])
+   +- Exchange(distribution=[hash[b1, b2]])
+      +- TableSourceScan(table=[[default_catalog, default_database, src2]], fields=[b0, b2, b1])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMultiRootsWithReusingDeltaJoin">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1])
++- LogicalProject(a0=[$0], a1=[$1], a2=[$2], a3=[$3], b0=[$4], b2=[$5], b1=[$6])
+   +- LogicalJoin(condition=[AND(=($1, $6), =($2, $5))], joinType=[inner])
+      :- LogicalTableScan(table=[[default_catalog, default_database, src1]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, src2]])
+
+LogicalSink(table=[default_catalog.default_database.snk2], fields=[a0, a1, a2, a3, b0, b2, b1])
++- LogicalProject(a0=[$0], a1=[$1], a2=[$2], a3=[$3], b0=[$4], b2=[$5], b1=[$6])
+   +- LogicalJoin(condition=[AND(=($1, $6), =($2, $5))], joinType=[inner])
+      :- LogicalTableScan(table=[[default_catalog, default_database, src1]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, src2]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1])
++- DeltaJoin(joinType=[InnerJoin], where=[AND(=(a1, b1), =(a2, b2))], select=[a0, a1, a2, a3, b0, b2, b1])
+   :- Exchange(distribution=[hash[a1, a2]])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, src1]], fields=[a0, a1, a2, a3])
+   +- Exchange(distribution=[hash[b1, b2]])
+      +- TableSourceScan(table=[[default_catalog, default_database, src2]], fields=[b0, b2, b1])
+
+Sink(table=[default_catalog.default_database.snk2], fields=[a0, a1, a2, a3, b0, b2, b1])
++- DeltaJoin(joinType=[InnerJoin], where=[AND(=(a1, b1), =(a2, b2))], select=[a0, a1, a2, a3, b0, b2, b1])
+   :- Exchange(distribution=[hash[a1, a2]])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, src1]], fields=[a0, a1, a2, a3])
+   +- Exchange(distribution=[hash[b1, b2]])
+      +- TableSourceScan(table=[[default_catalog, default_database, src2]], fields=[b0, b2, b1])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMultiRootsWithReusingJoinView2">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1])
++- LogicalProject(a0=[$0], a1=[$1], a2=[$2], a3=[$3], b0=[$4], b2=[$5], b1=[$6])
+   +- LogicalProject(a0=[$0], a1=[$1], a2=[$2], a3=[$3], b0=[$4], b2=[$5], b1=[$6])
+      +- LogicalJoin(condition=[AND(=($1, $6), =($2, $5))], joinType=[inner])
+         :- LogicalTableScan(table=[[default_catalog, default_database, src1]])
+         +- LogicalTableScan(table=[[default_catalog, default_database, src2]])
+
+LogicalSink(table=[default_catalog.default_database.snk2], fields=[a0, a1, a2, a3, b0, b2, b1])
++- LogicalProject(a0=[$0], a1=[$1], a2=[$2], a3=[$3], b0=[$4], b2=[$5], b1=[$6])
+   +- LogicalProject(a0=[$0], a1=[$1], a2=[$2], a3=[$3], b0=[$4], b2=[$5], b1=[$6])
+      +- LogicalJoin(condition=[AND(=($1, $6), =($2, $5))], joinType=[inner])
+         :- LogicalTableScan(table=[[default_catalog, default_database, src1]])
+         +- LogicalTableScan(table=[[default_catalog, default_database, src2]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Join(joinType=[InnerJoin], where=[((a1 = b1) AND (a2 = b2))], select=[a0, a1, a2, a3, b0, b2, b1], leftInputSpec=[HasUniqueKey], rightInputSpec=[HasUniqueKey])(reuse_id=[1])
+:- Exchange(distribution=[hash[a1, a2]])
+:  +- TableSourceScan(table=[[default_catalog, default_database, src1]], fields=[a0, a1, a2, a3])
++- Exchange(distribution=[hash[b1, b2]])
+   +- TableSourceScan(table=[[default_catalog, default_database, src2]], fields=[b0, b2, b1])
+
+Sink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1])
++- Reused(reference_id=[1])
+
+Sink(table=[default_catalog.default_database.snk2], fields=[a0, a1, a2, a3, b0, b2, b1])
++- Reused(reference_id=[1])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMultiRootsWithReusingJoinView">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1])
++- LogicalProject(a0=[$0], a1=[$1], a2=[$2], a3=[$3], b0=[$4], b2=[$5], b1=[$6])
+   +- LogicalProject(a0=[$0], a1=[$1], a2=[$2], a3=[$3], b0=[$4], b2=[$5], b1=[$6])
+      +- LogicalJoin(condition=[AND(=($1, $6), =($2, $5))], joinType=[inner])
+         :- LogicalTableScan(table=[[default_catalog, default_database, src1]])
+         +- LogicalTableScan(table=[[default_catalog, default_database, src2]])
+
+LogicalSink(table=[default_catalog.default_database.snk2], fields=[a0, a1, a2, a3, b0, b2, b1])
++- LogicalProject(a0=[$0], a1=[$1], a2=[$2], a3=[$3], b0=[$4], b2=[$5], b1=[$6])
+   +- LogicalProject(a0=[$0], a1=[$1], a2=[$2], a3=[$3], b0=[$4], b2=[$5], b1=[$6])
+      +- LogicalJoin(condition=[AND(=($1, $6), =($2, $5))], joinType=[inner])
+         :- LogicalTableScan(table=[[default_catalog, default_database, src1]])
+         +- LogicalTableScan(table=[[default_catalog, default_database, src2]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1])
++- DeltaJoin(joinType=[InnerJoin], where=[AND(=(a1, b1), =(a2, b2))], select=[a0, a1, a2, a3, b0, b2, b1])
+   :- Exchange(distribution=[hash[a1, a2]])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, src1]], fields=[a0, a1, a2, a3])
+   +- Exchange(distribution=[hash[b1, b2]])
+      +- TableSourceScan(table=[[default_catalog, default_database, src2]], fields=[b0, b2, b1])
+
+Sink(table=[default_catalog.default_database.snk2], fields=[a0, a1, a2, a3, b0, b2, b1])
++- DeltaJoin(joinType=[InnerJoin], where=[AND(=(a1, b1), =(a2, b2))], select=[a0, a1, a2, a3, b0, b2, b1])
+   :- Exchange(distribution=[hash[a1, a2]])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, src1]], fields=[a0, a1, a2, a3])
+   +- Exchange(distribution=[hash[b1, b2]])
+      +- TableSourceScan(table=[[default_catalog, default_database, src2]], fields=[b0, b2, b1])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSourceWithoutIndexes">
+    <Resource name="sql">
+      <![CDATA[insert into snk select * from src1 join non_index_src on src1.a1 = non_index_src.b1 and src1.a2 = non_index_src.b2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1])
++- LogicalProject(a0=[$0], a1=[$1], a2=[$2], a3=[$3], b0=[$4], b2=[$5], b1=[$6])
+   +- LogicalJoin(condition=[AND(=($1, $6), =($2, $5))], joinType=[inner])
+      :- LogicalTableScan(table=[[default_catalog, default_database, src1]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, non_index_src]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1])
++- Join(joinType=[InnerJoin], where=[AND(=(a1, b1), =(a2, b2))], select=[a0, a1, a2, a3, b0, b2, b1], leftInputSpec=[HasUniqueKey], rightInputSpec=[HasUniqueKey])
+   :- Exchange(distribution=[hash[a1, a2]])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, src1]], fields=[a0, a1, a2, a3])
+   +- Exchange(distribution=[hash[b1, b2]])
+      +- TableSourceScan(table=[[default_catalog, default_database, non_index_src]], fields=[b0, b2, b1])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSourceWithSourceAbilities">
+    <Resource name="sql">
+      <![CDATA[insert into snk select * from filterable_src join src2 on filterable_src.a1 = src2.b1 and filterable_src.a2 = src2.b2 and filterable_src.a3 = 1]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1])
++- LogicalProject(a0=[$0], a1=[$1], a2=[$2], a3=[$3], b0=[$4], b2=[$5], b1=[$6])
+   +- LogicalJoin(condition=[AND(=($1, $6), =($2, $5), =($3, 1))], joinType=[inner])
+      :- LogicalTableScan(table=[[default_catalog, default_database, filterable_src]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, src2]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1])
++- Calc(select=[a0, a1, a2, CAST(1 AS INTEGER) AS a3, b0, b2, b1])
+   +- Join(joinType=[InnerJoin], where=[AND(=(a1, b1), =(a2, b2))], select=[a0, a1, a2, b0, b2, b1], leftInputSpec=[HasUniqueKey], rightInputSpec=[HasUniqueKey])
+      :- Exchange(distribution=[hash[a1, a2]])
+      :  +- TableSourceScan(table=[[default_catalog, default_database, filterable_src, filter=[=(a3, 1)], project=[a0, a1, a2], metadata=[]]], fields=[a0, a1, a2])
+      +- Exchange(distribution=[hash[b1, b2]])
+         +- TableSourceScan(table=[[default_catalog, default_database, src2]], fields=[b0, b2, b1])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testWithAggregatingAfterJoin">
+    <Resource name="sql">
+      <![CDATA[insert into snk select a0, max(a1), max(a2), max(a3), max(b0), max(b2), b1 from src1 join src2 on src1.a1 = src2.b1 and src1.a2 = src2.b2 group by a0, b1]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.snk], fields=[a0, EXPR$1, EXPR$2, EXPR$3, EXPR$4, EXPR$5, b1])
++- LogicalProject(a0=[$0], EXPR$1=[$2], EXPR$2=[$3], EXPR$3=[$4], EXPR$4=[$5], EXPR$5=[$6], b1=[$1])
+   +- LogicalAggregate(group=[{0, 1}], EXPR$1=[MAX($2)], EXPR$2=[MAX($3)], EXPR$3=[MAX($4)], EXPR$4=[MAX($5)], EXPR$5=[MAX($6)])
+      +- LogicalProject(a0=[$0], b1=[$6], a1=[$1], a2=[$2], a3=[$3], b0=[$4], b2=[$5])
+         +- LogicalJoin(condition=[AND(=($1, $6), =($2, $5))], joinType=[inner])
+            :- LogicalTableScan(table=[[default_catalog, default_database, src1]])
+            +- LogicalTableScan(table=[[default_catalog, default_database, src2]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.snk], fields=[a0, EXPR$1, EXPR$2, EXPR$3, EXPR$4, EXPR$5, b1], upsertMaterialize=[true])
++- Calc(select=[a0, EXPR$1, EXPR$2, EXPR$3, EXPR$4, EXPR$5, b1])
+   +- GroupAggregate(groupBy=[a0, b1], select=[a0, b1, MAX(a1) AS EXPR$1, MAX(a2) AS EXPR$2, MAX(a3) AS EXPR$3, MAX(b0) AS EXPR$4, MAX(b2) AS EXPR$5])
+      +- Exchange(distribution=[hash[a0, b1]])
+         +- Join(joinType=[InnerJoin], where=[AND(=(a1, b1), =(a2, b2))], select=[a0, a1, a2, a3, b0, b2, b1], leftInputSpec=[HasUniqueKey], rightInputSpec=[HasUniqueKey])
+            :- Exchange(distribution=[hash[a1, a2]])
+            :  +- TableSourceScan(table=[[default_catalog, default_database, src1]], fields=[a0, a1, a2, a3])
+            +- Exchange(distribution=[hash[b1, b2]])
+               +- TableSourceScan(table=[[default_catalog, default_database, src2]], fields=[b0, b2, b1])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testWithCascadeJoin">
+    <Resource name="sql">
+      <![CDATA[insert into tmp_snk select * from src1 join src2 on src1.a1 = src2.b1 and src1.a2 = src2.b2 join src3 on src1.a1 = src3.b1 and src1.a2 = src3.b2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.tmp_snk], fields=[a0, a1, a2, a3, b0, b2, b1, b00, b20, b10])
++- LogicalProject(a0=[$0], a1=[$1], a2=[$2], a3=[$3], b0=[$4], b2=[$5], b1=[$6], b00=[$7], b20=[$8], b10=[$9])
+   +- LogicalJoin(condition=[AND(=($1, $9), =($2, $8))], joinType=[inner])
+      :- LogicalJoin(condition=[AND(=($1, $6), =($2, $5))], joinType=[inner])
+      :  :- LogicalTableScan(table=[[default_catalog, default_database, src1]])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, src2]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, src3]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.tmp_snk], fields=[a0, a1, a2, a3, b0, b2, b1, b00, b20, b10])
++- Join(joinType=[InnerJoin], where=[AND(=(a1, b10), =(a2, b20))], select=[a0, a1, a2, a3, b0, b2, b1, b00, b20, b10], leftInputSpec=[NoUniqueKey], rightInputSpec=[HasUniqueKey])
+   :- Exchange(distribution=[hash[a1, a2]])
+   :  +- Join(joinType=[InnerJoin], where=[AND(=(a1, b1), =(a2, b2))], select=[a0, a1, a2, a3, b0, b2, b1], leftInputSpec=[HasUniqueKey], rightInputSpec=[HasUniqueKey])
+   :     :- Exchange(distribution=[hash[a1, a2]])
+   :     :  +- TableSourceScan(table=[[default_catalog, default_database, src1]], fields=[a0, a1, a2, a3])
+   :     +- Exchange(distribution=[hash[b1, b2]])
+   :        +- TableSourceScan(table=[[default_catalog, default_database, src2]], fields=[b0, b2, b1])
+   +- Exchange(distribution=[hash[b1, b2]])
+      +- TableSourceScan(table=[[default_catalog, default_database, src3]], fields=[b0, b2, b1])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testWithAggregatingSourceTableBeforeJoin">
+    <Resource name="sql">
+      <![CDATA[insert into snk select * from (   select distinct max(a0) as a0, a1, max(a2) as a2, max(a3) as a3 from src1 group by a1) tmp join src2 on tmp.a1 = src2.b1 and tmp.a2 = src2.b2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1])
++- LogicalProject(a0=[$0], a1=[$1], a2=[$2], a3=[$3], b0=[$4], b2=[$5], b1=[$6])
+   +- LogicalJoin(condition=[AND(=($1, $6), =($2, $5))], joinType=[inner])
+      :- LogicalProject(a0=[$1], a1=[$0], a2=[$2], a3=[$3])
+      :  +- LogicalAggregate(group=[{0}], a0=[MAX($1)], a2=[MAX($2)], a3=[MAX($3)])
+      :     +- LogicalProject(a1=[$1], a0=[$0], a2=[$2], a3=[$3])
+      :        +- LogicalTableScan(table=[[default_catalog, default_database, src1]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, src2]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1], upsertMaterialize=[true])
++- Join(joinType=[InnerJoin], where=[AND(=(a1, b1), =(a2, b2))], select=[a0, a1, a2, a3, b0, b2, b1], leftInputSpec=[JoinKeyContainsUniqueKey], rightInputSpec=[HasUniqueKey])
+   :- Exchange(distribution=[hash[a1, a2]])
+   :  +- Calc(select=[a0, a1, a2, a3])
+   :     +- GroupAggregate(groupBy=[a1], select=[a1, MAX(a0) AS a0, MAX(a2) AS a2, MAX(a3) AS a3])
+   :        +- Exchange(distribution=[hash[a1]])
+   :           +- TableSourceScan(table=[[default_catalog, default_database, src1]], fields=[a0, a1, a2, a3])
+   +- Exchange(distribution=[hash[b1, b2]])
+      +- TableSourceScan(table=[[default_catalog, default_database, src2]], fields=[b0, b2, b1])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testWithAlwaysTrueJoinCondition">
+    <Resource name="sql">
+      <![CDATA[insert into snk select * from src1 join src2 on 1 = 1]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1])
++- LogicalProject(a0=[$0], a1=[$1], a2=[$2], a3=[$3], b0=[$4], b2=[$5], b1=[$6])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalTableScan(table=[[default_catalog, default_database, src1]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, src2]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1])
++- Join(joinType=[InnerJoin], where=[true], select=[a0, a1, a2, a3, b0, b2, b1], leftInputSpec=[HasUniqueKey], rightInputSpec=[HasUniqueKey])
+   :- Exchange(distribution=[single])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, src1]], fields=[a0, a1, a2, a3])
+   +- Exchange(distribution=[single])
+      +- TableSourceScan(table=[[default_catalog, default_database, src2]], fields=[b0, b2, b1])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testWithNonEquiCondition1">
+    <Resource name="sql">
+      <![CDATA[insert into snk select * from src1 join src2 on src1.a1 = src2.b1 and src1.a2 = src2.b2 and src2.b0 > src1.a0]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1])
++- LogicalProject(a0=[$0], a1=[$1], a2=[$2], a3=[$3], b0=[$4], b2=[$5], b1=[$6])
+   +- LogicalJoin(condition=[AND(=($1, $6), =($2, $5), >($4, $0))], joinType=[inner])
+      :- LogicalTableScan(table=[[default_catalog, default_database, src1]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, src2]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1])
++- DeltaJoin(joinType=[InnerJoin], where=[AND(=(a1, b1), =(a2, b2), >(b0, a0))], select=[a0, a1, a2, a3, b0, b2, b1])
+   :- Exchange(distribution=[hash[a1, a2]])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, src1]], fields=[a0, a1, a2, a3])
+   +- Exchange(distribution=[hash[b1, b2]])
+      +- TableSourceScan(table=[[default_catalog, default_database, src2]], fields=[b0, b2, b1])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testWithNonEquiCondition2">
+    <Resource name="sql">
+      <![CDATA[insert into snk select * from src1 join src2 on src1.a1 = src2.b1 and src1.a2 = src2.b2 and src2.b0 > src1.a0 and src2.b2 <> 'Hello' and src1.a0 > 99]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1])
++- LogicalProject(a0=[$0], a1=[$1], a2=[$2], a3=[$3], b0=[$4], b2=[$5], b1=[$6])
+   +- LogicalJoin(condition=[AND(=($1, $6), =($2, $5), >($4, $0), <>($5, _UTF-16LE'Hello'), >($0, 99))], joinType=[inner])
+      :- LogicalTableScan(table=[[default_catalog, default_database, src1]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, src2]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1])
++- Join(joinType=[InnerJoin], where=[AND(=(a1, b1), =(a2, b2), >(b0, a0))], select=[a0, a1, a2, a3, b0, b2, b1], leftInputSpec=[HasUniqueKey], rightInputSpec=[HasUniqueKey])
+   :- Exchange(distribution=[hash[a1, a2]])
+   :  +- Calc(select=[a0, a1, a2, a3], where=[AND(>(a0, 99), <>(a2, 'Hello'))])
+   :     +- TableSourceScan(table=[[default_catalog, default_database, src1, filter=[]]], fields=[a0, a1, a2, a3])
+   +- Exchange(distribution=[hash[b1, b2]])
+      +- Calc(select=[b0, b2, b1], where=[<>(b2, 'Hello')])
+         +- TableSourceScan(table=[[default_catalog, default_database, src2, filter=[]]], fields=[b0, b2, b1])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testWithUnsupportedJoinType">
+    <Resource name="sql">
+      <![CDATA[insert into snk select * from src1 left join src2 on src1.a1 = src2.b1 and src1.a2 = src2.b2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1])
++- LogicalProject(a0=[$0], a1=[$1], a2=[$2], a3=[$3], b0=[$4], b2=[$5], b1=[$6])
+   +- LogicalJoin(condition=[AND(=($1, $6), =($2, $5))], joinType=[left])
+      :- LogicalTableScan(table=[[default_catalog, default_database, src1]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, src2]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1])
++- Join(joinType=[LeftOuterJoin], where=[AND(=(a1, b1), =(a2, b2))], select=[a0, a1, a2, a3, b0, b2, b1], leftInputSpec=[HasUniqueKey], rightInputSpec=[HasUniqueKey])
+   :- Exchange(distribution=[hash[a1, a2]])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, src1]], fields=[a0, a1, a2, a3])
+   +- Exchange(distribution=[hash[b1, b2]])
+      +- TableSourceScan(table=[[default_catalog, default_database, src2]], fields=[b0, b2, b1])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testWithoutLookupTable">
+    <Resource name="sql">
+      <![CDATA[insert into snk select * from src1 join non_lookup_src on src1.a1 = non_lookup_src.b1 and src1.a2 = non_lookup_src.b2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1])
++- LogicalProject(a0=[$0], a1=[$1], a2=[$2], a3=[$3], b0=[$4], b2=[$5], b1=[$6])
+   +- LogicalJoin(condition=[AND(=($1, $6), =($2, $5))], joinType=[inner])
+      :- LogicalTableScan(table=[[default_catalog, default_database, src1]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, non_lookup_src]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.snk], fields=[a0, a1, a2, a3, b0, b2, b1])
++- Join(joinType=[InnerJoin], where=[AND(=(a1, b1), =(a2, b2))], select=[a0, a1, a2, a3, b0, b2, b1], leftInputSpec=[HasUniqueKey], rightInputSpec=[HasUniqueKey])
+   :- Exchange(distribution=[hash[a1, a2]])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, src1]], fields=[a0, a1, a2, a3])
+   +- Exchange(distribution=[hash[b1, b2]])
+      +- TableSourceScan(table=[[default_catalog, default_database, non_lookup_src]], fields=[b0, b2, b1])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testWithWatermarkAssigner">
+    <Resource name="sql">
+      <![CDATA[insert into tmp_sink select * from wm_source join src2 on wm_source.a1 = src2.b2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.tmp_sink], fields=[a0, a1, a2, b0, b2, b1])
++- LogicalProject(a0=[$0], a1=[$1], a2=[$2], b0=[$3], b2=[$4], b1=[$5])
+   +- LogicalJoin(condition=[=($1, $4)], joinType=[inner])
+      :- LogicalWatermarkAssigner(rowtime=[a2], watermark=[-($2, 1000:INTERVAL SECOND)])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, wm_source]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, src2]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.tmp_sink], fields=[a0, a1, a2, b0, b2, b1])
++- Join(joinType=[InnerJoin], where=[=(a1, b2)], select=[a0, a1, a2, b0, b2, b1], leftInputSpec=[NoUniqueKey], rightInputSpec=[HasUniqueKey])
+   :- Exchange(distribution=[hash[a1]])
+   :  +- Calc(select=[a0, a1, CAST(a2 AS TIMESTAMP(3)) AS a2])
+   :     +- WatermarkAssigner(rowtime=[a2], watermark=[-(a2, 1000:INTERVAL SECOND)])
+   :        +- TableSourceScan(table=[[default_catalog, default_database, wm_source]], fields=[a0, a1, a2])
+   +- Exchange(distribution=[hash[b2]])
+      +- TableSourceScan(table=[[default_catalog, default_database, src2]], fields=[b0, b2, b1])
+]]>
+    </Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/DeltaJoinTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/DeltaJoinTest.scala
@@ -1,0 +1,553 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.planner.plan.batch.sql
+
+import org.apache.flink.table.api.{DataTypes, ExplainDetail, Schema}
+import org.apache.flink.table.api.config.{ExecutionConfigOptions, OptimizerConfigOptions}
+import org.apache.flink.table.api.config.ExecutionConfigOptions.UpsertMaterialize
+import org.apache.flink.table.api.config.OptimizerConfigOptions.DeltaJoinStrategy
+import org.apache.flink.table.catalog.{CatalogTable, ObjectPath, ResolvedCatalogTable}
+import org.apache.flink.table.planner.JMap
+import org.apache.flink.table.planner.utils.{TableTestBase, TestingTableEnvironment}
+
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.{BeforeEach, Test}
+
+import java.util.{Collections, HashMap => JHashMap}
+
+/** Test for delta join. */
+class DeltaJoinTest extends TableTestBase {
+
+  private val util = streamTestUtil()
+  private val tEnv: TestingTableEnvironment = util.tableEnv.asInstanceOf[TestingTableEnvironment]
+
+  private val testComment = "test comment"
+  private val testValuesTableOptions: JMap[String, String] = {
+    val options = new JHashMap[String, String]()
+    options.put("connector", "values")
+    options.put("bounded", "false")
+    options.put("sink-insert-only", "false")
+    options.put("sink-changelog-mode-enforced", "I,UA,UB,D")
+    options.put("async", "true")
+    options
+  }
+
+  @BeforeEach
+  def setup(): Unit = {
+    util.tableConfig.set(
+      OptimizerConfigOptions.TABLE_OPTIMIZER_DELTA_JOIN_STRATEGY,
+      OptimizerConfigOptions.DeltaJoinStrategy.AUTO)
+
+    addTable(
+      "src1",
+      Schema
+        .newBuilder()
+        .column("a0", DataTypes.INT.notNull)
+        .column("a1", DataTypes.DOUBLE.notNull)
+        .column("a2", DataTypes.STRING)
+        .column("a3", DataTypes.INT)
+        .primaryKey("a0")
+        .index("a1", "a2")
+        .build()
+    )
+
+    addTable(
+      "src2",
+      Schema
+        .newBuilder()
+        .column("b0", DataTypes.INT.notNull)
+        .column("b2", DataTypes.STRING)
+        .column("b1", DataTypes.DOUBLE)
+        .primaryKey("b0")
+        .index("b2")
+        .build()
+    )
+
+    addTable(
+      "snk",
+      Schema
+        .newBuilder()
+        .column("l0", DataTypes.INT.notNull)
+        .column("l1", DataTypes.DOUBLE)
+        .column("l2", DataTypes.STRING)
+        .column("l3", DataTypes.INT)
+        .column("r0", DataTypes.INT.notNull)
+        .column("r2", DataTypes.STRING)
+        .column("r1", DataTypes.DOUBLE)
+        .primaryKey("l0", "r0")
+        .build()
+    )
+  }
+
+  @Test
+  def testJoinKeysContainIndexOnBothSide(): Unit = {
+    util.verifyRelPlanInsert(
+      "insert into snk select * from src1 join src2 " +
+        "on src1.a1 = src2.b1 " +
+        "and src1.a2 = src2.b2")
+  }
+
+  @Test
+  def testJoinKeysContainIndexOnBothSide2(): Unit = {
+    util.verifyRelPlanInsert(
+      "insert into snk select * from src1 join src2 " +
+        "on src1.a1 = src2.b1 " +
+        "and src1.a2 = src2.b2 " +
+        "and src1.a3 = src2.b0")
+  }
+
+  @Test
+  def testJoinKeysNotContainIndexOnOneSide(): Unit = {
+    util.verifyRelPlanInsert(
+      "insert into snk select * from src1 join src2 " +
+        "on src1.a2 = src2.b2")
+  }
+
+  @Test
+  def testWithNonEquiCondition1(): Unit = {
+    util.verifyRelPlanInsert(
+      "insert into snk select * from src1 join src2 " +
+        "on src1.a1 = src2.b1 " +
+        "and src1.a2 = src2.b2 " +
+        "and src2.b0 > src1.a0")
+  }
+
+  @Test
+  def testWithNonEquiCondition2(): Unit = {
+    // could not optimize into delta join because there is a calc between join and source
+    util.verifyRelPlanInsert(
+      "insert into snk select * from src1 join src2 " +
+        "on src1.a1 = src2.b1 " +
+        "and src1.a2 = src2.b2 " +
+        "and src2.b0 > src1.a0 " +
+        "and src2.b2 <> 'Hello' " +
+        "and src1.a0 > 99")
+  }
+
+  @Test
+  def testJsonPlanWithTableHints(): Unit = {
+    assertThatThrownBy(
+      () => {
+        util.verifyJsonPlan(
+          "insert into snk select * from src1 /*+ OPTIONS('failing-source'='true') */" +
+            "join src2 /*+ OPTIONS('failing-source'='true') */" +
+            "on src1.a1 = src2.b1 " +
+            "and src1.a2 = src2.b2 " +
+            "and src2.b0 > src1.a0")
+      }).hasMessage("Introduce delta join in runtime later")
+  }
+
+  @Test
+  def testFilterProjectFieldsAfterJoin(): Unit = {
+    // could not optimize into delta join because there is a calc between sink and join
+    util.verifyRelPlanInsert(
+      "insert into snk(l0, l1, r0) select a0, a1, b0 from src1 join src2 " +
+        "on src1.a1 = src2.b1 " +
+        "and src1.a2 = src2.b2 " +
+        "where a3 > b0")
+  }
+
+  @Test
+  def testMultiRootsWithReusingJoinView(): Unit = {
+    util.tableConfig.set(
+      OptimizerConfigOptions.TABLE_OPTIMIZER_REUSE_OPTIMIZE_BLOCK_WITH_DIGEST_ENABLED,
+      Boolean.box(true))
+
+    util.tableEnv.executeSql("create table snk2 like snk")
+
+    util.tableEnv.executeSql(
+      "create temporary view mv as " +
+        "select * from src1 join src2 " +
+        "on src1.a1 = src2.b1 " +
+        "and src1.a2 = src2.b2")
+
+    val stmt = tEnv.createStatementSet()
+    stmt.addInsertSql("insert into snk select * from mv")
+    stmt.addInsertSql("insert into snk2 select * from mv")
+
+    // TODO FLINK-37898 verify exec plan to check delta join reused
+    util.verifyRelPlan(stmt)
+  }
+
+  @Test
+  def testMultiRootsWithReusingJoinView2(): Unit = {
+    util.tableConfig.set(
+      OptimizerConfigOptions.TABLE_OPTIMIZER_REUSE_OPTIMIZE_BLOCK_WITH_DIGEST_ENABLED,
+      Boolean.box(true))
+
+    util.tableEnv.executeSql(
+      "create table snk2 like snk(" +
+        "  EXCLUDING CONSTRAINTS" +
+        ")")
+
+    util.tableEnv.executeSql(
+      "create temporary view mv as " +
+        "select * from src1 join src2 " +
+        "on src1.a1 = src2.b1 " +
+        "and src1.a2 = src2.b2")
+
+    val stmt = tEnv.createStatementSet()
+    stmt.addInsertSql("insert into snk select * from mv")
+    stmt.addInsertSql("insert into snk2 select * from mv")
+
+    // the join could not be optimized to delta join
+    // because one of the sink doesn't satisfy the requirement
+    util.verifyExecPlan(stmt)
+  }
+
+  @Test
+  def testMultiRootsWithReusingDeltaJoin(): Unit = {
+    util.tableEnv.executeSql("create table snk2 like snk")
+
+    val stmt = tEnv.createStatementSet()
+    stmt.addInsertSql(
+      "insert into snk select * from src1 join src2 " +
+        "on src1.a1 = src2.b1 " +
+        "and src1.a2 = src2.b2")
+
+    stmt.addInsertSql(
+      "insert into snk2 select * from src1 join src2 " +
+        "on src1.a1 = src2.b1 " +
+        "and src1.a2 = src2.b2")
+
+    // TODO FLINK-37898 verify exec plan to check delta join reused
+    util.verifyRelPlan(stmt)
+  }
+
+  @Test
+  def testMultiRootsWithoutReusingDeltaJoin(): Unit = {
+    util.tableEnv.executeSql(
+      "create table snk2 like snk(" +
+        "  EXCLUDING CONSTRAINTS" +
+        ")")
+
+    val stmt = tEnv.createStatementSet()
+    stmt.addInsertSql(
+      "insert into snk select * from src1 join src2 " +
+        "on src1.a1 = src2.b1 " +
+        "and src1.a2 = src2.b2")
+
+    stmt.addInsertSql(
+      "insert into snk2 select * from src1 join src2 " +
+        "on src1.a1 = src2.b1 " +
+        "and src1.a2 = src2.b2")
+
+    // TODO FLINK-37898 verify exec plan to check delta join not reused
+    util.verifyRelPlan(stmt)
+  }
+
+  @Test
+  def testExplainPlanAdvice(): Unit = {
+    assertThatThrownBy(
+      () =>
+        util.verifyExplainInsert(
+          "insert into snk select * from src1 join src2 " +
+            "on src1.a1 = src2.b1 " +
+            "and src1.a2 = src2.b2",
+          ExplainDetail.PLAN_ADVICE))
+      .hasMessage("Introduce delta join in runtime later")
+  }
+
+  @Test
+  def testWithWatermarkAssigner(): Unit = {
+    addTable(
+      "wm_source",
+      Schema
+        .newBuilder()
+        .column("a0", DataTypes.INT)
+        .column("a1", DataTypes.STRING)
+        .column("a2", DataTypes.TIMESTAMP(3))
+        .watermark("a2", "a2 - INTERVAL '1' SECOND")
+        .index("a1")
+        .build()
+    )
+    addTable(
+      "tmp_sink",
+      Schema
+        .newBuilder()
+        .column("l0", DataTypes.INT)
+        .column("l1", DataTypes.STRING)
+        .column("l2", DataTypes.TIMESTAMP(3))
+        .column("r0", DataTypes.INT.notNull)
+        .column("r2", DataTypes.STRING)
+        .column("r1", DataTypes.DOUBLE)
+        .build()
+    )
+
+    // could not optimize into delta join because there is a calc between join and source
+    util.verifyRelPlanInsert(
+      "insert into tmp_sink select * from wm_source join src2 " +
+        "on wm_source.a1 = src2.b2")
+  }
+
+  @Test
+  def testWithoutLookupTable(): Unit = {
+    util.tableEnv.executeSql(
+      "create table non_lookup_src with ('disable-lookup' = 'true') " +
+        "like src2 (OVERWRITING OPTIONS)")
+
+    util.verifyRelPlanInsert(
+      "insert into snk select * from src1 join non_lookup_src " +
+        "on src1.a1 = non_lookup_src.b1 " +
+        "and src1.a2 = non_lookup_src.b2")
+  }
+
+  @Test
+  def testConstantConditionInIndex(): Unit = {
+    // could not optimize into delta join because there is a calc between join and source
+    util.verifyRelPlanInsert(
+      "insert into snk select * from src1 join src2 " +
+        "on src1.a1 = 1.1 " +
+        "and src1.a2 = src2.b2")
+  }
+
+  @Test
+  def testComputeIndexKeyOnJoinCondition(): Unit = {
+    // could not optimize into delta join because there is a calc between join and source
+    util.verifyRelPlanInsert(
+      "insert into snk select * from src1 join src2 " +
+        "on src1.a1 = src2.b1 " +
+        "and src1.a2 = TRIM(src2.b2)")
+  }
+
+  @Test
+  def testCdcSource(): Unit = {
+    util.tableEnv.executeSql(
+      "create table cdc_src with ('changelog-mode' = 'I,UA,UB,D') " +
+        "like src2 (OVERWRITING OPTIONS)")
+
+    util.verifyRelPlanInsert(
+      "insert into snk select * from src1 join cdc_src " +
+        "on src1.a1 = cdc_src.b1 " +
+        "and src1.a2 = cdc_src.b2")
+  }
+
+  @Test
+  def testSourceWithSourceAbilities(): Unit = {
+    util.tableEnv.executeSql(
+      "create table filterable_src with ('filterable-fields' = 'a3') " +
+        "like src1 (OVERWRITING OPTIONS)")
+
+    util.verifyRelPlanInsert(
+      "insert into snk select * from filterable_src join src2 " +
+        "on filterable_src.a1 = src2.b1 " +
+        "and filterable_src.a2 = src2.b2 " +
+        "and filterable_src.a3 = 1")
+  }
+
+  @Test
+  def testWithAggregatingSourceTableBeforeJoin(): Unit = {
+    util.verifyRelPlanInsert(
+      "insert into snk select * from ( " +
+        "  select distinct max(a0) as a0, a1, max(a2) as a2, max(a3) as a3 from src1 group by a1" +
+        ") tmp join src2 " +
+        "on tmp.a1 = src2.b1 " +
+        "and tmp.a2 = src2.b2")
+  }
+
+  @Test
+  def testWithAggregatingAfterJoin(): Unit = {
+    util.verifyRelPlanInsert(
+      "insert into snk " +
+        "select a0, max(a1), max(a2), max(a3), max(b0), max(b2), b1 from src1 join src2 " +
+        "on src1.a1 = src2.b1 " +
+        "and src1.a2 = src2.b2 " +
+        "group by a0, b1")
+  }
+
+  @Test
+  def testWithCascadeJoin(): Unit = {
+    util.tableEnv.executeSql("create table src3 like src2")
+
+    addTable(
+      "tmp_snk",
+      Schema
+        .newBuilder()
+        .column("l0", DataTypes.INT.notNull)
+        .column("l1", DataTypes.DOUBLE)
+        .column("l2", DataTypes.STRING)
+        .column("l3", DataTypes.INT)
+        .column("r0", DataTypes.INT.notNull)
+        .column("r2", DataTypes.STRING)
+        .column("r1", DataTypes.DOUBLE)
+        .column("r00", DataTypes.INT.notNull)
+        .column("r22", DataTypes.STRING)
+        .column("r11", DataTypes.DOUBLE)
+        .primaryKey("l0", "r0", "r00")
+        .build()
+    )
+
+    util.verifyRelPlanInsert(
+      "insert into tmp_snk select * from src1 join src2 " +
+        "on src1.a1 = src2.b1 " +
+        "and src1.a2 = src2.b2 " +
+        "join src3 " +
+        "on src1.a1 = src3.b1 " +
+        "and src1.a2 = src3.b2")
+  }
+
+  @Test
+  def testWithUnsupportedJoinType(): Unit = {
+    util.tableConfig.set(
+      ExecutionConfigOptions.TABLE_EXEC_SINK_UPSERT_MATERIALIZE,
+      UpsertMaterialize.NONE)
+
+    util.verifyRelPlanInsert(
+      "insert into snk select * from src1 left join src2 " +
+        "on src1.a1 = src2.b1 " +
+        "and src1.a2 = src2.b2")
+  }
+
+  @Test
+  def testWithAlwaysTrueJoinCondition(): Unit = {
+    util.verifyRelPlanInsert(
+      "insert into snk select * from src1 join src2 " +
+        "on 1 = 1")
+  }
+  @Test
+  def testSourceWithoutIndexes(): Unit = {
+    addTable(
+      "non_index_src",
+      Schema
+        .newBuilder()
+        .column("b0", DataTypes.INT.notNull)
+        .column("b2", DataTypes.STRING)
+        .column("b1", DataTypes.DOUBLE)
+        .primaryKey("b0")
+        .build()
+    )
+
+    util.verifyRelPlanInsert(
+      "insert into snk select * from src1 join non_index_src " +
+        "on src1.a1 = non_index_src.b1 " +
+        "and src1.a2 = non_index_src.b2")
+  }
+
+  @Test
+  def testDeltaJoinStrategyWithNone(): Unit = {
+    util.tableConfig.set(
+      OptimizerConfigOptions.TABLE_OPTIMIZER_DELTA_JOIN_STRATEGY,
+      DeltaJoinStrategy.NONE)
+
+    util.verifyRelPlanInsert(
+      "insert into snk select * from src1 join src2 " +
+        "on src1.a1 = src2.b1 " +
+        "and src1.a2 = src2.b2")
+  }
+
+  @Test
+  def testDeltaJoinStrategyWithForce(): Unit = {
+    util.tableConfig.set(
+      OptimizerConfigOptions.TABLE_OPTIMIZER_DELTA_JOIN_STRATEGY,
+      DeltaJoinStrategy.FORCE)
+
+    util.verifyRelPlanInsert(
+      "insert into snk select * from src1 join src2 " +
+        "on src1.a1 = src2.b1 " +
+        "and src1.a2 = src2.b2")
+  }
+
+  @Test
+  def testDeltaJoinStrategyWithForce2(): Unit = {
+    util.tableConfig.set(
+      OptimizerConfigOptions.TABLE_OPTIMIZER_DELTA_JOIN_STRATEGY,
+      DeltaJoinStrategy.FORCE)
+
+    // the join could not be converted into the delta join
+    assertThatThrownBy(
+      () =>
+        util.verifyRelPlanInsert(
+          "insert into snk select * from src1 join src2 " +
+            "on src1.a1 = src2.b1"))
+      .hasMessageContaining("The current sql doesn't support to do delta join optimization.")
+
+  }
+
+  @Test
+  def testDeltaJoinStrategyWithForce3(): Unit = {
+    util.tableConfig.set(
+      OptimizerConfigOptions.TABLE_OPTIMIZER_DELTA_JOIN_STRATEGY,
+      DeltaJoinStrategy.FORCE)
+
+    util.tableEnv.executeSql(
+      "create table snk2 like snk(" +
+        "  EXCLUDING CONSTRAINTS" +
+        ")")
+
+    val stmt = tEnv.createStatementSet()
+    stmt.addInsertSql(
+      "insert into snk select * from src1 join src2 " +
+        "on src1.a1 = src2.b1 " +
+        "and src1.a2 = src2.b2")
+
+    stmt.addInsertSql(
+      "insert into snk2 select * from src1 join src2 " +
+        "on src1.a1 = src2.b1 " +
+        "and src1.a2 = src2.b2")
+
+    // one of the joins can be converted into the delta join
+    // TODO FLINK-37898 verify exec plan to check delta join not reused
+    util.verifyRelPlan(stmt)
+  }
+
+  @Test
+  def testDeltaJoinStrategyWithForce4(): Unit = {
+    util.tableConfig.set(
+      OptimizerConfigOptions.TABLE_OPTIMIZER_DELTA_JOIN_STRATEGY,
+      DeltaJoinStrategy.FORCE)
+
+    addTable(
+      "tmp_snk",
+      Schema
+        .newBuilder()
+        .column("l0", DataTypes.INT.notNull)
+        .column("l1", DataTypes.DOUBLE)
+        .primaryKey("l0")
+        .build()
+    )
+
+    // no joins on this query
+    util.verifyRelPlanInsert("insert into tmp_snk select a0, a1 from src1")
+  }
+
+  private def addTable(
+      tableName: String,
+      schema: Schema,
+      extraOptions: JMap[String, String] = Collections.emptyMap()): Unit = {
+    val currentCatalog = tEnv.getCurrentCatalog
+    val currentDatabase = tEnv.getCurrentDatabase
+    val tablePath = new ObjectPath(currentDatabase, tableName)
+    val catalog = tEnv.getCatalog(currentCatalog).get()
+    val schemaResolver = tEnv.getCatalogManager.getSchemaResolver
+
+    val options = new JHashMap[String, String](testValuesTableOptions)
+    options.putAll(extraOptions)
+
+    val original = CatalogTable
+      .newBuilder()
+      .schema(schema)
+      .comment(testComment)
+      .partitionKeys(Collections.emptyList())
+      .options(options)
+      .build()
+    val resolvedTable = new ResolvedCatalogTable(original, schemaResolver.resolve(schema))
+
+    catalog.createTable(tablePath, resolvedTable, false)
+  }
+
+}


### PR DESCRIPTION
## What is the purpose of the change

This pr tries to convert a regular join to a delta join for the simplest pattern in planner.
It requires:
- inner join
- only contains source, calc, join, sink, exchange
- no calc between source and join
- append-only source

## Brief change log

  - *Introduce a new rule to do the optimization*
  - *Add tests for it*

## Verifying this change

New tests are added to verity this pr.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? 