### PR TITLE
[FLINK-34251][core] ClosureCleaner to include reference classes for non-serialization exception

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/ClosureCleaner.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/ClosureCleaner.java
@@ -40,6 +40,8 @@ import java.lang.reflect.Modifier;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Set;
+import java.util.Stack;
+import java.util.stream.Collectors;
 
 /**
  * The closure cleaner is a utility that tries to truncate the closure (enclosing instance) of
@@ -66,14 +68,20 @@ public class ClosureCleaner {
      */
     public static void clean(
             Object func, ExecutionConfig.ClosureCleanerLevel level, boolean checkSerializable) {
-        clean(func, level, checkSerializable, Collections.newSetFromMap(new IdentityHashMap<>()));
+        clean(
+                func,
+                level,
+                checkSerializable,
+                Collections.newSetFromMap(new IdentityHashMap<>()),
+                new Stack<>());
     }
 
     private static void clean(
             Object func,
             ExecutionConfig.ClosureCleanerLevel level,
             boolean checkSerializable,
-            Set<Object> visited) {
+            Set<Object> visited,
+            Stack<Class<?>> clsReferences) {
         if (func == null) {
             return;
         }
@@ -102,6 +110,7 @@ public class ClosureCleaner {
         // be "this$x" depending on the nesting
         boolean closureAccessed = false;
 
+        clsReferences.push(cls);
         for (Field f : cls.getDeclaredFields()) {
             if (f.getName().startsWith("this$")) {
                 // found a closure referencing field - now try to clean
@@ -139,7 +148,8 @@ public class ClosureCleaner {
                             fieldObject,
                             ExecutionConfig.ClosureCleanerLevel.RECURSIVE,
                             true,
-                            visited);
+                            visited,
+                            clsReferences);
                 }
             }
         }
@@ -150,26 +160,32 @@ public class ClosureCleaner {
             } catch (Exception e) {
                 String functionType = getSuperClassOrInterfaceName(func.getClass());
 
-                String msg =
-                        functionType == null
-                                ? (func + " is not serializable.")
-                                : ("The implementation of the "
-                                        + functionType
-                                        + " is not serializable.");
-
+                final StringBuilder msgBuilder =
+                        new StringBuilder()
+                                .append(
+                                        functionType == null
+                                                ? (func + " is not serializable.")
+                                                : ("The implementation of the "
+                                                        + functionType
+                                                        + " is not serializable."))
+                                .append(" Referenced via ")
+                                .append(formatClassReferences(clsReferences));
                 if (closureAccessed) {
-                    msg +=
+                    msgBuilder.append(
                             " The implementation accesses fields of its enclosing class, which is "
                                     + "a common reason for non-serializability. "
                                     + "A common solution is to make the function a proper (non-inner) class, or "
-                                    + "a static inner class.";
+                                    + "a static inner class.");
                 } else {
-                    msg += " The object probably contains or references non serializable fields.";
+                    msgBuilder.append(
+                            " The object probably contains or references non serializable fields.");
                 }
 
-                throw new InvalidProgramException(msg, e);
+                throw new InvalidProgramException(msgBuilder.toString(), e);
             }
         }
+
+        clsReferences.pop();
     }
 
     private static boolean needsRecursion(Field f, Object fo) {
@@ -269,6 +285,12 @@ public class ClosureCleaner {
             }
             return null;
         }
+    }
+
+    private static String formatClassReferences(Stack<Class<?>> clsReferences) {
+        return "["
+                + clsReferences.stream().map(Class::getName).collect(Collectors.joining(" -> "))
+                + "]";
     }
 }
 

--- a/flink-core/src/test/java/org/apache/flink/api/java/ClosureCleanerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/ClosureCleanerTest.java
@@ -30,9 +30,11 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 /** Tests for {@link ClosureCleaner}. */
@@ -131,6 +133,30 @@ class ClosureCleanerTest {
         int result = complexMap.map(3);
 
         assertThat(result).isEqualTo(5);
+    }
+
+    @Test
+    public void testCleanNonSerializableNestedMap() throws Exception {
+        MapFunction<Integer, Integer> complexMap =
+                new ComplexMap(
+                        new MapFunction<>() {
+                            private final Object obj = new Object(); // non-serializable
+
+                            @Override
+                            public Integer map(Integer value) {
+                                return value + obj.hashCode();
+                            }
+                        });
+        try {
+            ClosureCleaner.clean(complexMap, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, true);
+            fail("Should have failed with InvalidProgramException exception");
+        } catch (InvalidProgramException e) {
+            final String msg = e.getMessage();
+            // Verify that the error message contains the reference chain
+            final String regex =
+                    ".*ComplexMap -> .*LocalMap -> .*ClosureCleanerTest.* -> .*Object.*";
+            assertThat(e.getMessage()).matches(Pattern.compile(regex));
+        }
     }
 
     @Test


### PR DESCRIPTION
This is a revised version of the previous (auto-)closed PR #24205
More discussions in the JIRA: https://issues.apache.org/jira/browse/FLINK-34251

## What is the purpose of the change

Currently the ClosureCleaner throws exception if {{checkSerializable} is enabled while some object is non-serializable. It includes the non-serializable (nested) object in the exception in the exception message.

However, when the user job program gets more complex pulling multiple operators each of which pulls multiple 3rd party libraries, it is unclear how the non-serializable object is referenced as some of those objects could be nested in multiple levels. For example, following exception is not straightforward where to check:
```
org.apache.flink.api.common.InvalidProgramException: java.lang.Object@528c868 is not serializable. 
```

It would be nice to include the reference stack in the exception message, as following:
```
org.apache.flink.api.common.InvalidProgramException: java.lang.Object@72437d8d is not serializable.
Referenced via [com.mycompany.myapp.ComplexMap -> com.mycompany.myapp.LocalMap -> 
com.yourcompany.yourapp.YourPojo -> com.hercompany.herapp.Random -> java.lang.Object]
```

## Verifying this change

This change is largely covered by existing tests, and new test case was added to `ClosureCleanerTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
