### PR TITLE
[hotfix][python] Use `uv run` to run Python lint/testing tools, rather than directly installing

### DIFF
--- a/flink-python/apache-flink-libraries/pyproject.toml
+++ b/flink-python/apache-flink-libraries/pyproject.toml
@@ -15,9 +15,30 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+[build-system]
+# Minimum requirements for the build system to execute.
+requires = [
+    "setuptools>=75.3",
+    "wheel",
+]
 
-[bdist_wheel]
-universal = 1
+[project]
+name = "apache-flink-libraries"
+description = "Apache Flink Libraries"
+readme = "README.md"
+license = "Apache-2.0"
+authors = [
+    {name = "Apache Software Foundation", email = "dev@flink.apache.org"}
+]
+requires-python = ">=3.9"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+dynamic = ["version", "dependencies"]
 
-[metadata]
-description-file = README.md
+[project.urls]
+homepage = "https://flink.apache.org"

--- a/flink-python/apache-flink-libraries/setup.py
+++ b/flink-python/apache-flink-libraries/setup.py
@@ -215,27 +215,11 @@ run sdist.
         PACKAGE_DATA['pyflink.licenses'] = ['*']
 
     setup(
-        name='apache-flink-libraries',
         version=VERSION,
         packages=PACKAGES,
         include_package_data=True,
         package_dir=PACKAGE_DIR,
         package_data=PACKAGE_DATA,
-        url='https://flink.apache.org',
-        license='https://www.apache.org/licenses/LICENSE-2.0',
-        author='Apache Software Foundation',
-        author_email='dev@flink.apache.org',
-        python_requires='>=3.9',
-        description='Apache Flink Libraries',
-        long_description=long_description,
-        long_description_content_type='text/markdown',
-        classifiers=[
-            'Development Status :: 5 - Production/Stable',
-            'License :: OSI Approved :: Apache Software License',
-            'Programming Language :: Python :: 3.9',
-            'Programming Language :: Python :: 3.10',
-            'Programming Language :: Python :: 3.11',
-            'Programming Language :: Python :: 3.12'],
     )
 finally:
     if in_flink_source:

