### PR TITLE
[hotfix][docs] Clarify Kryo behavior

### DIFF
--- a/docs/content.zh/docs/dev/datastream/fault-tolerance/serialization/types_serialization.md
+++ b/docs/content.zh/docs/dev/datastream/fault-tolerance/serialization/types_serialization.md
@@ -393,7 +393,7 @@ If you observe unexpected behavior, manually specify the return type using the `
 #### Serialization of POJO types
 
 The `PojoTypeInfo` is creating serializers for all the fields inside the POJO. Standard types such as
-int, long, String etc. are handled by serializers we ship with Flink.
+int, long, String, etc. are handled by serializers we ship with Flink.
 For all other types, we fall back to [Kryo](https://github.com/EsotericSoftware/kryo).
 
 If Kryo is not able to handle the type, you can ask the `PojoTypeInfo` to serialize the POJO using [Avro](https://avro.apache.org).
@@ -428,6 +428,15 @@ or via user-defined custom serializers. To do that, set:
 ```yaml
 pipeline.generic-types: false 
 ```
+
+{{< hint warning >}}
+Note that Kryo will deserialize any class on the classpath
+* when `pipeline.generic-types: true`
+* the Flink job has a type definition such as `DataStream<Object>`, or `DataStream<Tuple2<Integer,Object>>`.
+
+A malicious actor who knows the Flink job and controls the data input to Kryo will be able to instantiate classes which are
+not intended for instantiation.
+{{< /hint >}}
 
 An exception will be raised whenever a data type is encountered that would go through Kryo.
 

--- a/docs/content.zh/docs/ops/production_ready.md
+++ b/docs/content.zh/docs/ops/production_ready.md
@@ -81,6 +81,10 @@ It is a single point of failure within the cluster, and if it crashes, no new jo
 
 Configuring [High Availability]({{< ref "docs/deployment/ha/overview" >}}), in conjunction with Apache Zookeeper or Flinks Kubernetes based service, allows for a swift recovery and is highly recommended for production setups.
 
+### Harden Kryo Serialization
+
+[Disable support for generic Kryo types]({{< ref "docs/dev/datastream/fault-tolerance/serialization/types_serialization" >}}#disabling-kryo-fallback), as this is a security and performance concern.
+
 ### Secure Flink Cluster Access
 
 Flink is intentionally designed to support remote code execution.

--- a/docs/content/docs/dev/datastream/fault-tolerance/serialization/types_serialization.md
+++ b/docs/content/docs/dev/datastream/fault-tolerance/serialization/types_serialization.md
@@ -394,7 +394,7 @@ If you observe unexpected behavior, manually specify the return type using the `
 #### Serialization of POJO types
 
 The `PojoTypeInfo` is creating serializers for all the fields inside the POJO. Standard types such as
-int, long, String etc. are handled by serializers we ship with Flink.
+int, long, String, etc. are handled by serializers we ship with Flink.
 For all other types, we fall back to [Kryo](https://github.com/EsotericSoftware/kryo).
 
 If Kryo is not able to handle the type, you can ask the `PojoTypeInfo` to serialize the POJO using [Avro](https://avro.apache.org).
@@ -429,6 +429,15 @@ or via user-defined custom serializers. To do that, set:
 ```yaml
 pipeline.generic-types: false 
 ```
+
+{{< hint warning >}}
+Note that Kryo will deserialize any class on the classpath 
+ * when `pipeline.generic-types: true`
+ * the Flink job has a type definition such as `DataStream<Object>`, or `DataStream<Tuple2<Integer,Object>>`. 
+
+A malicious actor who knows the Flink job and controls the data input to Kryo will be able to instantiate classes which are 
+not intended for instantiation.
+{{< /hint >}}
 
 An exception will be raised whenever a data type is encountered that would go through Kryo.
 

--- a/docs/content/docs/ops/production_ready.md
+++ b/docs/content/docs/ops/production_ready.md
@@ -81,6 +81,10 @@ It is a single point of failure within the cluster, and if it crashes, no new jo
 
 Configuring [High Availability]({{< ref "docs/deployment/ha/overview" >}}), in conjunction with Apache Zookeeper or Flinks Kubernetes based service, allows for a swift recovery and is highly recommended for production setups.
 
+### Harden Kryo Serialization
+
+[Disable support for generic Kryo types]({{< ref "docs/dev/datastream/fault-tolerance/serialization/types_serialization" >}}#disabling-kryo-fallback), as this is a security and performance concern.
+
 ### Secure Flink Cluster Access
 
 Flink is intentionally designed to support remote code execution. 


### PR DESCRIPTION
This is a quick extension of the docs to clarify the potential risks of letting kryo initialize any class it finds in the input data stream.