### PR TITLE
[FLINK-38060][ci] Fix github action failed to build python wheel on linux

### DIFF
--- a/flink-python/dev/dev-requirements.txt
+++ b/flink-python/dev/dev-requirements.txt
@@ -24,7 +24,7 @@ avro>=1.12.0
 pandas>=1.3.0
 pyarrow>=5.0.0
 pytz>=2018.3
-numpy>=1.22.4,!=2.3.0
+numpy>=1.22.4,<2.3.0
 fastavro>=1.1.0,!=1.8.0
 grpcio>=1.29.0,<=1.71.0
 grpcio-tools>=1.29.0,<=1.71.0


### PR DESCRIPTION
Fix github action failed to build python wheel on linux, see more detail on the jira ticket.