### PR TITLE
[FLINK-38202][build] Allow to customize dynamic.max-pool-size-factor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,6 +217,7 @@ under the License.
 
 		<!-- Can be set to any value to reproduce a specific build. -->
 		<test.randomization.seed/>
+		<!-- default value taken from https://docs.junit.org/snapshot/user-guide/#writing-tests-parallel-execution-config-properties -->
 		<test.dynamic.max-pool-size-factor>256</test.dynamic.max-pool-size-factor>
 		<test.unit.pattern>**/*Test.*</test.unit.pattern>
 		<snappy.java.version>1.1.10.7</snappy.java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,8 @@ under the License.
 		<test.randomization.seed/>
 		<!-- default value taken from https://docs.junit.org/snapshot/user-guide/#writing-tests-parallel-execution-config-properties -->
 		<test.dynamic.max-pool-size-factor>256</test.dynamic.max-pool-size-factor>
-		<test.parallel.strategy>dynamic</test.parallel.strategy>
+		<!-- default value taken from https://docs.junit.org/snapshot/user-guide/#writing-tests-parallel-execution-config-properties -->
+		<test.dynamic.factor>1.0</test.dynamic.factor>
 		<test.unit.pattern>**/*Test.*</test.unit.pattern>
 		<snappy.java.version>1.1.10.7</snappy.java.version>
 	</properties>
@@ -1775,9 +1776,11 @@ under the License.
 						<!-- Tests suites are by default executed by a single thread; parallel execution is opt-in. -->
 						<junit.jupiter.execution.parallel.mode.classes.default>same_thread</junit.jupiter.execution.parallel.mode.classes.default>
 						<!-- automatically adjust parallelism based on available cpu/processor cores -->
-						<junit.jupiter.execution.parallel.config.strategy>${test.parallel.strategy}</junit.jupiter.execution.parallel.config.strategy>
+						<junit.jupiter.execution.parallel.config.strategy>dynamic</junit.jupiter.execution.parallel.config.strategy>
 						<!-- configuration parameter can be used to limit the maximum number of threads -->
 						<junit.jupiter.execution.parallel.config.dynamic.max-pool-size-factor>${test.dynamic.max-pool-size-factor}</junit.jupiter.execution.parallel.config.dynamic.max-pool-size-factor>
+						<!-- factor to be multiplied by the number of available processors/cores to determine the desired parallelism for the dynamic configuration strategy -->
+						<junit.jupiter.execution.parallel.config.dynamic.factor>${test.dynamic.factor}</junit.jupiter.execution.parallel.config.dynamic.factor>
 					</systemPropertyVariables>
 					<!-- This is picked up by IntelliJ -->
 					<argLine>${flink.surefire.baseArgLine}</argLine>

--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@ under the License.
 
 		<!-- Can be set to any value to reproduce a specific build. -->
 		<test.randomization.seed/>
-		<test.dynamic.max-pool-size-factor/>
+		<test.dynamic.max-pool-size-factor>256</test.dynamic.max-pool-size-factor>
 		<test.unit.pattern>**/*Test.*</test.unit.pattern>
 		<snappy.java.version>1.1.10.7</snappy.java.version>
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -217,6 +217,7 @@ under the License.
 
 		<!-- Can be set to any value to reproduce a specific build. -->
 		<test.randomization.seed/>
+		<test.dynamic.max-pool-size-factor/>
 		<test.unit.pattern>**/*Test.*</test.unit.pattern>
 		<snappy.java.version>1.1.10.7</snappy.java.version>
 	</properties>
@@ -1771,8 +1772,10 @@ under the License.
 						<junit.jupiter.execution.parallel.mode.default>same_thread</junit.jupiter.execution.parallel.mode.default>
 						<!-- Tests suites are by default executed by a single thread; parallel execution is opt-in. -->
 						<junit.jupiter.execution.parallel.mode.classes.default>same_thread</junit.jupiter.execution.parallel.mode.classes.default>
-						<!-- automatically adjust parallelism based on available cpu/processor cores-->
+						<!-- automatically adjust parallelism based on available cpu/processor cores -->
 						<junit.jupiter.execution.parallel.config.strategy>dynamic</junit.jupiter.execution.parallel.config.strategy>
+						<!-- configuration parameter can be used to limit the maximum number of threads -->
+						<junit.jupiter.execution.parallel.config.dynamic.max-pool-size-factor>${test.dynamic.max-pool-size-factor}</junit.jupiter.execution.parallel.config.dynamic.max-pool-size-factor>
 					</systemPropertyVariables>
 					<!-- This is picked up by IntelliJ -->
 					<argLine>${flink.surefire.baseArgLine}</argLine>

--- a/pom.xml
+++ b/pom.xml
@@ -219,6 +219,7 @@ under the License.
 		<test.randomization.seed/>
 		<!-- default value taken from https://docs.junit.org/snapshot/user-guide/#writing-tests-parallel-execution-config-properties -->
 		<test.dynamic.max-pool-size-factor>256</test.dynamic.max-pool-size-factor>
+		<test.parallel.strategy>dynamic</test.parallel.strategy>
 		<test.unit.pattern>**/*Test.*</test.unit.pattern>
 		<snappy.java.version>1.1.10.7</snappy.java.version>
 	</properties>
@@ -1774,7 +1775,7 @@ under the License.
 						<!-- Tests suites are by default executed by a single thread; parallel execution is opt-in. -->
 						<junit.jupiter.execution.parallel.mode.classes.default>same_thread</junit.jupiter.execution.parallel.mode.classes.default>
 						<!-- automatically adjust parallelism based on available cpu/processor cores -->
-						<junit.jupiter.execution.parallel.config.strategy>dynamic</junit.jupiter.execution.parallel.config.strategy>
+						<junit.jupiter.execution.parallel.config.strategy>${test.parallel.strategy}</junit.jupiter.execution.parallel.config.strategy>
 						<!-- configuration parameter can be used to limit the maximum number of threads -->
 						<junit.jupiter.execution.parallel.config.dynamic.max-pool-size-factor>${test.dynamic.max-pool-size-factor}</junit.jupiter.execution.parallel.config.dynamic.max-pool-size-factor>
 					</systemPropertyVariables>


### PR DESCRIPTION
## What is the purpose of the change

The PR allows to configure `dynamic.max-pool-size-factor` via `-Dtest.dynamic.max-pool-size-factor`

## Brief change log
pom.xml

## Verifying this change

existing ci and manual

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable )
