### PR TITLE
[FLINK-37854][table] Support DATE_FORMAT with zone

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/DateTimeUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/DateTimeUtils.java
@@ -729,7 +729,7 @@ public class DateTimeUtils {
     private static String formatTimestamp(TimestampData ts, String format, ZoneId zoneId) {
         DateTimeFormatter formatter = DATETIME_FORMATTER_CACHE.get(format);
         Instant instant = ts.toInstant();
-        return LocalDateTime.ofInstant(instant, zoneId).format(formatter);
+        return instant.atZone(zoneId).format(formatter);
     }
 
     public static String formatTimestampMillis(long ts, String format, TimeZone tz) {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
@@ -1446,6 +1446,41 @@ class CalcITCase extends BatchTestBase {
   }
 
   @Test
+  def testDateFormatWithZone(): Unit = {
+    // Test whether the output is correct, if typeInfo is Instant or DateTimeFormatter contains time zone information
+    val shanghai = ZoneId.of("Asia/Shanghai")
+    val ldt = localDateTime("2015-06-09 08:09:08")
+    val data = Seq(
+      row(
+        ldt,
+        ldt.toInstant(shanghai.getRules.getOffset(ldt))
+      )
+    )
+    registerCollection("T", data, new RowTypeInfo(LOCAL_DATE_TIME, INSTANT), "a, b")
+    checkResult(
+      "SELECT DATE_FORMAT(a, 'yy-M-d H:m:s')," +
+        " DATE_FORMAT(a, 'yyyy-MM-dd HH:mm:ss')," +
+        " DATE_FORMAT(b, 'yy-M-d H:m:s')," +
+        " DATE_FORMAT(b, 'yyyy-MM-dd HH:mm:ss')," +
+        " DATE_FORMAT(b, 'yyyy-MM-dd HH:mm:ssX')," +
+        " DATE_FORMAT(b, 'yyyy-MM-dd HH:mm:ssXX')," +
+        " DATE_FORMAT(b, 'yyyy-MM-dd HH:mm:ssXXX')" +
+        " FROM T",
+      Seq(
+        row(
+          "15-6-9 8:9:8",
+          "2015-06-09 08:09:08",
+          "15-6-9 8:9:8",
+          "2015-06-09 08:09:08",
+          "2015-06-09 08:09:08+08",
+          "2015-06-09 08:09:08+0800",
+          "2015-06-09 08:09:08+08:00"
+        )
+      )
+    )
+  }
+
+  @Test
   def testYear(): Unit = {
     checkResult(
       "SELECT j, YEAR(j) FROM testTable WHERE a = TRUE",


### PR DESCRIPTION
## What is the purpose of the change

In the past, LocalDateTime was used when performing DATE_FORMAT, which did not contain time zone, so errors occurred when parsing to, for example, 'yyyy-MM-dd HH:mm:ssXX'

## Brief change log

  - *Replace formatted class from LocalDateTime to Instant so as to solve DATE_FORMAT problem with zone.*
  - *Add test in CalcITCase.*


## Verifying this change

Existent tests and new added tests can verify this change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)