### PR TITLE
[BP-2.1][FLINK-33926][k8s] Allow using job JARs in the system classpath in native mode

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgramUtils.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgramUtils.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.dag.Pipeline;
 import org.apache.flink.client.FlinkPipelineTranslationUtil;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 
 import org.apache.commons.collections.CollectionUtils;
@@ -217,6 +218,10 @@ public enum PackagedProgramUtils {
             return uri;
         }
         return new File(path).getAbsoluteFile().toURI();
+    }
+
+    public static boolean usingSystemClassPath(Configuration configuration) {
+        return configuration.get(PipelineOptions.JARS) == null;
     }
 
     private static ProgramInvocationException generateException(

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterDescriptor.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterDescriptor.java
@@ -214,9 +214,11 @@ public class KubernetesClusterDescriptor implements ClusterDescriptor<String> {
 
         applicationConfiguration.applyToConfiguration(flinkConfig);
 
-        // No need to do pipelineJars validation if it is a PyFlink job.
+        // No need to do pipelineJars validation if it is a PyFlink job or using system classpath.
         if (!(PackagedProgramUtils.isPython(applicationConfiguration.getApplicationClassName())
-                || PackagedProgramUtils.isPython(applicationConfiguration.getProgramArguments()))) {
+                        || PackagedProgramUtils.isPython(
+                                applicationConfiguration.getProgramArguments()))
+                && !PackagedProgramUtils.usingSystemClassPath(flinkConfig)) {
             final List<URI> pipelineJars =
                     KubernetesUtils.checkJarFileForApplicationMode(flinkConfig);
             Preconditions.checkArgument(

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesApplicationClusterEntrypoint.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesApplicationClusterEntrypoint.java
@@ -125,9 +125,10 @@ public final class KubernetesApplicationClusterEntrypoint extends ApplicationClu
 
         final File userLibDir = ClusterEntrypointUtils.tryFindUserLibDirectory().orElse(null);
 
-        // No need to do pipelineJars validation if it is a PyFlink job.
+        // No need to do pipelineJars validation if it is a PyFlink job or using system classpath
         if (!(PackagedProgramUtils.isPython(jobClassName)
-                || PackagedProgramUtils.isPython(programArguments))) {
+                        || PackagedProgramUtils.isPython(programArguments))
+                && !PackagedProgramUtils.usingSystemClassPath(configuration)) {
             final ArtifactFetchManager.Result fetchRes = fetchArtifacts(configuration);
 
             return DefaultPackagedProgramRetriever.create(

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClusterDescriptorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClusterDescriptorTest.java
@@ -52,6 +52,7 @@ import java.util.concurrent.Executors;
 
 import static org.apache.flink.kubernetes.utils.Constants.ENV_FLINK_POD_IP_ADDRESS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for the {@link KubernetesClusterDescriptor}. */
@@ -218,6 +219,14 @@ class KubernetesClusterDescriptorTest extends KubernetesClientTestBase {
                                 assertThat(cause)
                                         .isInstanceOf(IllegalArgumentException.class)
                                         .hasMessageContaining("Should only have at most one jar"));
+    }
+
+    @Test
+    void testDeployApplicationClusterWithNoJar() {
+        flinkConfig.set(DeploymentOptions.TARGET, KubernetesDeploymentTarget.APPLICATION.getName());
+        assertThatNoException()
+                .isThrownBy(
+                        () -> descriptor.deployApplicationCluster(clusterSpecification, appConfig));
     }
 
     @Test


### PR DESCRIPTION
`release-2.1` backport of https://github.com/apache/flink/pull/25445