### PR TITLE
[FLINK-38181] Fix code generation for primitive type casting and improve cast consistency across compile-time and runtime paths

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/DateTimeUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/DateTimeUtils.java
@@ -568,7 +568,26 @@ public class DateTimeUtils {
         return ymdToUnixDate(y, m, d);
     }
 
-    public static Integer parseTime(String v) {
+    /**
+     * Parses a time string into milliseconds since midnight.
+     *
+     * <p>Supports various time formats:
+     *
+     * <ul>
+     *   <li>HH - hour only (e.g., "14")
+     *   <li>HH:mm - hour and minute (e.g., "14:30")
+     *   <li>HH:mm:ss - hour, minute, and second (e.g., "14:30:45")
+     *   <li>HH:mm:ss.fff - with fractional seconds (e.g., "14:30:45.123")
+     *   <li>Any of the above with timezone offset: [+|-]HH:mm (e.g., "14:30:45+02:00")
+     * </ul>
+     *
+     * <p>Follows W3C datetime format specification.
+     *
+     * @param v the time string to parse
+     * @return milliseconds since midnight (0-86399999), or {@code null} if parsing fails
+     * @see <a href="https://www.w3.org/TR/NOTE-datetime">W3C Date and Time Formats</a>
+     */
+    public static Integer parseTime(final String v) {
         final int start = 0;
         final int colon1 = v.indexOf(':', start);
         // timezone hh:mm:ss[.ssssss][[+|-]hh:mm:ss]
@@ -651,12 +670,34 @@ public class DateTimeUtils {
                 }
             }
         }
+
+        if (!isValidTime(hour, minute, second)) {
+            return null;
+        }
+
         hour += operator * timezoneHour;
         minute += operator * timezoneMinute;
         return hour * (int) MILLIS_PER_HOUR
                 + minute * (int) MILLIS_PER_MINUTE
                 + second * (int) MILLIS_PER_SECOND
                 + milli;
+    }
+
+    /**
+     * Validates time components are within valid ranges.
+     *
+     * @param hour hour component (0-23)
+     * @param minute minute component (0-59)
+     * @param second second component (0-59)
+     * @return true if all components are valid, false otherwise
+     */
+    private static boolean isValidTime(int hour, int minute, int second) {
+        return hour >= 0
+                && hour <= 23
+                && minute >= 0
+                && minute <= 59
+                && second >= 0
+                && second <= 59;
     }
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/DateTimeUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/DateTimeUtils.java
@@ -1541,7 +1541,7 @@ public class DateTimeUtils {
                         .toLocalDate());
     }
 
