### PR TITLE
[FLINK-32695] [Tests] Migrated SimpleStringGenerator to Source V2 Implementation

### DIFF
--- a/flink-tests/pom.xml
+++ b/flink-tests/pom.xml
@@ -61,6 +61,13 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils-connector</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-files</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>


### PR DESCRIPTION
## What is the purpose of the change

This PR migrates CheckpointedStreamingProgram from the deprecated legacy SourceFunction API to the modern FLIP-27 Source API.


## Brief change log

- Removed SimpleStringGenerator class that implemented the deprecated SourceFunction interface
- Configured a new SimpleStringGenerator based on FLIP-27 Source API. (Must be implemented inside the user JAR as user code, & Cannot depend on external source implementations)
- Updated imports to use FLIP-27 Source API classes


## Verifying this change

Existing tests already cover this change, [ClassLoaderITCase](https://github.com/apache/flink/blob/master/flink-tests/src/test/java/org/apache/flink/test/classloading/ClassLoaderITCase.java). 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
