### PR TITLE
[FLINK-38374][SQL API] Introduce new ARTIFACT keyword as an alternative to JAR

### DIFF
--- a/docs/content/docs/dev/table/functions/udfs.md
+++ b/docs/content/docs/dev/table/functions/udfs.md
@@ -246,6 +246,17 @@ based on different subclass types of `UserDefinedFunction`, e.g. `ScalarFunction
 More logic or optimization could be added in the framework in the future with no need to change any users' existing code. 
 {{< /hint >}}
 
+{{< hint info >}}
+**Registering Functions with Artifacts**
+
+When your function implementation and its dependencies are packaged in JAR files, ZIP archives, or other artifact formats, you can register the function using the `USING` clause in SQL or by providing `ResourceUri` objects in the Table API.
+
+- **SQL**: Use `CREATE FUNCTION ... USING JAR 'path.jar'` or `CREATE FUNCTION ... USING ARTIFACT 'path'` to specify artifact resources. The `ARTIFACT` keyword supports various archive formats and works with all languages (JAVA, SCALA, PYTHON), while `JAR` is limited to JAVA and SCALA functions.
+- **Table API**: Use `createFunction(path, className, List<ResourceUri>)` or `FunctionDescriptor` with `resourceUri()` to specify artifacts programmatically.
+
+See the [CREATE FUNCTION]({{< ref "docs/dev/table/sql/create" >}}#create-function) documentation for complete syntax, examples, and SQL-to-Table API mapping.
+{{< /hint >}}
+
 {{< top >}}
 
 Implementation Guide

--- a/docs/content/docs/sql/reference/ddl/create.md
+++ b/docs/content/docs/sql/reference/ddl/create.md
@@ -860,7 +860,7 @@ If the view already exists, nothing happens.
 CREATE [TEMPORARY|TEMPORARY SYSTEM] FUNCTION 
   [IF NOT EXISTS] [catalog_name.][db_name.]function_name 
   AS identifier [LANGUAGE JAVA|SCALA|PYTHON] 
-  [USING JAR '<path_to_filename>.jar' [, JAR '<path_to_filename>.jar']* ]
+  [USING {JAR|ARTIFACT} '<path_to_filename>' [, {JAR|ARTIFACT} '<path_to_filename>']* ]
   [WITH (key1=val1, key2=val2, ...)]
 ```
 
@@ -886,13 +886,13 @@ If the function already exists, nothing happens.
 
 **LANGUAGE JAVA\|SCALA\|PYTHON**
 
-Language tag to instruct Flink runtime how to execute the function. Currently only JAVA, SCALA and PYTHON are supported, the default language for a function is JAVA. 
+Language tag to instruct Flink runtime how to execute the function. Currently only JAVA, SCALA and PYTHON are supported, the default language for a function is JAVA.
 
 **USING**
 
-Specifies the list of jar resources that contain the implementation of the function along with its dependencies. The jar should be located in a local or remote [file system]({{< ref "docs/deployment/filesystems/overview" >}}) such as hdfs/s3/oss which Flink current supports. 
-
-<span class="label label-danger">Attention</span> Currently only JAVA, SCALA language support USING clause.
+Specifies a list of resources that contain the implementation of the function along with its dependencies. Resources can be specified with the `JAR` or `ARTIFACT` keyword:
+- `JAR`: Only supported for JAVA and SCALA functions. The jar should be located in a local or remote [file system]({{< ref "docs/deployment/filesystems/overview" >}}) such as hdfs/s3/oss which Flink currently supports.
+- `ARTIFACT`: Supported for all languages (JAVA, SCALA, and PYTHON). Provides a language-agnostic way to specify function dependencies.
 
 {{< top >}}
 

--- a/docs/content/docs/sql/reference/utility/describe.md
+++ b/docs/content/docs/sql/reference/utility/describe.md
@@ -91,8 +91,11 @@ tableEnv.executeSql("DESCRIBE CATALOG cat2").print();
 // print the complete metadata
 tableEnv.executeSql("DESC CATALOG EXTENDED cat2").print();
 
-// register a function named "MySum"
+// register a function named "MySum" using JAR
 tableEnv.executeSql("CREATE FUNCTION MySum as 'org.example.SumScalarFunction' USING JAR 'file://home/users/mysum-udf.jar';").print();
+
+// register a function using ARTIFACT (recommended for new code)
+tableEnv.executeSql("CREATE FUNCTION MySum2 as 'org.example.SumScalarFunction' LANGUAGE JAVA USING ARTIFACT 'file://home/users/mysum-udf.jar';").print();
 
 // print the metadata
 tableEnv.executeSql("DESCRIBE FUNCTION MySum").print();
@@ -133,8 +136,11 @@ tableEnv.executeSql("DESCRIBE CATALOG cat2").print()
 tableEnv.executeSql("DESC CATALOG EXTENDED cat2").print()
 
 
-// register a function named "MySum"
+// register a function named "MySum" using JAR
 tableEnv.executeSql("CREATE FUNCTION MySum as 'org.example.SumScalarFunction' USING JAR 'file://home/users/mysum-udf.jar';").print()
