### PR TITLE
[FLINK-38372][Runtime / Metrics] Introduces whitelist to the flink-metrics-prometheus

### DIFF
--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/AbstractPrometheusReporter.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/AbstractPrometheusReporter.java
@@ -48,6 +48,7 @@ import java.util.Map;
 import java.util.regex.Pattern;
 
 import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.FILTER_LABEL_VALUE_CHARACTER;
+import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.WHITE_LIST;
 
 /** base prometheus reporter for prometheus metrics. */
 @PublicEvolving
@@ -61,9 +62,12 @@ public abstract class AbstractPrometheusReporter implements MetricReporter {
 
     @VisibleForTesting static final char SCOPE_SEPARATOR = '_';
     @VisibleForTesting static final String SCOPE_PREFIX = "flink" + SCOPE_SEPARATOR;
+    @VisibleForTesting static final char DEFAULT_SCOPE_SEPARATOR = '.';
 
     private final Map<String, AbstractMap.SimpleImmutableEntry<Collector, Integer>>
             collectorsWithCountByMetricName = new HashMap<>();
+
+    private final List<String> whiteLists = new ArrayList<>();
 
     @VisibleForTesting
     static String replaceInvalidChars(final String input) {
@@ -87,6 +91,13 @@ public abstract class AbstractPrometheusReporter implements MetricReporter {
         if (!filterLabelValueCharacters) {
             labelValueCharactersFilter = input -> input;
         }
+
+        String whiteList = config.getString(WHITE_LIST.key(), WHITE_LIST.defaultValue());
+        for (String ele : whiteList.split(",")) {
+            if (!ele.trim().isEmpty()) {
+                whiteLists.add(ele.trim());
+            }
+        }
     }
 
     @Override
@@ -97,6 +108,11 @@ public abstract class AbstractPrometheusReporter implements MetricReporter {
     @Override
     public void notifyOfAddedMetric(
             final Metric metric, final String metricName, final MetricGroup group) {
+        String metricScope = LogicalScopeProvider.castFrom(group).getLogicalScope(CHARACTER_FILTER);
+        if (!whiteLists.isEmpty()
+                && !isInWhiteList(metricScope + DEFAULT_SCOPE_SEPARATOR + metricName, whiteLists)) {
+            return;
+        }
 
         List<String> dimensionKeys = new LinkedList<>();
         List<String> dimensionValues = new LinkedList<>();
@@ -389,5 +405,14 @@ public abstract class AbstractPrometheusReporter implements MetricReporter {
 
     private static String[] toArray(List<String> list) {
         return list.toArray(new String[list.size()]);
+    }
+
+    public static boolean isInWhiteList(String metricScopeName, List<String> patternList) {
+        for (String pattern : patternList) {
+            if (metricScopeName.contains(pattern)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterOptions.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterOptions.java
@@ -98,4 +98,11 @@ public class PrometheusPushGatewayReporterOptions {
                                                     "https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels",
                                                     "Prometheus requirements"))
                                     .build());
+
+    public static final ConfigOption<String> WHITE_LIST =
+            ConfigOptions.key("whiteList")
+                    .stringType()
+                    .defaultValue("")
+                    .withDescription(
+                            "The white-list of metric name. The default is to report all metrics");
 }

--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.Histogram;
 import org.apache.flink.metrics.Meter;
 import org.apache.flink.metrics.Metric;
+import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.metrics.util.TestHistogram;
@@ -43,6 +44,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
+import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.WHITE_LIST;
+import static org.apache.flink.metrics.prometheus.PrometheusReporterFactory.ARG_PORT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -241,6 +244,33 @@ class PrometheusReporterTest {
         String ports = reporter.getPort() + ", " + portRangeProvider.nextRange();
         PortRange portRange = new PortRange(ports);
         new PrometheusReporter(portRange).close();
+    }
+
+    @Test
+    public void testMetricFilter() throws Exception {
+        MetricConfig metricConfig = new MetricConfig();
+        metricConfig.setProperty(WHITE_LIST.key(), LOGICAL_SCOPE + ".metricName1");
+        metricConfig.setProperty(ARG_PORT, portRangeProvider.nextRange());
+
+        PrometheusReporterFactory prometheusReporterFactory = new PrometheusReporterFactory();
+        PrometheusReporter metricReporter =
+                prometheusReporterFactory.createMetricReporter(metricConfig);
+        metricReporter.open(metricConfig);
+
+        final Map<String, String> variables = new HashMap<>(metricGroup.getAllVariables());
+        final MetricGroup metricGroup2 = TestUtils.createTestMetricGroup(LOGICAL_SCOPE, variables);
+
+        Counter metric1 = new SimpleCounter();
+        metric1.inc(7);
+        Counter metric2 = new SimpleCounter();
+        metric2.inc(2);
+        metricReporter.notifyOfAddedMetric(metric1, "metricName1", metricGroup2);
+        metricReporter.notifyOfAddedMetric(metric2, "metricName2", metricGroup2);
+
+        String response = pollMetrics(metricReporter.getPort()).body();
+
+        assertThat(response).contains("metricName1");
+        assertThat(response).doesNotContain("metricName2");
     }
 
     private String addMetricAndPollResponse(Metric metric, String metricName)


### PR DESCRIPTION
## What is the purpose of the change

*Allowing users to specify a whitelist of metrics to be exposed through the Prometheus reporter.*


## Brief change log

  - *Adding a whiteList configuration option to PrometheusPushGatewayReporterOptions.*
  - *Filtering metrics in AbstractPrometheusReporter based on the configured whitelist.*
  - *Adding a unit test to verify the metric filtering functionality.*


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

This change added tests and can be verified as follows:

*(example:)*
  - *Added test testMetricFilter()*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
