### PR TITLE
[FLINK-36962] Avoid pushing down non-deterministic filter in FILTER_RULES

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkFilterAggregateTransposeRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkFilterAggregateTransposeRule.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.logical;
+
+import org.apache.flink.shaded.guava33.com.google.common.collect.ImmutableList;
+
+import org.apache.calcite.plan.Contexts;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelOptRuleOperand;
+import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Aggregate;
+import org.apache.calcite.rel.core.Aggregate.Group;
+import org.apache.calcite.rel.core.Filter;
+import org.apache.calcite.rel.core.RelFactories;
+import org.apache.calcite.rel.rules.AggregateFilterTransposeRule;
+import org.apache.calcite.rel.rules.CoreRules;
+import org.apache.calcite.rel.rules.TransformationRule;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexUtil;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.tools.RelBuilderFactory;
+import org.apache.calcite.util.ImmutableBitSet;
+import org.immutables.value.Value;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This rule is copied from Calcite's {@link
+ * org.apache.calcite.rel.rules.FilterAggregateTransposeRule}. Modification: - Only when the filter
+ * satisfies deterministic semantics, it will be allowed to be pushed down.
+ */
+
+/**
+ * Planner rule that pushes a {@link Filter} past a {@link Aggregate}.
+ *
+ * @see AggregateFilterTransposeRule
+ * @see CoreRules#FILTER_AGGREGATE_TRANSPOSE
+ */
+@Value.Enclosing
+public class FlinkFilterAggregateTransposeRule
+        extends RelRule<FlinkFilterAggregateTransposeRule.Config> implements TransformationRule {
+    public static final RelOptRule INSTANCE = new FlinkFilterAggregateTransposeRule(Config.DEFAULT);
+
+    /** Creates a FlinkFilterAggregateTransposeRule. */
+    protected FlinkFilterAggregateTransposeRule(Config config) {
+        super(config);
+    }
+
+    @Deprecated // to be removed before 2.0
+    public FlinkFilterAggregateTransposeRule(
+            Class<? extends Filter> filterClass,
+            RelBuilderFactory relBuilderFactory,
+            Class<? extends Aggregate> aggregateClass) {
+        this(
+                Config.DEFAULT
+                        .withRelBuilderFactory(relBuilderFactory)
+                        .as(Config.class)
+                        .withOperandFor(filterClass, aggregateClass));
+    }
+
+    @Deprecated // to be removed before 2.0
+    protected FlinkFilterAggregateTransposeRule(
+            RelOptRuleOperand operand, RelBuilderFactory relBuilderFactory) {
+        this(
+                Config.DEFAULT
+                        .withRelBuilderFactory(relBuilderFactory)
+                        .withOperandSupplier(b -> b.exactly(operand))
+                        .as(Config.class));
+    }
+
+    @Deprecated // to be removed before 2.0
+    public FlinkFilterAggregateTransposeRule(
+            Class<? extends Filter> filterClass,
+            RelFactories.FilterFactory filterFactory,
+            Class<? extends Aggregate> aggregateClass) {
+        this(filterClass, RelBuilder.proto(Contexts.of(filterFactory)), aggregateClass);
+    }
+
+    // ~ Methods ----------------------------------------------------------------
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+        final Filter filterRel = call.rel(0);
+        final Aggregate aggRel = call.rel(1);
+
+        final List<RexNode> conditions = RelOptUtil.conjunctions(filterRel.getCondition());
+        final RexBuilder rexBuilder = filterRel.getCluster().getRexBuilder();
+        final List<RelDataTypeField> origFields = aggRel.getRowType().getFieldList();
+        final int[] adjustments = new int[origFields.size()];
+        int j = 0;
+        for (int i : aggRel.getGroupSet()) {
+            adjustments[j] = i - j;
+            j++;
+        }
+        final List<RexNode> pushedConditions = new ArrayList<>();
+        final List<RexNode> remainingConditions = new ArrayList<>();
+
+        for (RexNode condition : conditions) {
+            ImmutableBitSet rCols = RelOptUtil.InputFinder.bits(condition);
+            if (canPush(aggRel, rCols) && RexUtil.isDeterministic(condition)) {
+                pushedConditions.add(
+                        condition.accept(
+                                new RelOptUtil.RexInputConverter(
+                                        rexBuilder,
+                                        origFields,
+                                        aggRel.getInput(0).getRowType().getFieldList(),
+                                        adjustments)));
+            } else {
+                remainingConditions.add(condition);
+            }
+        }
+
+        final RelBuilder builder = call.builder();
+        RelNode rel = builder.push(aggRel.getInput()).filter(pushedConditions).build();
+        if (rel == aggRel.getInput(0)) {
+            return;
+        }
+        rel = aggRel.copy(aggRel.getTraitSet(), ImmutableList.of(rel));
+        rel = builder.push(rel).filter(remainingConditions).build();
+        call.transformTo(rel);
+    }
+
+    private static boolean canPush(Aggregate aggregate, ImmutableBitSet rCols) {
+        // If the filter references columns not in the group key, we cannot push
+        final ImmutableBitSet groupKeys =
+                ImmutableBitSet.range(0, aggregate.getGroupSet().cardinality());
+        if (!groupKeys.contains(rCols)) {
+            return false;
+        }
+
+        if (aggregate.getGroupType() != Group.SIMPLE) {
+            // If grouping sets are used, the filter can be pushed if
+            // the columns referenced in the predicate are present in
+            // all the grouping sets.
+            for (ImmutableBitSet groupingSet : aggregate.getGroupSets()) {
+                if (!groupingSet.contains(rCols)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    /** Rule configuration. */
+    @Value.Immutable
+    public interface Config extends RelRule.Config {
+        Config DEFAULT =
+                ImmutableFlinkFilterAggregateTransposeRule.Config.builder()
+                        .build()
+                        .withOperandFor(Filter.class, Aggregate.class);
+
+        @Override
+        default FlinkFilterAggregateTransposeRule toRule() {
+            return new FlinkFilterAggregateTransposeRule(this);
+        }
+
+        /** Defines an operand tree for the given 2 classes. */
+        default Config withOperandFor(
+                Class<? extends Filter> filterClass, Class<? extends Aggregate> aggregateClass) {
+            return withOperandSupplier(
+                            b0 ->
+                                    b0.operand(filterClass)
+                                            .oneInput(b1 -> b1.operand(aggregateClass).anyInputs()))
+                    .as(Config.class);
+        }
+
+        /** Defines an operand tree for the given 3 classes. */
+        default Config withOperandFor(
+                Class<? extends Filter> filterClass,
+                Class<? extends Aggregate> aggregateClass,
+                Class<? extends RelNode> relClass) {
+            return withOperandSupplier(
+                            b0 ->
+                                    b0.operand(filterClass)
+                                            .oneInput(
+                                                    b1 ->
+                                                            b1.operand(aggregateClass)
+                                                                    .oneInput(
+                                                                            b2 ->
+                                                                                    b2.operand(
+                                                                                                    relClass)
+                                                                                            .anyInputs())))
+                    .as(Config.class);
+        }
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkFilterSetOpTransposeRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkFilterSetOpTransposeRule.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.logical;
+
+import org.apache.calcite.plan.Contexts;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Filter;
+import org.apache.calcite.rel.core.RelFactories;
+import org.apache.calcite.rel.core.SetOp;
+import org.apache.calcite.rel.rules.CoreRules;
+import org.apache.calcite.rel.rules.TransformationRule;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexUtil;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.tools.RelBuilderFactory;
+import org.immutables.value.Value;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * This rule is copied from Calcite's {@link org.apache.calcite.rel.rules.FilterSetOpTransposeRule}.
+ * Modification: - Only when the filter satisfies deterministic semantics, it will be allowed to be
+ * pushed down.
+ */
+
+/**
+ * Planner rule that pushes a {@link Filter} past a {@link SetOp}.
+ *
+ * @see CoreRules#FILTER_SET_OP_TRANSPOSE
+ */
+@Value.Enclosing
+public class FlinkFilterSetOpTransposeRule extends RelRule<FlinkFilterSetOpTransposeRule.Config>
+        implements TransformationRule {
+    public static final RelOptRule INSTANCE = new FlinkFilterSetOpTransposeRule(Config.DEFAULT);
+
+    /** Creates a FlinkFilterSetOpTransposeRule. */
+    protected FlinkFilterSetOpTransposeRule(Config config) {
+        super(config);
+    }
+
+    @Deprecated // to be removed before 2.0
+    public FlinkFilterSetOpTransposeRule(RelBuilderFactory relBuilderFactory) {
+        this(Config.DEFAULT.withRelBuilderFactory(relBuilderFactory).as(Config.class));
+    }
+
+    @Deprecated // to  be removed before 2.0
+    public FlinkFilterSetOpTransposeRule(RelFactories.FilterFactory filterFactory) {
+        this(
+                Config.DEFAULT
+                        .withRelBuilderFactory(RelBuilder.proto(Contexts.of(filterFactory)))
+                        .as(Config.class));
+    }
+
+    // ~ Methods ----------------------------------------------------------------
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+        Filter filterRel = call.rel(0);
+        SetOp setOp = call.rel(1);
+
+        final List<RexNode> conditions = RelOptUtil.conjunctions(filterRel.getCondition());
+        final List<RexNode> remainingConditions =
+                conditions.stream()
+                        .filter(f -> !RexUtil.isDeterministic(f))
+                        .collect(Collectors.toList());
+
+        // create filters on top of each setop child, modifying the filter
+        // condition to reference each setop child
+        RexBuilder rexBuilder = filterRel.getCluster().getRexBuilder();
+        final RelBuilder relBuilder = call.builder();
+        List<RelDataTypeField> origFields = setOp.getRowType().getFieldList();
+        int[] adjustments = new int[origFields.size()];
+        final List<RelNode> newSetOpInputs = new ArrayList<>();
+
+        for (RelNode input : setOp.getInputs()) {
+            final List<RexNode> pushedConditions = new ArrayList<>();
+            conditions.forEach(
+                    condition -> {
+                        if (RexUtil.isDeterministic(condition)) {
+                            pushedConditions.add(
+                                    condition.accept(
+                                            new RelOptUtil.RexInputConverter(
+                                                    rexBuilder,
+                                                    origFields,
+                                                    input.getRowType().getFieldList(),
+                                                    adjustments)));
+                        }
+                    });
+            newSetOpInputs.add(relBuilder.push(input).filter(pushedConditions).build());
+        }
+
+        // create a new setop whose children are the filters created above
+        SetOp newSetOp = setOp.copy(setOp.getTraitSet(), newSetOpInputs);
+        RelNode newFilterRel = relBuilder.push(newSetOp).filter(remainingConditions).build();
+
+        call.transformTo(newFilterRel);
+    }
+
+    /** Rule configuration. */
+    @Value.Immutable
+    public interface Config extends RelRule.Config {
+        Config DEFAULT =
+                ImmutableFlinkFilterSetOpTransposeRule.Config.builder()
+                        .build()
+                        .withOperandSupplier(
+                                b0 ->
+                                        b0.operand(Filter.class)
+                                                .oneInput(
+                                                        b1 -> b1.operand(SetOp.class).anyInputs()));
+
+        @Override
+        default FlinkFilterSetOpTransposeRule toRule() {
+            return new FlinkFilterSetOpTransposeRule(this);
+        }
+    }
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -143,11 +143,11 @@ object FlinkStreamRuleSets {
     // push filter into the children of a join
     FlinkFilterJoinRule.JOIN_CONDITION_PUSH,
     // push filter through an aggregation
-    CoreRules.FILTER_AGGREGATE_TRANSPOSE,
+    FlinkFilterAggregateTransposeRule.INSTANCE,
     // push a filter past a project
     FlinkFilterProjectTransposeRule.INSTANCE,
     // push a filter past a setop
-    CoreRules.FILTER_SET_OP_TRANSPOSE,
+    FlinkFilterSetOpTransposeRule.INSTANCE,
     CoreRules.FILTER_MERGE
   )
 

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/analyze/NonDeterministicUpdateAnalyzerTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/analyze/NonDeterministicUpdateAnalyzerTest.xml
@@ -29,12 +29,12 @@ on t1.a = t2.a and ndFunc(t2.b) > 100]]>
       <![CDATA[
 Sink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
 +- Calc(select=[a, b, c])
-   +- LookupJoin(table=[default_catalog.default_database.dim_with_pk], joinType=[InnerJoin], lookup=[a=a], where=[>(ndFunc(b), 100)], select=[a, b, c, a], upsertKey=[[0]])
+   +- LookupJoin(table=[default_catalog.default_database.dim_with_pk], joinType=[InnerJoin], lookup=[a=a], joinCondition=[>(ndFunc(b0), 100)], select=[a, b, c, a0, b0], upsertKey=[[0]])
       +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, b, c], metadata=[]]], fields=[a, b, c])
 
-advice[1]: [WARNING] There exists non deterministic function: 'ndFunc' in condition: '>(ndFunc($1), 100)' which may cause wrong result in update pipeline.
+advice[1]: [WARNING] There exists non deterministic function: 'ndFunc' in condition: '>(ndFunc($4), 100)' which may cause wrong result in update pipeline.
 related rel plan:
-LookupJoin(table=[default_catalog.default_database.dim_with_pk], joinType=[InnerJoin], lookup=[a=a], where=[>(ndFunc(b), 100)], select=[a, b, c, a], upsertKey=[[0]], changelogMode=[I,UB,UA,D])
+LookupJoin(table=[default_catalog.default_database.dim_with_pk], joinType=[InnerJoin], lookup=[a=a], joinCondition=[>(ndFunc(b0), 100)], select=[a, b, c, a0, b0], upsertKey=[[0]], changelogMode=[I,UB,UA,D])
 +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, b, c], metadata=[]]], fields=[a, b, c], changelogMode=[I,UB,UA,D], upsertKeys=[[a]])
 
 

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/NonDeterministicDagTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/NonDeterministicDagTest.xml
@@ -727,7 +727,7 @@ LogicalSink(table=[default_catalog.default_database.sink_with_pk], fields=[a, ve
       <![CDATA[
 Sink(table=[default_catalog.default_database.sink_with_pk], fields=[a, version, c], upsertMaterialize=[true])
 +- Calc(select=[a, b AS version, c])
-   +- LookupJoin(table=[default_catalog.default_database.dim_with_pk], joinType=[InnerJoin], lookup=[a=a], where=[(b > (UNIX_TIMESTAMP() - 300))], select=[a, a, b, c], upsertKey=[[0]])
+   +- LookupJoin(table=[default_catalog.default_database.dim_with_pk], joinType=[InnerJoin], lookup=[a=a], joinCondition=[(b > (UNIX_TIMESTAMP() - 300))], select=[a, a0, b, c], upsertKey=[[0]])
       +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a], metadata=[]]], fields=[a])
 ]]>
     </Resource>
