### PR TITLE
[FLINK-37914][table] Add built-in OBJECT_UPDATE function

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -1228,14 +1228,12 @@ valuemodification:
       This function takes a structured object and updates specified fields with new values.
       The keys must be string literals that correspond to existing fields in the structured type.
       If a key does not exist in the input object, an exception will be thrown.
-      If the value type is not compatible with the corresponding structured field type, 
-      an exception will also be thrown.
       
       The function expects alternating key-value pairs where keys are field names (non-null strings) 
       and values are the new values for those fields. At least one key-value pair must be provided.
       The total number of arguments must be odd (object + pairs of key-value arguments).
       
-      The result type is the same structured type as the input, with the specified fields
+      The result type is the same structured type class, with the specified fields
       updated to their new values.
       
       ```sql

--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -1241,11 +1241,11 @@ valuemodification:
       ```sql
       -- Update the 'name' field of a user object
       OBJECT_UPDATE(OBJECT_OF('com.example.User', 'name', 'Bob', 'age', 14), 'name', 'Alice')
-      -- Returns: User{name='Alice', age=14})
+      -- Returns: User{name='Alice', age=14}
       
       -- Update multiple fields
       OBJECT_UPDATE(OBJECT_OF('com.example.User', 'name', 'Bob', 'age', 14), 'name', 'Alice', 'age', 30)
-      -- Returns: User{name='Alice', age=30})
+      -- Returns: User{name='Alice', age=30}
       ```
 
 valueaccess:

--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -1219,6 +1219,35 @@ valueconstruction:
   - table: NUMERIC.rows
     description: Creates a NUMERIC interval of rows (commonly used in window creation).
 
+valuemodification:
+  - sql: OBJECT_UPDATE(object, key, value [, key, value , ...])
+    table: OBJECT.objectUpdate(key, value [, key, value , ...])
+    description: |
+      Updates existing fields in a structured object by providing key-value pairs.
+      
+      This function takes a structured object and updates specified fields with new values.
+      The keys must be string literals that correspond to existing fields in the structured type.
+      If a key does not exist in the input object, an exception will be thrown.
+      If the value type is not compatible with the corresponding structured field type, 
+      an exception will also be thrown.
+      
+      The function expects alternating key-value pairs where keys are field names (non-null strings) 
+      and values are the new values for those fields. At least one key-value pair must be provided.
+      The total number of arguments must be odd (object + pairs of key-value arguments).
+      
+      The result type is the same structured type as the input, with the specified fields
+      updated to their new values.
+      
+      ```sql
+      -- Update the 'name' field of a user object
+      OBJECT_UPDATE(OBJECT_OF('com.example.User', 'name', 'Bob', 'age', 14), 'name', 'Alice')
+      -- Returns: User{name='Alice', age=14})
+      
+      -- Update multiple fields
+      OBJECT_UPDATE(OBJECT_OF('com.example.User', 'name', 'Bob', 'age', 14), 'name', 'Alice', 'age', 30)
+      -- Returns: User{name='Alice', age=30})
+      ```
+
 valueaccess:
   - sql: tableName.compositeType.field
     table: |

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -1301,6 +1301,35 @@ valueconstruction:
   - table: NUMERIC.rows
     description: 创建一个 NUMERIC 行间隔（通常用于窗口创建）。
 
+valuemodification:
+  - sql: OBJECT_UPDATE(object, key, value [, key, value , ...])
+    table: OBJECT.objectUpdate(key, value [, key, value , ...])
+    description: |
+      Updates existing fields in a structured object by providing key-value pairs.
+      
+      This function takes a structured object and updates specified fields with new values.
+      The keys must be string literals that correspond to existing fields in the structured type.
+      If a key does not exist in the input object, an exception will be thrown.
+      If the value type is not compatible with the corresponding structured field type, 
+      an exception will also be thrown.
+      
+      The function expects alternating key-value pairs where keys are field names (non-null strings) 
+      and values are the new values for those fields. At least one key-value pair must be provided.
+      The total number of arguments must be odd (object + pairs of key-value arguments).
+      
+      The result type is the same structured type as the input, with the specified fields
+      updated to their new values.
+      
+      ```sql
+      -- Update the 'name' field of a user object
+      OBJECT_UPDATE(OBJECT_OF('com.example.User', 'name', 'Bob', 'age', 14), 'name', 'Alice')
+      -- Returns: User{name='Alice', age=14})
+      
+      -- Update multiple fields
+      OBJECT_UPDATE(OBJECT_OF('com.example.User', 'name', 'Bob', 'age', 14), 'name', 'Alice', 'age', 30)
+      -- Returns: User{name='Alice', age=30})
+      ```
+
 valueaccess:
   - sql: tableName.compositeType.field
     table: |

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -1323,11 +1323,11 @@ valuemodification:
       ```sql
       -- Update the 'name' field of a user object
       OBJECT_UPDATE(OBJECT_OF('com.example.User', 'name', 'Bob', 'age', 14), 'name', 'Alice')
-      -- Returns: User{name='Alice', age=14})
+      -- Returns: User{name='Alice', age=14}
       
       -- Update multiple fields
       OBJECT_UPDATE(OBJECT_OF('com.example.User', 'name', 'Bob', 'age', 14), 'name', 'Alice', 'age', 30)
-      -- Returns: User{name='Alice', age=30})
+      -- Returns: User{name='Alice', age=30}
       ```
 
 valueaccess:

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -1310,14 +1310,12 @@ valuemodification:
       This function takes a structured object and updates specified fields with new values.
       The keys must be string literals that correspond to existing fields in the structured type.
       If a key does not exist in the input object, an exception will be thrown.
-      If the value type is not compatible with the corresponding structured field type, 
-      an exception will also be thrown.
       
       The function expects alternating key-value pairs where keys are field names (non-null strings) 
       and values are the new values for those fields. At least one key-value pair must be provided.
       The total number of arguments must be odd (object + pairs of key-value arguments).
       
-      The result type is the same structured type as the input, with the specified fields
+      The result type is the same structured type class, with the specified fields
       updated to their new values.
       
       ```sql

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -331,6 +331,6 @@ value modification functions
 .. currentmodule:: pyflink.table.expression
 
 .. autosummary::
-
     :toctree: api/
+
     Expression.object_update

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -324,3 +324,13 @@ JSON functions
     Expression.json_query
     Expression.json_quote
     Expression.json_unquote
