### PR TITLE
[FLINK-38198] Support WITH Clause in CREATE FUNCTION Statement

### DIFF
--- a/docs/content.zh/docs/dev/table/sql/create.md
+++ b/docs/content.zh/docs/dev/table/sql/create.md
@@ -863,6 +863,7 @@ CREATE [TEMPORARY|TEMPORARY SYSTEM] FUNCTION
   [IF NOT EXISTS] [[catalog_name.]db_name.]function_name
   AS identifier [LANGUAGE JAVA|SCALA|PYTHON]
   [USING JAR '<path_to_filename>.jar' [, JAR '<path_to_filename>.jar']* ]
+  [WITH (key1=val1, key2=val2, ...)]
 ```
 
 创建一个有 catalog 和数据库命名空间的 catalog function ，需要指定一个 identifier ，可指定 language tag 。 若 catalog 中，已经有同名的函数注册了，则无法注册。

--- a/docs/content/docs/dev/table/sql/create.md
+++ b/docs/content/docs/dev/table/sql/create.md
@@ -860,6 +860,7 @@ CREATE [TEMPORARY|TEMPORARY SYSTEM] FUNCTION
   [IF NOT EXISTS] [catalog_name.][db_name.]function_name 
   AS identifier [LANGUAGE JAVA|SCALA|PYTHON] 
   [USING JAR '<path_to_filename>.jar' [, JAR '<path_to_filename>.jar']* ]
+  [WITH (key1=val1, key2=val2, ...)]
 ```
 
 Create a catalog function that has catalog and database namespaces with the identifier and optional language tag. If a function with the same name already exists in the catalog, an exception is thrown.

--- a/flink-python/pyflink/table/catalog.py
+++ b/flink-python/pyflink/table/catalog.py
@@ -1118,6 +1118,16 @@ class CatalogFunction(object):
         """
         return self._j_catalog_function.getFunctionLanguage()
 
+    def get_options(self) -> Dict[str, str]:
+        """
+        Returns a map of string-based options.
+
+        :return: Property map of the function.
+
+        .. versionadded:: 2.1.0
+        """
+        return dict(self._j_catalog_function.getOptions())
+
 
 @PublicEvolving()
 class CatalogModel(object):

--- a/flink-python/pyflink/table/catalog.py
+++ b/flink-python/pyflink/table/catalog.py
@@ -1124,7 +1124,7 @@ class CatalogFunction(object):
 
         :return: Property map of the function.
 
-        .. versionadded:: 2.1.0
+        .. versionadded:: 2.2.0
         """
         return dict(self._j_catalog_function.getOptions())
 

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -396,6 +396,7 @@ SqlCreate SqlCreateFunction(Span s, boolean replace, boolean isTemporary) :
     boolean ifNotExists = false;
     boolean isSystemFunction = false;
     SqlNodeList resourceInfos = SqlNodeList.EMPTY;
+    SqlNodeList propertyList = SqlNodeList.EMPTY;
     SqlParserPos functionLanguagePos = null;
 }
 {
@@ -466,6 +467,10 @@ SqlCreate SqlCreateFunction(Span s, boolean replace, boolean isTemporary) :
         )*
         {  resourceInfos = new SqlNodeList(resourceList, s.pos()); }
     ]
+    [
+        <WITH>
+        propertyList = Properties()
+    ]
     {
         return new SqlCreateFunction(
                     s.pos(),
@@ -475,7 +480,8 @@ SqlCreate SqlCreateFunction(Span s, boolean replace, boolean isTemporary) :
                     ifNotExists,
                     isTemporary,
                     isSystemFunction,
-                    resourceInfos);
+                    resourceInfos,
+                    propertyList);
     }
 }
 

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -2491,6 +2491,20 @@ class FlinkSqlParserImplTest extends SqlParserTest {
                                 + "Was expecting:\n"
                                 + "    \"JAR\" ...\n"
                                 + "    .*");
