### PR TITLE
[FLINK-38135][table] Fix call to non-existent method for RAW type hashing

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.serialization.SerializerConfigImpl
 import org.apache.flink.core.memory.MemorySegment
 import org.apache.flink.table.data._
 import org.apache.flink.table.data.binary._
-import org.apache.flink.table.data.binary.BinaryRowDataUtil.BYTE_ARRAY_BASE_OFFSET
 import org.apache.flink.table.data.util.DataFormatConverters
 import org.apache.flink.table.data.util.DataFormatConverters.IdentityConverter
 import org.apache.flink.table.data.utils.JoinedRowData
@@ -378,7 +377,7 @@ object CodeGenUtils {
             tirt.getTypeInformation.createSerializer(new SerializerConfigImpl)
         }
         val serTerm = ctx.addReusableObject(serializer, "serializer")
-        s"$BINARY_RAW_VALUE.getJavaObjectFromRawValueData($term, $serTerm).hashCode()"
+        s"$term.toObject($serTerm).hashCode()"
       case NULL | SYMBOL | UNRESOLVED =>
         throw new IllegalArgumentException("Illegal type: " + t)
     }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
@@ -2341,11 +2341,11 @@ class CalcITCase extends BatchTestBase {
     checkResult(
       s"""
          |SELECT str, COUNT(1) FROM (
-         |  SELECT RawOutUDF(id) AS str FROM (VALUES (0), (1), (2)) AS t(id)
+         |  SELECT RawOutUDF(id) AS str FROM (VALUES (0), (1), (2), (2), (1), (2)) AS t(id)
          |)
          |GROUP BY str
          |""".stripMargin,
-      Seq(row(0, 1), row(1, 1), row(2, 1))
+      Seq(row(0, 1), row(1, 2), row(2, 3))
     );
   }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
@@ -857,22 +857,22 @@ class CalcITCase extends BatchTestBase {
   }
 
   // TODO
