### PR TITLE
[FLINK-37969] Allow Transformation subgraphs to be merged during translation

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -63,6 +63,7 @@ import org.apache.flink.streaming.api.transformations.SideOutputTransformation;
 import org.apache.flink.streaming.api.transformations.SinkTransformation;
 import org.apache.flink.streaming.api.transformations.SourceTransformation;
 import org.apache.flink.streaming.api.transformations.SourceTransformationWrapper;
+import org.apache.flink.streaming.api.transformations.StubTransformation;
 import org.apache.flink.streaming.api.transformations.TimestampsAndWatermarksTransformation;
 import org.apache.flink.streaming.api.transformations.TwoInputTransformation;
 import org.apache.flink.streaming.api.transformations.UnionTransformation;
@@ -80,6 +81,7 @@ import org.apache.flink.streaming.runtime.translators.ReduceTransformationTransl
 import org.apache.flink.streaming.runtime.translators.SideOutputTransformationTranslator;
 import org.apache.flink.streaming.runtime.translators.SinkTransformationTranslator;
 import org.apache.flink.streaming.runtime.translators.SourceTransformationTranslator;
+import org.apache.flink.streaming.runtime.translators.StubTransformationTranslator;
 import org.apache.flink.streaming.runtime.translators.TimestampsAndWatermarksTransformationTranslator;
 import org.apache.flink.streaming.runtime.translators.TwoInputTransformationTranslator;
 import org.apache.flink.streaming.runtime.translators.UnionTransformationTranslator;
