### PR TITLE
[hotfix] Change community review job name from test to label

### DIFF
--- a/.github/workflows/community-review.yml
+++ b/.github/workflows/community-review.yml
@@ -30,7 +30,7 @@ permissions:
   pull-requests: write
   actions: write
 jobs:
-  test:
+  label:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION


## What is the purpose of the change

Amend the job name in the community review github action from test to label. This is a more natural name.