### PR TITLE
[FLINK-32695] [Tests] Add flink-test-utils-connectors module for Source V2 tests.

### DIFF
--- a/flink-test-utils-parent/flink-test-utils-connector/pom.xml
+++ b/flink-test-utils-parent/flink-test-utils-connector/pom.xml
@@ -25,23 +25,30 @@ under the License.
 
 	<parent>
 		<groupId>org.apache.flink</groupId>
-		<artifactId>flink-parent</artifactId>
+		<artifactId>flink-test-utils-parent</artifactId>
 		<version>2.2-SNAPSHOT</version>
 	</parent>
 
-	<artifactId>flink-test-utils-parent</artifactId>
-	<name>Flink : Test utils : </name>
+	<artifactId>flink-test-utils-connector</artifactId>
+	<name>Flink : Test utils : Connector</name>
 
-	<packaging>pom</packaging>
+	<packaging>jar</packaging>
 
-	<modules>
-		<module>flink-test-utils-junit</module>
-		<module>flink-test-utils</module>
-		<module>flink-test-utils-connector</module>
-		<module>flink-connector-test-utils</module>
-		<module>flink-clients-test-utils</module>
-		<module>flink-migration-test-utils</module>
-		<module>flink-table-filesystem-test-utils</module>
-	</modules>
+	<dependencies>
+		<!-- Core dependency for Source V2 APIs -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-core</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<!-- Test dependencies -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils-junit</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
 
 </project>

--- a/flink-test-utils-parent/flink-test-utils-connector/src/main/java/org/apache/flink/test/util/source/AbstractTestSource.java
+++ b/flink-test-utils-parent/flink-test-utils-connector/src/main/java/org/apache/flink/test/util/source/AbstractTestSource.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.util.source;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+/**
+ * Abstract base class for test sources that provides default implementations for all Source V2
+ * methods. This class fixes the enumerator checkpoint type to {@code Void} for the common case
+ * where no checkpoint state is needed.
+ *
+ * <p>For test cases that require checkpointing enumerator state, extend {@link
+ * AbstractTestSourceBase} directly with a custom checkpoint type.
+ *
+ * @param <T> The type of records produced by this source
+ */
+@PublicEvolving
+public abstract class AbstractTestSource<T> extends AbstractTestSourceBase<T, Void> {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public SimpleVersionedSerializer<Void> getEnumeratorCheckpointSerializer() {
+        return VoidSerializer.INSTANCE;
+    }
+}

--- a/flink-test-utils-parent/flink-test-utils-connector/src/main/java/org/apache/flink/test/util/source/AbstractTestSourceBase.java
+++ b/flink-test-utils-parent/flink-test-utils-connector/src/main/java/org/apache/flink/test/util/source/AbstractTestSourceBase.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.util.source;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.ReaderOutput;
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.core.io.InputStatus;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+/**
+ * Base class for test sources that allows customization of the enumerator checkpoint type.
+ *
+ * <p>Most test cases should extend {@link AbstractTestSource} which fixes the enumerator state to
+ * {@code Void}. Test cases that need checkpointing can create their own extensions of this base
+ * class.
+ *
+ * @param <T> The type of records produced by this source
+ * @param <EnumChkptState> The type of the enumerator checkpoint state
+ */
+@PublicEvolving
+public abstract class AbstractTestSourceBase<T, EnumChkptState>
+        implements Source<T, TestSplit, EnumChkptState> {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public Boundedness getBoundedness() {
+        return Boundedness.BOUNDED;
+    }
+
+    /**
+     * Creates a source reader. The default implementation returns an empty reader that immediately
+     * returns END_OF_INPUT. Subclasses can override this method to provide their specific reader
+     * implementation.
+     */
+    @Override
+    public SourceReader<T, TestSplit> createReader(SourceReaderContext readerContext) {
+        return new TestSourceReader<T>(readerContext) {
+            @Override
+            public InputStatus pollNext(ReaderOutput<T> output) {
+                return InputStatus.END_OF_INPUT;
+            }
+        };
+    }
+
+    /**
+     * Creates a new split enumerator for fresh starts. Subclasses can override this to provide
+     * custom enumerator behavior. The default implementation returns a {@link TestSplitEnumerator}
+     * with no checkpoint state.
+     *
+     * @param enumContext The enumerator context
+     * @return The split enumerator
+     */
+    @Override
+    public SplitEnumerator<TestSplit, EnumChkptState> createEnumerator(
+            SplitEnumeratorContext<TestSplit> enumContext) {
+        return new TestSplitEnumerator<>(enumContext, null);
+    }
+
+    /**
+     * Restores a split enumerator from a checkpoint. Subclasses can override this to provide custom
+     * restoration logic. The default implementation creates a new {@link TestSplitEnumerator} and
+     * ignores the checkpoint state.
+     *
+     * @param enumContext The enumerator context
+     * @param checkpoint The checkpoint state to restore from
+     * @return The restored split enumerator
+     */
+    @Override
+    public SplitEnumerator<TestSplit, EnumChkptState> restoreEnumerator(
+            SplitEnumeratorContext<TestSplit> enumContext, EnumChkptState checkpoint) {
+        return new TestSplitEnumerator<>(enumContext, checkpoint);
+    }
+
+    @Override
+    public SimpleVersionedSerializer<TestSplit> getSplitSerializer() {
+        return TestSplit.SERIALIZER;
+    }
+
+    /**
+     * Returns the serializer for enumerator checkpoints. Subclasses must implement this to provide
+     * the appropriate serializer for their checkpoint type.
+     */
+    @Override
+    public abstract SimpleVersionedSerializer<EnumChkptState> getEnumeratorCheckpointSerializer();
+}

