### PR TITLE
[FLINK-38151] Class MetricFetcherImpl's method fetchMetrics failed log level adjustment to error

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/MetricFetcherImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/MetricFetcherImpl.java
@@ -144,7 +144,7 @@ public class MetricFetcherImpl<T extends RestfulGateway> implements MetricFetche
                 jobDetailsFuture.whenCompleteAsync(
                         (MultipleJobsDetails jobDetails, Throwable throwable) -> {
                             if (throwable != null) {
-                                LOG.debug("Fetching of JobDetails failed.", throwable);
+                                LOG.error("Fetching of JobDetails failed.", throwable);
                             } else {
                                 ArrayList<String> toRetain =
                                         new ArrayList<>(jobDetails.getJobs().size());
@@ -163,7 +163,7 @@ public class MetricFetcherImpl<T extends RestfulGateway> implements MetricFetche
                 jmMetricsFuture.whenCompleteAsync(
                         (ignore, throwable) -> {
                             if (throwable != null) {
-                                LOG.debug("Failed to fetch the leader's metrics.", throwable);
+                                LOG.error("Failed to fetch the leader's metrics.", throwable);
                             }
                         },
                         executor);


### PR DESCRIPTION
when there is a jar conflict，the webUI keeps loading without any direct error message in the log, but Flink job is running normally.  This causing significant obstacles to identifying problems during troubleshooting. 

Strongly recommend adjusting the failed log level to ERROR!!
Only debug log as follows:
 DEBUG org.apache.flink.runtime.rest.handler.legacy.metrics.MetricFetcherImpl [] - Failed to fetch the TaskManager's metrics.
java.util.concurrent.CompletionException: java.util.concurrent.ExecutionException: Boxed Error
Caused by: java.lang.NoSuchMethodError: org.apache.commons.math3.stat.descriptive.rank.Percentile.withNaNStrategy(Lorg/apache/commons/math3/stat/ranking/NaNStrategy;)Lorg/apache/commons/math3/stat/descriptive/rank/Percentile;
<img width="1068" height="115" alt="image-2025-07-29-10-41-35-778" src="https://github.com/user-attachments/assets/40808d02-ba59-4473-9a86-e01db0fdfade" />
