### PR TITLE
[FLINK-38018][state] Migrate state processor API from sink API v1 to sink API v2

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/api/connector/sink/lib/OutputFormatSink.java
+++ b/flink-runtime/src/main/java/org/apache/flink/api/connector/sink/lib/OutputFormatSink.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.connector.sink.lib;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.io.CleanupWhenUnsuccessful;
+import org.apache.flink.api.common.io.OutputFormat;
+import org.apache.flink.api.common.io.RichOutputFormat;
+import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.api.connector.sink2.WriterInitContext;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
+import org.apache.flink.streaming.runtime.operators.sink.InitContextBase;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+
+/** A {@link Sink} that reads data using an {@link OutputFormat}. */
+@Internal
+public class OutputFormatSink<IN> implements Sink<IN> {
+    private final OutputFormat<IN> format;
+
+    public OutputFormatSink(OutputFormat<IN> format) {
+        this.format = format;
+    }
+
+    @Override
+    public SinkWriter<IN> createWriter(WriterInitContext writerContext) throws IOException {
+        RuntimeContext runtimeContext = null;
+        if (writerContext instanceof InitContextBase) {
+            runtimeContext = ((InitContextBase) writerContext).getRuntimeContext();
+        }
+        return new InputFormatSinkWriter<>(writerContext, format, runtimeContext);
+    }
+
+    private static class InputFormatSinkWriter<IN> implements SinkWriter<IN> {
+        private static final Logger LOG = LoggerFactory.getLogger(InputFormatSinkWriter.class);
+
+        private final OutputFormat<IN> format;
+        private boolean cleanupCalled = false;
+
+        public InputFormatSinkWriter(
+                WriterInitContext writerContext,
+                OutputFormat<IN> format,
+                @Nullable RuntimeContext runtimeContext)
+                throws IOException {
+            this.format = format;
+
+            if (format instanceof RichOutputFormat) {
+                ((RichOutputFormat<?>) format).setRuntimeContext(runtimeContext);
+            }
+            if (runtimeContext instanceof StreamingRuntimeContext) {
+                format.configure(((StreamingRuntimeContext) runtimeContext).getJobConfiguration());
+            } else {
+                format.configure(new Configuration());
+            }
+
+            int indexInSubtaskGroup = writerContext.getTaskInfo().getIndexOfThisSubtask();
+            int currentNumberOfSubtasks = writerContext.getTaskInfo().getNumberOfParallelSubtasks();
+            format.open(
+                    new OutputFormat.InitializationContext() {
+                        @Override
+                        public int getNumTasks() {
+                            return currentNumberOfSubtasks;
+                        }
+
+                        @Override
+                        public int getTaskNumber() {
+                            return indexInSubtaskGroup;
+                        }
+
+                        @Override
+                        public int getAttemptNumber() {
+                            return writerContext.getTaskInfo().getAttemptNumber();
+                        }
+                    });
+        }
+
+        @Override
+        public void write(IN element, Context context) throws IOException {
+            try {
+                format.writeRecord(element);
+            } catch (Exception ex) {
+                cleanup();
+                throw ex;
+            }
+        }
+
+        @Override
+        public void flush(boolean endOfInput) {}
+
+        @Override
+        public void close() throws Exception {
+            try {
+                format.close();
+            } catch (Exception ex) {
+                cleanup();
+                throw ex;
+            }
+        }
+
+        private void cleanup() {
+            try {
+                if (!cleanupCalled && format instanceof CleanupWhenUnsuccessful) {
+                    cleanupCalled = true;
+                    ((CleanupWhenUnsuccessful) format).tryCleanupOnError();
+                }
+            } catch (Throwable t) {
+                LOG.error("Cleanup on error failed.", t);
+            }
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/InitContextBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/InitContextBase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.runtime.operators.sink;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.JobInfo;
 import org.apache.flink.api.common.TaskInfo;
 import org.apache.flink.api.common.functions.RuntimeContext;
@@ -29,7 +30,8 @@ import java.util.OptionalLong;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** Base implementation for the {@link InitContext}. */
-class InitContextBase implements InitContext {
+@Internal
+public class InitContextBase implements InitContext {
 
     private final OptionalLong restoredCheckpointId;
 
@@ -55,7 +57,7 @@ class InitContextBase implements InitContext {
         return runtimeContext.getTaskInfo();
     }
 
-    RuntimeContext getRuntimeContext() {
+    public RuntimeContext getRuntimeContext() {
         return runtimeContext;
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

The state processor API is now depending on data sink v1 API and in the PR I've migrated it to data sink v2.

## Brief change log

Migrated state processor API from DSV1 to DSV2.

## Verifying this change

Existing unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