@@ -759,7 +759,7 @@ LogicalSink(table=[default_catalog.default_database.sink_without_pk], fields=[a,
       <![CDATA[
 Sink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
 +- Calc(select=[a, b, c])
-   +- LookupJoin(table=[default_catalog.default_database.dim_with_pk], joinType=[InnerJoin], lookup=[a=a], where=[(ndFunc(b) > 100)], select=[a, b, c, a], upsertKey=[[0]])
+   +- LookupJoin(table=[default_catalog.default_database.dim_with_pk], joinType=[InnerJoin], lookup=[a=a], joinCondition=[(ndFunc(b0) > 100)], select=[a, b, c, a0, b0], upsertKey=[[0]])
       +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, b, c], metadata=[]]], fields=[a, b, c])
 ]]>
     </Resource>
@@ -1563,56 +1563,6 @@ Sink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, c], up
 +- Calc(select=[CAST(a AS INTEGER) AS a, CAST(metadata_1 AS BIGINT) AS b, EXPR$0 AS c])
    +- Correlate(invocation=[str_split($cor0.c)], correlate=[table(str_split($cor0.c))], select=[a,b,c,d,metadata_1,metadata_2,metadata_3,EXPR$0], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, BOOLEAN d, INTEGER metadata_1, VARCHAR(2147483647) metadata_2, BIGINT metadata_3, VARCHAR(2147483647) EXPR$0)], joinType=[INNER])
       +- TableSourceScan(table=[[default_catalog, default_database, cdc_with_meta, metadata=[metadata_1, metadata_2, metadata_3]]], fields=[a, b, c, d, metadata_1, metadata_2, metadata_3])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testCdcWithMetaLegacySinkWithPk[nonDeterministicUpdateStrategy=IGNORE]">
