### PR TITLE
fix(backporting): fix on commiter operator

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperator.java
@@ -180,7 +180,12 @@ class CommitterOperator<CommT> extends AbstractStreamOperator<CommittableMessage
 
     private void emit(CheckpointCommittableManager<CommT> committableManager) {
         int subtaskId = getRuntimeContext().getTaskInfo().getIndexOfThisSubtask();
-        int numberOfSubtasks = getRuntimeContext().getTaskInfo().getNumberOfParallelSubtasks();
+        // Ensure that numberOfSubtasks is in sync with the number of actually emitted
+        // CommittableSummaries during upscaling recovery (see FLINK-37747).
+        int numberOfSubtasks =
+                Math.min(
+                        getRuntimeContext().getTaskInfo().getNumberOfParallelSubtasks(),
+                        committableManager.getNumberOfSubtasks());
         long checkpointId = committableManager.getCheckpointId();
         Collection<CommT> committables = committableManager.getSuccessfulCommittables();
         output.collect(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/SinkV2CommitterOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/SinkV2CommitterOperatorTest.java
@@ -20,6 +20,25 @@ package org.apache.flink.streaming.runtime.operators.sink;
 
 import org.apache.flink.api.connector.sink2.SupportsCommitter;
 
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
+
+import org.apache.flink.streaming.api.connector.sink2.CommittableSummary;
+import org.apache.flink.streaming.api.connector.sink2.CommittableSummaryAssert;
+import org.apache.flink.streaming.api.connector.sink2.CommittableWithLineage;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+
+import org.assertj.core.api.ListAssert;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.apache.flink.streaming.api.connector.sink2.SinkV2Assertions.committableSummary;
+import static org.apache.flink.streaming.api.connector.sink2.SinkV2Assertions.committableWithLineage;
+import static org.assertj.core.api.Assertions.as;
+import static org.assertj.core.api.Assertions.assertThat;
+
+
 import java.util.Collection;
 
 class SinkV2CommitterOperatorTest extends CommitterOperatorTestBase {
@@ -58,6 +77,112 @@ class SinkV2CommitterOperatorTest extends CommitterOperatorTestBase {
                 () -> committer.successfulCommits);
     }
 
+    @ParameterizedTest
+    @CsvSource({"1, 10, 9", "2, 1, 0", "2, 2, 1"})
+    void testStateRestoreWithScaling(
+            int parallelismBeforeScaling, int parallelismAfterScaling, int subtaskIdAfterRecovery)
+            throws Exception {
+
+        final int originalSubtaskId = 0;
+
+        final OneInputStreamOperatorTestHarness<
+                CommittableMessage<String>, CommittableMessage<String>>
+                testHarness =
+                createTestHarness(
+                        sinkWithPostCommitWithRetry().sink,
+                        false,
+                        true,
+                        parallelismBeforeScaling,
+                        parallelismBeforeScaling,
+                        originalSubtaskId);
+        testHarness.open();
+
+        // We cannot test a different checkpoint thant 0 because when using the OperatorTestHarness
+        // for recovery the lastCompleted checkpoint is always reset to 0.
+        long checkpointId = 0L;
+
+        final CommittableSummary<String> committableSummary =
+                new CommittableSummary<>(
+                        originalSubtaskId, parallelismBeforeScaling, checkpointId, 1, 0, 0);
+        testHarness.processElement(new StreamRecord<>(committableSummary));
+        final CommittableWithLineage<String> first =
+                new CommittableWithLineage<>("1", checkpointId, originalSubtaskId);
+        testHarness.processElement(new StreamRecord<>(first));
+
+        // another committable for the same checkpointId but from different subtask.
+        final CommittableSummary<String> committableSummary2 =
+                new CommittableSummary<>(
+                        originalSubtaskId + 1, parallelismBeforeScaling, checkpointId, 1, 0, 0);
+        testHarness.processElement(new StreamRecord<>(committableSummary2));
+        final CommittableWithLineage<String> second =
+                new CommittableWithLineage<>("2", checkpointId, originalSubtaskId + 1);
+        testHarness.processElement(new StreamRecord<>(second));
+
+        final OperatorSubtaskState snapshot = testHarness.snapshot(checkpointId, 2L);
+        assertThat(testHarness.getOutput()).isEmpty();
+        testHarness.close();
+
+        // create new testHarness but with different parallelism level and subtaskId that original
+        // one.
+        // we will make sure that new subtaskId was used during committable recovery.
+        SinkAndCounters restored = sinkWithPostCommit();
+        final OneInputStreamOperatorTestHarness<
+                CommittableMessage<String>, CommittableMessage<String>>
+                restoredHarness =
+                createTestHarness(
+                        restored.sink,
+                        false,
+                        true,
+                        parallelismAfterScaling,
+                        parallelismAfterScaling,
+                        subtaskIdAfterRecovery);
+
+        restoredHarness.initializeState(snapshot);
+        restoredHarness.open();
+
+        // Previous committables are immediately committed if possible
+        assertThat(restored.commitCounter.getAsInt()).isEqualTo(2);
+        ListAssert<CommittableMessage<String>> records =
+                assertThat(restoredHarness.extractOutputValues()).hasSize(3);
+        CommittableSummaryAssert<Object> objectCommittableSummaryAssert =
+                records.element(0, as(committableSummary()))
+                        .hasCheckpointId(checkpointId)
+                        .hasFailedCommittables(0)
+                        .hasSubtaskId(subtaskIdAfterRecovery)
+                        .hasNumberOfSubtasks(
+                                Math.min(parallelismBeforeScaling, parallelismAfterScaling));
+        objectCommittableSummaryAssert.hasOverallCommittables(2);
+
+        // Expect the same checkpointId that the original snapshot was made with.
+        records.element(1, as(committableWithLineage()))
+                .hasCheckpointId(checkpointId)
+                .hasSubtaskId(subtaskIdAfterRecovery)
+                .hasCommittable(first.getCommittable());
+        records.element(2, as(committableWithLineage()))
+                .hasCheckpointId(checkpointId)
+                .hasSubtaskId(subtaskIdAfterRecovery)
+                .hasCommittable(second.getCommittable());
+        restoredHarness.close();
+    }
+
+    private OneInputStreamOperatorTestHarness<
+            CommittableMessage<String>, CommittableMessage<String>>
+    createTestHarness(
+            SupportsCommitter<String> sink,
+            boolean isBatchMode,
+            boolean isCheckpointingEnabled,
+            int maxParallelism,
+            int parallelism,
+            int subtaskId)
+            throws Exception {
+        return new OneInputStreamOperatorTestHarness<>(
+                new CommitterOperatorFactory<>(sink, isBatchMode, isCheckpointingEnabled),
+                maxParallelism,
+                parallelism,
+                subtaskId);
+    }
+
+
     private static class ForwardingCommitter extends TestSinkV2.DefaultCommitter {
         private int successfulCommits = 0;
 
@@ -67,6 +192,7 @@ class SinkV2CommitterOperatorTest extends CommitterOperatorTestBase {
         }
 
         @Override
-        public void close() throws Exception {}
+        public void close() throws Exception {
+        }
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/SinkV2CommitterOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/SinkV2CommitterOperatorTest.java
@@ -38,7 +38,6 @@ import static org.apache.flink.streaming.api.connector.sink2.SinkV2Assertions.co
 import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 
-
 import java.util.Collection;
 
 class SinkV2CommitterOperatorTest extends CommitterOperatorTestBase {
@@ -181,7 +180,6 @@ class SinkV2CommitterOperatorTest extends CommitterOperatorTestBase {
                 parallelism,
                 subtaskId);
     }
-
 
     private static class ForwardingCommitter extends TestSinkV2.DefaultCommitter {
         private int successfulCommits = 0;

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2ITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2ITCase.java
@@ -17,34 +17,55 @@
 
 package org.apache.flink.test.streaming.runtime;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.api.common.typeinfo.IntegerTypeInfo;
 import org.apache.flink.api.connector.sink2.Committer;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.configuration.ExternalizedCheckpointRetention;
+import org.apache.flink.configuration.RestartStrategyOptions;
+import org.apache.flink.configuration.StateBackendOptions;
+import org.apache.flink.configuration.StateRecoveryOptions;
+import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.graph.StreamEdge;
 import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.flink.streaming.api.graph.StreamNode;
 import org.apache.flink.streaming.runtime.operators.sink.TestSinkV2;
 import org.apache.flink.streaming.util.FiniteTestSource;
+import org.apache.flink.test.junit5.InjectClusterClient;
+import org.apache.flink.test.junit5.InjectMiniCluster;
 import org.apache.flink.test.util.AbstractTestBaseJUnit4;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
+import java.io.File;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutionException;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
 
 /**
  * Integration test for {@link org.apache.flink.api.connector.sink.Sink} run time implementation.
@@ -64,7 +85,7 @@ public class SinkV2ITCase extends AbstractTestBaseJUnit4 {
                     .flatMap(
                             x ->
                                     Collections.nCopies(
-                                            2, Tuple3.of(x, null, Long.MIN_VALUE).toString())
+                                                    2, Tuple3.of(x, null, Long.MIN_VALUE).toString())
                                             .stream())
                     .collect(Collectors.toList());
 
@@ -99,7 +120,7 @@ public class SinkV2ITCase extends AbstractTestBaseJUnit4 {
                         TestSinkV2.<Integer>newBuilder()
                                 .setDefaultCommitter(
                                         (Supplier<Queue<Committer.CommitRequest<String>>>
-                                                        & Serializable)
+                                                & Serializable)
                                                 () -> COMMIT_QUEUE)
                                 .build());
         executeAndVerifyStreamGraph(env);
@@ -124,7 +145,7 @@ public class SinkV2ITCase extends AbstractTestBaseJUnit4 {
                         TestSinkV2.<Integer>newBuilder()
                                 .setDefaultCommitter(
                                         (Supplier<Queue<Committer.CommitRequest<String>>>
-                                                        & Serializable)
+                                                & Serializable)
                                                 () -> COMMIT_QUEUE)
                                 .setWithPreCommitTopology(true)
                                 .build());
@@ -151,7 +172,7 @@ public class SinkV2ITCase extends AbstractTestBaseJUnit4 {
                         TestSinkV2.<Integer>newBuilder()
                                 .setDefaultCommitter(
                                         (Supplier<Queue<Committer.CommitRequest<String>>>
-                                                        & Serializable)
+                                                & Serializable)
                                                 () -> COMMIT_QUEUE)
                                 .build());
         executeAndVerifyStreamGraph(env);
@@ -174,7 +195,7 @@ public class SinkV2ITCase extends AbstractTestBaseJUnit4 {
                         TestSinkV2.<Integer>newBuilder()
                                 .setDefaultCommitter(
                                         (Supplier<Queue<Committer.CommitRequest<String>>>
-                                                        & Serializable)
+                                                & Serializable)
                                                 () -> COMMIT_QUEUE)
                                 .setWithPreCommitTopology(true)
                                 .build());
@@ -189,6 +210,68 @@ public class SinkV2ITCase extends AbstractTestBaseJUnit4 {
                                 .toArray()));
     }
 
+    @ParameterizedTest
+    @CsvSource({"1, 2", "2, 1", "1, 1"})
+    public void writerAndCommitterExecuteInStreamingModeWithScaling(
+            int initialParallelism,
+            int scaledParallelism,
+            @TempDir File checkpointDir,
+            @InjectMiniCluster MiniCluster miniCluster,
+            @InjectClusterClient ClusterClient<?> clusterClient)
+            throws Exception {
+        final Configuration config = createConfigForScalingTest(checkpointDir, initialParallelism);
+
+        // first run
+        final JobID jobID = runStreamingWithScalingTest(config, clusterClient);
+
+        // second run
+        config.set(StateRecoveryOptions.SAVEPOINT_PATH, getCheckpointPath(miniCluster, jobID));
+        config.set(CoreOptions.DEFAULT_PARALLELISM, scaledParallelism);
+        runStreamingWithScalingTest(config, clusterClient);
+    }
+
+    private JobID runStreamingWithScalingTest(
+            Configuration config,
+            ClusterClient<?> clusterClient)
+            throws Exception {
+        final StreamExecutionEnvironment env = buildStreamEnvWithCheckpointDir(config);
+        final FiniteTestSource<Integer> source =
+                new FiniteTestSource<>(COMMIT_QUEUE_RECEIVE_ALL_DATA, SOURCE_DATA);
+
+        env.addSource(source, IntegerTypeInfo.INT_TYPE_INFO)
+                // Introduce the keyBy to assert unaligned checkpoint is enabled on the source ->
+                // sink writer edge
+                .keyBy((KeySelector<Integer, Integer>) value -> value)
+                .sinkTo(
+                        TestSinkV2.<Integer>newBuilder()
+                                .setDefaultCommitter(
+                                        (Supplier<Queue<Committer.CommitRequest<String>>>
+                                                & Serializable)
+                                                () -> COMMIT_QUEUE)
+                                .build());
+        executeAndVerifyStreamGraph(env);
+        assertThat(
+                COMMIT_QUEUE.stream()
+                        .map(Committer.CommitRequest::getCommittable)
+                        .collect(Collectors.toList()),
+                containsInAnyOrder(EXPECTED_COMMITTED_DATA_IN_STREAMING_MODE.toArray()));
+
+        final JobID jobId = clusterClient.submitJob(env.getStreamGraph().getJobGraph()).get();
+        clusterClient.requestJobResult(jobId).get();
+
+        return jobId;
+    }
+
+    private String getCheckpointPath(MiniCluster miniCluster, JobID secondJobId)
+            throws InterruptedException, ExecutionException, FlinkJobNotFoundException {
+        final Optional<String> completedCheckpoint =
+                CommonTestUtils.getLatestCompletedCheckpointPath(secondJobId, miniCluster);
+
+        assertThat(completedCheckpoint.isPresent(), is(true));
+        return completedCheckpoint.get();
+    }
+
+
     private StreamExecutionEnvironment buildStreamEnv() {
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setRuntimeMode(RuntimeExecutionMode.STREAMING);
@@ -196,10 +279,33 @@ public class SinkV2ITCase extends AbstractTestBaseJUnit4 {
         return env;
     }
 
+    private StreamExecutionEnvironment buildStreamEnvWithCheckpointDir(Configuration config) {
+        final StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(config);
+        env.setRuntimeMode(RuntimeExecutionMode.STREAMING);
+        env.enableCheckpointing(100);
+
+        return env;
+    }
+
     private StreamExecutionEnvironment buildBatchEnv() {
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setRuntimeMode(RuntimeExecutionMode.BATCH);
         return env;
+    }
+
+    private Configuration createConfigForScalingTest(File checkpointDir, int parallelism) {
+        final Configuration config = new Configuration();
+        config.set(CoreOptions.DEFAULT_PARALLELISM, parallelism);
+        config.set(StateBackendOptions.STATE_BACKEND, "hashmap");
+        config.set(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir.toURI().toString());
+        config.set(
+                CheckpointingOptions.EXTERNALIZED_CHECKPOINT_RETENTION,
+                ExternalizedCheckpointRetention.RETAIN_ON_CANCELLATION);
+        config.set(CheckpointingOptions.MAX_RETAINED_CHECKPOINTS, 2000);
+        config.set(RestartStrategyOptions.RESTART_STRATEGY, "disable");
+
+        return config;
     }
 
     private void executeAndVerifyStreamGraph(StreamExecutionEnvironment env) throws Exception {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
