### PR TITLE
[FLINK-38027][table] Simplify watermark expressions

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/calcite/LogicalWatermarkAssigner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/calcite/LogicalWatermarkAssigner.scala
@@ -61,6 +61,12 @@ object LogicalWatermarkAssigner {
       rowtimeFieldIndex: Int,
       watermarkExpr: RexNode): LogicalWatermarkAssigner = {
     val traits = cluster.traitSetOf(Convention.NONE)
-    new LogicalWatermarkAssigner(cluster, traits, input, hints, rowtimeFieldIndex, watermarkExpr)
+    new LogicalWatermarkAssigner(
+      cluster,
+      traits,
+      input,
+      hints,
+      rowtimeFieldIndex,
+      WatermarkUtils.simplify(cluster, watermarkExpr))
   }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/calcite/WatermarkAssigner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/calcite/WatermarkAssigner.scala
@@ -20,11 +20,11 @@ package org.apache.flink.table.planner.plan.nodes.calcite
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 
 import com.google.common.collect.ImmutableList
-import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.plan.{RelOptCluster, RelOptPredicateList, RelTraitSet}
 import org.apache.calcite.rel.`type`.{RelDataType, RelDataTypeFieldImpl}
 import org.apache.calcite.rel.{RelNode, RelWriter, SingleRel}
 import org.apache.calcite.rel.hint.{Hintable, RelHint}
-import org.apache.calcite.rex.RexNode
+import org.apache.calcite.rex.{RexNode, RexSimplify}
 import org.apache.calcite.sql.`type`.SqlTypeName
 
 import java.util
@@ -90,4 +90,13 @@ abstract class WatermarkAssigner(
   }
 
   def withHints(hintList: util.List[RelHint]): RelNode
+}
+
+object WatermarkUtils {
+  def simplify(cluster: RelOptCluster, watermarkExpr: RexNode): RexNode = {
+    new RexSimplify(
+      cluster.getRexBuilder,
+      RelOptPredicateList.EMPTY,
+      cluster.getPlanner.getExecutor).simplify(watermarkExpr)
+  }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/logical/FlinkLogicalWatermarkAssigner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/logical/FlinkLogicalWatermarkAssigner.scala
@@ -18,7 +18,7 @@
 package org.apache.flink.table.planner.plan.nodes.logical
 
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
-import org.apache.flink.table.planner.plan.nodes.calcite.{LogicalWatermarkAssigner, WatermarkAssigner}
+import org.apache.flink.table.planner.plan.nodes.calcite.{LogicalWatermarkAssigner, WatermarkAssigner, WatermarkUtils}
 
 import org.apache.calcite.plan._
 import org.apache.calcite.rel.RelNode
@@ -61,7 +61,7 @@ class FlinkLogicalWatermarkAssigner(
       input,
       hints,
       rowtimeFieldIndex,
-      watermarkExpr)
+      WatermarkUtils.simplify(cluster, watermarkExpr))
   }
 }
 
@@ -97,6 +97,6 @@ object FlinkLogicalWatermarkAssigner {
       input,
       Collections.emptyList(),
       rowtimeFieldIndex,
-      watermarkExpr)
+      WatermarkUtils.simplify(cluster, watermarkExpr))
   }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalWatermarkAssigner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalWatermarkAssigner.scala
@@ -18,7 +18,7 @@
 package org.apache.flink.table.planner.plan.nodes.physical.stream
 
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
-import org.apache.flink.table.planner.plan.nodes.calcite.WatermarkAssigner
+import org.apache.flink.table.planner.plan.nodes.calcite.{WatermarkAssigner, WatermarkUtils}
 import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, InputProperty}
 import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecWatermarkAssigner
 import org.apache.flink.table.planner.plan.utils.RelExplainUtil.preferExpressionFormat
@@ -74,7 +74,7 @@ class StreamPhysicalWatermarkAssigner(
   override def translateToExecNode(): ExecNode[_] = {
     new StreamExecWatermarkAssigner(
       unwrapTableConfig(this),
-      watermarkExpr,
+      WatermarkUtils.simplify(cluster, watermarkExpr),
       rowtimeFieldIndex,
       InputProperty.DEFAULT,
       FlinkTypeFactory.toLogicalRowType(getRowType),
@@ -88,6 +88,6 @@ class StreamPhysicalWatermarkAssigner(
       input,
       hints,
       rowtimeFieldIndex,
-      watermarkExpr)
+      WatermarkUtils.simplify(cluster, watermarkExpr))
   }
 }

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/SourceWatermarkTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/SourceWatermarkTest.xml
@@ -53,6 +53,60 @@ TableSourceScan(table=[[default_catalog, default_database, t1, project=[a, b, t]
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testProjectTransposeWatermarkAssignerWithSimplifiableWatermarks[[1] watermarkExp=`ts` - ( - ( - (INTERVAL &#39;10&#39; SECOND)))]">
+    <Resource name="sql">
+      <![CDATA[SELECT a, b, ts FROM t1]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], ts=[$5])
++- LogicalWatermarkAssigner(rowtime=[ts], watermark=[-($5, 10000:INTERVAL SECOND)])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], t=[$4], ts=[$4])
+      +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+TableSourceScan(table=[[default_catalog, default_database, t1, project=[a, b, t], metadata=[], watermark=[-(t, 10000:INTERVAL SECOND)], watermarkEmitStrategy=[on-periodic]]], fields=[a, b, t])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectTransposeWatermarkAssignerWithSimplifiableWatermarks[[2] watermarkExp=`ts` - ARRAY[INTERVAL &#39;10&#39; SECOND, INTERVAL &#39;1&#39; SECOND][1]]">
+    <Resource name="sql">
+      <![CDATA[SELECT a, b, ts FROM t1]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], ts=[$5])
++- LogicalWatermarkAssigner(rowtime=[ts], watermark=[-($5, ITEM(ARRAY(10000:INTERVAL SECOND, 1000:INTERVAL SECOND), 1))])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], t=[$4], ts=[$4])
+      +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+TableSourceScan(table=[[default_catalog, default_database, t1, project=[a, b, t], metadata=[], watermark=[-(t, ITEM(ARRAY(10000:INTERVAL SECOND, 1000:INTERVAL SECOND), 1))], watermarkEmitStrategy=[on-periodic]]], fields=[a, b, t])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectTransposeWatermarkAssignerWithSimplifiableWatermarks[[3] watermarkExp=`ts` - CASE WHEN true THEN INTERVAL &#39;10&#39; SECOND ELSE INTERVAL &#39;2&#39; SECOND END]">
+    <Resource name="sql">
+      <![CDATA[SELECT a, b, ts FROM t1]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], ts=[$5])
++- LogicalWatermarkAssigner(rowtime=[ts], watermark=[-($5, 10000:INTERVAL SECOND)])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], t=[$4], ts=[$4])
+      +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+TableSourceScan(table=[[default_catalog, default_database, t1, project=[a, b, t], metadata=[], watermark=[-(t, 10000:INTERVAL SECOND)], watermarkEmitStrategy=[on-periodic]]], fields=[a, b, t])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testSimpleWatermarkPushDown">
     <Resource name="sql">
       <![CDATA[SELECT a, b, c FROM VirtualTable]]>


### PR DESCRIPTION

## What is the purpose of the change

The PR adds `simplify` call for watermark expressions 

## Verifying this change

_SourceWatermarkTest.scala_

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
