### PR TITLE
[FLINK-38253] Allow usage of vertx/jdk/jetty/okhttp clients in fabric8 in flink-kubernetes

### DIFF
--- a/.github/workflows/template.flink-ci.yml
+++ b/.github/workflows/template.flink-ci.yml
@@ -286,6 +286,20 @@ jobs:
         if: ${{ !cancelled() && (failure() || !steps.docker-cache.cache.hit) }}
         run: ./tools/azure-pipelines/cache_docker_images.sh save
 
+  flink-kubernetes:
+    name: "Build & test flink-kubernetes with multiple HTTP clients"
+    needs: compile
+    strategy:
+      fail-fast: false
+      matrix:
+        http-client: [ "okhttp", "jdk", "jetty", "vertx" ]
+    uses: ./.github/workflows/template.flink-kubernetes-ci.yml
+    with:
+      http-client: ${{ matrix.http-client }}
+      jdk_version: ${{ inputs.jdk_version }}
+      cache-name: ${{ needs.compile.outputs.stringified-workflow-name }}-${{ github.run_number }}
+      environment: "${{ inputs.environment }}"
+
   e2e:
     name: "E2E (group ${{ matrix.group }})"
     needs: compile

--- a/.github/workflows/template.flink-kubernetes-ci.yml
+++ b/.github/workflows/template.flink-kubernetes-ci.yml
@@ -1,0 +1,98 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Workflow template for triggering the Flink's test suite.
+
+name: "Apache Flink Test Workflow Template - for module flink-kubernetes"
+
+on:
+  workflow_call:
+    inputs:
+      http-client:
+        description: "Type of fabric8 HTTP client implementation (okhttp, vertx, jetty, jdk)"
+        default: okhttp
+        type: string
+      jdk_version:
+        description: "Java version"
+        default: "17"
+        type: string
+      cache-name:
+        description: "Suffix for artifacts name in cache"
+        default: ""
+        type: string
+      environment:
+        description: "Defines environment variables for downstream scripts."
+        required: true
+        type: string
+
+permissions: read-all
+
+env:
+  # The following environment variables need to be overwritten here because the e2e tests do not
+  # run in containers.
+  MAVEN_REPO_FOLDER: ${{ github.workspace }}/.m2/repository
+  MAVEN_ARGS: -Dmaven.repo.local=${{ github.workspace }}/.m2/repository
+  FLINK_ARTIFACT_DIR: ${{ github.workspace }}
+  DOCKER_IMAGES_CACHE_FOLDER: ${{ github.workspace }}/.docker-cache
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: "Flink Checkout"
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: "Initialize job"
+        uses: "./.github/actions/job_init"
+        with:
+          jdk_version: ${{ inputs.jdk_version }}
+          maven_repo_folder: ${{ env.MAVEN_REPO_FOLDER }}
+
+      - name: "Download build artifacts from compile job"
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts-${{ inputs.cache-name }}
+          path: ${{ env.FLINK_ARTIFACT_DIR }}
+
+      - name: "Unpack build artifact"
+        run: ./tools/azure-pipelines/unpack_build_artifact.sh
+
+      - name: "Build Flink"
+        uses: "./.github/actions/run_mvn"
+        timeout-minutes: 20
+        with:
+          maven-parameters: "install -DskipTests -Dfast $PROFILE -Pskip-webui-build -Phttpclient-${{ inputs.http-client }}"
+          env: "${{ inputs.environment }}"
+
+      - name: "Build flink-kubernetes with ${{ inputs.http-client }} with unit tests"
+        timeout-minutes: 20
+        run: |
+          ./mvnw install -pl flink-kubernetes -Phttpclient-${{ inputs.http-client }}
+
+      - name: "Run ITs"
+        timeout-minutes: 20
+        run: |
+          FLINK_DIR=`pwd`/build-target ./flink-end-to-end-tests/run-single-test.sh ./flink-end-to-end-tests/test-scripts/test_kubernetes_itcases.sh
+        env:
+          MAVEN_ARGS: "-Phttpclient-${{ inputs.http-client }}"
+
+      - name: "Run e2e smoke"
+        timeout-minutes: 20
+        run: |
+          FLINK_DIR=`pwd`/build-target ./flink-end-to-end-tests/run-single-test.sh ./flink-end-to-end-tests/test-scripts/test_kubernetes_application.sh
+        env:
+          MAVEN_ARGS: "-Phttpclient-${{ inputs.http-client }}"