-    <Resource name="sql">
-      <![CDATA[
-insert into legacy_upsert_sink
-select a, metadata_3, c
-from cdc_with_meta
-]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalLegacySink(name=[`default_catalog`.`default_database`.`legacy_upsert_sink`], fields=[a, b, c])
-+- LogicalProject(a=[CAST($0):INTEGER], b=[$6], c=[CAST($2):VARCHAR(100) CHARACTER SET "UTF-16LE"])
-   +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], metadata_1=[$4], metadata_2=[$5], metadata_3=[$6])
-      +- LogicalTableScan(table=[[default_catalog, default_database, cdc_with_meta, metadata=[metadata_1, metadata_2, metadata_3]]])
-]]>
-    </Resource>
-    <Resource name="optimized exec plan">
-      <![CDATA[
-LegacySink(name=[`default_catalog`.`default_database`.`legacy_upsert_sink`], fields=[a, b, c])
-+- Calc(select=[CAST(a AS INTEGER) AS a, metadata_3 AS b, CAST(c AS VARCHAR(100)) AS c])
-   +- DropUpdateBefore
-      +- TableSourceScan(table=[[default_catalog, default_database, cdc_with_meta, project=[a, c], metadata=[metadata_3]]], fields=[a, c, metadata_3])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testCdcWithMetaLegacySinkWithPk[nonDeterministicUpdateStrategy=TRY_RESOLVE]">
-    <Resource name="sql">
-      <![CDATA[
-insert into legacy_upsert_sink
-select a, metadata_3, c
-from cdc_with_meta
-]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalLegacySink(name=[`default_catalog`.`default_database`.`legacy_upsert_sink`], fields=[a, b, c])
-+- LogicalProject(a=[CAST($0):INTEGER], b=[$6], c=[CAST($2):VARCHAR(100) CHARACTER SET "UTF-16LE"])
-   +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], metadata_1=[$4], metadata_2=[$5], metadata_3=[$6])
-      +- LogicalTableScan(table=[[default_catalog, default_database, cdc_with_meta, metadata=[metadata_1, metadata_2, metadata_3]]])
-]]>
-    </Resource>
-    <Resource name="optimized exec plan">
-      <![CDATA[
-LegacySink(name=[`default_catalog`.`default_database`.`legacy_upsert_sink`], fields=[a, b, c])
-+- Calc(select=[CAST(a AS INTEGER) AS a, metadata_3 AS b, CAST(c AS VARCHAR(100)) AS c])
-   +- DropUpdateBefore
-      +- TableSourceScan(table=[[default_catalog, default_database, cdc_with_meta, project=[a, c], metadata=[metadata_3]]], fields=[a, c, metadata_3])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/UnionTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/UnionTest.xml
@@ -16,6 +16,43 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <Root>
+  <TestCase name="testCalcWithNonDeterministicFilterAfterUnion">
+    <Resource name="sql">
+      <![CDATA[
+SELECT *
+FROM (
+      SELECT a, c FROM MyTable1
+      UNION
+      SELECT a, c FROM MyTable2
+)
+WHERE TO_TIMESTAMP(c, 'yyyy-MM-dd HH:mm:ss')
+      < NOW()
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], c=[$1])
++- LogicalFilter(condition=[<(TO_TIMESTAMP($1, _UTF-16LE'yyyy-MM-dd HH:mm:ss'), NOW())])
+   +- LogicalUnion(all=[false])
+      :- LogicalProject(a=[$0], c=[$2])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, MyTable1]])
+      +- LogicalProject(a=[$0], c=[$2])
+         +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, c], where=[(TO_TIMESTAMP(c, 'yyyy-MM-dd HH:mm:ss') < NOW())])
++- GroupAggregate(groupBy=[a, c], select=[a, c])
+   +- Exchange(distribution=[hash[a, c]])
+      +- Union(all=[true], union=[a, c])
+         :- Calc(select=[a, c])
+         :  +- TableSourceScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c])
+         +- Calc(select=[a, c])
+            +- TableSourceScan(table=[[default_catalog, default_database, MyTable2]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testUnionDiffRowTime">
     <Resource name="sql">
       <![CDATA[

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/AggregateTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/AggregateTest.xml
@@ -224,6 +224,65 @@ GroupAggregate(select=[AVG_RETRACT(a) AS EXPR$0], changelogMode=[I,UA,D])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testCalcWithNonDeterministicFilterAfterAgg1">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * from(
+  SELECT SUM(b) b, MAX(c) c
+  FROM T1
+  GROUP BY a
+)
+WHERE TO_TIMESTAMP(c, 'yyyy-MM-dd HH:mm:ss')
+      < TIMESTAMPADD(HOUR, -2, CAST(CURRENT_TIME AS TIMESTAMP(3)))
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(b=[$0], c=[$1])
++- LogicalFilter(condition=[<(TO_TIMESTAMP($1, _UTF-16LE'yyyy-MM-dd HH:mm:ss'), +(CAST(CURRENT_TIME()):TIMESTAMP(3) NOT NULL, *(3600000:INTERVAL HOUR, -2)))])
+   +- LogicalProject(b=[$1], c=[$2])
+      +- LogicalAggregate(group=[{0}], b=[SUM($1)], c=[MAX($2)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, T1]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[b, c], where=[(TO_TIMESTAMP(c, 'yyyy-MM-dd HH:mm:ss') < (CAST(CURRENT_TIME() AS TIMESTAMP(3)) + -7200000:INTERVAL HOUR))])
++- GroupAggregate(groupBy=[a], select=[a, SUM(b) AS b, MAX(c) AS c])
+   +- Exchange(distribution=[hash[a]])
+      +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCalcWithNonDeterministicFilterAfterAgg2">
+    <Resource name="sql">
+      <![CDATA[
+SELECT MAX(b)
+FROM T1
+GROUP BY c
+HAVING c > '2022-01-01 00:00:00'
+AND TO_TIMESTAMP(c, 'yyyy-MM-dd HH:mm:ss') < TIMESTAMPADD(HOUR, -2, NOW())
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(EXPR$0=[$1])
++- LogicalFilter(condition=[AND(>($0, _UTF-16LE'2022-01-01 00:00:00'), <(TO_TIMESTAMP($0, _UTF-16LE'yyyy-MM-dd HH:mm:ss'), +(NOW(), *(3600000:INTERVAL HOUR, -2))))])
+   +- LogicalAggregate(group=[{0}], EXPR$0=[MAX($1)])
+      +- LogicalProject(c=[$2], b=[$1])
+         +- LogicalTableScan(table=[[default_catalog, default_database, T1]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[EXPR$0], where=[(TO_TIMESTAMP(c, 'yyyy-MM-dd HH:mm:ss') < (NOW() + -7200000:INTERVAL HOUR))])
++- GroupAggregate(groupBy=[c], select=[c, MAX(b) AS EXPR$0])
+   +- Exchange(distribution=[hash[c]])
+      +- Calc(select=[b, c], where=[(c > '2022-01-01 00:00:00')])
+         +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testColumnIntervalValidation">
     <Resource name="sql">
       <![CDATA[SELECT b, SUM(a) FROM MyTable WHERE a > 0.1 and a < 10 GROUP BY b]]>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/JoinTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/JoinTest.xml
@@ -16,6 +16,158 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <Root>
+  <TestCase name="testCalcWithNonDeterministicFilterAfterJoin1">
+    <Resource name="sql">
+      <![CDATA[
+SELECT a1
+FROM (
+  SELECT a1,
+         c1,
+         c2
+  FROM  MyTable1
+  JOIN  MyTable2
+  ON    b1 = b2
+)
+WHERE TO_TIMESTAMP(c1, 'yyyy-MM-dd HH:mm:ss') <
+      TIMESTAMPADD(HOUR, -2, NOW())
+  AND c2 > '2022-01-01 00:00:00'
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0])
++- LogicalFilter(condition=[AND(<(TO_TIMESTAMP($1, _UTF-16LE'yyyy-MM-dd HH:mm:ss'), +(NOW(), *(3600000:INTERVAL HOUR, -2))), >($2, _UTF-16LE'2022-01-01 00:00:00'))])
+   +- LogicalProject(a1=[$0], c1=[$2], c2=[$5])
+      +- LogicalJoin(condition=[=($1, $4)], joinType=[inner])
+         :- LogicalTableScan(table=[[default_catalog, default_database, MyTable1]])
+         +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a1], where=[(TO_TIMESTAMP(c1, 'yyyy-MM-dd HH:mm:ss') < (NOW() + -7200000:INTERVAL HOUR))])
++- Join(joinType=[InnerJoin], where=[(b1 = b2)], select=[a1, b1, c1, b2], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+   :- Exchange(distribution=[hash[b1]])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, MyTable1]], fields=[a1, b1, c1])
+   +- Exchange(distribution=[hash[b2]])
+      +- Calc(select=[b2], where=[(c2 > '2022-01-01 00:00:00')])
+         +- TableSourceScan(table=[[default_catalog, default_database, MyTable2]], fields=[a2, b2, c2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCalcWithNonDeterministicFilterAfterJoin2">
+    <Resource name="sql">
+      <![CDATA[
+SELECT a1
+FROM (
+  SELECT a1,
+         c1,
+         c2
+  FROM  MyTable1
+  JOIN  MyTable2
+  ON    b1 = b2
+)
+WHERE TO_TIMESTAMP(c1, 'yyyy-MM-dd HH:mm:ss')
+      < TIMESTAMPADD(HOUR, -2, CAST(CURRENT_TIME AS TIMESTAMP(3)))
+  AND c2 > '2022-01-01 00:00:00'
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0])
++- LogicalFilter(condition=[AND(<(TO_TIMESTAMP($1, _UTF-16LE'yyyy-MM-dd HH:mm:ss'), +(CAST(CURRENT_TIME()):TIMESTAMP(3) NOT NULL, *(3600000:INTERVAL HOUR, -2))), >($2, _UTF-16LE'2022-01-01 00:00:00'))])
+   +- LogicalProject(a1=[$0], c1=[$2], c2=[$5])
+      +- LogicalJoin(condition=[=($1, $4)], joinType=[inner])
+         :- LogicalTableScan(table=[[default_catalog, default_database, MyTable1]])
+         +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a1], where=[(TO_TIMESTAMP(c1, 'yyyy-MM-dd HH:mm:ss') < (CAST(CURRENT_TIME() AS TIMESTAMP(3)) + -7200000:INTERVAL HOUR))])
++- Join(joinType=[InnerJoin], where=[(b1 = b2)], select=[a1, b1, c1, b2], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+   :- Exchange(distribution=[hash[b1]])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, MyTable1]], fields=[a1, b1, c1])
+   +- Exchange(distribution=[hash[b2]])
+      +- Calc(select=[b2], where=[(c2 > '2022-01-01 00:00:00')])
+         +- TableSourceScan(table=[[default_catalog, default_database, MyTable2]], fields=[a2, b2, c2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCalcWithNonDeterministicFilterAfterJoin3">
+    <Resource name="sql">
+      <![CDATA[
+SELECT a1
+FROM (
+  SELECT a1,
+         c1,
+         c2
+  FROM  MyTable1
+  JOIN  MyTable2
+  ON    b1 = b2
+  AND   c1 = c2
+)
+WHERE TO_TIMESTAMP(c1, 'yyyy-MM-dd HH:mm:ss') <
+      TIMESTAMPADD(HOUR, -2, NOW())
+  AND c2 > '2022-01-01 00:00:00'
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0])
++- LogicalFilter(condition=[AND(<(TO_TIMESTAMP($1, _UTF-16LE'yyyy-MM-dd HH:mm:ss'), +(NOW(), *(3600000:INTERVAL HOUR, -2))), >($2, _UTF-16LE'2022-01-01 00:00:00'))])
+   +- LogicalProject(a1=[$0], c1=[$2], c2=[$5])
+      +- LogicalJoin(condition=[AND(=($1, $4), =($2, $5))], joinType=[inner])
+         :- LogicalTableScan(table=[[default_catalog, default_database, MyTable1]])
+         +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a1], where=[(TO_TIMESTAMP(c1, 'yyyy-MM-dd HH:mm:ss') < (NOW() + -7200000:INTERVAL HOUR))])
++- Join(joinType=[InnerJoin], where=[((b1 = b2) AND (c1 = c2))], select=[a1, b1, c1, b2, c2], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+   :- Exchange(distribution=[hash[b1, c1]])
+   :  +- Calc(select=[a1, b1, c1], where=[(c1 > '2022-01-01 00:00:00')])
+   :     +- TableSourceScan(table=[[default_catalog, default_database, MyTable1]], fields=[a1, b1, c1])
+   +- Exchange(distribution=[hash[b2, c2]])
+      +- Calc(select=[b2, c2], where=[(c2 > '2022-01-01 00:00:00')])
+         +- TableSourceScan(table=[[default_catalog, default_database, MyTable2]], fields=[a2, b2, c2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCalcWithNonDeterministicFilterAfterJoin4">
+    <Resource name="sql">
+      <![CDATA[
+  SELECT a1,
+         b1,
+         c2
+  FROM  MyTable1
+  JOIN  MyTable2
+  ON    b1 = b2
+  AND   c1 < TIMESTAMPADD(HOUR, -2, NOW())
+  AND   c2 > '2022-01-01 00:00:00'
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1], c2=[$5])
++- LogicalJoin(condition=[AND(=($1, $4), <(CAST($2):TIMESTAMP_WITH_LOCAL_TIME_ZONE(3), +(NOW(), *(3600000:INTERVAL HOUR, -2))), >($5, _UTF-16LE'2022-01-01 00:00:00'))], joinType=[inner])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable1]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a1, b1, c2])
++- Join(joinType=[InnerJoin], where=[((b1 = b2) AND (CAST(c1 AS TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)) < (NOW() + -7200000:INTERVAL HOUR)))], select=[a1, b1, c1, b2, c2], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+   :- Exchange(distribution=[hash[b1]])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, MyTable1]], fields=[a1, b1, c1])
+   +- Exchange(distribution=[hash[b2]])
+      +- Calc(select=[b2, c2], where=[(c2 > '2022-01-01 00:00:00')])
+         +- TableSourceScan(table=[[default_catalog, default_database, MyTable2]], fields=[a2, b2, c2])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testDependentConditionDerivationInnerJoin">
     <Resource name="sql">
       <![CDATA[SELECT a1, b1 FROM A JOIN B ON (a1 = 1 AND b1 = 1) OR (a2 = 2 AND b2 = 2)]]>
