### PR TITLE
[BP-2.0][FLINK-37952] Skip compressing built python wheels by hand in Nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -116,10 +116,8 @@ jobs:
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair -w {dest_dir} {wheel}"
           # Skip repair on MacOS
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: ""
-      - name: "Tar python artifact"
-        run: tar -czvf python-wheel-${{ matrix.os_name }}.tar.gz -C flink-python/dist .
-      - name: "Upload python artifact"
+      - name: "Upload python wheels"
         uses: actions/upload-artifact@v4
         with:
           name: wheel_${{ matrix.os_name }}_${{ steps.stringify_workflow.outputs.stringified_value }}-${{ github.run_number }}
-          path: python-wheel-${{ matrix.os_name }}.tar.gz
+          path: flink-python/dist/**


### PR DESCRIPTION
2.0 backport of https://github.com/apache/flink/pull/26675