### PR TITLE
[FLINK-38103][table] Fix error for inline structured types in DataTypeFactory

### DIFF
--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeDuplicatorTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeDuplicatorTest.java
@@ -29,8 +29,10 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.MultisetType;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.RowType.RowField;
 import org.apache.flink.table.types.logical.SmallIntType;
 import org.apache.flink.table.types.logical.StructuredType;
+import org.apache.flink.table.types.logical.StructuredType.StructuredAttribute;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.types.logical.utils.LogicalTypeDuplicator;
 
@@ -39,7 +41,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
-import java.util.Collections;
+import java.util.List;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -62,7 +64,8 @@ class LogicalTypeDuplicatorTest {
                 Arguments.of(
                         createDistinctType(new IntType()), createDistinctType(new BigIntType())),
                 Arguments.of(createUserType(new IntType()), createUserType(new BigIntType())),
-                Arguments.of(createHumanType(), createHumanType()));
+                Arguments.of(createHumanType(), createHumanType()),
+                Arguments.of(createNonClassType(), createNonClassType()));
     }
 
     @ParameterizedTest(name = "{index}: {0}")
@@ -107,17 +110,15 @@ class LogicalTypeDuplicatorTest {
     private static RowType createRowType(LogicalType replacedType) {
         return new RowType(
                 Arrays.asList(
-                        new RowType.RowField("field1", new CharType(2)),
-                        new RowType.RowField("field2", new BooleanType()),
-                        new RowType.RowField("field3", replacedType)));
+                        new RowField("field1", new CharType(2)),
+                        new RowField("field2", new BooleanType()),
+                        new RowField("field3", replacedType)));
     }
 
     private static StructuredType createHumanType() {
         return StructuredType.newBuilder(ObjectIdentifier.of("cat", "db", "Human"), Human.class)
                 .attributes(
-                        Collections.singletonList(
-                                new StructuredType.StructuredAttribute(
-                                        "name", new VarCharType(), "Description.")))
+                        List.of(new StructuredAttribute("name", new VarCharType(), "Description.")))
                 .description("Human type desc.")
                 .setFinal(false)
                 .setInstantiable(false)
@@ -126,9 +127,7 @@ class LogicalTypeDuplicatorTest {
 
     private static StructuredType createUserType(LogicalType replacedType) {
         return StructuredType.newBuilder(ObjectIdentifier.of("cat", "db", "User"), User.class)
-                .attributes(
-                        Collections.singletonList(
-                                new StructuredType.StructuredAttribute("setting", replacedType)))
+                .attributes(List.of(new StructuredAttribute("setting", replacedType)))
                 .description("User type desc.")
                 .setFinal(false)
                 .setInstantiable(true)
@@ -136,10 +135,18 @@ class LogicalTypeDuplicatorTest {
                 .build();
     }
 
+    private static StructuredType createNonClassType() {
+        return StructuredType.newBuilder("NotInClassPathType")
+                .attributes(List.of(new StructuredAttribute("setting", new BooleanType())))
+                .build();
+    }
+
+    @SuppressWarnings("unused")
     private abstract static class Human {
         public String name;
     }
 
+    @SuppressWarnings("unused")
     private static final class User extends Human {
         public int setting;
     }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalTypeJsonSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalTypeJsonSerdeTest.java
@@ -294,7 +294,7 @@ public class LogicalTypeJsonSerdeTest {
                                                         "f2", new VarCharType(200), "desc")))
                                 .build(),
                         // inline structured type with class name only
-                        StructuredType.newBuilder(PojoClass.class.getName())
+                        StructuredType.newBuilder("NotInClassPathPojo")
                                 .attributes(
                                         Arrays.asList(
                                                 new StructuredAttribute("f0", new IntType(true)),


### PR DESCRIPTION
## What is the purpose of the change

Fixes a problem in `DataTypeFactoryImpl` and structured types where the class is not in the classpath.


## Brief change log

DataTypeFactoryImpl and LogicalTypeDuplicator have been simplified and updated.

## Verifying this change

This change added tests and can be verified.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
