### PR TITLE
[FLINK-38109] [flink-runtime] Fix BlobClient address when bindhost is set

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/executors/EmbeddedExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/executors/EmbeddedExecutor.java
@@ -195,10 +195,11 @@ public class EmbeddedExecutor implements PipelineExecutor {
 
         return dispatcherGateway
                 .getBlobServerPort(rpcTimeout)
-                .thenApply(
-                        blobServerPort ->
+                .thenCombine(
+                        dispatcherGateway.getBlobServerAddress(rpcTimeout),
+                        (blobServerPort, blobServerAddress) ->
                                 new InetSocketAddress(
-                                        dispatcherGateway.getHostname(), blobServerPort))
+                                        blobServerAddress.getHostName(), blobServerPort))
                 .thenCompose(
                         blobServerAddress -> {
                             try {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobCacheService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobCacheService.java
@@ -25,6 +25,7 @@ import javax.annotation.Nullable;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -112,5 +113,10 @@ public class BlobCacheService implements TaskExecutorBlobService {
     public int getPort() {
         // NOTE: both blob stores connect to the same server!
         return permanentBlobCache.getPort();
+    }
+
+    @Override
+    public InetAddress getAddress() {
+        return permanentBlobCache.serverAddress.getAddress();
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
@@ -52,6 +52,7 @@ import java.io.InputStream;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
+import java.net.UnknownHostException;
 import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -1007,6 +1008,24 @@ public class BlobServer extends Thread
     @Override
     public int getPort() {
         return this.serverSocket.getLocalPort();
+    }
+
+    /**
+     * Returns the address on which the server is listening.
+     *
+     * @return address on which the server is listening
+     */
+    @Override
+    public InetAddress getAddress() {
+        InetAddress bindAddr = serverSocket.getInetAddress();
+        if (bindAddr.getHostAddress().equals(NetUtils.getWildcardIPAddress())) {
+            try {
+                return InetAddress.getLocalHost();
+            } catch (UnknownHostException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return bindAddr;
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobService.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.blob;
 
 import java.io.Closeable;
+import java.net.InetAddress;
 
 /** A simple store and retrieve binary large objects (BLOBs). */
 public interface BlobService extends Closeable {
@@ -43,4 +44,14 @@ public interface BlobService extends Closeable {
      * @return the port of the blob server.
      */
     int getPort();
+
+    /**
+     * Returns the network address of the BLOB server that this BLOB service is working with. This
+     * default implementation returns the loopback address.
+     *
+     * @return the InetAddress of the BLOB server.
+     */
+    default InetAddress getAddress() {
+        return InetAddress.getLoopbackAddress();
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -111,6 +111,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -996,6 +997,11 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId>
     @Override
     public CompletableFuture<Integer> getBlobServerPort(Duration timeout) {
         return CompletableFuture.completedFuture(blobServer.getPort());
+    }
+
+    @Override
+    public CompletableFuture<InetAddress> getBlobServerAddress(Duration timeout) {
+        return CompletableFuture.completedFuture(blobServer.getAddress());
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherGateway.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.rpc.RpcTimeout;
 import org.apache.flink.runtime.webmonitor.RestfulGateway;
 import org.apache.flink.streaming.api.graph.ExecutionPlan;
 
+import java.net.InetAddress;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
@@ -63,6 +64,14 @@ public interface DispatcherGateway extends FencedRpcGateway<DispatcherId>, Restf
      * @return A future integer of the blob server port
      */
     CompletableFuture<Integer> getBlobServerPort(@RpcTimeout Duration timeout);
+
+    /**
+     * Returns the address of the blob server.
+     *
+     * @param timeout of the operation
+     * @return A future InetAddress of the blob server address
+     */
+    CompletableFuture<InetAddress> getBlobServerAddress(@RpcTimeout Duration timeout);
 
     default CompletableFuture<Acknowledge> shutDownCluster(ApplicationStatus applicationStatus) {
         return shutDownCluster();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -1163,10 +1163,11 @@ public class MiniCluster implements AutoCloseableAsync {
                         dispatcherGateway ->
                                 dispatcherGateway
                                         .getBlobServerPort(rpcTimeout)
-                                        .thenApply(
-                                                blobServerPort ->
+                                        .thenCombine(
+                                                dispatcherGateway.getBlobServerAddress(rpcTimeout),
+                                                (blobServerPort, blobServerAddress) ->
                                                         new InetSocketAddress(
-                                                                dispatcherGateway.getHostname(),
+                                                                blobServerAddress.getHostName(),
                                                                 blobServerPort)))
                 .thenCompose(Function.identity());
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/TestingDispatcherGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/TestingDispatcherGateway.java
@@ -46,6 +46,7 @@ import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.concurrent.FutureUtils;
 import org.apache.flink.util.function.TriFunction;
 
+import java.net.InetAddress;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
@@ -93,6 +94,7 @@ public final class TestingDispatcherGateway extends TestingRestfulGateway
             submitFailedFunction;
     private final Supplier<CompletableFuture<Collection<JobID>>> listFunction;
     private final int blobServerPort;
+    private InetAddress blobServerAddress;
     private final DispatcherId fencingToken;
     private final Function<JobID, CompletableFuture<ArchivedExecutionGraph>>
             requestArchivedJobFunction;
@@ -206,6 +208,11 @@ public final class TestingDispatcherGateway extends TestingRestfulGateway
         this.submitFailedFunction = submitFailedFunction;
         this.listFunction = listFunction;
         this.blobServerPort = blobServerPort;
+        try {
+            this.blobServerAddress = InetAddress.getByName(hostname);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to resolve hostname: " + hostname, e);
+        }
         this.fencingToken = fencingToken;
         this.requestArchivedJobFunction = requestArchivedJobFunction;
         this.clusterShutdownWithStatusFunction = clusterShutdownWithStatusFunction;
@@ -234,6 +241,11 @@ public final class TestingDispatcherGateway extends TestingRestfulGateway
     @Override
     public CompletableFuture<Integer> getBlobServerPort(Duration timeout) {
         return CompletableFuture.completedFuture(blobServerPort);
+    }
+
+    @Override
+    public CompletableFuture<InetAddress> getBlobServerAddress(Duration timeout) {
+        return CompletableFuture.completedFuture(blobServerAddress);
     }
 
     @Override


### PR DESCRIPTION
https://issues.apache.org/jira/browse/FLINK-38109

## What is the purpose of the change

The current implementation of BlobServer is to inherit the JobManager bind-host, however theres implicit assumptions that the BlobClient can use the dispatcher gateway host name. 
This pull request surfaces the BlobServer hostname directly to the BlobClient, similar to how the BlobServer port works today.

## Brief change log
- BlobClient uses the correct host name when the JobManager bind-host is set.

## Verifying this change
Updates the current BlobClientTest to use the BlobServer address instead of `localhost`.
Additional tests added for blobserver binding to a routable address and a configured address inherited by the JobManager bind-host.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

no to all 

## Documentation
  - Does this pull request introduce a new feature? (yes / no)
no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
not applicable
