### PR TITLE
[FLINK-37976][table-runtime] Fix the inconsistency between the number handled by the table async execution controller and the number in the epoch

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/DeltaJoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/DeltaJoinITCase.scala
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.{BeforeEach, Test}
 import javax.annotation.Nullable
 
 import java.time.LocalDateTime
+import java.util.concurrent.TimeUnit
 
 import scala.collection.JavaConversions._
 
@@ -434,7 +435,7 @@ class DeltaJoinITCase extends StreamingTestBase {
 
     tEnv
       .executeSql(s"insert into testSnk select * from testLeft join testRight on $joinKeyStr")
-      .await()
+      .await(60, TimeUnit.SECONDS)
     val result = TestValuesTableFactory.getResultsAsStrings("testSnk")
 
     assertThat(result.sorted).isEqualTo(expected.sorted)

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/lookup/keyordered/Epoch.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/lookup/keyordered/Epoch.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.runtime.operators.join.lookup.keyordered;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.streaming.api.operators.async.queue.StreamElementQueueEntry;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.util.Preconditions;
@@ -140,6 +141,11 @@ public class Epoch<OUT> {
     public String toString() {
         return String.format(
                 "Epoch{watermark=%s, ongoingRecord=%d}", watermark, ongoingRecordCount);
+    }
+
+    @VisibleForTesting
+    public int getOngoingRecordCount() {
+        return ongoingRecordCount;
     }
 
     /** The status of an epoch. */

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/lookup/keyordered/Epoch.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/lookup/keyordered/Epoch.java
@@ -73,8 +73,8 @@ public class Epoch<OUT> {
     }
 
     public void decrementCount() {
+        Preconditions.checkState(ongoingRecordCount > 0);
         ongoingRecordCount--;
-        Preconditions.checkState(ongoingRecordCount >= 0);
     }
 
     public void incrementCount() {

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/lookup/keyordered/Epoch.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/lookup/keyordered/Epoch.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.runtime.operators.join.lookup.keyordered;
 
 import org.apache.flink.streaming.api.operators.async.queue.StreamElementQueueEntry;
 import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
 
@@ -72,6 +73,7 @@ public class Epoch<OUT> {
 
     public void decrementCount() {
         ongoingRecordCount--;
+        Preconditions.checkState(ongoingRecordCount >= 0);
     }
 
     public void incrementCount() {

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/lookup/keyordered/EpochManager.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/lookup/keyordered/EpochManager.java
@@ -105,6 +105,11 @@ public class EpochManager<OUT> {
         return activeEpoch;
     }
 
+    @VisibleForTesting
+    public LinkedList<Epoch<OUT>> getOutputQueue() {
+        return outputQueue;
+    }
+
     private void tryFinishInQueue() {
         // If one epoch has been closed before and all records in
         // this epoch have finished, the epoch will be removed from the output queue.

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/lookup/keyordered/TableAsyncExecutionController.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/lookup/keyordered/TableAsyncExecutionController.java
@@ -203,6 +203,11 @@ public class TableAsyncExecutionController<IN, OUT, KEY> {
     }
 
     @VisibleForTesting
+    public EpochManager<OUT> getEpochManager() {
+        return epochManager;
+    }
+
+    @VisibleForTesting
     public int getBlockingSize() {
         return recordsBuffer.getBlockingSize();
     }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/lookup/keyordered/TableAsyncExecutionController.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/lookup/keyordered/TableAsyncExecutionController.java
@@ -161,6 +161,7 @@ public class TableAsyncExecutionController<IN, OUT, KEY> {
         if (epoch != null) {
             // only for recovery in case finding proper epoch in epochManager
             currentEpoch = epoch;
+            epoch.incrementCount();
         } else {
             currentEpoch = epochManager.onRecord();
         }

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/lookup/TableKeyedAsyncWaitOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/lookup/TableKeyedAsyncWaitOperatorTest.java
@@ -340,7 +340,6 @@ public class TableKeyedAsyncWaitOperatorTest {
         testHarness.close();
 
         testLazyAsyncFunction = new LazyAsyncFunction();
-        testLazyAsyncFunction.countDown();
         testHarness = createKeyedTestHarness(testLazyAsyncFunction, TIMEOUT, 10);
 
         testHarness.initializeState(snapshot);


### PR DESCRIPTION
## What is the purpose of the change

Fix the inconsistency between the number handled by the table async execution controller and the number in the epoch. This bug causes the delta join itcases to hang.

## Brief change log

  - *Fix the bug*
  - *Adapt the origin test*
  - *Add timeout for delta join itcases*


## Verifying this change

Original test is adapted to verify this bug.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? 
