### PR TITLE
[FLINK-38268] Fix incorrect serialization of VARIANT type FLOAT

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariantInternalBuilder.java
+++ b/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariantInternalBuilder.java
@@ -290,7 +290,7 @@ public class BinaryVariantInternalBuilder {
     public void appendFloat(float f) {
         checkCapacity(1 + 4);
         writeBuffer[writePos++] = primitiveHeader(FLOAT);
-        writeLong(writeBuffer, writePos, Float.floatToIntBits(f), 8);
+        writeLong(writeBuffer, writePos, Float.floatToIntBits(f), 4);
         writePos += 4;
     }
 

--- a/flink-core/src/test/java/org/apache/flink/types/variant/BinaryVariantInternalBuilderTest.java
+++ b/flink-core/src/test/java/org/apache/flink/types/variant/BinaryVariantInternalBuilderTest.java
@@ -22,8 +22,11 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class BinaryVariantInternalBuilderTest {
@@ -115,5 +118,13 @@ class BinaryVariantInternalBuilderTest {
         variant = BinaryVariantInternalBuilder.parseJson("{\"k1\":1,\"k1\":2,\"k2\":1.5}", true);
         assertThat(variant.getField("k1").getByte()).isEqualTo((byte) 2);
         assertThat(variant.getField("k2").getDecimal()).isEqualTo(BigDecimal.valueOf(1.5));
+    }
+
+    @Test
+    void testAppendFloat() {
+        BinaryVariantInternalBuilder builder = new BinaryVariantInternalBuilder(false);
+        ArrayList<Float> floatList = new ArrayList<>(Collections.nCopies(25, 4.2f));
+
+        assertThatCode(() -> floatList.forEach(builder::appendFloat)).doesNotThrowAnyException();
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

There is a small bug that `appendFloat` appends 8 bytes, which should be 4 instead. This may cause an ArrayIndexOutOfBoundsException when the buffer doesn't have enough capacity.

The page url is https://issues.apache.org/jira/browse/FLINK-38268


## Brief change log

  - FIX BinaryVariantInternalBuilder#appendFloat  bug .

## Verifying this change

Add a new unit test for FLOAT type. It would fail (throw an exception) without the fix. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: yes
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