--- a/flink-python/dev/build-wheels.sh
+++ b/flink-python/dev/build-wheels.sh
@@ -30,23 +30,23 @@ done
 
 ## 3. build wheels
 for ((i=0;i<${#py_env[@]};i++)) do
+    source `pwd`/dev/.uv/envs/${py_env[i]}/bin/activate
     echo "Building wheel for environment: ${py_env[i]}"
     if [[ "$(uname)" != "Darwin" ]]; then
         # force the linker to use the older glibc version in Linux
         export CFLAGS="-I. -include dev/glibc_version_fix.h"
     fi
-    ${PY_ENV_DIR}/${py_env[i]}/bin/python setup.py bdist_wheel
+    uv build --wheel
+    deactivate
 done
 
 ## 4. convert linux_x86_64 wheel to manylinux1 wheel in Linux
 if [[ "$(uname)" != "Darwin" ]]; then
     echo "Converting linux_x86_64 wheel to manylinux1"
     source `pwd`/dev/.uv/bin/activate
-    # 4.1 install patchelf and auditwheel
-    uv pip install patchelf==0.17.2.1 auditwheel==3.2.0
-    # 4.2 convert Linux wheel
+    # 4.1 convert Linux wheel
     for wheel_file in dist/*.whl; do
-        auditwheel repair ${wheel_file} -w dist
+        uv run --group auditwheel auditwheel repair ${wheel_file} -w dist
         rm -f ${wheel_file}
     done
     deactivate

--- a/flink-python/dev/install_command.sh
+++ b/flink-python/dev/install_command.sh
@@ -17,15 +17,8 @@
 # limitations under the License.
 ################################################################################
 if [[ "$@" =~ 'apache-flink-libraries' ]]; then
-    # As of Python 3.12, setuptools is no longer a seed package.
-    # We should ensure its existence.
-    python -m pip install setuptools
-    pushd apache-flink-libraries
-    python setup.py sdist
-    pushd dist
-    python -m pip install *
-    popd
-    popd
+    uv build --sdist apache-flink-libraries
+    python -m pip install apache-flink-libraries/dist/*
 fi
 
 if [[ `uname -s` == "Darwin" && `uname -m` == "arm64" ]]; then

--- a/flink-python/dev/lint-python.sh
+++ b/flink-python/dev/lint-python.sh
@@ -137,7 +137,7 @@ function parse_component_args() {
         if [[ `contains_element "${SUPPORTED_INSTALLATION_COMPONENTS[*]}" "${component}"` = true ]]; then
             REAL_COMPONENTS+=(${component})
         else
-            echo "unknown install component ${component}, currently we only support installing basic,py_env,tox,flake8,sphinx,mypy,all."
+            echo "unknown install component ${component}, currently we only support installing basic,py_env,all."
             exit 1
         fi
     done
@@ -253,102 +253,6 @@ function install_py_env() {
     done
 }
 
-# Install tox.
-# In some situations,you need to run the script with "sudo". e.g. sudo ./lint-python.sh
-function install_tox() {
-    source $ENV_HOME/bin/activate
-    if [ -f "$TOX_PATH" ]; then
-        $UV_PATH pip uninstall tox -q 2>&1 >/dev/null
-        if [ $? -ne 0 ]; then
-            echo "uv pip uninstall tox failed \
-            please try to exec the script again.\
-            if failed many times, you can try to exec in the form of sudo ./lint-python.sh -f"
-            exit 1
-        fi
-    fi
-
-    $CURRENT_DIR/install_command.sh -q --group "${PYPROJECT_PATH}:tox" 2>&1 >/dev/null
-    if [ $? -ne 0 ]; then
-        echo "uv pip install tox failed \
-        please try to exec the script again.\
-        if failed many times, you can try to exec in the form of sudo ./lint-python.sh -f"
-        exit 1
-    fi
-    deactivate
-}
-
-# Install flake8.
-# In some situations,you need to run the script with "sudo". e.g. sudo ./lint-python.sh
-function install_flake8() {
-    source $UV_HOME/bin/activate
-    if [ -f "$FLAKE8_PATH" ]; then
-        $UV_PATH pip uninstall flake8 -q 2>&1 >/dev/null
-        if [ $? -ne 0 ]; then
-            echo "uv pip uninstall flake8 failed \
-            please try to exec the script again.\
-            if failed many times, you can try to exec in the form of sudo ./lint-python.sh -f"
-            exit 1
-        fi
-    fi
-
-    $CURRENT_DIR/install_command.sh -q --group "${PYPROJECT_PATH}:flake8" 2>&1 >/dev/null
-    if [ $? -ne 0 ]; then
-        echo "uv pip install flake8 failed \
-        please try to exec the script again.\
-        if failed many times, you can try to exec in the form of sudo ./lint-python.sh -f"
-        exit 1
-    fi
-    deactivate
-}
-
-# Install sphinx.
-# In some situations,you need to run the script with "sudo". e.g. sudo ./lint-python.sh
-function install_sphinx() {
-    source $UV_HOME/bin/activate
-    if [ -f "$SPHINX_PATH" ]; then
-        $UV_PATH pip uninstall Sphinx -q 2>&1 >/dev/null
-        if [ $? -ne 0 ]; then
-            echo "uv pip uninstall sphinx failed \
-            please try to exec the script again.\
-            if failed many times, you can try to exec in the form of sudo ./lint-python.sh -f"
-            exit 1
-        fi
-    fi
-
-    $CURRENT_DIR/install_command.sh -q --group "${PYPROJECT_PATH}:sphinx" 2>&1 >/dev/null
-    if [ $? -ne 0 ]; then
-        echo "uv pip install sphinx failed \
-        please try to exec the script again.\
-        if failed many times, you can try to exec in the form of sudo ./lint-python.sh -f"
-        exit 1
-    fi
-    deactivate
-}
-
-
-# Install mypy.
-# In some situations, you need to run the script with "sudo". e.g. sudo ./lint-python.sh
-function install_mypy() {
-    source ${UV_HOME}/bin/activate
-    if [[ -f "$MYPY_PATH" ]]; then
-        ${UV_PATH} pip uninstall mypy -q 2>&1 >/dev/null
-        if [[ $? -ne 0 ]]; then
-            echo "uv pip uninstall mypy failed \
-            please try to exec the script again.\
-            if failed many times, you can try to exec in the form of sudo ./lint-python.sh -f"
-            exit 1
-        fi
-    fi
-    ${CURRENT_DIR}/install_command.sh -q --group "${PYPROJECT_PATH}:mypy" 2>&1 >/dev/null
-    if [[ $? -ne 0 ]]; then
-        echo "uv pip install mypy failed \
-        please try to exec the script again.\
-        if failed many times, you can try to exec in the form of sudo ./lint-python.sh -f"
-        exit 1
-    fi
-    deactivate
-}
-
 function need_install_component() {
     if [[ `contains_element "${SUPPORTED_INSTALLATION_COMPONENTS[*]}" "$1"` = true ]]; then
         echo true
@@ -385,42 +289,6 @@ function install_environment() {
         STEP=2
         checkpoint_stage $STAGE $STEP
         print_function "STEP" "install python environment... [SUCCESS]"
-    fi
-
-    # step-3 install tox
-    if [ $STEP -lt 3 ] && [ `need_install_component "tox"` = true ]; then
-        print_function "STEP" "installing tox..."
-        install_tox
-        STEP=3
-        checkpoint_stage $STAGE $STEP
-        print_function "STEP" "install tox... [SUCCESS]"
-    fi
-
-    # step-4 install  flake8
-    if [ $STEP -lt 4 ] && [ `need_install_component "flake8"` = true ]; then
-        print_function "STEP" "installing flake8..."
-        install_flake8
-        STEP=4
-        checkpoint_stage $STAGE $STEP
-        print_function "STEP" "install flake8... [SUCCESS]"
-    fi
-
-    # step-5 install sphinx
-    if [ $STEP -lt 5 ] && [ `need_install_component "sphinx"` = true ]; then
-        print_function "STEP" "installing sphinx..."
-        install_sphinx
-        STEP=5
-        checkpoint_stage $STAGE $STEP
-        print_function "STEP" "install sphinx... [SUCCESS]"
-    fi
-
-    # step-5 install mypy
-    if [[ ${STEP} -lt 6 ]] && [[ `need_install_component "mypy"` = true ]]; then
-        print_function "STEP" "installing mypy..."
-        install_mypy
-        STEP=6
-        checkpoint_stage ${STAGE} ${STEP}
-        print_function "STEP" "install mypy... [SUCCESS]"
     fi
 
     print_function "STAGE"  "install environment... [SUCCESS]"
@@ -559,6 +427,7 @@ function check_stage() {
 #########################
 # Tox check
 function tox_check() {
+    local TOX="$UV_PATH run --group tox tox"
     LATEST_PYTHON="py312"
     print_function "STAGE" "tox checks"
     # Set created py-env in $PATH for tox's creating virtual env
@@ -569,10 +438,10 @@ function tox_check() {
 
     if [[ ${BUILD_REASON} = 'IndividualCI' ]]; then
         # Only run test in latest python version triggered by a Git push
-        $TOX_PATH -vv -c $FLINK_PYTHON_DIR/tox.ini -e ${LATEST_PYTHON} --recreate 2>&1 | tee -a $LOG_FILE
+        $TOX -vv -c $FLINK_PYTHON_DIR/tox.ini -e ${LATEST_PYTHON} --recreate 2>&1 | tee -a $LOG_FILE
     else
         # Only run random selected python version in nightly CI.
-        ENV_LIST_STRING=`$TOX_PATH -l -c $FLINK_PYTHON_DIR/tox.ini`
+        ENV_LIST_STRING=`$TOX -l -c $FLINK_PYTHON_DIR/tox.ini`
         _OLD_IFS=$IFS
         IFS=$'\n'
         ENV_LIST=(${ENV_LIST_STRING})
@@ -580,7 +449,7 @@ function tox_check() {
 
         ENV_LIST_SIZE=${#ENV_LIST[@]}
         index=$(($RANDOM % ENV_LIST_SIZE))
-        $TOX_PATH -vv -c $FLINK_PYTHON_DIR/tox.ini -e ${ENV_LIST[$index]} --recreate 2>&1 | tee -a $LOG_FILE
+        $TOX -vv -c $FLINK_PYTHON_DIR/tox.ini -e ${ENV_LIST[$index]} --recreate 2>&1 | tee -a $LOG_FILE
     fi
 
     TOX_RESULT=$((grep -c "congratulations :)" "$LOG_FILE") 2>&1)
@@ -600,13 +469,10 @@ function tox_check() {
 
 # Flake8 check
 function flake8_check() {
+    local FLAKE8="$UV_PATH run --group flake8 flake8"
     local PYTHON_SOURCE="$(find . \( -path ./dev -o -path ./.tox \) -prune -o -type f -name "*.py" -print )"
 
     print_function "STAGE" "flake8 checks"
-    if [ ! -f "$FLAKE8_PATH" ]; then
-        echo "For some unknown reasons, the flake8 package is not complete,\
-        you should exec the script with the parameter: -f"
-    fi
 
     if [[ ! "$PYTHON_SOURCE" ]]; then
         echo "No python files found!  Something is wrong exiting."
@@ -616,7 +482,7 @@ function flake8_check() {
     # the return value of a pipeline is the status of the last command to exit
     # with a non-zero status or zero if no command exited with a non-zero status
     set -o pipefail
-    ($FLAKE8_PATH  --config=tox.ini $PYTHON_SOURCE) 2>&1 | tee -a $LOG_FILE
+    ($FLAKE8 --config=tox.ini $PYTHON_SOURCE) 2>&1 | tee -a $LOG_FILE
 
     PYCODESTYLE_STATUS=$?
     if [ $PYCODESTYLE_STATUS -ne 0 ]; then
@@ -630,7 +496,7 @@ function flake8_check() {
 
 # Sphinx check
 function sphinx_check() {
-    export SPHINXBUILD=$SPHINX_PATH
+    export SPHINXBUILD="$UV_PATH run --group sphinx sphinx-build"
     # cd to $FLINK_PYTHON_DIR
     pushd "$FLINK_PYTHON_DIR"/docs &> /dev/null
     make clean
@@ -653,13 +519,14 @@ function sphinx_check() {
 
 # mypy check
 function mypy_check() {
+    local MYPY="$UV_PATH run --group mypy mypy"
     print_function "STAGE" "mypy checks"
 
     # the return value of a pipeline is the status of the last command to exit
     # with a non-zero status or zero if no command exited with a non-zero status
     set -o pipefail
 
-    (${MYPY_PATH} --install-types --non-interactive --config-file tox.ini) 2>&1 | tee -a ${LOG_FILE}
+    ($MYPY --install-types --non-interactive --config-file tox.ini) 2>&1 | tee -a ${LOG_FILE}
     TYPE_HINT_CHECK_STATUS=$?
     if [ ${TYPE_HINT_CHECK_STATUS} -ne 0 ]; then
         print_function "STAGE" "mypy checks... [FAILED]"
@@ -694,18 +561,6 @@ UV_PATH=$UV_HOME/bin/uv
 # pip path
 PIP_PATH=$ENV_HOME/bin/pip
 
-# tox path
-TOX_PATH=$ENV_HOME/bin/tox
-
-# flake8 path
-FLAKE8_PATH=$ENV_HOME/bin/flake8
-
-# sphinx path
-SPHINX_PATH=$ENV_HOME/bin/sphinx-build
-
-# mypy path
-MYPY_PATH=$ENV_HOME/bin/mypy
-
 _OLD_PATH="$PATH"
 
 SUPPORT_OS=("Darwin" "Linux")
@@ -739,7 +594,7 @@ UV_VERSION=0.7.20
 UV_INSTALL_SH=$CURRENT_DIR/download/uv.sh
 
 # stage "install" includes the num of steps.
-STAGE_INSTALL_STEPS=6
+STAGE_INSTALL_STEPS=2
 
 # whether force to restart the script.
 FORCE_START=0
@@ -768,11 +623,12 @@ USAGE="
 usage: $0 [options]
 -h          print this help message and exit
 -f          force to exec from the progress of installing environment
--s [basic,py_env,tox,flake8,sphinx,mypy,all]
+-s [basic,py_env,all]
             install environment with specified components which split by comma(,)
             note:
                 This option is used to install environment components and will skip all subsequent checks,
                 so do not use this option with -e,-i simultaneously.
+                Tools like tox, flake8, sphinx, mypy are run via 'uv run' and don't need separate installation.
 -e [tox,flake8,sphinx,mypy]
             exclude checks which split by comma(,)
 -i [tox,flake8,sphinx,mypy]
@@ -780,13 +636,12 @@ usage: $0 [options]
 -l          list all checks supported.
 Examples:
   ./lint-python.sh -s basic        =>  install environment with basic components.
-  ./lint-python.sh -s all          =>  install environment with all components such as python env,tox,flake8,sphinx,mypy etc.
-  ./lint-python.sh -s tox,flake8   =>  install environment with tox,flake8.
-  ./lint-python.sh -s tox -f       =>  reinstall environment with tox.
+  ./lint-python.sh -s all          =>  install environment with all components (uv and python environments).
+  ./lint-python.sh -s py_env       =>  install only python environments.
   ./lint-python.sh -e tox,flake8   =>  exclude checks tox,flake8.
   ./lint-python.sh -i flake8       =>  include checks flake8.
   ./lint-python.sh                 =>  exec all checks.
-  ./lint-python.sh -f              =>  reinstall environment with all components and exec all checks.
+  ./lint-python.sh -f              =>  reinstall environment and exec all checks.
   ./lint-python.sh -l              =>  list all checks supported.
   ./lint-python.sh -r              =>  clean up python environment.
 "

--- a/flink-python/docs/Makefile
+++ b/flink-python/docs/Makefile
@@ -27,9 +27,9 @@ endif
 # If SPHINXBUILD is set, the command is 'sphinx-build'.
 # Elseif SPHINXPYTHON is set, the command is 'python -m sphinx'.
 ifdef SPHINXBUILD
-# Check whether sphinx-build is installed
-ifeq ($(shell hash $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
-$(error The command '$(SPHINXBUILD)' was not found.If you don't have Sphinx installed, grab it from http://sphinx-doc.org/)
+# Check whether sphinx-build command works (supports compound commands like "uv run sphinx-build")
+ifeq ($(shell $(SPHINXBUILD) --help >/dev/null 2>&1; echo $$?), 1)
+$(error The command '$(SPHINXBUILD)' was not found or failed. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/)
 endif
 else
 ifeq ($(shell $(SPHINXPYTHON) -c 'import sphinx' >/dev/null 2>&1; echo $$?), 1)

--- a/flink-python/pyproject.toml
+++ b/flink-python/pyproject.toml
@@ -27,6 +27,27 @@ requires = [
     "cython>=0.29.24"
 ]
 
+[project]
+name = "apache-flink"
+description = "Apache Flink Python API"
+readme = "README.md"
+license = "Apache-2.0"
+authors = [
+    {name = "Apache Software Foundation", email = "dev@flink.apache.org"}
+]
+requires-python = ">=3.9"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+dynamic = ["version", "scripts", "dependencies"]
+
+[project.urls]
+homepage = "https://flink.apache.org"
+
 [dependency-groups]
 dev = [
   "pip>=20.3",
@@ -52,7 +73,7 @@ dev = [
   "ruamel.yaml>=0.18.4",
 ]
 tox = [
-    "tox==3.14.0"
+    "tox==3.28.0"
 ]
 flake8 = [
     "flake8==7.2.0"
@@ -75,6 +96,10 @@ mypy = [
     "types-pytz",
     "types-python-dateutil"
 ]
+auditwheel = [
+    "patchelf==0.17.2.1",
+    "auditwheel==3.2.0"
+]
 
 
 [tool.cibuildwheel]
@@ -85,3 +110,6 @@ archs = ["x86_64", "arm64"]
 
 [tool.cibuildwheel.linux]
 archs = ["x86_64"]
+
+[tool.uv.sources]
+apache-flink-libraries = { path = "apache-flink-libraries/" }

--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -330,31 +330,15 @@ try:
                         apache_flink_libraries_dependency]
 
     setup(
-        name='apache-flink',
         version=VERSION,
         packages=PACKAGES,
         include_package_data=True,
         package_dir=PACKAGE_DIR,
         package_data=PACKAGE_DATA,
         scripts=scripts,
-        url='https://flink.apache.org',
-        license='https://www.apache.org/licenses/LICENSE-2.0',
-        author='Apache Software Foundation',
-        author_email='dev@flink.apache.org',
-        python_requires='>=3.9',
         install_requires=install_requires,
         cmdclass={'build_ext': build_ext},
-        description='Apache Flink Python API',
-        long_description=long_description,
-        long_description_content_type='text/markdown',
         zip_safe=False,
-        classifiers=[
-            'Development Status :: 5 - Production/Stable',
-            'License :: OSI Approved :: Apache Software License',
-            'Programming Language :: Python :: 3.9',
-            'Programming Language :: Python :: 3.10',
-            'Programming Language :: Python :: 3.11',
-            'Programming Language :: Python :: 3.12'],
         ext_modules=extensions
     )
 finally:


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

With [FLINK-37775](https://issues.apache.org/jira/browse/FLINK-37775) and [FLINK-36900](https://issues.apache.org/jira/browse/FLINK-36900) we have started to use `uv` for managing Python testing environments and installing linting tools, as well as defining test/lint/typecheck dependencies in `pyproject.toml`. 

Previously, the `lint-python.sh` script would have install and then tool run steps where it would first install the required tool for a lint stage into a venv, and then run the tool later. This PR removes this install step, instead using `uv run` to run the tools directly, which takes care of installing the tools and dependencies into a virtual environment. This simplifies the `lint-python.sh` script a little. I've also changed the tox install command to use uv to build apache-flink-libraries when needed, as well as using uv in the build-wheels script. 

To do this, the apache-flink pyproject.toml needed a `project` table, so I've moved the static metadata out of the `setup.py` and into the pyproject's `project` table.

Lastly, I also added the `apache-flink-libraries` path as a source for uv to use in development. This means that if you do `uv pip install .` in the `apache-flink` project, `uv` automatically resolves the `apache-flink-libraries` dependency by building and installing it from source, so users no longer need to `python setup.py sdist` and `pip install dist/*` manually to get the `apache-flink-libraries` dependency.

## Brief change log

  - Modified `lint-python.sh` to use `uv run` for running testing/lint/doc tools, rather than installing into a venv directly.
  - Modified `build-wheels.sh` to use `uv` for both building the packages and for running auditwheel in linux environments.
  - Moved `apache-flink`'s static metadata to `pyproject.toml`
  - Added `apache-flink-libraries` as a local path source for `uv` for local development


## Verifying this change

This change is already covered by existing tests, such as the Python CI tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (no)
