### PR TITLE
[FLINK-38082][datastream] Avoid unexpected retries when user async function invokes completeExceptionally

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
@@ -118,12 +118,12 @@ public class AsyncWaitOperatorTest {
     @RegisterExtension
     private final SharedObjectsExtension sharedObjects = SharedObjectsExtension.create();
 
-    private static AsyncRetryStrategy emptyResultFixedDelayRetryStrategy =
+    private static final AsyncRetryStrategy emptyResultFixedDelayRetryStrategy =
             new AsyncRetryStrategies.FixedDelayRetryStrategyBuilder(2, 10L)
                     .ifResult(RetryPredicates.EMPTY_RESULT_PREDICATE)
                     .build();
 
-    private static AsyncRetryStrategy exceptionRetryStrategy =
+    private static final AsyncRetryStrategy exceptionRetryStrategy =
             new AsyncRetryStrategies.FixedDelayRetryStrategyBuilder(2, 10L)
                     .ifException(RetryPredicates.HAS_EXCEPTION_PREDICATE)
                     .build();
@@ -1334,6 +1334,50 @@ public class AsyncWaitOperatorTest {
     }
 
     @Test
+    void testProcessingTimeWithAlwaysTimeoutFunctionUnorderedWithRetry() throws Exception {
+        testProcessingTimeAlwaysTimeoutFunction(AsyncDataStream.OutputMode.UNORDERED);
+    }
+
+    @Test
+    void testProcessingTimeWithAlwaysTimeoutFunctionOrderedWithRetry() throws Exception {
+        testProcessingTimeAlwaysTimeoutFunction(AsyncDataStream.OutputMode.ORDERED);
+    }
+
+    private void testProcessingTimeAlwaysTimeoutFunction(AsyncDataStream.OutputMode mode)
+            throws Exception {
+        StreamTaskMailboxTestHarnessBuilder<Integer> builder =
+                new StreamTaskMailboxTestHarnessBuilder<>(
+                                OneInputStreamTask::new, BasicTypeInfo.INT_TYPE_INFO)
+                        .addInput(BasicTypeInfo.INT_TYPE_INFO);
+
+        try (StreamTaskMailboxTestHarness<Integer> testHarness =
+                builder.setupOutputForSingletonOperatorChain(
+                                new AsyncWaitOperatorFactory<Integer, Integer>(
+                                        new AlwaysTimeoutAsyncFunction(),
+                                        TIMEOUT,
+                                        10,
+                                        mode,
+                                        exceptionRetryStrategy))
+                        .build()) {
+
+            final long initialTime = 0L;
+            AtomicReference<Throwable> error = new AtomicReference<>();
+            testHarness.getStreamMockEnvironment().setExternalExceptionHandler(error::set);
+
+            try {
+                testHarness.processElement(new StreamRecord<>(1, initialTime + 1));
+                testHarness.processElement(new StreamRecord<>(2, initialTime + 2));
+                while (error.get() == null) {
+                    testHarness.processAll();
+                }
+            } catch (Exception e) {
+                error.set(e);
+            }
+            ExceptionUtils.assertThrowableWithMessage(error.get(), "Dummy timeout error");
+        }
+    }
+
+    @Test
     public void testProcessingTimeWithMailboxThreadOrdered() throws Exception {
         testProcessingTimeWithCollectFromMailboxThread(
                 AsyncDataStream.OutputMode.ORDERED, NO_RETRY_STRATEGY);
@@ -1557,6 +1601,13 @@ public class AsyncWaitOperatorTest {
         public void timeout(Integer input, ResultFuture<Integer> resultFuture) {
             // collect a default value -1 when timeout
             resultFuture.complete(Collections.singletonList(-1));
+        }
+    }
+
+    private static class AlwaysTimeoutAsyncFunction extends LazyAsyncFunction {
+        @Override
+        public void timeout(Integer input, ResultFuture<Integer> resultFuture) {
+            resultFuture.completeExceptionally(new TimeoutException("Dummy timeout error"));
         }
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
@@ -1623,7 +1623,7 @@ public class AsyncWaitOperatorTest {
 
         @Override
         public void timeout(Integer input, ResultFuture<Integer> resultFuture) {
-            // simulate the use case in https://issues.apache.org/jira/browse/FLINK-38082
+            // simulate the case reported in https://issues.apache.org/jira/browse/FLINK-38082
             resultFuture.completeExceptionally(new TimeoutException("Dummy timeout error"));
         }
     }


### PR DESCRIPTION
## What is the purpose of the change
As discussed in https://lists.apache.org/thread/8gncfyy42cmj6xtyk4fqvpxwf22xk9x5, an issue that unexpected extra retries will be triggered when user async function invoke completeExceptionally in timeout.
We can fix this by adding a start timestamp for future handler to help check if a retry still within configured timeout.

## Brief change log
* adding a start timestamp for future handler to help check if a retry still within configured timeout.

## Verifying this change
newly added test cases:
* testProcessingTimeWithAlwaysTimeoutFunctionUnorderedWithRetry
* testProcessingTimeWithAlwaysTimeoutFunctionOrderedWithRetry

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (no)