### PR TITLE
[FLINK-32695] [Tests] Migrate Common Test cases away from legacy Source/Sink 

### DIFF
--- a/flink-streaming-java/pom.xml
+++ b/flink-streaming-java/pom.xml
@@ -99,6 +99,13 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils-source</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorWatermarksTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorWatermarksTest.java
@@ -18,17 +18,26 @@
 
 package org.apache.flink.streaming.runtime.operators;
 
+import org.apache.flink.api.common.eventtime.Watermark;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.connector.source.ReaderOutput;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.jobgraph.OperatorID;
-import org.apache.flink.streaming.api.functions.source.legacy.RichSourceFunction;
-import org.apache.flink.streaming.api.functions.source.legacy.SourceFunction;
 import org.apache.flink.streaming.api.graph.StreamConfig;
-import org.apache.flink.streaming.api.operators.StreamSource;
-import org.apache.flink.streaming.api.watermark.Watermark;
-import org.apache.flink.streaming.runtime.tasks.SourceStreamTask;
+import org.apache.flink.streaming.api.operators.SourceOperatorFactory;
+import org.apache.flink.streaming.runtime.tasks.SourceOperatorStreamTask;
 import org.apache.flink.streaming.runtime.tasks.StreamTaskTestHarness;
+import org.apache.flink.test.util.source.AbstractTestSource;
+import org.apache.flink.test.util.source.TestSourceReader;
+import org.apache.flink.test.util.source.TestSplit;
+import org.apache.flink.test.util.source.TestSplitEnumerator;
 import org.apache.flink.util.ExceptionUtils;
 
 import org.junit.jupiter.api.Test;
