### PR TITLE
[FLINK-38319][python] Allow TO_TIMESTAMP_LTZ to accept expression in PyFlink

### DIFF
--- a/flink-python/pyflink/table/expressions.py
+++ b/flink-python/pyflink/table/expressions.py
@@ -355,15 +355,15 @@ def to_timestamp_ltz(*args) -> Expression:
                                         "UTC"))  # string with format and timezone
     """
     if len(args) == 1:
-        return _unary_op("toTimestampLtz", lit(args[0]))
+        return _unary_op("toTimestampLtz", args[0])
 
     # For two arguments case (numeric + precision or string + format)
     elif len(args) == 2:
-        return _binary_op("toTimestampLtz", lit(args[0]), lit(args[1]))
+        return _binary_op("toTimestampLtz", args[0], args[1])
 
     # For three arguments case (string + format + timezone)
     else:
-        return _ternary_op("toTimestampLtz", lit(args[0]), lit(args[1]), lit(args[2]))
+        return _ternary_op("toTimestampLtz", args[0], args[1], args[2])
 
 
 @PublicEvolving()

--- a/flink-python/pyflink/table/tests/test_expression.py
+++ b/flink-python/pyflink/table/tests/test_expression.py
@@ -295,6 +295,12 @@ class PyFlinkBatchExpressionTests(PyFlinkTestCase):
         self.assertEqual("TO_TIMESTAMP_LTZ('2023-01-01 00:00:00', 'yyyy-MM-dd HH:mm:ss', 'UTC')",
                          str(to_timestamp_ltz("2023-01-01 00:00:00", "yyyy-MM-dd HH:mm:ss", "UTC")))
         self.assertEqual("TO_TIMESTAMP_LTZ(123, 0)", str(to_timestamp_ltz(123, 0)))
+        self.assertEqual('TO_TIMESTAMP_LTZ(a)', str(to_timestamp_ltz(expr1))
+        self.assertEqual('TO_TIMESTAMP_LTZ(a, 0)', str(to_timestamp_ltz(expr1, 0))
+        self.assertEqual("TO_TIMESTAMP_LTZ(a, 'MM/dd/yyyy HH:mm:ss')",
+                         str(to_timestamp_ltz(expr1, "MM/dd/yyyy HH:mm:ss"))
+        self.assertEqual("TO_TIMESTAMP_LTZ(a, 'MM/dd/yyyy HH:mm:ss', 'UTC')",
+                         str(to_timestamp_ltz(expr1, "MM/dd/yyyy HH:mm:ss", "UTC"))
         self.assertEqual("toTimestamp('1970-01-01 08:01:40')",
                          str(to_timestamp('1970-01-01 08:01:40')))
         self.assertEqual("toTimestamp('1970-01-01 08:01:40', 'yyyy-MM-dd HH:mm:ss')",

--- a/flink-python/pyflink/table/tests/test_expression.py
+++ b/flink-python/pyflink/table/tests/test_expression.py
@@ -295,12 +295,12 @@ class PyFlinkBatchExpressionTests(PyFlinkTestCase):
         self.assertEqual("TO_TIMESTAMP_LTZ('2023-01-01 00:00:00', 'yyyy-MM-dd HH:mm:ss', 'UTC')",
                          str(to_timestamp_ltz("2023-01-01 00:00:00", "yyyy-MM-dd HH:mm:ss", "UTC")))
         self.assertEqual("TO_TIMESTAMP_LTZ(123, 0)", str(to_timestamp_ltz(123, 0)))
-        self.assertEqual('TO_TIMESTAMP_LTZ(a)', str(to_timestamp_ltz(expr1))
-        self.assertEqual('TO_TIMESTAMP_LTZ(a, 0)', str(to_timestamp_ltz(expr1, 0))
-        self.assertEqual("TO_TIMESTAMP_LTZ(a, 'MM/dd/yyyy HH:mm:ss')",
-                         str(to_timestamp_ltz(expr1, "MM/dd/yyyy HH:mm:ss"))
-        self.assertEqual("TO_TIMESTAMP_LTZ(a, 'MM/dd/yyyy HH:mm:ss', 'UTC')",
-                         str(to_timestamp_ltz(expr1, "MM/dd/yyyy HH:mm:ss", "UTC"))
+        self.assertEqual("TO_TIMESTAMP_LTZ(col('a')", str(to_timestamp_ltz(expr1)))
+        self.assertEqual("TO_TIMESTAMP_LTZ(col('a'), 0)", str(to_timestamp_ltz(expr1, 0)))
+        self.assertEqual("TO_TIMESTAMP_LTZ(col('a'), 'MM/dd/yyyy HH:mm:ss')",
+                         str(to_timestamp_ltz(expr1, "MM/dd/yyyy HH:mm:ss")))
+        self.assertEqual("TO_TIMESTAMP_LTZ(col('a'), 'MM/dd/yyyy HH:mm:ss', 'UTC')",
+                         str(to_timestamp_ltz(expr1, "MM/dd/yyyy HH:mm:ss", "UTC")))
         self.assertEqual("toTimestamp('1970-01-01 08:01:40')",
                          str(to_timestamp('1970-01-01 08:01:40')))
         self.assertEqual("toTimestamp('1970-01-01 08:01:40', 'yyyy-MM-dd HH:mm:ss')",

--- a/flink-python/pyflink/table/tests/test_expression.py
+++ b/flink-python/pyflink/table/tests/test_expression.py
@@ -295,11 +295,11 @@ class PyFlinkBatchExpressionTests(PyFlinkTestCase):
         self.assertEqual("TO_TIMESTAMP_LTZ('2023-01-01 00:00:00', 'yyyy-MM-dd HH:mm:ss', 'UTC')",
                          str(to_timestamp_ltz("2023-01-01 00:00:00", "yyyy-MM-dd HH:mm:ss", "UTC")))
         self.assertEqual("TO_TIMESTAMP_LTZ(123, 0)", str(to_timestamp_ltz(123, 0)))
-        self.assertEqual("TO_TIMESTAMP_LTZ(col('a')", str(to_timestamp_ltz(expr1)))
-        self.assertEqual("TO_TIMESTAMP_LTZ(col('a'), 0)", str(to_timestamp_ltz(expr1, 0)))
-        self.assertEqual("TO_TIMESTAMP_LTZ(col('a'), 'MM/dd/yyyy HH:mm:ss')",
+        self.assertEqual("TO_TIMESTAMP_LTZ(a)", str(to_timestamp_ltz(expr1)))
+        self.assertEqual("TO_TIMESTAMP_LTZ(a), 0)", str(to_timestamp_ltz(expr1, 0)))
+        self.assertEqual("TO_TIMESTAMP_LTZ(a), 'MM/dd/yyyy HH:mm:ss')",
                          str(to_timestamp_ltz(expr1, "MM/dd/yyyy HH:mm:ss")))
-        self.assertEqual("TO_TIMESTAMP_LTZ(col('a'), 'MM/dd/yyyy HH:mm:ss', 'UTC')",
+        self.assertEqual("TO_TIMESTAMP_LTZ(a), 'MM/dd/yyyy HH:mm:ss', 'UTC')",
                          str(to_timestamp_ltz(expr1, "MM/dd/yyyy HH:mm:ss", "UTC")))
         self.assertEqual("toTimestamp('1970-01-01 08:01:40')",
                          str(to_timestamp('1970-01-01 08:01:40')))

--- a/flink-python/pyflink/table/tests/test_expression.py
+++ b/flink-python/pyflink/table/tests/test_expression.py
@@ -296,10 +296,10 @@ class PyFlinkBatchExpressionTests(PyFlinkTestCase):
                          str(to_timestamp_ltz("2023-01-01 00:00:00", "yyyy-MM-dd HH:mm:ss", "UTC")))
         self.assertEqual("TO_TIMESTAMP_LTZ(123, 0)", str(to_timestamp_ltz(123, 0)))
         self.assertEqual("TO_TIMESTAMP_LTZ(a)", str(to_timestamp_ltz(expr1)))
-        self.assertEqual("TO_TIMESTAMP_LTZ(a), 0)", str(to_timestamp_ltz(expr1, 0)))
-        self.assertEqual("TO_TIMESTAMP_LTZ(a), 'MM/dd/yyyy HH:mm:ss')",
+        self.assertEqual("TO_TIMESTAMP_LTZ(a, 0)", str(to_timestamp_ltz(expr1, 0)))
+        self.assertEqual("TO_TIMESTAMP_LTZ(a, 'MM/dd/yyyy HH:mm:ss')",
                          str(to_timestamp_ltz(expr1, "MM/dd/yyyy HH:mm:ss")))
-        self.assertEqual("TO_TIMESTAMP_LTZ(a), 'MM/dd/yyyy HH:mm:ss', 'UTC')",
+        self.assertEqual("TO_TIMESTAMP_LTZ(a, 'MM/dd/yyyy HH:mm:ss', 'UTC')",
                          str(to_timestamp_ltz(expr1, "MM/dd/yyyy HH:mm:ss", "UTC")))
         self.assertEqual("toTimestamp('1970-01-01 08:01:40')",
                          str(to_timestamp('1970-01-01 08:01:40')))


### PR DESCRIPTION
## What is the purpose of the change

This PR will fix the issue in PyFlink where to_timestamp_ltz only accepts literal values


## Brief change log
- Remove lit expression within to_timestamp_ltz function
- Add tests

## Verifying this change

This change added tests

## Does this pull request potentially affect one of the following parts:
Dependencies (does it add or upgrade a dependency): (no)
The public API, i.e., is any changed class annotated with @Public(Evolving): (yes)
The serializers: (no)
The runtime per-record code paths (performance sensitive): (no)
Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
The S3 file system connector: (no)

## Documentation
Does this pull request introduce a new feature? (no)
If yes, how is the feature documented? (not applicable)