### PR TITLE
[FLINK-38378][table] Use ValidationException in CatalogManager in case of user error

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -708,7 +708,7 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
         return getTable(objectIdentifier)
                 .orElseThrow(
                         () ->
-                                new TableException(
+                                new ValidationException(
                                         String.format(
                                                 "Cannot find table '%s' in any of the catalogs %s, nor as a temporary table.",
                                                 objectIdentifier, listCatalogs())));
@@ -748,7 +748,7 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
                 if (timestamp != null) {
                     table = currentCatalog.getTable(objectPath, timestamp);
                     if (table.getTableKind() == TableKind.VIEW) {
-                        throw new TableException(
+                        throw new ValidationException(
                                 String.format(
                                         "%s is a view, but time travel is not supported for view.",
                                         objectIdentifier.asSummaryString()));
@@ -1448,7 +1448,7 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
         return getModel(objectIdentifier)
                 .orElseThrow(
                         () ->
-                                new TableException(
+                                new ValidationException(
                                         String.format(
                                                 "Cannot find model '%s' in any of the catalogs %s.",
                                                 objectIdentifier, listCatalogs())));


### PR DESCRIPTION


## What is the purpose of the change

The PR makes using `ValidationException` in `CatalogManager` rather than `TableException` for user errors
as mentioned at https://github.com/apache/flink/blob/d08abb7b1697a3ba78ee0bc5d31f841eb0c9d386/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/ValidationException.java#L24-L26

## Brief change log
CatalogManager


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
