### PR TITLE
[BP-2.0][FLINK-38082][datastream] Avoid unexpected retries when user async function invokes completeExceptionally

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
@@ -90,6 +90,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
@@ -112,12 +112,12 @@ class AsyncWaitOperatorTest {
     @RegisterExtension
     private final SharedObjectsExtension sharedObjects = SharedObjectsExtension.create();
 
-    private static AsyncRetryStrategy emptyResultFixedDelayRetryStrategy =
+    private static final AsyncRetryStrategy emptyResultFixedDelayRetryStrategy =
             new AsyncRetryStrategies.FixedDelayRetryStrategyBuilder(2, 10L)
                     .ifResult(RetryPredicates.EMPTY_RESULT_PREDICATE)
                     .build();
 
-    private static AsyncRetryStrategy exceptionRetryStrategy =
+    private static final AsyncRetryStrategy exceptionRetryStrategy =
             new AsyncRetryStrategies.FixedDelayRetryStrategyBuilder(2, 10L)
                     .ifException(RetryPredicates.HAS_EXCEPTION_PREDICATE)
                     .build();
@@ -1324,6 +1324,49 @@ class AsyncWaitOperatorTest {
         }
     }
 
+    @Test
+    void testProcessingTimeWithAlwaysTimeoutFunctionUnorderedWithRetry() throws Exception {
+        testProcessingTimeAlwaysTimeoutFunction(AsyncDataStream.OutputMode.UNORDERED);
+    }
+
+    @Test
+    void testProcessingTimeWithAlwaysTimeoutFunctionOrderedWithRetry() throws Exception {
+        testProcessingTimeAlwaysTimeoutFunction(AsyncDataStream.OutputMode.ORDERED);
+    }
+
+    private void testProcessingTimeAlwaysTimeoutFunction(AsyncDataStream.OutputMode mode)
+            throws Exception {
+        StreamTaskMailboxTestHarnessBuilder<Integer> builder =
+                new StreamTaskMailboxTestHarnessBuilder<>(
+                                OneInputStreamTask::new, BasicTypeInfo.INT_TYPE_INFO)
+                        .addInput(BasicTypeInfo.INT_TYPE_INFO);
+
+        AlwaysTimeoutAsyncFunction asyncFunction = new AlwaysTimeoutAsyncFunction();
+        try (StreamTaskMailboxTestHarness<Integer> testHarness =
+                builder.setupOutputForSingletonOperatorChain(
+                                new AsyncWaitOperatorFactory<Integer, Integer>(
+                                        asyncFunction, TIMEOUT, 10, mode, exceptionRetryStrategy))
+                        .build()) {
+
+            final long initialTime = 0L;
+            AtomicReference<Throwable> error = new AtomicReference<>();
+            testHarness.getStreamMockEnvironment().setExternalExceptionHandler(error::set);
+
+            try {
+                testHarness.processElement(new StreamRecord<>(1, initialTime + 1));
+                testHarness.processElement(new StreamRecord<>(2, initialTime + 2));
+                while (error.get() == null) {
+                    testHarness.processAll();
+                }
+            } catch (Exception e) {
+                error.set(e);
+            }
+            ExceptionUtils.assertThrowableWithMessage(error.get(), "Dummy timeout error");
+            // verify the 1st element's try count is exactly 1
+            assertThat(asyncFunction.getTryCount(1)).isEqualTo(1);
+        }
+    }
+
     private static class CollectableFuturesAsyncFunction<IN> implements AsyncFunction<IN, IN> {
 
         private static final long serialVersionUID = -4214078239227288637L;
@@ -1397,7 +1440,7 @@ class AsyncWaitOperatorTest {
 
         private static final long serialVersionUID = 1L;
 
-        private static Map<Integer, Integer> tryCounts = new HashMap<>();
+        protected static Map<Integer, Integer> tryCounts = new HashMap<>();
 
         @VisibleForTesting
         public int getTryCount(Integer item) {
@@ -1429,6 +1472,31 @@ class AsyncWaitOperatorTest {
         public void timeout(Integer input, ResultFuture<Integer> resultFuture) {
             // collect a default value -1 when timeout
             resultFuture.complete(Collections.singletonList(-1));
+        }
+    }
+
+    private static class AlwaysTimeoutAsyncFunction
+            extends AlwaysTimeoutWithDefaultValueAsyncFunction {
+
+        private final transient CountDownLatch latch = new CountDownLatch(1);
+
+        @Override
+        public void asyncInvoke(Integer input, ResultFuture<Integer> resultFuture) {
+            tryCounts.merge(input, 1, Integer::sum);
+            CompletableFuture.runAsync(
+                    () -> {
+                        try {
+                            latch.await();
+                        } catch (InterruptedException e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+        }
+
+        @Override
+        public void timeout(Integer input, ResultFuture<Integer> resultFuture) {
+            // simulate the case reported in https://issues.apache.org/jira/browse/FLINK-38082
+            resultFuture.completeExceptionally(new TimeoutException("Dummy timeout error"));
         }
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarness.java
@@ -195,4 +195,8 @@ public class StreamTaskMailboxTestHarness<OUT> implements AutoCloseable {
     public TestCheckpointResponder getCheckpointResponder() {
         return (TestCheckpointResponder) taskStateManager.getCheckpointResponder();
     }
+
+    public StreamMockEnvironment getStreamMockEnvironment() {
+        return streamMockEnvironment;
+    }
 }


### PR DESCRIPTION
This is a backport pr to 2.0 branch