### PR TITLE
[FLINK-38138] Fix OOB error in ColumnarArrayData

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/columnar/ColumnarArrayData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/columnar/ColumnarArrayData.java
@@ -141,7 +141,8 @@ public final class ColumnarArrayData implements ArrayData, TypedSetters {
         if (byteArray.len == byteArray.data.length) {
             return byteArray.data;
         } else {
-            return Arrays.copyOfRange(byteArray.data, byteArray.offset, byteArray.len);
+            return Arrays.copyOfRange(
+                    byteArray.data, byteArray.offset, byteArray.offset + byteArray.len);
         }
     }
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/data/columnar/ColumnarArrayDataTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/data/columnar/ColumnarArrayDataTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.data.columnar;
+
+import org.apache.flink.table.data.columnar.vector.heap.HeapBytesVector;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+class ColumnarArrayDataTest {
+
+    @Test
+    @DisplayName("getBinary() should work correctly for slices with position 0")
+    void testGetBinaryWhenOffsetIsZero() {
+        HeapBytesVector vector = new HeapBytesVector(2);
+        byte[] sourceData = new byte[] {10, 20, 30, 40, 50};
+
+        vector.appendBytes(0, sourceData, 0, 3);
+
+        ColumnarArrayData arrayData = new ColumnarArrayData(vector, 0, 1);
+
+        byte[] actual = arrayData.getBinary(0);
+
+        byte[] expected = new byte[] {10, 20, 30};
+        assertArrayEquals(expected, actual);
+    }
+
+    @Test
+    @DisplayName("getBinary() should return correct sub-array when slice position is non-zero")
+    void testGetBinaryWhenPositionNonZero() {
+        HeapBytesVector vector = new HeapBytesVector(3);
+
+        // Append a DUMMY element first
+        byte[] dummyData = new byte[] {99, 99, 99, 99};
+        vector.appendBytes(0, dummyData, 0, 4);
+
+        // Append the REAL data
+        byte[] sourceData1 = new byte[] {30, 40, 50, 60};
+        vector.appendBytes(1, sourceData1, 0, 4);
+
+        byte[] sourceData2 = new byte[] {70, 80, 90, 100};
+        vector.appendBytes(2, sourceData2, 0, 4);
+
+        // Create a ColumnarArrayData that wraps the entire vector
+        ColumnarArrayData arrayData = new ColumnarArrayData(vector, 0, 1);
+        assertArrayEquals(dummyData, arrayData.getBinary(0));
+        assertArrayEquals(sourceData1, arrayData.getBinary(1));
+        assertArrayEquals(sourceData2, arrayData.getBinary(2));
+    }
+}

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/data/columnar/ColumnarArrayDataTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/data/columnar/ColumnarArrayDataTest.java
@@ -23,7 +23,7 @@ import org.apache.flink.table.data.columnar.vector.heap.HeapBytesVector;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class ColumnarArrayDataTest {
 
@@ -40,7 +40,7 @@ class ColumnarArrayDataTest {
         byte[] actual = arrayData.getBinary(0);
 
         byte[] expected = new byte[] {10, 20, 30};
-        assertArrayEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -61,8 +61,8 @@ class ColumnarArrayDataTest {
 
         // Create a ColumnarArrayData that wraps the entire vector
         ColumnarArrayData arrayData = new ColumnarArrayData(vector, 0, 1);
-        assertArrayEquals(dummyData, arrayData.getBinary(0));
-        assertArrayEquals(sourceData1, arrayData.getBinary(1));
-        assertArrayEquals(sourceData2, arrayData.getBinary(2));
+        assertThat(arrayData.getBinary(0)).isEqualTo(dummyData);
+        assertThat(arrayData.getBinary(1)).isEqualTo(sourceData1);
+        assertThat(arrayData.getBinary(2)).isEqualTo(sourceData2);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

We have noticed that an OOB error is being thrown when trying to invoke getBinary when the following conditions are met:

1. There are multiple elements in a HeapArrayVector
2. When trying to get an element from a non-zero offset of the array
3. When trying to convert this array that we have obtained to a binary

```
Caused by: java.lang.IllegalArgumentException: 72 > 36
	at java.util.Arrays.copyOfRange(Arrays.java:3519)
	at org.apache.flink.table.data.columnar.ColumnarArrayData.getBinary(ColumnarArrayData.java:138)
	at org.apache.hudi.table.format.cow.vector.ColumnarGroupRowData.getBinary(ColumnarGroupRowData.java:121)
	at org.apache.flink.table.data.RowData.lambda$createFieldGetter$245ca7d1$3(RowData.java:228)
	at org.apache.flink.table.runtime.typeutils.RowDataSerializer.toBinaryRow(RowDataSerializer.java:207)
	at org.apache.flink.table.data.writer.AbstractBinaryWriter.writeRow(AbstractBinaryWriter.java:147)
	at org.apache.flink.table.data.writer.BinaryArrayWriter.writeRow(BinaryArrayWriter.java:30)
	at org.apache.flink.table.data.writer.BinaryWriter.write(BinaryWriter.java:155)
	at org.apache.flink.table.runtime.typeutils.MapDataSerializer.toBinaryMap(MapDataSerializer.java:179)
	at org.apache.flink.table.runtime.typeutils.MapDataSerializer.copy(MapDataSerializer.java:113)
	at org.apache.flink.table.runtime.typeutils.MapDataSerializer.copy(MapDataSerializer.java:44)
	at org.apache.flink.table.runtime.typeutils.RowDataSerializer.copyRowData(RowDataSerializer.java:170)
	at org.apache.flink.table.runtime.typeutils.RowDataSerializer.copy(RowDataSerializer.java:131)
```

The error below is caused by the code below:

```
@Override
public byte[] getBinary(int pos) {
    BytesColumnVector.Bytes byteArray = getByteArray(pos);
    if (byteArray.len == byteArray.data.length) {
        return byteArray.data;
    } else {
        return Arrays.copyOfRange(byteArray.data, byteArray.offset, byteArray.len);
    }
} 
```

The function signature of `Arrays.copyOfRange` is as such:

```java
public static byte[] copyOfRange(byte[] original, int from, int to) 
```

The `java.util.Arrays.copyOfRange(original, from, to)` method copies the specified range of the original array into a new array.
1. `from`: The initial index of the range to be copied, inclusive.
2. `to`: The final index of the range to be copied, exclusive.


Hence, the correct way of invoking `Arrays.copyOfRange`` should be:

```java
return Arrays.copyOfRange(
        byteArray.data, byteArray.offset, byteArray.offset + byteArray.len);  
```

## Brief change log

  - Fix the OOB error by ensuring that getBinary is calling Arrays.copyOfRange with the correct arguments.


## Verifying this change

  - Added unit tests for `ColumnarArrayData` to verify fix. Test fails before fix, but passes after

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? (no)
