### PR TITLE
[FLINK-38286][table] Fix: MAP function with duplicate keys produces non-deterministic results

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
@@ -802,4 +802,19 @@ object GenerateUtils {
     compares.mkString
   }
 
+  /**
+   * Groups the input sequence by the key function, and keeps the order of the first appearance of
+   * each key.
+   */
+  def groupByOrdered[A, K](xs: collection.Seq[A])(
+      f: A => K): collection.Seq[(K, collection.Seq[A])] = {
+    val m = collection.mutable.LinkedHashMap.empty[K, collection.mutable.ArrayBuffer[A]]
+    xs.foreach {
+      x =>
+        val k = f(x)
+        m.getOrElseUpdate(k, collection.mutable.ArrayBuffer.empty[A]) += x
+    }
+    m.toSeq.map { case (k, buffer) => (k, buffer) }
+  }
+
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -1510,28 +1510,23 @@ object ScalarOperatorGens {
     val mapType = resultType.asInstanceOf[MapType]
     val baseMap = newName(ctx, "map")
 
-    // prepare map key array
-    val keyElements = elements
+    val keyValues = elements
       .grouped(2)
       .map { case Seq(key, value) => (key, value) }
       .toSeq
-      .groupBy(_._1)
-      .map(_._2.last)
-      .keys
-      .toSeq
+
+    val deduplicatedKeyValues = groupByOrdered(keyValues)(_._1).map {
+      case (_, pairs) =>
+        pairs.last // Take the last occurrence
+    }
+    // prepare map key array
+    val keyElements = deduplicatedKeyValues.map(_._1)
     val keyType = mapType.getKeyType
     val keyExpr = generateArray(ctx, new ArrayType(keyType), keyElements)
     val isKeyFixLength = isPrimitive(keyType)
 
     // prepare map value array
-    val valueElements = elements
-      .grouped(2)
-      .map { case Seq(key, value) => (key, value) }
-      .toSeq
-      .groupBy(_._1)
-      .map(_._2.last)
-      .values
-      .toSeq
+    val valueElements = deduplicatedKeyValues.map(_._2)
     val valueType = mapType.getValueType
     val valueExpr = generateArray(ctx, new ArrayType(valueType), valueElements)
     val isValueFixLength = isPrimitive(valueType)

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/MapFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/MapFunctionITCase.java
@@ -98,8 +98,15 @@ public class MapFunctionITCase extends BuiltInFunctionTestBase {
                                 BOOLEAN().notNull())
                         .testResult(
                                 resultSpec(
+                                        map(
+                                                1, 1, 1, 2, 1, 9, 1, 3, 2, 24, 2, 29, 1, 0, 2, 22,
+                                                1, 8, 2, 25, 2, 20),
+                                        "MAP[1, 1, 1, 2, 1, 9, 1, 3, 2, 24, 2, 29, 1, 0, 2, 22, 1, 8, 2, 25, 2, 20]",
+                                        Map.ofEntries(Map.entry(1, 8), Map.entry(2, 20)),
+                                        DataTypes.MAP(INT().notNull(), INT().notNull()).notNull()),
+                                resultSpec(
                                         map($("f0"), $("f0"), $("f0"), $("f1")),
-                                        "MAP[f0, f1]",
+                                        "MAP[f0, f0, f0, f1]",
                                         Collections.singletonMap(1, 2),
                                         DataTypes.MAP(INT().notNull(), INT().notNull()).notNull()),
                                 resultSpec(


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes non-deterministic behavior in the MAP function when duplicate keys are provided. The MAP function was producing inconsistent results across different environments and test runs, causing CI failures and breaking reproducibility guarantees.

The root cause was in the code generation logic in `ScalarOperatorGens.scala`, where `groupBy` was used to deduplicate keys, but the subsequent `.keys` and `.values` extraction had non-deterministic iteration order, breaking the correspondence between key and value arrays in the generated code.

## Brief change log

- Added `groupByOrdered` utility method in `GenerateUtils` that uses `LinkedHashMap` to preserve insertion order during grouping operations
- Updated MAP function code generation in `ScalarOperatorGens.scala` to use deterministic order-preserving deduplication instead of non-deterministic `groupBy`
- Ensured "last value wins" semantics for duplicate keys by taking the last occurrence in argument order
- Fixed key-value array correspondence in generated code to prevent mismatched entries

## Verifying this change

This change is already covered by existing tests, such as:

- **MapFunctionITCase.test()** - Contains the specific failing test case `map(f0, f0, f0, f1)` that was producing non-deterministic results
- The fix makes the previously flaky test `MAP[1, 1, 1, 2] → {1=2}` consistently pass
- All existing MAP function tests continue to pass with deterministic behavior
- Manual verification shows consistent results across multiple test runs and environments

The change specifically addresses test failures that occurred when constant folding was disabled, ensuring both code paths (optimized and runtime) produce consistent results.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): **no**
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
- The serializers: **no**
- The runtime per-record code paths (performance sensitive): **yes** - affects MAP function code generation, but with minimal performance impact (same O(n) complexity)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
- The S3 file system connector: **no**

## Documentation

- Does this pull request introduce a new feature? **no**
- If yes, how is the feature documented? **not applicable** - this is a bug fix that