### PR TITLE
[BP-2.0][FLINK-37944][test] Add utils for initializing process function test harnesses with async state

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/streaming/util/ProcessFunctionTestHarnesses.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/util/ProcessFunctionTestHarnesses.java
@@ -21,6 +21,8 @@ package org.apache.flink.streaming.util;
 import org.apache.flink.api.common.state.MapStateDescriptor;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.runtime.asyncprocessing.operators.AsyncKeyedProcessOperator;
+import org.apache.flink.runtime.asyncprocessing.operators.co.AsyncKeyedCoProcessOperator;
 import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
 import org.apache.flink.streaming.api.functions.ProcessFunction;
 import org.apache.flink.streaming.api.functions.co.BroadcastProcessFunction;
@@ -33,6 +35,8 @@ import org.apache.flink.streaming.api.operators.co.CoBroadcastWithKeyedOperator;
 import org.apache.flink.streaming.api.operators.co.CoBroadcastWithNonKeyedOperator;
 import org.apache.flink.streaming.api.operators.co.CoProcessOperator;
 import org.apache.flink.streaming.api.operators.co.KeyedCoProcessOperator;
+import org.apache.flink.streaming.util.asyncprocessing.AsyncKeyedOneInputStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.asyncprocessing.AsyncKeyedTwoInputStreamOperatorTestHarness;
 import org.apache.flink.util.Preconditions;
 
 import java.util.Arrays;
@@ -87,6 +91,24 @@ public class ProcessFunctionTestHarnesses {
         return testHarness;
     }
 
