### PR TITLE
[hotfix] Use `simplifiedCondition` to check for `isAlwaysTrue` in `PushCalcPastChangelogNormalizeRule`

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/PushCalcPastChangelogNormalizeRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/PushCalcPastChangelogNormalizeRule.java
@@ -328,7 +328,7 @@ public class PushCalcPastChangelogNormalizeRule
             final RexNode condition = relBuilder.and(conditions);
             final RexNode simplifiedCondition =
                     FlinkRexUtil.simplify(relBuilder.getRexBuilder(), condition, rexExecutor);
-            if (!condition.isAlwaysTrue()) {
+            if (!simplifiedCondition.isAlwaysTrue()) {
                 programBuilder.addCondition(adjustInputRef(simplifiedCondition, inputRefMapping));
             }
         }


### PR DESCRIPTION

## What is the purpose of the change
This is a small follow up for the commit https://github.com/apache/flink/commit/aa97d86c1ed252d92c3cc4e31718d42b50408f64

## Verifying this change
covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
