### PR TITLE
[FLINK-38036][table] Make `PlannerBase#getExecNodeGraphProcessors` public

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/BatchPlanner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/BatchPlanner.scala
@@ -71,7 +71,7 @@ class BatchPlanner(
 
   override protected def getOptimizer: Optimizer = new BatchCommonSubGraphBasedOptimizer(this)
 
-  override protected def getExecNodeGraphProcessors: Seq[ExecNodeGraphProcessor] = {
+  override def getExecNodeGraphProcessors: Seq[ExecNodeGraphProcessor] = {
     val processors = new util.ArrayList[ExecNodeGraphProcessor]()
     // deadlock breakup
     processors.add(new DeadlockBreakupProcessor())

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
@@ -436,7 +436,7 @@ abstract class PlannerBase(
     processors.foldLeft(execGraph)((graph, processor) => processor.process(graph, context))
   }
 
-  protected def getExecNodeGraphProcessors: Seq[ExecNodeGraphProcessor]
+  def getExecNodeGraphProcessors: Seq[ExecNodeGraphProcessor]
 
   /**
    * Translates an [[ExecNodeGraph]] into a [[Transformation]] DAG.

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/StreamPlanner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/StreamPlanner.scala
@@ -73,7 +73,7 @@ class StreamPlanner(
 
   override protected def getOptimizer: Optimizer = new StreamCommonSubGraphBasedOptimizer(this)
 
-  override protected def getExecNodeGraphProcessors: Seq[ExecNodeGraphProcessor] = Seq()
+  override def getExecNodeGraphProcessors: Seq[ExecNodeGraphProcessor] = Seq()
 
   override protected def translateToPlan(execGraph: ExecNodeGraph): util.List[Transformation[_]] = {
     beforeTranslation()


### PR DESCRIPTION
## What is the purpose of the change

This is a follow up for https://github.com/apache/flink/pull/26618 where these method were missed



## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

This change is already covered by existing tests, such as *(please describe tests)*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
