### PR TITLE
[FLINK-38105][python] Change NamespaceAggsHandleFunctionBase.get_accumulators to cpdef

### DIFF
--- a/flink-python/pyflink/fn_execution/table/window_aggregate_fast.pxd
+++ b/flink-python/pyflink/fn_execution/table/window_aggregate_fast.pxd
@@ -25,7 +25,7 @@ cdef class NamespaceAggsHandleFunctionBase:
     cdef void retract(self, InternalRow input_data)
     cpdef void merge(self, object namespace, list accumulators)
     cpdef void set_accumulators(self, object namespace, list accumulators)
-    cdef list get_accumulators(self)
+    cpdef list get_accumulators(self)
     cpdef list create_accumulators(self)
     cpdef void cleanup(self, object namespace)
     cdef void close(self)

--- a/flink-python/pyflink/fn_execution/table/window_aggregate_fast.pyx
+++ b/flink-python/pyflink/fn_execution/table/window_aggregate_fast.pyx
@@ -81,7 +81,7 @@ cdef class NamespaceAggsHandleFunctionBase:
         """
         pass
 
-    cdef list get_accumulators(self):
+    cpdef list get_accumulators(self):
         """
         Gets the current accumulators (saved in a list) which contains the current
         aggregated results.
@@ -287,7 +287,7 @@ cdef class SimpleNamespaceAggsHandleFunction(NamespaceAggsHandleFunction):
                     accumulators[i][index] = data_view
         self._accumulators = accumulators
 
-    cdef list get_accumulators(self):
+    cpdef list get_accumulators(self):
         return self._accumulators
 
     cpdef list create_accumulators(self):


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fixes the issue that get_accumulators could not be found during job start up. As it's called from python script, it should be declared as cpdef instead of cdef. *


## Brief change log

  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
