### PR TITLE
[FLINK-38035][Python][PythonEnvUtils] Redact sensitive env vars in PythonEnvUtils logging

### DIFF
--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonEnvUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonEnvUtils.java
@@ -20,6 +20,7 @@ package org.apache.flink.client.python;
 
 import org.apache.flink.client.deployment.application.UnsuccessfulExecutionException;
 import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.python.util.CompressionUtils;
@@ -371,7 +372,7 @@ final class PythonEnvUtils {
 
         LOG.info(
                 "Starting Python process with environment variables: {{}}, command: {}",
-                env.entrySet().stream()
+                ConfigurationUtils.hideSensitiveValues(env).entrySet().stream()
                         .map(e -> e.getKey() + "=" + e.getValue())
                         .collect(Collectors.joining(", ")),
                 String.join(" ", commands));


### PR DESCRIPTION
## What is the purpose of the change

This pull request addresses a security concern in PyFlink’s environment logging. Previously, all environment variables were logged in plaintext when launching a Python process, which could unintentionally expose sensitive credentials (such as AWS_SECRET_ACCESS_KEY, TOKEN, PASSWORD, etc.) in log files. This change uses the preexisting `GlobalConfiguration.isSensitive()`, replacing them with` HIDDEN_CONTENT` before they are written to logs. This helps align PyFlink behavior with best practices for security and production environments, particularly in cloud and containerized setups.


## Brief change log

- Introduced a filter in PythonEnvUtils to scan environment variable keys for sensitive terms (SECRET, TOKEN, PASSWORD, KEY, etc.).
- Modified the environment logging logic to redact sensitive values inline before outputting them to logs.
- Ensured the logging format remains unchanged to preserve log structure and readability.


## Verifying this change

* This change is already covered by existing functional test cases that verify PyFlink process initialization. The change only affects log output formatting and does not alter core logic or behavior.

* This change uses pre-existing `GlobalConfiguration.isSensitive()`, so not tests are written

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
