### PR TITLE
[FLINK-37955] Don't load all records into main memory to avoid OOM

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/common/JoinTestPrograms.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/common/JoinTestPrograms.java
@@ -18,10 +18,14 @@
 
 package org.apache.flink.table.planner.plan.nodes.exec.common;
 
+import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecJoin;
 import org.apache.flink.table.test.program.SinkTestStep;
 import org.apache.flink.table.test.program.SourceTestStep;
 import org.apache.flink.table.test.program.TableTestProgram;
 import org.apache.flink.types.Row;
+import org.apache.flink.types.RowKind;
+
+import java.util.stream.IntStream;
 
 /** {@link TableTestProgram} definitions for testing {@link StreamExecJoin}. */
 public class JoinTestPrograms {
@@ -40,6 +44,63 @@ public class JoinTestPrograms {
     public static final TableTestProgram ANTI_JOIN;
     public static final TableTestProgram JOIN_WITH_STATE_TTL_HINT;
     public static final TableTestProgram SEMI_ANTI_JOIN_WITH_LITERAL_AGG;
+
+    public static final TableTestProgram MULTI_JOIN_BUG =
+            TableTestProgram.of("join-duplicate-emission-bug", "bug with CTE and left join")
+                    .setupTableSource(
+                            SourceTestStep.newBuilder("upsert_table_with_duplicates")
+                                    .addSchema(
+                                            "`execution_plan_id` VARCHAR(2147483647) NOT NULL",
+                                            "`workflow_id` VARCHAR(2147483647) NOT NULL",
+                                            "`event_section_id` VARCHAR(2147483647) NOT NULL",
+                                            "CONSTRAINT `PRIMARY` PRIMARY KEY (`execution_plan_id`, `event_section_id`) NOT ENFORCED")
+                                    .addOption("changelog-mode", "I, UA,D")
+                                    .producedValues(
+                                            IntStream.range(0, 13)
+                                                    .mapToObj(
+                                                            i ->
+                                                                    Row.ofKind(
+                                                                            RowKind.UPDATE_AFTER,
+                                                                            "section_id_1",
+                                                                            "section_id_2",
+                                                                            "section_id_3"))
+                                                    .toArray(Row[]::new))
+                                    .build())
+                    .setupTableSink(
+                            SinkTestStep.newBuilder("sink")
+                                    .addSchema("event_element_id STRING", "cnt BIGINT")
+                                    .testMaterializedData()
+                                    .consumedValues(Row.of("pk-1", 1), Row.of("pk-2", 1))
+                                    .build())
+                    .runSql(
+                            "INSERT INTO sink WITH\n"
+                                    + "    section_detail as (\n"
+                                    + "        SELECT s.event_section_id\n"
+                                    + "        \n"
+                                    + "        FROM upsert_table_with_duplicates s\n"
+                                    + "    ),\n"
+                                    + "\n"
+                                    + "    event_element as (\n"
+                                    + "        SELECT\n"
+                                    + "            ed.id as event_element_id\n"
+                                    + "        FROM (\n"
+                                    + "          SELECT\n"
+                                    + "                 'pk-2' id,\n"
+                                    + "                 'section_id_3' section_id\n"
+                                    + "           UNION ALL\n"
+                                    + "          SELECT\n"
+                                    + "                 'pk-1' id,\n"
+                                    + "                 'section_id_3' section_id\n"
+                                    + "        ) ed  \n"
+                                    + "        LEFT JOIN\n"
+                                    + "            section_detail as s\n"
+                                    + "            ON s.event_section_id = ed.section_id\n"
+                                    + "    )\n"
+                                    + "\n"
+                                    + "SELECT  event_element_id, COUNT(*) cnt\n"
+                                    + "FROM event_element\n"
+                                    + "GROUP BY event_element_id")
+                    .build();
 
     static final SourceTestStep EMPLOYEE =
             SourceTestStep.newBuilder("EMPLOYEE")

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/MiscSemanticTests.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/MiscSemanticTests.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.planner.plan.nodes.exec.stream;
 
 import org.apache.flink.table.planner.plan.nodes.exec.common.CalcTestPrograms;
+import org.apache.flink.table.planner.plan.nodes.exec.common.JoinTestPrograms;
 import org.apache.flink.table.planner.plan.nodes.exec.testutils.SemanticTestBase;
 import org.apache.flink.table.test.program.TableTestProgram;
 
@@ -31,6 +32,7 @@ public class MiscSemanticTests extends SemanticTestBase {
     public List<TableTestProgram> programs() {
         return List.of(
                 WindowRankTestPrograms.WINDOW_RANK_HOP_TVF_NAMED_MIN_TOP_1,
-                CalcTestPrograms.CURRENT_WATERMARK);
+                CalcTestPrograms.CURRENT_WATERMARK,
+                JoinTestPrograms.MULTI_JOIN_BUG);
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