+
+// register a function using ARTIFACT (recommended for new code)
+tableEnv.executeSql("CREATE FUNCTION MySum2 as 'org.example.SumScalarFunction' LANGUAGE JAVA USING ARTIFACT 'file://home/users/mysum-udf.jar';").print()
 
 // print the metadata
 tableEnv.executeSql("DESCRIBE FUNCTION MySum").print()
@@ -175,10 +181,13 @@ table_env.execute_sql("DESCRIBE CATALOG cat2").print()
 table_env.execute_sql("DESC CATALOG EXTENDED cat2").print()
 
 
-// register a function named "MySum"
+# register a function named "MySum" using JAR
 table_env.execute_sql("CREATE FUNCTION MySum as 'org.example.SumScalarFunction' USING JAR 'file://home/users/mysum-udf.jar';").print()
 
-// print the metadata
+# register a Python function using ARTIFACT
+table_env.execute_sql("CREATE FUNCTION MyPyFunc as 'my_package.my_module.my_func' LANGUAGE PYTHON USING ARTIFACT 'file://home/users/my_package.zip';").print()
+
+# print the metadata
 table_env.execute_sql("DESCRIBE FUNCTION MySum").print()
 
 // print the complete metadata
@@ -212,6 +221,8 @@ Flink SQL> DESCRIBE CATALOG cat2;
 Flink SQL> DESC CATALOG EXTENDED cat2;
 
 Flink SQL> CREATE FUNCTION MySum as 'org.example.SumScalarFunction' USING JAR 'file://home/users/mysum-udf.jar';
+
+Flink SQL> CREATE FUNCTION MySum2 as 'org.example.SumScalarFunction' LANGUAGE JAVA USING ARTIFACT 'file://home/users/mysum-udf.jar';
 
 Flink SQL> DESCRIBE FUNCTION MySum;
 

