### PR TITLE
[FLINK-38257][SQL] Add module dynamic function loading possibility

### DIFF
--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/table/SavepointMetadataTableFunction.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/table/SavepointMetadataTableFunction.java
@@ -24,9 +24,14 @@ import org.apache.flink.runtime.checkpoint.metadata.CheckpointMetadata;
 import org.apache.flink.state.api.runtime.SavepointLoader;
 import org.apache.flink.table.annotation.DataTypeHint;
 import org.apache.flink.table.annotation.FunctionHint;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.functions.BuiltInFunctionDefinition;
 import org.apache.flink.table.functions.SpecializedFunction;
 import org.apache.flink.table.functions.TableFunction;
+import org.apache.flink.table.types.inference.TypeStrategies;
 import org.apache.flink.types.Row;
+
+import static org.apache.flink.table.functions.FunctionKind.TABLE;
 
 @Internal
 @FunctionHint(
@@ -41,6 +46,40 @@ import org.apache.flink.types.Row;
                                 + "operator-coordinator-state-size-in-bytes BIGINT NOT NULL, "
                                 + "operator-total-size-in-bytes BIGINT NOT NULL>"))
 public class SavepointMetadataTableFunction extends TableFunction<Row> {
+
+    public static final BuiltInFunctionDefinition SAVEPOINT_METADATA =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("savepoint_metadata")
+                    .kind(TABLE)
+                    .runtimeClass(SavepointMetadataTableFunction.class.getName())
+                    .outputTypeStrategy(
+                            TypeStrategies.explicit(
+                                    DataTypes.ROW(
+                                            DataTypes.FIELD(
+                                                    "checkpoint-id", DataTypes.BIGINT().notNull()),
+                                            DataTypes.FIELD("operator-name", DataTypes.STRING()),
+                                            DataTypes.FIELD("operator-uid", DataTypes.STRING()),
+                                            DataTypes.FIELD(
+                                                    "operator-uid-hash",
+                                                    DataTypes.STRING().notNull()),
+                                            DataTypes.FIELD(
+                                                    "operator-parallelism",
+                                                    DataTypes.INT().notNull()),
+                                            DataTypes.FIELD(
+                                                    "operator-max-parallelism",
+                                                    DataTypes.INT().notNull()),
+                                            DataTypes.FIELD(
+                                                    "operator-subtask-state-count",
+                                                    DataTypes.INT().notNull()),
+                                            DataTypes.FIELD(
+                                                    "operator-coordinator-state-size-in-bytes",
+                                                    DataTypes.BIGINT().notNull()),
+                                            DataTypes.FIELD(
+                                                    "operator-total-size-in-bytes",
+                                                    DataTypes.BIGINT().notNull()))))
+                    .notDeterministic()
+                    .build();
+
     public SavepointMetadataTableFunction(SpecializedFunction.SpecializedContext context) {}
 
     public void eval(String savepointPath) {

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/table/module/ExampleDynamicBuiltInFunctionDefinitionFactory.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/table/module/ExampleDynamicBuiltInFunctionDefinitionFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.table.module;
+
+import org.apache.flink.table.functions.BuiltInFunctionDefinition;
+import org.apache.flink.table.functions.DynamicBuiltInFunctionDefinitionFactory;
+
+import java.util.List;
+
+public class ExampleDynamicBuiltInFunctionDefinitionFactory
+        implements DynamicBuiltInFunctionDefinitionFactory {
+    @Override
+    public String factoryIdentifier() {
+        return StateModule.IDENTIFIER + ".example_function_factory";
+    }
+
+    @Override
+    public List<BuiltInFunctionDefinition> getBuiltInFunctionDefinitions() {
+        return List.of(ExampleDynamicTableFunction.FUNCTION_DEFINITION);
+    }
+}

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/table/module/ExampleDynamicTableFunction.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/table/module/ExampleDynamicTableFunction.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.table.module;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.annotation.DataTypeHint;
+import org.apache.flink.table.annotation.FunctionHint;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.functions.BuiltInFunctionDefinition;
+import org.apache.flink.table.functions.SpecializedFunction;
+import org.apache.flink.table.functions.TableFunction;
+import org.apache.flink.table.types.inference.TypeStrategies;
+import org.apache.flink.types.Row;
+
+import static org.apache.flink.table.functions.FunctionKind.TABLE;
+
+@Internal
+@FunctionHint(output = @DataTypeHint("ROW<my-column STRING NOT NULL>"))
+public class ExampleDynamicTableFunction extends TableFunction<Row> {
+
+    public static final BuiltInFunctionDefinition FUNCTION_DEFINITION =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("example_dynamic_table_function")
+                    .kind(TABLE)
+                    .runtimeClass(ExampleDynamicTableFunction.class.getName())
+                    .outputTypeStrategy(
+                            TypeStrategies.explicit(
+                                    DataTypes.ROW(
+                                            DataTypes.FIELD(
+                                                    "my-column", DataTypes.STRING().notNull()))))
+                    .build();
+
+    public ExampleDynamicTableFunction(SpecializedFunction.SpecializedContext context) {}
+
+    public void eval() {
+        Row row = Row.withNames();
+        row.setField("my-column", "my-value");
+        collect(row);
+    }
+}

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/table/module/StateModuleTest.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/table/module/StateModuleTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.table.module;
+
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.types.Row;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Iterator;
+import java.util.List;
+
+import static org.apache.flink.configuration.ExecutionOptions.RUNTIME_MODE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Unit tests for the savepoint SQL reader. */
+public class StateModuleTest {
+    @Test
+    public void testDynamicBuiltinFunctionShouldBeLoaded() throws Exception {
+        Configuration config = new Configuration();
+        config.set(RUNTIME_MODE, RuntimeExecutionMode.BATCH);
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment(config);
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+
+        tEnv.executeSql("LOAD MODULE state");
+        Table table = tEnv.sqlQuery("SELECT * FROM example_dynamic_table_function()");
+        List<Row> result = tEnv.toDataStream(table).executeAndCollect(100);
+
+        assertThat(result.size()).isEqualTo(1);
+        Iterator<Row> it = result.iterator();
+        assertThat(it.next().toString()).isEqualTo("+I[my-value]");
+    }
+
+    @Test
+    public void testMultipleFunctionsWithSameNameShouldThrow() {
+        assertThatThrownBy(
+                        () ->
+                                StateModule.checkDuplicatedFunctions(
+                                        List.of(
+                                                ExampleDynamicTableFunction.FUNCTION_DEFINITION,
+                                                ExampleDynamicTableFunction.FUNCTION_DEFINITION)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Duplicate function names found: example_dynamic_table_function");
+    }
+}

--- a/flink-libraries/flink-state-processing-api/src/test/resources/META-INF/services/org.apache.flink.table.functions.DynamicBuiltInFunctionDefinitionFactory
+++ b/flink-libraries/flink-state-processing-api/src/test/resources/META-INF/services/org.apache.flink.table.functions.DynamicBuiltInFunctionDefinitionFactory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.state.table.module.ExampleDynamicBuiltInFunctionDefinitionFactory

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/DynamicBuiltInFunctionDefinitionFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/DynamicBuiltInFunctionDefinitionFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions;
+
+import org.apache.flink.annotation.Experimental;
+
+import java.util.List;
+
+/**
+ * {@link BuiltInFunctionDefinition} factory for dynamic function registration. This could be useful
+ * when functions wanted to be automatically loaded from SQL modules. A good example usage is that
+ * state processor API SQL module is providing extra table functions from Kafka connector.
+ */
+@Experimental
+public interface DynamicBuiltInFunctionDefinitionFactory {
+    /**
+     * Returns the unique identifier of the factory. The suggested pattern is the following:
+     * [module-name].[factory-name]. Such case modules can load all [module-name] prefixed functions
+     * which belong to them.
+     */
+    String factoryIdentifier();
+
+    /** Returns list of {@link BuiltInFunctionDefinition} which can be registered dynamically. */
+    List<BuiltInFunctionDefinition> getBuiltInFunctionDefinitions();
+}


### PR DESCRIPTION
## What is the purpose of the change

Modules like the state processor API could add SQL functions which are coming from external connectors like Kafka, Iceberg, etc... It would be good to add a generic way to add such methods. The intended end-user interaction would look like the following:

- Add Kafka connector jar to the classpath
- `LOAD MODULE state`
- `SELECT * FROM get_kafka_offsets(...)`

In this PR I've added purely the possibility to load SQL functions with service loader.

## Brief change log

Added module dynamic function loading possibility.

## Verifying this change

Added new automated test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not applicable
