### PR TITLE
[hotfix] Reuse the final field barrierId

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointBarrierTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointBarrierTracker.java
@@ -102,7 +102,7 @@ public class CheckpointBarrierTracker extends CheckpointBarrierHandler {
         // 2. Received EndOfPartition from channel 0.
         // 3. Received barrier from channel 1.
         // In this case we should finish the existing pending checkpoint.
-        if (receivedBarrier.getId() > latestPendingCheckpointID && numOpenChannels == 1) {
+        if (barrierId > latestPendingCheckpointID && numOpenChannels == 1) {
             markAlignmentStartAndEnd(barrierId, receivedBarrier.getTimestamp());
             notifyCheckpoint(receivedBarrier);
             return;


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to reuse the final field `barrierId` in `CheckpointBarrierTracker`.
Because the `barrierId` is a final field, we can reuse it safely.


## Brief change log

Reuse the final field `barrierId`.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