--- a/flink-test-utils-parent/flink-test-utils-connector/src/main/java/org/apache/flink/test/util/source/SingleSplitEnumerator.java
+++ b/flink-test-utils-parent/flink-test-utils-connector/src/main/java/org/apache/flink/test/util/source/SingleSplitEnumerator.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.util.source;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+
+/**
+ * A split enumerator where the first reader gets one split, others get nothing.
+ *
+ * <p>Useful for tests that need minimal data processing on a single subtask.
+ */
+@PublicEvolving
+public class SingleSplitEnumerator extends TestSplitEnumerator<Void> {
+
+    private boolean assigned = false;
+
+    public SingleSplitEnumerator(SplitEnumeratorContext<TestSplit> context) {
+        super(context, null);
+    }
+
+    @Override
+    public void addReader(int subtaskId) {
+        if (!assigned) {
+            context.assignSplit(TestSplit.INSTANCE, subtaskId);
+            assigned = true;
+        }
+        context.signalNoMoreSplits(subtaskId);
+    }
+}

--- a/flink-test-utils-parent/flink-test-utils-connector/src/main/java/org/apache/flink/test/util/source/TestReaderOutput.java
+++ b/flink-test-utils-parent/flink-test-utils-connector/src/main/java/org/apache/flink/test/util/source/TestReaderOutput.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.util.source;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.eventtime.Watermark;
+import org.apache.flink.api.connector.source.ReaderOutput;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Test utility for capturing output from SourceReader implementations. Provides convenient methods
+ * to verify emitted records without implementing the full ReaderOutput interface.
+ *
+ * @param <T> The type of records emitted by the source
+ */
+@PublicEvolving
+public class TestReaderOutput<T> implements ReaderOutput<T> {
+
+    private final List<T> collected = new ArrayList<>();
+
+    @Override
+    public void collect(T record) {
+        collected.add(record);
+    }
+
+    @Override
+    public void collect(T record, long timestamp) {
+        collected.add(record);
+    }
+
+    @Override
+    public void releaseOutputForSplit(String splitId) {
+        // No-op for testing
+    }
+
+    @Override
+    public ReaderOutput<T> createOutputForSplit(String splitId) {
+        return this;
+    }
+
+    @Override
+    public void markIdle() {
+        // No-op for testing
+    }
+
+    @Override
+    public void emitWatermark(Watermark watermark) {
+        // No-op for testing
+    }
+
+    @Override
+    public void markActive() {
+        // No-op for testing
+    }
+
+    /**
+     * Returns all records collected by this output.
+     *
+     * @return List of all collected records
+     */
+    public List<T> getCollected() {
+        return new ArrayList<>(collected);
+    }
+
+    /**
+     * Returns the last emitted record, or null if no records have been emitted.
+     *
+     * @return The most recently emitted record
+     */
+    public T getLastEmitted() {
+        return collected.isEmpty() ? null : collected.get(collected.size() - 1);
+    }
+
+    /**
+     * Returns the number of records collected.
+     *
+     * @return Count of collected records
+     */
+    public int getCollectedCount() {
+        return collected.size();
+    }
+
+    /** Clears all collected records. */
+    public void clear() {
+        collected.clear();
+    }
+}