--- a/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
@@ -194,6 +194,7 @@
   # Please keep the keyword in alphabetical order if new keyword is added.
   keywords: [
     "ANALYZE"
+    "ARTIFACT"
     "BUCKETS"
     "BYTES"
     "CATALOGS"
@@ -273,6 +274,7 @@
     "ALWAYS"
     "APPLY"
     "ARRAY_AGG"
+    "ARTIFACT"
     "ASC"
     "ASSERTION"
     "ASSIGNMENT"

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -447,20 +447,15 @@ SqlCreate SqlCreateFunction(Span s, boolean replace, boolean isTemporary) :
     ]
     [
         <USING> {
-            if ("SQL".equals(functionLanguage) || "PYTHON".equals(functionLanguage)) {
-                throw SqlUtil.newContextException(
-                    functionLanguagePos,
-                    ParserResource.RESOURCE.createFunctionUsingJar(functionLanguage));
-            }
             List<SqlNode> resourceList = new ArrayList<SqlNode>();
             SqlResource sqlResource = null;
         }
-        sqlResource = SqlResourceInfo() {
+        sqlResource = SqlResourceInfo(functionLanguage) {
             resourceList.add(sqlResource);
         }
         (
             <COMMA>
-            sqlResource = SqlResourceInfo() {
+            sqlResource = SqlResourceInfo(functionLanguage) {
                 resourceList.add(sqlResource);
             }
         )*
@@ -487,16 +482,30 @@ SqlCreate SqlCreateFunction(Span s, boolean replace, boolean isTemporary) :
 /**
  * Parse resource type and path.
  */
-SqlResource SqlResourceInfo() :
+SqlResource SqlResourceInfo(String functionLanguage) :
 {
     String resourcePath;
 }
 {
     <JAR> <QUOTED_STRING> {
         resourcePath = SqlParserUtil.parseString(token.image);
+        if ("SQL".equals(functionLanguage) || "PYTHON".equals(functionLanguage)) {
+            throw SqlUtil.newContextException(
+                getPos(),
+                ParserResource.RESOURCE.createFunctionUsingJar(functionLanguage));
+        }
         return new SqlResource(
                     getPos(),
                     SqlResourceType.JAR.symbol(getPos()),
+                    SqlLiteral.createCharString(resourcePath, getPos()));
+    }
+|
+    <ARTIFACT> <QUOTED_STRING> {
+        resourcePath = SqlParserUtil.parseString(token.image);
+        // ARTIFACT can be used by any language
+        return new SqlResource(
+                    getPos(),
+                    SqlResourceType.ARTIFACT.symbol(getPos()),
                     SqlLiteral.createCharString(resourcePath, getPos()));
     }
 }

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/resource/SqlResourceType.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/resource/SqlResourceType.java
@@ -25,7 +25,8 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 public enum SqlResourceType {
     FILE("FILE"),
     JAR("JAR"),
-    ARCHIVE("ARCHIVE");
+    ARCHIVE("ARCHIVE"),
+    ARTIFACT("ARTIFACT");
 
     private final String digest;
 

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -2526,16 +2526,17 @@ class FlinkSqlParserImplTest extends SqlParserTest {
                 .ok(
                         "CREATE FUNCTION `FUNCTION1` AS 'org.apache.flink.function.function1' LANGUAGE JAVA USING JAR 'file:///path/to/test.jar', JAR 'hdfs:///path/to/test2.jar'");
 
-        sql("create temporary function function1 as 'org.apache.flink.function.function1' language ^sql^ using jar 'file:///path/to/test.jar'")
+        sql("create temporary function function1 as 'org.apache.flink.function.function1' language sql using jar ^'file:///path/to/test.jar'^")
                 .fails("CREATE FUNCTION USING JAR syntax is not applicable to SQL language.");
 
-        sql("create temporary function function1 as 'org.apache.flink.function.function1' language ^python^ using jar 'file:///path/to/test.jar'")
+        sql("create temporary function function1 as 'org.apache.flink.function.function1' language python using jar ^'file:///path/to/test.jar'^")
                 .fails("CREATE FUNCTION USING JAR syntax is not applicable to PYTHON language.");
 
         sql("create temporary function function1 as 'org.apache.flink.function.function1' language java using ^file^ 'file:///path/to/test'")
                 .fails(
                         "Encountered \"file\" at line 1, column 98.\n"
-                                + "Was expecting:\n"
+                                + "Was expecting one of:\n"
+                                + "    \"ARTIFACT\" ...\n"
                                 + "    \"JAR\" ...\n"
                                 + "    .*");
 
@@ -2552,6 +2553,52 @@ class FlinkSqlParserImplTest extends SqlParserTest {
                                 + "  'k1' = 'v1',\n"
                                 + "  'k2' = 'v2'\n"
                                 + ")");
+
+        // test create function using artifact
+        sql("create temporary function function1 as 'org.apache.flink.function.function1' language java using artifact 'file:///path/to/test.artifact'")
+                .ok(
+                        "CREATE TEMPORARY FUNCTION `FUNCTION1` AS 'org.apache.flink.function.function1' LANGUAGE JAVA USING ARTIFACT 'file:///path/to/test.artifact'");
+
+        sql("create temporary function function1 as 'org.apache.flink.function.function1' language scala using artifact '/path/to/test.artifact'")
+                .ok(
+                        "CREATE TEMPORARY FUNCTION `FUNCTION1` AS 'org.apache.flink.function.function1' LANGUAGE SCALA USING ARTIFACT '/path/to/test.artifact'");
+
+        sql("create function function1 as 'org.apache.flink.function.function1' language java using artifact 'file:///path/to/test.artifact', artifact 'hdfs:///path/to/test2.artifact'")
+                .ok(
+                        "CREATE FUNCTION `FUNCTION1` AS 'org.apache.flink.function.function1' LANGUAGE JAVA USING ARTIFACT 'file:///path/to/test.artifact', ARTIFACT 'hdfs:///path/to/test2.artifact'");
+
+        // SQL language cannot use JAR but can use ARTIFACT
+        sql("create temporary function function1 as 'org.apache.flink.function.function1' language sql using jar ^'file:///path/to/test.jar'^")
+                .fails("CREATE FUNCTION USING JAR syntax is not applicable to SQL language.");
+        sql("create temporary function function1 as 'org.apache.flink.function.function1' language sql using artifact 'file:///path/to/test.artifact'")
+                .ok(
+                        "CREATE TEMPORARY FUNCTION `FUNCTION1` AS 'org.apache.flink.function.function1' LANGUAGE SQL USING ARTIFACT 'file:///path/to/test.artifact'");
+
+        // PYTHON language cannot use JAR but can use ARTIFACT
+        sql("create temporary function function1 as 'org.apache.flink.function.function1' language python using jar ^'file:///path/to/test.jar'^")
+                .fails("CREATE FUNCTION USING JAR syntax is not applicable to PYTHON language.");
+        sql("create temporary function function1 as 'org.apache.flink.function.function1' language python using artifact 'file:///path/to/test.artifact'")
+                .ok(
+                        "CREATE TEMPORARY FUNCTION `FUNCTION1` AS 'org.apache.flink.function.function1' LANGUAGE PYTHON USING ARTIFACT 'file:///path/to/test.artifact'");
+
+        // Test ARTIFACT with SCALA language
+        sql("create temporary function function1 as 'org.apache.flink.function.function1' language scala using artifact 'file:///path/to/test.artifact'")
+                .ok(
+                        "CREATE TEMPORARY FUNCTION `FUNCTION1` AS 'org.apache.flink.function.function1' LANGUAGE SCALA USING ARTIFACT 'file:///path/to/test.artifact'");
+
+        sql("create function function1 as 'org.apache.flink.function.function1' language python using artifact 'file:///path/to/test.artifact', artifact 'hdfs:///path/to/dependency.artifact'")
+                .ok(
+                        "CREATE FUNCTION `FUNCTION1` AS 'org.apache.flink.function.function1' LANGUAGE PYTHON USING ARTIFACT 'file:///path/to/test.artifact', ARTIFACT 'hdfs:///path/to/dependency.artifact'");
+
+        // Test mixed JAR and ARTIFACT in the same USING clause
+        sql("create function function1 as 'org.apache.flink.function.function1' language java using jar 'file:///path/to/test.jar', artifact 'file:///path/to/test.artifact'")
+                .ok(
+                        "CREATE FUNCTION `FUNCTION1` AS 'org.apache.flink.function.function1' LANGUAGE JAVA USING JAR 'file:///path/to/test.jar', ARTIFACT 'file:///path/to/test.artifact'");
+
+        // Test ARTIFACT with default (implicit) language
+        sql("create function function1 as 'org.apache.flink.function.function1' using artifact 'file:///path/to/test.artifact'")
+                .ok(
+                        "CREATE FUNCTION `FUNCTION1` AS 'org.apache.flink.function.function1' USING ARTIFACT 'file:///path/to/test.artifact'");
     }
 
     @Test

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
@@ -141,12 +141,12 @@ public final class FunctionCatalog {
                             "Could not drop temporary system function. A function named '%s' doesn't exist.",
                             name));
         }
-        unregisterFunctionJarResources(function);
+        unregisterFunctionResources(function);
 
         return function != null;
     }
 
-    private void unregisterFunctionJarResources(@Nullable CatalogFunction function) {
+    private void unregisterFunctionResources(@Nullable CatalogFunction function) {
         if (function != null && function.getFunctionLanguage() == FunctionLanguage.JAVA) {
             resourceManager.unregisterFunctionResources(function.getFunctionResources());
         }
@@ -509,7 +509,7 @@ public final class FunctionCatalog {
                     .getTemporaryOperationListener(normalizedName)
                     .ifPresent(l -> l.onDropTemporaryFunction(normalizedName.toObjectPath()));
             tempCatalogFunctions.remove(normalizedName);
-            unregisterFunctionJarResources(fd);
+            unregisterFunctionResources(fd);
         } else if (!ignoreIfNotExist) {
             throw new ValidationException(
                     String.format("Temporary catalog function %s doesn't exist", identifier));
@@ -601,8 +601,7 @@ public final class FunctionCatalog {
         CatalogFunction potentialResult = tempCatalogFunctions.get(normalizedIdentifier);
 
         if (potentialResult != null) {
-            registerFunctionJarResources(
-                    oi.asSummaryString(), potentialResult.getFunctionResources());
+            registerFunctionResources(oi.asSummaryString(), potentialResult.getFunctionResources());
             return Optional.of(
                     ContextResolvedFunction.temporary(
                             FunctionIdentifier.of(oi),
@@ -622,7 +621,7 @@ public final class FunctionCatalog {
                 FunctionDefinition fd;
                 if (catalog.getFunctionDefinitionFactory().isPresent()
                         && catalogFunction.getFunctionLanguage() != FunctionLanguage.PYTHON) {
-                    registerFunctionJarResources(
+                    registerFunctionResources(
                             oi.asSummaryString(), catalogFunction.getFunctionResources());
                     fd =
                             catalog.getFunctionDefinitionFactory()
@@ -656,7 +655,7 @@ public final class FunctionCatalog {
         String normalizedName = FunctionIdentifier.normalizeName(funcName);
         if (tempSystemFunctions.containsKey(normalizedName)) {
             CatalogFunction function = tempSystemFunctions.get(normalizedName);
-            registerFunctionJarResources(funcName, function.getFunctionResources());
+            registerFunctionResources(funcName, function.getFunctionResources());
             return Optional.of(
                     ContextResolvedFunction.temporary(
                             FunctionIdentifier.of(funcName),
@@ -691,7 +690,7 @@ public final class FunctionCatalog {
             }
             // Skip validation if it's not a UserDefinedFunction.
         } else if (function.getFunctionLanguage() == FunctionLanguage.JAVA) {
-            // If the jar resource of UDF used is not empty, register it to classloader before
+            // If the artifact resource of UDF used is not empty, register it to classloader before
             // validate.
             List<ResourceUri> resourceUris = function.getFunctionResources();
             try {
@@ -702,7 +701,7 @@ public final class FunctionCatalog {
             } catch (Exception e) {
                 throw new TableException(
                         String.format(
-                                "Failed to register function jar resource '%s' of function '%s'.",
+                                "Failed to register function artifact resource '%s' of function '%s'.",
                                 resourceUris, name),
                         e);
             }
@@ -730,9 +729,8 @@ public final class FunctionCatalog {
         if (function.getFunctionLanguage() == FunctionLanguage.PYTHON) {
             resourceManager.registerPythonResources();
         }
-        // If the jar resource of UDF used is not empty, register it to classloader before
-        // validate.
-        registerFunctionJarResources(name, function.getFunctionResources());
+        // If the resource of UDF used is not empty, register it to classloader before validate.
+        registerFunctionResources(name, function.getFunctionResources());
 
         return UserDefinedFunctionHelper.instantiateFunction(
                 resourceManager.getUserClassLoader(),
@@ -742,15 +740,17 @@ public final class FunctionCatalog {
                 function);
     }
 
-    public void registerFunctionJarResources(String functionName, List<ResourceUri> resourceUris) {
+    public void registerFunctionResources(String functionName, List<ResourceUri> resourceUris) {
         try {
             if (!resourceUris.isEmpty()) {
-                resourceManager.registerJarResources(resourceUris);
+                // Use generic registerArtifactResources to support all resource types
+                // (JAR, ARTIFACT, ARCHIVE) instead of JAR-only registerJarResources
+                resourceManager.registerArtifactResources(resourceUris, true);
             }
         } catch (Exception e) {
             throw new TableException(
                     String.format(
-                            "Failed to register jar resource '%s' of function '%s'.",
+                            "Failed to register resource '%s' of function '%s'.",
                             resourceUris, functionName),
                     e);
         }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/resource/ResourceManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/resource/ResourceManager.java
@@ -118,24 +118,83 @@ public class ResourceManager implements Closeable {
      * Due to anyone of the resource in list maybe fail during register, so we should stage it
      * before actual register to guarantee transaction process. If all the resources are available,
      * register them into the {@link ResourceManager}.
+     *
+     * <p>This method is specifically for JAR resources. For generic artifact resources (including
+     * JAR, ZIP, tar.gz, etc.), use {@link #registerArtifactResources(List, boolean)} instead.
+     *
+     * @param resourceUris list of JAR resource URIs. All resources must be of type JAR.
+     * @throws ValidationException if any resource is not of type JAR
      */
     public void registerJarResources(List<ResourceUri> resourceUris) throws IOException {
-        registerResources(
-                prepareStagingResources(
-                        resourceUris,
-                        ResourceType.JAR,
-                        true,
-                        url -> {
-                            try {
-                                JarUtils.checkJarFile(url);
-                            } catch (IOException e) {
-                                throw new ValidationException(
-                                        String.format("Failed to register jar resource [%s]", url),
-                                        e);
-                            }
-                        },
-                        false),
-                true);
+        // Validate all resources are JAR type for backward compatibility
+        for (ResourceUri uri : resourceUris) {
+            if (uri.getResourceType() != ResourceType.JAR) {
+                throw new ValidationException(
+                        String.format(
+                                "registerJarResources() only accepts JAR resources, but got %s for resource [%s]",
+                                uri.getResourceType(), uri.getUri()));
+            }
+        }
+        registerArtifactResources(resourceUris, true);
+    }
+
+    /**
+     * Register artifact resources (JAR, ZIP, tar.gz, or other archive formats) into the {@link
+     * ResourceManager}. This is a generic method that supports multiple resource types.
+     *
+     * <p>Due to anyone of the resource in list maybe fail during register, so we should stage it
+     * before actual register to guarantee transaction process. If all the resources are available,
+     * register them into the {@link ResourceManager}.
+     *
+     * @param resourceUris list of artifact resource URIs. Can contain mixed resource types (JAR,
+     *     ARTIFACT, ARCHIVE).
+     * @param addToClassLoader whether to add resources to the classloader. Set to true for JAR
+     *     files that need to be on the classpath.
+     */
+    public void registerArtifactResources(List<ResourceUri> resourceUris, boolean addToClassLoader)
+            throws IOException {
+        if (resourceUris.isEmpty()) {
+            return;
+        }
+
+        // Group resources by type for efficient processing
+        Map<ResourceType, List<ResourceUri>> resourcesByType =
+                resourceUris.stream().collect(Collectors.groupingBy(ResourceUri::getResourceType));
+
+        Map<ResourceUri, URL> allStagingResources = new HashMap<>();
+
+        for (Map.Entry<ResourceType, List<ResourceUri>> entry : resourcesByType.entrySet()) {
+            ResourceType resourceType = entry.getKey();
+            List<ResourceUri> typeResources = entry.getValue();
+
+            Map<ResourceUri, URL> stagingResources =
+                    prepareStagingResources(
+                            typeResources,
+                            resourceType,
+                            true,
+                            url -> {
+                                // Only validate JAR files with JarUtils
+                                // ARTIFACT and ARCHIVE types don't need JAR-specific validation
+                                if (resourceType == ResourceType.JAR) {
+                                    try {
+                                        JarUtils.checkJarFile(url);
+                                    } catch (IOException e) {
+                                        throw new ValidationException(
+                                                String.format(
+                                                        "Failed to register jar resource [%s]",
+                                                        url),
+                                                e);
+                                    }
+                                }
+                                // For other resource types, basic validation (existence, not
+                                // directory) is already performed in checkPath()
+                            },
+                            false);
+
+            allStagingResources.putAll(stagingResources);
+        }
+
+        registerResources(allStagingResources, addToClassLoader);
     }
 
     /**
@@ -166,22 +225,41 @@ public class ResourceManager implements Closeable {
      * remote, it will be copied to a local file. The declared resource will not be added to
      * resources and classloader if it is not used in the job.
      *
-     * @param resourceUris the resource uri for function.
+     * <p>This method supports multiple resource types (JAR, ARTIFACT, ARCHIVE, FILE). For JAR
+     * resources, it performs JAR-specific validation. For other resource types, only basic
+     * validation (existence, not a directory) is performed.
+     *
+     * @param resourceUris the resource uri for function. Can contain mixed resource types.
      */
     public void declareFunctionResources(Set<ResourceUri> resourceUris) throws IOException {
-        prepareStagingResources(
-                resourceUris,
-                ResourceType.JAR,
-                true,
-                url -> {
-                    try {
-                        JarUtils.checkJarFile(url);
-                    } catch (IOException e) {
-                        throw new ValidationException(
-                                String.format("Failed to register jar resource [%s]", url), e);
-                    }
-                },
-                true);
+        if (resourceUris.isEmpty()) {
+            return;
+        }
+
+        // Process each resource individually to handle different resource types
+        for (ResourceUri resourceUri : resourceUris) {
+            ResourceType resourceType = resourceUri.getResourceType();
+            prepareStagingResources(
+                    Collections.singleton(resourceUri),
+                    resourceType,
+                    true,
+                    url -> {
+                        // Only validate JAR files with JarUtils
+                        // ARTIFACT, ARCHIVE, and FILE types don't need JAR-specific validation
+                        if (resourceType == ResourceType.JAR) {
+                            try {
+                                JarUtils.checkJarFile(url);
+                            } catch (IOException e) {
+                                throw new ValidationException(
+                                        String.format("Failed to validate jar resource [%s]", url),
+                                        e);
+                            }
+                        }
+                        // For other resource types, basic validation (existence, not directory)
+                        // is already performed in checkPath()
+                    },
+                    true);
+        }
     }
 
     /**
@@ -230,12 +308,17 @@ public class ResourceManager implements Closeable {
     }
 
     /**
-     * Get the local jars' URL. Return the URL corresponding to downloaded jars in the local file
-     * system for the remote jar. For the local jar, return the registered URL.
+     * Get the local jars' URL. Return the URL corresponding to downloaded jars and artifacts in the
+     * local file system for remote resources. For local resources, return the registered URL.
      */
     public Set<URL> getLocalJarResources() {
         return resourceInfos.entrySet().stream()
-                .filter(entry -> ResourceType.JAR.equals(entry.getKey().getResourceType()))
+                .filter(
+                        entry -> {
+                            ResourceType type = entry.getKey().getResourceType();
+                            return ResourceType.JAR.equals(type)
+                                    || ResourceType.ARTIFACT.equals(type);
+                        })
                 .map(Map.Entry::getValue)
                 .collect(Collectors.toSet());
     }
@@ -514,7 +597,8 @@ public class ResourceManager implements Closeable {
 
             URL localUrl;
             ResourceUri localResourceUri = resourceUri;
-            if (expectedType == ResourceType.JAR
+            // Optimization: reuse already-declared function resources for JAR and ARTIFACT types
+            if ((expectedType == ResourceType.JAR || expectedType == ResourceType.ARTIFACT)
                     && functionResourceInfos.containsKey(resourceUri)) {
                 // Get local url from function resource infos.
                 localUrl = functionResourceInfos.get(resourceUri).url;

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/resource/ResourceManagerTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/resource/ResourceManagerTest.java
@@ -46,6 +46,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -58,7 +59,10 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import static org.apache.flink.table.utils.CatalogManagerMocks.DEFAULT_CATALOG;
 import static org.apache.flink.table.utils.CatalogManagerMocks.DEFAULT_DATABASE;
@@ -86,6 +90,8 @@ public class ResourceManagerTest {
 
     private static File file;
 
+    private static File artifactZip;
+
     private ResourceManager resourceManager;
 
     @BeforeAll
@@ -98,6 +104,15 @@ public class ResourceManagerTest {
                         String.format(GENERATED_LOWER_UDF_CODE, GENERATED_LOWER_UDF_CLASS));
         file = File.createTempFile("ResourceManagerTest", ".txt", tempFolder);
         FileUtils.writeFileUtf8(file, "Hello World");
+
+        // Create a ZIP file for ARTIFACT testing
+        artifactZip = new File(tempFolder, "test-artifact.zip");
+        try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(artifactZip))) {
+            ZipEntry entry = new ZipEntry("test-file.txt");
+            zos.putNextEntry(entry);
+            zos.write("Test artifact content".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+        }
     }
 
     @BeforeEach
@@ -222,8 +237,8 @@ public class ResourceManagerTest {
 
         CommonTestUtils.assertThrows(
                 String.format(
-                        "Expect the resource type to be jar, but encounter a resource [%s] with type %s.",
-                        fileUri, ResourceType.FILE.name().toLowerCase()),
+                        "registerJarResources() only accepts JAR resources, but got %s for resource [%s]",
+                        ResourceType.FILE, fileUri),
                 ValidationException.class,
                 () -> {
                     resourceManager.registerJarResources(
@@ -470,5 +485,136 @@ public class ResourceManagerTest {
 
     public static Stream<Arguments> provideResource() {
         return Stream.of(Arguments.of(udfJar.getPath(), true), Arguments.of(file.getPath(), false));
+    }
+
+    @Test
+    public void testDeclareFunctionResourcesWithArtifact() throws Exception {
+        ResourceUri artifactUri = new ResourceUri(ResourceType.ARTIFACT, artifactZip.getPath());
+
+        // Should not throw ValidationException for ARTIFACT type
+        resourceManager.declareFunctionResources(Collections.singleton(artifactUri));
+
+        // Verify resource is declared in function resource infos
+        Map<ResourceUri, ResourceManager.ResourceCounter> functionResourceInfos =
+                resourceManager.functionResourceInfos();
+        assertThat(functionResourceInfos).containsKey(artifactUri);
+        assertThat(functionResourceInfos.get(artifactUri).counter).isEqualTo(1);
+    }
+
+    @Test
+    public void testRegisterArtifactResources() throws Exception {
+        ResourceUri artifactUri = new ResourceUri(ResourceType.ARTIFACT, artifactZip.getPath());
+
+        // Should not throw ValidationException for ARTIFACT type
+        resourceManager.registerArtifactResources(Collections.singletonList(artifactUri), true);
+
+        // Verify resource is registered
+        Map<ResourceUri, URL> resources = resourceManager.getResources();
+        assertThat(resources).containsKey(artifactUri);
+    }
+
+    @Test
+    public void testMixedResourceTypes() throws Exception {
+        ResourceUri jarUri = new ResourceUri(ResourceType.JAR, udfJar.getPath());
+        ResourceUri artifactUri = new ResourceUri(ResourceType.ARTIFACT, artifactZip.getPath());
+
+        Set<ResourceUri> mixedResources = new HashSet<>();
+        mixedResources.add(jarUri);
+        mixedResources.add(artifactUri);
+
+        // Should handle both types correctly
+        resourceManager.declareFunctionResources(mixedResources);
+
+        Map<ResourceUri, ResourceManager.ResourceCounter> functionResourceInfos =
+                resourceManager.functionResourceInfos();
+        assertThat(functionResourceInfos).containsKey(jarUri);
+        assertThat(functionResourceInfos).containsKey(artifactUri);
+        assertThat(functionResourceInfos.get(jarUri).counter).isEqualTo(1);
+        assertThat(functionResourceInfos.get(artifactUri).counter).isEqualTo(1);
+    }
+
+    @Test
+    public void testArtifactResourceReuse() throws Exception {
+        ResourceUri artifactUri = new ResourceUri(ResourceType.ARTIFACT, artifactZip.getPath());
+
+        // Declare first
+        resourceManager.declareFunctionResources(Collections.singleton(artifactUri));
+        Map<ResourceUri, ResourceManager.ResourceCounter> functionResourceInfos =
+                resourceManager.functionResourceInfos();
+        URL declaredUrl = functionResourceInfos.get(artifactUri).url;
+
+        // Register should reuse declared resource (optimization)
+        resourceManager.registerArtifactResources(Collections.singletonList(artifactUri), true);
+
+        // Verify the same URL is reused (counter should be 2: 1 from declare, 1 from register)
+        // Note: registerArtifactResources with declareFunctionResource=false doesn't increase
+        // counter, but the optimization in prepareStagingResources should reuse the URL
+        assertThat(functionResourceInfos.get(artifactUri).url).isEqualTo(declaredUrl);
+    }
+
+    @Test
+    public void testRegisterArtifactResourcesWithMixedTypes() throws Exception {
+        ResourceUri jarUri = new ResourceUri(ResourceType.JAR, udfJar.getPath());
+        ResourceUri artifactUri = new ResourceUri(ResourceType.ARTIFACT, artifactZip.getPath());
+
+        List<ResourceUri> mixedResources = Arrays.asList(jarUri, artifactUri);
+
+        // Should handle both types correctly
+        resourceManager.registerArtifactResources(mixedResources, true);
+
+        Map<ResourceUri, URL> resources = resourceManager.getResources();
+        assertThat(resources).containsKey(jarUri);
+        assertThat(resources).containsKey(artifactUri);
+    }
+
+    @Test
+    public void testArtifactResourceWithoutJarValidation() throws Exception {
+        // Create a non-JAR file with .zip extension
+        File zipFile = new File(tempFolder, "test-deps.zip");
+        try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(zipFile))) {
+            ZipEntry entry = new ZipEntry("dependency.txt");
+            zos.putNextEntry(entry);
+            zos.write("Dependency content".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+        }
+
+        ResourceUri artifactUri = new ResourceUri(ResourceType.ARTIFACT, zipFile.getPath());
+
+        // Should not throw ValidationException even though it's not a valid JAR
+        // ARTIFACT type doesn't require JAR validation
+        resourceManager.declareFunctionResources(Collections.singleton(artifactUri));
+        resourceManager.registerArtifactResources(Collections.singletonList(artifactUri), false);
+
+        // Verify it was registered successfully
+        Map<ResourceUri, URL> resources = resourceManager.getResources();
+        assertThat(resources).containsKey(artifactUri);
+    }
+
+    @Test
+    public void testGetLocalJarResourcesIncludesArtifacts() throws Exception {
+        ResourceUri jarUri = new ResourceUri(ResourceType.JAR, udfJar.getPath());
+        ResourceUri artifactUri = new ResourceUri(ResourceType.ARTIFACT, artifactZip.getPath());
+
+        resourceManager.registerArtifactResources(Arrays.asList(jarUri, artifactUri), true);
+
+        Set<URL> localJarResources = resourceManager.getLocalJarResources();
+        // Both JAR and ARTIFACT resources should be included for pipeline distribution
+        assertThat(localJarResources).hasSize(2);
+    }
+
+    @Test
+    public void testRegisterJarResourcesRejectsArtifact() throws Exception {
+        ResourceUri artifactUri = new ResourceUri(ResourceType.ARTIFACT, artifactZip.getPath());
+
+        // registerJarResources should reject non-JAR resources
+        CommonTestUtils.assertThrows(
+                String.format(
+                        "registerJarResources() only accepts JAR resources, but got %s for resource [%s]",
+                        ResourceType.ARTIFACT, artifactZip.getPath()),
+                ValidationException.class,
+                () -> {
+                    resourceManager.registerJarResources(Collections.singletonList(artifactUri));
+                    return null;
+                });
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/resource/ResourceType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/resource/ResourceType.java
@@ -25,5 +25,6 @@ import org.apache.flink.annotation.PublicEvolving;
 public enum ResourceType {
     FILE,
     JAR,
-    ARCHIVE
+    ARCHIVE,
+    ARTIFACT
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/OperationConverterUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/OperationConverterUtils.java
@@ -199,10 +199,13 @@ public class OperationConverterUtils {
                                 case ARCHIVE:
                                     resourceType = ResourceType.ARCHIVE;
                                     break;
+                                case ARTIFACT:
+                                    resourceType = ResourceType.ARTIFACT;
+                                    break;
                                 default:
                                     throw new ValidationException(
                                             String.format(
-                                                    "Unsupported resource type: .",
+                                                    "Unsupported resource type: %s.",
                                                     sqlResourceType));
                             }
                             // get resource path

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/FunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/FunctionITCase.java
@@ -102,6 +102,34 @@ class FunctionITCase extends BatchTestBase {
     }
 
     @Test
+    void testUserDefinedTemporarySystemFunctionByUsingArtifact() throws Exception {
+        String functionDDL =
+                String.format(
+                        "create temporary system function lowerUdf as '%s' language java using artifact '%s'",
+                        udfClassName, jarPath);
+
+        String dropFunctionDDL = "drop temporary system function lowerUdf";
+        testUserDefinedFunctionByUsingJar(functionDDL, dropFunctionDDL);
+    }
+
+    @Test
+    void testCreateTemporarySystemFunctionByUsingArtifact() {
+        String ddl =
+                String.format(
+                        "CREATE TEMPORARY SYSTEM FUNCTION f10 AS '%s' LANGUAGE JAVA USING ARTIFACT '%s'",
+                        udfClassName, jarPath);
+        tEnv().executeSql(ddl);
+
+        List<String> functions = Arrays.asList(tEnv().listFunctions());
+        assertThat(functions).contains("f10");
+
+        tEnv().executeSql("DROP TEMPORARY SYSTEM FUNCTION f10");
+
+        functions = Arrays.asList(tEnv().listFunctions());
+        assertThat(functions).doesNotContain("f10");
+    }
+
+    @Test
     void testOrderByScopeRawTypeCast() throws Exception {
         final List<Row> sourceData = List.of(Row.of(1), Row.of(2), Row.of(3), Row.of(4), Row.of(5));
         TestCollectionTableFactory.reset();


### PR DESCRIPTION

## Contribution Checklist
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

## What is the purpose of the change

Currently, the CREATE FUNCTION USING syntax only supports JAR resources, which limits the flexibility for specifying different types of dependencies for user-defined functions. Users need the ability to specify artifact dependencies in addition to JAR files.


## Brief change log

1. Parser Configuration
* Added ARTIFACT keyword to Parser.tdd in both keywords and nonReservedKeywords lists
* Added ARTIFACT to SqlResourceType enum
2. Parser Implementation
* Modified SqlResourceInfo() method in parserImpls.ftl to accept ARTIFACT resources
* Updated method signature to accept functionLanguage parameter for validation
* Implemented flexible validation logic:
  * JAR resources: Only allowed for JAVA and SCALA languages
  * ARTIFACT resources: Allowed for all languages (JAVA, SCALA, SQL, PYTHON)
3. Testing
* Added tests for ARTIFACT syntax with all supported languages
* Added tests for validation rules (ensuring proper blocking/allowing)
* Added tests for multiple artifact resources

## Does this pull request potentially affect one of the following parts:

  - Modifies

## Documentation

  - TODO
