### PR TITLE
[FLINK-38267][checkpoint] Fix the test timeout for UnalignedCheckpointRescaleWithMixedExchangesITCase.testRescaleFromUnalignedCheckpoint

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointRescaleWithMixedExchangesITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointRescaleWithMixedExchangesITCase.java
@@ -230,7 +230,7 @@ public class UnalignedCheckpointRescaleWithMixedExchangesITCase extends TestLogg
 
         sourceStream1
                 .rebalance()
-                .connect(forwardedStream)
+                .connect(forwardedStream.rebalance())
                 .map(new SleepingCoMap())
                 .name("Co-Map")
                 .setParallelism(getRandomParallelism());
@@ -307,7 +307,7 @@ public class UnalignedCheckpointRescaleWithMixedExchangesITCase extends TestLogg
         DataStream<Long> multiInputMap =
                 sourceStream1
                         .rebalance()
-                        .connect(forwardedStream)
+                        .connect(forwardedStream.rebalance())
                         .map(new SleepingCoMap())
                         .name("Co-Map")
                         .setParallelism(getRandomParallelism());


### PR DESCRIPTION
A fix for test failure of https://github.com/apache/flink/pull/26931

## What is the purpose of the change

When one task has multiple inputs, and the unaligned checkpoint will be disabled for all inputs once one input exchange does not support unaligned checkpoint. It caused no inflight buffers, but `UnalignedCheckpointRescaleWithMixedExchangesITCase.testRescaleFromUnalignedCheckpoint` always wait for checkpoint with inflight buffers.

Explicitly specifying rebalance can avoid the forward exchange.

See more from https://github.com/apache/flink/pull/26935#issuecomment-3220787873

## Brief change log

[FLINK-38267][checkpoint] Fix the test timeout for UnalignedCheckpointRescaleWithMixedExchangesITCase.testRescaleFromUnalignedCheckpoint

Explicitly specifying rebalance can avoid the forward exchange.



## Verifying this change

- Change UnalignedCheckpointRescaleWithMixedExchangesITCase.testRescaleFromUnalignedCheckpoint
- And run UnalignedCheckpointRescaleWithMixedExchangesITCase more than 100 times locally

