### PR TITLE
Add input validation to WordCount Tokenizer for robustness

### DIFF
--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/wordcount/WordCount.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/wordcount/WordCount.java
@@ -193,6 +193,10 @@ public class WordCount {
 
         @Override
         public void flatMap(String value, Collector<Tuple2<String, Integer>> out) {
+            if (value == null || value.trim().isEmpty()) {
+                return;
+            }
+            
             // normalize and split the line
             String[] tokens = value.toLowerCase().split("\\W+");
 


### PR DESCRIPTION
Introduces a defensive check at the beginning of the ‘flatMap’ method in the WordCount.Tokenizer class to ensure the input string is neither null nor blank. This change prevents unnecessary computation and avoids potential runtime exceptions caused by malformed or empty input data. It increases the robustness of the WordCount example, especially in streaming scenarios where data sources may emit invalid or incomplete records. This contributes to safer processing and better fault tolerance. 