### PR TITLE
[FLINK-38345][flink-connector-base] Annotate SourceSwitchContext#getPreviousEnumerator as nullable for recovery scenarios

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSource.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSource.java
@@ -31,6 +31,8 @@ import org.apache.flink.api.java.ClosureCleaner;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.util.Preconditions;
 
+import javax.annotation.Nullable;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -159,6 +161,16 @@ public class HybridSource<T> implements Source<T, HybridSourceSplit, HybridSourc
      */
     @PublicEvolving
     public interface SourceSwitchContext<EnumT> {
+        /**
+         * Returns the previous {@link SplitEnumerator} from memory.
+         *
+         * <p>{@link SplitEnumerator} instances are not persistent. When jobs restart or checkpoint
+         * recovery occurs, the previous enumerator state is not maintained. In these cases, this
+         * method will return null.
+         *
+         * @return an instance of a {@link SplitEnumerator} or null.
+         */
+        @Nullable
         EnumT getPreviousEnumerator();
     }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*Annotating the SourceSwitchContext#getPreviousEnumerator method as nullable. Enumerator instances are not serializable nor checkpointed by default. Upon job recovery to a source index that depends on the previous enumerator to be instantiated, we encounter NPEs when accessing the previous enumerator.*


## Brief change log

  - *Annotated the SourceSwitchContext#getPreviousEnumerator method as nullable*


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( _no_)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (_yes_)
  - The serializers: (_no_)
  - The runtime per-record code paths (performance sensitive): (_no_ )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (_no_)
  - The S3 file system connector: (_no_)

## Documentation

  - Does this pull request introduce a new feature? (yes / _no_)
  - If yes, how is the feature documented? (_JavaDocs_)
