### PR TITLE
[FLINK-38112] Align default of yarn.application-attempt-failures-validity-interval with YARN

### DIFF
--- a/docs/layouts/shortcodes/generated/yarn_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/yarn_config_configuration.html
@@ -27,10 +27,10 @@
             <td>A general option to probe Yarn configuration through prefix 'flink.yarn.'. Flink will remove the prefix 'flink.' to get yarn.&lt;key&gt; (from <a href="https://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-common/yarn-default.xml">yarn-default.xml</a>) then set the yarn.&lt;key&gt; and value to Yarn configuration. For example, flink.yarn.resourcemanager.container.liveness-monitor.interval-ms=300000 in Flink configuration and convert to yarn.resourcemanager.container.liveness-monitor.interval-ms=300000 in Yarn configuration.</td>
         </tr>
         <tr>
-            <td><h5>yarn.application-attempt-failures-validity-interval</h5></td>
+            <td><h5>yarn.application-attempt-failures-global-validity-interval</h5></td>
             <td style="word-wrap: break-word;">-1</td>
             <td>Long</td>
-            <td>Time window in milliseconds which defines the number of application attempt failures when restarting the AM. Failures which fall outside of this window are not being considered. The default (-1) counts globally. See <a href="https://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-site/ResourceManagerRest.html#Cluster_Applications_API.28Submit_Application.29">here</a> for more information.</td>
+            <td>Defines a global validity interval for counting application attempt failures. The default (-1) counts all failures, regardless of when they occurred. This option supersedes the deprecated `yarn.application-attempt-failures-validity-interval` and should be used instead. See <a href="https://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-site/ResourceManagerRest.html#Cluster_Applications_API.28Submit_Application.29">here</a> for more information.</td>
         </tr>
         <tr>
             <td><h5>yarn.application-attempts</h5></td>

--- a/docs/layouts/shortcodes/generated/yarn_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/yarn_config_configuration.html
@@ -30,7 +30,7 @@
             <td><h5>yarn.application-attempt-failures-validity-interval</h5></td>
             <td style="word-wrap: break-word;">-1</td>
             <td>Long</td>
-            <td>Time window in milliseconds which defines the number of application attempt failures when restarting the AM. Failures which fall outside of this window are not being considered. The default (-1) counts globally. See <a href="https://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-site/ResourceManagerRest.html#Cluster_Applications_API.28Submit_Application.29">here</a> for more information.</td>
+            <td>Time window in milliseconds which defines the number of application attempt failures when restarting the AM. Failures which fall outside of this window are not being considered. The default (-1) counts globally.See <a href="https://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-site/ResourceManagerRest.html#Cluster_Applications_API.28Submit_Application.29">here</a> for more information.</td>
         </tr>
         <tr>
             <td><h5>yarn.application-attempts</h5></td>

--- a/docs/layouts/shortcodes/generated/yarn_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/yarn_config_configuration.html
@@ -30,7 +30,7 @@
             <td><h5>yarn.application-attempt-failures-validity-interval</h5></td>
             <td style="word-wrap: break-word;">-1</td>
             <td>Long</td>
-            <td>Time window in milliseconds which defines the number of application attempt failures when restarting the AM. Failures which fall outside of this window are not being considered. The default (-1) counts globally.See <a href="https://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-site/ResourceManagerRest.html#Cluster_Applications_API.28Submit_Application.29">here</a> for more information.</td>
+            <td>Time window in milliseconds which defines the number of application attempt failures when restarting the AM. Failures which fall outside of this window are not being considered. The default (-1) counts globally. See <a href="https://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-site/ResourceManagerRest.html#Cluster_Applications_API.28Submit_Application.29">here</a> for more information.</td>
         </tr>
         <tr>
             <td><h5>yarn.application-attempts</h5></td>

--- a/docs/layouts/shortcodes/generated/yarn_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/yarn_config_configuration.html
@@ -28,9 +28,9 @@
         </tr>
         <tr>
             <td><h5>yarn.application-attempt-failures-validity-interval</h5></td>
-            <td style="word-wrap: break-word;">10000</td>
+            <td style="word-wrap: break-word;">-1</td>
             <td>Long</td>
