### PR TITLE
[FLINK-37991][python] Upgrade pemja to 0.5.3

### DIFF
--- a/flink-python/dev/dev-requirements.txt
+++ b/flink-python/dev/dev-requirements.txt
@@ -28,7 +28,7 @@ numpy>=1.22.4,!=2.3.0
 fastavro>=1.1.0,!=1.8.0
 grpcio>=1.29.0,<=1.71.0
 grpcio-tools>=1.29.0,<=1.71.0
-pemja==0.5.1; platform_system != 'Windows'
+pemja>=0.5.0,<0.6.0; platform_system != 'Windows'
 httplib2>=0.19.0
 protobuf~=4.25
 pytest~=8.0

--- a/flink-python/pom.xml
+++ b/flink-python/pom.xml
@@ -133,7 +133,7 @@ under the License.
 		<dependency>
 			<groupId>com.alibaba</groupId>
 			<artifactId>pemja</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.3</version>
 			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 

--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -324,7 +324,7 @@ try:
                         'numpy>=1.22.4',
                         'pandas>=1.3.0',
                         'pyarrow>=5.0.0',
-                        'pemja==0.5.1;platform_system != "Windows"',
+                        'pemja>=0.5.0,<0.6.0;platform_system != "Windows"',
                         'httplib2>=0.19.0',
                         'ruamel.yaml>=0.18.4',
                         apache_flink_libraries_dependency]

--- a/flink-python/src/main/resources/META-INF/NOTICE
+++ b/flink-python/src/main/resources/META-INF/NOTICE
@@ -28,7 +28,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.beam:beam-sdks-java-transform-service-launcher:2.54.0
 - org.apache.beam:beam-vendor-guava-32_1_2-jre:0.1
 - org.apache.beam:beam-vendor-grpc-1_60_1:0.1
-- com.alibaba:pemja:0.5.1
+- com.alibaba:pemja:0.5.3
 
 This project bundles the following dependencies under the BSD license.
 See bundled license files for details


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will upgrade pemja to 0.5.3*


## Brief change log

  - *Upgrade pemja to 0.5.3 to fix some problem*


## Verifying this change

This change added tests and can be verified as follows:

  - *Origional tests*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
