### PR TITLE
[FLINK-32695] [Tests] Migrated TableFactoryHarness.ScanSourceBase to Source V2

### DIFF
--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -170,6 +170,13 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils-connector</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
 		<!-- ArchUnit test dependencies -->
 		<dependency>
 			<groupId>org.apache.flink</groupId>


### PR DESCRIPTION
## What is the purpose of the change

This PR migrates legacy SourceFunction and SinkFunction implementations in table planner tests from the deprecated legacy APIs to the modern FLIP-27 Source API


## Brief change log

   - Migrated TableFactoryHarness.ScanSourceBase from SourceFunctionProvider to SourceProvider with DataGeneratorSource
  - Migrated TableFactoryHarness.SinkBase from SinkFunctionProvider to SinkV2Provider with TestSinkV2
  - Implemented custom Source V2 in CommonExecSinkITCase.TestSource to preserve timestamp ordering
  - Updated BuiltInAggregateFunctionTestBase to use DataGeneratorSource instead of legacy SourceFunction


## Verifying this change

Existing tests already cover these changes:
  - BuiltInAggregateFunctionTestBase: ModuleITCase, HashcodeITCase, MiscAggFunctionITCase, ArrayAggFunctionITCase, JsonAggregationFunctionsITCase, PercentileAggFunctionITCase
  - CommonExecSinkITCase: testStreamRecordTimestampInserterSinkRuntimeProvider and other timestamp-related tests
  - TableFactoryHarness: All dependent test cases using the harness framework

  All tests pass.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