@@ -36,47 +45,57 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-/** Tests for {@link StreamSource} operators. */
-@SuppressWarnings("serial")
+/** Tests for Source V2 operators watermark behavior. */
 class StreamSourceOperatorWatermarksTest {
 
     @Test
     void testEmitMaxWatermarkForFiniteSource() throws Exception {
-        StreamSource<String, ?> sourceOperator = new StreamSource<>(new FiniteSource<>());
+        SourceOperatorFactory<String> factory =
+                new SourceOperatorFactory<>(
+                        finiteSource(), WatermarkStrategy.noWatermarks(), false, 1);
         StreamTaskTestHarness<String> testHarness =
-                setupSourceStreamTask(sourceOperator, BasicTypeInfo.STRING_TYPE_INFO);
+                setupSourceOperatorTask(factory, BasicTypeInfo.STRING_TYPE_INFO);
 
         testHarness.invoke();
         testHarness.waitForTaskCompletion();
 
         assertThat(testHarness.getOutput()).hasSize(1);
-        assertThat(testHarness.getOutput().peek()).isEqualTo(Watermark.MAX_WATERMARK);
+        assertThat(testHarness.getOutput().peek())
+                .isEqualTo(new org.apache.flink.streaming.api.watermark.Watermark(Long.MAX_VALUE));
     }
 
     @Test
     void testDisabledProgressiveWatermarksForFiniteSource() throws Exception {
-        StreamSource<String, ?> sourceOperator =
-                new StreamSource<>(new FiniteSourceWithWatermarks<>(), false);
+        SourceOperatorFactory<String> factory =
+                new SourceOperatorFactory<>(
+                        finiteSourceWithSelfEmittedWMs(),
+                        WatermarkStrategy.noWatermarks(),
+                        true,
+                        1);
         StreamTaskTestHarness<String> testHarness =
-                setupSourceStreamTask(sourceOperator, BasicTypeInfo.STRING_TYPE_INFO);
+                setupSourceOperatorTask(factory, BasicTypeInfo.STRING_TYPE_INFO);
 
         testHarness.invoke();
         testHarness.waitForTaskCompletion();
 
         // sent by source function
-        assertThat(testHarness.getOutput().poll()).isEqualTo(Watermark.MAX_WATERMARK);
+        assertThat(testHarness.getOutput().poll())
+                .isEqualTo(new org.apache.flink.streaming.api.watermark.Watermark(Long.MAX_VALUE));
 
         // sent by framework
-        assertThat(testHarness.getOutput().poll()).isEqualTo(Watermark.MAX_WATERMARK);
+        assertThat(testHarness.getOutput().poll())
+                .isEqualTo(new org.apache.flink.streaming.api.watermark.Watermark(Long.MAX_VALUE));
 
         assertThat(testHarness.getOutput()).isEmpty();
     }
 
     @Test
     void testNoMaxWatermarkOnImmediateCancel() throws Exception {
-        StreamSource<String, ?> sourceOperator = new StreamSource<>(new InfiniteSource<>());
+        SourceOperatorFactory<String> factory =
+                new SourceOperatorFactory<>(
+                        infiniteSource(), WatermarkStrategy.noWatermarks(), false, 1);
         StreamTaskTestHarness<String> testHarness =
-                setupSourceStreamTask(sourceOperator, BasicTypeInfo.STRING_TYPE_INFO, true);
+                setupSourceOperatorTask(factory, BasicTypeInfo.STRING_TYPE_INFO, true);
 
         testHarness.invoke();
         assertThatThrownBy(testHarness::waitForTaskCompletion)
@@ -87,9 +106,11 @@ class StreamSourceOperatorWatermarksTest {
 
     @Test
     void testNoMaxWatermarkOnAsyncCancel() throws Exception {
-        StreamSource<String, ?> sourceOperator = new StreamSource<>(new InfiniteSource<>());
+        SourceOperatorFactory<String> factory =
+                new SourceOperatorFactory<>(
+                        infiniteSource(), WatermarkStrategy.noWatermarks(), false, 1);
         StreamTaskTestHarness<String> testHarness =
-                setupSourceStreamTask(sourceOperator, BasicTypeInfo.STRING_TYPE_INFO);
+                setupSourceOperatorTask(factory, BasicTypeInfo.STRING_TYPE_INFO);
 
         testHarness.invoke();
         testHarness.waitForTaskRunning();
@@ -107,80 +128,131 @@ class StreamSourceOperatorWatermarksTest {
 
     // ------------------------------------------------------------------------
 
-    private static <T> StreamTaskTestHarness<T> setupSourceStreamTask(
-            StreamSource<T, ?> sourceOperator, TypeInformation<T> outputType) {
-
-        return setupSourceStreamTask(sourceOperator, outputType, false);
+    private static <T> StreamTaskTestHarness<T> setupSourceOperatorTask(
+            SourceOperatorFactory<T> factory, TypeInformation<T> outputType) {
+        return setupSourceOperatorTask(factory, outputType, false);
     }
 
-    private static <T> StreamTaskTestHarness<T> setupSourceStreamTask(
-            StreamSource<T, ?> sourceOperator,
+    private static <T> StreamTaskTestHarness<T> setupSourceOperatorTask(
+            SourceOperatorFactory<T> factory,
             TypeInformation<T> outputType,
-            final boolean cancelImmediatelyAfterCreation) {
+            boolean cancelImmediately) {
 
-        final StreamTaskTestHarness<T> testHarness =
+        StreamTaskTestHarness<T> h =
                 new StreamTaskTestHarness<>(
                         (env) -> {
-                            SourceStreamTask<T, ?, ?> sourceTask = new SourceStreamTask<>(env);
-                            if (cancelImmediatelyAfterCreation) {
-                                try {
-                                    sourceTask.cancel();
-                                } catch (Exception e) {
-                                    throw new RuntimeException(e);
-                                }
+                            SourceOperatorStreamTask<T> t = new SourceOperatorStreamTask<>(env);
+                            if (cancelImmediately) {
+                                t.cancel();
                             }
-                            return sourceTask;
+                            return t;
                         },
                         outputType);
-        testHarness.setupOutputForSingletonOperatorChain();
+        h.setupOutputForSingletonOperatorChain();
 
-        StreamConfig streamConfig = testHarness.getStreamConfig();
-        streamConfig.setStreamOperator(sourceOperator);
-        streamConfig.setOperatorID(new OperatorID());
-
-        return testHarness;
+        StreamConfig cfg = h.getStreamConfig();
+        cfg.setStreamOperatorFactory(factory);
+        cfg.setOperatorID(new OperatorID());
+        return h;
     }
 
-    // ------------------------------------------------------------------------
+    /**
+     * Creates a simple split enumerator that assigns one split and optionally signals completion.
+     */
+    private static SplitEnumerator<TestSplit, Void> createSimpleEnumerator(
+            SplitEnumeratorContext<TestSplit> context, boolean signalNoMoreSplits) {
+        return new TestSplitEnumerator<>(context, null) {
+            private boolean assigned = false;
 
-    private static final class FiniteSource<T> extends RichSourceFunction<T> {
-
-        @Override
-        public void run(SourceContext<T> ctx) {}
-
-        @Override
-        public void cancel() {}
-    }
-
-    private static final class FiniteSourceWithWatermarks<T> extends RichSourceFunction<T> {
-
-        @Override
-        public void run(SourceContext<T> ctx) {
-            synchronized (ctx.getCheckpointLock()) {
-                ctx.emitWatermark(new Watermark(1000));
-                ctx.emitWatermark(new Watermark(2000));
-                ctx.emitWatermark(Watermark.MAX_WATERMARK);
+            @Override
+            public void addReader(int subtaskId) {
+                if (!assigned) {
+                    context.assignSplit(TestSplit.INSTANCE, subtaskId);
+                    assigned = true;
+                }
+                if (signalNoMoreSplits) {
+                    context.signalNoMoreSplits(subtaskId);
+                }
             }
-        }
-
-        @Override
-        public void cancel() {}
+        };
     }
 
-    private static final class InfiniteSource<T> implements SourceFunction<T> {
+    /** Finite (bounded) source → framework emits MAX_WM. */
+    private static AbstractTestSource<String> finiteSource() {
+        return new AbstractTestSource<>() {
+            @Override
+            public SourceReader<String, TestSplit> createReader(SourceReaderContext ctx) {
+                return new TestSourceReader<>(ctx) {
+                    private boolean done = false;
 
-        private volatile boolean running = true;
-
-        @Override
-        public void run(SourceContext<T> ctx) throws Exception {
-            while (running) {
-                Thread.sleep(20);
+                    @Override
+                    public InputStatus pollNext(ReaderOutput<String> out) {
+                        if (!done) {
+                            done = true;
+                            return InputStatus.END_OF_INPUT;
+                        }
+                        return InputStatus.NOTHING_AVAILABLE;
+                    }
+                };
             }
-        }
 
-        @Override
-        public void cancel() {
-            running = false;
-        }
+            @Override
+            public SplitEnumerator<TestSplit, Void> createEnumerator(
+                    SplitEnumeratorContext<TestSplit> context) {
+                return createSimpleEnumerator(context, true);
+            }
+        };
+    }
+
+    /** Finite source that self-emits WM_MAX (then framework also emits MAX_WM). */
+    private static AbstractTestSource<String> finiteSourceWithSelfEmittedWMs() {
+        return new AbstractTestSource<>() {
+            @Override
+            public SourceReader<String, TestSplit> createReader(SourceReaderContext ctx) {
+                return new TestSourceReader<String>(ctx) {
+                    private int step = 0;
+
+                    @Override
+                    public InputStatus pollNext(ReaderOutput<String> out) {
+                        if (step == 0) {
+                            out.emitWatermark(new Watermark(Long.MAX_VALUE));
+                            step = 1;
+                            return InputStatus.NOTHING_AVAILABLE; // give the operator a tick
+                        } else if (step == 1) {
+                            step = 2;
+                            return InputStatus.END_OF_INPUT; // bounded completion
+                        }
+                        return InputStatus.NOTHING_AVAILABLE;
+                    }
+                };
+            }
+
+            @Override
+            public SplitEnumerator<TestSplit, Void> createEnumerator(
+                    SplitEnumeratorContext<TestSplit> context) {
+                return createSimpleEnumerator(context, true); // bounded → framework MAX_WM too
+            }
+        };
+    }
+
+    /** Infinite (unbounded) source → no framework MAX_WM on cancel. */
+    private static AbstractTestSource<String> infiniteSource() {
+        return new AbstractTestSource<>() {
+            @Override
+            public SourceReader<String, TestSplit> createReader(SourceReaderContext ctx) {
+                return new TestSourceReader<>(ctx) {
+                    @Override
+                    public InputStatus pollNext(ReaderOutput<String> out) {
+                        return InputStatus.NOTHING_AVAILABLE; // idle forever until cancel
+                    }
+                };
+            }
+
+            @Override
+            public SplitEnumerator<TestSplit, Void> createEnumerator(
+                    SplitEnumeratorContext<TestSplit> context) {
+                return createSimpleEnumerator(context, false); // unbounded → no signalNoMoreSplits
+            }
+        };
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskSystemExitTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskSystemExitTest.java
@@ -20,8 +20,15 @@ package org.apache.flink.streaming.runtime.tasks;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.connector.source.ReaderOutput;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.core.security.FlinkSecurityManager;
 import org.apache.flink.core.security.UserSystemExitException;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
@@ -58,12 +65,15 @@ import org.apache.flink.runtime.taskmanager.Task;
 import org.apache.flink.runtime.taskmanager.TaskManagerActions;
 import org.apache.flink.runtime.taskmanager.TaskManagerRuntimeInfo;
 import org.apache.flink.runtime.util.TestingTaskManagerRuntimeInfo;
-import org.apache.flink.streaming.api.functions.source.legacy.SourceFunction;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
-import org.apache.flink.streaming.api.operators.StreamOperator;
-import org.apache.flink.streaming.api.operators.StreamSource;
+import org.apache.flink.streaming.api.operators.SourceOperatorFactory;
+import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxDefaultAction;
+import org.apache.flink.test.util.source.AbstractTestSource;
+import org.apache.flink.test.util.source.SingleSplitEnumerator;
+import org.apache.flink.test.util.source.TestSourceReader;
+import org.apache.flink.test.util.source.TestSplit;
 import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.concurrent.Executors;
 
@@ -114,7 +124,9 @@ class StreamTaskSystemExitTest {
 
     @Test
     void testInitSystemExitStreamTask() throws Exception {
-        Task task = createSystemExitTask(InitSystemExitStreamTask.class.getName(), null);
+        Task task =
+                createSystemExitTask(
+                        InitSystemExitStreamTask.class.getName(), (StreamOperatorFactory<?>) null);
         task.run();
         assertThat(task.getFailureCause())
                 .isNotNull()
@@ -123,7 +135,10 @@ class StreamTaskSystemExitTest {
 
     @Test
     void testProcessInputSystemExitStreamTask() throws Exception {
-        Task task = createSystemExitTask(ProcessInputSystemExitStreamTask.class.getName(), null);
+        Task task =
+                createSystemExitTask(
+                        ProcessInputSystemExitStreamTask.class.getName(),
+                        (StreamOperatorFactory<?>) null);
         task.run();
         assertThat(task.getFailureCause())
                 .isNotNull()
@@ -142,22 +157,25 @@ class StreamTaskSystemExitTest {
 
     @Test
     void testStreamSourceSystemExitStreamTask() throws Exception {
-        final TestStreamSource<String, SystemExitSourceFunction> testStreamSource =
-                new TestStreamSource<>(new SystemExitSourceFunction());
+        SourceOperatorFactory<String> factory =
+                new SourceOperatorFactory<>(
+                        systemExitSource(), WatermarkStrategy.<String>noWatermarks(), false, 1);
         Task task =
-                createSystemExitTask(SystemExitSourceStreamTask.class.getName(), testStreamSource);
+                createSystemExitTask(SystemExitSourceOperatorStreamTask.class.getName(), factory);
         task.run();
         assertThat(task.getFailureCause())
                 .isNotNull()
                 .isExactlyInstanceOf(UserSystemExitException.class);
     }
 
-    private Task createSystemExitTask(final String invokableClassName, StreamOperator<?> operator)
-            throws Exception {
+    private Task createSystemExitTask(
+            final String invokableClassName, StreamOperatorFactory<?> factory) throws Exception {
         final Configuration taskConfiguration = new Configuration();
         final StreamConfig streamConfig = new StreamConfig(taskConfiguration);
         streamConfig.setOperatorID(new OperatorID());
-        streamConfig.setStreamOperator(operator);
+        if (factory != null) {
+            streamConfig.setStreamOperatorFactory(factory);
+        }
         streamConfig.serializeAllConfigs();
 
         final JobInformation jobInformation =
@@ -280,37 +298,33 @@ class StreamTaskSystemExitTest {
         }
     }
 
-    /**
-     * SourceStreamTask emulating system exit behavior in run function by {@link
-     * SystemExitSourceFunction}.
-     */
-    public static class SystemExitSourceStreamTask
-            extends SourceStreamTask<
-                    String,
-                    SystemExitSourceFunction,
-                    StreamTaskTest.TestStreamSource<String, SystemExitSourceFunction>> {
+    /** SourceOperatorStreamTask emulating system exit behavior in Source V2. */
+    public static class SystemExitSourceOperatorStreamTask
+            extends SourceOperatorStreamTask<String> {
 
-        public SystemExitSourceStreamTask(Environment env) throws Exception {
+        public SystemExitSourceOperatorStreamTask(Environment env) throws Exception {
             super(env);
         }
     }
 
-    private static class SystemExitSourceFunction implements SourceFunction<String> {
+    private static AbstractTestSource<String> systemExitSource() {
+        return new AbstractTestSource<String>() {
+            @Override
+            public SourceReader<String, TestSplit> createReader(SourceReaderContext ctx) {
+                return new TestSourceReader<String>(ctx) {
+                    @Override
+                    public InputStatus pollNext(ReaderOutput<String> out) {
+                        systemExit(); // User code that must be intercepted
+                        return InputStatus.END_OF_INPUT;
+                    }
+                };
+            }
 
-        @Override
-        public void run(SourceContext<String> ctx) {
-            systemExit();
-        }
-
-        @Override
-        public void cancel() {}
-    }
-
-    static class TestStreamSource<OUT, SRC extends SourceFunction<OUT>>
-            extends StreamSource<OUT, SRC> {
-
-        public TestStreamSource(SRC sourceFunction) {
-            super(sourceFunction);
-        }
+            @Override
+            public SplitEnumerator<TestSplit, Void> createEnumerator(
+                    SplitEnumeratorContext<TestSplit> context) {
+                return new SingleSplitEnumerator(context);
+            }
+        };
     }
 }

--- a/flink-tests/pom.xml
+++ b/flink-tests/pom.xml
@@ -154,6 +154,13 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils-source</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-examples-streaming</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/CheckpointStoreITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/CheckpointStoreITCase.java
@@ -18,10 +18,17 @@
 package org.apache.flink.test.checkpointing;
 
 import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.connector.source.ReaderOutput;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.checkpoint.PerJobCheckpointRecoveryFactory;
 import org.apache.flink.runtime.checkpoint.StandaloneCompletedCheckpointStore;
@@ -31,10 +38,12 @@ import org.apache.flink.runtime.highavailability.nonha.embedded.EmbeddedHaServic
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.v2.DiscardingSink;
-import org.apache.flink.streaming.api.functions.source.legacy.SourceFunction;
 import org.apache.flink.streaming.util.RestartStrategyUtils;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
-import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.test.util.source.AbstractTestSource;
+import org.apache.flink.test.util.source.SingleSplitEnumerator;
+import org.apache.flink.test.util.source.TestSourceReader;
+import org.apache.flink.test.util.source.TestSplit;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.function.SerializableSupplier;
 
@@ -80,7 +89,10 @@ public class CheckpointStoreITCase extends TestLogger {
         env.enableCheckpointing(10);
         RestartStrategyUtils.configureFixedDelayRestartStrategy(
                 env, 2 /* failure on processing + on recovery */, 0L);
-        env.addSource(emitUntil(() -> FailingMapper.failedAndProcessed))
+        env.fromSource(
+                        new EmitUntilSource(() -> FailingMapper.failedAndProcessed),
+                        WatermarkStrategy.noWatermarks(),
+                        "EmitUntilSourceV2")
                 .map(new FailingMapper())
                 .sinkTo(new DiscardingSink<>());
         final JobClient jobClient = env.executeAsync();
@@ -154,29 +166,42 @@ public class CheckpointStoreITCase extends TestLogger {
         }
     }
 
-    private SourceFunction<Integer> emitUntil(SerializableSupplier<Boolean> until) {
-        return new SourceFunction<Integer>() {
+    private static final class EmitUntilSource extends AbstractTestSource<Integer> {
+        private final SerializableSupplier<Boolean> until;
 
-            private volatile boolean running = true;
+        EmitUntilSource(SerializableSupplier<Boolean> until) {
+            this.until = until;
+        }
 
-            @Override
-            public void run(SourceContext<Integer> ctx) {
-                while (running && !until.get()) {
-                    synchronized (ctx.getCheckpointLock()) {
-                        ctx.collect(0);
-                        try {
-                            Thread.sleep(100);
-                        } catch (InterruptedException e) {
-                            ExceptionUtils.rethrow(e);
-                        }
+        @Override
+        public SourceReader<Integer, TestSplit> createReader(SourceReaderContext ctx) {
+            return new TestSourceReader<>(ctx) {
+                @Override
+                public InputStatus pollNext(ReaderOutput<Integer> out) {
+                    if (until.get()) {
+                        return InputStatus.END_OF_INPUT;
                     }
+                    out.collect(0);
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        return InputStatus.NOTHING_AVAILABLE;
+                    }
+                    return InputStatus.MORE_AVAILABLE;
                 }
-            }
+            };
+        }
 
-            @Override
-            public void cancel() {
-                running = false;
-            }
-        };
+        @Override
+        public SplitEnumerator<TestSplit, Void> createEnumerator(
+                SplitEnumeratorContext<TestSplit> ctx) {
+            return new SingleSplitEnumerator(ctx) {
+                @Override
+                public void handleSplitRequest(int subtaskId, String host) {
+                    addReader(subtaskId);
+                }
+            };
+        }
     }
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/NotifyCheckpointAbortedITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/NotifyCheckpointAbortedITCase.java
@@ -20,10 +20,16 @@ package org.apache.flink.test.checkpointing;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.connector.source.ReaderOutput;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.client.program.ClusterClient;
@@ -35,6 +41,7 @@ import org.apache.flink.configuration.StateRecoveryOptions;
 import org.apache.flink.core.execution.CheckpointingMode;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
@@ -67,11 +74,14 @@ import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.legacy.SinkFunction;
-import org.apache.flink.streaming.api.functions.source.legacy.SourceFunction;
 import org.apache.flink.streaming.api.operators.StreamMap;
 import org.apache.flink.streaming.api.operators.StreamSink;
 import org.apache.flink.streaming.util.StateBackendUtils;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.test.util.source.AbstractTestSource;
+import org.apache.flink.test.util.source.TestSourceReader;
+import org.apache.flink.test.util.source.TestSplit;
+import org.apache.flink.test.util.source.TestSplitEnumerator;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.After;
@@ -87,7 +97,9 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -168,7 +180,10 @@ public class NotifyCheckpointAbortedITCase extends TestLogger {
                 env,
                 "org.apache.flink.test.checkpointing.NotifyCheckpointAbortedITCase$DeclineSinkFailingStateBackendFactory");
 
-        env.addSource(new NormalSource())
+        env.fromSource(
+                        new NormalSource(),
+                        WatermarkStrategy.<Tuple2<Integer, Integer>>noWatermarks(),
+                        "NormalSource")
                 .name("NormalSource")
                 .keyBy((KeySelector<Tuple2<Integer, Integer>, Integer>) value -> value.f0)
                 .transform("NormalMap", TypeInformation.of(Integer.class), new NormalMap())
@@ -215,46 +230,61 @@ public class NotifyCheckpointAbortedITCase extends TestLogger {
         assertEquals(expectedTimes, DeclineSink.notifiedAbortedTimes.get());
     }
 
-    /** Normal source function. */
-    private static class NormalSource
-            implements SourceFunction<Tuple2<Integer, Integer>>, CheckpointedFunction {
-        private static final long serialVersionUID = 1L;
-        protected volatile boolean running;
+    /** Source V2 implementation using AbstractTestSource that replaces the legacy NormalSource. */
+    private static final class NormalSource extends AbstractTestSource<Tuple2<Integer, Integer>> {
 
-        NormalSource() {
-            this.running = true;
-        }
-
-        @Override
-        public void run(SourceContext<Tuple2<Integer, Integer>> ctx) throws Exception {
-            while (running) {
-                synchronized (ctx.getCheckpointLock()) {
-                    ctx.collect(
-                            Tuple2.of(
-                                    ThreadLocalRandom.current().nextInt(),
-                                    ThreadLocalRandom.current().nextInt()));
-                }
-                Thread.sleep(10);
-            }
-        }
-
-        @Override
-        public void cancel() {
-            this.running = false;
-        }
-
-        @Override
-        public void snapshotState(FunctionSnapshotContext context) throws Exception {
-            if (context.getCheckpointId() == DECLINE_CHECKPOINT_ID) {
-                DECLINE_CHECKPOINT_WAIT_LATCH.await();
-            }
-        }
-
-        @Override
-        public void initializeState(FunctionInitializationContext context) throws Exception {}
-
+        // let the test reset the latch just like before
         static void reset() {
             DECLINE_CHECKPOINT_WAIT_LATCH.reset();
+        }
+
+        @Override
+        public SourceReader<Tuple2<Integer, Integer>, TestSplit> createReader(
+                SourceReaderContext ctx) {
+            return new TestSourceReader<Tuple2<Integer, Integer>>(ctx) {
+
+                private final ThreadLocalRandom rnd = ThreadLocalRandom.current();
+
+                @Override
+                public InputStatus pollNext(ReaderOutput<Tuple2<Integer, Integer>> out) {
+                    out.collect(Tuple2.of(rnd.nextInt(), rnd.nextInt()));
+
+                    try {
+                        Thread.sleep(10);
+                    } catch (InterruptedException ignored) {
+                    }
+                    return InputStatus.MORE_AVAILABLE;
+                }
+
+                @Override
+                public List<TestSplit> snapshotState(long checkpointId) {
+                    if (checkpointId == DECLINE_CHECKPOINT_ID) {
+                        try {
+                            DECLINE_CHECKPOINT_WAIT_LATCH.await();
+                        } catch (InterruptedException ignored) {
+                            Thread.currentThread().interrupt();
+                        }
+                    }
+                    return Collections.emptyList();
+                }
+            };
+        }
+
+        @Override
+        public SplitEnumerator<TestSplit, Void> createEnumerator(
+                SplitEnumeratorContext<TestSplit> ctx) {
+            return new TestSplitEnumerator<Void>(ctx, null) {
+                private boolean assigned = false;
+
+                @Override
+                public void addReader(int subtaskId) {
+                    if (!assigned) {
+                        ctx.assignSplit(TestSplit.INSTANCE, subtaskId);
+                        assigned = true;
+                    }
+                    ctx.signalNoMoreSplits(subtaskId);
+                }
+            };
         }
     }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RestoreUpgradedJobITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RestoreUpgradedJobITCase.java
@@ -18,26 +18,37 @@
 
 package org.apache.flink.test.checkpointing;
 
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.api.connector.source.ReaderOutput;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ExternalizedCheckpointRetention;
 import org.apache.flink.configuration.StateRecoveryOptions;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.core.execution.SavepointFormatType;
+import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.sink.legacy.SinkFunction;
-import org.apache.flink.streaming.api.functions.source.legacy.SourceFunction;
 import org.apache.flink.streaming.util.CheckpointStorageUtils;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.test.util.source.AbstractTestSource;
+import org.apache.flink.test.util.source.SingleSplitEnumerator;
+import org.apache.flink.test.util.source.TestSourceReader;
+import org.apache.flink.test.util.source.TestSplit;
 import org.apache.flink.testutils.junit.SharedObjects;
 import org.apache.flink.testutils.junit.SharedReference;
 import org.apache.flink.util.TestLogger;
@@ -54,7 +65,6 @@ import javax.annotation.Nonnull;
 import java.util.Iterator;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.locks.LockSupport;
 
 import static org.apache.flink.runtime.testutils.CommonTestUtils.waitForAllTaskRunning;
 import static org.apache.flink.test.checkpointing.RestoreUpgradedJobITCase.MapName.MAP_1;
@@ -184,7 +194,11 @@ public class RestoreUpgradedJobITCase extends TestLogger {
         env.enableCheckpointing(Integer.MAX_VALUE);
 
         // Different order of maps before and after savepoint.
-        env.addSource(new IntSource(allDataEmittedLatch))
+        env.fromSource(
+                        new IntSourceV2(allDataEmittedLatch),
+                        WatermarkStrategy.<Integer>noWatermarks(),
+                        "IntSourceV2")
+                .setParallelism(1)
                 .map(new IntMap(MAP_5.id()))
                 .uid(MAP_5.name())
                 .forward()
@@ -203,7 +217,7 @@ public class RestoreUpgradedJobITCase extends TestLogger {
                 .rescale()
                 .map(new IntMap(MAP_3.id()))
                 .uid(MAP_3.name())
-                .addSink(new IntSink(result))
+                .sinkTo(createIntSink(result))
                 // one sink for easy calculation.
                 .setParallelism(1);
 
@@ -224,7 +238,11 @@ public class RestoreUpgradedJobITCase extends TestLogger {
         conf.set(CheckpointingOptions.FILE_MERGING_ENABLED, false);
         env = StreamExecutionEnvironment.getExecutionEnvironment(conf);
         env.setParallelism(PARALLELISM);
-        env.addSource(new StringSource(allDataEmittedLatch))
+        env.fromSource(
+                        new StringSourceV2(allDataEmittedLatch),
+                        WatermarkStrategy.<String>noWatermarks(),
+                        "StringSourceV2")
+                .setParallelism(1)
                 .map(new StringMap(MAP_1.id()))
                 .uid(MAP_1.name())
                 .forward()
@@ -247,7 +265,7 @@ public class RestoreUpgradedJobITCase extends TestLogger {
                 .broadcast()
                 .map(new StringMap(MAP_6.id()))
                 .uid(MAP_6.name())
-                .addSink(new StringSink(result))
+                .sinkTo(createStringSink(result))
                 // one sink for easy calculation.
                 .setParallelism(1);
 
@@ -294,30 +312,42 @@ public class RestoreUpgradedJobITCase extends TestLogger {
         return snapshotPath;
     }
 
-    private static class IntSink implements SinkFunction<Integer> {
-        private final SharedReference<AtomicLong> result;
-
-        public IntSink(SharedReference<AtomicLong> result) {
-            this.result = result;
-        }
-
-        @Override
-        public void invoke(Integer value, Context context) throws Exception {
-            result.get().addAndGet(value);
-        }
+    /** Creates a simple split enumerator that assigns one split (unbounded source pattern). */
+    private static SplitEnumerator<TestSplit, Void> createSimpleEnumerator(
+            SplitEnumeratorContext<TestSplit> context) {
+        return new SingleSplitEnumerator(context);
     }
 
-    private static class StringSink implements SinkFunction<String> {
-        private final SharedReference<AtomicLong> result;
+    private static Sink<Integer> createIntSink(SharedReference<AtomicLong> result) {
+        return context ->
+                new SinkWriter<Integer>() {
+                    @Override
+                    public void write(Integer element, Context ctx) {
+                        result.get().addAndGet(element);
+                    }
 
-        public StringSink(SharedReference<AtomicLong> result) {
-            this.result = result;
-        }
+                    @Override
+                    public void flush(boolean endOfInput) {}
 
-        @Override
-        public void invoke(String value, Context context) throws Exception {
-            result.get().addAndGet(Integer.parseInt(value));
-        }
+                    @Override
+                    public void close() {}
+                };
+    }
+
+    private static Sink<String> createStringSink(SharedReference<AtomicLong> result) {
+        return context ->
+                new SinkWriter<String>() {
+                    @Override
+                    public void write(String element, Context ctx) {
+                        result.get().addAndGet(Integer.parseInt(element));
+                    }
+
+                    @Override
+                    public void flush(boolean endOfInput) {}
+
+                    @Override
+                    public void close() {}
+                };
     }
 
     private static class IntMap extends AbstractMap<Integer> {
@@ -387,58 +417,75 @@ public class RestoreUpgradedJobITCase extends TestLogger {
         }
     }
 
-    private static class IntSource extends TestSource<Integer> {
-        public IntSource(SharedReference<OneShotLatch> dataEmitted) {
-            super(dataEmitted);
-        }
-
-        @Override
-        void collect(SourceContext<Integer> ctx, int index) {
-            ctx.collect(index);
-        }
-    }
-
-    private static class StringSource extends TestSource<String> {
-        public StringSource(SharedReference<OneShotLatch> dataEmitted) {
-            super(dataEmitted);
-        }
-
-        @Override
-        void collect(SourceContext<String> ctx, int index) {
-            ctx.collect(String.valueOf(index));
-        }
-    }
-
-    private abstract static class TestSource<T> implements SourceFunction<T> {
-
-        private static final long serialVersionUID = 1L;
+    /** Source V2 (bounded emission, keeps task alive afterwards). */
+    private static class IntSourceV2 extends AbstractTestSource<Integer> {
         private final SharedReference<OneShotLatch> dataEmitted;
 
-        private volatile boolean isRunning = true;
-
-        public TestSource(SharedReference<OneShotLatch> dataEmitted) {
+        IntSourceV2(SharedReference<OneShotLatch> dataEmitted) {
             this.dataEmitted = dataEmitted;
         }
 
         @Override
-        public void run(SourceContext<T> ctx) throws Exception {
-            int i = TOTAL_RECORDS;
-            while (i-- > 0) {
-                synchronized (ctx.getCheckpointLock()) {
-                    collect(ctx, i);
+        public SourceReader<Integer, TestSplit> createReader(SourceReaderContext ctx) {
+            return new TestSourceReader<Integer>(ctx) {
+                private int next = TOTAL_RECORDS - 1;
+                private boolean signaled = false;
+
+                @Override
+                public InputStatus pollNext(ReaderOutput<Integer> out) {
+                    if (next >= 0) {
+                        out.collect(next--);
+                        if (next < 0 && !signaled && ctx.getIndexOfSubtask() == 0) {
+                            dataEmitted.get().trigger(); // like legacy run() after last emit
+                            signaled = true;
+                        }
+                        return InputStatus.MORE_AVAILABLE;
+                    }
+                    // stay alive; the job will be stopped via checkpoint/savepoint/cancel
+                    return InputStatus.NOTHING_AVAILABLE;
                 }
-            }
-            dataEmitted.get().trigger();
-            while (isRunning) {
-                LockSupport.parkNanos(100000);
-            }
+            };
         }
 
-        abstract void collect(SourceContext<T> ctx, int index);
+        @Override
+        public SplitEnumerator<TestSplit, Void> createEnumerator(
+                SplitEnumeratorContext<TestSplit> context) {
+            return createSimpleEnumerator(context);
+        }
+    }
+
+    private static class StringSourceV2 extends AbstractTestSource<String> {
+        private final SharedReference<OneShotLatch> dataEmitted;
+
+        StringSourceV2(SharedReference<OneShotLatch> dataEmitted) {
+            this.dataEmitted = dataEmitted;
+        }
 
         @Override
-        public void cancel() {
-            isRunning = false;
+        public SourceReader<String, TestSplit> createReader(SourceReaderContext ctx) {
+            return new TestSourceReader<>(ctx) {
+                private int next = TOTAL_RECORDS - 1;
+                private boolean signaled = false;
+
+                @Override
+                public InputStatus pollNext(ReaderOutput<String> out) {
+                    if (next >= 0) {
+                        out.collect(String.valueOf(next--));
+                        if (next < 0 && !signaled && ctx.getIndexOfSubtask() == 0) {
+                            dataEmitted.get().trigger();
+                            signaled = true;
+                        }
+                        return InputStatus.MORE_AVAILABLE;
+                    }
+                    return InputStatus.NOTHING_AVAILABLE;
+                }
+            };
+        }
+
+        @Override
+        public SplitEnumerator<TestSplit, Void> createEnumerator(
+                SplitEnumeratorContext<TestSplit> context) {
+            return createSimpleEnumerator(context);
         }
     }
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/BufferTimeoutITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/BufferTimeoutITCase.java
@@ -18,13 +18,25 @@
 
 package org.apache.flink.test.streaming.runtime;
 
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.ReaderOutput;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.runtime.io.network.api.writer.RecordWriter;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.sink.legacy.SinkFunction;
-import org.apache.flink.streaming.api.functions.source.legacy.SourceFunction;
 import org.apache.flink.test.util.AbstractTestBaseJUnit4;
+import org.apache.flink.test.util.source.AbstractTestSource;
+import org.apache.flink.test.util.source.SingleSplitEnumerator;
+import org.apache.flink.test.util.source.TestSourceReader;
+import org.apache.flink.test.util.source.TestSplit;
 import org.apache.flink.testutils.junit.SharedObjects;
 import org.apache.flink.testutils.junit.SharedReference;
 
@@ -52,28 +64,12 @@ public class BufferTimeoutITCase extends AbstractTestBaseJUnit4 {
         env.setBufferTimeout(-1);
         final SharedReference<ArrayList<Integer>> results = sharedObjects.add(new ArrayList<>());
 
-        env.addSource(
-                        new SourceFunction<Integer>() {
-
-                            @Override
-                            public void run(SourceContext<Integer> ctx) throws Exception {
-                                ctx.collect(1);
-                                // just sleep forever
-                                Thread.sleep(Long.MAX_VALUE);
-                            }
-
-                            @Override
-                            public void cancel() {}
-                        })
+        env.fromSource(
+                        createSingleElementIdleSource(),
+                        WatermarkStrategy.<Integer>noWatermarks(),
+                        "v2-src")
                 .slotSharingGroup("source")
-                .addSink(
-                        new SinkFunction<Integer>() {
-
-                            @Override
-                            public void invoke(Integer value, Context context) {
-                                results.get().add(value);
-                            }
-                        })
+                .sinkTo(createResultCollectingSink(results))
                 .slotSharingGroup("sink");
 
         final JobClient jobClient = env.executeAsync();
@@ -89,5 +85,55 @@ public class BufferTimeoutITCase extends AbstractTestBaseJUnit4 {
                                                 .startsWith(
                                                         RecordWriter
                                                                 .DEFAULT_OUTPUT_FLUSH_THREAD_NAME)));
+    }
+
+    /** Sink V2 that collects results in shared reference. */
+    private static Sink<Integer> createResultCollectingSink(
+            SharedReference<ArrayList<Integer>> results) {
+        return context ->
+                new SinkWriter<>() {
+                    @Override
+                    public void write(Integer element, Context ctx) {
+                        results.get().add(element);
+                    }
+
+                    @Override
+                    public void flush(boolean endOfInput) {}
+
+                    @Override
+                    public void close() {}
+                };
+    }
+
+    /** Source V2 that emits one element then stays idle (unbounded). */
+    private static AbstractTestSource<Integer> createSingleElementIdleSource() {
+        return new AbstractTestSource<Integer>() {
+            @Override
+            public SourceReader<Integer, TestSplit> createReader(SourceReaderContext ctx) {
+                return new TestSourceReader<>(ctx) {
+                    private boolean emitted = false;
+
+                    @Override
+                    public InputStatus pollNext(ReaderOutput<Integer> out) {
+                        if (!emitted) {
+                            out.collect(1);
+                            emitted = true;
+                        }
+                        return InputStatus.NOTHING_AVAILABLE;
+                    }
+                };
+            }
+
+            @Override
+            public SplitEnumerator<TestSplit, Void> createEnumerator(
+                    SplitEnumeratorContext<TestSplit> context) {
+                return new SingleSplitEnumerator(context);
+            }
+
+            @Override
+            public Boundedness getBoundedness() {
+                return Boundedness.CONTINUOUS_UNBOUNDED;
+            }
+        };
     }
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SideOutputITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SideOutputITCase.java
@@ -17,10 +17,17 @@
 
 package org.apache.flink.test.streaming.runtime;
 
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.FlatMapFunction;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.connector.source.ReaderOutput;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -28,7 +35,6 @@ import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
 import org.apache.flink.streaming.api.functions.ProcessFunction;
 import org.apache.flink.streaming.api.functions.co.CoProcessFunction;
 import org.apache.flink.streaming.api.functions.co.KeyedCoProcessFunction;
-import org.apache.flink.streaming.api.functions.source.legacy.SourceFunction;
 import org.apache.flink.streaming.api.functions.windowing.AllWindowFunction;
 import org.apache.flink.streaming.api.functions.windowing.ProcessAllWindowFunction;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
@@ -42,6 +48,10 @@ import org.apache.flink.streaming.runtime.operators.util.WatermarkStrategyWithPu
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.test.streaming.runtime.util.TestListResultSink;
 import org.apache.flink.test.util.AbstractTestBaseJUnit4;
+import org.apache.flink.test.util.source.AbstractTestSource;
+import org.apache.flink.test.util.source.TestSourceReader;
+import org.apache.flink.test.util.source.TestSplit;
+import org.apache.flink.test.util.source.TestSplitEnumerator;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.OutputTag;
 
@@ -89,24 +99,11 @@ public class SideOutputITCase extends AbstractTestBaseJUnit4 implements Serializ
         env.setParallelism(3);
 
         DataStream<Integer> dataStream =
-                env.addSource(
-                        new SourceFunction<Integer>() {
-                            private static final long serialVersionUID = 1L;
-
-                            @Override
-                            public void run(SourceContext<Integer> ctx) throws Exception {
-                                ctx.collectWithTimestamp(1, 0);
-                                ctx.emitWatermark(new Watermark(0));
-                                ctx.collectWithTimestamp(2, 1);
-                                ctx.collectWithTimestamp(5, 2);
-                                ctx.emitWatermark(new Watermark(2));
-                                ctx.collectWithTimestamp(3, 3);
-                                ctx.collectWithTimestamp(4, 4);
-                            }
-
-                            @Override
-                            public void cancel() {}
-                        });
+                env.fromSource(
+                                createTimestampedWatermarkSource(),
+                                WatermarkStrategy.<Integer>noWatermarks(),
+                                "timestamped-source")
+                        .setParallelism(1);
 
         SingleOutputStreamOperator<Integer> passThroughtStream =
                 dataStream.process(
@@ -1142,5 +1139,72 @@ public class SideOutputITCase extends AbstractTestBaseJUnit4 implements Serializ
         assertEquals(Arrays.asList(2, 2, 4, 4), evensUEvensResultSink.getSortedResult());
 
         assertEquals(Arrays.asList(1, 2, 3, 4), oddsUEvensExternalResultSink.getSortedResult());
+    }
+
+    /** Source V2 that emits timestamped elements with watermarks for side output testing. */
+    private static AbstractTestSource<Integer> createTimestampedWatermarkSource() {
+        return new AbstractTestSource<>() {
+            @Override
+            public SourceReader<Integer, TestSplit> createReader(SourceReaderContext ctx) {
+                return new TestSourceReader<Integer>(ctx) {
+                    private int step = 0;
+
+                    @Override
+                    public InputStatus pollNext(ReaderOutput<Integer> out) {
+                        switch (step) {
+                            case 0:
+                                out.collect(1, 0);
+                                step++;
+                                return InputStatus.MORE_AVAILABLE;
+                            case 1:
+                                out.emitWatermark(
+                                        new org.apache.flink.api.common.eventtime.Watermark(0));
+                                step++;
+                                return InputStatus.MORE_AVAILABLE;
+                            case 2:
+                                out.collect(2, 1);
+                                step++;
+                                return InputStatus.MORE_AVAILABLE;
+                            case 3:
+                                out.collect(5, 2);
+                                step++;
+                                return InputStatus.MORE_AVAILABLE;
+                            case 4:
+                                out.emitWatermark(
+                                        new org.apache.flink.api.common.eventtime.Watermark(2));
+                                step++;
+                                return InputStatus.MORE_AVAILABLE;
+                            case 5:
+                                out.collect(3, 3);
+                                step++;
+                                return InputStatus.MORE_AVAILABLE;
+                            case 6:
+                                out.collect(4, 4);
+                                step++;
+                                return InputStatus.END_OF_INPUT;
+                            default:
+                                return InputStatus.END_OF_INPUT;
+                        }
+                    }
+                };
+            }
+
+            @Override
+            public SplitEnumerator<TestSplit, Void> createEnumerator(
+                    SplitEnumeratorContext<TestSplit> context) {
+                return new TestSplitEnumerator<>(context, null) {
+                    private boolean assigned = false;
+
+                    @Override
+                    public void addReader(int subtaskId) {
+                        if (!assigned) {
+                            context.assignSplit(TestSplit.INSTANCE, subtaskId);
+                            assigned = true;
+                        }
+                        context.signalNoMoreSplits(subtaskId);
+                    }
+                };
+            }
+        };
     }
 }


### PR DESCRIPTION
### What is the purpose of the change

This PR migrates the following test cases to Source/Sink V2:

  - StreamTaskFinalCheckpointsTest
  - StreamTaskSystemExitTest 
  - StreamSourceOperatorWatermarksTest
  - RestoreUpgradedJobITCase
  - BufferTimeoutITCase
  - SideOutputITCase
  - NotifyCheckpointAbortedITCase
  - JobManagerMetricsITCase
  - CheckpointStoreITCase


### Brief change log

  - StreamTaskFinalCheckpointsTest : Removed redundant createImmediatelyFinishingSource() method and replaced its usage with a static ImmediatelyFinishingSource class that uses AbstractTestSource's default END_OF_INPUT behavior.
  - StreamTaskSystemExitTest : Replaced legacy SourceFunction with Source V2 implementation using AbstractTestSource
  - StreamSourceOperatorWatermarksTest - Migrated tests from legacy SourceFunction-based StreamSource to Source V2 using SourceOperatorFactory and SourceOperatorStreamTask. Implemented finite/infinite AbstractTestSource variants, WatermarkStrategy.noWatermarks, simple enumerator, and updated assertions for reader and framework MAX_WM emission.
  - RestoreUpgradedJobITCase - The legacy TestSource (with subclasses IntSource and StringSource) was migrated to Source V2 implementations: IntSourceV2 and StringSourceV2, along with sink v2.
  - BufferTimeoutITCase - Replaced addSource(emitUntil(...)) with fromSource(createSingleElementIdleSource(), ...) and addSink(new CollectSink(...)) with sinkTo(createResultCollectingSink(...)) using static factory methods.
  - SideOutputITCase -Replaced legacy addSource(new SourceFunction...) with fromSource(createTimestampedWatermarkSource(), ...) and added createTimestampedWatermarkSource() static factory method in testWatermarkForwarding().
  - NotifyCheckpointAbortedITCase - Replaced addSource(new NormalSource()) with fromSource(new NormalSource(), WatermarkStrategy.noWatermarks(), "NormalSource") and converted NormalSource to extend AbstractTestSource.
  - JobManagerMetricsITCase - Replaced addSource(new SourceFunction...) with fromSource(new BlockingSource(), WatermarkStrategy.noWatermarks(), "BlockingSourceV2") and addSink(new PrintSinkFunction()) with sinkTo(new PrintSink<>()).
  - CheckpointStoreITCase - Replaced addSource(emitUntil(...)) with fromSource(new EmitUntilSource(...), WatermarkStrategy.noWatermarks(), "EmitUntilSourceV2") and removed the emitUntil() method.

### Verifying this change

 - All test cases run.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with @Public(Evolving): no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

  ### Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

Stacked PR – depends on #26910

This PR is part of the FLINK-32695 migration effort.

- Parent PR: #26910 (introduces Common Source Test Utils)
- Current PR: Migrates common test cases to use those utils
