### PR TITLE
[hotfix][table] Fix incorrect state ttl setting in KeyedLookupJoinWrapper

### DIFF
--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/lookup/KeyedLookupJoinWrapper.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/lookup/KeyedLookupJoinWrapper.java
@@ -97,10 +97,10 @@ public class KeyedLookupJoinWrapper extends KeyedProcessFunction<RowData, RowDat
         } else {
             ValueStateDescriptor<List<RowData>> valueStateDescriptor =
                     new ValueStateDescriptor<>("values", new ListSerializer<>(serializer));
-            state = getRuntimeContext().getState(valueStateDescriptor);
             if (ttlConfig.isEnabled()) {
                 valueStateDescriptor.enableTimeToLive(ttlConfig);
             }
+            state = getRuntimeContext().getState(valueStateDescriptor);
         }
         emptyRow = initEmptyRow(lookupJoinRunner.tableFieldsCount);
         collectListener = new FetchedRecordListener();


### PR DESCRIPTION
## What is the purpose of the change
This is a trivial bugfix for state ttl setting in KeyedLookupJoinWrapper, we should enable state ttl config before create state instance.

## Brief change log
correct state ttl setting

## Verifying this change
Add new case into`KeyedLookupJoinHarnessTest`

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (no)