### PR TITLE
[FLINK-38321][table] Optimize the timer registration logic in window e…

### DIFF
--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/window/groupwindow/triggers/ProcessingTimeTriggers.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/window/groupwindow/triggers/ProcessingTimeTriggers.java
@@ -109,10 +109,7 @@ public class ProcessingTimeTriggers {
             ReducingState<Long> nextFiring = ctx.getPartitionedState(nextFiringStateDesc);
             Long timer = nextFiring.get();
             if (timer != null && timer == time) {
-                long newTimer = time + interval;
-                ctx.registerProcessingTimeTimer(newTimer);
                 nextFiring.clear();
-                nextFiring.add(newTimer);
                 return true;
             } else {
                 return false;


### PR DESCRIPTION
## What is the purpose of the change

Optimize the timer registration logic in window early/late firing scenarios. For keys that will not receive subsequent data, it is unnecessary to repeatedly register processing timers, thereby reducing the number of timers and state access to improve performance.

## Verifying this change

**org.apache.flink.table.runtime.operators.window.groupwindow.operator.WindowOperatorTest#testEventTimeTumblingWindowsWithEarlyFiring
org.apache.flink.table.runtime.operators.window.groupwindow.operator.WindowOperatorTest#testEventTimeTumblingWindowsWithEarlyAndLateFirings**


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
