### PR TITLE
Use isEmpty() instead of length() > 0 in WordCount Tokenizer

### DIFF
--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/wordcount/WordCount.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/wordcount/WordCount.java
@@ -198,7 +198,7 @@ public class WordCount {
 
             // emit the pairs
             for (String token : tokens) {
-                if (token.length() > 0) {
+                if (!token.isEmpty()) {
                     out.collect(new Tuple2<>(token, 1));
                 }
             }


### PR DESCRIPTION
The change enhances code clarity by using the semantically appropriate method provided by the String API. Although functionally equivalent, ‘isEmpty()’ more clearly communicates the intent of checking for an empty string, aligning with common Java coding practices. This improves maintainability and consistency across the codebase.