+
+value modification functions
+----------------------------
+
+.. currentmodule:: pyflink.table.expression
+
+.. autosummary::
+
+    :toctree: api/
+    Expression.object_update

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -2193,6 +2193,55 @@ class Expression(Generic[T]):
         """
         return _unary_op("jsonUnquote")(self)
 
+    # ---------------------------- value modification functions -----------------------------
+
+    def object_update(self, *kv) -> "Expression":
+        """
+        Updates existing fields in a structured object by providing key-value pairs.
+
+        This function takes a structured object and updates specified fields with new values.
+        The keys must be string literals that correspond to existing fields in the structured type.
+        If a key does not exist in the input object, an exception will be thrown.
+        If the value type is not compatible with the corresponding structured field type,
+        an exception will also be thrown.
+
+        The function expects alternating key-value pairs where keys are field names
+        (non-null strings) and values are the new values for those fields.
+        At least one key-value pair must be provided.
+        The total number of arguments must be odd (object + pairs of key-value arguments).
+
+        The result type is the same structured type as the input, with the specified fields
+        updated to their new values.
+
+        Example:
+        ::
+
+            >>> # Update the 'name' field of a user object
+            >>> user_obj.object_update("name", "Alice")
+            >>> # Returns an updated user object with 'name' set to "Alice"
+            >>>
+            >>> # Update multiple fields
+            >>> user_obj.object_update("name", "Alice", "age", 30)
+            >>> # Returns an updated user object with 'name' set to "Alice" and 'age' set to 30
+
+        The result type is the same structured type as the input, with the specified
+        fields updated to their new values.
+
+        :param kv: key-value pairs where even-indexed elements are field names
+                   (strings) and odd-indexed elements are the new values for those
+                   fields
+        :return: expression representing the updated structured type with modified
+                 field values
+        """
+        gateway = get_gateway()
+        ApiExpressionUtils = (
+            gateway.jvm.org.apache.flink.table.expressions.ApiExpressionUtils
+        )
+        exprs = [
+            ApiExpressionUtils.objectToExpression(_get_java_expression(e)) for e in kv
+        ]
+        return _binary_op("objectUpdate")(self, to_jarray(gateway.jvm.Object, exprs))
+
 
 # add the docs
 _make_math_log_doc()

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -2202,15 +2202,13 @@ class Expression(Generic[T]):
         This function takes a structured object and updates specified fields with new values.
         The keys must be string literals that correspond to existing fields in the structured type.
         If a key does not exist in the input object, an exception will be thrown.
-        If the value type is not compatible with the corresponding structured field type,
-        an exception will also be thrown.
 
         The function expects alternating key-value pairs where keys are field names
         (non-null strings) and values are the new values for those fields.
         At least one key-value pair must be provided.
         The total number of arguments must be odd (object + pairs of key-value arguments).
 
-        The result type is the same structured type as the input, with the specified fields
+        The result type is the same structured class, with the specified fields
         updated to their new values.
 
         Example:
@@ -2224,7 +2222,7 @@ class Expression(Generic[T]):
             >>> user_obj.object_update("name", "Alice", "age", 30)
             >>> # Returns an updated user object with 'name' set to "Alice" and 'age' set to 30
 
-        The result type is the same structured type as the input, with the specified
+        The result type is the same structured type class, with the specified
         fields updated to their new values.
 
         :param kv: key-value pairs where even-indexed elements are field names

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -2233,14 +2233,7 @@ class Expression(Generic[T]):
         :return: expression representing the updated structured type with modified
                  field values
         """
-        gateway = get_gateway()
-        ApiExpressionUtils = (
-            gateway.jvm.org.apache.flink.table.expressions.ApiExpressionUtils
-        )
-        exprs = [
-            ApiExpressionUtils.objectToExpression(_get_java_expression(e)) for e in kv
-        ]
-        return _binary_op("objectUpdate")(self, to_jarray(gateway.jvm.Object, exprs))
+        return _varargs_op("objectUpdate")(self, *kv)
 
 
 # add the docs

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -2502,27 +2502,12 @@ public abstract class BaseExpressions<InType, OutType> {
      * strings) and values are the new values for those fields. At least one key-value pair must be
      * provided.
      *
-     * <p>Example usage:
-     *
-     * <pre>{@code
-     * // Create a structured object representing a user
-     * User userObject = objectOf("com.example.User", "name", "Bob", "age", 25);
-     *
-     * // Update the 'name' field of a user object
-     * User updatedUser1 = userObject.objectUpdate("name", "Alice")
-     *
-     * // Update multiple fields
-     * User updatedUser2 = userObject.objectUpdate("name", "Alice", "age", 30)
-     *
-     * }</pre>
-     *
      * <p>The result type is the same structured type as the input, with the specified fields
      * updated to their new values.
      *
      * @param kv key-value pairs where even-indexed elements are field names (strings) and
      *     odd-indexed elements are the new values for those fields
      * @return expression representing a new structured object with updated field values
-     * @see org.apache.flink.table.functions.BuiltInFunctionDefinitions#OBJECT_UPDATE
      */
     public OutType objectUpdate(InType... kv) {
         final Expression[] expressions =

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -148,6 +148,7 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.MOD;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.NOT;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.NOT_BETWEEN;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.NOT_EQUALS;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.OBJECT_UPDATE;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.OR;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ORDER_ASC;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ORDER_DESC;
@@ -2487,5 +2488,49 @@ public abstract class BaseExpressions<InType, OutType> {
                         toExpr(),
                         objectToExpression(percentage),
                         objectToExpression(frequency)));
