### PR TITLE
[FLINK-38391][build] Bump maven-shade-plugin to 3.6.1 to support java 25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2266,7 +2266,7 @@ under the License.
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-shade-plugin</artifactId>
-					<version>3.5.3</version>
+					<version>3.6.1</version>
 				</plugin>
 				<!-- Pin the version of the maven remote resource plugin -->
 				<plugin>


### PR DESCRIPTION
## What is the purpose of the change

bump maven-shade-plugin version

## Brief change log

pom.xml
## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

also could be verified by building with java25 target

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes )
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
