### PR TITLE
[hotfix][docs] Update build documentation to require Java 17 

### DIFF
--- a/docs/content.zh/docs/flinkDev/building.md
+++ b/docs/content.zh/docs/flinkDev/building.md
@@ -35,7 +35,7 @@ under the License.
 
 首先需要准备源码。可以[从发布版本下载源码]({{< downloads >}}) 或者[从 Git 库克隆 Flink 源码]({{< github_repo >}})。
 
-还需要准备 **Maven 3.8.6** 和 **JDK** (Java开发套件)。Flink 依赖 **Java 11** 来进行构建。
+还需要准备 **Maven 3.8.6** 和 **JDK** (Java开发套件)。Flink 依赖 **Java 17** 来进行构建。
 
 输入以下命令从 Git 克隆代码
 

--- a/docs/content/docs/flinkDev/building.md
+++ b/docs/content/docs/flinkDev/building.md
@@ -33,7 +33,7 @@ This page covers how to build Flink {{< version >}} from sources.
 
 In order to build Flink you need the source code. Either [download the source of a release]({{< downloads >}}) or [clone the git repository]({{< github_repo >}}).
 
-In addition you need **Maven 3.8.6** and a **JDK** (Java Development Kit). Flink requires **Java 11** to build.
+In addition you need **Maven 3.8.6** and a **JDK** (Java Development Kit). Flink requires **Java 17** to build.
 
 To clone from git, enter:
 


### PR DESCRIPTION
The README correctly states that JDK 17 is the default for building Flink. However, the build instructions in the docs still state Java 11 is required. The default build commands will fail (without the correct profile being set) on Java 11. This PR updates the docs to state Java 17 is required.

## Documentation

  - Does this pull request introduce a new feature? no