@@ -177,6 +179,7 @@ public class StreamGraphGenerator {
         tmp.put(LegacySinkTransformation.class, new LegacySinkTransformationTranslator<>());
         tmp.put(LegacySourceTransformation.class, new LegacySourceTransformationTranslator<>());
         tmp.put(UnionTransformation.class, new UnionTransformationTranslator<>());
+        tmp.put(StubTransformation.class, new StubTransformationTranslator<>());
         tmp.put(PartitionTransformation.class, new PartitionTransformationTranslator<>());
         tmp.put(SideOutputTransformation.class, new SideOutputTransformationTranslator<>());
         tmp.put(ReduceTransformation.class, new ReduceTransformationTranslator<>());
@@ -603,7 +606,8 @@ public class StreamGraphGenerator {
                                 .collect(Collectors.toList()));
 
         final TransformationTranslator.Context context =
-                new ContextImpl(this, streamGraph, slotSharingGroup, configuration);
+                new ContextImpl(
+                        this, streamGraph, slotSharingGroup, configuration, transformations);
 
         return shouldExecuteInBatchMode
                 ? translator.translateForBatch(transform, context)
@@ -671,15 +675,20 @@ public class StreamGraphGenerator {
 
         private final ReadableConfig config;
 
+        private final Collection<Transformation<?>> transformations;
+
         public ContextImpl(
                 final StreamGraphGenerator streamGraphGenerator,
                 final StreamGraph streamGraph,
                 final String slotSharingGroup,
-                final ReadableConfig config) {
+                final ReadableConfig config,
+                Collection<Transformation<?>> transformations) {
             this.streamGraphGenerator = checkNotNull(streamGraphGenerator);
             this.streamGraph = checkNotNull(streamGraph);
             this.slotSharingGroup = checkNotNull(slotSharingGroup);
             this.config = checkNotNull(config);
+            this.transformations =
+                    checkNotNull(transformations, "transformations must not be null");
         }
 
         @Override
@@ -716,6 +725,11 @@ public class StreamGraphGenerator {
         @Override
         public Collection<Integer> transform(Transformation<?> transformation) {
             return streamGraphGenerator.transform(transformation);
+        }
+
+        @Override
+        public Collection<Transformation<?>> getSinkTransformations() {
+            return transformations;
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/TransformationTranslator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/TransformationTranslator.java
@@ -88,5 +88,8 @@ public interface TransformationTranslator<OUT, T extends Transformation<OUT>> {
 
         /** Transforms the transformation and updates the current stream graph. */
         Collection<Integer> transform(Transformation<?> transformation);
+
+        /** Returns all sink transformations that should be translated into the StreamGraph. */
+        Collection<Transformation<?>> getSinkTransformations();
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/transformations/StubTransformation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/transformations/StubTransformation.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.transformations;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.dag.Transformation;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A stub transformation that is later connected to an existing {@link Transformation}. This
+ * implementation is useful when the full DAG of transformations cannot be constructed at once. For
+ * example, an SQL query may not be fully defined at the time of its creation and later refined
+ * (e.g., connecting side outputs).
+ *
+ * <p>Usage:
+ *
+ * <p>To create a stub which will later connect to an upstream operator, use {@link
+ * #create(TypeInformation, Predicate)}:
+ *
+ * <pre>{@code
+ * TypeInformation<T> typeInfo = ...; // expected output type of the upstream transformation
+ * StubTransformation<T> inputStub = StubTransformation.create(typeInfo,
+ *     t -> t.getName().equals("decoupled-transformation"));
+ * Transformation<T> output = new PartitionTransformation<>(inputStub, new ShufflePartitioner<T>());
+ * ...
+ * }</pre>
+ *
+ * <p>The upstream part that may be created before or after the stub:
+ *
+ * <pre>{@code
+ * Transformation<T> input = new OneInputTransformation<>(typeInfo, "decoupled-transformation", ...);
+ * ... // independent subtopology
+ * }</pre>
+ *
+ * <p>While translating the Transformation, the stub will find one or more upstream transformations
+ * based on the predicate provided in the {@link StubTransformation} and implicitly connect
+ * upstreams to the downstream transformations of the {@link StubTransformation} which effectively
+ * means that it replaces itself with the union (all) of the upstream transformations.
+ */
+@Internal
+public class StubTransformation<T> extends Transformation<T> {
+    private final Predicate<Transformation<?>> upstreamFinder;
+    private final Function<Transformation<?>, Transformation<?>> inputAdjuster;
+
+    /**
+     * Creates a new {@link StubTransformation} with the given name, output type, and parallelism.
+     * All the properties can be modified later when the transformation is properly connected.
+     */
+    private StubTransformation(
+            String name,
+            TypeInformation<T> outputType,
+            int parallelism,
+            Predicate<Transformation<?>> upstreamFinder,
+            Function<Transformation<?>, Transformation<?>> inputAdjuster) {
+        super(name, outputType, parallelism);
+        this.upstreamFinder = upstreamFinder;
+        this.inputAdjuster = inputAdjuster;
+    }
+
+    /**
+     * Creates a new {@link StubTransformation} with the given type information and predicate to
+     * find the upstream transformation.
+     */
+    public static <T> StubTransformation<T> create(
+            TypeInformation<T> typeInformation, Predicate<Transformation<?>> upstreamFinder) {
+        return create(typeInformation, upstreamFinder, Function.identity());
+    }
+
+    /**
+     * Creates a new {@link StubTransformation} with the given type information and predicate to
+     * find the upstream transformation and additionally allows the upstream transformation to be
+     * adjusted before connecting it to the downstream transformations. A common use case for the
+     * adjuster is to attach the downstream transformations to the side-output of the upstream
+     * transformation.
+     */
+    public static <T> StubTransformation<T> create(
+            TypeInformation<T> typeInformation,
+            Predicate<Transformation<?>> upstreamFinder,
+            Function<Transformation<?>, Transformation<?>> inputAdjuster) {
+        checkNotNull(upstreamFinder, "upstreamFinder must not be null");
+        checkNotNull(inputAdjuster, "inputAdjuster must not be null");
+        return new StubTransformation<>(
+                "unconnected", typeInformation, 1, upstreamFinder, inputAdjuster);
+    }
+
+    public Function<Transformation<?>, Transformation<?>> getInputAdjuster() {
+        return inputAdjuster;
+    }
+
+    public Predicate<Transformation<?>> getUpstreamFinder() {
+        return upstreamFinder;
+    }
+
+    @Override
+    protected List<Transformation<?>> getTransitivePredecessorsInternal() {
+        // This transformation does not have any inputs.
+        // It will be implicitly connected to an upstream transformation during translation.
+        return List.of(this);
+    }
+
+    @Override
+    public List<Transformation<?>> getInputs() {
+        // This transformation does not have any inputs.
+        // It will be implicitly connected to an upstream transformation during translation.
+        return List.of();
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/translators/StubTransformationTranslator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/translators/StubTransformationTranslator.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.translators;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.graph.SimpleTransformationTranslator;
+import org.apache.flink.streaming.api.graph.TransformationTranslator;
+import org.apache.flink.streaming.api.transformations.StubTransformation;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * A {@link TransformationTranslator} for the {@link StubTransformation}.
+ *
+ * <p>The translator finds the upstream transformation based on the predicate provided in the {@link
+ * StubTransformation} and implicitly connects upstream to the downstream transformations of the
+ * {@link StubTransformation}.
+ *
+ * @param <OUT> The type of the elements that result from the {@link StubTransformation} being
+ *     translated.
+ */
+@Internal
+public class StubTransformationTranslator<OUT>
+        extends SimpleTransformationTranslator<OUT, StubTransformation<OUT>> {
+
+    @Override
+    protected Collection<Integer> translateForBatchInternal(
+            final StubTransformation<OUT> transformation, final Context context) {
+        return translateInternal(transformation, context);
+    }
+
+    @Override
+    protected Collection<Integer> translateForStreamingInternal(
+            final StubTransformation<OUT> transformation, final Context context) {
+        return translateInternal(transformation, context);
+    }
+
+    private Collection<Integer> translateInternal(
+            final StubTransformation<OUT> stubTransformation, final Context context) {
+        checkNotNull(stubTransformation);
+        checkNotNull(context);
+
+        Collection<Transformation<?>> upstreams =
+                findUpstreams(stubTransformation, context.getSinkTransformations());
+
+        List<Transformation<?>> inputs = extractInputs(upstreams, stubTransformation);
+
+        return inputs.stream()
+                .flatMap(input -> context.transform(input).stream())
+                .collect(Collectors.toList());
+    }
+
+    private List<Transformation<?>> extractInputs(
+            Collection<Transformation<?>> upstreams, StubTransformation<OUT> stubTransformation) {
+        List<Transformation<?>> inputs =
+                upstreams.stream()
+                        .map(stubTransformation.getInputAdjuster())
+                        .collect(Collectors.toList());
+        for (Transformation<?> input : inputs) {
+            checkState(
+                    input.getOutputType().equals(stubTransformation.getOutputType()),
+                    "The output type of the input transformation does not match the expected output type of the StubTransformation. StubTransformation: %s, Input Transformation: %s, Expected Output Type: %s, Actual Output Type: %s",
+                    stubTransformation,
+                    input,
+                    stubTransformation.getOutputType(),
+                    input.getOutputType());
+        }
+        return inputs;
+    }
+
+    private Collection<Transformation<?>> findUpstreams(
+            StubTransformation<?> stubTransformation, Collection<Transformation<?>> sinks) {
+        Predicate<Transformation<?>> upstreamFinder = stubTransformation.getUpstreamFinder();
+        Map<Integer, Transformation<?>> upstreams = new HashMap<>();
+        for (Transformation<?> sink : sinks) {
+            for (Transformation<?> transformation : sink.getTransitivePredecessors()) {
+                if (upstreamFinder.test(transformation)) {
+                    upstreams.put(transformation.getId(), transformation);
+                }
+            }
+        }
+        if (upstreams.isEmpty()) {
+            throw new IllegalStateException(
+                    "No upstream transformation found for StubTransformation: "
+                            + stubTransformation);
+        }
+        return upstreams.values();
+    }
+}


### PR DESCRIPTION




<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Transformations are immutable by design and thus planner or DataStream API need to generate a subgraph in one pass. However, there are some use cases where we would attach some small subgraph to a larger subgraph before translation into a StreamGraph. For example, system views in SQL may actually refer to specific parts of the query where we would like to add a subgraph to a side-output.

This commit adds StubTransformation that is later connected to an existing Transformation by defining a predicate to find the upstream transformations to which to connect the downstream transformations.


## Brief change log

- Adds TransformationTranslator.Context#getTransformations
- Adds StubTransformation(Translation)


## Verifying this change

Added unit tests in StreamGraphGeneratorTest.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