-    public static int timestampWithOutLocalZoneToTime(TimestampData ts, int precision) {
+    public static int timestampWithoutLocalZoneToTime(TimestampData ts, int precision) {
         final int millisecond = (int) (ts.getMillisecond() % DateTimeUtils.MILLIS_PER_DAY);
         return applyTimePrecisionTruncation(millisecond, precision);
     }
@@ -1573,20 +1573,20 @@ public class DateTimeUtils {
      * </table>
      *
      * @param timeMillis time value as milliseconds since midnight (0-86399999)
-     * @param targetPrecision the target precision for fractional seconds (0-9)
+     * @param precision the target precision for fractional seconds (0-9)
      * @return the truncated time value in milliseconds
      */
-    public static int applyTimePrecisionTruncation(int timeMillis, int targetPrecision) {
-        if (targetPrecision >= 3) {
-            // Precision 3 or higher: no truncation needed (millisecond resolution or finer)
-            return timeMillis;
-        } else {
-            // Truncate to the target precision:
-            // - Precision 0: truncate to whole seconds (remove milliseconds)
-            // - Precision 1: truncate to deciseconds (100ms resolution)
-            // - Precision 2: truncate to centiseconds (10ms resolution)
-            final int factor = (int) Math.pow(10, 3 - targetPrecision);
-            return (timeMillis / factor) * factor;
+    public static int applyTimePrecisionTruncation(int timeMillis, int precision) {
+        switch (precision) {
+            case 0:
+                return (timeMillis / 1000) * 1000;
+            case 1:
+                return (timeMillis / 100) * 100;
+            case 2:
+                return (timeMillis / 10) * 10;
+            default:
+                // precision 3 or higher, no truncation needed
+                return timeMillis;
         }
     }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/StringToTimeCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/StringToTimeCastRule.java
@@ -22,6 +22,7 @@ import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeFamily;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
 
 import static org.apache.flink.table.planner.codegen.calls.BuiltInMethods.STRING_DATA_TO_TIME;
 import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.staticCall;
@@ -48,7 +49,8 @@ class StringToTimeCastRule extends AbstractExpressionCodeGeneratorCastRule<Strin
             String inputTerm,
             LogicalType inputLogicalType,
             LogicalType targetLogicalType) {
-        return staticCall(STRING_DATA_TO_TIME(), inputTerm);
+        final int targetPrecision = LogicalTypeChecks.getPrecision(targetLogicalType);
+        return staticCall(STRING_DATA_TO_TIME(), inputTerm, targetPrecision);
     }
 
     @Override

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/TimestampToTimeCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/TimestampToTimeCastRule.java
@@ -22,11 +22,8 @@ import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.planner.codegen.calls.BuiltInMethods;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
-import org.apache.flink.table.utils.DateTimeUtils;
+import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
 
-import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.cast;
-import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.methodCall;
-import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.operator;
 import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.staticCall;
 
 /**
@@ -54,21 +51,20 @@ class TimestampToTimeCastRule
             String inputTerm,
             LogicalType inputLogicalType,
             LogicalType targetLogicalType) {
+        final int targetPrecision = LogicalTypeChecks.getPrecision(targetLogicalType);
 
         if (inputLogicalType.is(LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE)) {
-            return cast(
-                    "int",
-                    operator(
-                            methodCall(inputTerm, "getMillisecond"),
-                            "%",
-                            DateTimeUtils.MILLIS_PER_DAY));
+            return staticCall(
+                    BuiltInMethods.TIMESTAMP_WITH_OUT_LOCAL_TIME_ZONE_TO_TIME(),
+                    inputTerm,
+                    targetPrecision);
         } else if (inputLogicalType.is(LogicalTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE)) {
             return staticCall(
                     BuiltInMethods.TIMESTAMP_WITH_LOCAL_TIME_ZONE_TO_TIME(),
                     inputTerm,
-                    context.getSessionTimeZoneTerm());
-        } else {
-            throw new IllegalArgumentException("This is a bug. Please file an issue.");
+                    context.getSessionTimeZoneTerm(),
+                    targetPrecision);
         }
+        throw new IllegalArgumentException("This is a bug. Please file an issue.");
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/TimestampToTimeCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/TimestampToTimeCastRule.java
@@ -55,7 +55,7 @@ class TimestampToTimeCastRule
 
         if (inputLogicalType.is(LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE)) {
             return staticCall(
-                    BuiltInMethods.TIMESTAMP_WITH_OUT_LOCAL_TIME_ZONE_TO_TIME(),
+                    BuiltInMethods.TIMESTAMP_WITHOUT_LOCAL_TIME_ZONE_TO_TIME(),
                     inputTerm,
                     targetPrecision);
         } else if (inputLogicalType.is(LogicalTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE)) {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.serialization.SerializerConfigImpl
 import org.apache.flink.core.memory.MemorySegment
 import org.apache.flink.table.data._
 import org.apache.flink.table.data.binary._
-import org.apache.flink.table.data.binary.BinaryRowDataUtil.BYTE_ARRAY_BASE_OFFSET
 import org.apache.flink.table.data.util.DataFormatConverters
 import org.apache.flink.table.data.util.DataFormatConverters.IdentityConverter
 import org.apache.flink.table.data.utils.JoinedRowData
@@ -301,7 +300,9 @@ object CodeGenUtils {
     // ordered by type root definition
     case CHAR | VARCHAR => s"$BINARY_STRING.EMPTY_UTF8"
     case BOOLEAN => "false"
-    case TINYINT | SMALLINT | INTEGER | DATE | TIME_WITHOUT_TIME_ZONE | INTERVAL_YEAR_MONTH => "-1"
+    case TINYINT => "((byte) -1)"
+    case SMALLINT => "((short) -1)"
+    case INTEGER | DATE | TIME_WITHOUT_TIME_ZONE | INTERVAL_YEAR_MONTH => "-1"
     case BIGINT | INTERVAL_DAY_TIME => "-1L"
     case FLOAT => "-1.0f"
     case DOUBLE => "-1.0d"

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
@@ -300,9 +300,7 @@ object CodeGenUtils {
     // ordered by type root definition
     case CHAR | VARCHAR => s"$BINARY_STRING.EMPTY_UTF8"
     case BOOLEAN => "false"
-    case TINYINT => "((byte) -1)"
-    case SMALLINT => "((short) -1)"
-    case INTEGER | DATE | TIME_WITHOUT_TIME_ZONE | INTERVAL_YEAR_MONTH => "-1"
+    case TINYINT | SMALLINT | INTEGER | DATE | TIME_WITHOUT_TIME_ZONE | INTERVAL_YEAR_MONTH => "-1"
     case BIGINT | INTERVAL_DAY_TIME => "-1L"
     case FLOAT => "-1.0f"
     case DOUBLE => "-1.0d"
@@ -310,6 +308,17 @@ object CodeGenUtils {
     case DISTINCT_TYPE => primitiveDefaultValue(t.asInstanceOf[DistinctType].getSourceType)
 
     case _ => "null"
+  }
+
+  /**
+   * Gets a properly typed default value for a primitive type. For example: ((short) -1) for
+   * SMALLINT, ((byte) -1) for TINYINT. This ensures the generated code compiles correctly when the
+   * default value is used in method calls expecting specific primitive types.
+   */
+  def primitiveDefaultValueWithCast(logicalType: LogicalType): String = {
+    val resultTerm = primitiveDefaultValue(logicalType)
+    val resultTypeTerm = primitiveTypeTermForType(logicalType)
+    s"(($resultTypeTerm) $resultTerm)"
   }
 
   @tailrec

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
@@ -301,9 +301,7 @@ object CodeGenUtils {
     // ordered by type root definition
     case CHAR | VARCHAR => s"$BINARY_STRING.EMPTY_UTF8"
     case BOOLEAN => "false"
-    case TINYINT => "((byte) -1)"
-    case SMALLINT => "((short) -1)"
-    case INTEGER | DATE | TIME_WITHOUT_TIME_ZONE | INTERVAL_YEAR_MONTH => "-1"
+    case TINYINT | SMALLINT | INTEGER | DATE | TIME_WITHOUT_TIME_ZONE | INTERVAL_YEAR_MONTH => "-1"
     case BIGINT | INTERVAL_DAY_TIME => "-1L"
     case FLOAT => "-1.0f"
     case DOUBLE => "-1.0d"

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
@@ -301,8 +301,8 @@ object CodeGenUtils {
     // ordered by type root definition
     case CHAR | VARCHAR => s"$BINARY_STRING.EMPTY_UTF8"
     case BOOLEAN => "false"
-    case TINYINT => "((byte)-1)"
-    case SMALLINT => "((short)-1)"
+    case TINYINT => "((byte) -1)"
+    case SMALLINT => "((short) -1)"
     case INTEGER | DATE | TIME_WITHOUT_TIME_ZONE | INTERVAL_YEAR_MONTH => "-1"
     case BIGINT | INTERVAL_DAY_TIME => "-1L"
     case FLOAT => "-1.0f"

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
@@ -264,8 +264,10 @@ object GenerateUtils {
   }
 
   def generateNullLiteral(resultType: LogicalType): GeneratedExpression = {
+    val defaultValue = primitiveDefaultValue(resultType)
+    val resultTypeTerm = primitiveTypeTermForType(resultType)
     GeneratedExpression(
-      primitiveDefaultValue(resultType),
+      s"(($resultTypeTerm) $defaultValue)",
       ALWAYS_NULL,
       NO_CODE,
       resultType,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
@@ -265,7 +265,7 @@ object GenerateUtils {
 
   def generateNullLiteral(resultType: LogicalType): GeneratedExpression = {
     GeneratedExpression(
-      primitiveDefaultValueWithCast(resultType),
+      primitiveDefaultValue(resultType),
       ALWAYS_NULL,
       NO_CODE,
       resultType,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
@@ -264,10 +264,8 @@ object GenerateUtils {
   }
 
   def generateNullLiteral(resultType: LogicalType): GeneratedExpression = {
-    val defaultValue = primitiveDefaultValue(resultType)
-    val resultTypeTerm = primitiveTypeTermForType(resultType)
     GeneratedExpression(
-      s"(($resultTypeTerm) $defaultValue)",
+      primitiveDefaultValueWithCast(resultType),
       ALWAYS_NULL,
       NO_CODE,
       resultType,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
@@ -340,9 +340,9 @@ object BuiltInMethods {
     classOf[TimestampData],
     classOf[TimeZone])
 
-  val TIMESTAMP_WITH_OUT_LOCAL_TIME_ZONE_TO_TIME = Types.lookupMethod(
+  val TIMESTAMP_WITHOUT_LOCAL_TIME_ZONE_TO_TIME = Types.lookupMethod(
     classOf[DateTimeUtils],
-    "timestampWithOutLocalZoneToTime",
+    "timestampWithoutLocalZoneToTime",
     classOf[TimestampData],
     classOf[Int])
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
@@ -340,11 +340,18 @@ object BuiltInMethods {
     classOf[TimestampData],
     classOf[TimeZone])
 
+  val TIMESTAMP_WITH_OUT_LOCAL_TIME_ZONE_TO_TIME = Types.lookupMethod(
+    classOf[DateTimeUtils],
+    "timestampWithOutLocalZoneToTime",
+    classOf[TimestampData],
+    classOf[Int])
+
   val TIMESTAMP_WITH_LOCAL_TIME_ZONE_TO_TIME = Types.lookupMethod(
     classOf[DateTimeUtils],
     "timestampWithLocalZoneToTime",
     classOf[TimestampData],
-    classOf[TimeZone])
+    classOf[TimeZone],
+    classOf[Int])
 
   val DATE_TO_TIMESTAMP_WITH_LOCAL_TIME_ZONE = Types.lookupMethod(
     classOf[DateTimeUtils],
@@ -536,7 +543,11 @@ object BuiltInMethods {
     Types.lookupMethod(classOf[BinaryStringDataUtil], "toDate", classOf[BinaryStringData])
 
   val STRING_DATA_TO_TIME =
-    Types.lookupMethod(classOf[BinaryStringDataUtil], "toTime", classOf[BinaryStringData])
+    Types.lookupMethod(
+      classOf[BinaryStringDataUtil],
+      "toTime",
+      classOf[BinaryStringData],
+      classOf[Int])
 
   val STRING_DATA_TO_TIMESTAMP = Types.lookupMethod(
     classOf[BinaryStringDataUtil],

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/JsonCallGen.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/JsonCallGen.scala
@@ -35,8 +35,13 @@ class JsonCallGen extends CallGenerator {
 
     val resultCode =
       s"""
-         |Object $rawResultTerm =
-         |    ${qualifyMethod(BuiltInMethods.JSON)}(${stringArg.resultTerm}.toString());
+         |${stringArg.code}
+         |Object $rawResultTerm;
+         |if (${stringArg.nullTerm}) {
+         |  $rawResultTerm = null;
+         |} else {
+         |  $rawResultTerm = ${qualifyMethod(BuiltInMethods.JSON)}(${stringArg.resultTerm}.toString());
+         |}
          |$nullTerm = $rawResultTerm == null;
          |$resultTerm = $BINARY_STRING.fromString(java.lang.String.valueOf($rawResultTerm));
          |""".stripMargin

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -1155,8 +1155,12 @@ object ScalarOperatorGens {
               element
             } else {
               val tpe = fieldTypes(idx)
-              val resultTerm = primitiveDefaultValue(tpe)
-              GeneratedExpression(resultTerm, ALWAYS_NULL, NO_CODE, tpe, Some(null))
+              GeneratedExpression(
+                primitiveDefaultValueWithCast(tpe),
+                ALWAYS_NULL,
+                NO_CODE,
+                tpe,
+                Some(null))
             }
         }
         val row = generateLiteralRow(ctx, rowType, mapped)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -1155,7 +1155,14 @@ object ScalarOperatorGens {
               element
             } else {
               val tpe = fieldTypes(idx)
-              GeneratedExpression(primitiveDefaultValue(tpe), ALWAYS_NULL, NO_CODE, tpe, Some(null))
+              val defaultValue = primitiveDefaultValue(tpe)
+              val resultTypeTerm = primitiveTypeTermForType(tpe)
+              GeneratedExpression(
+                s"(($resultTypeTerm) $defaultValue)",
+                ALWAYS_NULL,
+                NO_CODE,
+                tpe,
+                Some(null))
             }
         }
         val row = generateLiteralRow(ctx, rowType, mapped)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -1155,12 +1155,7 @@ object ScalarOperatorGens {
               element
             } else {
               val tpe = fieldTypes(idx)
-              GeneratedExpression(
-                primitiveDefaultValueWithCast(tpe),
-                ALWAYS_NULL,
-                NO_CODE,
-                tpe,
-                Some(null))
+              GeneratedExpression(primitiveDefaultValue(tpe), ALWAYS_NULL, NO_CODE, tpe, Some(null))
             }
         }
         val row = generateLiteralRow(ctx, rowType, mapped)

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/BuiltInFunctionTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/BuiltInFunctionTestBase.java
@@ -18,17 +18,6 @@
 
 package org.apache.flink.table.planner.functions;
 
-import static org.apache.flink.core.testutils.FlinkAssertions.anyCauseMatches;
-import static org.apache.flink.table.api.Expressions.$;
-import static org.apache.flink.table.api.Expressions.call;
-import static org.apache.flink.table.api.Expressions.row;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.catchThrowable;
-
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
-
 import org.apache.flink.client.program.MiniClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.minicluster.MiniCluster;
@@ -55,12 +44,15 @@ import org.apache.flink.types.Row;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.SerializedThrowable;
+
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -71,7 +63,15 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import javax.annotation.Nullable;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.apache.flink.core.testutils.FlinkAssertions.anyCauseMatches;
+import static org.apache.flink.table.api.Expressions.$;
+import static org.apache.flink.table.api.Expressions.call;
+import static org.apache.flink.table.api.Expressions.row;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 /**
  * Test interface implementing the logic to execute tests for {@link BuiltInFunctionDefinition}.

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/BuiltInFunctionTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/BuiltInFunctionTestBase.java
@@ -754,7 +754,7 @@ abstract class BuiltInFunctionTestBase {
                 tableApiExpression, sqlExpression, result, tableApiDataType, sqlQueryDataType);
     }
 
-    /** Identity function that forces the parser to skip constant folding. */
+    /** Identity function that forces the planner to skip constant folding. */
     public static class IdentityFunction extends ScalarFunction {
         public Object eval(Object input) {
             return input;

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/BuiltInFunctionTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/BuiltInFunctionTestBase.java
@@ -18,6 +18,17 @@
 
 package org.apache.flink.table.planner.functions;
 
+import static org.apache.flink.core.testutils.FlinkAssertions.anyCauseMatches;
+import static org.apache.flink.table.api.Expressions.$;
+import static org.apache.flink.table.api.Expressions.call;
+import static org.apache.flink.table.api.Expressions.row;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+
 import org.apache.flink.client.program.MiniClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.minicluster.MiniCluster;
@@ -32,25 +43,24 @@ import org.apache.flink.table.catalog.DataTypeFactory;
 import org.apache.flink.table.expressions.DefaultSqlFactory;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.functions.BuiltInFunctionDefinition;
+import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.table.functions.UserDefinedFunction;
 import org.apache.flink.table.operations.ProjectQueryOperation;
 import org.apache.flink.table.types.AbstractDataType;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.TypeInference;
 import org.apache.flink.test.junit5.InjectMiniCluster;
 import org.apache.flink.test.junit5.MiniClusterExtension;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.SerializedThrowable;
-
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-
-import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -61,13 +71,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
-import static org.apache.flink.core.testutils.FlinkAssertions.anyCauseMatches;
-import static org.apache.flink.table.api.Expressions.row;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.catchThrowable;
+import javax.annotation.Nullable;
 
 /**
  * Test interface implementing the logic to execute tests for {@link BuiltInFunctionDefinition}.
@@ -151,37 +155,78 @@ abstract class BuiltInFunctionTestBase {
 
         private @Nullable AbstractDataType<?>[] fieldDataTypes;
 
-        private TestSetSpec(BuiltInFunctionDefinition definition, @Nullable String description) {
+        private TestSetSpec(
+                @Nullable BuiltInFunctionDefinition definition, @Nullable String description) {
             this.definition = definition;
             this.description = description;
             this.functions = new ArrayList<>();
             this.testItems = new ArrayList<>();
         }
 
+        /**
+         * Creates a new test specification for a built-in function.
+         *
+         * <p>The function definition is used for test organization and readability only. It does
+         * not affect test execution behavior, which is determined by the actual test methods like
+         * {@link #testSqlResult} or {@link #testTableApiResult}.
+         */
         static TestSetSpec forFunction(BuiltInFunctionDefinition definition) {
             return forFunction(definition, null);
         }
 
+        /**
+         * Creates a new test specification for a built-in function with description.
+         *
+         * <p>Both the function definition and description are used for test organization and
+         * readability only. They help identify what is being tested but do not affect the actual
+         * test execution behavior.
+         */
         static TestSetSpec forFunction(BuiltInFunctionDefinition definition, String description) {
             return new TestSetSpec(Preconditions.checkNotNull(definition), description);
         }
 
+        /**
+         * Creates a new test specification for arbitrary expressions.
+         *
+         * <p>The description is used for test organization and readability only. It helps identify
+         * what is being tested but does not affect the actual test execution behavior.
+         */
         static TestSetSpec forExpression(String description) {
             return new TestSetSpec(null, Preconditions.checkNotNull(description));
         }
 
+        /**
+         * Sets the field data for creating an input table.
+         *
+         * <p>If called with arguments, creates an input table with the provided data as a single
+         * row. SQL queries will include {@code FROM <inputTable>}. If called with no arguments or
+         * not called, no input table is created and SQL queries run as standalone expressions.
+         *
+         * <p>When used together with {@link #andDataTypes(AbstractDataType...)}, constant folding
+         * is disabled by wrapping field accesses in {@link IdentityFunction}.
+         */
         TestSetSpec onFieldsWithData(Object... fieldData) {
             this.fieldData = fieldData;
             return this;
         }
 
+        /**
+         * Sets the data types for the input table fields.
+         *
+         * <p>Must be used together with {@link #onFieldsWithData(Object...)}. The number of data
+         * types should match the number of field data values. When used, constant folding is
+         * disabled to force runtime code generation paths.
+         */
         TestSetSpec andDataTypes(AbstractDataType<?>... fieldDataType) {
             this.fieldDataTypes = fieldDataType;
             return this;
         }
 
+        /**
+         * Registers a user-defined function under the class simple name for use in test
+         * expressions.
+         */
         TestSetSpec withFunction(Class<? extends UserDefinedFunction> functionClass) {
-            // the function will be registered under the class simple name
             this.functions.add(functionClass);
             return this;
         }
@@ -271,6 +316,7 @@ abstract class BuiltInFunctionTestBase {
             return this;
         }
 
+        /** Tests both Table API and SQL expressions expecting successful results. */
         TestSetSpec testResult(
                 Expression expression,
                 String sqlExpression,
@@ -279,6 +325,7 @@ abstract class BuiltInFunctionTestBase {
             return testResult(expression, sqlExpression, result, dataType, dataType);
         }
 
+        /** Tests both Table API and SQL expressions expecting successful results. */
         TestSetSpec testResult(ResultSpec... resultSpecs) {
             final int cols = resultSpecs.length;
             final List<Expression> expressions = new ArrayList<>(cols);
@@ -298,6 +345,7 @@ abstract class BuiltInFunctionTestBase {
                     expressions, sqlExpressions, results, tableApiDataTypes, sqlDataTypes);
         }
 
+        /** Tests both Table API and SQL expressions expecting successful results. */
         TestSetSpec testResult(
                 Expression expression,
                 String sqlExpression,
@@ -312,6 +360,7 @@ abstract class BuiltInFunctionTestBase {
                     singletonList(sqlDataType));
         }
 
+        /** Tests both Table API and SQL expressions expecting successful results. */
         TestSetSpec testResult(
                 List<Expression> expression,
                 List<String> sqlExpression,
@@ -325,6 +374,7 @@ abstract class BuiltInFunctionTestBase {
             return this;
         }
 
+        /** Generates test cases from this specification. */
         Stream<TestCase> getTestCases(Configuration configuration) {
             return testItems.stream().map(testItem -> getTestCase(configuration, testItem));
         }
@@ -358,7 +408,25 @@ abstract class BuiltInFunctionTestBase {
                                                             DataTypes.FIELD(
                                                                     "f" + i, fieldDataTypes[i]))
                                             .toArray(DataTypes.UnresolvedField[]::new);
-                            inputTable = env.fromValues(DataTypes.ROW(fields), Row.of(fieldData));
+
+                            final Expression[] expressions =
+                                    IntStream.range(0, fieldDataTypes.length)
+                                            .mapToObj(i -> $(fields[i].getName()))
+                                            .toArray(Expression[]::new);
+
+                            final Expression[] aliasedExpressions =
+                                    IntStream.range(0, expressions.length)
+                                            .mapToObj(
+                                                    i ->
+                                                            call(
+                                                                            IdentityFunction.class,
+                                                                            expressions[i])
+                                                                    .as(fields[i].getName()))
+                                            .toArray(Expression[]::new);
+
+                            inputTable =
+                                    env.fromValues(DataTypes.ROW(fields), Row.of(fieldData))
+                                            .select(aliasedExpressions);
                         }
 
                         testItem.test(env, inputTable, clusterClient);
@@ -684,5 +752,24 @@ abstract class BuiltInFunctionTestBase {
             AbstractDataType<?> sqlQueryDataType) {
         return new ResultSpec(
                 tableApiExpression, sqlExpression, result, tableApiDataType, sqlQueryDataType);
+    }
+
+    /** Identity function that forces the parser to skip constant folding. */
+    public static class IdentityFunction extends ScalarFunction {
+        public Object eval(Object input) {
+            return input;
+        }
+
+        @Override
+        public TypeInference getTypeInference(final DataTypeFactory typeFactory) {
+            return TypeInference.newBuilder()
+                    .outputTypeStrategy(c -> Optional.of(c.getArgumentDataTypes().get(0)))
+                    .build();
+        }
+
+        @Override
+        public boolean supportsConstantFolding() {
+            return false;
+        }
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
@@ -551,7 +551,7 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .failRuntime(STRING(), "Apache", NumberFormatException.class)
                         .fromCase(STRING(), "1.234", 1.234f)
                         .fromCase(STRING(), "123", 123.0f)
-                        .fromCase(STRING(), "-3276913443134", -3.2769135E12f)
+                        .fromCase(STRING(), "-3276913443134", -3.27691351E12f)
                         .fromCase(BOOLEAN(), true, 1.0f)
                         .fromCase(BOOLEAN(), false, 0.0f)
                         // Not supported - no fix
@@ -649,8 +649,8 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                                 BIGINT(), DEFAULT_POSITIVE_BIGINT, (double) DEFAULT_POSITIVE_BIGINT)
                         .fromCase(
                                 BIGINT(), DEFAULT_NEGATIVE_BIGINT, (double) DEFAULT_NEGATIVE_BIGINT)
-                        .fromCase(FLOAT(), DEFAULT_POSITIVE_FLOAT, 123.45600128173828)
-                        .fromCase(FLOAT(), DEFAULT_NEGATIVE_FLOAT, -123.45600128173828)
+                        .fromCase(FLOAT(), DEFAULT_POSITIVE_FLOAT, 123.45600128173828d)
+                        .fromCase(FLOAT(), DEFAULT_NEGATIVE_FLOAT, -123.45600128173828d)
                         .fromCase(FLOAT(), 9234567891.12, 9.234568192E9)
                         .fromCase(DOUBLE(), DEFAULT_POSITIVE_DOUBLE, DEFAULT_POSITIVE_DOUBLE)
                         .fromCase(DOUBLE(), DEFAULT_NEGATIVE_DOUBLE, DEFAULT_NEGATIVE_DOUBLE)
@@ -726,10 +726,9 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .failRuntime(STRING(), "2021-09-27 12:34:56", DateTimeException.class)
                         // https://issues.apache.org/jira/browse/FLINK-17224 Fractional seconds are
                         // lost
-                        .fromCase(
-                                STRING(),
-                                "12:34:56.123456789",
-                                LocalTime.of(12, 34, 56, 123_000_000))
+                        .fromCase(STRING(), "23", LocalTime.of(23, 0, 0, 0))
+                        .fromCase(STRING(), "23:45", LocalTime.of(23, 45, 0, 0))
+                        .fromCase(STRING(), "12:34:56.123456789", LocalTime.of(12, 34, 56, 0))
                         .failRuntime(
                                 STRING(), "2021-09-27 12:34:56.123456789", DateTimeException.class)
                         // Not supported - no fix
@@ -746,27 +745,16 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .failValidation(DOUBLE(), DEFAULT_POSITIVE_DOUBLE)
                         .failValidation(DATE(), DEFAULT_DATE)
                         .fromCase(TIME(5), DEFAULT_TIME, LocalTime.of(12, 34, 56, 0))
-                        .fromCase(
-                                TIMESTAMP(),
-                                DEFAULT_TIMESTAMP,
-                                LocalTime.of(12, 34, 56, 123_000_000))
-                        .fromCase(
-                                TIMESTAMP(4),
-                                DEFAULT_TIMESTAMP,
-                                LocalTime.of(12, 34, 56, 123_000_000))
+                        .fromCase(TIMESTAMP(), DEFAULT_TIMESTAMP, LocalTime.of(12, 34, 56, 0))
+                        .fromCase(TIMESTAMP(4), DEFAULT_TIMESTAMP, LocalTime.of(12, 34, 56, 0))
 
                         // https://issues.apache.org/jira/browse/FLINK-20869
                         // TIMESTAMP_WITH_TIME_ZONE
 
                         // https://issues.apache.org/jira/browse/FLINK-24422 - Accept only Instant
+                        .fromCase(TIMESTAMP_LTZ(4), DEFAULT_TIMESTAMP, LocalTime.of(12, 34, 56, 0))
                         .fromCase(
-                                TIMESTAMP_LTZ(4),
-                                DEFAULT_TIMESTAMP,
-                                LocalTime.of(12, 34, 56, 123_000_000))
-                        .fromCase(
-                                TIMESTAMP_LTZ(4),
-                                DEFAULT_TIMESTAMP_LTZ,
-                                LocalTime.of(7, 54, 56, 123_000_000))
+                                TIMESTAMP_LTZ(4), DEFAULT_TIMESTAMP_LTZ, LocalTime.of(7, 54, 56, 0))
                         // Not supported - no fix
                         .failValidation(INTERVAL(YEAR(), MONTH()), DEFAULT_INTERVAL_YEAR)
                         .failValidation(INTERVAL(DAY(), SECOND()), DEFAULT_INTERVAL_DAY)

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
@@ -551,7 +551,7 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .failRuntime(STRING(), "Apache", NumberFormatException.class)
                         .fromCase(STRING(), "1.234", 1.234f)
                         .fromCase(STRING(), "123", 123.0f)
-                        .fromCase(STRING(), "-3276913443134", -3.27691403E12f)
+                        .fromCase(STRING(), "-3276913443134", -3.2769135E12f)
                         .fromCase(BOOLEAN(), true, 1.0f)
                         .fromCase(BOOLEAN(), false, 0.0f)
                         // Not supported - no fix
@@ -649,9 +649,9 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                                 BIGINT(), DEFAULT_POSITIVE_BIGINT, (double) DEFAULT_POSITIVE_BIGINT)
                         .fromCase(
                                 BIGINT(), DEFAULT_NEGATIVE_BIGINT, (double) DEFAULT_NEGATIVE_BIGINT)
-                        .fromCase(FLOAT(), DEFAULT_POSITIVE_FLOAT, 123.456d)
-                        .fromCase(FLOAT(), DEFAULT_NEGATIVE_FLOAT, -123.456)
-                        .fromCase(FLOAT(), 9234567891.12, 9234567891.12d)
+                        .fromCase(FLOAT(), DEFAULT_POSITIVE_FLOAT, 123.45600128173828)
+                        .fromCase(FLOAT(), DEFAULT_NEGATIVE_FLOAT, -123.45600128173828)
+                        .fromCase(FLOAT(), 9234567891.12, 9.234568192E9)
                         .fromCase(DOUBLE(), DEFAULT_POSITIVE_DOUBLE, DEFAULT_POSITIVE_DOUBLE)
                         .fromCase(DOUBLE(), DEFAULT_NEGATIVE_DOUBLE, DEFAULT_NEGATIVE_DOUBLE)
                         .fromCase(DOUBLE(), 1239234567891.1234567891234, 1.2392345678911235E12d)
@@ -720,13 +720,16 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .failRuntime(CHAR(3), "foo", DateTimeException.class)
                         .failRuntime(VARCHAR(5), "Flink", DateTimeException.class)
                         .failRuntime(STRING(), "Flink", DateTimeException.class)
-                        .fromCase(STRING(), "123", LocalTime.of(23, 0, 0))
-                        .fromCase(STRING(), "123:45", LocalTime.of(23, 45, 0))
+                        .failRuntime(STRING(), "123", DateTimeException.class)
+                        .failRuntime(STRING(), "123:45", DateTimeException.class)
                         .failRuntime(STRING(), "2021-09-27", DateTimeException.class)
                         .failRuntime(STRING(), "2021-09-27 12:34:56", DateTimeException.class)
                         // https://issues.apache.org/jira/browse/FLINK-17224 Fractional seconds are
                         // lost
-                        .fromCase(STRING(), "12:34:56.123456789", LocalTime.of(12, 34, 56, 0))
+                        .fromCase(
+                                STRING(),
+                                "12:34:56.123456789",
+                                LocalTime.of(12, 34, 56, 123_000_000))
                         .failRuntime(
                                 STRING(), "2021-09-27 12:34:56.123456789", DateTimeException.class)
                         // Not supported - no fix
@@ -742,18 +745,28 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .failValidation(FLOAT(), DEFAULT_POSITIVE_FLOAT)
                         .failValidation(DOUBLE(), DEFAULT_POSITIVE_DOUBLE)
                         .failValidation(DATE(), DEFAULT_DATE)
-                        //
                         .fromCase(TIME(5), DEFAULT_TIME, LocalTime.of(12, 34, 56, 0))
-                        .fromCase(TIMESTAMP(), DEFAULT_TIMESTAMP, LocalTime.of(12, 34, 56, 0))
-                        .fromCase(TIMESTAMP(4), DEFAULT_TIMESTAMP, LocalTime.of(12, 34, 56, 0))
+                        .fromCase(
+                                TIMESTAMP(),
+                                DEFAULT_TIMESTAMP,
+                                LocalTime.of(12, 34, 56, 123_000_000))
+                        .fromCase(
+                                TIMESTAMP(4),
+                                DEFAULT_TIMESTAMP,
+                                LocalTime.of(12, 34, 56, 123_000_000))
 
                         // https://issues.apache.org/jira/browse/FLINK-20869
                         // TIMESTAMP_WITH_TIME_ZONE
 
                         // https://issues.apache.org/jira/browse/FLINK-24422 - Accept only Instant
-                        .fromCase(TIMESTAMP_LTZ(4), DEFAULT_TIMESTAMP, LocalTime.of(12, 34, 56, 0))
                         .fromCase(
-                                TIMESTAMP_LTZ(4), DEFAULT_TIMESTAMP_LTZ, LocalTime.of(7, 54, 56, 0))
+                                TIMESTAMP_LTZ(4),
+                                DEFAULT_TIMESTAMP,
+                                LocalTime.of(12, 34, 56, 123_000_000))
+                        .fromCase(
+                                TIMESTAMP_LTZ(4),
+                                DEFAULT_TIMESTAMP_LTZ,
+                                LocalTime.of(7, 54, 56, 123_000_000))
                         // Not supported - no fix
                         .failValidation(INTERVAL(YEAR(), MONTH()), DEFAULT_INTERVAL_YEAR)
                         .failValidation(INTERVAL(DAY(), SECOND()), DEFAULT_INTERVAL_DAY)

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/RowFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/RowFunctionITCase.java
@@ -93,24 +93,23 @@ class RowFunctionITCase extends BuiltInFunctionTestBase {
     }
 
     @Test
-    public void testCastToSmallIntAndTinyIntIfInputIsNonLiteral() throws Exception {
+    void testRowFromNonLiteralInput() throws Exception {
         final TableEnvironment env = TableEnvironment.create(EnvironmentSettings.inStreamingMode());
 
         TableResult result =
                 env.executeSql(
-                        "SELECT ROW(CAST(a AS SMALLINT), CAST(b AS TINYINT)) FROM (VALUES (1, 2)) AS T(a, b)");
+                        "SELECT "
+                                + "CAST(ROW(CAST(a AS SMALLINT), CAST(b AS TINYINT)) AS ROW<a SMALLINT, b TINYINT>) "
+                                + "AS `row` "
+                                + "FROM (VALUES (1, 2)) AS T(a, b)");
         assertThat(result.getResolvedSchema())
                 .isEqualTo(
                         ResolvedSchema.of(
                                 Column.physical(
-                                        "EXPR$0",
+                                        "row",
                                         DataTypes.ROW(
-                                                        DataTypes.FIELD(
-                                                                "EXPR$0",
-                                                                DataTypes.SMALLINT().notNull()),
-                                                        DataTypes.FIELD(
-                                                                "EXPR$1",
-                                                                DataTypes.TINYINT().notNull()))
+                                                        DataTypes.FIELD("a", DataTypes.SMALLINT()),
+                                                        DataTypes.FIELD("b", DataTypes.TINYINT()))
                                                 .notNull())));
 
         try (CloseableIterator<Row> it = result.collect()) {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
@@ -480,7 +480,7 @@ class CastRulesTest {
                         .fromCase(
                                 STRING(),
                                 fromString("12:34:56.123456789"),
-                                DateTimeUtils.toInternal(LocalTime.of(12, 34, 56, 123_000_000)))
+                                DateTimeUtils.toInternal(LocalTime.of(12, 34, 56, 0)))
                         .fail(
                                 STRING(),
                                 fromString("2021-09-27 12:34:56.123456789"),
@@ -488,11 +488,11 @@ class CastRulesTest {
                         .fromCase(
                                 TIMESTAMP(6),
                                 TIMESTAMP,
-                                DateTimeUtils.toInternal(LocalTime.of(12, 34, 56, 123_000_000)))
+                                DateTimeUtils.toInternal(LocalTime.of(12, 34, 56, 0)))
                         .fromCase(
                                 TIMESTAMP_LTZ(8),
                                 TIMESTAMP_LTZ,
-                                DateTimeUtils.toInternal(LocalTime.of(11, 34, 56, 123_000_000))),
+                                DateTimeUtils.toInternal(LocalTime.of(11, 34, 56, 0))),
                 CastTestSpecBuilder.testCastTo(TIMESTAMP(9))
                         .fail(CHAR(3), fromString("foo"), TableRuntimeException.class)
                         .fail(VARCHAR(5), fromString("Flink"), TableRuntimeException.class)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/codegen/CodeGenUtilsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/codegen/CodeGenUtilsTest.scala
@@ -17,18 +17,23 @@
  */
 package org.apache.flink.table.planner.codegen
 
+import org.apache.flink.api.common.typeutils.base.VoidSerializer
 import org.apache.flink.configuration.Configuration
-
+import org.apache.flink.table.catalog.ObjectIdentifier
+import org.apache.flink.table.types.logical._
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.{Arguments, MethodSource}
 
+import java.util.stream
 import scala.collection.mutable.ArrayBuffer
 
 class CodeGenUtilsTest {
-  private val classLoader = Thread.currentThread().getContextClassLoader
 
   @Test
   def testNewName(): Unit = {
+    val classLoader = Thread.currentThread().getContextClassLoader
     // Use name counter in CodeGenUtils.
     assertEquals("name$i0", CodeGenUtils.newName(null, "name"))
     assertEquals("name$i1", CodeGenUtils.newName(null, "name"))
@@ -57,5 +62,98 @@ class CodeGenUtilsTest {
     assertEquals("name$6", CodeGenUtils.newName(context4, "name"))
     assertEquals(ArrayBuffer("name$7", "id$7"), CodeGenUtils.newNames(context4, "name", "id"))
     assertEquals(ArrayBuffer("name$8", "id$8"), CodeGenUtils.newNames(context4, "name", "id"))
+  }
+
+  @ParameterizedTest
+  @MethodSource(Array("basicTypesTestData"))
+  def testPrimitiveDefaultValueForBasicTypes(
+      logicalType: LogicalType,
+      expectedDefault: String): Unit = {
+    assertEquals(expectedDefault, CodeGenUtils.primitiveDefaultValue(logicalType))
+  }
+
+  @ParameterizedTest
+  @MethodSource(Array("distinctTypeTestData"))
+  def testPrimitiveDefaultValueForDistinctType(
+      distinctType: DistinctType,
+      expectedDefault: String): Unit = {
+    assertEquals(expectedDefault, CodeGenUtils.primitiveDefaultValue(distinctType))
+  }
+}
+
+object CodeGenUtilsTest {
+
+  @MethodSource
+  def basicTypesTestData(): stream.Stream[Arguments] = {
+    java.util.stream.Stream.of(
+      // Basic primitive types
+      Arguments.of(new BooleanType(), "false"),
+      Arguments.of(new TinyIntType(), "((byte) -1)"),
+      Arguments.of(new SmallIntType(), "((short) -1)"),
+      Arguments.of(new IntType(), "-1"),
+      Arguments.of(new BigIntType(), "-1L"),
+      Arguments.of(new FloatType(), "-1.0f"),
+      Arguments.of(new DoubleType(), "-1.0d"),
+
+      // Date/time types that map to int/long
+      Arguments.of(new DateType(), "-1"),
+      Arguments.of(new TimeType(), "-1"),
+      Arguments.of(new LocalZonedTimestampType(3), "null"),
+      Arguments.of(new TimestampType(3), "null"),
+
+      // Interval types
+      Arguments.of(
+        new YearMonthIntervalType(YearMonthIntervalType.YearMonthResolution.YEAR_TO_MONTH),
+        "-1"),
+      Arguments.of(
+        new DayTimeIntervalType(DayTimeIntervalType.DayTimeResolution.DAY_TO_SECOND),
+        "-1L"),
+
+      // String types
+      Arguments.of(new VarCharType(100), s"${CodeGenUtils.BINARY_STRING}.EMPTY_UTF8"),
+      Arguments.of(new CharType(10), s"${CodeGenUtils.BINARY_STRING}.EMPTY_UTF8"),
+
+      // Complex types that should return "null"
+      Arguments.of(new ArrayType(new IntType()), "null"),
+      Arguments.of(new MapType(new IntType(), new VarCharType()), "null"),
+      Arguments.of(RowType.of(new IntType(), new VarCharType()), "null"),
+      Arguments.of(new DecimalType(10, 2), "null"),
+      Arguments.of(new BinaryType(10), "null"),
+      Arguments.of(new VarBinaryType(100), "null"),
+      Arguments.of(new RawType(classOf[Void], VoidSerializer.INSTANCE), "null")
+    )
+  }
+
+  @MethodSource
+  def distinctTypeTestData(): stream.Stream[Arguments] = {
+    val objectIdentifier = ObjectIdentifier.of("catalog", "database", "distinct_type")
+    java.util.stream.Stream.of(
+      // Distinct types based on basic types
+      Arguments.of(
+        DistinctType
+          .newBuilder(objectIdentifier, new IntType())
+          .build(),
+        "-1"),
+      Arguments.of(
+        DistinctType
+          .newBuilder(objectIdentifier, new SmallIntType())
+          .build(),
+        "((short) -1)"),
+      Arguments.of(
+        DistinctType
+          .newBuilder(objectIdentifier, new TinyIntType())
+          .build(),
+        "((byte) -1)"),
+      Arguments.of(
+        DistinctType
+          .newBuilder(objectIdentifier, new BigIntType())
+          .build(),
+        "-1L"),
+      Arguments.of(
+        DistinctType
+          .newBuilder(objectIdentifier, new BooleanType())
+          .build(),
+        "false")
+    )
   }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/codegen/CodeGenUtilsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/codegen/CodeGenUtilsTest.scala
@@ -82,11 +82,6 @@ class CodeGenUtilsTest {
     assertEquals(expectedDefault, CodeGenUtils.primitiveDefaultValue(distinctType))
   }
 
-  @ParameterizedTest
-  @MethodSource(Array("primitiveDefaultValueWithCastData"))
-  def testPrimitiveDefaultValueForType(logicalType: LogicalType, expectedDefault: String): Unit = {
-    assertEquals(expectedDefault, CodeGenUtils.primitiveDefaultValueWithCast(logicalType))
-  }
 }
 
 object CodeGenUtilsTest {
@@ -96,8 +91,8 @@ object CodeGenUtilsTest {
     java.util.stream.Stream.of(
       // Basic primitive types
       Arguments.of(new BooleanType(), "false"),
-      Arguments.of(new TinyIntType(), "-1"),
-      Arguments.of(new SmallIntType(), "-1"),
+      Arguments.of(new TinyIntType(), "((byte)-1)"),
+      Arguments.of(new SmallIntType(), "((short)-1)"),
       Arguments.of(new IntType(), "-1"),
       Arguments.of(new BigIntType(), "-1L"),
       Arguments.of(new FloatType(), "-1.0f"),
@@ -133,29 +128,6 @@ object CodeGenUtilsTest {
   }
 
   @MethodSource
-  def primitiveDefaultValueWithCastData(): stream.Stream[Arguments] = {
-    java.util.stream.Stream.of(
-      Arguments.of(new BooleanType(), "((boolean) false)"),
-      Arguments.of(new TinyIntType(), "((byte) -1)"),
-      Arguments.of(new SmallIntType(), "((short) -1)"),
-      Arguments.of(new IntType(), "((int) -1)"),
-      Arguments.of(new BigIntType(), "((long) -1L)"),
-      Arguments.of(new FloatType(), "((float) -1.0f)"),
-      Arguments.of(new DoubleType(), "((double) -1.0d)"),
-
-      // Additional test cases for other types
-      Arguments.of(new DateType(), "((int) -1)"),
-      Arguments.of(new TimeType(), "((int) -1)"),
-      Arguments.of(
-        new YearMonthIntervalType(YearMonthIntervalType.YearMonthResolution.YEAR_TO_MONTH),
-        "((int) -1)"),
-      Arguments.of(
-        new DayTimeIntervalType(DayTimeIntervalType.DayTimeResolution.DAY_TO_SECOND),
-        "((long) -1L)")
-    )
-  }
-
-  @MethodSource
   def distinctTypeTestData(): stream.Stream[Arguments] = {
     val objectIdentifier = ObjectIdentifier.of("catalog", "database", "distinct_type")
     java.util.stream.Stream.of(
@@ -169,12 +141,12 @@ object CodeGenUtilsTest {
         DistinctType
           .newBuilder(objectIdentifier, new SmallIntType())
           .build(),
-        "-1"),
+        "((short)-1)"),
       Arguments.of(
         DistinctType
           .newBuilder(objectIdentifier, new TinyIntType())
           .build(),
-        "-1"),
+        "((byte)-1)"),
       Arguments.of(
         DistinctType
           .newBuilder(objectIdentifier, new BigIntType())

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/codegen/CodeGenUtilsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/codegen/CodeGenUtilsTest.scala
@@ -91,8 +91,8 @@ object CodeGenUtilsTest {
     java.util.stream.Stream.of(
       // Basic primitive types
       Arguments.of(new BooleanType(), "false"),
-      Arguments.of(new TinyIntType(), "((byte) -1)"),
-      Arguments.of(new SmallIntType(), "((short) -1)"),
+      Arguments.of(new TinyIntType(), "-1"),
+      Arguments.of(new SmallIntType(), "-1"),
       Arguments.of(new IntType(), "-1"),
       Arguments.of(new BigIntType(), "-1L"),
       Arguments.of(new FloatType(), "-1.0f"),
@@ -141,12 +141,12 @@ object CodeGenUtilsTest {
         DistinctType
           .newBuilder(objectIdentifier, new SmallIntType())
           .build(),
-        "((short) -1)"),
+        "-1"),
       Arguments.of(
         DistinctType
           .newBuilder(objectIdentifier, new TinyIntType())
           .build(),
-        "((byte) -1)"),
+        "-1"),
       Arguments.of(
         DistinctType
           .newBuilder(objectIdentifier, new BigIntType())

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/codegen/CodeGenUtilsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/codegen/CodeGenUtilsTest.scala
@@ -21,12 +21,14 @@ import org.apache.flink.api.common.typeutils.base.VoidSerializer
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.table.catalog.ObjectIdentifier
 import org.apache.flink.table.types.logical._
+
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.{Arguments, MethodSource}
 
 import java.util.stream
+
 import scala.collection.mutable.ArrayBuffer
 
 class CodeGenUtilsTest {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/codegen/CodeGenUtilsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/codegen/CodeGenUtilsTest.scala
@@ -91,8 +91,8 @@ object CodeGenUtilsTest {
     java.util.stream.Stream.of(
       // Basic primitive types
       Arguments.of(new BooleanType(), "false"),
-      Arguments.of(new TinyIntType(), "((byte)-1)"),
-      Arguments.of(new SmallIntType(), "((short)-1)"),
+      Arguments.of(new TinyIntType(), "((byte) -1)"),
+      Arguments.of(new SmallIntType(), "((short) -1)"),
       Arguments.of(new IntType(), "-1"),
       Arguments.of(new BigIntType(), "-1L"),
       Arguments.of(new FloatType(), "-1.0f"),
@@ -141,12 +141,12 @@ object CodeGenUtilsTest {
         DistinctType
           .newBuilder(objectIdentifier, new SmallIntType())
           .build(),
-        "((short)-1)"),
+        "((short) -1)"),
       Arguments.of(
         DistinctType
           .newBuilder(objectIdentifier, new TinyIntType())
           .build(),
-        "((byte)-1)"),
+        "((byte) -1)"),
       Arguments.of(
         DistinctType
           .newBuilder(objectIdentifier, new BigIntType())

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/codegen/CodeGenUtilsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/codegen/CodeGenUtilsTest.scala
@@ -81,6 +81,12 @@ class CodeGenUtilsTest {
       expectedDefault: String): Unit = {
     assertEquals(expectedDefault, CodeGenUtils.primitiveDefaultValue(distinctType))
   }
+
+  @ParameterizedTest
+  @MethodSource(Array("primitiveDefaultValueWithCastData"))
+  def testPrimitiveDefaultValueForType(logicalType: LogicalType, expectedDefault: String): Unit = {
+    assertEquals(expectedDefault, CodeGenUtils.primitiveDefaultValueWithCast(logicalType))
+  }
 }
 
 object CodeGenUtilsTest {
@@ -90,8 +96,8 @@ object CodeGenUtilsTest {
     java.util.stream.Stream.of(
       // Basic primitive types
       Arguments.of(new BooleanType(), "false"),
-      Arguments.of(new TinyIntType(), "((byte) -1)"),
-      Arguments.of(new SmallIntType(), "((short) -1)"),
+      Arguments.of(new TinyIntType(), "-1"),
+      Arguments.of(new SmallIntType(), "-1"),
       Arguments.of(new IntType(), "-1"),
       Arguments.of(new BigIntType(), "-1L"),
       Arguments.of(new FloatType(), "-1.0f"),
@@ -127,6 +133,29 @@ object CodeGenUtilsTest {
   }
 
   @MethodSource
+  def primitiveDefaultValueWithCastData(): stream.Stream[Arguments] = {
+    java.util.stream.Stream.of(
+      Arguments.of(new BooleanType(), "((boolean) false)"),
+      Arguments.of(new TinyIntType(), "((byte) -1)"),
+      Arguments.of(new SmallIntType(), "((short) -1)"),
+      Arguments.of(new IntType(), "((int) -1)"),
+      Arguments.of(new BigIntType(), "((long) -1L)"),
+      Arguments.of(new FloatType(), "((float) -1.0f)"),
+      Arguments.of(new DoubleType(), "((double) -1.0d)"),
+
+      // Additional test cases for other types
+      Arguments.of(new DateType(), "((int) -1)"),
+      Arguments.of(new TimeType(), "((int) -1)"),
+      Arguments.of(
+        new YearMonthIntervalType(YearMonthIntervalType.YearMonthResolution.YEAR_TO_MONTH),
+        "((int) -1)"),
+      Arguments.of(
+        new DayTimeIntervalType(DayTimeIntervalType.DayTimeResolution.DAY_TO_SECOND),
+        "((long) -1L)")
+    )
+  }
+
+  @MethodSource
   def distinctTypeTestData(): stream.Stream[Arguments] = {
     val objectIdentifier = ObjectIdentifier.of("catalog", "database", "distinct_type")
     java.util.stream.Stream.of(
@@ -140,12 +169,12 @@ object CodeGenUtilsTest {
         DistinctType
           .newBuilder(objectIdentifier, new SmallIntType())
           .build(),
-        "((short) -1)"),
+        "-1"),
       Arguments.of(
         DistinctType
           .newBuilder(objectIdentifier, new TinyIntType())
           .build(),
-        "((byte) -1)"),
+        "-1"),
       Arguments.of(
         DistinctType
           .newBuilder(objectIdentifier, new BigIntType())

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/OverAggregateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/OverAggregateITCase.scala
@@ -1222,7 +1222,7 @@ class OverAggregateITCase extends BatchTestBase {
           3.14,
           "EFG",
           localDate("2017-05-20"),
-          localTime("09:46:18"),
+          localTime("09:45:58"),
           localDateTime("2015-11-19 10:00:01"),
           3,
           2,

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/TestData.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/TestData.scala
@@ -473,7 +473,7 @@ object TestData {
       3.14,
       "EFG",
       localDate("2017-05-20"),
-      localTime("09:45:78"),
+      localTime("09:45:58"),
       localDateTime("2015-11-19 10:00:01")),
     row(
       4,

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/binary/BinaryStringDataUtil.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/binary/BinaryStringDataUtil.java
@@ -597,7 +597,11 @@ public class BinaryStringDataUtil {
     public static int toTime(BinaryStringData input) throws DateTimeException {
         Integer date = DateTimeUtils.parseTime(input.toString());
         if (date == null) {
-            throw new DateTimeException("For input string: '" + input + "'.");
+            throw new DateTimeException(
+                    "Invalid time format: '"
+                            + input
+                            + "'. "
+                            + "Expected format: HH:mm:ss[.fff] where HH is 00-23, mm is 00-59, ss is 00-59");
         }
 
         return date;

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/binary/BinaryStringDataUtil.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/binary/BinaryStringDataUtil.java
@@ -594,17 +594,16 @@ public class BinaryStringDataUtil {
         return date;
     }
 
-    public static int toTime(BinaryStringData input) throws DateTimeException {
-        Integer date = DateTimeUtils.parseTime(input.toString());
-        if (date == null) {
+    public static int toTime(BinaryStringData input, int precision) throws DateTimeException {
+        Integer milliSeconds = DateTimeUtils.parseTime(input.toString());
+        if (milliSeconds == null) {
             throw new DateTimeException(
                     "Invalid time format: '"
                             + input
                             + "'. "
                             + "Expected format: HH:mm:ss[.fff] where HH is 00-23, mm is 00-59, ss is 00-59");
         }
-
-        return date;
+        return DateTimeUtils.applyTimePrecisionTruncation(milliSeconds, precision);
     }
 
     /** Used by {@code CAST(x as TIMESTAMP)}. */


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes a critical code generation compilation error and addresses multiple casting inconsistencies discovered during the investigation. The initial issue occurred when using `ROW()` with `CAST()` to `SMALLINT`/`TINYINT` on non-literal expressions, but the fix exposed several deeper problems in Flink's casting behavior when comparing constant folding (compile-time) vs. runtime code generation paths.

## Brief change log

### Core Fix
* Fixed `primitiveDefaultValue()` in `CodeGenUtils.scala` to return properly typed literals:
  - `TINYINT`: `"-1"` → `"((byte) -1)"`  
  - `SMALLINT`: `"-1"` → `"((short) -1)"`

### Test Infrastructure Improvements
* Enhanced `BuiltInFunctionTestBase` with `disableConstantFolding()` capability to force runtime code generation paths
* Added comprehensive unit tests for `primitiveDefaultValue()` and `primitiveDefaultValueForType()`
* Added compilation validation tests ensuring generated code compiles correctly

### Casting Consistency Fixes
* **Binary casting**: Fixed `BinaryToBinaryCastRule` to correctly handle `BINARY` (exact length) vs `VARBINARY` (preserve length) semantics
* **Float/Double precision**: Updated test expectations to match actual runtime precision behavior (IEEE 754 limitations)
* **TIME parsing**: Added validation to `DateTimeUtils.parseTime()` for hour/minute/second ranges (0-23, 0-59, 0-59)
* **TIME precision**: Implemented consistent precision truncation in `StringToTimeCastRule` and `TimestampToTimeCastRule`
* **Utility method**: Added `applyTimePrecisionTruncation()` with comprehensive JavaDoc documentation

### Documentation
* Enhanced JavaDoc for test framework methods explaining constant folding behavior
* Added detailed documentation for TIME precision truncation with examples table
* Updated method documentation for clarity and accuracy

## Root Cause Analysis

The initial `SMALLINT`/`TINYINT` issue revealed that Flink's casting behavior differed significantly between:
1. **Compile-time optimization** (constant folding enabled)
2. **Runtime code generation** (constant folding disabled)

By introducing the ability to disable constant folding in tests, we exposed several pre-existing inconsistencies that were previously hidden by the optimizer's constant folding behavior.

## Verifying this change

### Unit Tests
* Added parameterized tests for all primitive type default value generation
* Added Java compilation validation for generated default values
* Added tests for `primitiveDefaultValue()` and `primitiveDefaultValueForType()` consistency

### Integration Tests
* Added tests in `RowFunctionITCase.java` reproducing the original failure
* Updated `CastFunctionITCase.java` with corrected expectations for runtime precision behavior
* Added comprehensive TIME casting tests with various precision values

### Manual Verification
* Verified original failing query now works: `SELECT ROW(CAST(IDTARIFAV AS SMALLINT)) FROM (VALUES (1), (2), (3)) AS T(IDTARIFAV)`
* Tested edge cases for TIME parsing and precision truncation
* Validated BINARY/VARBINARY padding behavior matches SQL standard

## Does this pull request potentially affect one of the following parts:

- [x] **Dependencies**: No
- [x] **Public API**: No  
- [x] **Serializers**: No
- [x] **Runtime per-record code paths**: Yes - affects code generation for primitive type handling and casting operations
- [x] **Deployment/Recovery**: No
- [x] **S3 file system connector**: No

## Documentation

- [x] **Does this pull request introduce a new feature?** No - this is a bug fix with improved test infrastructure
- [x] **If yes, how is the feature documented?** N/A - Enhanced existing JavaDoc documentation for better maintainability

---

**Summary**: This comprehensive fix ensures that Flink's type casting behavior is consistent, well-tested, and properly documented across all code generation paths, resolving both the immediate compilation issue and multiple related casting inconsistencies.