### PR TITLE
[hotfix] ELEMENT should throw TableRuntimeException

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -1423,7 +1423,7 @@ object ScalarOperatorGens {
          |    $resultTerm = $nullTerm ? $defaultValue : $arrayGet;
          |    break;
          |  default:
-         |    throw new RuntimeException("Array has more than one element.");
+         |    throw new org.apache.flink.table.api.TableRuntimeException("Array has more than one element.");
          |}
          |""".stripMargin
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/ArrayTypeTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/ArrayTypeTest.scala
@@ -190,17 +190,6 @@ class ArrayTypeTest extends ArrayTypeTestBase {
 
     testAllApis('f11.cardinality(), "CARDINALITY(f11)", "1")
 
-    // element
-    testAllApis('f9.element(), "ELEMENT(f9)", "1")
-
-    testAllApis('f8.element(), "ELEMENT(f8)", "4.0")
-
-    testAllApis('f10.element(), "ELEMENT(f10)", "NULL")
-
-    testAllApis('f4.element(), "ELEMENT(f4)", "NULL")
-
-    testAllApis('f11.element(), "ELEMENT(f11)", "1")
-
     // comparison
     testAllApis('f2 === 'f5.at(1), "f2 = f5[1]", "TRUE")
 


### PR DESCRIPTION
`RuntimeException` is too generic, we should throw a more specific `TableRuntimeException` here.