### PR TITLE
[FLINK-38057][runtime] Fix the error value between getting and using idleStartTime in source reader metric group

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/InternalSourceReaderMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/InternalSourceReaderMetricGroup.java
@@ -155,7 +155,6 @@ public class InternalSourceReaderMetricGroup extends ProxyMetricGroup<MetricGrou
         // this class is not thread-safe, use the local variable to get a snapshot value.
         long currentIdleStartTime = idleStartTime;
         if (isIdling(currentIdleStartTime)) {
-            // isIdling
             return this.clock.absoluteTimeMillis() - currentIdleStartTime;
         }
         return 0;
@@ -170,7 +169,6 @@ public class InternalSourceReaderMetricGroup extends ProxyMetricGroup<MetricGrou
         // this class is not thread-safe, use the local variable to get a snapshot value.
         long currentIdleStartTime = idleStartTime;
         if (isIdling(currentIdleStartTime)) {
-            // isIdling
             return currentIdleStartTime;
         }
         return clock.absoluteTimeMillis();


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixed the error value between getting and using idleStartTime in source reader metric group.

## Brief change log

Use a snapshot value when accessing the `idleStartTime`.


## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no 
  - The S3 file system connector:no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 