--- a/flink-kubernetes/pom.xml
+++ b/flink-kubernetes/pom.xml
@@ -32,6 +32,10 @@ under the License.
 
 	<properties>
 		<kubernetes.client.version>7.3.1</kubernetes.client.version>
+        <!-- valid options can be checked at https://central.sonatype.com/search?q=kubernetes-httpclient- currently: okhttp, jdk, jetty, vertx -->
+        <!-- when using a value other than okhttp disable the `depend-on-okhttp4` profile as well. -->
+        <kubernetes.client.httpclient.impl>okhttp</kubernetes.client.httpclient.impl>
+
 		<netty.override.version>4.1.108.Final</netty.override.version>
 		<surefire.module.config><!--
 			CommonTestUtils#setEnv
@@ -79,9 +83,15 @@ under the License.
 		<!-- Since 7.0.0, Fabric8 uses Vert.x as its HTTP client, but we want to use OkHttp to keep the same dependencies as used before this version. -->
 		<dependency>
 			<groupId>io.fabric8</groupId>
-			<artifactId>kubernetes-httpclient-okhttp</artifactId>
+			<artifactId>kubernetes-httpclient-${kubernetes.client.httpclient.impl}</artifactId>
 			<version>${kubernetes.client.version}</version>
 			<optional>${flink.markBundledAsOptional}</optional>
+			<exclusions>
+				<exclusion>
+					<groupId>io.fabric8</groupId>
+					<artifactId>kubernetes-httpclient-vertx</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<!-- test dependencies -->
@@ -252,4 +262,243 @@ under the License.
 			</plugin>
 		</plugins>
 	</build>
