### PR TITLE
[FLINK-38291][REST] Reduce thread lock overhead for REST handlers

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/SubtaskCurrentAttemptDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/SubtaskCurrentAttemptDetailsHandler.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.rest.handler.HandlerRequest;
 import org.apache.flink.runtime.rest.handler.RestHandlerException;
 import org.apache.flink.runtime.rest.handler.legacy.ExecutionGraphCache;
 import org.apache.flink.runtime.rest.handler.legacy.metrics.MetricFetcher;
+import org.apache.flink.runtime.rest.handler.legacy.metrics.MetricStore;
 import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
 import org.apache.flink.runtime.rest.messages.JobVertexIdPathParameter;
@@ -87,18 +88,20 @@ public class SubtaskCurrentAttemptDetailsHandler
         final Collection<AccessExecution> attempts = executionVertex.getCurrentExecutions();
         List<SubtaskExecutionAttemptDetailsInfo> otherConcurrentAttempts = null;
 
+        metricFetcher.update();
+        MetricStore.JobMetricStoreSnapshot jobMetrics = metricFetcher.getMetricStore().getJobs();
         if (attempts.size() > 1) {
             otherConcurrentAttempts = new ArrayList<>();
             for (AccessExecution attempt : attempts) {
                 if (attempt.getAttemptNumber() != execution.getAttemptNumber()) {
                     otherConcurrentAttempts.add(
                             SubtaskExecutionAttemptDetailsInfo.create(
-                                    attempt, metricFetcher, jobID, jobVertexID, null));
+                                    attempt, jobMetrics, jobID, jobVertexID, null));
                 }
             }
         }
 
         return SubtaskExecutionAttemptDetailsInfo.create(
-                execution, metricFetcher, jobID, jobVertexID, otherConcurrentAttempts);
+                execution, jobMetrics, jobID, jobVertexID, otherConcurrentAttempts);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptDetailsHandler.java
@@ -101,8 +101,9 @@ public class SubtaskExecutionAttemptDetailsHandler
         final JobID jobID = request.getPathParameter(JobIDPathParameter.class);
         final JobVertexID jobVertexID = request.getPathParameter(JobVertexIdPathParameter.class);
 
+        metricFetcher.update();
         return SubtaskExecutionAttemptDetailsInfo.create(
-                execution, metricFetcher, jobID, jobVertexID, null);
+                execution, metricFetcher.getMetricStore().getJobs(), jobID, jobVertexID, null);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/metrics/AggregatingSubtasksMetricsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/metrics/AggregatingSubtasksMetricsHandler.java
@@ -76,6 +76,7 @@ public class AggregatingSubtasksMetricsHandler
         JobID jobID = request.getPathParameter(JobIDPathParameter.class);
         JobVertexID taskID = request.getPathParameter(JobVertexIdPathParameter.class);
 
