### PR TITLE
[FLINK-38179] Upgrade os-maven-plugin for RISC-V riscv64 support

### DIFF
--- a/flink-formats/flink-parquet/pom.xml
+++ b/flink-formats/flink-parquet/pom.xml
@@ -298,7 +298,7 @@ under the License.
 			<extension>
 				<groupId>kr.motd.maven</groupId>
 				<artifactId>os-maven-plugin</artifactId>
-				<version>1.7.0</version>
+				<version>1.7.1</version>
 			</extension>
 		</extensions>
 


### PR DESCRIPTION
This upgrade ensures that RISC-V architecture (riscv64) is supported, allowing builds on RISC-V processors.
Testing was performed on an SG2042-based board, and the upgrade was successful. The board functioned as expected, and all tests passed without issues.

For details, see the commit from trustin:
- commit: https://github.com/trustin/os-maven-plugin/commit/4df54948f9eae82c6e5d9e20cc1e4d82c9a83872

CC @trustin 