### PR TITLE
[FLINK-38114][runtime] Allow asynchronous offloading of TaskRestore

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/testutils/TestingUtils.java
+++ b/flink-core/src/test/java/org/apache/flink/testutils/TestingUtils.java
@@ -31,6 +31,7 @@ import java.util.Collection;
 import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
 import java.util.function.Predicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -53,8 +54,36 @@ public class TestingUtils {
         return Duration.ofDays(365L);
     }
 
+    // To make debugging logs easier, we use a custom thread factory that names the thread.
+    static class JmMainSingleThreadPoolFactory implements ThreadFactory {
+        public Thread newThread(final Runnable r) {
+            return new Thread(r, "jm-main-thread");
+        }
+    }
+
+    // To make debugging logs easier, we use a custom thread factory that names the thread.
+    static class AsyncSingleThreadPoolFactory implements ThreadFactory {
+        public Thread newThread(final Runnable r) {
+            return new Thread(r, "async-single-thread-pool");
+        }
+    }
+
     public static TestExecutorExtension<ScheduledExecutorService> defaultExecutorExtension() {
         return new TestExecutorExtension<>(Executors::newSingleThreadScheduledExecutor);
+    }
+
+    public static TestExecutorExtension<ScheduledExecutorService> jmMainThreadExecutorExtension() {
+        return new TestExecutorExtension<>(
+                () ->
+                        Executors.newSingleThreadScheduledExecutor(
+                                new JmMainSingleThreadPoolFactory()));
+    }
+
+    public static TestExecutorExtension<ScheduledExecutorService> jmAsyncThreadExecutorExtension() {
+        return new TestExecutorExtension<>(
+                () ->
+                        Executors.newSingleThreadScheduledExecutor(
+                                new AsyncSingleThreadPoolFactory()));
     }
 
     public static TestExecutorResource<ScheduledExecutorService> defaultExecutorResource() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptor.java
