### PR TITLE
[BP-1.20][FLINK-37747][runtime] Use old subtask count for restored committable… #26546

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperator.java
@@ -180,7 +180,12 @@ class CommitterOperator<CommT> extends AbstractStreamOperator<CommittableMessage
 
     private void emit(CheckpointCommittableManager<CommT> committableManager) {
         int subtaskId = getRuntimeContext().getTaskInfo().getIndexOfThisSubtask();
-        int numberOfSubtasks = getRuntimeContext().getTaskInfo().getNumberOfParallelSubtasks();
+        // Ensure that numberOfSubtasks is in sync with the number of actually emitted
+        // CommittableSummaries during upscaling recovery (see FLINK-37747).
+        int numberOfSubtasks =
+                Math.min(
+                        getRuntimeContext().getTaskInfo().getNumberOfParallelSubtasks(),
+                        committableManager.getNumberOfSubtasks());
         long checkpointId = committableManager.getCheckpointId();
         Collection<CommT> committables = committableManager.getSuccessfulCommittables();
         output.collect(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSinkV2.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSinkV2.java
@@ -243,7 +243,7 @@ public class TestSinkV2<InputT> implements Sink<InputT> {
         @Override
         public void addPostCommitTopology(DataStream<CommittableMessage<String>> committables) {
             StandardSinkTopologies.addGlobalCommitter(
-                    committables, DefaultCommitter::new, this::getCommittableSerializer);
+                    committables, () -> createCommitter(null), this::getCommittableSerializer);
         }
     }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2ITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2ITCase.java
@@ -73,6 +73,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -248,7 +249,14 @@ public class SinkV2ITCase extends AbstractTestBase {
                 COMMIT_QUEUE.stream()
                         .map(Committer.CommitRequest::getCommittable)
                         .collect(Collectors.toList()),
-                containsInAnyOrder(EXPECTED_COMMITTED_DATA_IN_STREAMING_MODE.toArray()));
+                containsInAnyOrder(duplicate(EXPECTED_COMMITTED_DATA_IN_STREAMING_MODE).toArray()));
+    }
+
+    private static List<String> duplicate(List<String> values) {
+        return IntStream.range(0, 2)
+                .boxed()
+                .flatMap(i -> values.stream())
+                .collect(Collectors.toList());
     }
 
     private JobID runStreamingWithScalingTest(

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2ITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2ITCase.java
@@ -218,7 +218,7 @@ public class SinkV2ITCase extends AbstractTestBase {
     }
 
     @ParameterizedTest
-    @CsvSource({"1, 2"})
+    @CsvSource({"1, 2", "2, 1", "1, 1"})
     public void writerAndCommitterExecuteInStreamingModeWithScaling(
             int initialParallelism,
             int scaledParallelism,

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2ITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2ITCase.java
@@ -17,34 +17,55 @@
 
 package org.apache.flink.test.streaming.runtime;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.api.common.typeinfo.IntegerTypeInfo;
 import org.apache.flink.api.connector.sink2.Committer;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.configuration.ExternalizedCheckpointRetention;
+import org.apache.flink.configuration.RestartStrategyOptions;
+import org.apache.flink.configuration.StateBackendOptions;
+import org.apache.flink.configuration.StateRecoveryOptions;
+import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.graph.StreamEdge;
 import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.flink.streaming.api.graph.StreamNode;
 import org.apache.flink.streaming.runtime.operators.sink.TestSinkV2;
 import org.apache.flink.streaming.util.FiniteTestSource;
+import org.apache.flink.test.junit5.InjectClusterClient;
+import org.apache.flink.test.junit5.InjectMiniCluster;
 import org.apache.flink.test.util.AbstractTestBaseJUnit4;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
+import java.io.File;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutionException;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
 
 /**
  * Integration test for {@link org.apache.flink.api.connector.sink.Sink} run time implementation.
@@ -64,7 +85,7 @@ public class SinkV2ITCase extends AbstractTestBaseJUnit4 {
                     .flatMap(
                             x ->
                                     Collections.nCopies(
-                                            2, Tuple3.of(x, null, Long.MIN_VALUE).toString())
+                                                    2, Tuple3.of(x, null, Long.MIN_VALUE).toString())
                                             .stream())
                     .collect(Collectors.toList());
 
@@ -99,7 +120,7 @@ public class SinkV2ITCase extends AbstractTestBaseJUnit4 {
                         TestSinkV2.<Integer>newBuilder()
                                 .setDefaultCommitter(
                                         (Supplier<Queue<Committer.CommitRequest<String>>>
-                                                        & Serializable)
+                                                & Serializable)
                                                 () -> COMMIT_QUEUE)
                                 .build());
         executeAndVerifyStreamGraph(env);
@@ -124,7 +145,7 @@ public class SinkV2ITCase extends AbstractTestBaseJUnit4 {
                         TestSinkV2.<Integer>newBuilder()
                                 .setDefaultCommitter(
                                         (Supplier<Queue<Committer.CommitRequest<String>>>
-                                                        & Serializable)
+                                                & Serializable)
                                                 () -> COMMIT_QUEUE)
                                 .setWithPreCommitTopology(true)
                                 .build());
@@ -151,7 +172,7 @@ public class SinkV2ITCase extends AbstractTestBaseJUnit4 {
                         TestSinkV2.<Integer>newBuilder()
                                 .setDefaultCommitter(
                                         (Supplier<Queue<Committer.CommitRequest<String>>>
-                                                        & Serializable)
+                                                & Serializable)
                                                 () -> COMMIT_QUEUE)
                                 .build());
         executeAndVerifyStreamGraph(env);
@@ -174,7 +195,7 @@ public class SinkV2ITCase extends AbstractTestBaseJUnit4 {
                         TestSinkV2.<Integer>newBuilder()
                                 .setDefaultCommitter(
                                         (Supplier<Queue<Committer.CommitRequest<String>>>
-                                                        & Serializable)
+                                                & Serializable)
                                                 () -> COMMIT_QUEUE)
                                 .setWithPreCommitTopology(true)
                                 .build());
@@ -189,6 +210,68 @@ public class SinkV2ITCase extends AbstractTestBaseJUnit4 {
                                 .toArray()));
     }
 
+    @ParameterizedTest
+    @CsvSource({"1, 2", "2, 1", "1, 1"})
+    public void writerAndCommitterExecuteInStreamingModeWithScaling(
+            int initialParallelism,
+            int scaledParallelism,
+            @TempDir File checkpointDir,
+            @InjectMiniCluster MiniCluster miniCluster,
+            @InjectClusterClient ClusterClient<?> clusterClient)
+            throws Exception {
+        final Configuration config = createConfigForScalingTest(checkpointDir, initialParallelism);
+
+        // first run
+        final JobID jobID = runStreamingWithScalingTest(config, clusterClient);
+
+        // second run
+        config.set(StateRecoveryOptions.SAVEPOINT_PATH, getCheckpointPath(miniCluster, jobID));
+        config.set(CoreOptions.DEFAULT_PARALLELISM, scaledParallelism);
+        runStreamingWithScalingTest(config, clusterClient);
+    }
+
+    private JobID runStreamingWithScalingTest(
+            Configuration config,
+            ClusterClient<?> clusterClient)
+            throws Exception {
+        final StreamExecutionEnvironment env = buildStreamEnvWithCheckpointDir(config);
+        final FiniteTestSource<Integer> source =
+                new FiniteTestSource<>(COMMIT_QUEUE_RECEIVE_ALL_DATA, SOURCE_DATA);
+
+        env.addSource(source, IntegerTypeInfo.INT_TYPE_INFO)
+                // Introduce the keyBy to assert unaligned checkpoint is enabled on the source ->
+                // sink writer edge
+                .keyBy((KeySelector<Integer, Integer>) value -> value)
+                .sinkTo(
+                        TestSinkV2.<Integer>newBuilder()
+                                .setDefaultCommitter(
+                                        (Supplier<Queue<Committer.CommitRequest<String>>>
+                                                & Serializable)
+                                                () -> COMMIT_QUEUE)
+                                .build());
+        executeAndVerifyStreamGraph(env);
+        assertThat(
+                COMMIT_QUEUE.stream()
+                        .map(Committer.CommitRequest::getCommittable)
+                        .collect(Collectors.toList()),
+                containsInAnyOrder(EXPECTED_COMMITTED_DATA_IN_STREAMING_MODE.toArray()));
+
+        final JobID jobId = clusterClient.submitJob(env.getStreamGraph().getJobGraph()).get();
+        clusterClient.requestJobResult(jobId).get();
+
+        return jobId;
+    }
+
+    private String getCheckpointPath(MiniCluster miniCluster, JobID secondJobId)
+            throws InterruptedException, ExecutionException, FlinkJobNotFoundException {
+        final Optional<String> completedCheckpoint =
+                CommonTestUtils.getLatestCompletedCheckpointPath(secondJobId, miniCluster);
+
+        assertThat(completedCheckpoint.isPresent(), is(true));
+        return completedCheckpoint.get();
+    }
+
+
     private StreamExecutionEnvironment buildStreamEnv() {
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setRuntimeMode(RuntimeExecutionMode.STREAMING);
@@ -196,10 +279,33 @@ public class SinkV2ITCase extends AbstractTestBaseJUnit4 {
         return env;
     }
 
+    private StreamExecutionEnvironment buildStreamEnvWithCheckpointDir(Configuration config) {
+        final StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(config);
+        env.setRuntimeMode(RuntimeExecutionMode.STREAMING);
+        env.enableCheckpointing(100);
+
+        return env;
+    }
+
     private StreamExecutionEnvironment buildBatchEnv() {
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setRuntimeMode(RuntimeExecutionMode.BATCH);
         return env;
+    }
+
+    private Configuration createConfigForScalingTest(File checkpointDir, int parallelism) {
+        final Configuration config = new Configuration();
+        config.set(CoreOptions.DEFAULT_PARALLELISM, parallelism);
+        config.set(StateBackendOptions.STATE_BACKEND, "hashmap");
+        config.set(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir.toURI().toString());
+        config.set(
+                CheckpointingOptions.EXTERNALIZED_CHECKPOINT_RETENTION,
+                ExternalizedCheckpointRetention.RETAIN_ON_CANCELLATION);
+        config.set(CheckpointingOptions.MAX_RETAINED_CHECKPOINTS, 2000);
+        config.set(RestartStrategyOptions.RESTART_STRATEGY, "disable");
+
+        return config;
     }
 
     private void executeAndVerifyStreamGraph(StreamExecutionEnvironment env) throws Exception {

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2ITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2ITCase.java
@@ -266,7 +266,7 @@ public class SinkV2ITCase extends AbstractTestBase {
             ClusterClient<?> clusterClient)
             throws Exception {
         final StreamExecutionEnvironment env = buildStreamEnvWithCheckpointDir(config);
-        final Source<Integer, ?, ?> source = createStreamingSource();
+        final Source<Integer, ?, ?> source = createStreamingSourceForScalingTest();
 
         env.fromSource(source, WatermarkStrategy.noWatermarks(), "source")
                 .rebalance()
@@ -359,7 +359,7 @@ public class SinkV2ITCase extends AbstractTestBase {
      * for two more checkpoints to complete, 3) then re-emits the same elements before 4) waiting
      * for another two checkpoints and 5) exiting.
      */
-    private Source<Integer, ?, ?> createStreamingSource() {
+    private Source<Integer, ?, ?> createStreamingSourceForScalingTest() {
         RateLimiterStrategy rateLimiterStrategy =
                 parallelism -> new BurstingRateLimiter(SOURCE_DATA.size() / 4, 2);
         return new DataGeneratorSource<>(


### PR DESCRIPTION
Backport of https://github.com/apache/flink/pull/26518

A simple commit cherry pick did not work due to the changes introduced in Flink 2.0. The test `SinkV2ITCase` is what required most of the changes compared to the backport to 2.0 https://github.com/apache/flink/pull/26546.