### PR TITLE
[FLINK-38242][docs] Improve upgrading documentation for SQL/Table API state compatibility and add Flink 2.x to compatibility table

### DIFF
--- a/docs/content.zh/docs/ops/upgrading.md
+++ b/docs/content.zh/docs/ops/upgrading.md
@@ -247,6 +247,12 @@ $ bin/flink run -s :savepointPath [:runArgs]
 
 ***注意***：此处的“兼容”仅指 Savepoint 内部数据格式的兼容性，并不包含 SQL 算子或其他上层改动的兼容性。
 在实践中，只要 Flink SQL 语义没有发生变化，这种状态格式的兼容性通常也能保证作业级别的兼容性。
+对于 SQL/Table API 作业，即使是小版本升级（例如 1.18 到 1.20）也可能产生不兼容的 Savepoint，
+因为新的优化器规则或更专用的运行时算子会改变执行计划，详见上文 [Table API & SQL](#table-api--sql) 部分。
+
+1.x 与 2.x 之间不保证状态兼容性，参见
+[Flink 2.0 release notes](https://nightlies.apache.org/flink/flink-docs-release-2.0/release-notes/flink-2.0/#misc)，
+因此对于使用 1.x 版本创建的 Savepoint，表中 2.x 的列均留空。
 
 <table class="table table-bordered" style="font-size:8pt">
   <thead>
@@ -256,7 +262,10 @@ $ bin/flink run -s :savepointPath [:runArgs]
       <th class="text-center">1.18.x</th>
       <th class="text-center">1.19.x</th>
       <th class="text-center">1.20.x</th>
-      <th class="text-center" style="width: 50%">限制</th>
+      <th class="text-center">2.0.x</th>
+      <th class="text-center">2.1.x</th>
+      <th class="text-center">2.2.x</th>
+      <th class="text-center" style="width: 35%">限制</th>
     </tr>
   </thead>
   <tbody>
@@ -266,6 +275,9 @@ $ bin/flink run -s :savepointPath [:runArgs]
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
           <td class="text-left"></td>
     </tr>
     <tr>
@@ -274,6 +286,9 @@ $ bin/flink run -s :savepointPath [:runArgs]
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
           <td class="text-left"></td>
     </tr>
     <tr>
@@ -282,6 +297,9 @@ $ bin/flink run -s :savepointPath [:runArgs]
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
           <td class="text-left"></td>
     </tr>
     <tr>
@@ -290,6 +308,9 @@ $ bin/flink run -s :savepointPath [:runArgs]
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
           <td class="text-left"></td>
     </tr>
     <tr>
@@ -298,6 +319,9 @@ $ bin/flink run -s :savepointPath [:runArgs]
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
           <td class="text-left"></td>
         </tr>
     <tr>
@@ -306,6 +330,9 @@ $ bin/flink run -s :savepointPath [:runArgs]
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
           <td class="text-left">Don't upgrade from 1.12.x to 1.13.x with an unaligned checkpoint. Please use a savepoint for migrating.</td>
         </tr>
     <tr>
@@ -314,6 +341,9 @@ $ bin/flink run -s :savepointPath [:runArgs]
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
           <td class="text-left"></td>
         </tr>
     <tr>
@@ -322,6 +352,9 @@ $ bin/flink run -s :savepointPath [:runArgs]
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
           <td class="text-left">
             For Table API: 1.15.0 and 1.15.1 generated non-deterministic UIDs for operators that 
             make it difficult/impossible to restore state or upgrade to next patch version. A new 
@@ -338,6 +371,9 @@ $ bin/flink run -s :savepointPath [:runArgs]
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
           <td class="text-left"></td>
         </tr>
     <tr>
@@ -346,6 +382,9 @@ $ bin/flink run -s :savepointPath [:runArgs]
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
           <td class="text-left"></td>
         </tr>
     <tr>
@@ -354,6 +393,9 @@ $ bin/flink run -s :savepointPath [:runArgs]
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
           <td class="text-left"></td>
         </tr>
     <tr>
@@ -362,10 +404,49 @@ $ bin/flink run -s :savepointPath [:runArgs]
           <td class="text-center"></td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
           <td class="text-left"></td>
         </tr>
     <tr>
           <td class="text-center"><strong>1.20.x</strong></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center">O</td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-left"></td>
+        </tr>
+    <tr>
+          <td class="text-center"><strong>2.0.x</strong></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center">O</td>
+          <td class="text-center">O</td>
+          <td class="text-center">O</td>
+          <td class="text-left"></td>
+        </tr>
+    <tr>
+          <td class="text-center"><strong>2.1.x</strong></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center">O</td>
+          <td class="text-center">O</td>
+          <td class="text-left"></td>
+        </tr>
+    <tr>
+          <td class="text-center"><strong>2.2.x</strong></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
           <td class="text-center"></td>
           <td class="text-center"></td>
           <td class="text-center"></td>

--- a/docs/content/docs/ops/upgrading.md
+++ b/docs/content/docs/ops/upgrading.md
@@ -276,7 +276,7 @@ $ bin/flink run -s :savepointPath [:runArgs]
 For more details, please take a look at the [savepoint documentation]({{< ref "docs/ops/state/savepoints" >}}).
 
 ## Compatibility Table
-> **Note:** For SQL/Table API jobs, even minor version upgrades (e.g., 1.16 → 1.20) can cause incompatible savepoints due to changes in query optimizers and operator topologies. See the [Table API & SQL](#table-api--sql) section above for important compatibility considerations.
+> **Note:** For SQL/Table API jobs, even minor version upgrades (e.g., 1.18 → 1.20) can cause incompatible savepoints due to changes in query optimizers and operator topologies. See the [Table API & SQL](#table-api--sql) section above for important compatibility considerations.
 
 Savepoints are compatible across Flink versions as indicated by the table below:
 

--- a/docs/content/docs/ops/upgrading.md
+++ b/docs/content/docs/ops/upgrading.md
@@ -276,6 +276,7 @@ $ bin/flink run -s :savepointPath [:runArgs]
 For more details, please take a look at the [savepoint documentation]({{< ref "docs/ops/state/savepoints" >}}).
 
 ## Compatibility Table
+> **Note:** For SQL/Table API jobs, even minor version upgrades (e.g., 1.16 → 1.20) can cause incompatible savepoints due to changes in query optimizers and operator topologies. See the [Table API & SQL](#table-api--sql) section above for important compatibility considerations.
 
 Savepoints are compatible across Flink versions as indicated by the table below:
 
@@ -287,7 +288,9 @@ Savepoints are compatible across Flink versions as indicated by the table below:
       <th class="text-center">1.18.x</th>
       <th class="text-center">1.19.x</th>
       <th class="text-center">1.20.x</th>
-      <th class="text-center" style="width: 50%">Limitations</th>
+      <th class="text-center">2.0.x</th>
+      <th class="text-center">2.1.x</th>
+      <th class="text-center" style="width: 40%">Limitations</th>
     </tr>
   </thead>
   <tbody>
@@ -297,6 +300,8 @@ Savepoints are compatible across Flink versions as indicated by the table below:
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
           <td class="text-left"></td>
     </tr>
     <tr>
@@ -305,6 +310,8 @@ Savepoints are compatible across Flink versions as indicated by the table below:
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
           <td class="text-left"></td>
     </tr>
     <tr>
@@ -313,6 +320,8 @@ Savepoints are compatible across Flink versions as indicated by the table below:
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
           <td class="text-left"></td>
     </tr>
     <tr>
@@ -321,6 +330,8 @@ Savepoints are compatible across Flink versions as indicated by the table below:
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
           <td class="text-left"></td>
     </tr>
     <tr>
@@ -329,6 +340,8 @@ Savepoints are compatible across Flink versions as indicated by the table below:
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
           <td class="text-left"></td>
         </tr>
     <tr>
@@ -337,6 +350,8 @@ Savepoints are compatible across Flink versions as indicated by the table below:
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
           <td class="text-left">Don't upgrade from 1.12.x to 1.13.x with an unaligned checkpoint. Please use a savepoint for migrating.</td>
         </tr>
     <tr>
@@ -345,6 +360,8 @@ Savepoints are compatible across Flink versions as indicated by the table below:
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
           <td class="text-left"></td>
         </tr>
     <tr>
@@ -353,6 +370,8 @@ Savepoints are compatible across Flink versions as indicated by the table below:
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
           <td class="text-left">
             For Table API: 1.15.0 and 1.15.1 generated non-deterministic UIDs for operators that 
             make it difficult/impossible to restore state or upgrade to next patch version. A new 
@@ -369,6 +388,8 @@ Savepoints are compatible across Flink versions as indicated by the table below:
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
           <td class="text-left"></td>
         </tr>
     <tr>
@@ -377,6 +398,8 @@ Savepoints are compatible across Flink versions as indicated by the table below:
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
           <td class="text-left"></td>
         </tr>
     <tr>
@@ -385,6 +408,8 @@ Savepoints are compatible across Flink versions as indicated by the table below:
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
           <td class="text-left"></td>
         </tr>
     <tr>
@@ -393,10 +418,34 @@ Savepoints are compatible across Flink versions as indicated by the table below:
           <td class="text-center"></td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
           <td class="text-left"></td>
         </tr>
     <tr>
           <td class="text-center"><strong>1.20.x</strong></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center">O</td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-left"></td>
+        </tr>
+    <tr>
+          <td class="text-center"><strong>2.0.x</strong></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center">O</td>
+          <td class="text-center">O</td>
+          <td class="text-left">State compatibility is not guaranteed between 1.x and 2.x.</td>
+        </tr>
+    <tr>
+          <td class="text-center"><strong>2.1.x</strong></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
           <td class="text-center"></td>
           <td class="text-center"></td>
           <td class="text-center"></td>

--- a/docs/content/docs/ops/upgrading.md
+++ b/docs/content/docs/ops/upgrading.md
@@ -282,7 +282,14 @@ Savepoints are compatible across Flink versions as indicated by the table below:
 **Note**: "Compatible" here refers specifically to compatibility of the internal data format in
 savepoints. It does not cover compatibility of SQL operators or other Upper-level changes. In
 practice, provided there are no changes to Flink SQL semantics, this state format compatibility
-typically also ensures job-level compatibility.
+typically also ensures job-level compatibility. For SQL/Table API jobs, a minor version upgrade
+(e.g. 1.18 to 1.20) can still produce an incompatible savepoint, because new optimizer rules or
+more specialized runtime operators change the execution plan. See [Table API & SQL](#table-api--sql)
+above for details.
+
+State compatibility is not guaranteed between 1.x and 2.x, as stated in the
+[Flink 2.0 release notes](https://nightlies.apache.org/flink/flink-docs-release-2.0/release-notes/flink-2.0/#misc),
+so the 2.x columns are left empty for savepoints created with a 1.x version.
 
 <table class="table table-bordered" style="font-size:8pt">
   <thead>
@@ -292,7 +299,10 @@ typically also ensures job-level compatibility.
       <th class="text-center">1.18.x</th>
       <th class="text-center">1.19.x</th>
       <th class="text-center">1.20.x</th>
-      <th class="text-center" style="width: 50%">Limitations</th>
+      <th class="text-center">2.0.x</th>
+      <th class="text-center">2.1.x</th>
+      <th class="text-center">2.2.x</th>
+      <th class="text-center" style="width: 35%">Limitations</th>
     </tr>
   </thead>
   <tbody>
@@ -302,6 +312,9 @@ typically also ensures job-level compatibility.
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
           <td class="text-left"></td>
     </tr>
     <tr>
@@ -310,6 +323,9 @@ typically also ensures job-level compatibility.
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
           <td class="text-left"></td>
     </tr>
     <tr>
@@ -318,6 +334,9 @@ typically also ensures job-level compatibility.
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
           <td class="text-left"></td>
     </tr>
     <tr>
@@ -326,6 +345,9 @@ typically also ensures job-level compatibility.
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
           <td class="text-left"></td>
     </tr>
     <tr>
@@ -334,6 +356,9 @@ typically also ensures job-level compatibility.
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
           <td class="text-left"></td>
         </tr>
     <tr>
@@ -342,6 +367,9 @@ typically also ensures job-level compatibility.
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
           <td class="text-left">Don't upgrade from 1.12.x to 1.13.x with an unaligned checkpoint. Please use a savepoint for migrating.</td>
         </tr>
     <tr>
@@ -350,6 +378,9 @@ typically also ensures job-level compatibility.
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
           <td class="text-left"></td>
         </tr>
     <tr>
@@ -358,6 +389,9 @@ typically also ensures job-level compatibility.
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
           <td class="text-left">
             For Table API: 1.15.0 and 1.15.1 generated non-deterministic UIDs for operators that 
             make it difficult/impossible to restore state or upgrade to next patch version. A new 
@@ -374,6 +408,9 @@ typically also ensures job-level compatibility.
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
           <td class="text-left"></td>
         </tr>
     <tr>
@@ -382,6 +419,9 @@ typically also ensures job-level compatibility.
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
           <td class="text-left"></td>
         </tr>
     <tr>
@@ -390,6 +430,9 @@ typically also ensures job-level compatibility.
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
           <td class="text-left"></td>
         </tr>
     <tr>
@@ -398,10 +441,49 @@ typically also ensures job-level compatibility.
           <td class="text-center"></td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
           <td class="text-left"></td>
         </tr>
     <tr>
           <td class="text-center"><strong>1.20.x</strong></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center">O</td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-left"></td>
+        </tr>
+    <tr>
+          <td class="text-center"><strong>2.0.x</strong></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center">O</td>
+          <td class="text-center">O</td>
+          <td class="text-center">O</td>
+          <td class="text-left"></td>
+        </tr>
+    <tr>
+          <td class="text-center"><strong>2.1.x</strong></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center">O</td>
+          <td class="text-center">O</td>
+          <td class="text-left"></td>
+        </tr>
+    <tr>
+          <td class="text-center"><strong>2.2.x</strong></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
           <td class="text-center"></td>
           <td class="text-center"></td>
           <td class="text-center"></td>


### PR DESCRIPTION
## What is the purpose of the change

The savepoint compatibility table in the upgrading documentation stops at Flink 1.20.x, so it says nothing about the 2.x line that users are upgrading to today. This pull request adds 2.0.x, 2.1.x and 2.2.x to the table, and records two compatibility facts that the table alone does not convey: state compatibility is not guaranteed across the 1.x/2.x boundary, and a SQL/Table API job can end up with an incompatible savepoint even across a minor version upgrade.

## Brief change log

- Added 2.0.x, 2.1.x and 2.2.x columns and rows to the compatibility table, in both `docs/content` and `docs/content.zh`.
- Stated that state compatibility is not guaranteed between 1.x and 2.x, citing the Flink 2.0 release notes. This is what the empty 2.x cells mean for the 1.x rows.
- Extended the note added by FLINK-38960 to cover SQL/Table API jobs: new optimizer rules or more specialized runtime operators can change the execution plan across a minor version upgrade, so a savepoint may not be restorable even though the state format itself is compatible. The note links to the Table API & SQL section above.

## Verifying this change

This change is a documentation-only change without any test coverage. The compatibility claims come from the existing documentation and release notes: `Misc` in the [Flink 2.0 release notes](https://nightlies.apache.org/flink/flink-docs-release-2.0/release-notes/flink-2.0/#misc) states that state compatibility is not guaranteed between 1.x and 2.x, and the `Table API & SQL` section of this same page already describes how the planner can change the operator topology across versions.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (Anthropic Claude Opus 5)
