### PR TITLE
[FLINK-38390][table] Compiliation of flink-core and flink-table-planner fails because of annotation processors

### DIFF
--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -56,6 +56,7 @@ under the License.
 			-->--add-opens=java.base/java.util.concurrent.locks=ALL-UNNAMED <!--
 			-->--add-opens=java.base/java.lang.reflect=ALL-UNNAMED
 		</surefire.module.config>
+		<lombok.version>1.18.42</lombok.version>
 	</properties>
 
 	<dependencies>
@@ -169,7 +170,7 @@ under the License.
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.42</version>
+			<version>${lombok.version}</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -192,6 +193,19 @@ under the License.
 				</configuration>
 			</plugin>
 
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+							<version>${lombok.version}</version>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
 			<!-- publish some test base classes -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -56,6 +56,7 @@ under the License.
 			https://junit.org/junit5/docs/current/user-guide/#extensions-supported-utilities-search-semantics
 			-->-Djunit.platform.reflection.search.useLegacySemantics=true
 		</surefire.module.config>
+		<immutables.version>2.11.3</immutables.version>
 	</properties>
 
 	<dependencies>
@@ -74,12 +75,12 @@ under the License.
 		<dependency>
 			<groupId>org.immutables</groupId>
 			<artifactId>value</artifactId>
-			<version>2.8.8</version>
+			<version>${immutables.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.immutables</groupId>
 			<artifactId>value-annotations</artifactId>
-			<version>2.8.8</version>
+			<version>${immutables.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
@@ -306,6 +307,20 @@ under the License.
 						</goals>
 					</execution>
 				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.immutables</groupId>
+							<artifactId>value</artifactId>
+							<version>${immutables.version}</version>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
 			</plugin>
 
 			<plugin>


### PR DESCRIPTION
## What is the purpose of the change

After applying this change and
https://github.com/apache/flink/pull/27007
https://github.com/apache/flink/pull/27008
https://github.com/apache/flink/pull/27009

flink will be compilable (with jdk25) with a command 
```
./mvnw clean install -DskipTests -Pfast
```

## Brief change log
pom.xml


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