+    }
+
+    /**
+     * Updates existing fields in a structured object by providing key-value pairs.
+     *
+     * <p>This function takes a structured object and updates specified fields with new values. The
+     * keys must be string literals that correspond to existing fields in the structured type. If a
+     * key does not exist in the input object, an exception will be thrown. If the value type is not
+     * compatible with the corresponding structured field type, an exception will also be thrown.
+     *
+     * <p>The function expects alternating key-value pairs where keys are field names (non-null
+     * strings) and values are the new values for those fields. At least one key-value pair must be
+     * provided.
+     *
+     * <p>Example usage:
+     *
+     * <pre>{@code
+     * // Create a structured object representing a user
+     * User userObject = objectOf("com.example.User", "name", "Bob", "age", 25);
+     *
+     * // Update the 'name' field of a user object
+     * User updatedUser1 = userObject.objectUpdate("name", "Alice")
+     *
+     * // Update multiple fields
+     * User updatedUser2 = userObject.objectUpdate("name", "Alice", "age", 30)
+     *
+     * }</pre>
+     *
+     * <p>The result type is the same structured type as the input, with the specified fields
+     * updated to their new values.
+     *
+     * @param kv key-value pairs where even-indexed elements are field names (strings) and
+     *     odd-indexed elements are the new values for those fields
+     * @return expression representing a new structured object with updated field values
+     * @see org.apache.flink.table.functions.BuiltInFunctionDefinitions#OBJECT_UPDATE
+     */
+    public OutType objectUpdate(InType... kv) {
+        final Expression[] expressions =
+                Stream.concat(
+                                Stream.of(toExpr()),
+                                Stream.of(kv).map(ApiExpressionUtils::objectToExpression))
+                        .toArray(Expression[]::new);
+        return toApiSpecificExpression(
+                ApiExpressionUtils.unresolvedCall(OBJECT_UPDATE, expressions));
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -2495,15 +2495,14 @@ public abstract class BaseExpressions<InType, OutType> {
      *
      * <p>This function takes a structured object and updates specified fields with new values. The
      * keys must be string literals that correspond to existing fields in the structured type. If a
-     * key does not exist in the input object, an exception will be thrown. If the value type is not
-     * compatible with the corresponding structured field type, an exception will also be thrown.
+     * key does not exist in the input object, an exception will be thrown.
      *
      * <p>The function expects alternating key-value pairs where keys are field names (non-null
      * strings) and values are the new values for those fields. At least one key-value pair must be
      * provided.
      *
-     * <p>The result type is the same structured type as the input, with the specified fields
-     * updated to their new values.
+     * <p>The result type is the same structured type class, with the specified fields updated to
+     * their new values.
      *
      * @param kv key-value pairs where even-indexed elements are field names (strings) and
      *     odd-indexed elements are the new values for those fields

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -1628,6 +1628,16 @@ public final class BuiltInFunctionDefinitions {
                             "org.apache.flink.table.runtime.functions.scalar.ObjectOfFunction")
                     .build();
 
+    public static final BuiltInFunctionDefinition OBJECT_UPDATE =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("OBJECT_UPDATE")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(SpecificInputTypeStrategies.OBJECT_UPDATE)
+                    .outputTypeStrategy(SpecificTypeStrategies.OBJECT_UPDATE)
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.scalar.ObjectUpdateFunction")
+                    .build();
+
     // --------------------------------------------------------------------------------------------
     // Math functions
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ObjectUpdateInputTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ObjectUpdateInputTypeStrategy.java
@@ -53,7 +53,6 @@ import java.util.stream.Collectors;
  *   <li>Validates that key arguments are non-null string literals
  *   <li>Ensures field names are not repeated in the key-value pairs
  *   <li>Ensures field names are part of the structured type's attributes
- *   <li>Ensures field values match the expected types defined in the structured type
  * </ul>
  *
  * <p>The expected signature is: {@code OBJECT_UPDATE(object, key1, value1, key2, value2, ...)}
@@ -103,17 +102,16 @@ public class ObjectUpdateInputTypeStrategy implements InputTypeStrategy {
                                         StructuredAttribute::getType));
 
         for (int i = 1; i < argumentDataTypes.size(); i += 2) {
-            final String keyName =
-                    validateFieldNameArgument(
-                            callContext,
-                            argumentDataTypes,
-                            i,
-                            structuredTypeAttributeNameToLogicalType,
-                            fieldNames);
+            validateFieldNameArgument(
+                    callContext,
+                    argumentDataTypes,
+                    i,
+                    structuredTypeAttributeNameToLogicalType,
+                    fieldNames);
         }
     }
 
-    private static String validateFieldNameArgument(
+    private static void validateFieldNameArgument(
             final CallContext callContext,
             final List<DataType> argumentDataTypes,
             final int pos,
@@ -156,8 +154,6 @@ public class ObjectUpdateInputTypeStrategy implements InputTypeStrategy {
                             fieldName, pos + 1, attributes.keySet());
             throw new ValidationException(message);
         }
-
-        return fieldName;
     }
 
     @Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ObjectUpdateInputTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ObjectUpdateInputTypeStrategy.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.types.inference.strategies;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.FunctionDefinition;
@@ -50,7 +49,7 @@ import java.util.stream.Collectors;
  *
  * <ul>
  *   <li>Ensures the function has an odd number of arguments (at least 3)
- *   <li>Validates the first argument is a non-null structured type
+ *   <li>Validates the first argument is a structured type
  *   <li>Validates that key arguments are non-null string literals
  *   <li>Ensures field names are not repeated in the key-value pairs
  *   <li>Ensures field names are part of the structured type's attributes
@@ -111,9 +110,6 @@ public class ObjectUpdateInputTypeStrategy implements InputTypeStrategy {
                             i,
                             structuredTypeAttributeNameToLogicalType,
                             fieldNames);
-
-            validateValueArgument(
-                    argumentDataTypes, i + 1, structuredTypeAttributeNameToLogicalType, keyName);
         }
     }
 
@@ -162,32 +158,6 @@ public class ObjectUpdateInputTypeStrategy implements InputTypeStrategy {
         }
 
         return fieldName;
-    }
-
-    private static void validateValueArgument(
-            final List<DataType> argumentDataTypes,
-            final int pos,
-            final Map<String, LogicalType> structuredTypeAttributes,
-            final String keyNameToBeUpdated) {
-        final DataType argumentValueDataType = argumentDataTypes.get(pos);
-        final LogicalType argumentValueLogicalType = argumentValueDataType.getLogicalType();
-
-        final LogicalType expectedType = structuredTypeAttributes.get(keyNameToBeUpdated);
-        final DataType expectedDataType = DataTypes.of(expectedType);
-
-        // Validate that the updated value type matches the expected type
-        if (!argumentValueLogicalType
-                .getDefaultConversion()
-                .equals(expectedDataType.getConversionClass())) {
-            final String message =
-                    String.format(
-                            "The value type for field '%s' at position %d is expected to be %s, but was %s.",
-                            keyNameToBeUpdated,
-                            pos + 1,
-                            expectedType.asSummaryString(),
-                            argumentValueDataType.getLogicalType().asSummaryString());
-            throw new ValidationException(message);
-        }
     }
 
     @Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ObjectUpdateInputTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ObjectUpdateInputTypeStrategy.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference.strategies;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.ArgumentCount;
