### PR TITLE
[FLINK-38113][runtime] Rethrow fatal (including OOM) errors in Execution.deploy

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -671,6 +671,7 @@ public class Execution
                             jobMasterMainThreadExecutor);
 
         } catch (Throwable t) {
+            ExceptionUtils.rethrowIfFatalErrorOrOOM(t);
             markFailed(t);
         }
     }


### PR DESCRIPTION
## What is the purpose of the change

This change allows rethrowing fatal or OOM errors that happened during Execution.deploy. It allows to fail fast and improve recovery time.

## Brief change log

Rethrow fatal or OOM errors from Execution.deploy


## Verifying this change
* Trivial change, relying on existing tests. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
