### PR TITLE
[FLINK-38327] Use vertex id instead of operator id in checkpoint file-merging manager

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/SubtaskFileMergingManagerRestoreOperation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/SubtaskFileMergingManagerRestoreOperation.java
@@ -21,7 +21,7 @@ package org.apache.flink.runtime.checkpoint.filemerging;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.TaskInfo;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
-import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.state.IncrementalRemoteKeyedStateHandle;
 import org.apache.flink.runtime.state.KeyGroupsStateHandle;
 import org.apache.flink.runtime.state.KeyedStateHandle;
@@ -51,7 +51,7 @@ public class SubtaskFileMergingManagerRestoreOperation {
     private final TaskInfo taskInfo;
 
     /** The id of the operator to which the subtask belongs. */
-    private final OperatorID operatorID;
+    private final JobVertexID vertexID;
 
     private final FileMergingSnapshotManager fileMergingSnapshotManager;
 
@@ -63,19 +63,19 @@ public class SubtaskFileMergingManagerRestoreOperation {
             FileMergingSnapshotManager fileMergingSnapshotManager,
             JobID jobID,
             TaskInfo taskInfo,
-            OperatorID operatorID,
+            JobVertexID vertexID,
             OperatorSubtaskState subtaskState) {
         this.checkpointId = checkpointId;
         this.fileMergingSnapshotManager = fileMergingSnapshotManager;
         this.jobID = jobID;
         this.taskInfo = Preconditions.checkNotNull(taskInfo);
-        this.operatorID = Preconditions.checkNotNull(operatorID);
+        this.vertexID = Preconditions.checkNotNull(vertexID);
         this.subtaskState = Preconditions.checkNotNull(subtaskState);
     }
 
     public void restore() {
         FileMergingSnapshotManager.SubtaskKey subtaskKey =
-                new FileMergingSnapshotManager.SubtaskKey(jobID, operatorID, taskInfo);
+                new FileMergingSnapshotManager.SubtaskKey(jobID, vertexID, taskInfo);
 
         Stream<? extends StateObject> keyedStateHandles =
                 Stream.concat(

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.checkpoint.SubTaskInitializationMetricsBuilder;
 import org.apache.flink.runtime.checkpoint.filemerging.FileMergingSnapshotManager;
 import org.apache.flink.runtime.checkpoint.filemerging.SubtaskFileMergingManagerRestoreOperation;
 import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.metrics.MetricNames;
 import org.apache.flink.runtime.state.AsyncKeyedStateBackend;
@@ -162,7 +163,8 @@ public class StreamTaskStateInitializerImpl implements StreamTaskStateInitialize
             throws Exception {
 
         TaskInfo taskInfo = environment.getTaskInfo();
-        registerRestoredStateToFileMergingManager(environment.getJobID(), taskInfo, operatorID);
+        registerRestoredStateToFileMergingManager(
+                environment.getJobID(), taskInfo, environment.getJobVertexId(), operatorID);
 
         OperatorSubtaskDescriptionText operatorSubtaskDescription =
                 new OperatorSubtaskDescriptionText(
@@ -361,7 +363,7 @@ public class StreamTaskStateInitializerImpl implements StreamTaskStateInitialize
     }
 
     private void registerRestoredStateToFileMergingManager(
-            JobID jobID, TaskInfo taskInfo, OperatorID operatorID) {
+            JobID jobID, TaskInfo taskInfo, JobVertexID jobVertexID, OperatorID operatorID) {
         FileMergingSnapshotManager fileMergingSnapshotManager =
                 taskStateManager.getFileMergingSnapshotManager();
         Optional<Long> restoredCheckpointId = taskStateManager.getRestoreCheckpointId();
@@ -377,7 +379,7 @@ public class StreamTaskStateInitializerImpl implements StreamTaskStateInitialize
                             fileMergingSnapshotManager,
                             jobID,
                             taskInfo,
-                            operatorID,
+                            jobVertexID,
                             subtaskState.get());
             restoreOperation.restore();
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManagerTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManagerTestBase.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.checkpoint.filemerging.FileMergingSnapshotManager.SpaceStat;
 import org.apache.flink.runtime.checkpoint.filemerging.FileMergingSnapshotManager.SubtaskKey;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.state.CheckpointedStateScope;
@@ -73,7 +74,7 @@ public abstract class FileMergingSnapshotManagerTestBase {
 
     final JobID jobID = new JobID();
 
-    final OperatorID operatorID = new OperatorID(289347923L, 75893479L);
+    final JobVertexID vertexID = new JobVertexID(289347923L, 75893479L);
 
     SubtaskKey subtaskKey1;
     SubtaskKey subtaskKey2;
@@ -89,9 +90,9 @@ public abstract class FileMergingSnapshotManagerTestBase {
     @BeforeEach
     public void setup(@TempDir java.nio.file.Path tempFolder) {
         subtaskKey1 =
-                new SubtaskKey(jobID, operatorID, new TaskInfoImpl("TestingTask", 128, 0, 128, 3));
+                new SubtaskKey(jobID, vertexID, new TaskInfoImpl("TestingTask", 128, 0, 128, 3));
         subtaskKey2 =
-                new SubtaskKey(jobID, operatorID, new TaskInfoImpl("TestingTask", 128, 1, 128, 3));
+                new SubtaskKey(jobID, vertexID, new TaskInfoImpl("TestingTask", 128, 1, 128, 3));
 
         checkpointBaseDir = new Path(tempFolder.toString(), jobID.toHexString());
         sharedStateDir = new Path(checkpointBaseDir, CHECKPOINT_SHARED_STATE_DIR);
@@ -492,12 +493,21 @@ public abstract class FileMergingSnapshotManagerTestBase {
                         (FileMergingSnapshotManagerBase)
                                 createFileMergingSnapshotManager(checkpointBaseDir);
                 CloseableRegistry closeableRegistry = new CloseableRegistry()) {
-
+            fmsm.registerSubtaskForSharedStates(subtaskKey1);
             fmsm.notifyCheckpointStart(subtaskKey1, checkpointId);
 
             Map<OperatorID, OperatorSubtaskState> subtaskStatesByOperatorID = new HashMap<>();
+            // Here, we simulate a task with 2 operators, each operator has one keyed state and one
+            // operator state. The second operator's id is the same as the vertexID.
+            // first operator
             subtaskStatesByOperatorID.put(
-                    operatorID, buildOperatorSubtaskState(checkpointId, fmsm, closeableRegistry));
+                    new OperatorID(777L, 75893479L),
+                    buildOperatorSubtaskState(checkpointId, fmsm, closeableRegistry));
+
+            // second operator
+            subtaskStatesByOperatorID.put(
+                    OperatorID.fromJobVertexID(vertexID),
+                    buildOperatorSubtaskState(checkpointId, fmsm, closeableRegistry));
             taskStateSnapshot = new TaskStateSnapshot(subtaskStatesByOperatorID);
             oldSpaceStat = fmsm.spaceStat;
 
@@ -510,6 +520,7 @@ public abstract class FileMergingSnapshotManagerTestBase {
         try (FileMergingSnapshotManagerBase fmsm =
                 (FileMergingSnapshotManagerBase)
                         createFileMergingSnapshotManager(checkpointBaseDir)) {
+            fmsm.registerSubtaskForSharedStates(subtaskKey1);
             TaskInfo taskInfo =
                     new TaskInfoImpl(
                             "test restore",
@@ -521,19 +532,15 @@ public abstract class FileMergingSnapshotManagerTestBase {
                     taskStateSnapshot.getSubtaskStateMappings()) {
                 SubtaskFileMergingManagerRestoreOperation restoreOperation =
                         new SubtaskFileMergingManagerRestoreOperation(
-                                checkpointId,
-                                fmsm,
-                                jobID,
-                                taskInfo,
-                                entry.getKey(),
-                                entry.getValue());
+                                checkpointId, fmsm, jobID, taskInfo, vertexID, entry.getValue());
                 restoreOperation.restore();
             }
             TreeMap<Long, Set<LogicalFile>> stateFiles = fmsm.getUploadedStates();
             assertThat(stateFiles.size()).isEqualTo(1);
             Set<LogicalFile> restoreFileSet = stateFiles.get(checkpointId);
             assertThat(restoreFileSet).isNotNull();
-            assertThat(restoreFileSet.size()).isEqualTo(4);
+            // 2 operators * (2 keyed state + 2 operator state)
+            assertThat(restoreFileSet.size()).isEqualTo(8);
             assertThat(fmsm.spaceStat).isEqualTo(oldSpaceStat);
             for (LogicalFile file : restoreFileSet) {
                 assertThat(fmsm.getLogicalFile(file.getFileId())).isEqualTo(file);
@@ -662,7 +669,10 @@ public abstract class FileMergingSnapshotManagerTestBase {
                         Collections.singletonList(
                                 IncrementalKeyedStateHandle.HandleAndLocalPath.of(
                                         buildOneSegmentFileHandle(
-                                                checkpointId, fmsm, closeableRegistry),
+                                                checkpointId,
+                                                fmsm,
+                                                CheckpointedStateScope.SHARED,
+                                                closeableRegistry),
                                         "localPath")),
                         Collections.emptyList(),
                         null);
@@ -670,21 +680,33 @@ public abstract class FileMergingSnapshotManagerTestBase {
         KeyGroupsStateHandle keyedStateHandle2 =
                 new KeyGroupsStateHandle(
                         new KeyGroupRangeOffsets(0, 8),
-                        buildOneSegmentFileHandle(checkpointId, fmsm, closeableRegistry));
+                        buildOneSegmentFileHandle(
+                                checkpointId,
+                                fmsm,
+                                CheckpointedStateScope.EXCLUSIVE,
+                                closeableRegistry));
 
         OperatorStateHandle operatorStateHandle1 =
                 new FileMergingOperatorStreamStateHandle(
                         null,
                         null,
                         Collections.emptyMap(),
-                        buildOneSegmentFileHandle(checkpointId, fmsm, closeableRegistry));
+                        buildOneSegmentFileHandle(
+                                checkpointId,
+                                fmsm,
+                                CheckpointedStateScope.EXCLUSIVE,
+                                closeableRegistry));
 
         OperatorStateHandle operatorStateHandle2 =
                 new FileMergingOperatorStreamStateHandle(
                         null,
                         null,
                         Collections.emptyMap(),
-                        buildOneSegmentFileHandle(checkpointId, fmsm, closeableRegistry));
+                        buildOneSegmentFileHandle(
+                                checkpointId,
+                                fmsm,
+                                CheckpointedStateScope.EXCLUSIVE,
+                                closeableRegistry));
 
         return OperatorSubtaskState.builder()
                 .setManagedKeyedState(keyedStateHandle1)
@@ -695,10 +717,13 @@ public abstract class FileMergingSnapshotManagerTestBase {
     }
 
     private SegmentFileStateHandle buildOneSegmentFileHandle(
-            long checkpointId, FileMergingSnapshotManager fmsm, CloseableRegistry closeableRegistry)
+            long checkpointId,
+            FileMergingSnapshotManager fmsm,
+            CheckpointedStateScope scope,
+            CloseableRegistry closeableRegistry)
             throws Exception {
         FileMergingCheckpointStateOutputStream outputStream =
-                writeCheckpointAndGetStream(checkpointId, fmsm, closeableRegistry);
+                writeCheckpointAndGetStream(checkpointId, fmsm, scope, closeableRegistry);
         return outputStream.closeAndGetHandle();
     }
 
@@ -741,15 +766,13 @@ public abstract class FileMergingSnapshotManagerTestBase {
     }
 
     FileMergingCheckpointStateOutputStream writeCheckpointAndGetStream(
-            long checkpointId, FileMergingSnapshotManager fmsm, CloseableRegistry closeableRegistry)
+            long checkpointId,
+            FileMergingSnapshotManager fmsm,
+            CheckpointedStateScope scope,
+            CloseableRegistry closeableRegistry)
             throws IOException {
         return writeCheckpointAndGetStream(
-                subtaskKey1,
-                checkpointId,
-                CheckpointedStateScope.EXCLUSIVE,
-                fmsm,
-                closeableRegistry,
-                32);
+                subtaskKey1, checkpointId, scope, fmsm, closeableRegistry, 32);
     }
 
     FileMergingCheckpointStateOutputStream writeCheckpointAndGetStream(


### PR DESCRIPTION
## What is the purpose of the change

Currently, the file-merging manager’s recovery logic uses the Operator ID to parse the destination directory, whereas the manager initialization uses the Job Vertex ID. This mismatch can lead to a NPE. This may happen for the recovery of operators which are not at the head of operator chain. Typically this kind of operator has no state to recovery in SQL jobs, but it's possible for Datastream jobs.

This PR fixes it by using Job Vertex ID everywhere.

## Brief change log

 - Use JobVertexID in Subtaskkey of file-merging.


## Verifying this change

This change modifies the existing tests `FileMergingSnapshotManagerTestBase` to cover this case.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