+import org.apache.flink.table.types.inference.CallContext;
+import org.apache.flink.table.types.inference.InputTypeStrategy;
+import org.apache.flink.table.types.inference.Signature;
+import org.apache.flink.table.types.inference.Signature.Argument;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeFamily;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.StructuredType;
+import org.apache.flink.table.types.logical.StructuredType.StructuredAttribute;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Input type strategy for the {@link BuiltInFunctionDefinitions#OBJECT_UPDATE} function.
+ *
+ * <p>This strategy validates the input arguments for updating existing fields in a structured type:
+ *
+ * <ul>
+ *   <li>Ensures the function has an odd number of arguments (at least 3)
+ *   <li>Validates the first argument is a non-null structured type
+ *   <li>Validates that key arguments are non-null string literals
+ *   <li>Ensures field names are not repeated in the key-value pairs
+ *   <li>Ensures field names are part of the structured type's attributes
+ *   <li>Ensures field values match the expected types defined in the structured type
+ * </ul>
+ *
+ * <p>The expected signature is: {@code OBJECT_UPDATE(object, key1, value1, key2, value2, ...)}
+ */
+@Internal
+public class ObjectUpdateInputTypeStrategy implements InputTypeStrategy {
+
+    private static final ArgumentCount AT_LEAST_THREE_AND_ODD =
+            new ArgumentCount() {
+                @Override
+                public boolean isValidCount(final int count) {
+                    return count % 2 == 1;
+                }
+
+                @Override
+                public Optional<Integer> getMinCount() {
+                    return Optional.of(3);
+                }
+
+                @Override
+                public Optional<Integer> getMaxCount() {
+                    return Optional.empty();
+                }
+            };
+
+    private static StructuredType validateObjectArgument(final DataType firstArgumentType) {
+        final LogicalType firstArgumentLogicalType = firstArgumentType.getLogicalType();
+        if (!firstArgumentLogicalType.is(LogicalTypeRoot.STRUCTURED_TYPE)) {
+            throw new ValidationException(
+                    String.format(
+                            "The first argument must be a structured type, but was %s.",
+                            firstArgumentLogicalType));
+        }
+        return (StructuredType) firstArgumentLogicalType;
+    }
+
+    private static void validateKeyValueArguments(
+            final CallContext callContext,
+            final List<DataType> argumentDataTypes,
+            final StructuredType structuredType) {
+        final Set<String> fieldNames = new HashSet<>();
+        final Map<String, LogicalType> structuredTypeAttributeNameToLogicalType =
+                structuredType.getAttributes().stream()
+                        .collect(
+                                Collectors.toMap(
+                                        StructuredAttribute::getName,
+                                        StructuredAttribute::getType));
+
+        for (int i = 1; i < argumentDataTypes.size(); i += 2) {
+            final String keyName =
+                    validateFieldNameArgument(
+                            callContext,
+                            argumentDataTypes,
+                            i,
+                            structuredTypeAttributeNameToLogicalType,
+                            fieldNames);
+
+            validateValueArgument(
+                    argumentDataTypes, i + 1, structuredTypeAttributeNameToLogicalType, keyName);
+        }
+    }
+
+    private static String validateFieldNameArgument(
+            final CallContext callContext,
+            final List<DataType> argumentDataTypes,
+            final int pos,
+            final Map<String, LogicalType> attributes,
+            final Set<String> fieldNames) {
+        final LogicalType fieldNameLogicalType = argumentDataTypes.get(pos).getLogicalType();
+        if (!fieldNameLogicalType.is(LogicalTypeFamily.CHARACTER_STRING)) {
+            final String message =
+                    String.format(
+                            "The field key at position %d must be a non-null character string, but was %s.",
+                            pos + 1, fieldNameLogicalType.asSummaryString());
+            throw new ValidationException(message);
+        }
+
+        final String fieldName =
+                callContext
+                        .getArgumentValue(pos, String.class)
+                        .orElseThrow(
+                                () -> {
+                                    final String message =
+                                            String.format(
+                                                    "The field key at position %d must be a non-null character string literal.",
+                                                    pos + 1);
+                                    return new ValidationException(message);
+                                });
+
+        // validate that the field name is not repeated
+        if (!fieldNames.add(fieldName)) {
+            final String message =
+                    String.format(
+                            "The field name '%s' at position %d is repeated.", fieldName, pos + 1);
+            throw new ValidationException(message);
+        }
+
+        // validate that the field name is part of the structured type attributes
+        if (!attributes.containsKey(fieldName)) {
+            final String message =
+                    String.format(
+                            "The field name '%s' at position %d is not part of the structured type attributes. Available attributes: %s.",
+                            fieldName, pos + 1, attributes.keySet());
+            throw new ValidationException(message);
+        }
+
+        return fieldName;
+    }
+
+    private static void validateValueArgument(
+            final List<DataType> argumentDataTypes,
+            final int pos,
+            final Map<String, LogicalType> structuredTypeAttributes,
+            final String keyNameToBeUpdated) {
+        final DataType argumentValueDataType = argumentDataTypes.get(pos);
+        final LogicalType argumentValueLogicalType = argumentValueDataType.getLogicalType();
+
+        final LogicalType expectedType = structuredTypeAttributes.get(keyNameToBeUpdated);
+        final DataType expectedDataType = DataTypes.of(expectedType);
+
+        // Validate that the updated value type matches the expected type
+        if (!argumentValueLogicalType
+                .getDefaultConversion()
+                .equals(expectedDataType.getConversionClass())) {
+            final String message =
+                    String.format(
+                            "The value type for field '%s' at position %d is expected to be %s, but was %s.",
+                            keyNameToBeUpdated,
+                            pos + 1,
+                            expectedType.asSummaryString(),
+                            argumentValueDataType.getLogicalType().asSummaryString());
+            throw new ValidationException(message);
+        }
+    }
+
+    @Override
+    public ArgumentCount getArgumentCount() {
+        return AT_LEAST_THREE_AND_ODD;
+    }
+
+    @Override
+    public Optional<List<DataType>> inferInputTypes(
+            final CallContext callContext, final boolean throwOnFailure) {
+        final List<DataType> argumentDataTypes = callContext.getArgumentDataTypes();
+        try {
+            final DataType firstArgumentType = argumentDataTypes.get(0);
+            final StructuredType structuredType = validateObjectArgument(firstArgumentType);
+            validateKeyValueArguments(callContext, argumentDataTypes, structuredType);
+        } catch (ValidationException e) {
+            return callContext.fail(throwOnFailure, e.getMessage());
+        }
+
+        return Optional.of(argumentDataTypes);
+    }
+
+    @Override
+    public List<Signature> getExpectedSignatures(final FunctionDefinition definition) {
+        // OBJECT_UPDATE expects: object, key1, value1, key2, value2, ...
+        // OBJECT_UPDATE(<object>, <key>, <value> [, <key>, <value> , ...] )
+        final List<Signature.Argument> arguments = new ArrayList<>();
+
+        // object (required)
+        final Argument classArgument = Argument.of("object", "STRUCTURED_TYPE");
+        arguments.add(classArgument);
+
+        // Key-value pairs (at least on pair, repeating)
+        arguments.add(Signature.Argument.ofVarying("[STRING, ANY]+"));
+
+        return List.of(Signature.of(arguments));
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ObjectUpdateTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ObjectUpdateTypeStrategy.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference.strategies;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.DataTypes.Field;
+import org.apache.flink.table.catalog.DataTypeFactory;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.CallContext;
+import org.apache.flink.table.types.inference.TypeStrategy;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.StructuredType;
+import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
+import org.apache.flink.table.types.utils.TypeConversions;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Type strategy for the {@link BuiltInFunctionDefinitions#OBJECT_UPDATE} function.
+ *
+ * <p>This strategy infers the return type for the OBJECT_UPDATE function by:
+ *
+ * <ul>
+ *   <li>Extracting the field definitions from the input structured type
+ *   <li>Resolving the class from the structured type
+ *   <li>
+ *   <li>Creating a new structured type with the same class but updating field types to match the
+ *       types of the new values being assigned
+ * </ul>
+ *
+ * <p>The return type preserves the original class and field names but may have different field
+ * types than the input structured type, as field types are updated to match the types of the values
+ * being assigned during the update operation.
+ */
+@Internal
+public class ObjectUpdateTypeStrategy implements TypeStrategy {
+
+    private static Class<?> extractClass(
+            final CallContext callContext, final StructuredType structuredType) {
+        final DataTypeFactory dataTypeFactory = callContext.getDataTypeFactory();
+        final ClassLoader classLoader = dataTypeFactory.getClassLoader();
+        String className = structuredType.getClassName().orElseThrow(IllegalStateException::new);
+
+        return StructuredType.resolveClass(classLoader, className)
+                .orElseThrow(IllegalStateException::new);
+    }
+
+    private static Field[] extractFields(
+            final CallContext callContext,
+            final List<DataType> argumentDataTypes,
+            final StructuredType structuredType) {
+        final List<String> existingFieldNames = LogicalTypeChecks.getFieldNames(structuredType);
+        final List<LogicalType> existingFieldTypes =
+                LogicalTypeChecks.getFieldTypes(structuredType);
+
+        final Map<String, LogicalType> fieldNameToTypeIndex =
+                IntStream.range(0, existingFieldNames.size())
+                        .boxed()
+                        .collect(
+                                Collectors.toMap(existingFieldNames::get, existingFieldTypes::get));
+
+        for (int i = 1; i < argumentDataTypes.size(); i += 2) {
+            final String fieldNameToBeUpdated =
+                    callContext
+                            .getArgumentValue(i, String.class)
+                            .orElseThrow(IllegalStateException::new);
+
+            final LogicalType valueDataTypeToBeUpdated =
+                    argumentDataTypes.get(i + 1).getLogicalType();
+
+            final LogicalType valueLogicalType = fieldNameToTypeIndex.get(fieldNameToBeUpdated);
+
+            if (!valueDataTypeToBeUpdated.equals(valueLogicalType)) {
+                fieldNameToTypeIndex.put(fieldNameToBeUpdated, valueDataTypeToBeUpdated);
+            }
+        }
+
+        return fieldNameToTypeIndex.entrySet().stream()
+                .map(e -> toFieldType(e.getKey(), e.getValue()))
+                .toArray(Field[]::new);
+    }
+
+    private static Field toFieldType(final String name, final LogicalType logicalType) {
+        return DataTypes.FIELD(name, TypeConversions.fromLogicalToDataType(logicalType));
+    }
+
+    @Override
+    public Optional<DataType> inferType(final CallContext callContext) {
+        final List<DataType> argumentDataTypes = callContext.getArgumentDataTypes();
+        final DataType firstArgumentDataType = argumentDataTypes.get(0);
+        final StructuredType structuredType =
+                (StructuredType) firstArgumentDataType.getLogicalType();
+
+        final Class<?> resolveClass = extractClass(callContext, structuredType);
+        final Field[] fields = extractFields(callContext, argumentDataTypes, structuredType);
+
+        return Optional.of(DataTypes.STRUCTURED(resolveClass, fields));
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ObjectUpdateTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ObjectUpdateTypeStrategy.java
@@ -43,7 +43,6 @@ import java.util.stream.IntStream;
  *
  * <ul>
  *   <li>Extracting the field definitions from the input structured type
- *   <li>Resolving the class from the structured type
  *   <li>Creating a new structured type with the same class but updating field types to match the
  *       types of the new values being assigned
  * </ul>

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificInputTypeStrategies.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificInputTypeStrategies.java
@@ -66,6 +66,9 @@ public final class SpecificInputTypeStrategies {
     /** See {@link ObjectOfInputTypeStrategy}. */
     public static final InputTypeStrategy OBJECT_OF = new ObjectOfInputTypeStrategy();
 
+    /** See {@link ObjectUpdateInputTypeStrategy}. */
+    public static final InputTypeStrategy OBJECT_UPDATE = new ObjectUpdateInputTypeStrategy();
+
     /** See {@link WindowTimeIndictorInputTypeStrategy}. */
     public static InputTypeStrategy windowTimeIndicator(TimestampKind timestampKind) {
         return new WindowTimeIndictorInputTypeStrategy(timestampKind);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificTypeStrategies.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificTypeStrategies.java
@@ -191,6 +191,9 @@ public final class SpecificTypeStrategies {
     /** Type strategy specific for {@link BuiltInFunctionDefinitions#OBJECT_OF}. */
     public static final TypeStrategy OBJECT_OF = new ObjectOfTypeStrategy();
 
+    /** Type strategy specific for {@link BuiltInFunctionDefinitions#OBJECT_UPDATE}. */
+    public static final TypeStrategy OBJECT_UPDATE = new ObjectUpdateTypeStrategy();
+
     private SpecificTypeStrategies() {
         // no instantiation
     }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/strategies/ObjectUpdateInputTypeStrategyTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/strategies/ObjectUpdateInputTypeStrategyTest.java
@@ -125,16 +125,6 @@ class ObjectUpdateInputTypeStrategyTest extends InputTypeStrategiesTestBase {
                         .calledWithLiteralAt(1, "someRandomFieldName")
                         .calledWithLiteralAt(2, 42)
                         .expectErrorMessage(
-                                "The field name 'someRandomFieldName' at position 2 is not part of the structured type attributes. Available attributes: [name, age]."),
-                // Invalid test case - field value is not compatible with the structured type
-                TestSpec.forStrategy(
-                                "Invalid OBJECT_UPDATE with field value not compatible with structured type",
-                                OBJECT_UPDATE_INPUT_STRATEGY)
-                        .calledWithArgumentTypes(
-                                STRUCTURED_TYPE, DataTypes.STRING().notNull(), DataTypes.BOOLEAN())
-                        .calledWithLiteralAt(1, "name")
-                        .calledWithLiteralAt(2, true)
-                        .expectErrorMessage(
-                                "The value type for field 'name' at position 3 is expected to be STRING, but was BOOLEAN."));
+                                "The field name 'someRandomFieldName' at position 2 is not part of the structured type attributes. Available attributes: [name, age]."));
     }
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/strategies/ObjectUpdateInputTypeStrategyTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/strategies/ObjectUpdateInputTypeStrategyTest.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference.strategies;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.InputTypeStrategiesTestBase;
+import org.apache.flink.table.types.inference.InputTypeStrategy;
+import org.apache.flink.table.types.utils.DataTypeFactoryMock;
+
+import java.util.stream.Stream;
+
+/** Tests for {@link ObjectUpdateInputTypeStrategy}. */
+class ObjectUpdateInputTypeStrategyTest extends InputTypeStrategiesTestBase {
+
+    private static final InputTypeStrategy OBJECT_UPDATE_INPUT_STRATEGY =
+            BuiltInFunctionDefinitions.OBJECT_UPDATE
+                    .getTypeInference(new DataTypeFactoryMock())
+                    .getInputTypeStrategy();
+
+    private static final String USER_CLASS_PATH = "com.example.User";
+
+    private static final DataType STRUCTURED_TYPE =
+            DataTypes.STRUCTURED(
+                            USER_CLASS_PATH,
+                            DataTypes.FIELD("name", DataTypes.STRING()),
+                            DataTypes.FIELD("age", DataTypes.INT()))
+                    .notNull();
+
+    @Override
+    protected Stream<TestSpec> testData() {
+        return Stream.of(
+                // Test valid OBJECT_UPDATE with a pair of key-value arguments
+                TestSpec.forStrategy(
+                                "Valid OBJECT_UPDATE with a pair of key-value arguments",
+                                OBJECT_UPDATE_INPUT_STRATEGY)
+                        .calledWithArgumentTypes(
+                                STRUCTURED_TYPE, DataTypes.STRING().notNull(), DataTypes.INT())
+                        .calledWithLiteralAt(1, "age")
+                        .calledWithLiteralAt(2, 14)
+                        .expectSignature("f(object STRUCTURED_TYPE, [STRING, ANY]+...)")
+                        .expectArgumentTypes(
+                                STRUCTURED_TYPE, DataTypes.STRING().notNull(), DataTypes.INT()),
+                // Test valid OBJECT_UPDATE with multiple pair of key-value arguments
+                TestSpec.forStrategy(
+                                "Valid OBJECT_UPDATE with multiple pair of key-value arguments",
+                                OBJECT_UPDATE_INPUT_STRATEGY)
+                        .calledWithArgumentTypes(
+                                STRUCTURED_TYPE,
+                                DataTypes.STRING().notNull(),
+                                DataTypes.STRING(),
+                                DataTypes.STRING().notNull(),
+                                DataTypes.INT())
+                        .calledWithLiteralAt(1, "name")
+                        .calledWithLiteralAt(2, "Alice")
+                        .calledWithLiteralAt(3, "age")
+                        .calledWithLiteralAt(4, 14)
+                        .expectArgumentTypes(
+                                STRUCTURED_TYPE,
+                                DataTypes.STRING().notNull(),
+                                DataTypes.STRING(),
+                                DataTypes.STRING().notNull(),
+                                DataTypes.INT()),
+                // Invalid test case - only one argument passed
+                TestSpec.forStrategy(
+                                "Invalid OBJECT_UPDATE with only one argument",
+                                OBJECT_UPDATE_INPUT_STRATEGY)
+                        .calledWithArgumentTypes(STRUCTURED_TYPE)
+                        .expectErrorMessage(
+                                "Invalid number of arguments. At least 3 arguments expected but 1 passed."),
+                // Invalid test case - only two arguments passed
+                TestSpec.forStrategy(
+                                "Invalid OBJECT_UPDATE with only two arguments",
+                                OBJECT_UPDATE_INPUT_STRATEGY)
+                        .calledWithArgumentTypes(STRUCTURED_TYPE, DataTypes.STRING().notNull())
+                        .expectErrorMessage(
+                                "Invalid number of arguments. At least 3 arguments expected but 2 passed."),
+                // Invalid test case - field key is null
+                TestSpec.forStrategy(
+                                "Invalid OBJECT_UPDATE with field key as null",
+                                OBJECT_UPDATE_INPUT_STRATEGY)
+                        .calledWithArgumentTypes(
+                                STRUCTURED_TYPE, DataTypes.STRING(), DataTypes.INT())
+                        .calledWithLiteralAt(1, null)
+                        .expectErrorMessage(
+                                "The field key at position 2 must be a non-null character string literal."),
+                // Invalid test case - field key is repeated
+                TestSpec.forStrategy(
+                                "Invalid OBJECT_UPDATE with field repeated",
+                                OBJECT_UPDATE_INPUT_STRATEGY)
+                        .calledWithArgumentTypes(
+                                STRUCTURED_TYPE,
+                                DataTypes.STRING().notNull(),
+                                DataTypes.INT(),
+                                DataTypes.STRING().notNull(),
+                                DataTypes.INT())
+                        .calledWithLiteralAt(1, "age")
+                        .calledWithLiteralAt(2, 42)
+                        .calledWithLiteralAt(3, "age") // Repeated field key
+                        .calledWithLiteralAt(4, 14)
+                        .expectErrorMessage("The field name 'age' at position 4 is repeated."),
+                // Invalid test case - field key is not present in the structured type
+                TestSpec.forStrategy(
+                                "Invalid OBJECT_UPDATE with field invalid field name",
+                                OBJECT_UPDATE_INPUT_STRATEGY)
+                        .calledWithArgumentTypes(
+                                STRUCTURED_TYPE, DataTypes.STRING().notNull(), DataTypes.INT())
+                        .calledWithLiteralAt(1, "someRandomFieldName")
+                        .calledWithLiteralAt(2, 42)
+                        .expectErrorMessage(
+                                "The field name 'someRandomFieldName' at position 2 is not part of the structured type attributes. Available attributes: [name, age]."),
+                // Invalid test case - field value is not compatible with the structured type
+                TestSpec.forStrategy(
+                                "Invalid OBJECT_UPDATE with field value not compatible with structured type",
+                                OBJECT_UPDATE_INPUT_STRATEGY)
+                        .calledWithArgumentTypes(
+                                STRUCTURED_TYPE, DataTypes.STRING().notNull(), DataTypes.BOOLEAN())
+                        .calledWithLiteralAt(1, "name")
+                        .calledWithLiteralAt(2, true)
+                        .expectErrorMessage(
+                                "The value type for field 'name' at position 3 is expected to be STRING, but was BOOLEAN."));
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StructuredFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StructuredFunctionsITCase.java
@@ -289,6 +289,16 @@ public class StructuredFunctionsITCase extends BuiltInFunctionTestBase {
                                         Type1.class.getName(),
                                         DataTypes.FIELD("a", DataTypes.INT().notNull()),
                                         DataTypes.FIELD("b", DataTypes.STRING())))
+                        // Test first argument is null
+                        .testSqlResult(
+                                "OBJECT_UPDATE(CAST(NULL AS STRUCTURED<'"
+                                        + Type1.class.getName()
+                                        + "', a INT, b STRING>), 'a', 16, 'b', 'Alice')",
+                                null,
+                                DataTypes.STRUCTURED(
+                                        Type1.class.getName(),
+                                        DataTypes.FIELD("a", DataTypes.INT().notNull()),
+                                        DataTypes.FIELD("b", DataTypes.CHAR(5).notNull())))
                         // Invalid Test - name of the field to update is not in the structured type
                         .testSqlValidationError(
                                 "OBJECT_UPDATE(OBJECT_OF('"

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StructuredFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StructuredFunctionsITCase.java
@@ -269,6 +269,14 @@ public class StructuredFunctionsITCase extends BuiltInFunctionTestBase {
                                                         Type2.class.getName(),
                                                         DataTypes.FIELD("a", DataTypes.INT()),
                                                         DataTypes.FIELD("b", DataTypes.STRING())))))
+                        // Test when class not found
+                        .testSqlResult(
+                                "OBJECT_UPDATE(OBJECT_OF('not.existing.clazz', 'a', 42, 'b', 'Bob'), 'b', 'Alice')",
+                                Row.of(42, "Alice"),
+                                DataTypes.STRUCTURED(
+                                        "not.existing.clazz",
+                                        DataTypes.FIELD("a", DataTypes.INT().notNull()),
+                                        DataTypes.FIELD("b", DataTypes.CHAR(5).notNull())))
                         // Test update field to null
                         .testResult(
                                 objectOf(Type1.class, "a", 42, "b", "Bob")
@@ -286,13 +294,7 @@ public class StructuredFunctionsITCase extends BuiltInFunctionTestBase {
                                 "OBJECT_UPDATE(OBJECT_OF('"
                                         + Type1.class.getName()
                                         + "', 'a', f0, 'b', f1), 'someRandomName', 16)",
-                                "The field name 'someRandomName' at position 2 is not part of the structured type attributes. Available attributes: [a, b].")
-                        // Invalid Test - value type for field to update is not compatible
-                        .testSqlValidationError(
-                                "OBJECT_UPDATE(OBJECT_OF('"
-                                        + Type1.class.getName()
-                                        + "', 'a', f0, 'b', f1), 'a', true)",
-                                "The value type for field 'a' at position 3 is expected to be INT, but was BOOLEAN NOT NULL"));
+                                "The field name 'someRandomName' at position 2 is not part of the structured type attributes. Available attributes: [a, b]."));
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StructuredFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StructuredFunctionsITCase.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.planner.functions;
 
 import org.apache.flink.table.api.DataTypes;
-import org.apache.flink.table.api.Expressions;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.table.types.logical.StructuredType;
@@ -31,12 +30,18 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 
+import static org.apache.flink.table.api.Expressions.$;
+import static org.apache.flink.table.api.Expressions.call;
+import static org.apache.flink.table.api.Expressions.nullOf;
+import static org.apache.flink.table.api.Expressions.objectOf;
+
 /** Tests for functions dealing with {@link StructuredType}. */
 public class StructuredFunctionsITCase extends BuiltInFunctionTestBase {
 
     @Override
     Stream<TestSetSpec> getTestSetSpecs() {
-        return Stream.of(structuredTypeTestCases(), objectOfTestCases()).flatMap(s -> s);
+        return Stream.of(structuredTypeTestCases(), objectOfTestCases(), objectUpdateTestCases())
+                .flatMap(s -> s);
     }
 
     private static Stream<TestSetSpec> structuredTypeTestCases() {
@@ -126,7 +131,7 @@ public class StructuredFunctionsITCase extends BuiltInFunctionTestBase {
                         .withFunction(NestedType.NestedConstructor.class)
                         // Test with OBJECT_OF
                         .testResult(
-                                Expressions.objectOf(Type1.class, "a", 42, "b", "Bob"),
+                                objectOf(Type1.class, "a", 42, "b", "Bob"),
                                 "OBJECT_OF('" + Type1.class.getName() + "', 'a', 42, 'b', 'Bob')",
                                 type1,
                                 DataTypes.STRUCTURED(
@@ -135,12 +140,12 @@ public class StructuredFunctionsITCase extends BuiltInFunctionTestBase {
                                         DataTypes.FIELD("b", DataTypes.CHAR(3).notNull())))
                         // Test with nested structured types
                         .testResult(
-                                Expressions.objectOf(
+                                objectOf(
                                         NestedType.class,
                                         "n1",
-                                        Expressions.objectOf(Type1.class, "a", 42, "b", "Bob"),
+                                        objectOf(Type1.class, "a", 42, "b", "Bob"),
                                         "n2",
-                                        Expressions.objectOf(Type2.class, "a", 15, "b", "Alice")),
+                                        objectOf(Type2.class, "a", 15, "b", "Alice")),
                                 "OBJECT_OF('"
                                         + NestedType.class.getName()
                                         + "', 'n1', OBJECT_OF('"
@@ -195,6 +200,99 @@ public class StructuredFunctionsITCase extends BuiltInFunctionTestBase {
                         .testSqlValidationError(
                                 "OBJECT_OF(CAST(NULL AS STRING), 'a', '12', 'b', 'Alice')",
                                 "The first argument must be a non-nullable character string literal representing the class name."));
+    }
+
+    private static Stream<TestSetSpec> objectUpdateTestCases() {
+        return Stream.of(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.OBJECT_UPDATE)
+                        .onFieldsWithData(42, "Bob")
+                        .andDataTypes(DataTypes.INT(), DataTypes.STRING())
+                        .withFunction(Type1.Type1Constructor.class)
+                        .withFunction(Type2.Type2Constructor.class)
+                        .withFunction(NestedType.NestedConstructor.class)
+                        // Test update all fields equality
+                        .testResult(
+                                call("Type1Constructor", $("f0"), $("f1"))
+                                        .objectUpdate("a", 16, "b", "Alice"),
+                                "OBJECT_UPDATE(OBJECT_OF('"
+                                        + Type1.class.getName()
+                                        + "', 'a', f0, 'b', f1), 'a', 16, 'b', 'Alice')",
+                                Type1.of(16, "Alice"),
+                                DataTypes.STRUCTURED(
+                                        Type1.class.getName(),
+                                        DataTypes.FIELD("a", DataTypes.INT().notNull()),
+                                        DataTypes.FIELD("b", DataTypes.CHAR(5).notNull())))
+                        // Test update single field
+                        .testResult(
+                                objectOf(Type1.class, "a", 42, "b", "Bob")
+                                        .objectUpdate("b", "Alice"),
+                                "OBJECT_UPDATE(OBJECT_OF('"
+                                        + Type1.class.getName()
+                                        + "', 'a', 42, 'b', 'Bob'), 'b', 'Alice')",
+                                Type1.of(42, "Alice"),
+                                DataTypes.STRUCTURED(
+                                        Type1.class.getName(),
+                                        DataTypes.FIELD("a", DataTypes.INT().notNull()),
+                                        DataTypes.FIELD("b", DataTypes.CHAR(5).notNull())))
+                        // Test nested structured types
+                        .testResult(
+                                objectOf(
+                                                NestedType.class,
+                                                "n1",
+                                                call("Type1Constructor", $("f0"), $("f1")),
+                                                "n2",
+                                                call("Type2Constructor", 15, "Alice"))
+                                        .objectUpdate(
+                                                "n1",
+                                                objectOf(Type1.class, "a", 16, "b", "UpdatedBob")),
+                                "OBJECT_UPDATE(OBJECT_OF('"
+                                        + NestedType.class.getName()
+                                        + "', 'n1', Type1Constructor(f0, f1), 'n2', Type2Constructor(15, 'Alice')), "
+                                        + "'n1', OBJECT_OF('"
+                                        + Type1.class.getName()
+                                        + "', 'a', 16, 'b', 'UpdatedBob'))",
+                                NestedType.of(Type1.of(16, "UpdatedBob"), Type2.of(15, "Alice")),
+                                DataTypes.STRUCTURED(
+                                        NestedType.class.getName(),
+                                        DataTypes.FIELD(
+                                                "n1",
+                                                DataTypes.STRUCTURED(
+                                                        Type1.class.getName(),
+                                                        DataTypes.FIELD(
+                                                                "a", DataTypes.INT().notNull()),
+                                                        DataTypes.FIELD(
+                                                                "b",
+                                                                DataTypes.CHAR(10).notNull()))),
+                                        DataTypes.FIELD(
+                                                "n2",
+                                                DataTypes.STRUCTURED(
+                                                        Type2.class.getName(),
+                                                        DataTypes.FIELD("a", DataTypes.INT()),
+                                                        DataTypes.FIELD("b", DataTypes.STRING())))))
+                        // Test update field to null
+                        .testResult(
+                                objectOf(Type1.class, "a", 42, "b", "Bob")
+                                        .objectUpdate("b", nullOf(DataTypes.STRING())),
+                                "OBJECT_UPDATE(OBJECT_OF('"
+                                        + Type1.class.getName()
+                                        + "', 'a', 42, 'b', 'Bob'), 'b', CAST(NULL AS STRING))",
+                                Type1.of(42, null),
+                                DataTypes.STRUCTURED(
+                                        Type1.class.getName(),
+                                        DataTypes.FIELD("a", DataTypes.INT().notNull()),
+                                        DataTypes.FIELD("b", DataTypes.STRING())))
+                        // Invalid Test - name of the field to update is not in the structured type
+                        .testSqlValidationError(
+                                "OBJECT_UPDATE(OBJECT_OF('"
+                                        + Type1.class.getName()
+                                        + "', 'a', f0, 'b', f1), 'someRandomName', 16)",
+                                "The field name 'someRandomName' at position 2 is not part of the structured type attributes. Available attributes: [a, b].")
+                        // Invalid Test - value type for field to update is not compatible
+                        .testSqlValidationError(
+                                "OBJECT_UPDATE(OBJECT_OF('"
+                                        + Type1.class.getName()
+                                        + "', 'a', f0, 'b', f1), 'a', true)",
+                                "The value type for field 'a' at position 3 is expected to be INT, but was BOOLEAN NOT NULL"));
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ObjectUpdateFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ObjectUpdateFunction.java
@@ -44,6 +44,10 @@ public class ObjectUpdateFunction extends BuiltInScalarFunction {
     }
 
     public RowData eval(RowData rowData, Object... fieldNameAndValuePairs) {
+        if (rowData == null) {
+            return null;
+        }
+
         GenericRowData updatedRow = (GenericRowData) rowData;
 
         for (int i = 0; i < fieldNameAndValuePairs.length; i += 2) {

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ObjectUpdateFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ObjectUpdateFunction.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction;
+import org.apache.flink.table.functions.SpecializedFunction.SpecializedContext;
+import org.apache.flink.table.types.logical.StructuredType;
+import org.apache.flink.table.types.logical.StructuredType.StructuredAttribute;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#OBJECT_UPDATE}. */
+@Internal
+public class ObjectUpdateFunction extends BuiltInScalarFunction {
+
+    private Map<String, Integer> fieldNameToRowPosIndex = new HashMap<>();
+
+    public ObjectUpdateFunction(SpecializedFunction.SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.OBJECT_UPDATE, context);
+        this.fieldNameToRowPosIndex = createIndex(context);
+    }
+
+    public RowData eval(RowData rowData, Object... fieldNameAndValuePairs) {
+        GenericRowData updatedRow = (GenericRowData) rowData;
+
+        for (int i = 0; i < fieldNameAndValuePairs.length; i += 2) {
+            final String fieldName = fieldNameAndValuePairs[i].toString();
+            final int position = fieldNameToRowPosIndex.get(fieldName);
+            final Object fieldValue = fieldNameAndValuePairs[i + 1];
+            updatedRow.setField(position, fieldValue);
+        }
+
+        return updatedRow;
+    }
+
+    private Map<String, Integer> createIndex(final SpecializedContext context) {
+        StructuredType structuredType =
+                (StructuredType)
+                        context.getCallContext().getArgumentDataTypes().get(0).getLogicalType();
+        final List<StructuredAttribute> attributes = structuredType.getAttributes();
+
+        Map<String, Integer> fieldToPosIndex = new HashMap<>();
+
+        IntStream.range(0, attributes.size())
+                .forEach(pos -> fieldToPosIndex.put(attributes.get(pos).getName(), pos));
+
+        return fieldToPosIndex;
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This pull request implements the `OBJECT_UPDATE` built-in function as part of [FLIP-520](https://cwiki.apache.org/confluence/display/FLINK/FLIP-520%3A+Simplify+StructuredType+handling): Simplify StructuredType handling. The function allows users to update existing fields in structured objects by providing key-value pairs, enabling mutation operations on structured types in both SQL and Table API without requiring custom UDFs.

## Brief change log

- Added `ObjectUpdateInputTypeStrategy` for validating input arguments (structured object + key-value pairs)
- Added `ObjectUpdateTypeStrategy` for inferring return types (same as input structured type)
- Implemented `ObjectUpdateFunction` runtime function for performing field updates
- Added `OBJECT_UPDATE` to `BuiltInFunctionDefinitions` with proper type inference strategies
- Added Table API expression support via `objectUpdate()` method on expressions
- Updated SQL and Table API documentation with examples and usage patterns
- Added comprehensive validation for field names, types, and compatibility checking
- Implemented proper error handling for non-existent fields and type mismatches

## Verifying this change

This change added tests and can be verified as follows:

- Added unit tests in `ObjectUpdateInputTypeStrategyTest` for input validation scenarios
- Added integration tests in `StructuredFunctionsITCase` for end-to-end SQL functionality

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes (new built-in function)
- The serializers: no
- The runtime per-record code paths (performance sensitive): yes (new scalar function execution)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? yes
- If yes, how is the feature documented? docs / JavaDocs (updated SQL functions documentation and comprehensive JavaDoc comments)