### PR TITLE
[FLINK-38329][GithubAction] Add target release label for back port PRs

### DIFF
--- a/.github/workflows/community-review.sh
+++ b/.github/workflows/community-review.sh
@@ -425,7 +425,7 @@ ensure_label_exists() {
   local token="${1?missing token}"
   local label_name="${2?missing label name}"
   
-  local color="90EE90"
+  local color="5d069e"
   
   # Check if the label exists
   local label_exists=$(curl --fail --no-progress-meter -s \


### PR DESCRIPTION
## What is the purpose of the change

This is a Github action to add labels of the target branch for back ports. so it is easier to see the backports as they often have the same PR title.

## Brief change log

Ammded the community review github action. This already has the right permissions


## Verifying this change

I tested locally to ensure the logic and the caching worked as expected.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no 
  - The runtime per-record code paths (performance sensitive): no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper:no 
  - The S3 file system connector:  no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 
