### PR TITLE
[FLINK-37988] Allows AsyncTableFunction to have empty results for left join

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecAsyncCorrelate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecAsyncCorrelate.java
@@ -135,9 +135,10 @@ public class CommonExecAsyncCorrelate extends ExecNodeBase<RowData>
         DataStructureConverter<RowData, Object> fetcherConverter =
                 cast(
                         DataStructureConverters.getConverter(
-                                TypeConversions.fromLogicalToDataType(
-                                        FlinkTypeFactory.toLogicalType(invocation.getType()))));
-        AsyncCorrelateRunner func = new AsyncCorrelateRunner(generatedFunction, fetcherConverter);
+                                TypeConversions.fromLogicalToDataType(resultTypeInfo)));
+        AsyncCorrelateRunner func =
+                new AsyncCorrelateRunner(
+                        generatedFunction, fetcherConverter, joinType, resultTypeInfo);
         FunctionCallUtil.AsyncOptions options = AsyncTableUtil.getAsyncOptions(config);
         return new AsyncWaitOperatorFactory<>(
                 func,


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Currently `AsyncTableFunction` handles inner joins, but not left joins of the form:
```
SELECT * FROM t1 LEFT OUTER JOIN LATERAL TABLE(MyAsyncTableFunction(f1)) ON TRUE
```

The intention is that `MyAsyncTableFunction` should be allowed to return empty for the right side of the join, resulting in a left value paired with a null right value.

## Brief change log

*(for example:)*
  - Adds an explicit check for an empty response, which results in a null right side response.


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

This change added tests and can be verified as follows:

  - Added ITCase which returns empty results and verifies output.
  - Adds unit tests in `AsyncCorrelateRunnerTest` for various join types.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
    - For empty responses, additional handling is now there to output null results.  This is pretty minimal and for current incorrect handling of left joins.
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
