### PR TITLE
[hotfix] Do not use syntax requiring java higher than java 11

### DIFF
--- a/flink-architecture-tests/flink-architecture-tests-production/src/main/java/org/apache/flink/architecture/rules/CheckpointingConfigurationAccessRules.java
+++ b/flink-architecture-tests/flink-architecture-tests-production/src/main/java/org/apache/flink/architecture/rules/CheckpointingConfigurationAccessRules.java
@@ -182,12 +182,11 @@ public class CheckpointingConfigurationAccessRules {
                             })
                     .allowEmptyShould(true) // Allow until we refactor all existing usages
                     .because(
-                            """
-                                    Direct use of certain CheckpointingOptions configuration fields with Configuration.get() or Configuration.getOptional() should be avoided. \
-                                    Use the appropriate helper methods which include proper validation logic:
-                                    - ENABLE_UNALIGNED: Use CheckpointingOptions.isUnalignedCheckpointEnabled(Configuration)
-                                    - CHECKPOINTING_CONSISTENCY_MODE: Use CheckpointingOptions.getCheckpointingMode(Configuration)
-                                    - ENABLE_UNALIGNED_INTERRUPTIBLE_TIMERS: Use CheckpointingOptions.isUnalignedCheckpointInterruptibleTimersEnabled(Configuration)""");
+                            "Direct use of certain CheckpointingOptions configuration fields with Configuration.get() or Configuration.getOptional() should be avoided. \n"
+                                    + "Use the appropriate helper methods which include proper validation logic:\n"
+                                    + "- ENABLE_UNALIGNED: Use CheckpointingOptions.isUnalignedCheckpointEnabled(Configuration)\n"
+                                    + "- CHECKPOINTING_CONSISTENCY_MODE: Use CheckpointingOptions.getCheckpointingMode(Configuration)\n"
+                                    + "- ENABLE_UNALIGNED_INTERRUPTIBLE_TIMERS: Use CheckpointingOptions.isUnalignedCheckpointInterruptibleTimersEnabled(Configuration)");
 
     private static boolean isProhibitedConfigFieldAccess(JavaFieldAccess fieldAccess) {
         return PROHIBITED_CONFIG_FIELDS.contains(fieldAccess.getTarget().getName())


### PR DESCRIPTION

## What is the purpose of the change

It seems after it sopped being compiled with java 11
The PR fixes this

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