-  //  @Test
-  //  def testUDFWithGetResultTypeFromLiteral(): Unit = {
-  //    registerFunction("hashCode0", LiteralHashCode)
-  //    registerFunction("hashCode1", LiteralHashCode)
-  //    val data = Seq(row("a"), row("b"), row("c"))
-  //    tEnv.registerCollection("MyTable", data, new RowTypeInfo(STRING_TYPE_INFO), "text")
-  //    checkResult(
-  //      "SELECT hashCode0(text, 'int') FROM MyTable",
-  //      Seq(row(97), row(98), row(99)
-  //      ))
-  //
-  //    checkResult(
-  //      "SELECT hashCode1(text, 'string') FROM MyTable",
-  //      Seq(row("str97"), row("str98"), row("str99")
-  //      ))
-  //  }
+//  @Test
+//  def testUDFWithGetResultTypeFromLiteral(): Unit = {
+//    registerFunction("hashCode0", LiteralHashCode)
+//    registerFunction("hashCode1", LiteralHashCode)
+//    val data = Seq(row("a"), row("b"), row("c"))
+//    tEnv.registerCollection("MyTable", data, new RowTypeInfo(STRING_TYPE_INFO), "text")
+//    checkResult(
+//      "SELECT hashCode0(text, 'int') FROM MyTable",
+//      Seq(row(97), row(98), row(99)
+//      ))
+//
+//    checkResult(
+//      "SELECT hashCode1(text, 'string') FROM MyTable",
+//      Seq(row("str97"), row("str98"), row("str99")
+//      ))
+//  }
 
   @Test
   def testInNonConstantValue(): Unit = {
@@ -1692,10 +1692,9 @@ class CalcITCase extends BatchTestBase {
 
     tEnv.createTemporaryView("myTable", source)
 
-    val query =
-      """
-        |select * from myTable where f0 in (1.0, 2.0, 3.0)
-        |""".stripMargin
+    val query = """
+                  |select * from myTable where f0 in (1.0, 2.0, 3.0)
+                  |""".stripMargin
 
     checkResult(
       query,

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
@@ -857,22 +857,22 @@ class CalcITCase extends BatchTestBase {
   }
 
   // TODO
-//  @Test
-//  def testUDFWithGetResultTypeFromLiteral(): Unit = {
-//    registerFunction("hashCode0", LiteralHashCode)
-//    registerFunction("hashCode1", LiteralHashCode)
-//    val data = Seq(row("a"), row("b"), row("c"))
-//    tEnv.registerCollection("MyTable", data, new RowTypeInfo(STRING_TYPE_INFO), "text")
-//    checkResult(
-//      "SELECT hashCode0(text, 'int') FROM MyTable",
-//      Seq(row(97), row(98), row(99)
-//      ))
-//
-//    checkResult(
-//      "SELECT hashCode1(text, 'string') FROM MyTable",
-//      Seq(row("str97"), row("str98"), row("str99")
-//      ))
-//  }
+  //  @Test
+  //  def testUDFWithGetResultTypeFromLiteral(): Unit = {
+  //    registerFunction("hashCode0", LiteralHashCode)
+  //    registerFunction("hashCode1", LiteralHashCode)
+  //    val data = Seq(row("a"), row("b"), row("c"))
+  //    tEnv.registerCollection("MyTable", data, new RowTypeInfo(STRING_TYPE_INFO), "text")
+  //    checkResult(
+  //      "SELECT hashCode0(text, 'int') FROM MyTable",
+  //      Seq(row(97), row(98), row(99)
+  //      ))
+  //
+  //    checkResult(
+  //      "SELECT hashCode1(text, 'string') FROM MyTable",
+  //      Seq(row("str97"), row("str98"), row("str99")
+  //      ))
+  //  }
 
   @Test
   def testInNonConstantValue(): Unit = {
@@ -1692,9 +1692,10 @@ class CalcITCase extends BatchTestBase {
 
     tEnv.createTemporaryView("myTable", source)
 
-    val query = """
-                  |select * from myTable where f0 in (1.0, 2.0, 3.0)
-                  |""".stripMargin
+    val query =
+      """
+        |select * from myTable where f0 in (1.0, 2.0, 3.0)
+        |""".stripMargin
 
     checkResult(
       query,
@@ -2332,5 +2333,20 @@ class CalcITCase extends BatchTestBase {
   def testIfNull(): Unit = {
     // reported in FLINK-35832
     checkResult("SELECT IFNULL(JSON_VALUE('{\"a\":16}','$.a'),'0')", Seq(row("16")));
+  }
+
+  @Test
+  def testRawHash(): Unit = {
+    // reported in FLINK-38135
+    tEnv.createTemporarySystemFunction("RawOutUDF", RawOutUDF)
+    checkResult(
+      s"""
+         |SELECT str, COUNT(1) FROM (
+         |  SELECT RawOutUDF(id) AS str FROM (VALUES (0), (1), (2)) AS t(id)
+         |)
+         |GROUP BY str
+         |""".stripMargin,
+      Seq(row(0, 1), row(1, 1), row(2, 1))
+    );
   }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/UserDefinedFunctionTestUtils.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/UserDefinedFunctionTestUtils.scala
@@ -443,6 +443,12 @@ object UserDefinedFunctionTestUtils {
     override def getResultType(signature: Array[Class[_]]): TypeInformation[_] = Types.BOOLEAN
   }
 
+  @SerialVersionUID(1L)
+  object RawOutUDF extends ScalarFunction {
+    @DataTypeHint(value = "RAW", bridgedTo = classOf[String])
+    def eval(id: Int): String = id.toString
+  }
+
   // ------------------------------------------------------------------------------------
   // POJOs
   // ------------------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

Fix call to non-existent method for RAW type hashing.

## Brief change log

Use `BinaryRawValueData#toObject`.

## Verifying this change

`CalcITCase#testRawHash`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? ()