+
+    <profiles>
+        <!-- OKHTTP (default) -->
+        <profile>
+            <id>httpclient-okhttp</id>
+            <activation><activeByDefault>true</activeByDefault></activation>
+            <properties>
+                <kubernetes.client.httpclient.impl>okhttp</kubernetes.client.httpclient.impl>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>kubernetes-httpclient-${kubernetes.client.httpclient.impl}</artifactId>
+                    <version>${kubernetes.client.version}</version>
+                    <optional>${flink.markBundledAsOptional}</optional>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>io.fabric8</groupId>
+                            <artifactId>kubernetes-httpclient-vertx</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+            </dependencies>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>ban-non-okhttp-providers</id>
+                                <goals><goal>enforce</goal></goals>
+                                <configuration>
+                                    <rules>
+                                        <bannedDependencies>
+                                            <searchTransitive>true</searchTransitive>
+                                            <excludes>
+                                                <!-- ban vertx, jdk, jetty -->
+                                                <exclude>io.fabric8:kubernetes-httpclient-vertx</exclude>
+                                                <exclude>io.fabric8:kubernetes-httpclient-jdk</exclude>
+                                                <exclude>io.fabric8:kubernetes-httpclient-jetty</exclude>
+                                            </excludes>
+                                        </bannedDependencies>
+                                    </rules>
+                                    <fail>true</fail>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <!-- VERT.X -->
+        <profile>
+            <id>httpclient-vertx</id>
+            <properties>
+                <kubernetes.client.httpclient.impl>vertx</kubernetes.client.httpclient.impl>
+            </properties>
+
+            <dependencies>
+                <dependency>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>kubernetes-httpclient-${kubernetes.client.httpclient.impl}</artifactId>
+                    <version>${kubernetes.client.version}</version>
+                    <optional>${flink.markBundledAsOptional}</optional>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>com.squareup.okhttp3</groupId>
+                            <artifactId>okhttp</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-codec-http</artifactId>
+                    <version>${netty.override.version}</version>
+                    <scope>compile</scope>
+                </dependency>
+            </dependencies>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-shade-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>shade-flink</id>
+                                <configuration>
+                                    <!--  add Vert.x and Netty -->
+                                    <artifactSet>
+                                        <includes combine.children="append">
+                                            <include>io.vertx:*</include>
+                                            <include>io.netty:*</include>
+                                        </includes>
+                                    </artifactSet>
+                                    <!-- Vertx and Netty shading-->
+                                    <relocations combine.children="append">
+                                        <relocation>
+                                            <pattern>io.vertx</pattern>
+                                            <shadedPattern>org.apache.flink.kubernetes.shaded.io.vertx</shadedPattern>
+                                        </relocation>
+                                        <relocation>
+                                            <pattern>io.netty</pattern>
+                                            <shadedPattern>org.apache.flink.kubernetes.shaded.io.netty</shadedPattern>
+                                        </relocation>
+                                    </relocations>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!-- ban default OkHttp, Jetty, jdk -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>ban-okhttp-when-vertx</id>
+                                <goals><goal>enforce</goal></goals>
+                                <configuration>
+                                    <rules>
+                                        <bannedDependencies>
+                                            <excludes>
+                                                <exclude>com.squareup.okhttp3:okhttp</exclude>
+                                                <exclude>io.fabric8:kubernetes-httpclient-jetty</exclude>
+                                                <exclude>io.fabric8:kubernetes-httpclient-jdk</exclude>
+                                            </excludes>
+                                        </bannedDependencies>
+                                    </rules>
+                                    <fail>true</fail>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <!-- JETTY -->
+        <profile>
+            <id>httpclient-jetty</id>
+            <properties>
+                <kubernetes.client.httpclient.impl>jetty</kubernetes.client.httpclient.impl>
+            </properties>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-shade-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>shade-flink</id>
+                                <configuration>
+                                    <!-- add Jetty client impl -->
+                                    <artifactSet>
+                                        <includes combine.children="append">
+                                            <include>org.eclipse.jetty:*</include>
+                                            <include>org.eclipse.jetty.http2:*</include>
+                                            <include>org.eclipse.jetty.websocket:*</include>
+                                        </includes>
+                                    </artifactSet>
+                                    <!-- Jetty shading -->
+                                    <relocations combine.children="append">
+                                        <relocation>
+                                            <pattern>org.eclipse.jetty</pattern>
+                                            <shadedPattern>org.apache.flink.kubernetes.shaded.org.eclipse.jetty</shadedPattern>
+                                        </relocation>
+                                    </relocations>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!-- ban OkHttp, vertx, jdk -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>ban-okhttp-when-jetty</id>
+                                <goals><goal>enforce</goal></goals>
+                                <configuration>
+                                    <rules>
+                                        <bannedDependencies>
+                                            <excludes>
+                                                <exclude>com.squareup.okhttp3:okhttp</exclude>
+                                                <exclude>io.fabric8:kubernetes-httpclient-vertx</exclude>
+                                                <exclude>io.fabric8:kubernetes-httpclient-jdk</exclude>
+                                            </excludes>
+                                        </bannedDependencies>
+                                    </rules>
+                                    <fail>true</fail>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <!-- JDK (java.net.http) -->
+        <profile>
+            <id>httpclient-jdk</id>
+            <properties>
+                <kubernetes.client.httpclient.impl>jdk</kubernetes.client.httpclient.impl>
+            </properties>
+            <build>
+                <plugins>
+                    <!-- ban default OkHttp -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>ban-okhttp-when-jdk</id>
+                                <goals><goal>enforce</goal></goals>
+                                <configuration>
+                                    <rules>
+                                        <bannedDependencies>
+                                            <excludes>
+                                                <exclude>com.squareup.okhttp3:okhttp</exclude>
+                                                <exclude>io.fabric8:kubernetes-httpclient-vertx</exclude>
+                                                <exclude>io.fabric8:kubernetes-httpclient-jetty</exclude>
+                                            </excludes>
+                                        </bannedDependencies>
+                                    </rules>
+                                    <fail>true</fail>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This PR add an option to use different HTTP client implementation in fabric8 used within `flink-kubernetes` module. It basically sync with operator repo, where this option was introduced few months ago as part of https://github.com/apache/flink-kubernetes-operator/pull/881.

The default client implementation remains `okhttp`, but the change will allow usage of new profiles that switch used http client implementations to `vertx`, `jdk`, or `jetty`.


## Brief change log

Enable to build `flink-kubernetes` with `vertx`, `jdk`, or `jetty` http clients implementations for fabric8.


## Verifying this change

This change is already covered by existing tests, such as all tests related to `flink-kubernetes` module.

I also added new CI workflow that runs unit/ITs with all of the mentioned implementations and also smoke e2e test with minikube.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
