### PR TITLE
[FLINK-32695] [Tests] Migrate CoGroupJoinITCase new Source/Sink V2

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/CoGroupJoinITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/CoGroupJoinITCase.java
@@ -113,7 +113,7 @@ public class CoGroupJoinITCase extends AbstractTestBaseJUnit4 {
                                 out.collect(result.toString());
                             }
                         })
-                .sinkTo(new CollectingSink());
+                .sinkTo(new TestSink());
 
         env.execute("CoGroup Test");
 
@@ -177,7 +177,7 @@ public class CoGroupJoinITCase extends AbstractTestBaseJUnit4 {
                                 return first + ":" + second;
                             }
                         })
-                .sinkTo(new CollectingSink());
+                .sinkTo(new TestSink());
 
         env.execute("Join Test");
 
@@ -243,7 +243,7 @@ public class CoGroupJoinITCase extends AbstractTestBaseJUnit4 {
                                 return first + ":" + second;
                             }
                         })
-                .sinkTo(new CollectingSink());
+                .sinkTo(new TestSink());
 
         env.execute("Self-Join Test");
 
@@ -379,7 +379,7 @@ public class CoGroupJoinITCase extends AbstractTestBaseJUnit4 {
         }
     }
 
-    private static class CollectingSink implements Sink<String> {
+    private static class TestSink implements Sink<String> {
 
         @Override
         public SinkWriter<String> createWriter(WriterInitContext context) {


### PR DESCRIPTION
## What is the purpose of the change

This pull request migrates CoGroupJoinITCase integration tests from deprecated SourceFunction/SinkFunction APIs to modern Source V2 and Sink V2 APIs.

## Brief change log

  - Replaced 5 inline SourceFunction implementations with env.fromData() calls for static test data
  - Migrated 3 SinkFunction implementations to custom CollectingSink using Sink V2 API
  - Maintained identical test behavior and assertions while modernizing the underlying APIs


## Verifying this change

This change is already covered by existing tests, such as:
  - All test methods in CoGroupJoinITCase (testCoGroup, testJoin, testSelfJoin, testCoGroupOperatorWithCheckpoint)
  - Tests verify identical windowed join/coGroup behavior with updated APIs
  - Same expected results and assertions maintained across the migration.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