+        MetricStore.JobMetricStoreSnapshot jobMetrics = store.getJobs();
         Collection<String> subtaskRanges =
                 request.getQueryParameter(SubtasksFilterQueryParameter.class);
         if (subtaskRanges.isEmpty()) {
@@ -91,7 +92,8 @@ public class AggregatingSubtasksMetricsHandler
             Collection<MetricStore.ComponentMetricStore> subtaskStores = new ArrayList<>(8);
             for (int subtask : subtasks) {
                 MetricStore.ComponentMetricStore subtaskMetricStore =
-                        store.getSubtaskMetricStore(jobID.toString(), taskID.toString(), subtask);
+                        jobMetrics.getSubtaskMetricStore(
+                                jobID.toString(), taskID.toString(), subtask);
                 if (subtaskMetricStore != null) {
                     subtaskStores.add(subtaskMetricStore);
                 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/metrics/SubtaskMetricsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/metrics/SubtaskMetricsHandler.java
@@ -40,7 +40,7 @@ import java.util.Map;
 /**
  * Handler that returns subtask metrics.
  *
- * @see MetricStore#getSubtaskMetricStore(String, String, int)
+ * @see MetricStore.JobMetricStoreSnapshot#getSubtaskMetricStore (String, String, int)
  */
 public class SubtaskMetricsHandler extends AbstractMetricsHandler<SubtaskMetricsMessageParameters> {
 
@@ -67,7 +67,8 @@ public class SubtaskMetricsHandler extends AbstractMetricsHandler<SubtaskMetrics
         final JobVertexID vertexId = request.getPathParameter(JobVertexIdPathParameter.class);
         final int subtaskIndex = request.getPathParameter(SubtaskIndexPathParameter.class);
 
-        return metricStore.getSubtaskMetricStore(
-                jobId.toString(), vertexId.toString(), subtaskIndex);
+        return metricStore
+                .getJobs()
+                .getSubtaskMetricStore(jobId.toString(), vertexId.toString(), subtaskIndex);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/SubtaskExecutionAttemptDetailsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/SubtaskExecutionAttemptDetailsInfo.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.AccessExecution;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
-import org.apache.flink.runtime.rest.handler.legacy.metrics.MetricFetcher;
+import org.apache.flink.runtime.rest.handler.legacy.metrics.MetricStore;
 import org.apache.flink.runtime.rest.handler.util.MutableIOMetrics;
 import org.apache.flink.runtime.rest.messages.ResponseBody;
 import org.apache.flink.runtime.rest.messages.job.metrics.IOMetricsInfo;
@@ -195,7 +195,7 @@ public class SubtaskExecutionAttemptDetailsInfo implements ResponseBody {
 
     public static SubtaskExecutionAttemptDetailsInfo create(
             AccessExecution execution,
-            @Nullable MetricFetcher metricFetcher,
+            @Nullable MetricStore.JobMetricStoreSnapshot jobMetrics,
             JobID jobID,
             JobVertexID jobVertexID,
             @Nullable List<SubtaskExecutionAttemptDetailsInfo> otherConcurrentAttempts) {
@@ -215,7 +215,7 @@ public class SubtaskExecutionAttemptDetailsInfo implements ResponseBody {
         final long duration = startTime > 0 ? ((endTime > 0 ? endTime : now) - startTime) : -1;
 
         final MutableIOMetrics ioMetrics = new MutableIOMetrics();
-        ioMetrics.addIOMetrics(execution, metricFetcher, jobID.toString(), jobVertexID.toString());
+        ioMetrics.addIOMetrics(execution, jobMetrics, jobID.toString(), jobVertexID.toString());
 
         final IOMetricsInfo ioMetricsInfo =
                 new IOMetricsInfo(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/metrics/MetricStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/metrics/MetricStoreTest.java
@@ -50,7 +50,7 @@ class MetricStoreTest {
     @Test
     void testAdd() {
         MetricStore store = setupStore(new MetricStore());
-
+        MetricStore.JobMetricStoreSnapshot jobMetrics = store.getJobs();
         assertThat(store.getJobManagerMetricStore().getMetric("abc.metric1", "-1")).isEqualTo("0");
         assertThat(store.getTaskManagerMetricStore("tmid").getMetric("abc.metric2", "-1"))
                 .isEqualTo("1");
@@ -64,15 +64,18 @@ class MetricStoreTest {
                                 .getMetric("8.abc.metric5", "-1"))
                 .isEqualTo("14");
         assertThat(
-                        store.getSubtaskMetricStore(JOB_ID.toString(), "taskid", 8)
+                        jobMetrics
+                                .getSubtaskMetricStore(JOB_ID.toString(), "taskid", 8)
                                 .getMetric("abc.metric5", "-1"))
                 .isEqualTo("14");
         assertThat(
-                        store.getSubtaskAttemptMetricStore(JOB_ID.toString(), "taskid", 8, 1)
+                        jobMetrics
+                                .getSubtaskAttemptMetricStore(JOB_ID.toString(), "taskid", 8, 1)
                                 .getMetric("abc.metric5", "-1"))
                 .isEqualTo("4");
         assertThat(
-                        store.getSubtaskAttemptMetricStore(JOB_ID.toString(), "taskid", 8, 2)
+                        jobMetrics
+                                .getSubtaskAttemptMetricStore(JOB_ID.toString(), "taskid", 8, 2)
                                 .getMetric("abc.metric5", "-1"))
                 .isEqualTo("14");
 
@@ -89,20 +92,25 @@ class MetricStoreTest {
                                 .getMetric("1.opname.abc.metric7", "-1"))
                 .isEqualTo("6");
         assertThat(
-                        store.getSubtaskMetricStore(JOB_ID.toString(), "taskid", 1)
+                        jobMetrics
+                                .getSubtaskMetricStore(JOB_ID.toString(), "taskid", 1)
                                 .getMetric("opname.abc.metric7", "-1"))
                 .isEqualTo("6");
-        assertThat(store.getSubtaskAttemptMetricStore(JOB_ID.toString(), "taskid", 1, 2)).isNull();
+        assertThat(jobMetrics.getSubtaskAttemptMetricStore(JOB_ID.toString(), "taskid", 1, 2))
+                .isNull();
         assertThat(
-                        store.getSubtaskAttemptMetricStore(JOB_ID.toString(), "taskid", 1, 3)
+                        jobMetrics
+                                .getSubtaskAttemptMetricStore(JOB_ID.toString(), "taskid", 1, 3)
                                 .getMetric("opname.abc.metric7", "-1"))
                 .isEqualTo("6");
         assertThat(
-                        store.getSubtaskAttemptMetricStore(JOB_ID.toString(), "taskid", 8, 2)
+                        jobMetrics
+                                .getSubtaskAttemptMetricStore(JOB_ID.toString(), "taskid", 8, 2)
                                 .getMetric("opname.abc.metric7", "-1"))
                 .isEqualTo("6");
         assertThat(
-                        store.getSubtaskAttemptMetricStore(JOB_ID.toString(), "taskid", 8, 4)
+                        jobMetrics
+                                .getSubtaskAttemptMetricStore(JOB_ID.toString(), "taskid", 8, 4)
                                 .getMetric("opname.abc.metric7", "-1"))
                 .isEqualTo("16");
 
@@ -135,13 +143,13 @@ class MetricStoreTest {
         // -----verify that no side effects occur
         assertThat(store.getJobManagerMetricStore().metrics).isEmpty();
         assertThat(store.getTaskManagers()).isEmpty();
-        assertThat(store.getJobs()).isEmpty();
+        assertThat(store.getJobs().values()).isEmpty();
     }
 
     @Test
     void testUpdateCurrentExecutionAttemptsWithNonExistentComponentMetricStore() {
         MetricStore metricStore = new MetricStore();
-        assertThat(metricStore.getJobs()).isEmpty();
+        assertThat(metricStore.getJobs().values()).isEmpty();
 
         JobDetails jobDetail =
                 new JobDetails(


### PR DESCRIPTION
## What is the purpose of the change

This PR optimizes the latency of Flink REST handlers used to generate the DAG in Flink UI.

In the current implementation, REST handlers like `JobDetailsHandler` would iterate through all vertexes of a job, and invoke `MetricStore#getSubtaskAttemptMetricStore` during each iteration. Given that this is a synchronized method, invocations to this method could possibly be blocked until other threads finished invoking other synchronized methods. This blocking overhead is accumulated with the for loop, resulting in high latency  when Flink UI tries to render the status of a Flink job through `JobDetailsHandler`.

In order to solve this problem, this PR proposes to reduce the number of synchronized invocations in REST handlers. A snapshot of the MetricStore jobs is acquired for each handler (and the synchronization overhead is accumulated only once here), and the snapshot is then reused in the for loops. The snapshot is read only so it needs not be synchronized.

As for benchmark results, we manually measured the latency for the Flink UI to display the DAG of a sophisticated Flink job in our company. Before optimization, the Flink UI needs more than 1 minute to finish the display. After the optimization, the latency decreased to less than 10 seconds.

## Brief change log

- Introduce MetricStore.MetricStoreJobs to manage a snapshot of all jobs in the MetricStore. Compared with original implementation to operate on MetricStore jobs, the new implementation does not need synchronized keywords on the methods.

## Verifying this change

The correctness of this PR is covered by existing tests, such as JobDetailsHandlerTest and MetricStoreTest.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
