### PR TITLE
[FLINK-32695] [Tests] Removed SourceFunction Dependency from YarnTestCacheJob.

### DIFF
--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/testjob/YarnTestCacheJob.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/testjob/YarnTestCacheJob.java
@@ -21,11 +21,9 @@ package org.apache.flink.yarn.testjob;
 import org.apache.flink.api.common.functions.OpenContext;
 import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.v2.DiscardingSink;
-import org.apache.flink.streaming.api.functions.source.legacy.SourceFunction;
 
 import org.apache.flink.shaded.guava33.com.google.common.collect.ImmutableList;
 
@@ -54,7 +52,7 @@ public class YarnTestCacheJob {
         env.registerCachedFile(testDirectory.getAbsolutePath(), TEST_DIRECTORY_NAME);
         env.registerCachedFile(cacheFilePath, "cacheFile", false);
 
-        env.addSource(new GenericSourceFunction(LIST, TypeInformation.of(String.class)))
+        env.fromData(LIST)
                 .setParallelism(1)
                 .map(new MapperFunction(), TypeInformation.of(String.class))
                 .setParallelism(1)
@@ -92,33 +90,6 @@ public class YarnTestCacheJob {
             final String property = (String) properties.getOrDefault(value, "null");
             checkState(property.equals(value + "_property"));
             return value;
-        }
-    }
-
-    private static class GenericSourceFunction<T>
-            implements SourceFunction<T>, ResultTypeQueryable<T> {
-        private List<T> inputDataset;
-        private TypeInformation returnType;
-
-        GenericSourceFunction(List<T> inputDataset, TypeInformation returnType) {
-            this.inputDataset = inputDataset;
-            this.returnType = returnType;
-        }
-
-        @Override
-        public void run(SourceContext<T> ctx) throws Exception {
-
-            for (T t : inputDataset) {
-                ctx.collect(t);
-            }
-        }
-
-        @Override
-        public void cancel() {}
-
-        @Override
-        public TypeInformation getProducedType() {
-            return this.returnType;
         }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Removing SourceFunction Dependency from YarnTestCacheJob.


## Brief change log

- Replaced custom GenericSourceFunction implementation with env.fromData() in YarnTestCacheJob


## Verifying this change

Existing tests already cover this change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
