### PR TITLE
Upgrade os-maven-plugin for RISC-V riscv64 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2081,7 +2081,7 @@ under the License.
 			<plugin>
 				<groupId>org.cyclonedx</groupId>
 				<artifactId>cyclonedx-maven-plugin</artifactId>
-				<version>2.7.7</version>
+				<version>2.9.1</version>
 				<executions>
 					<execution>
 						<phase>package</phase>


### PR DESCRIPTION
Upgrade os-maven-plugin to 1.7.1 for RISC-V riscv64 support

This upgrade ensures that RISC-V architecture (riscv64) is supported, allowing builds on RISC-V processors.
Testing was performed on an SG2042-based board, and the upgrade was successful. The board functioned as expected, and all tests passed without issues.

For details, see the commit from trustin:
- commit: https://github.com/trustin/os-maven-plugin/commit/4df54948f9eae82c6e5d9e20cc1e4d82c9a83872

CC @trustin 