### PR TITLE
FLINK-32695 Migrated SavepointReaderITTestBase to SourceV2.

### DIFF
--- a/flink-libraries/flink-state-processing-api/pom.xml
+++ b/flink-libraries/flink-state-processing-api/pom.xml
@@ -114,6 +114,13 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils-connector</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
## What is the purpose of the change

This PR migrates all legacy SourceFunction in SavepointReaderITTestBase to Source V2 API


## Brief change log

- Migrated SavepointSource to Source V2.

## Verifying this change

All child classes the test pass.
(SavepointReaderCustomSerializerITCase, SavepointReaderITCase, SavepointReaderUidHashITCase)

## Does this pull request potentially affect one of the following parts:

 - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
