### PR TITLE
[hotfix][docs] `WITH` in `CREATE DATABASE` is optional

### DIFF
--- a/docs/content.zh/docs/dev/table/sql/create.md
+++ b/docs/content.zh/docs/dev/table/sql/create.md
@@ -822,7 +822,7 @@ catalog 属性一般用于存储关于这个 catalog 的额外的信息。
 ```sql
 CREATE DATABASE [IF NOT EXISTS] [catalog_name.]db_name
   [COMMENT database_comment]
-  WITH (key1=val1, key2=val2, ...)
+  [WITH (key1=val1, key2=val2, ...)]
 ```
 
 根据给定的表属性创建数据库。若数据库中已存在同名表会抛出异常。

--- a/docs/content/docs/dev/table/sql/create.md
+++ b/docs/content/docs/dev/table/sql/create.md
@@ -819,7 +819,7 @@ Check out more details at [Catalogs]({{< ref "docs/dev/table/catalogs" >}}).
 ```sql
 CREATE DATABASE [IF NOT EXISTS] [catalog_name.]db_name
   [COMMENT database_comment]
-  WITH (key1=val1, key2=val2, ...)
+  [WITH (key1=val1, key2=val2, ...)]
 ```
 
 Create a database with the given database properties. If a database with the same name already exists in the catalog, an exception is thrown.


### PR DESCRIPTION


## What is the purpose of the change

The PR is to fix docs description for `CREATE` `CATALOG`, `DATABASE`, `MODEL`  to show that `WITH` is optional there
## Brief change log
create.md
## Verifying this change
just docs

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? ( docs)