+
+        sql("create function function1 as 'org.apache.flink.function.function1' language java using jar 'file:///path/to/test.jar' WITH ('k1' = 'v1', 'k2' = 'v2')")
+                .ok(
+                        "CREATE FUNCTION `FUNCTION1` AS 'org.apache.flink.function.function1' LANGUAGE JAVA USING JAR 'file:///path/to/test.jar' WITH (\n"
+                                + "  'k1' = 'v1',\n"
+                                + "  'k2' = 'v2'\n"
+                                + ")");
+
+        sql("create temporary function function1 as 'org.apache.flink.function.function1' language java using jar 'file:///path/to/test.jar' WITH ('k1' = 'v1', 'k2' = 'v2')")
+                .ok(
+                        "CREATE TEMPORARY FUNCTION `FUNCTION1` AS 'org.apache.flink.function.function1' LANGUAGE JAVA USING JAR 'file:///path/to/test.jar' WITH (\n"
+                                + "  'k1' = 'v1',\n"
+                                + "  'k2' = 'v2'\n"
+                                + ")");
     }
 
     @Test

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/FunctionDescriptor.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/FunctionDescriptor.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.catalog.CatalogFunction;
+import org.apache.flink.table.catalog.FunctionLanguage;
+import org.apache.flink.table.functions.UserDefinedFunction;
+import org.apache.flink.table.functions.UserDefinedFunctionHelper;
+import org.apache.flink.table.resource.ResourceUri;
+import org.apache.flink.util.Preconditions;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Describes a {@link CatalogFunction}.
+ *
+ * <p>A {@link FunctionDescriptor} is a template for creating a {@link CatalogFunction} instance. It
+ * closely resembles the "CREATE FUNCTION" SQL DDL statement.
+ *
+ * <p>This can be used to register a table in the Table API, see {@link
+ * TableEnvironment#createFunction(String, FunctionDescriptor)}.
+ */
+@PublicEvolving
+public class FunctionDescriptor {
+
+    private final String className;
+    private final FunctionLanguage language;
+    private final List<ResourceUri> resourceUris;
+    private final Map<String, String> options;
+
+    private FunctionDescriptor(
+            String className,
+            FunctionLanguage language,
+            List<ResourceUri> resourceUris,
+            Map<String, String> options) {
+        this.className = className;
+        this.language = language;
+        this.resourceUris = resourceUris;
+        this.options = options;
+    }
+
+    /** Creates a {@link Builder} for a function descriptor with the given class name. */
+    public static Builder forClassName(String className) {
+        return new Builder(className);
+    }
+
+    /** Creates a {@link Builder} for a function descriptor for the given function class. */
+    public static Builder forFunctionClass(Class<? extends UserDefinedFunction> functionClass) {
+        try {
+            UserDefinedFunctionHelper.validateClass(functionClass);
+        } catch (Throwable t) {
+            throw new ValidationException(
+                    String.format(
+                            "Can not create a function '%s' due to implementation errors.",
+                            functionClass.getName()),
+                    t);
+        }
+        return new Builder(functionClass.getName()).language(FunctionLanguage.JAVA);
+    }
+
+    public String getClassName() {
+        return className;
+    }
+
+    public FunctionLanguage getLanguage() {
+        return language;
+    }
+
+    public List<ResourceUri> getResourceUris() {
+        return resourceUris;
+    }
+
+    public Map<String, String> getOptions() {
+        return options;
+    }
+
+    /** Builder for {@link FunctionDescriptor}. */
+    @PublicEvolving
+    public static final class Builder {
+        private final String className;
+        private FunctionLanguage language = FunctionLanguage.JAVA;
+        private final List<ResourceUri> resourceUris = new ArrayList<>();
+        private final Map<String, String> options = new HashMap<>();
+
+        private Builder(String className) {
+            this.className = className;
+        }
+
+        /**
+         * Sets the language of the function. Equivalent to the {@code LANGUAGE} clause in the
+         * "CREATE FUNCTION" SQL DDL statement.
+         */
+        public Builder language(FunctionLanguage language) {
+            Preconditions.checkNotNull(language, "Function language must not be null.");
+            this.language = language;
+            return this;
+        }
+
+        /**
+         * Adds a list of resource URIs to the function descriptor. Equivalent to the {@code USING}
+         * clause in the "CREATE FUNCTION" SQL DDL statement.
+         */
+        public Builder resourceUris(List<ResourceUri> uri) {
+            Preconditions.checkNotNull(uri, "Resource URIs must not be null.");
+            this.resourceUris.addAll(uri);
+            return this;
+        }
+
+        /**
+         * Adds a single resource URI to the function descriptor. Equivalent to the {@code USING}
+         * clause in the "CREATE FUNCTION" SQL DDL statement.
+         */
+        public Builder resourceUri(ResourceUri uri) {
+            Preconditions.checkNotNull(uri, "Resource URI must not be null.");
+            this.resourceUris.add(uri);
+            return this;
+        }
+
+        /**
+         * Adds an option to the function descriptor. Equivalent to the {@code WITH} clause in the
+         * "CREATE FUNCTION" SQL DDL statement.
+         */
+        public Builder option(String key, String value) {
+            Preconditions.checkNotNull(key, "Option key must not be null.");
+            Preconditions.checkNotNull(value, "Option value must not be null.");
+            this.options.put(key, value);
+            return this;
+        }
+
+        /**
+         * Adds multiple options to the function descriptor. Equivalent to the {@code WITH} clause
+         * in the "CREATE FUNCTION" SQL DDL statement.
+         */
+        public Builder options(Map<String, String> options) {
+            Preconditions.checkNotNull(options, "Options must not be null.");
+            this.options.putAll(options);
+            return this;
+        }
+
+        public FunctionDescriptor build() {
+            return new FunctionDescriptor(
+                    className,
+                    language,
+                    Collections.unmodifiableList(resourceUris),
+                    Collections.unmodifiableMap(options));
+        }
+    }
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -562,6 +562,21 @@ public interface TableEnvironment {
     void createFunction(String path, String className, List<ResourceUri> resourceUris);
 
     /**
+     * Creates a catalog function in the given path described by a {@link FunctionDescriptor}.
+     *
+     * <p>Compared to system functions with a globally defined name, catalog functions are always
+     * (implicitly or explicitly) identified by a catalog and database.
+     *
+     * <p>There must not be another function (temporary or permanent) registered under the same
+     * path.
+     *
+     * @param path The path under which the function will be registered. See also the {@link
+     *     TableEnvironment} class description for the format of the path.
+     * @param functionDescriptor The descriptor of the function to create.
+     */
+    void createFunction(String path, FunctionDescriptor functionDescriptor);
+
+    /**
      * Registers a {@link UserDefinedFunction} class as a catalog function in the given path by the
      * specific class name and user defined resource uri.
      *
@@ -586,6 +601,23 @@ public interface TableEnvironment {
      */
     void createFunction(
             String path, String className, List<ResourceUri> resourceUris, boolean ignoreIfExists);
+
+    /**
+     * Creates a catalog function in the given path described by a {@link FunctionDescriptor}.
+     *
+     * <p>Compared to system functions with a globally defined name, catalog functions are always
+     * (implicitly or explicitly) identified by a catalog and database.
+     *
+     * <p>There must not be another function (temporary or permanent) registered under the same
+     * path.
+     *
+     * @param path The path under which the function will be registered. See also the {@link
+     *     TableEnvironment} class description for the format of the path.
+     * @param functionDescriptor The descriptor of the function to create.
+     * @param ignoreIfExists If a function exists under the given path and this flag is set, no
+     *     operation is executed. An exception is thrown otherwise.
+     */
+    void createFunction(String path, FunctionDescriptor functionDescriptor, boolean ignoreIfExists);
 
     /**
      * Registers a {@link UserDefinedFunction} class as a temporary catalog function.
@@ -652,6 +684,24 @@ public interface TableEnvironment {
     void createTemporaryFunction(String path, String className, List<ResourceUri> resourceUris);
 
     /**
+     * Creates a temporary catalog function using a {@link FunctionDescriptor} to describe the
+     * function.
+     *
+     * <p>Compared to {@link #createTemporarySystemFunction(String, String, List)} with a globally
+     * defined name, catalog functions are always (implicitly or explicitly) identified by a catalog
+     * and database.
+     *
+     * <p>Temporary functions can shadow permanent ones. If a permanent function under a given name
+     * exists, it will be inaccessible in the current session. To make the permanent function
+     * available again one can drop the corresponding temporary function.
+     *
+     * @param path The path under which the function will be registered. See also the {@link
+     *     TableEnvironment} class description for the format of the path.
+     * @param functionDescriptor The descriptor of the function to create.
+     */
+    void createTemporaryFunction(String path, FunctionDescriptor functionDescriptor);
+
+    /**
      * Registers a {@link UserDefinedFunction} class as a temporary system function by the specific
      * class name and user defined resource uri.
      *
@@ -671,6 +721,19 @@ public interface TableEnvironment {
      */
     void createTemporarySystemFunction(
             String name, String className, List<ResourceUri> resourceUris);
+
+    /**
+     * Creates a temporary system function using a {@link FunctionDescriptor} to describe the
+     * function.
+     *
+     * <p>Temporary functions can shadow permanent ones. If a permanent function under a given name
+     * exists, it will be inaccessible in the current session. To make the permanent function
+     * available again one can drop the corresponding temporary system function.
+     *
+     * @param name The name under which the function will be registered globally.
+     * @param functionDescriptor The descriptor of the function to create.
+     */
+    void createTemporarySystemFunction(String name, FunctionDescriptor functionDescriptor);
 
     /**
      * Drops a catalog function registered in the given path.

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogFunctionImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogFunctionImpl.java
@@ -24,6 +24,7 @@ import org.apache.flink.util.StringUtils;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -36,6 +37,7 @@ public class CatalogFunctionImpl implements CatalogFunction {
     private final String className; // Fully qualified class name of the function
     private final FunctionLanguage functionLanguage;
     private final List<ResourceUri> resourceUris;
+    private final Map<String, String> options;
 
     public CatalogFunctionImpl(String className) {
         this(className, FunctionLanguage.JAVA, Collections.emptyList());
@@ -47,12 +49,21 @@ public class CatalogFunctionImpl implements CatalogFunction {
 
     public CatalogFunctionImpl(
             String className, FunctionLanguage functionLanguage, List<ResourceUri> resourceUris) {
+        this(className, functionLanguage, resourceUris, Collections.emptyMap());
+    }
+
+    public CatalogFunctionImpl(
+            String className,
+            FunctionLanguage functionLanguage,
+            List<ResourceUri> resourceUris,
+            Map<String, String> options) {
         checkArgument(
                 !StringUtils.isNullOrWhitespaceOnly(className),
                 "className cannot be null or empty");
         this.className = className;
         this.functionLanguage = checkNotNull(functionLanguage, "functionLanguage cannot be null");
         this.resourceUris = resourceUris;
+        this.options = checkNotNull(options, "options cannot be null");
     }
 
     @Override
@@ -63,7 +74,10 @@ public class CatalogFunctionImpl implements CatalogFunction {
     @Override
     public CatalogFunction copy() {
         return new CatalogFunctionImpl(
-                getClassName(), functionLanguage, Collections.unmodifiableList(resourceUris));
+                getClassName(),
+                functionLanguage,
+                Collections.unmodifiableList(resourceUris),
+                Collections.unmodifiableMap(options));
     }
 
     @Override
@@ -87,22 +101,30 @@ public class CatalogFunctionImpl implements CatalogFunction {
     }
 
     @Override
+    public Map<String, String> getOptions() {
+        return options;
+    }
+
+    @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
+
         CatalogFunctionImpl that = (CatalogFunctionImpl) o;
         return Objects.equals(className, that.className)
                 && functionLanguage == that.functionLanguage
-                && Objects.equals(resourceUris, that.resourceUris);
+                && Objects.equals(resourceUris, that.resourceUris)
+                && Objects.equals(options, that.options);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(className, functionLanguage, resourceUris);
+        int result = Objects.hashCode(className);
+        result = 31 * result + Objects.hashCode(functionLanguage);
+        result = 31 * result + Objects.hashCode(resourceUris);
+        result = 31 * result + Objects.hashCode(options);
+        return result;
     }
 
     @Override
@@ -116,6 +138,9 @@ public class CatalogFunctionImpl implements CatalogFunction {
                 + "', "
                 + "functionResource='"
                 + getFunctionResources()
-                + "'}";
+                + "', "
+                + "options='"
+                + getOptions()
+                + "'";
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogFunctionImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogFunctionImpl.java
@@ -141,6 +141,6 @@ public class CatalogFunctionImpl implements CatalogFunction {
                 + "', "
                 + "options='"
                 + getOptions()
-                + "'";
+                + "'}";
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/ContextResolvedFunction.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/ContextResolvedFunction.java
@@ -184,20 +184,23 @@ public final class ContextResolvedFunction {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
+
         ContextResolvedFunction that = (ContextResolvedFunction) o;
         return isTemporary == that.isTemporary
                 && Objects.equals(functionIdentifier, that.functionIdentifier)
-                && functionDefinition.equals(that.functionDefinition);
+                && functionDefinition.equals(that.functionDefinition)
+                && Objects.equals(catalogFunction, that.catalogFunction);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(isTemporary, functionIdentifier, functionDefinition);
+        int result = Boolean.hashCode(isTemporary);
+        result = 31 * result + Objects.hashCode(functionIdentifier);
+        result = 31 * result + functionDefinition.hashCode();
+        result = 31 * result + Objects.hashCode(catalogFunction);
+        return result;
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/CreateTempSystemFunctionOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/CreateTempSystemFunctionOperation.java
@@ -48,11 +48,12 @@ public class CreateTempSystemFunctionOperation implements CreateOperation {
             String functionClass,
             boolean ignoreIfExists,
             FunctionLanguage functionLanguage,
-            List<ResourceUri> resourceUris) {
+            List<ResourceUri> resourceUris,
+            Map<String, String> options) {
         this.functionName = functionName;
         this.ignoreIfExists = ignoreIfExists;
         this.catalogFunction =
-                new CatalogFunctionImpl(functionClass, functionLanguage, resourceUris);
+                new CatalogFunctionImpl(functionClass, functionLanguage, resourceUris, options);
     }
 
     public CreateTempSystemFunctionOperation(

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/resource/ResourceManagerTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/resource/ResourceManagerTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.testutils.CommonTestUtils;
+import org.apache.flink.table.api.FunctionDescriptor;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.CatalogFunctionImpl;
 import org.apache.flink.table.catalog.FunctionCatalog;
@@ -385,7 +386,12 @@ public class ResourceManagerTest {
                         new ModuleManager());
 
         functionCatalog.registerCatalogFunction(
-                FULL_UNRESOLVED_IDENTIFIER1, GENERATED_LOWER_UDF_CLASS, resourceUris, false);
+                FULL_UNRESOLVED_IDENTIFIER1,
+                FunctionDescriptor.forClassName(GENERATED_LOWER_UDF_CLASS)
+                        .language(FunctionLanguage.JAVA)
+                        .resourceUris(resourceUris)
+                        .build(),
+                false);
 
         Map<ResourceUri, ResourceManager.ResourceCounter> functionResourceInfos =
                 resourceManager.functionResourceInfos();
@@ -396,7 +402,12 @@ public class ResourceManagerTest {
         // Register catalog function again to validate that unregister catalog function will not
         // decrease the reference count of resourceUris.
         functionCatalog.registerCatalogFunction(
-                FULL_UNRESOLVED_IDENTIFIER1, GENERATED_LOWER_UDF_CLASS, resourceUris, false);
+                FULL_UNRESOLVED_IDENTIFIER1,
+                FunctionDescriptor.forClassName(GENERATED_LOWER_UDF_CLASS)
+                        .language(FunctionLanguage.JAVA)
+                        .resourceUris(resourceUris)
+                        .build(),
+                false);
         functionCatalog.registerTemporaryCatalogFunction(
                 FULL_UNRESOLVED_IDENTIFIER2,
                 new CatalogFunctionImpl(

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogFunction.java
@@ -21,7 +21,9 @@ package org.apache.flink.table.catalog;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.resource.ResourceUri;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /** Interface for a function in a catalog. */
@@ -69,4 +71,9 @@ public interface CatalogFunction {
      * @return an {@link ResourceUri} list of the function
      */
     List<ResourceUri> getFunctionResources();
+
+    /** Returns a map of string-based options. */
+    default Map<String, String> getOptions() {
+        return Collections.emptyMap();
+    }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeToOperationConversion.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeToOperationConversion.java
@@ -558,20 +558,29 @@ public class SqlNodeToOperationConversion {
         UnresolvedIdentifier unresolvedIdentifier =
                 UnresolvedIdentifier.of(sqlCreateFunction.getFunctionIdentifier());
         List<ResourceUri> resourceUris = getFunctionResources(sqlCreateFunction.getResourceInfos());
+        final Map<String, String> options =
+                sqlCreateFunction.getPropertyList().getList().stream()
+                        .map(SqlTableOption.class::cast)
+                        .collect(
+                                Collectors.toMap(
+                                        SqlTableOption::getKeyString,
+                                        SqlTableOption::getValueString));
         if (sqlCreateFunction.isSystemFunction()) {
             return new CreateTempSystemFunctionOperation(
                     unresolvedIdentifier.getObjectName(),
                     sqlCreateFunction.getFunctionClassName().getValueAs(String.class),
                     sqlCreateFunction.isIfNotExists(),
                     parseLanguage(sqlCreateFunction.getFunctionLanguage()),
-                    resourceUris);
+                    resourceUris,
+                    options);
         } else {
             FunctionLanguage language = parseLanguage(sqlCreateFunction.getFunctionLanguage());
             CatalogFunction catalogFunction =
                     new CatalogFunctionImpl(
                             sqlCreateFunction.getFunctionClassName().getValueAs(String.class),
                             language,
-                            resourceUris);
+                            resourceUris,
+                            options);
             ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
 
             return new CreateCatalogFunctionOperation(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlDdlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlDdlToOperationConverterTest.java
@@ -1075,7 +1075,7 @@ class SqlDdlToOperationConverterTest extends SqlNodeToOperationConversionTestBas
                         "CREATE TEMPORARY SYSTEM FUNCTION: (functionName: [test_udf2], "
                                 + "catalogFunction: [CatalogFunctionImpl{className='org.apache.fink.function.function2', "
                                 + "functionLanguage='SCALA', "
-                                + "functionResource='[ResourceUri{resourceType=JAR, uri='file:///path/to/test.jar'}]', options='{}'], "
+                                + "functionResource='[ResourceUri{resourceType=JAR, uri='file:///path/to/test.jar'}]', options='{}'}], "
                                 + "ignoreIfExists: [false], functionLanguage: [SCALA])");
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlDdlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlDdlToOperationConverterTest.java
@@ -1075,7 +1075,7 @@ class SqlDdlToOperationConverterTest extends SqlNodeToOperationConversionTestBas
                         "CREATE TEMPORARY SYSTEM FUNCTION: (functionName: [test_udf2], "
                                 + "catalogFunction: [CatalogFunctionImpl{className='org.apache.fink.function.function2', "
                                 + "functionLanguage='SCALA', "
-                                + "functionResource='[ResourceUri{resourceType=JAR, uri='file:///path/to/test.jar'}]'}], "
+                                + "functionResource='[ResourceUri{resourceType=JAR, uri='file:///path/to/test.jar'}]', options='{}'], "
                                 + "ignoreIfExists: [false], functionLanguage: [SCALA])");
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlMaterializedTableNodeToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlMaterializedTableNodeToOperationConverterTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.planner.operations;
 
 import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.FunctionDescriptor;
 import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.CatalogMaterializedTable;
@@ -161,7 +162,7 @@ public class SqlMaterializedTableNodeToOperationConverterTest
                 UnresolvedIdentifier.of(
                         ObjectIdentifier.of(
                                 catalogManager.getCurrentCatalog(), "default", "myFunc")),
-                TableFunc0.class,
+                FunctionDescriptor.forFunctionClass(TableFunc0.class).build(),
                 true);
 
         final String sql =


### PR DESCRIPTION
## What is the purpose of the change

Adds support for `WITH` clause in `CREATE FUNCTION`


## Verifying this change

Extended existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) : todo
