### PR TITLE
[FLINK-38121] Ensure latest pip version before building Python wheels

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -110,7 +110,7 @@ jobs:
           # Use manylinux2014 on Linux
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_BEFORE_ALL_LINUX: pip install patchelf
-          CIBW_BEFORE_BUILD_LINUX: pip install --group flink-python/pyproject.toml:dev
+          CIBW_BEFORE_BUILD_LINUX: pip install --upgrade pip && pip install --group flink-python/pyproject.toml:dev
           CIBW_ENVIRONMENT_LINUX: CFLAGS="-I. -include ./dev/glibc_version_fix.h"
           # Run auditwheel repair on Linux
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair -w {dest_dir} {wheel}"


### PR DESCRIPTION
## What is the purpose of the change

The nightly build wheel jobs are failing because the version of `pip` the cibuildwheel container is using is not the latest, so doesnt have the `--group` flag for pip installing from groups.

This PR ensures that the pip version is updated during builds and before pip install dev dependencies.

## Brief change log

*(for example:)*
  - *Ensured pip version is latest in building python wheels GHA job.*