### PR TITLE
[FLINK-38385][build] Bump mockito to 5.19.0 and byte-buddy to 1.17.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@ under the License.
 		<junit4.version>4.13.2</junit4.version>
 		<junit5.version>5.11.4</junit5.version>
 		<archunit.version>1.2.0</archunit.version>
-		<mockito.version>5.14.2</mockito.version>
+		<mockito.version>5.19.0</mockito.version>
 		<hamcrest.version>1.3</hamcrest.version>
 		<assertj.version>3.27.3</assertj.version>
 		<py4j.version>0.10.9.7</py4j.version>
@@ -610,13 +610,13 @@ under the License.
 			<dependency>
 				<groupId>net.bytebuddy</groupId>
 				<artifactId>byte-buddy</artifactId>
-				<version>1.15.11</version>
+				<version>1.17.6</version>
 			</dependency>
 
 			<dependency>
 				<groupId>net.bytebuddy</groupId>
 				<artifactId>byte-buddy-agent</artifactId>
-				<version>1.15.11</version>
+				<version>1.17.6</version>
 			</dependency>
 
 			<!-- For dependency convergence -->


### PR DESCRIPTION

## What is the purpose of the change

This is one of the first steps towards build with jdk25
this commit is going to fix failure of tests
```
Caused by: java.lang.IllegalArgumentException: Java 25 (69) is not supported by the current version of Byte Buddy which officially supports Java 24 (68) - update Byte Buddy or set net.bytebuddy.experimental as a VM property
	at net.bytebuddy.utility.OpenedClassReader.of(OpenedClassReader.java:120)
	at net.bytebuddy.utility.OpenedClassReader.of(OpenedClassReader.java:95)
	at net.bytebuddy.utility.AsmClassReader$Factory$Default.make(AsmClassReader.java:82)
	at net.bytebuddy.dynamic.scaffold.TypeWriter$Default$ForInlining.create(TypeWriter.java:4031)
	at net.bytebuddy.dynamic.scaffold.TypeWriter$Default.make(TypeWriter.java:2246)
	at net.bytebuddy.dynamic.DynamicType$Builder$AbstractBase$UsingTypeWriter.make(DynamicType.java:4085)
	at net.bytebuddy.dynamic.DynamicType$Builder$AbstractBase.make(DynamicType.java:3769)
	at org.mockito.internal.creation.bytebuddy.InlineBytecodeGenerator.transform(InlineBytecodeGener
```


## Brief change log

pom.xml


## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.
also manually with jdk 25 (the ci for jdk25 will be setup later)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
