### PR TITLE
[FLINK-38386][build] Fix attaching type annotations for jdk23+

### DIFF
--- a/flink-table/flink-sql-parser/pom.xml
+++ b/flink-table/flink-sql-parser/pom.xml
@@ -151,10 +151,6 @@ under the License.
 					<artifactId>joda-time</artifactId>
 				</exclusion>
 				<exclusion>
-					<groupId>org.apache.calcite</groupId>
-					<artifactId>calcite-linq4j</artifactId>
-				</exclusion>
-				<exclusion>
 					<groupId>org.codehaus.janino</groupId>
 					<artifactId>janino</artifactId>
 				</exclusion>
@@ -243,12 +239,6 @@ under the License.
 					<artifactId>scott-data-hsqldb</artifactId>
 				</exclusion>
 			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.calcite</groupId>
-			<artifactId>calcite-linq4j</artifactId>
-			<version>${calcite.version}</version>
-			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-table/flink-table-calcite-bridge/pom.xml
+++ b/flink-table/flink-table-calcite-bridge/pom.xml
@@ -180,6 +180,11 @@ under the License.
 		</dependency>
 
 		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-annotations</artifactId>
 			<version>${project.version}</version>


### PR DESCRIPTION

## What is the purpose of the change

Another step towards build with jdk25

## Brief change log

pom.xml


## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
