### PR TITLE
[FLINK-38396][tests] Make `DefaultKubernetesArtifactUploaderTest` more stable

### DIFF
--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/artifact/DefaultKubernetesArtifactUploaderTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/artifact/DefaultKubernetesArtifactUploaderTest.java
@@ -27,7 +27,6 @@ import org.apache.flink.kubernetes.utils.KubernetesUtils;
 import org.apache.flink.testutils.TestingUtils;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -44,7 +43,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link DefaultKubernetesArtifactUploader}. */
-@Disabled
 class DefaultKubernetesArtifactUploaderTest {
 
     private final DefaultKubernetesArtifactUploader artifactUploader =

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/artifact/DefaultKubernetesArtifactUploaderTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/artifact/DefaultKubernetesArtifactUploaderTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.kubernetes.artifact;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.client.cli.ArtifactFetchOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.PipelineOptions;
@@ -26,6 +27,7 @@ import org.apache.flink.kubernetes.utils.KubernetesUtils;
 import org.apache.flink.testutils.TestingUtils;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -42,6 +44,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link DefaultKubernetesArtifactUploader}. */
+@Disabled
 class DefaultKubernetesArtifactUploaderTest {
 
     private final DefaultKubernetesArtifactUploader artifactUploader =
@@ -80,7 +83,9 @@ class DefaultKubernetesArtifactUploaderTest {
 
     @Test
     void testUploadAllWithOneJobJar() throws Exception {
-        File jar = getFlinkKubernetesJar();
+        // flink-kubernetes depends on flink-annotations
+        // that means flink-annotations jar should be present before test execution
+        File jar = getFlinkAnnotationsJar();
         String localUri = "local://" + jar.getAbsolutePath();
 
         config.set(PipelineOptions.JARS, Collections.singletonList(localUri));
@@ -91,7 +96,9 @@ class DefaultKubernetesArtifactUploaderTest {
 
     @Test
     void testUploadAllWithAdditionalArtifacts() throws Exception {
-        File jobJar = getFlinkKubernetesJar();
+        // flink-kubernetes depends on flink-annotations
+        // that means flink-annotations jar should be present before test execution
+        File jobJar = getFlinkAnnotationsJar();
         File addArtifact1 = TestingUtils.getClassFile(DefaultKubernetesArtifactUploader.class);
         File addArtifact2 = TestingUtils.getClassFile(KubernetesUtils.class);
         String localJobUri = "local://" + jobJar.getAbsolutePath();
@@ -135,7 +142,9 @@ class DefaultKubernetesArtifactUploaderTest {
 
     @Test
     void testUpload() throws Exception {
-        File jar = getFlinkKubernetesJar();
+        // flink-kubernetes depends on flink-annotations
+        // that means flink-annotations jar should be present before test execution
+        File jar = getFlinkAnnotationsJar();
         String localUri = "local://" + jar.getAbsolutePath();
 
         String expectedUri = "dummyfs:" + tmpDir.resolve(jar.getName());
@@ -146,7 +155,9 @@ class DefaultKubernetesArtifactUploaderTest {
 
     @Test
     void testUploadNoOverwrite() throws Exception {
-        File jar = getFlinkKubernetesJar();
+        // flink-kubernetes depends on flink-annotations
+        // that means flink-annotations jar should be present before test execution
+        File jar = getFlinkAnnotationsJar();
         String localUri = "local://" + jar.getAbsolutePath();
         Files.createFile(tmpDir.resolve(jar.getName()));
 
@@ -158,7 +169,9 @@ class DefaultKubernetesArtifactUploaderTest {
 
     @Test
     void testUploadOverwrite() throws Exception {
-        File jar = getFlinkKubernetesJar();
+        // flink-kubernetes depends on flink-annotations
+        // that means flink-annotations jar should be present before test execution
+        File jar = getFlinkAnnotationsJar();
         String localUri = "local://" + jar.getAbsolutePath();
         Files.createFile(tmpDir.resolve(jar.getName()));
 
@@ -199,12 +212,12 @@ class DefaultKubernetesArtifactUploaderTest {
         return "dummyfs://" + tmpDir;
     }
 
-    private File getFlinkKubernetesJar() throws IOException {
+    private File getFlinkAnnotationsJar() throws IOException {
         return TestingUtils.getFileFromTargetDir(
-                DefaultKubernetesArtifactUploader.class,
+                FlinkVersion.class,
                 p ->
                         org.apache.flink.util.FileUtils.isJarFile(p)
-                                && p.toFile().getName().startsWith("flink-kubernetes"));
+                                && p.toFile().getName().contains("flink-annotations"));
     }
 
     private void assertJobJarUri(String filename) {


### PR DESCRIPTION
## What is the purpose of the change

It expects kubernetes jar being in target folder
so this commands will succeed (and this is how it is done in CI: first compile without tests and then execute tests, that's why it doesn't fail there)
```
./mvnw clean install -DskipTests -pl flink-kubernetes && ./mvnw install  -pl flink-kubernetes 
```

and this fails which is usually used locally
```
./mvnw clean install -pl flink-kubernetes
```


## Brief change log

`DefaultKubernetesArtifactUploaderTest` 

## Verifying this change

`./mvnw clean install -pl flink-kubernetes`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