+    public static <K, IN, OUT>
+            KeyedOneInputStreamOperatorTestHarness<K, IN, OUT> forKeyedProcessFunctionWithStateV2(
+                    final KeyedProcessFunction<K, IN, OUT> function,
+                    final KeySelector<IN, K> keySelector,
+                    final TypeInformation<K> keyType)
+                    throws Exception {
+        KeyedOneInputStreamOperatorTestHarness<K, IN, OUT> testHarness =
+                AsyncKeyedOneInputStreamOperatorTestHarness.create(
+                        new AsyncKeyedProcessOperator<>(Preconditions.checkNotNull(function)),
+                        keySelector,
+                        keyType,
+                        1,
+                        1,
+                        0);
+        testHarness.open();
+        return testHarness;
+    }
+
     /**
      * Returns an initialized test harness for {@link CoProcessFunction} with two input streams.
      *
@@ -129,6 +151,29 @@ public class ProcessFunctionTestHarnesses {
         KeyedTwoInputStreamOperatorTestHarness<K, IN1, IN2, OUT> testHarness =
                 new KeyedTwoInputStreamOperatorTestHarness<>(
                         new KeyedCoProcessOperator<>(Preconditions.checkNotNull(function)),
+                        keySelector1,
+                        keySelector2,
+                        keyType,
+                        1,
+                        1,
+                        0);
+
+        testHarness.open();
+        return testHarness;
+    }
+
+    public static <K, IN1, IN2, OUT>
+            KeyedTwoInputStreamOperatorTestHarness<K, IN1, IN2, OUT>
+                    forKeyedCoProcessFunctionWithStateV2(
+                            final KeyedCoProcessFunction<K, IN1, IN2, OUT> function,
+                            final KeySelector<IN1, K> keySelector1,
+                            final KeySelector<IN2, K> keySelector2,
+                            final TypeInformation<K> keyType)
+                            throws Exception {
+
+        KeyedTwoInputStreamOperatorTestHarness<K, IN1, IN2, OUT> testHarness =
+                AsyncKeyedTwoInputStreamOperatorTestHarness.create(
+                        new AsyncKeyedCoProcessOperator<>(Preconditions.checkNotNull(function)),
                         keySelector1,
                         keySelector2,
                         keyType,

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/util/ProcessFunctionTestHarnessesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/util/ProcessFunctionTestHarnessesTest.java
@@ -18,18 +18,24 @@
 
 package org.apache.flink.streaming.util;
 
+import org.apache.flink.api.common.functions.OpenContext;
 import org.apache.flink.api.common.state.MapStateDescriptor;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
 import org.apache.flink.streaming.api.functions.ProcessFunction;
 import org.apache.flink.streaming.api.functions.co.BroadcastProcessFunction;
 import org.apache.flink.streaming.api.functions.co.CoProcessFunction;
 import org.apache.flink.streaming.api.functions.co.KeyedBroadcastProcessFunction;
 import org.apache.flink.streaming.api.functions.co.KeyedCoProcessFunction;
+import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
 import org.apache.flink.util.Collector;
 
 import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -72,6 +78,41 @@ class ProcessFunctionTestHarnessesTest {
         harness.processElement(1, 10);
 
         assertThat(harness.extractOutputValues()).containsExactly(1);
+    }
+
+    @Test
+    void testHarnessForAsyncKeyedProcessFunction() throws Exception {
+        KeyedProcessFunction<Integer, Integer, Integer> function =
+                new KeyedProcessFunction<>() {
+
+                    org.apache.flink.api.common.state.v2.ValueState<Integer> state;
+                    org.apache.flink.api.common.state.v2.ValueStateDescriptor<Integer>
+                            asyncStateDescriptor;
+
+                    @Override
+                    public void open(OpenContext openContext) {
+                        asyncStateDescriptor =
+                                new org.apache.flink.api.common.state.v2.ValueStateDescriptor<>(
+                                        "state", Types.INT);
+                        state =
+                                ((StreamingRuntimeContext) getRuntimeContext())
+                                        .getValueState(asyncStateDescriptor);
+                    }
+
+                    @Override
+                    public void processElement(Integer value, Context ctx, Collector<Integer> out)
+                            throws Exception {
+                        state.asyncUpdate(value + 1);
+                        state.asyncValue().thenAccept(out::collect);
+                    }
+                };
+        OneInputStreamOperatorTestHarness<Integer, Integer> harness =
+                ProcessFunctionTestHarnesses.forKeyedProcessFunctionWithStateV2(
+                        function, x -> x, BasicTypeInfo.INT_TYPE_INFO);
+
+        harness.processElement(1, 10);
+
+        assertThat(harness.extractOutputValues()).containsExactly(2);
     }
 
     @Test
@@ -126,6 +167,57 @@ class ProcessFunctionTestHarnessesTest {
         harness.processElement2(1, 10);
 
         assertThat(harness.extractOutputValues()).containsExactly(0, 1);
+    }
+
+    @Test
+    void testHarnessForKeyedAsyncCoProcessFunction() throws Exception {
+        KeyedCoProcessFunction<Integer, Integer, Integer, Integer> function =
+                new KeyedCoProcessFunction<>() {
+
+                    org.apache.flink.api.common.state.v2.ListState<Integer> state;
+                    org.apache.flink.api.common.state.v2.ListStateDescriptor<Integer>
+                            asyncStateDescriptor;
+
+                    @Override
+                    public void open(OpenContext openContext) {
+                        asyncStateDescriptor =
+                                new org.apache.flink.api.common.state.v2.ListStateDescriptor<>(
+                                        "state", Types.INT);
+                        state =
+                                ((StreamingRuntimeContext) getRuntimeContext())
+                                        .getListState(asyncStateDescriptor);
+                    }
+
+                    @Override
+                    public void processElement2(Integer value, Context ctx, Collector<Integer> out)
+                            throws Exception {
+                        state.asyncAdd(value);
+                    }
+
+                    @Override
+                    public void processElement1(Integer value, Context ctx, Collector<Integer> out)
+                            throws Exception {
+                        state.asyncAdd(value);
+                        state.asyncGet()
+                                .thenAccept(
+                                        itr -> {
+                                            List<Integer> iterated = new ArrayList<>();
+                                            itr.onNext(
+                                                    value1 -> {
+                                                        iterated.add(value1);
+                                                    });
+                                            out.collect(iterated.size());
+                                        });
+                    }
+                };
+        KeyedTwoInputStreamOperatorTestHarness<Integer, Integer, Integer, Integer> harness =
+                ProcessFunctionTestHarnesses.forKeyedCoProcessFunctionWithStateV2(
+                        function, x -> x, x -> x, TypeInformation.of(Integer.class));
+
+        harness.processElement2(1, 1);
+        harness.processElement1(1, 10);
+
+        assertThat(harness.extractOutputValues()).containsExactly(2);
     }
 
     @Test


### PR DESCRIPTION
```release-2.0``` backport of ([#26697](https://github.com/apache/flink/pull/26697))