--- a/flink-test-utils-parent/flink-test-utils-connector/src/main/java/org/apache/flink/test/util/source/TestSourceReader.java
+++ b/flink-test-utils-parent/flink-test-utils-connector/src/main/java/org/apache/flink/test/util/source/TestSourceReader.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.util.source;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.connector.source.ReaderOutput;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.core.io.InputStatus;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Base class for test source readers that provides default implementations for all SourceReader
+ * methods. Tests can extend this class and override only the methods they need to customize,
+ * typically just {@link #pollNext(ReaderOutput)}.
+ *
+ * <p>By default, this reader:
+ *
+ * <ul>
+ *   <li>Returns {@link InputStatus#END_OF_INPUT} from {@link #pollNext(ReaderOutput)}
+ *   <li>Returns empty list from {@link #snapshotState(long)}
+ *   <li>Provides a completed future from {@link #isAvailable()}
+ *   <li>No-ops for all other methods
+ * </ul>
+ *
+ * @param <T> The type of records produced by this reader
+ */
+@PublicEvolving
+public class TestSourceReader<T> implements SourceReader<T, TestSplit> {
+
+    protected final SourceReaderContext context;
+
+    public TestSourceReader(SourceReaderContext context) {
+        this.context = context;
+    }
+
+    @Override
+    public void start() {
+        // No-op by default
+    }
+
+    @Override
+    public InputStatus pollNext(ReaderOutput<T> output) throws Exception {
+        // By default, immediately signal end of input
+        // Tests should override this method to produce actual records
+        return InputStatus.END_OF_INPUT;
+    }
+
+    @Override
+    public List<TestSplit> snapshotState(long checkpointId) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public CompletableFuture<Void> isAvailable() {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public void addSplits(List<TestSplit> splits) {
+        // No-op by default - most test sources work with a single split
+    }
+
+    @Override
+    public void notifyNoMoreSplits() {
+        // No-op by default
+    }
+
+    @Override
+    public void close() throws Exception {
+        // No-op by default
+    }
+}

--- a/flink-test-utils-parent/flink-test-utils-connector/src/main/java/org/apache/flink/test/util/source/TestSplit.java
+++ b/flink-test-utils-parent/flink-test-utils-connector/src/main/java/org/apache/flink/test/util/source/TestSplit.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.util.source;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.connector.source.SourceSplit;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+/**
+ * A simple test split implementation that can be reused across test sources. This provides a
+ * minimal split that is sufficient for most testing scenarios.
+ */
+@PublicEvolving
+public class TestSplit implements SourceSplit {
+
+    /** Singleton instance for reuse across all test sources. */
+    public static final TestSplit INSTANCE = new TestSplit();
+
+    /** Serializer for TestSplit instances. */
+    public static final SimpleVersionedSerializer<TestSplit> SERIALIZER = new TestSplitSerializer();
+
+    private static final String SPLIT_ID = "test-split";
+
+    private TestSplit() {
+        // Private constructor for singleton pattern
+    }
+
+    @Override
+    public String splitId() {
+        return SPLIT_ID;
+    }
+
+    @Override
+    public String toString() {
+        return "TestSplit{id=" + SPLIT_ID + "}";
+    }
+
+    /** Serializer for TestSplit that always returns the singleton instance. */
+    private static class TestSplitSerializer implements SimpleVersionedSerializer<TestSplit> {
+
+        @Override
+        public int getVersion() {
+            return 1;
+        }
+
+        @Override
+        public byte[] serialize(TestSplit split) {
+            return new byte[0];
+        }
+
+        @Override
+        public TestSplit deserialize(int version, byte[] serialized) {
+            return INSTANCE;
+        }
+    }
+}

--- a/flink-test-utils-parent/flink-test-utils-connector/src/main/java/org/apache/flink/test/util/source/TestSplitEnumerator.java
+++ b/flink-test-utils-parent/flink-test-utils-connector/src/main/java/org/apache/flink/test/util/source/TestSplitEnumerator.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.util.source;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+
+import java.util.List;
+
+/**
+ * Base split enumerator for test sources that provides sensible defaults for most methods.
+ *
+ * <p>By default, this enumerator immediately signals no more splits to ensure bounded completion.
+ * Test sources can extend this class and only override the methods they need, typically just {@link
+ * #snapshotState(long)} for checkpointing behavior or {@link #addReader(int)} for custom split
+ * assignment.
+ *
+ * <p>For common patterns, use the concrete implementations:
+ *
+ * <ul>
+ *   <li>{@link SingleSplitEnumerator} - First reader gets one split, others get nothing
+ * </ul>
+ *
+ * @param <EnumChkptState> The type of the enumerator checkpoint state
+ */
+@PublicEvolving
+public class TestSplitEnumerator<EnumChkptState>
+        implements SplitEnumerator<TestSplit, EnumChkptState> {
+
+    protected final SplitEnumeratorContext<TestSplit> context;
+    protected final EnumChkptState checkpointState;
+
+    public TestSplitEnumerator(
+            SplitEnumeratorContext<TestSplit> context, EnumChkptState checkpointState) {
+        this.context = context;
+        this.checkpointState = checkpointState;
+    }
+
+    @Override
+    public void start() {
+        // No-op implementation
+    }
+
+    @Override
+    public void handleSplitRequest(int subtaskId, String requesterHostname) {
+        // Most common case: split request means reader is ready for work
+        addReader(subtaskId);
+    }
+
+    @Override
+    public void addSplitsBack(List<TestSplit> splits, int subtaskId) {
+        // No-op implementation
+    }
+
+    @Override
+    public void addReader(int subtaskId) {
+        // Signal no more splits to ensure immediate completion
+        context.signalNoMoreSplits(subtaskId);
+    }
+
+    @Override
+    public void close() {
+        // No-op implementation
+    }
+
+    /**
+     * Subclasses should override this method to provide their checkpoint state. The default
+     * implementation returns the checkpoint state passed in the constructor.
+     */
+    @Override
+    public EnumChkptState snapshotState(long checkpointId) {
+        return checkpointState;
+    }
+}

--- a/flink-test-utils-parent/flink-test-utils-connector/src/main/java/org/apache/flink/test/util/source/VoidSerializer.java
+++ b/flink-test-utils-parent/flink-test-utils-connector/src/main/java/org/apache/flink/test/util/source/VoidSerializer.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.util.source;
+
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+import java.io.IOException;
+
+/**
+ * A serializer for Void checkpoint states. This is useful for test sources that don't need to store
+ * any checkpoint state. The serializer always returns null during deserialization and stores no
+ * data during serialization.
+ */
+public enum VoidSerializer implements SimpleVersionedSerializer<Void> {
+    INSTANCE;
+
+    @Override
+    public int getVersion() {
+        return 1;
+    }
+
+    @Override
+    public byte[] serialize(Void obj) throws IOException {
+        // Always return empty byte array for Void objects
+        return new byte[0];
+    }
+
+    @Override
+    public Void deserialize(int version, byte[] serialized) throws IOException {
+        // Always return null - Void objects have no state to restore
+        return null;
+    }
+}

--- a/flink-test-utils-parent/flink-test-utils-connector/src/test/java/org/apache/flink/test/util/source/SourcePatternExamplesTest.java
+++ b/flink-test-utils-parent/flink-test-utils-connector/src/test/java/org/apache/flink/test/util/source/SourcePatternExamplesTest.java
@@ -1,0 +1,441 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.util.source;
+
+import org.apache.flink.api.common.eventtime.Watermark;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.ReaderOutput;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.core.io.InputStatus;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests showing how to create sources using AbstractTestSource utilities for common patterns. */
+class SourcePatternExamplesTest {
+
+    /*
+     * Testing: Source that must call external service on each data emission
+     * Why: Common pattern where legacy sources coordinate with external systems during processing
+     * Pattern: Business logic goes in pollNext(), everything else uses defaults from AbstractTestSource
+     */
+    @Test
+    void testSourceThatInteractsWithProcessingTimeService() throws Exception {
+        TestProcessingTimeService processingTimeService = new TestProcessingTimeService();
+        List<Long> processingTimes = Arrays.asList(1000L, 2000L);
+        AbstractTestSource<Long> source =
+                new AbstractTestSource<Long>() {
+                    @Override
+                    public SourceReader<Long, TestSplit> createReader(
+                            SourceReaderContext readerContext) {
+                        return new TestSourceReader<Long>(readerContext) {
+                            private int currentIndex = 0;
+                            private volatile boolean cancelled = false;
+
+                            @Override
+                            public InputStatus pollNext(ReaderOutput<Long> output) {
+                                if (cancelled || currentIndex >= processingTimes.size()) {
+                                    return InputStatus.END_OF_INPUT;
+                                }
+                                Long processingTime = processingTimes.get(currentIndex++);
+                                processingTimeService.setCurrentTime(processingTime);
+                                output.collect(processingTime);
+                                return currentIndex >= processingTimes.size()
+                                        ? InputStatus.END_OF_INPUT
+                                        : InputStatus.MORE_AVAILABLE;
+                            }
+
+                            @Override
+                            public void close() throws Exception {
+                                cancelled = true;
+                                super.close();
+                            }
+                        };
+                    }
+                };
+
+        // Test the coordination pattern: verify each poll calls external service + emits data
+        SourceReader<Long, TestSplit> reader = source.createReader(null);
+        TestReaderOutput<Long> output = new TestReaderOutput<>();
+
+        // First poll: time advances to 1000L and emits it
+        reader.pollNext(output);
+        assertThat(output.getLastEmitted()).isEqualTo(1000L);
+        assertThat(processingTimeService.getCurrentTime()).isEqualTo(1000L);
+
+        // Second poll: time advances to 2000L and emits it
+        reader.pollNext(output);
+        assertThat(output.getLastEmitted()).isEqualTo(2000L);
+        assertThat(processingTimeService.getCurrentTime()).isEqualTo(2000L);
+
+        // Third poll: no more data, should signal end
+        InputStatus status = reader.pollNext(output);
+        assertThat(status).isEqualTo(InputStatus.END_OF_INPUT);
+    }
+
+    /*
+     * Testing: Source that generates infinite data stream without meaningful checkpointing
+     * Why: Common pattern for continuous data generation that doesn't actually checkpoint state
+     * Pattern: Use AbstractTestSource for unbounded sources that don't need real checkpointing
+     */
+    @Test
+    void testInfiniteStringGeneratorWithoutCheckpointing() throws Exception {
+        AbstractTestSource<String> source =
+                new AbstractTestSource<>() {
+
+                    @Override
+                    public SourceReader<String, TestSplit> createReader(
+                            SourceReaderContext readerContext) {
+                        return new TestSourceReader<>(readerContext) {
+                            private volatile boolean running = true;
+                            private int emissionCount = 0;
+
+                            @Override
+                            public InputStatus pollNext(ReaderOutput<String> output)
+                                    throws Exception {
+                                if (!running) {
+                                    return InputStatus.END_OF_INPUT;
+                                }
+                                output.collect("someString");
+                                emissionCount++;
+                                // Stop after 3 emissions to avoid infinite test
+                                if (emissionCount >= 3) {
+                                    running = false;
+                                    return InputStatus.END_OF_INPUT;
+                                }
+
+                                return InputStatus.MORE_AVAILABLE;
+                            }
+
+                            @Override
+                            public void close() throws Exception {
+                                running = false;
+                                super.close();
+                            }
+                        };
+                    }
+                };
+
+        // Test data generation pattern
+        SourceReader<String, TestSplit> reader = source.createReader(null);
+        TestReaderOutput<String> output = new TestReaderOutput<>();
+
+        // First poll: generates "someString"
+        reader.pollNext(output);
+        assertThat(output.getLastEmitted()).isEqualTo("someString");
+
+        // Second poll: generates another "someString"
+        reader.pollNext(output);
+        assertThat(output.getLastEmitted()).isEqualTo("someString");
+        assertThat(output.getCollectedCount()).isEqualTo(2);
+
+        // Third poll: generates final "someString" and signals end
+        InputStatus status = reader.pollNext(output);
+        assertThat(status).isEqualTo(InputStatus.END_OF_INPUT);
+        assertThat(output.getCollectedCount()).isEqualTo(3);
+    }
+
+    /*
+     * Testing: Source that blocks using Thread.sleep() until external signal
+     * Why: Some sources legitimately need blocking behavior in pollNext()
+     * Pattern: Keep Thread.sleep() in pollNext() when blocking is actually required
+     */
+    @Test
+    void testSourceWithLegitimateBlocking() throws Exception {
+        final boolean[] shouldCloseSource = {false};
+
+        AbstractTestSource<String> source =
+                new AbstractTestSource<>() {
+
+                    @Override
+                    public SourceReader<String, TestSplit> createReader(
+                            SourceReaderContext readerContext) {
+                        return new TestSourceReader<String>(readerContext) {
+                            private int pollCount = 0;
+
+                            @Override
+                            public InputStatus pollNext(ReaderOutput<String> output)
+                                    throws Exception {
+                                pollCount++;
+
+                                if (shouldCloseSource[0]) {
+                                    return InputStatus.END_OF_INPUT;
+                                }
+                                Thread.sleep(100);
+                                if (pollCount >= 2) {
+                                    shouldCloseSource[0] = true;
+                                    return InputStatus.END_OF_INPUT;
+                                }
+
+                                return InputStatus.NOTHING_AVAILABLE;
+                            }
+
+                            @Override
+                            public void close() throws Exception {
+                                shouldCloseSource[0] = true;
+                                super.close();
+                            }
+                        };
+                    }
+                };
+
+        // Test blocking behavior (but limit to avoid infinite test)
+        SourceReader<String, TestSplit> reader = source.createReader(null);
+        TestReaderOutput<String> output = new TestReaderOutput<>();
+        reader.pollNext(output);
+        assertThat(reader.pollNext(output)).isEqualTo(InputStatus.END_OF_INPUT);
+        assertThat(output.getCollectedCount()).isEqualTo(0);
+    }
+
+    /*
+     * Testing: Source that emits timestamped data and watermarks
+     * Why: Common pattern for event-time processing with explicit timestamp assignment
+     * Pattern: Use collect(record, timestamp) and emitWatermark() in pollNext()
+     */
+    @Test
+    void testSourceWithTimestampsAndWatermarks() throws Exception {
+        AbstractTestSource<Integer> source =
+                new AbstractTestSource<Integer>() {
+                    @Override
+                    public SourceReader<Integer, TestSplit> createReader(
+                            SourceReaderContext readerContext) {
+                        return new TestSourceReader<Integer>(readerContext) {
+                            private int step = 0;
+
+                            @Override
+                            public InputStatus pollNext(ReaderOutput<Integer> output)
+                                    throws Exception {
+                                switch (step++) {
+                                    case 0:
+                                        // Emit record with timestamp
+                                        output.collect(1, 0);
+                                        return InputStatus.MORE_AVAILABLE;
+                                    case 1:
+                                        // Emit watermark
+                                        output.emitWatermark(new Watermark(0));
+                                        return InputStatus.MORE_AVAILABLE;
+                                    case 2:
+                                        output.collect(2, 1);
+                                        return InputStatus.END_OF_INPUT;
+                                    default:
+                                        return InputStatus.END_OF_INPUT;
+                                }
+                            }
+                        };
+                    }
+                };
+
+        // Verify source handles timestamped data and watermarks
+        assertThat(source.getBoundedness()).isEqualTo(Boundedness.BOUNDED);
+
+        // Test timestamp and watermark emission pattern
+        SourceReader<Integer, TestSplit> reader = source.createReader(null);
+        TestReaderOutput<Integer> output = new TestReaderOutput<>();
+
+        // Step through the sequence of emissions
+        assertThat(reader.pollNext(output)).isEqualTo(InputStatus.MORE_AVAILABLE); // collect(1, 0)
+        assertThat(output.getCollectedCount()).isEqualTo(1);
+        assertThat(output.getLastEmitted()).isEqualTo(1);
+
+        assertThat(reader.pollNext(output))
+                .isEqualTo(InputStatus.MORE_AVAILABLE); // emitWatermark(0)
+        assertThat(reader.pollNext(output)).isEqualTo(InputStatus.END_OF_INPUT); // collect(2, 1)
+        assertThat(output.getCollectedCount()).isEqualTo(2);
+        assertThat(output.getLastEmitted()).isEqualTo(2);
+    }
+
+    /*
+     * Testing: Source with custom enumerator checkpointing that AbstractTestSource cannot handle
+     * Why: Demonstrates how to use AbstractTestSourceBase when you need real checkpoint state
+     * Pattern: Custom checkpoint type (Integer) with stateful enumerator that tracks emission count
+     */
+    @Test
+    void testSourceWithCustomEnumeratorCheckpointing() throws Exception {
+        AbstractTestSourceBase<String, Integer> source =
+                new AbstractTestSourceBase<>() {
+                    @Override
+                    public SourceReader<String, TestSplit> createReader(
+                            SourceReaderContext readerContext) {
+                        return new TestSourceReader<>(readerContext) {
+                            private int emissionCount = 0;
+
+                            @Override
+                            public InputStatus pollNext(ReaderOutput<String> output) {
+                                if (emissionCount >= 3) {
+                                    return InputStatus.END_OF_INPUT;
+                                }
+                                output.collect("data-" + emissionCount);
+                                emissionCount++;
+                                return emissionCount >= 3
+                                        ? InputStatus.END_OF_INPUT
+                                        : InputStatus.MORE_AVAILABLE;
+                            }
+                        };
+                    }
+
+                    @Override
+                    public SplitEnumerator<TestSplit, Integer> createEnumerator(
+                            SplitEnumeratorContext<TestSplit> enumContext) {
+                        return new TestSplitEnumerator<Integer>(enumContext, null) {
+                            @Override
+                            public Integer snapshotState(long checkpointId) {
+                                return 1;
+                            }
+                        };
+                    }
+
+                    @Override
+                    public SplitEnumerator<TestSplit, Integer> restoreEnumerator(
+                            SplitEnumeratorContext<TestSplit> enumContext, Integer checkpoint) {
+                        return new TestSplitEnumerator<Integer>(enumContext, checkpoint) {
+                            @Override
+                            public Integer snapshotState(long checkpointId) {
+                                return checkpoint != null ? checkpoint + 1 : 1;
+                            }
+                        };
+                    }
+
+                    @Override
+                    public SimpleVersionedSerializer<Integer> getEnumeratorCheckpointSerializer() {
+                        return new SimpleVersionedSerializer<Integer>() {
+                            @Override
+                            public int getVersion() {
+                                return 1;
+                            }
+
+                            @Override
+                            public byte[] serialize(Integer obj) throws IOException {
+                                return obj != null ? obj.toString().getBytes() : new byte[0];
+                            }
+
+                            @Override
+                            public Integer deserialize(int version, byte[] serialized) {
+                                return serialized.length > 0
+                                        ? Integer.parseInt(new String(serialized))
+                                        : 0;
+                            }
+                        };
+                    }
+                };
+
+        // Test source reader functionality
+        SourceReader<String, TestSplit> reader = source.createReader(null);
+        TestReaderOutput<String> output = new TestReaderOutput<>();
+
+        assertThat(reader.pollNext(output)).isEqualTo(InputStatus.MORE_AVAILABLE);
+        assertThat(output.getLastEmitted()).isEqualTo("data-0");
+
+        assertThat(reader.pollNext(output)).isEqualTo(InputStatus.MORE_AVAILABLE);
+        assertThat(output.getLastEmitted()).isEqualTo("data-1");
+
+        assertThat(reader.pollNext(output)).isEqualTo(InputStatus.END_OF_INPUT);
+        assertThat(output.getLastEmitted()).isEqualTo("data-2");
+        assertThat(output.getCollectedCount()).isEqualTo(3);
+    }
+
+    /*
+     * Testing: No-op source that requires no reader implementation
+     * Why: Some tests just need a source for framework testing without data emission
+     * Pattern: Use AbstractTestSourceBase/AbstractTestSource directly without overriding createReader
+     */
+    @Test
+    void testNoopSourceWithDefaultReader() throws Exception {
+        // Create a no-op source with Void checkpointing (most common case)
+        AbstractTestSource<String> noopSource = new AbstractTestSource<>() {};
+
+        // Test that it works without any reader implementation
+        SourceReader<String, TestSplit> reader = noopSource.createReader(null);
+        TestReaderOutput<String> output = new TestReaderOutput<>();
+
+        // Should immediately return END_OF_INPUT without emitting anything
+        assertThat(reader.pollNext(output)).isEqualTo(InputStatus.END_OF_INPUT);
+        assertThat(output.getCollectedCount()).isEqualTo(0);
+        assertThat(output.getLastEmitted()).isNull();
+
+        // Verify source properties
+        assertThat(noopSource.getBoundedness()).isEqualTo(Boundedness.BOUNDED);
+    }
+
+    /*
+     * Testing: No-op source with custom checkpoint state but no data emission
+     * Why: Testing enumerator checkpointing behavior without reader complexity
+     * Pattern: Use AbstractTestSourceBase with custom state, rely on default empty reader
+     */
+    @Test
+    void testNoopSourceWithCustomCheckpointing() throws Exception {
+        AbstractTestSourceBase<Integer, String> noopSourceWithCheckpoint =
+                new AbstractTestSourceBase<Integer, String>() {
+                    @Override
+                    public SimpleVersionedSerializer<String> getEnumeratorCheckpointSerializer() {
+                        return new SimpleVersionedSerializer<String>() {
+                            @Override
+                            public int getVersion() {
+                                return 1;
+                            }
+
+                            @Override
+                            public byte[] serialize(String obj) {
+                                return obj != null ? obj.getBytes() : new byte[0];
+                            }
+
+                            @Override
+                            public String deserialize(int version, byte[] serialized) {
+                                return serialized.length > 0 ? new String(serialized) : "";
+                            }
+                        };
+                    }
+                };
+
+        // Test that reader works without implementation
+        SourceReader<Integer, TestSplit> reader = noopSourceWithCheckpoint.createReader(null);
+        TestReaderOutput<Integer> output = new TestReaderOutput<>();
+
+        assertThat(reader.pollNext(output)).isEqualTo(InputStatus.END_OF_INPUT);
+        assertThat(output.getCollectedCount()).isEqualTo(0);
+
+        // Test enumerator checkpoint serialization
+        SimpleVersionedSerializer<String> serializer =
+                noopSourceWithCheckpoint.getEnumeratorCheckpointSerializer();
+        byte[] data = serializer.serialize("test-checkpoint");
+        String restored = serializer.deserialize(serializer.getVersion(), data);
+        assertThat(restored).isEqualTo("test-checkpoint");
+    }
+
+    // Helper classes for testing
+    private static class TestProcessingTimeService {
+        private long currentTime = 0;
+
+        public void setCurrentTime(long time) {
+            this.currentTime = time;
+        }
+
+        public long getCurrentTime() {
+            return currentTime;
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Added a minimal, test-only utility module for FLIP-27 (Source V2) tests to reduce boilerplate when using Source V2 in Test cases. This is being done as a part of FLINK-32695 to migrate all the legacy test sources.

While migrating legacy SourceFunction–based tests to FLIP-27 (Source V2), a recurring pattern was noticed: many tests only need a mostly no-op scaffold (e.g., a source/enumerator that does nothing) or just one component—most often the SourceReader—to exercise a specific behavior. Hence this change is being made so that those patterns can be captured and test authors can plug in a tiny override (reader/enumerator/serializer) without re-implementing boilerplate.

Module path: flink-test-utils-parent/flink-test-utils-source

## Brief change log

  - Add new module in flink-test-utils-parent (packaging: jar).
  - Introduced a reusable scaffolding under org.apache.flink.test.util.source:
    - AbstractTestSource<T> — default BOUNDED Source V2 with sensible no-op implementations; easy to extend.
    - TestSourceReader<T> — minimal SourceReader (default END_OF_INPUT), plumbs SourceReaderContext.
    - TestSplit — lightweight split with singleton-style serializer for simple tests.
    - TestSplitEnumerator — assigns a single split on request and signals no-more-splits to avoid hanging tests.
    - VoidSerializer — serializer for Void enumerator checkpoints.
  - Keep dependencies lean:
    - flink-core
  - No production modules changed.  


## Verifying this change

  - Module builds with the existing Flink parent
  - Unit tests added in SourcePatternExamplesTest exercise the new test-utils and cover complex Source V2 behaviors

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable, Javadoc added to new classes to describe intended usage and extension points.