@@ -555,30 +707,6 @@ Calc(select=[a1, a2, b1, b2], changelogMode=[I,UB,UA])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinAndSelectOnPartialCompositePrimaryKey">
-    <Resource name="sql">
-      <![CDATA[SELECT A.a1 FROM A LEFT JOIN tableWithCompositePk T ON A.a1 = T.pk1]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalProject(a1=[$0])
-+- LogicalJoin(condition=[=($0, $3)], joinType=[left])
-   :- LogicalTableScan(table=[[default_catalog, default_database, A]])
-   +- LogicalTableScan(table=[[default_catalog, default_database, tableWithCompositePk]])
-]]>
-    </Resource>
-    <Resource name="optimized exec plan">
-      <![CDATA[
-Calc(select=[a1])
-+- Join(joinType=[LeftOuterJoin], where=[(a1 = pk1)], select=[a1, pk1], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
-   :- Exchange(distribution=[hash[a1]])
-   :  +- Calc(select=[a1])
-   :     +- TableSourceScan(table=[[default_catalog, default_database, A]], fields=[a1, a2, a3])
-   +- Exchange(distribution=[hash[pk1]])
-      +- TableSourceScan(table=[[default_catalog, default_database, tableWithCompositePk, project=[pk1], metadata=[]]], fields=[pk1])
-]]>
-    </Resource>
-  </TestCase>
   <TestCase name="testJoinAccessSourcePkWithMiniBatchAssigner">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
@@ -609,6 +737,30 @@ Sink(table=[default_catalog.default_database.sink], fields=[a, b, d])
       +- Exchange(distribution=[hash[c]])
          +- MiniBatchAssigner(interval=[10000ms], mode=[ProcTime])
             +- TableSourceScan(table=[[default_catalog, default_database, right_table]], fields=[c, d])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinAndSelectOnPartialCompositePrimaryKey">
+    <Resource name="sql">
+      <![CDATA[SELECT A.a1 FROM A LEFT JOIN tableWithCompositePk T ON A.a1 = T.pk1]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0])
++- LogicalJoin(condition=[=($0, $3)], joinType=[left])
+   :- LogicalTableScan(table=[[default_catalog, default_database, A]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, tableWithCompositePk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a1])
++- Join(joinType=[LeftOuterJoin], where=[(a1 = pk1)], select=[a1, pk1], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+   :- Exchange(distribution=[hash[a1]])
+   :  +- Calc(select=[a1])
+   :     +- TableSourceScan(table=[[default_catalog, default_database, A]], fields=[a1, a2, a3])
+   +- Exchange(distribution=[hash[pk1]])
+      +- TableSourceScan(table=[[default_catalog, default_database, tableWithCompositePk, project=[pk1], metadata=[]]], fields=[pk1])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/NonDeterministicDagTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/NonDeterministicDagTest.scala
@@ -658,7 +658,7 @@ class NonDeterministicDagTest(nonDeterministicUpdateStrategy: NonDeterministicUp
       // not select lookup source field, but with NonDeterministicCondition, expect exception
       assertThatThrownBy(callable)
         .hasMessageContaining(
-          "exists non deterministic function: 'ndFunc' in condition: '>(ndFunc($1), 100)' which may cause wrong result")
+          "exists non deterministic function: 'ndFunc' in condition: '>(ndFunc($4), 100)' which may cause wrong result")
         .isInstanceOf[TableException]
     } else {
       assertThatCode(callable).doesNotThrowAnyException()
@@ -683,7 +683,7 @@ class NonDeterministicDagTest(nonDeterministicUpdateStrategy: NonDeterministicUp
     if (tryResolve) {
       assertThatThrownBy(callable)
         .hasMessageContaining(
-          "exists non deterministic function: 'UNIX_TIMESTAMP' in condition: '>($1, -(UNIX_TIMESTAMP(), 300))' which may cause wrong result")
+          "exists non deterministic function: 'UNIX_TIMESTAMP' in condition: '>($2, -(UNIX_TIMESTAMP(), 300))' which may cause wrong result")
         .isInstanceOf[TableException]
     } else {
       assertThatCode(callable).doesNotThrowAnyException()

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/UnionTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/UnionTest.scala
@@ -147,4 +147,20 @@ class UnionTest extends TableTestBase {
     error.isInstanceOf(classOf[ValidationException])
     error.hasMessageContaining("Type mismatch in column 3 of UNION ALL")
   }
+
+  @Test
+  def testCalcWithNonDeterministicFilterAfterUnion(): Unit = {
+    val sqlQuery =
+      """
+        |SELECT *
+        |FROM (
+        |      SELECT a, c FROM MyTable1
+        |      UNION
+        |      SELECT a, c FROM MyTable2
+        |)
+        |WHERE TO_TIMESTAMP(c, 'yyyy-MM-dd HH:mm:ss')
+        |      < NOW()
+        |""".stripMargin
+    util.verifyExecPlan(sqlQuery)
+  }
 }


### PR DESCRIPTION
## What is the purpose of the change

Currently, filters with non deterministic features will be pushed down to join/agg/union, which can result in errors.

## Brief change log

  - *Added non deterministic check in rules in FILTER_RULE.*
  - *Add Test and ITCase in related operator.*

## Verifying this change

Existent tests and new added tests can verify this change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)