### PR TITLE
[FLINK-38131][flink-runtime] fix that JM still redistributes broadcas…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/RoundRobinOperatorStateRepartitioner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/RoundRobinOperatorStateRepartitioner.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.OperatorStreamStateHandle;
@@ -488,13 +489,16 @@ public class RoundRobinOperatorStateRepartitioner
         }
     }
 
-    private static final class StateEntry {
+    @VisibleForTesting
+    static final class StateEntry {
         final List<Tuple2<StreamStateHandle, OperatorStateHandle.StateMetaInfo>> entries;
         final BitSet reportedSubtaskIndices;
+        final int parallelism;
 
         public StateEntry(int estimatedEntrySize, int parallelism) {
             this.entries = new ArrayList<>(estimatedEntrySize);
             this.reportedSubtaskIndices = new BitSet(parallelism);
+            this.parallelism = parallelism;
         }
 
         void addEntry(
@@ -506,7 +510,7 @@ public class RoundRobinOperatorStateRepartitioner
 
         boolean isPartiallyReported() {
             return reportedSubtaskIndices.cardinality() > 0
-                    && reportedSubtaskIndices.cardinality() < reportedSubtaskIndices.size();
+                    && reportedSubtaskIndices.cardinality() < parallelism;
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperationTest.java
@@ -47,6 +47,7 @@ import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.testutils.executor.TestExecutorExtension;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -160,6 +161,23 @@ class StateAssignmentOperationTest {
                 1, OperatorSubtaskState.builder().setManagedOperatorState(osh2).build());
 
         verifyOneKindPartitionableStateRescale(operatorState, operatorID);
+    }
+
+    @Test
+    public void testPartiallyReported() {
+        RoundRobinOperatorStateRepartitioner.StateEntry stateEntry =
+                new RoundRobinOperatorStateRepartitioner.StateEntry(0, 5);
+        stateEntry.addEntry(0, null);
+        stateEntry.addEntry(1, null);
+        stateEntry.addEntry(3, null);
+
+        // assert partially report
+        Assertions.assertTrue(stateEntry.isPartiallyReported());
+
+        // assert fully report
+        stateEntry.addEntry(2, null);
+        stateEntry.addEntry(4, null);
+        Assertions.assertFalse(stateEntry.isPartiallyReported());
     }
 
     @Test


### PR DESCRIPTION
…t state when all subtask have reported their states.

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

fix that JM still redistributes broadcast state when all subtask have reported their states.

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

Fixed the logic of judging whether a Broadcast state is partially reported.

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

added new UT for testing partially reported logic.
org.apache.flink.runtime.checkpoint.StateAssignmentOperationTest#testPartiallyReported

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

The correctness of broad cast state repartition is covered by existing tests, such as:

1. org.apache.flink.runtime.checkpoint.StateAssignmentOperationTest#testRepartitionBroadcastState
2. org.apache.flink.runtime.checkpoint.StateAssignmentOperationTest#testRepartitionBroadcastStateWithNullSubtaskState
3. org.apache.flink.runtime.checkpoint.StateAssignmentOperationTest#testRepartitionBroadcastStateWithEmptySubtaskState

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
