### PR TITLE
[FLINK-38356] Respect terminating flag for test values source

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
@@ -1717,7 +1717,7 @@ public final class TestValuesTableFactory
             try {
                 return SourceFunctionProvider.of(
                         new TestValuesRuntimeFunctions.FromElementSourceFunctionWithWatermark(
-                                tableName, serializer, values, watermarkStrategy),
+                                tableName, serializer, values, watermarkStrategy, terminating),
                         false);
             } catch (IOException e) {
                 throw new TableException("Fail to init source function", e);


### PR DESCRIPTION
## What is the purpose of the change

Makes the combination of lookup-disabled and watermark pushdown enabled respect the terminating flag.

## Verifying this change

Run savepoint generation for `WatermarkAssignerTestPrograms.WATERMARK_ASSIGNER_PUSHDOWN_METADATA`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