@@ -118,6 +118,12 @@ public final class TaskDeploymentDescriptor implements Serializable {
      */
     private transient TaskInformation taskInformation;
 
+    /** Information to restore the task. This can be null if there is no state to restore. */
+    @Nullable private final MaybeOffloaded<JobManagerTaskRestore> serializedTaskRestore;
+
+    /** Information to restore the task. This can be null if there is no state to restore. */
+    @Nullable private transient JobManagerTaskRestore taskRestore;
+
     /**
      * The ID referencing the job this task belongs to.
      *
@@ -138,16 +144,13 @@ public final class TaskDeploymentDescriptor implements Serializable {
     /** The list of consumed intermediate result partitions. */
     private final List<InputGateDeploymentDescriptor> inputGates;
 
-    /** Information to restore the task. This can be null if there is no state to restore. */
-    @Nullable private final JobManagerTaskRestore taskRestore;
-
     public TaskDeploymentDescriptor(
             JobID jobId,
             MaybeOffloaded<JobInformation> serializedJobInformation,
             MaybeOffloaded<TaskInformation> serializedTaskInformation,
             ExecutionAttemptID executionAttemptId,
             AllocationID allocationId,
-            @Nullable JobManagerTaskRestore taskRestore,
+            @Nullable MaybeOffloaded<JobManagerTaskRestore> serializedTaskRestore,
             List<ResultPartitionDeploymentDescriptor> resultPartitionDeploymentDescriptors,
             List<InputGateDeploymentDescriptor> inputGateDeploymentDescriptors) {
 
@@ -159,7 +162,7 @@ public final class TaskDeploymentDescriptor implements Serializable {
         this.executionId = Preconditions.checkNotNull(executionAttemptId);
         this.allocationId = Preconditions.checkNotNull(allocationId);
 
-        this.taskRestore = taskRestore;
+        this.serializedTaskRestore = serializedTaskRestore;
 
         this.producedPartitions = Preconditions.checkNotNull(resultPartitionDeploymentDescriptors);
         this.inputGates = Preconditions.checkNotNull(inputGateDeploymentDescriptors);
@@ -241,8 +244,16 @@ public final class TaskDeploymentDescriptor implements Serializable {
     }
 
     @Nullable
-    public JobManagerTaskRestore getTaskRestore() {
-        return taskRestore;
+    public JobManagerTaskRestore getTaskRestore() throws IOException, ClassNotFoundException {
+        if (taskRestore != null || serializedTaskRestore == null) {
+            return taskRestore;
+        }
+        if (serializedTaskRestore instanceof NonOffloaded) {
+            NonOffloaded<JobManagerTaskRestore> taskRestore =
+                    (NonOffloaded<JobManagerTaskRestore>) serializedTaskRestore;
+            return taskRestore.serializedValue.deserializeValue(getClass().getClassLoader());
+        }
+        throw new IllegalStateException("Trying to work with offloaded serialized task restore.");
     }
 
     public AllocationID getAllocationId() {
@@ -309,6 +320,21 @@ public final class TaskDeploymentDescriptor implements Serializable {
                 taskInformationCache.put(jobId, taskInfoKey, taskInformation);
             }
             this.taskInformation = taskInformation.deepCopy();
+        }
+
+        if (serializedTaskRestore == null) {
+            this.taskRestore = null;
+        } else if (serializedTaskRestore instanceof Offloaded) {
+            final PermanentBlobKey blobKey =
+                    ((Offloaded<JobManagerTaskRestore>) serializedTaskRestore).serializedValueKey;
+
+            Preconditions.checkNotNull(blobService);
+
+            final File dataFile = blobService.getFile(jobId, blobKey);
+            taskRestore =
+                    InstantiationUtil.deserializeObject(
+                            new BufferedInputStream(Files.newInputStream(dataFile.toPath())),
+                            getClass().getClassLoader());
         }
 
         for (InputGateDeploymentDescriptor inputGate : inputGates) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactory.java
@@ -112,7 +112,7 @@ public class TaskDeploymentDescriptorFactory {
     public TaskDeploymentDescriptor createDeploymentDescriptor(
             Execution execution,
             AllocationID allocationID,
-            @Nullable JobManagerTaskRestore taskRestore,
+            @Nullable Either<SerializedValue<JobManagerTaskRestore>, PermanentBlobKey> taskRestore,
             Collection<ResultPartitionDeploymentDescriptor> producedPartitions)
             throws IOException, ClusterDatasetCorruptedException {
         final ExecutionVertex executionVertex = execution.getVertex();
@@ -124,7 +124,7 @@ public class TaskDeploymentDescriptorFactory {
                         executionVertex.getJobVertex().getTaskInformationOrBlobKey()),
                 execution.getAttemptId(),
                 allocationID,
-                taskRestore,
+                taskRestore != null ? getSerializedTaskRestore(taskRestore) : null,
                 new ArrayList<>(producedPartitions),
                 createInputGateDeploymentDescriptors(executionVertex));
     }
@@ -293,6 +293,13 @@ public class TaskDeploymentDescriptorFactory {
         return taskInfo.isLeft()
                 ? new TaskDeploymentDescriptor.NonOffloaded<>(taskInfo.left())
                 : new TaskDeploymentDescriptor.Offloaded<>(taskInfo.right());
+    }
+
+    private static MaybeOffloaded<JobManagerTaskRestore> getSerializedTaskRestore(
+            Either<SerializedValue<JobManagerTaskRestore>, PermanentBlobKey> either) {
+        return either.isLeft()
+                ? new TaskDeploymentDescriptor.NonOffloaded<>(either.left())
+                : new TaskDeploymentDescriptor.Offloaded<>(either.right());
     }
 
     public static ShuffleDescriptor getConsumedPartitionShuffleDescriptor(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -24,6 +24,8 @@ import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.core.io.InputSplit;
 import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
+import org.apache.flink.runtime.blob.BlobWriter;
+import org.apache.flink.runtime.blob.PermanentBlobKey;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.JobManagerTaskRestore;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
@@ -43,6 +45,7 @@ import org.apache.flink.runtime.jobmaster.LogicalSlot;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.operators.coordination.TaskNotRunningException;
+import org.apache.flink.runtime.scheduler.ClusterDatasetCorruptedException;
 import org.apache.flink.runtime.scheduler.strategy.ConsumerVertexGroup;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.shuffle.PartitionDescriptor;
@@ -51,17 +54,20 @@ import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorOperatorEventGateway;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.types.Either;
 import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.OptionalFailure;
 import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.concurrent.FutureUtils;
+import org.apache.flink.util.function.FunctionUtils;
 
 import org.slf4j.Logger;
 
 import javax.annotation.Nullable;
 
+import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -74,7 +80,9 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.runtime.deployment.TaskDeploymentDescriptorFactory.getConsumedPartitionShuffleDescriptor;
@@ -164,6 +172,13 @@ public class Execution
 
     private Optional<ErrorInfo> failureCause =
             Optional.empty(); // once an ErrorInfo is set, never changes
+
+    /**
+     * Future that indicates {@link TaskDeploymentDescriptor} being created after the most recent
+     * deploy. This is only used for testing purposes to handle race conditions caused by thread
+     * switching between main and async pool in #deploy().
+     */
+    @Nullable private volatile CompletableFuture<Void> tddCreatedDuringDeployFuture;
 
     /**
      * Information to restore the task on recovery, such as checkpoint id and task state snapshot.
@@ -595,14 +610,8 @@ public class Execution
         try {
 
             // race double check, did we fail/cancel and do we need to release the slot?
-            if (this.state != DEPLOYING) {
-                slot.releaseSlot(
-                        new FlinkException(
-                                "Actual state of execution "
-                                        + this
-                                        + " ("
-                                        + state
-                                        + ") does not match expected state DEPLOYING."));
+            if (state != DEPLOYING) {
+                releaseSlotWhenNotInDeployingState(slot);
                 return;
             }
 
@@ -615,18 +624,6 @@ public class Execution
                     getAssignedResourceLocation(),
                     slot.getAllocationId());
 
-            final TaskDeploymentDescriptor deployment =
-                    vertex.getExecutionGraphAccessor()
-                            .getTaskDeploymentDescriptorFactory()
-                            .createDeploymentDescriptor(
-                                    this,
-                                    slot.getAllocationId(),
-                                    taskRestore,
-                                    producedPartitions.values());
-
-            // null taskRestore to let it be GC'ed
-            taskRestore = null;
-
             final TaskManagerGateway taskManagerGateway = slot.getTaskManagerGateway();
 
             final ComponentMainThreadExecutor jobMasterMainThreadExecutor =
@@ -636,44 +633,217 @@ public class Execution
             // We run the submission in the future executor so that the serialization of large TDDs
             // does not block
             // the main thread and sync back to the main thread once submission is completed.
-            CompletableFuture.supplyAsync(
-                            () -> taskManagerGateway.submitTask(deployment, rpcTimeout), executor)
-                    .thenCompose(Function.identity())
+            AtomicReference<Either<SerializedValue<JobManagerTaskRestore>, PermanentBlobKey>>
+                    maybeOffloadedTaskRestoreCleanupRef = new AtomicReference<>();
+            final CompletableFuture<TaskDeploymentDescriptor> taskDeploymentDescriptorFuture =
+                    CompletableFuture.supplyAsync(
+                                    initOffloadedTaskRestoreRef(
+                                            // Passing a copy of the task restore from the
+                                            // main thread to the I/O executor in order to
+                                            // avoid synchronization issues
+                                            taskRestore, maybeOffloadedTaskRestoreCleanupRef),
+                                    executor)
+                            // back to main thread because this accesses execution graph
+                            // internals
+                            .thenComposeAsync(
+                                    tryGetTaskDeploymentDescriptorForSlot(slot),
+                                    jobMasterMainThreadExecutor);
+            this.tddCreatedDuringDeployFuture = taskDeploymentDescriptorFuture.thenRun(() -> {});
+            // back to io executor for TDD serialization
+            taskDeploymentDescriptorFuture
+                    .thenComposeAsync(
+                            deploymentDescriptor ->
+                                    taskManagerGateway.submitTask(deploymentDescriptor, rpcTimeout),
+                            executor)
                     .whenCompleteAsync(
-                            (ack, failure) -> {
-                                if (failure == null) {
-                                    vertex.notifyCompletedDeployment(this);
-                                } else {
-                                    final Throwable actualFailure =
-                                            ExceptionUtils.stripCompletionException(failure);
-
-                                    if (actualFailure instanceof TimeoutException) {
-                                        String taskname =
-                                                vertex.getTaskNameWithSubtaskIndex()
-                                                        + " ("
-                                                        + attemptId
-                                                        + ')';
-
-                                        markFailed(
-                                                new Exception(
-                                                        "Cannot deploy task "
-                                                                + taskname
-                                                                + " - TaskManager ("
-                                                                + getAssignedResourceLocation()
-                                                                + ") not responding after a rpcTimeout of "
-                                                                + rpcTimeout,
-                                                        actualFailure));
-                                    } else {
-                                        markFailed(actualFailure);
-                                    }
-                                }
-                            },
+                            (ack, failure) ->
+                                    handleDeploymentCompletionAndCleanup(
+                                            maybeOffloadedTaskRestoreCleanupRef, ack, failure),
                             jobMasterMainThreadExecutor);
 
         } catch (Throwable t) {
             ExceptionUtils.rethrowIfFatalErrorOrOOM(t);
             markFailed(t);
         }
+    }
+
+    private void handleDeploymentCompletionAndCleanup(
+            AtomicReference<Either<SerializedValue<JobManagerTaskRestore>, PermanentBlobKey>>
+                    cleanupRef,
+            @Nullable final Acknowledge ack,
+            @Nullable final Throwable failure) {
+
+        // Running in async thread to avoid blocking the main thread on cleanup.
+        CompletableFuture.runAsync(() -> cleanUpOffloadedTaskRestore(cleanupRef), executor)
+                .exceptionally(
+                        cleanupError -> {
+                            LOG.warn(
+                                    "Failed to cleanup offloaded task restore for "
+                                            + "{} (attempt #{}) with attempt "
+                                            + "id {} and vertex id {} to {}",
+                                    vertex.getTaskNameWithSubtaskIndex(),
+                                    getAttemptNumber(),
+                                    attemptId,
+                                    vertex.getID(),
+                                    getAssignedResourceLocation(),
+                                    cleanupError);
+                            return null;
+                        });
+
+        finalizeDeploymentAndCleanUpInMainThread(ack, failure);
+    }
+
+    private Supplier<Either<SerializedValue<JobManagerTaskRestore>, PermanentBlobKey>>
+            initOffloadedTaskRestoreRef(
+                    final JobManagerTaskRestore taskRestoreSnapshot,
+                    final AtomicReference<
+                                    Either<
+                                            SerializedValue<JobManagerTaskRestore>,
+                                            PermanentBlobKey>>
+                            maybeOffloadedTaskRestoreCleanupRef) {
+        return FunctionUtils.uncheckedSupplier(
+                () -> {
+                    maybeOffloadedTaskRestoreCleanupRef.set(
+                            getMaybeOffloadedTaskRestore(taskRestoreSnapshot));
+                    return maybeOffloadedTaskRestoreCleanupRef.get();
+                });
+    }
+
+    private void finalizeDeploymentAndCleanUpInMainThread(
+            @Nullable final Acknowledge ack, @Nullable final Throwable failure) {
+        // Verify that we are back in the job master main thread
+        assertRunningInJobMasterMainThread();
+        // null taskRestore to let it be GC'ed
+        taskRestore = null;
+
+        if (failure == null) {
+            vertex.notifyCompletedDeployment(this);
+        } else {
+            final Throwable actualFailure = ExceptionUtils.stripCompletionException(failure);
+
+            if (actualFailure instanceof TimeoutException) {
+                String taskname = vertex.getTaskNameWithSubtaskIndex() + " (" + attemptId + ')';
+
+                markFailed(
+                        new Exception(
+                                "Cannot deploy task "
+                                        + taskname
+                                        + " - TaskManager ("
+                                        + getAssignedResourceLocation()
+                                        + ") not responding after a rpcTimeout of "
+                                        + rpcTimeout,
+                                actualFailure));
+            } else {
+                markFailed(actualFailure);
+            }
+        }
+    }
+
+    private Function<
+                    Either<SerializedValue<JobManagerTaskRestore>, PermanentBlobKey>,
+                    CompletableFuture<TaskDeploymentDescriptor>>
+            tryGetTaskDeploymentDescriptorForSlot(final LogicalSlot slot) {
+        return FunctionUtils.uncheckedFunction(
+                (maybeOffloadedTaskRestore) -> {
+                    // Check that we are in jm main thread while creating
+                    // task deployment descriptor.
+                    assertRunningInJobMasterMainThread();
+                    if (state != DEPLOYING) {
+                        return FutureUtils.completedExceptionally(
+                                new IllegalStateException(
+                                        String.format(
+                                                "Cannot deploy %s (attempt #%s) with attempt "
+                                                        + "id %s and vertex id %s to %s "
+                                                        + "with allocation id %s "
+                                                        + "because execution state has switched to %s "
+                                                        + "during task restore offload",
+                                                vertex.getTaskNameWithSubtaskIndex(),
+                                                getAttemptNumber(),
+                                                attemptId,
+                                                vertex.getID(),
+                                                getAssignedResourceLocation(),
+                                                slot.getAllocationId(),
+                                                state)));
+                    }
+                    return CompletableFuture.completedFuture(
+                            getDeploymentDescriptor(maybeOffloadedTaskRestore, slot));
+                });
+    }
+
+    /**
+     * Helper method to release the slot when Execution is not in DEPLOYING state.
+     *
+     * @param slot The slot to release.
+     */
+    private void releaseSlotWhenNotInDeployingState(final LogicalSlot slot) {
+        slot.releaseSlot(
+                new FlinkException(
+                        "Actual state of execution "
+                                + this
+                                + " ("
+                                + state
+                                + ") does not match expected state DEPLOYING."));
+    }
+
+    /**
+     * Cleans up the offloaded task restore if it was offloaded to the blob store.
+     *
+     * @param maybeOffloadedTaskRestoreCleanupRef The reference to the offloaded task restore
+     */
+    private void cleanUpOffloadedTaskRestore(
+            final AtomicReference<Either<SerializedValue<JobManagerTaskRestore>, PermanentBlobKey>>
+                    maybeOffloadedTaskRestoreCleanupRef) {
+        if (maybeOffloadedTaskRestoreCleanupRef.get() != null
+                && maybeOffloadedTaskRestoreCleanupRef.get().isRight()) {
+            vertex.getExecutionGraphAccessor()
+                    .deleteBlobs(
+                            Collections.singletonList(
+                                    maybeOffloadedTaskRestoreCleanupRef.get().right()));
+            maybeOffloadedTaskRestoreCleanupRef.set(null);
+        }
+    }
+
+    /**
+     * Creates the task deployment descriptor for the task.
+     *
+     * @param maybeOffloadedTaskRestore The serialized task restore information or the blob key if
+     *     it was offloaded
+     * @param slot The slot to which the task is deployed
+     * @return The task deployment descriptor
+     * @throws IOException If an I/O error occurs
+     * @throws ClusterDatasetCorruptedException If the cluster dataset is corrupted
+     */
+    private TaskDeploymentDescriptor getDeploymentDescriptor(
+            final Either<SerializedValue<JobManagerTaskRestore>, PermanentBlobKey>
+                    maybeOffloadedTaskRestore,
+            final LogicalSlot slot)
+            throws IOException, ClusterDatasetCorruptedException {
+        return vertex.getExecutionGraphAccessor()
+                .getTaskDeploymentDescriptorFactory()
+                .createDeploymentDescriptor(
+                        this,
+                        slot.getAllocationId(),
+                        maybeOffloadedTaskRestore,
+                        producedPartitions.values());
+    }
+
+    /**
+     * Returns the serialized task restore information or the blob key if it was offloaded.
+     *
+     * @param taskRestoreSnapshot Task restore snapshot value at the time of deployment.
+     * @return The serialized task restore information or the blob key if it was offloaded
+     * @throws IOException If an I/O error occurs
+     */
+    @VisibleForTesting
+    protected Either<SerializedValue<JobManagerTaskRestore>, PermanentBlobKey>
+            getMaybeOffloadedTaskRestore(final JobManagerTaskRestore taskRestoreSnapshot)
+                    throws IOException {
+        return taskRestoreSnapshot == null
+                ? null
+                : BlobWriter.serializeAndTryOffload(
+                        taskRestoreSnapshot,
+                        vertex.getJobId(),
+                        vertex.getExecutionGraphAccessor().getBlobWriter());
     }
 
     public void cancel() {
@@ -1635,6 +1805,18 @@ public class Execution
     @Override
     public ArchivedExecution archive() {
         return new ArchivedExecution(this);
+    }
+
+    @VisibleForTesting
+    public CompletableFuture<Void> getTddCreationDuringDeployFuture() {
+        // Defensive copy in case future is set to null between check and join.
+        final CompletableFuture<Void> future = tddCreatedDuringDeployFuture;
+        if (future == null) {
+            throw new IllegalStateException(
+                    "Task deployment descriptor creation future is null, "
+                            + "please ensure that this method is called after `Execution.deploy()`.");
+        }
+        return future;
     }
 
     private void assertRunningInJobMasterMainThread() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -576,6 +576,11 @@ public class ExecutionVertex
         return currentExecution == execution;
     }
 
+    @VisibleForTesting
+    public CompletableFuture<Void> getTddCreationDuringDeployFuture() {
+        return currentExecution.getTddCreationDuringDeployFuture();
+    }
+
     // --------------------------------------------------------------------------------------------
     //  Utilities
     // --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -717,9 +717,11 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
             // deserialize the pre-serialized information
             final JobInformation jobInformation;
             final TaskInformation taskInformation;
+            final JobManagerTaskRestore taskRestore;
             try {
                 jobInformation = tdd.getJobInformation();
                 taskInformation = tdd.getTaskInformation();
+                taskRestore = tdd.getTaskRestore();
             } catch (IOException | ClassNotFoundException e) {
                 throw new TaskSubmissionException(
                         "Could not deserialize the job or task information.", e);
@@ -811,8 +813,6 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
             } catch (IOException e) {
                 throw new TaskSubmissionException(e);
             }
-
-            final JobManagerTaskRestore taskRestore = tdd.getTaskRestore();
 
             final TaskStateManager taskStateManager =
                     new TaskStateManagerImpl(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorBuilder.java
@@ -49,7 +49,7 @@ public class TaskDeploymentDescriptorBuilder {
     private List<ResultPartitionDeploymentDescriptor> producedPartitions;
     private List<InputGateDeploymentDescriptor> inputGates;
 
-    @Nullable private JobManagerTaskRestore taskRestore;
+    @Nullable private MaybeOffloaded<JobManagerTaskRestore> serializedTaskRestore;
 
     private TaskDeploymentDescriptorBuilder(JobID jobId, String invokableClassName)
             throws IOException {
@@ -71,7 +71,7 @@ public class TaskDeploymentDescriptorBuilder {
         this.allocationId = new AllocationID();
         this.producedPartitions = Collections.emptyList();
         this.inputGates = Collections.emptyList();
-        this.taskRestore = null;
+        this.serializedTaskRestore = null;
     }
 
     public TaskDeploymentDescriptorBuilder setSerializedJobInformation(
@@ -113,9 +113,9 @@ public class TaskDeploymentDescriptorBuilder {
         return this;
     }
 
-    public TaskDeploymentDescriptorBuilder setTaskRestore(
-            @Nullable JobManagerTaskRestore taskRestore) {
-        this.taskRestore = taskRestore;
+    public TaskDeploymentDescriptorBuilder setSerializedTaskRestore(
+            @Nullable MaybeOffloaded<JobManagerTaskRestore> serializedTaskRestore) {
+        this.serializedTaskRestore = serializedTaskRestore;
         return this;
     }
 
@@ -126,7 +126,7 @@ public class TaskDeploymentDescriptorBuilder {
                 serializedTaskInformation,
                 executionId,
                 allocationId,
-                taskRestore,
+                serializedTaskRestore,
                 producedPartitions,
                 inputGates);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTest.java
@@ -82,8 +82,8 @@ class TaskDeploymentDescriptorTest {
     private static final List<PermanentBlobKey> requiredJars = new ArrayList<>(0);
     private static final List<URL> requiredClasspaths = new ArrayList<>(0);
     private static final TaskStateSnapshot taskStateHandles = new TaskStateSnapshot();
-    private static final JobManagerTaskRestore taskRestore =
-            new JobManagerTaskRestore(1L, taskStateHandles);
+    private final SerializedValue<JobManagerTaskRestore> taskRestore =
+            new SerializedValue<>(new JobManagerTaskRestore(1L, taskStateHandles));
 
     private final SerializedValue<ExecutionConfig> executionConfig =
             new SerializedValue<>(new ExecutionConfig());
@@ -237,7 +237,7 @@ class TaskDeploymentDescriptorTest {
                 taskInformation,
                 execId,
                 allocationId,
-                taskRestore,
+                new TaskDeploymentDescriptor.NonOffloaded<>(taskRestore),
                 producedResults,
                 inputGates);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentWithSmallBlobCacheSizeLimitTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentWithSmallBlobCacheSizeLimitTest.java
@@ -25,6 +25,8 @@ import org.apache.flink.runtime.blob.BlobCacheSizeTracker;
 import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.blob.PermanentBlobCache;
 import org.apache.flink.runtime.blob.VoidBlobStore;
+import org.apache.flink.runtime.checkpoint.JobManagerTaskRestore;
+import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
@@ -59,6 +61,7 @@ import java.util.concurrent.BlockingQueue;
 
 import static org.apache.flink.runtime.util.JobVertexConnectionUtils.connectNewDataSetAsInput;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests {@link ExecutionGraph} deployment when job and task information are offloaded into the BLOB
@@ -121,6 +124,8 @@ class DefaultExecutionGraphDeploymentWithSmallBlobCacheSizeLimitTest
         taskManagerGateway.setSubmitConsumer(
                 FunctionUtils.uncheckedConsumer(
                         taskDeploymentDescriptor -> {
+                            assertThatThrownBy(taskDeploymentDescriptor::getTaskRestore)
+                                    .isInstanceOf(IllegalStateException.class);
                             taskDeploymentDescriptor.loadBigData(
                                     blobCache,
                                     new NoOpGroupCache<>(),
@@ -138,9 +143,12 @@ class DefaultExecutionGraphDeploymentWithSmallBlobCacheSizeLimitTest
                         new TestingLogicalSlotBuilder()
                                 .setTaskManagerGateway(taskManagerGateway)
                                 .createTestingLogicalSlot();
+                JobManagerTaskRestore jobManagerTaskRestore =
+                        new JobManagerTaskRestore(0, new TaskStateSnapshot());
                 final Execution execution = ev.getCurrentExecutionAttempt();
                 execution.transitionState(ExecutionState.SCHEDULED);
                 execution.registerProducedPartitions(slot.getTaskManagerLocation()).get();
+                execution.setInitialState(jobManagerTaskRestore);
                 ev.deployToSlot(slot);
                 assertThat(ev.getExecutionState()).isEqualTo(ExecutionState.DEPLOYING);
 
@@ -149,6 +157,10 @@ class DefaultExecutionGraphDeploymentWithSmallBlobCacheSizeLimitTest
 
                 List<InputGateDeploymentDescriptor> igdds = tdd.getInputGates();
                 assertThat(igdds).hasSize(ev.getAllConsumedPartitionGroups().size());
+
+                assertThat(tdd.getTaskRestore()).isNotNull();
+                assertThat(tdd.getTaskRestore().getRestoreCheckpointId())
+                        .isEqualTo(jobManagerTaskRestore.getRestoreCheckpointId());
 
                 if (igdds.size() > 0) {
                     checkShuffleDescriptors(igdds.get(0), ev.getConsumedPartitionGroup(0));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/utils/ExecutionUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/utils/ExecutionUtils.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.flink.runtime.executiongraph.utils;
+
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+
+public final class ExecutionUtils {
+
+    private ExecutionUtils() {
+        // Private constructor for utility class.
+    }
+
+    /**
+     * Waits for the task deployment descriptors to be created for the given execution vertices.
+     *
+     * @param executionVertices the execution vertices to wait for
+     */
+    public static void waitForTaskDeploymentDescriptorsCreation(
+            final ExecutionVertex... executionVertices) {
+        for (ExecutionVertex ev : executionVertices) {
+            ev.getTddCreationDuringDeployFuture().join();
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/UpdatePartitionConsumersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/UpdatePartitionConsumersTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.jobmanager.scheduler;
 
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
@@ -49,10 +50,12 @@ import org.junit.Test;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.runtime.executiongraph.utils.ExecutionUtils.waitForTaskDeploymentDescriptorsCreation;
 import static org.apache.flink.runtime.util.JobVertexConnectionUtils.connectNewDataSetAsInput;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -132,10 +135,17 @@ public class UpdatePartitionConsumersTest extends TestLogger {
         final SimpleAckingTaskManagerGateway taskManagerGateway =
                 new SimpleAckingTaskManagerGateway();
 
+        final ScheduledExecutorService mainThreadExecutorService =
+                Executors.newSingleThreadScheduledExecutor();
+
+        final ComponentMainThreadExecutor singleThreadMainThreadExecutor =
+                ComponentMainThreadExecutorServiceAdapter.forSingleThreadExecutor(
+                        mainThreadExecutorService);
+
         final SchedulerBase scheduler =
                 new DefaultSchedulerBuilder(
                                 jobGraph,
-                                ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                                singleThreadMainThreadExecutor,
                                 EXECUTOR_RESOURCE.getExecutor())
                         .setExecutionSlotAllocatorFactory(
                                 new TestExecutionSlotAllocatorFactory(taskManagerGateway))
@@ -159,21 +169,27 @@ public class UpdatePartitionConsumersTest extends TestLogger {
                     }
                 });
 
-        scheduler.startScheduling();
+        CompletableFuture.runAsync(scheduler::startScheduling, singleThreadMainThreadExecutor)
+                .join();
+
+        waitForTaskDeploymentDescriptorsCreation(ev1, ev2, ev3, ev4);
 
         assertThat(ev1.getExecutionState(), is(ExecutionState.DEPLOYING));
         assertThat(ev2.getExecutionState(), is(ExecutionState.DEPLOYING));
         assertThat(ev3.getExecutionState(), is(ExecutionState.DEPLOYING));
         assertThat(ev4.getExecutionState(), is(ExecutionState.DEPLOYING));
 
-        updateState(scheduler, ev1, ExecutionState.INITIALIZING);
-        updateState(scheduler, ev1, ExecutionState.RUNNING);
-        updateState(scheduler, ev2, ExecutionState.INITIALIZING);
-        updateState(scheduler, ev2, ExecutionState.RUNNING);
-        updateState(scheduler, ev3, ExecutionState.INITIALIZING);
-        updateState(scheduler, ev3, ExecutionState.RUNNING);
-        updateState(scheduler, ev4, ExecutionState.INITIALIZING);
-        updateState(scheduler, ev4, ExecutionState.RUNNING);
+        mainThreadExecutorService.execute(
+                () -> {
+                    updateState(scheduler, ev1, ExecutionState.INITIALIZING);
+                    updateState(scheduler, ev1, ExecutionState.RUNNING);
+                    updateState(scheduler, ev2, ExecutionState.INITIALIZING);
+                    updateState(scheduler, ev2, ExecutionState.RUNNING);
+                    updateState(scheduler, ev3, ExecutionState.INITIALIZING);
+                    updateState(scheduler, ev3, ExecutionState.RUNNING);
+                    updateState(scheduler, ev4, ExecutionState.INITIALIZING);
+                    updateState(scheduler, ev4, ExecutionState.RUNNING);
+                });
 
         final InputGateDeploymentDescriptor ev4Igdd2 =
                 ev4TddFuture.get(TIMEOUT, TimeUnit.MILLISECONDS).getInputGates().get(1);
@@ -196,8 +212,11 @@ public class UpdatePartitionConsumersTest extends TestLogger {
                     updatePartitionFuture.complete(null);
                 });
 
-        updateState(scheduler, ev1, ExecutionState.FINISHED);
-        updateState(scheduler, ev3, ExecutionState.FINISHED);
+        mainThreadExecutorService.execute(
+                () -> {
+                    updateState(scheduler, ev1, ExecutionState.FINISHED);
+                    updateState(scheduler, ev3, ExecutionState.FINISHED);
+                });
 
         updatePartitionFuture.get(TIMEOUT, TimeUnit.MILLISECONDS);
     }


### PR DESCRIPTION
## What is the purpose of the change

Reduces risks of pekko framesize exceeded errors during task deployment caused by large TaskRestore through asynchronous offloading to the BlobStore. 

## Brief change log
* Modifies `Execution#deploy()` to offload large TaskRestore values using BlobWriter (BlobWriter decides on threshold). 
* Offloading of TaskRestore is done asynchronously to avoid blocks the main thread.
* As `deploy` method now returns earlier, additional `CompletableFuture<Void>` is exported from Execution for testing purposes.
* Existing impacted tests are adjusted for new behaviour of `Execution#deploy`. 
* Added new tests to verify new code path.

## Verifying this change
* Existing tests. 
* Additional unit test to verify new code path: `ExecutionTest#testExecutionCancelledDuringTaskRestoreOffload`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / no / **don't know**)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
