### PR TITLE
[DOCS] List 3rd Party connector for NATS

### DIFF
--- a/docs/content/docs/connectors/datastream/overview.md
+++ b/docs/content/docs/connectors/datastream/overview.md
@@ -90,5 +90,8 @@ in order to enrich the primary datastream.
 Flink offers an API for [Asynchronous I/O]({{< ref "docs/dev/datastream/operators/asyncio" >}})
 to make it easier to do this kind of enrichment efficiently and robustly.
 
+### 3rd Party Connnectors
+* [NATS Connector](https://github.com/synadia-io/flink-connector-nats) (Core and JetStream sinks/sources)
+
 {{< top >}}
 


### PR DESCRIPTION
## What is the purpose of the change

Looking for a way to include the official NATS connector somewhere. It is developed by Synadia, the primary maintainers of NATS.

## Contribution Checklist

## Brief change log

- Edit of docs/content/docs/connectors/datastream/overview.md

## Verifying this change

- Trivial documentation changed. Content/intention needs approval by a human.

## Does this pull request potentially affect one of the following parts:

- Change does not affect any code.

## Documentation
- Does this pull request introduce a new feature? no
