### PR TITLE
[FLINK-38392] Fix failing test in StreamPandasConversionTests

### DIFF
--- a/flink-python/pyflink/table/tests/test_pandas_conversion.py
+++ b/flink-python/pyflink/table/tests/test_pandas_conversion.py
@@ -171,10 +171,10 @@ class PandasConversionITTests(PandasConversionTestBase):
         result_pdf = table.group_by(table.f1).select(table.f2.max.alias('f2')).to_pandas()
         import pandas as pd
         import numpy as np
-        assert_frame_equal(result_pdf, pd.DataFrame(data={'f2': np.int16([2])}))
+        assert_frame_equal(result_pdf, pd.DataFrame(data={'f2': np.int16([2])}), check_dtype=False)
 
         result_pdf = table.group_by(table.f2).select(table.f1.max.alias('f2')).to_pandas()
-        assert_frame_equal(result_pdf, pd.DataFrame(data={'f2': np.int8([1, 1])}))
+        assert_frame_equal(result_pdf, pd.DataFrame(data={'f2': np.int8([1, 1])}), check_dtype=False)
 
     def assert_equal_field(self, expected_field, result_field):
         import numpy as np
@@ -237,4 +237,4 @@ class StreamPandasConversionTests(PandasConversionITTests,
         import pandas as pd
         os.remove(source_path)
         expected_df = pd.DataFrame(data={"rowtime": pd.Series(data, dtype="datetime64[ms]")})
-        assert_frame_equal(result_pdf, expected_df)
+        assert_frame_equal(result_pdf, expected_df, check_dtype=False)


### PR DESCRIPTION


## What is the purpose of the change

Fix failing test associated with StreamPandasConversionTests 

## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