-            <td>Time window in milliseconds which defines the number of application attempt failures when restarting the AM. Failures which fall outside of this window are not being considered. Set this value to -1 in order to count globally. See <a href="https://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-site/ResourceManagerRest.html#Cluster_Application_Attempts_API">here</a> for more information.</td>
+            <td>Time window in milliseconds which defines the number of application attempt failures when restarting the AM. Failures which fall outside of this window are not being considered. The default (-1) counts globally. See <a href="https://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-site/ResourceManagerRest.html#Cluster_Applications_API.28Submit_Application.29">here</a> for more information.</td>
         </tr>
         <tr>
             <td><h5>yarn.application-attempts</h5></td>

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -1511,7 +1511,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
         reflector.setAttemptFailuresValidityInterval(
                 appContext,
                 flinkConfiguration.get(
-                        YarnConfigOptions.APPLICATION_ATTEMPT_FAILURE_VALIDITY_INTERVAL));
+                        YarnConfigOptions.APPLICATION_ATTEMPT_FAILURES_GLOBAL_VALIDITY_INTERVAL));
     }
 
     private void setApplicationTags(final ApplicationSubmissionContext appContext)

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
@@ -106,11 +106,12 @@ public class YarnConfigOptions {
                                                     "yarn.resourcemanager.am.max-attempts"))
                                     .build());
 
-    /** The config parameter defining the attemptFailuresValidityInterval of Yarn application. */
-    public static final ConfigOption<Long> APPLICATION_ATTEMPT_FAILURE_VALIDITY_INTERVAL =
-            key("yarn.application-attempt-failures-validity-interval")
+    /** The config parameter defining the global attemptFailuresValidityInterval of YARN applications. */
+    public static final ConfigOption<Long> APPLICATION_ATTEMPT_FAILURES_GLOBAL_VALIDITY_INTERVAL =
+            key("yarn.application-attempt-failures-global-validity-interval")
                     .longType()
                     .defaultValue(-1L)
+                    .withDeprecatedKeys("yarn.application-attempt-failures-validity-interval")
                     .withDescription(
                             Description.builder()
                                     .text(

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
@@ -110,16 +110,16 @@ public class YarnConfigOptions {
     public static final ConfigOption<Long> APPLICATION_ATTEMPT_FAILURE_VALIDITY_INTERVAL =
             key("yarn.application-attempt-failures-validity-interval")
                     .longType()
-                    .defaultValue(10000L)
+                    .defaultValue(-1L)
                     .withDescription(
                             Description.builder()
                                     .text(
                                             "Time window in milliseconds which defines the number of application attempt failures when restarting the AM. "
                                                     + "Failures which fall outside of this window are not being considered. "
-                                                    + "Set this value to -1 in order to count globally. "
+                                                    + "The default (-1) counts globally."
                                                     + "See %s for more information.",
                                             link(
-                                                    "https://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-site/ResourceManagerRest.html#Cluster_Application_Attempts_API",
+                                                    "https://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-site/ResourceManagerRest.html#Cluster_Applications_API.28Submit_Application.29",
                                                     "here"))
                                     .build());
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request aligns Flink’s default for the YARN configuration option  `yarn.application-attempt-failures-validity-interval` with YARN itself.  
The previous default (10 000 ms) caused unexpected endless AM restarts once the interval between two failures exceeded ten seconds.

**Why `-1` instead of another fixed window?**  
Since every environment performs differently, some restart AM in 30 seconds, some in 3 seconds. There is no fixed time that fits everyone.
Setting the default to **`-1` (global counting)** removes the hidden assumption and lets users choose a window that matches their own infrastructure when needed.

JIRA: FLINK-38112

---

## Brief change log

* **`YarnConfigOptions`**
  * `defaultValue` changed from `10000L` to `-1L`
  * description text updated accordingly, including a correct REST-API link
* **Docs**
  * Regenerated configuration HTML/Markdown via `generate-configdocs` so the tables reflect the new default

---

## Verifying this change

This change is a **trivial configuration default update**.  
No new tests are required; existing unit and IT cases already cover option parsing, and the full Maven build (`mvn -T1C clean verify`) now passes on JDK 17.

---

## Does this pull request potentially affect one of the following parts

| Area | Impact |
|------|--------|
| Dependencies | **no** |
| Public API (`@Public`/`@PublicEvolving`) | **no** |
| Serializers | **no** |
| Runtime per-record code paths | **no** |
| Deployment / Recovery components (JM, Checkpointing, K8s/YARN, ZooKeeper) | **yes – YARN only (default value change)** |
| S3 file-system connector | **no** |

---

## Documentation

*Does this pull request introduce a new feature?* **no**

The existing docs were **regenerated**; no manual doc text was added.
