### PR TITLE
[FLINK-36663][Window]Fix the first processWatermark has extra data after restore by restore timeService's watermark.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerService.java
@@ -38,6 +38,9 @@ public interface InternalTimerService<N> {
     /** Returns the current event-time watermark. */
     long currentWatermark();
 
+    /** Initialize watermark after restore. */
+    void initializeWatermark(long watermark);
+
     /**
      * Registers a timer to be fired when processing time passes the given time. The namespace you
      * pass here will be provided when the timer fires.

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerServiceImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerServiceImpl.java
@@ -225,6 +225,11 @@ public class InternalTimerServiceImpl<K, N> implements InternalTimerService<N> {
     }
 
     @Override
+    public void initializeWatermark(long watermark) {
+        this.currentWatermark = watermark;
+    }
+
+    @Override
     public void registerProcessingTimeTimer(N namespace, long time) {
         InternalTimer<K, N> oldHead = processingTimeTimersQueue.peek();
         if (processingTimeTimersQueue.add(

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionInternalTimeService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionInternalTimeService.java
@@ -83,6 +83,11 @@ public class BatchExecutionInternalTimeService<K, N> implements InternalTimerSer
     }
 
     @Override
+    public void initializeWatermark(long watermark) {
+        this.currentWatermark = watermark;
+    }
+
+    @Override
     public void registerProcessingTimeTimer(N namespace, long time) {
         // the currentWatermark == Long.MAX_VALUE indicates the timer was registered from the
         // callback

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/TestInternalTimerService.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/TestInternalTimerService.java
@@ -68,6 +68,11 @@ public class TestInternalTimerService<K, N> implements InternalTimerService<N> {
     }
 
     @Override
+    public void initializeWatermark(long watermark) {
+        this.currentWatermark = watermark;
+    }
+
+    @Override
     public void registerProcessingTimeTimer(N namespace, long time) {
         @SuppressWarnings("unchecked")
         Timer<K, N> timer = new Timer<>(time, (K) keyContext.getCurrentKey(), namespace);

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/window/async/tvf/common/AsyncStateWindowAggOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/window/async/tvf/common/AsyncStateWindowAggOperator.java
@@ -116,6 +116,9 @@ public final class AsyncStateWindowAggOperator<K, W> extends AsyncStateTableStre
         internalTimerService =
                 getInternalTimerService(
                         "window-timers", windowProcessor.createWindowSerializer(), this);
+        // Restore the watermark of timerService to prevent expired data from being treated as
+        // not expired when flushWindowBuffer is executed.
+        internalTimerService.initializeWatermark(currentWatermark);
 
         windowProcessor.open(
                 new WindowProcessorAsyncStateContext<>(

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/window/tvf/common/WindowAggOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/window/tvf/common/WindowAggOperator.java
@@ -145,7 +145,9 @@ public final class WindowAggOperator<K, W> extends TableStreamOperator<RowData>
         internalTimerService =
                 getInternalTimerService(
                         "window-timers", windowProcessor.createWindowSerializer(), this);
-
+        // Restore the watermark of timerService to prevent expired data from being treated as
+        // not expired when flushWindowBuffer is executed.
+        internalTimerService.initializeWatermark(currentWatermark);
         windowProcessor.open(
                 new WindowProcessorSyncStateContext<>(
                         getContainingTask(),


### PR DESCRIPTION
## What is the purpose of the change

Restore the currentWatermark of WindowTimerService. If not restored, the slidingWindow will output extra data.

## Brief change log

Restore the currentWatermark of WindowTimerService.


## Verifying this change

This change added tests and can be verified as follows:

  - *Added test that validates whether the hopping window restores the output data consistently.*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no 
  - The runtime per-record code paths (performance sensitive): no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no 
  - The S3 file system connector: no 

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 