### PR TITLE
[FLINK-38384][build] Bump lombok to 1.18.40

### DIFF
--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -169,7 +169,7 @@ under the License.
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.30</version>
+			<version>1.18.42</version>
 			<scope>test</scope>
 		</dependency>
 


### PR DESCRIPTION
## What is the purpose of the change

This is one of the first steps towards jdk25
current PR fixes failure 
```
flink-core: Fatal error compiling: java.lang.ExceptionInInitializerError: com.sun.tools.javac.code.TypeTag :: UNKNOWN 
```
after 
```
./mvnw clean install -DskipTests -Pfast -Pskip-webui-build  -U
```

## Brief change log

pom.xml
## Verifying this change


This change is already covered by existing tests, such as *(please describe tests)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes )
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
