### PR TITLE
[FLINK-38328][GithubAction] Remove redundant label mutations in Flink community review Github action script

### DIFF
--- a/.github/workflows/community-review.sh
+++ b/.github/workflows/community-review.sh
@@ -237,8 +237,10 @@ process_pr_reviews() {
     existing_labels=$(call_github_get_labels_api "$pr_number")
 
     if [[ ! "$existing_labels" =~ (^|[[:space:]])"$label_to_post"($|[[:space:]]) ]]; then
-      call_github_mutate_label_api "$token" "$label_to_delete" "DELETE" "$pr_number" || exit
       call_github_mutate_label_api "$token" "$label_to_post" "POST" "$pr_number" || exit
+    fi
+    if [[ "$existing_labels" =~ (^|[[:space:]])"$label_to_delete"($|[[:space:]]) ]]; then
+      call_github_mutate_label_api "$token" "$label_to_delete" "DELETE" "$pr_number" || exit
     fi
   fi
 }


### PR DESCRIPTION
## What is the purpose of the change

Remove redundant label mutations. Only add labels when there is not one. Only delete labels if there is one to delete. 
## Brief change log
Changed the shell script in the github action

I suspect the message we see relating the the bot adding a removing the same label - is accurately logging an add and remove but the log message inserts are not correct. With this change there should mostly be only and add or remove and rarely both. 

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

I manually verified the logic locally. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector:  no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
