### PR TITLE
[FLINK-38417] Ensure attribute ordering when managing join attributes in JoinKeyExtractor

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/MultiJoinSemanticTests.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/MultiJoinSemanticTests.java
@@ -51,7 +51,9 @@ public class MultiJoinSemanticTests extends SemanticTestBase {
                 MultiJoinTestPrograms.MULTI_JOIN_MIXED_CHANGELOG_MODES,
                 MultiJoinTestPrograms.MULTI_JOIN_LEFT_OUTER_WITH_NULL_KEYS,
                 MultiJoinTestPrograms.MULTI_JOIN_NULL_SAFE_JOIN_WITH_NULL_KEYS,
-                MultiJoinTestPrograms
-                        .MULTI_JOIN_WITH_TIME_ATTRIBUTES_IN_CONDITIONS_MATERIALIZATION);
+                MultiJoinTestPrograms.MULTI_JOIN_WITH_TIME_ATTRIBUTES_IN_CONDITIONS_MATERIALIZATION,
+                MultiJoinTestPrograms.MULTI_JOIN_TWO_WAY_INNER_JOIN_WITH_WHERE_IN,
+                MultiJoinTestPrograms.MULTI_JOIN_THREE_WAY_INNER_JOIN_MULTI_KEY_TYPES,
+                MultiJoinTestPrograms.MULTI_JOIN_FOUR_WAY_MIXED_JOIN_MULTI_KEY_TYPES_SHUFFLED);
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/MultiJoinTestPrograms.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/MultiJoinTestPrograms.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.planner.plan.nodes.exec.stream;
 
 import org.apache.flink.table.api.config.OptimizerConfigOptions;
+import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.test.program.SinkTestStep;
 import org.apache.flink.table.test.program.SourceTestStep;
 import org.apache.flink.table.test.program.TableTestProgram;
@@ -170,7 +171,7 @@ public class MultiJoinTestPrograms {
                                             "name STRING",
                                             "cash INT",
                                             "user_id_0 STRING PRIMARY KEY NOT ENFORCED")
-                                    .addOption("changelog-mode", "I,UA,D")
+                                    .addMode(ChangelogMode.upsert())
                                     .producedValues(
                                             Row.ofKind(RowKind.INSERT, "Gus", 100, "1"),
                                             Row.ofKind(RowKind.INSERT, "Joe no order", 10, "8"),
@@ -194,7 +195,7 @@ public class MultiJoinTestPrograms {
                                             "order_id STRING PRIMARY KEY NOT ENFORCED",
                                             "product STRING",
                                             "user_id_1 STRING")
-                                    .addOption("changelog-mode", "I,D")
+                                    .addMode(ChangelogMode.insertOnly())
                                     .producedValues(
                                             Row.ofKind(RowKind.INSERT, "order0", "ProdB", "1"),
                                             Row.ofKind(RowKind.INSERT, "order6", "ProdF", "6"),
@@ -211,7 +212,7 @@ public class MultiJoinTestPrograms {
                                             "payment_id STRING PRIMARY KEY NOT ENFORCED",
                                             "price INT",
                                             "user_id_2 STRING")
-                                    .addOption("changelog-mode", "I")
+                                    .addMode(ChangelogMode.insertOnly())
                                     .producedValues(
                                             Row.ofKind(RowKind.INSERT, "payment1", 50, "1"),
                                             Row.ofKind(RowKind.INSERT, "payment5", -1, "5"),
@@ -224,7 +225,7 @@ public class MultiJoinTestPrograms {
                     .setupTableSource(
                             SourceTestStep.newBuilder("Shipments")
                                     .addSchema("location STRING", "user_id_3 STRING")
-                                    .addOption("changelog-mode", "I,UA,UB,D")
+                                    .addMode(ChangelogMode.all())
                                     .producedValues(
                                             Row.ofKind(RowKind.INSERT, "London", "1"),
                                             Row.ofKind(RowKind.INSERT, "Paris", "2"),
@@ -241,7 +242,7 @@ public class MultiJoinTestPrograms {
                                             "order_id STRING",
                                             "payment_id STRING",
                                             "location STRING")
-                                    .addOption("changelog-mode", "I,UA,UB,D")
+                                    .addMode(ChangelogMode.all())
                                     .consumedValues(
                                             "+I[3, Nomad, order3, payment3, New York]",
                                             "+I[1, Gus, order0, payment1, London]",
@@ -517,7 +518,7 @@ public class MultiJoinTestPrograms {
                                             "name STRING",
                                             "user_id_0 STRING PRIMARY KEY NOT ENFORCED",
                                             "cash INT")
-                                    .addOption("changelog-mode", "I,UA,D")
+                                    .addMode(ChangelogMode.upsert())
                                     .producedBeforeRestore(
                                             Row.ofKind(RowKind.INSERT, "Gus", "1", 100),
                                             Row.ofKind(RowKind.INSERT, "Nomad", "3", 50),
@@ -542,7 +543,7 @@ public class MultiJoinTestPrograms {
                                             "order_id STRING PRIMARY KEY NOT ENFORCED",
                                             "product STRING",
                                             "user_id_1 STRING")
-                                    .addOption("changelog-mode", "I,D")
+                                    .addMode(ChangelogMode.insertOnly())
                                     .producedBeforeRestore(
                                             Row.ofKind(RowKind.INSERT, "order2", "ProdB", "2"),
                                             Row.ofKind(RowKind.INSERT, "order0", "ProdB", "1"),
@@ -560,7 +561,7 @@ public class MultiJoinTestPrograms {
                                             "user_id_2 STRING",
                                             "payment_id STRING PRIMARY KEY NOT ENFORCED",
                                             "price INT")
-                                    .addOption("changelog-mode", "I")
+                                    .addMode(ChangelogMode.insertOnly())
                                     .producedBeforeRestore(
                                             Row.ofKind(RowKind.INSERT, "3", "3", 30),
                                             Row.ofKind(RowKind.INSERT, "1", "1", 50),
@@ -574,7 +575,7 @@ public class MultiJoinTestPrograms {
                     .setupTableSource(
                             SourceTestStep.newBuilder("Shipments")
                                     .addSchema("location STRING", "user_id_3 STRING")
-                                    .addOption("changelog-mode", "I,UA,UB,D")
+                                    .addMode(ChangelogMode.all())
                                     .producedBeforeRestore(
                                             Row.ofKind(RowKind.INSERT, "Paris", "2"),
                                             Row.ofKind(RowKind.INSERT, "London", "1"),
@@ -592,7 +593,7 @@ public class MultiJoinTestPrograms {
                                             "order_id STRING",
                                             "payment_id STRING",
                                             "location STRING")
-                                    .addOption("sink-changelog-mode-enforced", "I,UA,UB,D")
+                                    .addMode(ChangelogMode.all())
                                     .consumedBeforeRestore(
                                             "+I[1, Gus, order0, 1, London]",
                                             "+I[1, Gus, order1, 1, London]",
@@ -625,7 +626,7 @@ public class MultiJoinTestPrograms {
                                             "name STRING",
                                             "cash INT",
                                             "user_id_0 STRING PRIMARY KEY NOT ENFORCED")
-                                    .addOption("changelog-mode", "I,UA,D")
+                                    .addMode(ChangelogMode.upsert())
                                     .producedValues(
                                             Row.ofKind(RowKind.INSERT, "Gus", 100, "1"),
                                             Row.ofKind(RowKind.INSERT, "Joe no order", 10, "8"),
@@ -649,7 +650,7 @@ public class MultiJoinTestPrograms {
                                             "order_id STRING PRIMARY KEY NOT ENFORCED",
                                             "product STRING",
                                             "user_id_1 STRING")
-                                    .addOption("changelog-mode", "I,D")
+                                    .addMode(ChangelogMode.insertOnly())
                                     .producedValues(
                                             Row.ofKind(RowKind.INSERT, "order0", "ProdB", "1"),
                                             Row.ofKind(RowKind.INSERT, "order6", "ProdF", "6"),
@@ -666,7 +667,7 @@ public class MultiJoinTestPrograms {
                                             "payment_id STRING PRIMARY KEY NOT ENFORCED",
                                             "price INT",
                                             "user_id_2 STRING")
-                                    .addOption("changelog-mode", "I")
+                                    .addMode(ChangelogMode.insertOnly())
                                     .producedValues(
                                             Row.ofKind(RowKind.INSERT, "1", 50, "1"),
                                             Row.ofKind(RowKind.INSERT, "5", -1, "5"),
@@ -679,7 +680,7 @@ public class MultiJoinTestPrograms {
                     .setupTableSource(
                             SourceTestStep.newBuilder("Shipments")
                                     .addSchema("location STRING", "user_id_3 STRING")
-                                    .addOption("changelog-mode", "I,UA,UB,D")
+                                    .addMode(ChangelogMode.all())
                                     .producedValues(
                                             Row.ofKind(RowKind.INSERT, "London", "1"),
                                             Row.ofKind(RowKind.INSERT, "Paris", "2"),
@@ -696,7 +697,7 @@ public class MultiJoinTestPrograms {
                                             "order_id STRING",
                                             "payment_id STRING",
                                             "location STRING")
-                                    .addOption("sink-changelog-mode-enforced", "I,UA,UB,D")
+                                    .addMode(ChangelogMode.all())
                                     .consumedValues(
                                             "+I[1, Gus, order0, 1, London]",
                                             "+I[1, Gus, order1, 1, London]",
@@ -728,7 +729,7 @@ public class MultiJoinTestPrograms {
                                             "name STRING",
                                             "user_id_0 STRING PRIMARY KEY NOT ENFORCED",
                                             "cash INT")
-                                    .addOption("changelog-mode", "I,UA,D")
+                                    .addMode(ChangelogMode.upsert())
                                     .producedBeforeRestore(
                                             Row.ofKind(RowKind.INSERT, "Gus", "1", 100),
                                             Row.ofKind(RowKind.INSERT, "Nomad", "3", 50),
@@ -753,7 +754,7 @@ public class MultiJoinTestPrograms {
                                             "order_id STRING PRIMARY KEY NOT ENFORCED",
                                             "product STRING",
                                             "user_id_1 STRING")
-                                    .addOption("changelog-mode", "I,D")
+                                    .addMode(ChangelogMode.insertOnly())
                                     .producedBeforeRestore(
                                             Row.ofKind(RowKind.INSERT, "order2", "ProdB", "2"),
                                             Row.ofKind(RowKind.INSERT, "order0", "ProdB", "1"),
@@ -771,7 +772,7 @@ public class MultiJoinTestPrograms {
                                             "user_id_2 STRING",
                                             "payment_id STRING PRIMARY KEY NOT ENFORCED",
                                             "price INT")
-                                    .addOption("changelog-mode", "I")
+                                    .addMode(ChangelogMode.insertOnly())
                                     .producedBeforeRestore(
                                             Row.ofKind(RowKind.INSERT, "3", "payment3", 30),
                                             Row.ofKind(RowKind.INSERT, "1", "payment1", 50),
@@ -785,7 +786,7 @@ public class MultiJoinTestPrograms {
                     .setupTableSource(
                             SourceTestStep.newBuilder("Shipments")
                                     .addSchema("location STRING", "user_id_3 STRING")
-                                    .addOption("changelog-mode", "I,UA,UB,D")
+                                    .addMode(ChangelogMode.all())
                                     .producedBeforeRestore(
                                             Row.ofKind(RowKind.INSERT, "Paris", "2"),
                                             Row.ofKind(RowKind.INSERT, "London", "1"),
@@ -803,7 +804,7 @@ public class MultiJoinTestPrograms {
                                             "order_id STRING",
                                             "payment_id STRING",
                                             "location STRING")
-                                    .addOption("sink-changelog-mode-enforced", "I,UA,UB,D")
+                                    .addMode(ChangelogMode.all())
                                     .consumedBeforeRestore(
                                             "+I[1, Gus, order0, payment1, London]",
                                             "+I[1, Gus, order1, payment1, London]",
@@ -850,7 +851,7 @@ public class MultiJoinTestPrograms {
                                                     "user_id_1 STRING NOT NULL",
                                                     "product STRING",
                                                     "CONSTRAINT `PRIMARY` PRIMARY KEY (`order_id`, `user_id_1`) NOT ENFORCED")
-                                            .addOption("changelog-mode", "I")
+                                            .addMode(ChangelogMode.insertOnly())
                                             .producedBeforeRestore(
                                                     Row.ofKind(
                                                             RowKind.INSERT, "order1", "1", "ProdA"))
@@ -865,7 +866,7 @@ public class MultiJoinTestPrograms {
                                                     "user_id_2 STRING NOT NULL",
                                                     "price INT",
                                                     "CONSTRAINT `PRIMARY` PRIMARY KEY (`payment_id`, `user_id_2`) NOT ENFORCED")
-                                            .addOption("changelog-mode", "I")
+                                            .addMode(ChangelogMode.insertOnly())
                                             .producedBeforeRestore(
                                                     Row.ofKind(
                                                             RowKind.INSERT, "payment1", "1", 100),
@@ -881,7 +882,7 @@ public class MultiJoinTestPrograms {
                                                     "user_id_3 STRING NOT NULL",
                                                     "location STRING",
                                                     "CONSTRAINT `PRIMARY` PRIMARY KEY (`user_id_3`) NOT ENFORCED")
-                                            .addOption("changelog-mode", "I")
+                                            .addMode(ChangelogMode.insertOnly())
                                             .producedBeforeRestore(
                                                     Row.ofKind(RowKind.INSERT, "1", "London"),
                                                     Row.ofKind(RowKind.INSERT, "3", "Berlin"))
@@ -890,7 +891,7 @@ public class MultiJoinTestPrograms {
                                             .build())
                             .setupTableSink(
                                     SinkTestStep.newBuilder("sink")
-                                            .addOption("changelog-mode", "I, UA, D")
+                                            .addMode(ChangelogMode.upsert())
                                             .addSchema(
                                                     "user_id_0 STRING NOT NULL",
                                                     "order_id STRING NOT NULL",
@@ -1059,7 +1060,7 @@ public class MultiJoinTestPrograms {
                     .setupTableSource(
                             SourceTestStep.newBuilder("AppendTable")
                                     .addSchema("id STRING PRIMARY KEY NOT ENFORCED, val STRING")
-                                    .addOption("changelog-mode", "I")
+                                    .addMode(ChangelogMode.insertOnly())
                                     .producedValues(
                                             Row.ofKind(RowKind.INSERT, "1", "append1"),
                                             Row.ofKind(RowKind.INSERT, "2", "append2"),
@@ -1068,7 +1069,7 @@ public class MultiJoinTestPrograms {
                     .setupTableSource(
                             SourceTestStep.newBuilder("RetractTable")
                                     .addSchema("ref_id STRING, data STRING")
-                                    .addOption("changelog-mode", "I,UA,UB,D")
+                                    .addMode(ChangelogMode.all())
                                     .producedValues(
                                             Row.ofKind(RowKind.INSERT, "1", "retract1"),
                                             Row.ofKind(RowKind.INSERT, "2", "retract2"),
@@ -1080,7 +1081,7 @@ public class MultiJoinTestPrograms {
                             SourceTestStep.newBuilder("UpsertTable")
                                     .addSchema(
                                             "key_id STRING PRIMARY KEY NOT ENFORCED, status STRING")
-                                    .addOption("changelog-mode", "I,UA,D")
+                                    .addMode(ChangelogMode.upsert())
                                     .producedValues(
                                             Row.ofKind(RowKind.INSERT, "1", "active"),
                                             Row.ofKind(RowKind.INSERT, "2", "pending"),
@@ -1095,7 +1096,7 @@ public class MultiJoinTestPrograms {
                                             "val STRING",
                                             "data STRING",
                                             "status STRING")
-                                    .addOption("sink-changelog-mode-enforced", "I,UA,UB,D")
+                                    .addMode(ChangelogMode.all())
                                     .consumedValues(
                                             "+I[1, append1, retract1, active]",
                                             "+I[2, append2, retract2, active]",
@@ -1122,7 +1123,7 @@ public class MultiJoinTestPrograms {
                                             "user_id STRING",
                                             "order_id STRING PRIMARY KEY NOT ENFORCED",
                                             "product STRING")
-                                    .addOption("changelog-mode", "I, UA,D")
+                                    .addMode(ChangelogMode.upsert())
                                     .producedValues(
                                             Row.ofKind(RowKind.INSERT, "2", "order2", "Product B"),
                                             Row.ofKind(
@@ -1250,7 +1251,7 @@ public class MultiJoinTestPrograms {
                     .setupConfig(OptimizerConfigOptions.TABLE_OPTIMIZER_MULTI_JOIN_ENABLED, true)
                     .setupTableSource(
                             SourceTestStep.newBuilder("Users")
-                                    .addOption("changelog-mode", "I, UA,D")
+                                    .addMode(ChangelogMode.upsert())
                                     .addSchema(
                                             "user_id INT NOT NULL",
                                             "shard_id INT NOT NULL",
@@ -1263,7 +1264,7 @@ public class MultiJoinTestPrograms {
                                     .build())
                     .setupTableSource(
                             SourceTestStep.newBuilder("Orders")
-                                    .addOption("changelog-mode", "I, UA,D")
+                                    .addMode(ChangelogMode.upsert())
                                     .addSchema(
                                             "user_id INT NOT NULL",
                                             "order_id BIGINT NOT NULL",
@@ -1280,7 +1281,7 @@ public class MultiJoinTestPrograms {
                                     .build())
                     .setupTableSink(
                             SinkTestStep.newBuilder("sink")
-                                    .addOption("changelog-mode", "I, UA, D")
+                                    .addMode(ChangelogMode.upsert())
                                     .addSchema(
                                             "`user_id` INT NOT NULL",
                                             "`order_id` BIGINT NOT NULL",
@@ -1310,7 +1311,7 @@ public class MultiJoinTestPrograms {
                     .setupConfig(OptimizerConfigOptions.TABLE_OPTIMIZER_MULTI_JOIN_ENABLED, true)
                     .setupTableSource(
                             SourceTestStep.newBuilder("Users")
-                                    .addOption("changelog-mode", "I, UA,D")
+                                    .addMode(ChangelogMode.upsert())
                                     .addSchema(
                                             "user_id INT NOT NULL",
                                             "shard_id INT NOT NULL",
@@ -1323,7 +1324,7 @@ public class MultiJoinTestPrograms {
                                     .build())
                     .setupTableSource(
                             SourceTestStep.newBuilder("Orders")
-                                    .addOption("changelog-mode", "I, UA,D")
+                                    .addMode(ChangelogMode.upsert())
                                     .addSchema(
                                             "user_id INT NOT NULL",
                                             "order_id BIGINT NOT NULL",
@@ -1338,7 +1339,7 @@ public class MultiJoinTestPrograms {
                                     .build())
                     .setupTableSource(
                             SourceTestStep.newBuilder("Payments")
-                                    .addOption("changelog-mode", "I, UA,D")
+                                    .addMode(ChangelogMode.upsert())
                                     .addSchema(
                                             "user_id INT NOT NULL",
                                             "payment_id BIGINT NOT NULL",
@@ -1353,7 +1354,7 @@ public class MultiJoinTestPrograms {
                                     .build())
                     .setupTableSink(
                             SinkTestStep.newBuilder("sink")
-                                    .addOption("changelog-mode", "I, UA, D")
+                                    .addMode(ChangelogMode.upsert())
                                     .addSchema(
                                             "`user_id` INT NOT NULL",
                                             "`order_id` BIGINT NOT NULL",
@@ -1406,7 +1407,7 @@ public class MultiJoinTestPrograms {
                                                     "auctionDateTime AS TO_TIMESTAMP(auctionTimestamp)",
                                                     "expires AS TO_TIMESTAMP(expiresTimestamp)",
                                                     "WATERMARK FOR auctionDateTime AS auctionDateTime - INTERVAL '1' SECOND")
-                                            .addOption("changelog-mode", "I")
+                                            .addMode(ChangelogMode.insertOnly())
                                             .producedValues(
                                                     Row.ofKind(
                                                             RowKind.INSERT,
@@ -1435,7 +1436,7 @@ public class MultiJoinTestPrograms {
                                                     "bidTimestamp STRING",
                                                     "bidDateTime AS TO_TIMESTAMP(bidTimestamp)",
                                                     "WATERMARK FOR bidDateTime AS bidDateTime - INTERVAL '1' SECOND")
-                                            .addOption("changelog-mode", "I")
+                                            .addMode(ChangelogMode.insertOnly())
                                             .producedValues(
                                                     Row.ofKind(
                                                             RowKind.INSERT,
@@ -1496,7 +1497,7 @@ public class MultiJoinTestPrograms {
                                     .addSchema(
                                             "`record_id` STRING PRIMARY KEY NOT ENFORCED",
                                             "`user_id` INT")
-                                    .addOption("changelog-mode", "I,UA,D")
+                                    .addMode(ChangelogMode.upsert())
                                     .producedValues(
                                             Row.ofKind(RowKind.INSERT, "record_1", 1),
                                             Row.ofKind(RowKind.INSERT, "record_2", 2),
@@ -1506,7 +1507,7 @@ public class MultiJoinTestPrograms {
                             SourceTestStep.newBuilder("Users")
                                     .addSchema(
                                             "`user_id` INT PRIMARY KEY NOT ENFORCED", "`id` STRING")
-                                    .addOption("changelog-mode", "I,UA,D")
+                                    .addMode(ChangelogMode.upsert())
                                     .producedValues(
                                             Row.ofKind(RowKind.INSERT, 1, "record_1"),
                                             Row.ofKind(RowKind.INSERT, 2, "record_2"),
@@ -1515,7 +1516,7 @@ public class MultiJoinTestPrograms {
                     .setupTableSink(
                             SinkTestStep.newBuilder("sink")
                                     .addSchema("record_id STRING", "`user_id` INT", "id STRING")
-                                    .addOption("sink-changelog-mode-enforced", "I,UA,UB,D")
+                                    .addMode(ChangelogMode.all())
                                     .consumedValues(
                                             // Only records with user_id 1 and 2 should be
                                             // included due to WHERE IN clause
@@ -1551,7 +1552,6 @@ public class MultiJoinTestPrograms {
                                                     + "k3 BOOLEAN,"
                                                     + "k1 STRING,"
                                                     + "k4 STRING")
-                                    .addOption("changelog-mode", "I")
                                     .producedValues(
                                             // Matches Gus (Users3K: K1,100,true)
                                             Row.ofKind(
@@ -1607,7 +1607,6 @@ public class MultiJoinTestPrograms {
                                             "payment_id STRING",
                                             "k3 BOOLEAN",
                                             "k2 INT")
-                                    .addOption("changelog-mode", "I")
                                     .producedValues(
                                             // Matches Gus (Users3K: K1,100,true)
                                             Row.ofKind(RowKind.INSERT, "K1", "payment1", true, 100),
@@ -1637,7 +1636,7 @@ public class MultiJoinTestPrograms {
                                             "k1 STRING",
                                             "k2 INT",
                                             "k3 BOOLEAN")
-                                    .addOption("sink-changelog-mode-enforced", "I")
+                                    .addMode(ChangelogMode.insertOnly())
                                     .consumedValues(
                                             "+I[Gus, order1, payment1, K1, 100, true]",
                                             "+I[Bob, order2, payment2, A1, 200, false]")
@@ -1709,7 +1708,6 @@ public class MultiJoinTestPrograms {
                                             "k3 BOOLEAN",
                                             "k1 STRING",
                                             "k4 STRING")
-                                    .addOption("changelog-mode", "I")
                                     .producedValues(
                                             // Matches Gus (Users4K: K1,100,true,k4_val1)
                                             Row.ofKind(
@@ -1746,7 +1744,6 @@ public class MultiJoinTestPrograms {
                                                     + "k3 BOOLEAN,"
                                                     + "k2 INT,"
                                                     + "k4 STRING")
-                                    .addOption("changelog-mode", "I")
                                     .producedValues(
                                             // Matches Gus (Users4K: K1,100,true,k4_val1)
                                             Row.ofKind(
@@ -1779,7 +1776,6 @@ public class MultiJoinTestPrograms {
                                             "k3 BOOLEAN PRIMARY KEY NOT ENFORCED",
                                             "k4 STRING",
                                             "ship_id STRING")
-                                    .addOption("changelog-mode", "I")
                                     .producedValues(
                                             // Matches Gus
                                             Row.ofKind(RowKind.INSERT, true, "k4_val1", "ship1"),
@@ -1813,7 +1809,7 @@ public class MultiJoinTestPrograms {
                                             "k2 INT",
                                             "k3 BOOLEAN",
                                             "k4 STRING")
-                                    .addOption("changelog-mode", "I,UA,UB,D")
+                                    .addMode(ChangelogMode.all())
                                     .consumedValues(
                                             "+I[Bob, order2, payment2, null, A1, 200, false, k4_val2]")
                                     .testMaterializedData()

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/keyselector/AttributeBasedJoinKeyExtractor.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/keyselector/AttributeBasedJoinKeyExtractor.java
@@ -189,9 +189,6 @@ public class AttributeBasedJoinKeyExtractor implements JoinKeyExtractor, Seriali
             keyExtractors.add(createKeyExtractor(leftAttrRef));
         }
 
-        keyExtractors.sort(
-                Comparator.comparingInt(KeyExtractor::getInputIdToAccess)
-                        .thenComparingInt(KeyExtractor::getFieldIndexInSourceRow));
         return keyExtractors;
     }
 
@@ -443,7 +440,14 @@ public class AttributeBasedJoinKeyExtractor implements JoinKeyExtractor, Seriali
                 }
             }
         }
-        commonAttrsForThisInput.sort(Comparator.comparingInt(attr -> attr.fieldIndex));
+
+        // Important: ensure a consistent conceptual attribute ordering derived from roots.
+        commonAttrsForThisInput.sort(
+                Comparator.<AttributeRef>comparingInt(a -> parent.get(a).fieldIndex)
+                        // This is for stable ordering when two roots happen to have the same
+                        // fieldIndex
+                        .thenComparingInt(a -> a.fieldIndex));
+
         return commonAttrsForThisInput;
     }
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/keyselector/AttributeBasedJoinKeyExtractor.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/keyselector/AttributeBasedJoinKeyExtractor.java
@@ -35,13 +35,23 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
- * A {@link JoinKeyExtractor} that derives keys based on {@link AttributeRef} mappings provided in
- * {@code joinAttributeMap}. It defines how attributes from different input streams are related
- * through equi-join conditions, assuming input 0 is the base and subsequent inputs join to
- * preceding ones.
+ * A {@link JoinKeyExtractor} that derives keys from {@link AttributeRef} mappings in {@code
+ * joinAttributeMap}. It describes how attributes from different inputs are equated via equi-join
+ * conditions. Input 0 is the base; each subsequent input joins to one of the preceding inputs.
+ *
+ * <p>Example used throughout the comments: t1.id1 = t2.user_id2 and t3.user_id3 = t2.user_id2. All
+ * three attributes (t1.id1, t2.user_id2, t3.user_id3) represent the same conceptual key.
+ *
+ * <p>The {@code joinAttributeMap} for this example would be structured as follows:
+ *
+ * <ul>
+ *   <li>Key `1` (for t2): A list containing one element `ConditionAttributeRef(leftInputId=0,
+ *       leftFieldIndex=id1_idx, rightInputId=1, rightFieldIndex=user_id2_idx)`.
+ *   <li>Key `2` (for t3): A list containing one element `ConditionAttributeRef(leftInputId=1,
+ *       leftFieldIndex=user_id2_idx, rightInputId=2, rightFieldIndex=user_id3_idx)`.
+ * </ul>
  */
 public class AttributeBasedJoinKeyExtractor implements JoinKeyExtractor, Serializable {
     private static final long serialVersionUID = 1L;
@@ -49,9 +59,15 @@ public class AttributeBasedJoinKeyExtractor implements JoinKeyExtractor, Seriali
     private final Map<Integer, List<ConditionAttributeRef>> joinAttributeMap;
     private final List<RowType> inputTypes;
 
-    // Cache for pre-computed key extraction structures
-    private final Map<Integer, List<KeyExtractor>> inputIdToExtractorsMap;
-    private final Map<Integer, List<Integer>> inputKeyFieldIndices;
+    // Cache for pre-computed key extraction structures.
+    // leftKeyExtractorsMap: extractors that read the left side (joined row so far)
+    //   using the same attribute order as in joinAttributeMap.
+    private final Map<Integer, List<KeyExtractor>> leftKeyExtractorsMap;
+    // rightKeyExtractorsMap: extractors to extract the right-side key from each input.
+    private final Map<Integer, List<KeyExtractor>> rightKeyExtractorsMap;
+
+    // Data structures for the "common join key" shared by all inputs.
+    // Input 0 provides the canonical order and defines commonJoinKeyType.
     private final Map<Integer, List<KeyExtractor>> commonJoinKeyExtractors;
     private RowType commonJoinKeyType;
 
@@ -69,18 +85,19 @@ public class AttributeBasedJoinKeyExtractor implements JoinKeyExtractor, Seriali
             final List<RowType> inputTypes) {
         this.joinAttributeMap = joinAttributeMap;
         this.inputTypes = inputTypes;
-        this.inputIdToExtractorsMap = new HashMap<>();
-        this.inputKeyFieldIndices = new HashMap<>();
+        this.leftKeyExtractorsMap = new HashMap<>();
+        this.rightKeyExtractorsMap = new HashMap<>();
         this.commonJoinKeyExtractors = new HashMap<>();
 
         initializeCaches();
         initializeCommonJoinKeyStructures();
+        validateKeyStructures();
     }
 
     // ==================== Public Interface Methods ====================
 
     @Override
-    public RowData getJoinKey(RowData row, int inputId) {
+    public RowData getJoinKey(final RowData row, final int inputId) {
         if (inputId == 0) {
             return null;
         }
@@ -90,50 +107,51 @@ public class AttributeBasedJoinKeyExtractor implements JoinKeyExtractor, Seriali
             return null;
         }
 
-        final List<Integer> keyFieldIndices = inputKeyFieldIndices.get(inputId);
-        if (keyFieldIndices == null || keyFieldIndices.isEmpty()) {
-            return null;
-        }
-
-        return buildKeyRow(row, inputId, keyFieldIndices);
-    }
-
-    @Override
-    public RowData getLeftSideJoinKey(int depth, RowData joinedRowData) {
-        if (depth == 0) {
-            return null;
-        }
-
-        List<KeyExtractor> keyExtractors = inputIdToExtractorsMap.get(depth);
+        final List<KeyExtractor> keyExtractors = rightKeyExtractorsMap.get(inputId);
         if (keyExtractors == null || keyExtractors.isEmpty()) {
             return null;
         }
 
-        return buildKeyRow(keyExtractors, joinedRowData);
+        return buildKeyRowFromSourceRow(row, keyExtractors);
+    }
+
+    @Override
+    public RowData getLeftSideJoinKey(final int depth, final RowData joinedRowData) {
+        if (depth == 0) {
+            return null;
+        }
+
+        final List<KeyExtractor> keyExtractors = leftKeyExtractorsMap.get(depth);
+        if (keyExtractors == null || keyExtractors.isEmpty()) {
+            return null;
+        }
+
+        return buildKeyRowFromJoinedRow(keyExtractors, joinedRowData);
     }
 
     @Override
     @Nullable
-    public RowType getJoinKeyType(int inputId) {
+    public RowType getJoinKeyType(final int inputId) {
         if (inputId == 0) {
             return null;
         }
 
-        final List<Integer> keyFieldIndices = createJoinKeyFieldInputExtractors(inputId);
-        if (keyFieldIndices.isEmpty()) {
+        final List<KeyExtractor> keyExtractors = this.rightKeyExtractorsMap.get(inputId);
+
+        if (keyExtractors == null || keyExtractors.isEmpty()) {
             return null;
         }
 
-        return buildJoinKeyType(inputId, keyFieldIndices);
+        return buildJoinKeyType(inputId, keyExtractors);
     }
 
     @Override
-    public int[] getJoinKeyIndices(int inputId) {
-        final List<Integer> keyFieldIndices = this.inputKeyFieldIndices.get(inputId);
+    public int[] getJoinKeyIndices(final int inputId) {
+        final List<KeyExtractor> keyFieldIndices = this.rightKeyExtractorsMap.get(inputId);
         if (keyFieldIndices == null) {
             return new int[0];
         }
-        return keyFieldIndices.stream().mapToInt(i -> i).toArray();
+        return keyFieldIndices.stream().mapToInt(KeyExtractor::getFieldIndexInSourceRow).toArray();
     }
 
     @Override
@@ -143,18 +161,18 @@ public class AttributeBasedJoinKeyExtractor implements JoinKeyExtractor, Seriali
     }
 
     @Override
-    public @Nullable RowData getCommonJoinKey(RowData row, int inputId) {
-        List<KeyExtractor> extractors = commonJoinKeyExtractors.get(inputId);
+    public @Nullable RowData getCommonJoinKey(final RowData row, final int inputId) {
+        final List<KeyExtractor> extractors = commonJoinKeyExtractors.get(inputId);
         if (extractors == null || extractors.isEmpty()) {
             return null;
         }
 
-        return buildCommonJoinKey(row, extractors);
+        return buildKeyRowFromSourceRow(row, extractors);
     }
 
     @Override
-    public int[] getCommonJoinKeyIndices(int inputId) {
-        List<KeyExtractor> extractors = commonJoinKeyExtractors.get(inputId);
+    public int[] getCommonJoinKeyIndices(final int inputId) {
+        final List<KeyExtractor> extractors = commonJoinKeyExtractors.get(inputId);
         if (extractors == null || extractors.isEmpty()) {
             return new int[0];
         }
@@ -167,52 +185,92 @@ public class AttributeBasedJoinKeyExtractor implements JoinKeyExtractor, Seriali
     private void initializeCaches() {
         if (this.inputTypes != null) {
             for (int i = 0; i < this.inputTypes.size(); i++) {
-                this.inputIdToExtractorsMap.put(i, createLeftJoinKeyFieldExtractors(i));
-                this.inputKeyFieldIndices.put(i, createJoinKeyFieldInputExtractors(i));
+                this.leftKeyExtractorsMap.put(i, createLeftJoinKeyFieldExtractors(i));
+                this.rightKeyExtractorsMap.put(i, createRightJoinKeyExtractors(i));
             }
         }
     }
 
-    private List<KeyExtractor> createLeftJoinKeyFieldExtractors(int depth) {
-        if (depth == 0) {
+    private List<KeyExtractor> createLeftJoinKeyFieldExtractors(final int inputId) {
+        if (inputId == 0) {
             return Collections.emptyList();
         }
 
-        List<ConditionAttributeRef> attributeMapping = joinAttributeMap.get(depth);
+        final List<ConditionAttributeRef> attributeMapping = joinAttributeMap.get(inputId);
         if (attributeMapping == null || attributeMapping.isEmpty()) {
             return Collections.emptyList();
         }
 
-        List<KeyExtractor> keyExtractors = new ArrayList<>();
-        for (ConditionAttributeRef entry : attributeMapping) {
-            AttributeRef leftAttrRef = getLeftAttributeRef(depth, entry);
+        final List<KeyExtractor> keyExtractors = new ArrayList<>();
+        for (final ConditionAttributeRef entry : attributeMapping) {
+            final AttributeRef leftAttrRef = getLeftAttributeRef(inputId, entry);
             keyExtractors.add(createKeyExtractor(leftAttrRef));
         }
 
         return keyExtractors;
     }
 
-    private static AttributeRef getLeftAttributeRef(int depth, ConditionAttributeRef entry) {
-        AttributeRef leftAttrRef = new AttributeRef(entry.leftInputId, entry.leftFieldIndex);
-        if (leftAttrRef.inputId >= depth) {
+    private List<KeyExtractor> createRightJoinKeyExtractors(final int inputId) {
+        if (inputId == 0) {
+            return Collections.emptyList();
+        }
+
+        final List<ConditionAttributeRef> attributeMapping = joinAttributeMap.get(inputId);
+        if (attributeMapping == null) {
+            return Collections.emptyList();
+        }
+
+        final List<KeyExtractor> keyExtractors = new ArrayList<>();
+        for (final ConditionAttributeRef entry : attributeMapping) {
+            final AttributeRef rightAttrRef = getRightAttributeRef(inputId, entry);
+            keyExtractors.add(createKeyExtractor(rightAttrRef));
+        }
+
+        return keyExtractors;
+    }
+
+    private static AttributeRef getLeftAttributeRef(
+            final int inputId, final ConditionAttributeRef entry) {
+        final AttributeRef leftAttrRef = new AttributeRef(entry.leftInputId, entry.leftFieldIndex);
+        if (leftAttrRef.inputId >= inputId) {
             throw new IllegalStateException(
-                    "Invalid joinAttributeMap configuration for depth "
-                            + depth
+                    "Invalid joinAttributeMap configuration for inputId "
+                            + inputId
                             + ". Left attribute "
                             + leftAttrRef
                             + " does not reference a previous input (< "
-                            + depth
+                            + inputId
                             + ").");
         }
         return leftAttrRef;
     }
 
-    private KeyExtractor createKeyExtractor(AttributeRef attrRef) {
-        RowType rowType = inputTypes.get(attrRef.inputId);
-        validateFieldIndex(attrRef.inputId, attrRef.fieldIndex, rowType);
-        LogicalType fieldType = rowType.getTypeAt(attrRef.fieldIndex);
+    private static AttributeRef getRightAttributeRef(
+            final int inputId, final ConditionAttributeRef entry) {
+        final AttributeRef rightAttrRef =
+                new AttributeRef(entry.rightInputId, entry.rightFieldIndex);
+        // For a given join step (e.g., input 2 joining to a previous input), the "right"
+        // attribute in the join condition belongs to the current input (input 2).
+        if (rightAttrRef.inputId != inputId) {
+            throw new IllegalStateException(
+                    "Invalid joinAttributeMap configuration for inputId "
+                            + inputId
+                            + ". Right attribute "
+                            + rightAttrRef
+                            + " must reference the current input ("
+                            + inputId
+                            + ").");
+        }
+        return rightAttrRef;
+    }
 
-        // Calculate absolute field index by summing up field counts of previous inputs
+    private KeyExtractor createKeyExtractor(final AttributeRef attrRef) {
+        final RowType rowType = inputTypes.get(attrRef.inputId);
+        validateFieldIndex(attrRef.inputId, attrRef.fieldIndex, rowType);
+        final LogicalType fieldType = rowType.getTypeAt(attrRef.fieldIndex);
+
+        // Absolute field index within the concatenated joined row =
+        // current field index + sum(field counts of all previous inputs).
         int absoluteFieldIndex = attrRef.fieldIndex;
         for (int i = 0; i < attrRef.inputId; i++) {
             absoluteFieldIndex += inputTypes.get(i).getFieldCount();
@@ -221,71 +279,45 @@ public class AttributeBasedJoinKeyExtractor implements JoinKeyExtractor, Seriali
         return new KeyExtractor(attrRef.inputId, attrRef.fieldIndex, absoluteFieldIndex, fieldType);
     }
 
-    private List<Integer> createJoinKeyFieldInputExtractors(int inputId) {
-        final List<ConditionAttributeRef> attributeMapping = joinAttributeMap.get(inputId);
-        if (attributeMapping == null) {
-            return Collections.emptyList();
-        }
-
-        return attributeMapping.stream()
-                .filter(rightAttrRef -> rightAttrRef.rightInputId == inputId)
-                .map(rightAttrRef -> rightAttrRef.rightFieldIndex)
-                .distinct()
-                .sorted()
-                .collect(Collectors.toList());
-    }
-
     // ==================== Key Building Methods ====================
 
-    private RowData buildKeyRow(List<KeyExtractor> keyExtractors, RowData joinedRowData) {
+    private RowData buildKeyRowFromJoinedRow(
+            final List<KeyExtractor> keyExtractors, final RowData joinedRowData) {
         if (keyExtractors.isEmpty()) {
             return null;
         }
 
-        GenericRowData keyRow = new GenericRowData(keyExtractors.size());
+        final GenericRowData keyRow = new GenericRowData(keyExtractors.size());
         for (int i = 0; i < keyExtractors.size(); i++) {
             keyRow.setField(i, keyExtractors.get(i).getLeftSideKey(joinedRowData));
         }
         return keyRow;
     }
 
-    private GenericRowData buildKeyRow(
-            RowData sourceRow, int inputId, List<Integer> keyFieldIndices) {
-        final GenericRowData keyRow = new GenericRowData(keyFieldIndices.size());
-        final RowType rowType = inputTypes.get(inputId);
+    private GenericRowData buildKeyRowFromSourceRow(
+            final RowData sourceRow, final List<KeyExtractor> keyExtractors) {
+        if (keyExtractors.isEmpty()) {
+            return null;
+        }
 
-        for (int i = 0; i < keyFieldIndices.size(); i++) {
-            final int fieldIndex = keyFieldIndices.get(i);
-            validateFieldIndex(inputId, fieldIndex, rowType);
-
-            final LogicalType fieldType = rowType.getTypeAt(fieldIndex);
-            final RowData.FieldGetter fieldGetter =
-                    RowData.createFieldGetter(fieldType, fieldIndex);
-            final Object value = fieldGetter.getFieldOrNull(sourceRow);
-            keyRow.setField(i, value);
+        final GenericRowData keyRow = new GenericRowData(keyExtractors.size());
+        for (int i = 0; i < keyExtractors.size(); i++) {
+            keyRow.setField(i, keyExtractors.get(i).getRightSideKey(sourceRow));
         }
         return keyRow;
     }
 
-    private RowData buildCommonJoinKey(RowData row, List<KeyExtractor> extractors) {
-        GenericRowData commonJoinKeyRow = new GenericRowData(extractors.size());
-
-        for (int i = 0; i < extractors.size(); i++) {
-            commonJoinKeyRow.setField(i, extractors.get(i).getRightSideKey(row));
-        }
-        return commonJoinKeyRow;
-    }
-
-    private RowType buildJoinKeyType(int inputId, List<Integer> keyFieldIndices) {
+    private RowType buildJoinKeyType(final int inputId, final List<KeyExtractor> keyExtractors) {
         final RowType originalRowType = inputTypes.get(inputId);
-        final LogicalType[] keyTypes = new LogicalType[keyFieldIndices.size()];
-        final String[] keyNames = new String[keyFieldIndices.size()];
+        final LogicalType[] keyTypes = new LogicalType[keyExtractors.size()];
+        final String[] keyNames = new String[keyExtractors.size()];
 
-        for (int i = 0; i < keyFieldIndices.size(); i++) {
-            final int fieldIndex = keyFieldIndices.get(i);
+        for (int i = 0; i < keyExtractors.size(); i++) {
+            final KeyExtractor extractor = keyExtractors.get(i);
+            final int fieldIndex = extractor.getFieldIndexInSourceRow();
             validateFieldIndex(inputId, fieldIndex, originalRowType);
 
-            keyTypes[i] = originalRowType.getTypeAt(fieldIndex);
+            keyTypes[i] = extractor.fieldType;
             keyNames[i] = originalRowType.getFieldNames().get(fieldIndex) + "_key";
         }
 
@@ -294,6 +326,34 @@ public class AttributeBasedJoinKeyExtractor implements JoinKeyExtractor, Seriali
 
     // ==================== Common Key Methods ====================
 
+    /**
+     * Builds the data structures that describe the common join key shared by all inputs.
+     *
+     * <p>Algorithm:
+     *
+     * <ol>
+     *   <li>Collect all attributes referenced by any equality condition.
+     *   <li>Run union-find: for each equi-join condition, union the two attributes so that directly
+     *       or transitively equal attributes end up in the same set.
+     *   <li>Form equivalence sets by grouping attributes that share the same union-find root.
+     *   <li>Keep only those sets that touch every join step (see {@link
+     *       #isCommonConceptualAttributeSet(Set)}). Each kept set is one conceptual key common to
+     *       all inputs.
+     *   <li>For each input, pick that input's attributes from the kept sets (in a consistent order)
+     *       and create per-input key extractors. For input 0, also build the {@link RowType} of the
+     *       common key.
+     * </ol>
+     *
+     * <p><b>Example (same throughout):</b>
+     *
+     * <ol>
+     *   <li>Join conditions: t1.id1 = t2.user_id2 and t3.user_id3 = t2.user_id2.
+     *   <li>Union-find groups attributes into { (t1,id1), (t2,user_id2), (t3,user_id3) }.
+     *   <li>The group touches both steps (t2↔t1 and t3↔t2), so it is the common key.
+     *   <li>Create extractors for t1.id1, t2.user_id2, and t3.user_id3.
+     *   <li>Define a one-field commonJoinKeyType based on t1.id1.
+     * </ol>
+     */
     private void initializeCommonJoinKeyStructures() {
         this.commonJoinKeyType = null;
 
@@ -308,28 +368,43 @@ public class AttributeBasedJoinKeyExtractor implements JoinKeyExtractor, Seriali
             return;
         }
 
-        Map<AttributeRef, AttributeRef> parent = new HashMap<>();
-        Map<AttributeRef, Integer> rank = new HashMap<>();
-        Set<AttributeRef> allAttrRefs = collectAllAttributeRefs();
+        // Maps an attribute to the representative of its equivalence set.
+        final Map<AttributeRef, AttributeRef> attributeToRoot = new HashMap<>();
+        // Used for the union-by-rank optimization to keep the union-find tree shallow.
+        final Map<AttributeRef, Integer> rootRank = new HashMap<>();
+        final Set<AttributeRef> allAttrRefs = collectAllAttributeRefs();
 
         if (allAttrRefs.isEmpty()) {
             return;
         }
 
-        initializeDisjointSets(parent, rank, allAttrRefs);
-        processJoinConditions(parent, rank);
-        Map<AttributeRef, Set<AttributeRef>> equivalenceSets =
-                buildEquivalenceSets(parent, allAttrRefs);
-        List<Set<AttributeRef>> commonConceptualAttributeSets =
-                findCommonConceptualAttributeSets(equivalenceSets);
+        initializeDisjointSets(attributeToRoot, rootRank, allAttrRefs);
+        findAttributeRoots(attributeToRoot, rootRank);
+        final Map<AttributeRef, Set<AttributeRef>> equivalenceSets =
+                buildEquivalenceSets(attributeToRoot, allAttrRefs);
 
-        processCommonAttributes(commonConceptualAttributeSets);
+        // From all equivalence sets, keep only those that touch every join step.
+        final List<Set<AttributeRef>> commonConceptualAttributeSets =
+                findCommonConceptualAttributeSets(equivalenceSets);
+        processCommonAttributes(commonConceptualAttributeSets, attributeToRoot);
     }
 
+    /**
+     * Returns every attribute reference (input id + field index) present in the configured equality
+     * conditions.
+     *
+     * <p>Example: with t1.id1 = t2.user_id2 and t3.user_id3 = t2.user_id2, this returns { (t1,id1),
+     * (t2,user_id2), (t3,user_id3) }.
+     */
     private Set<AttributeRef> collectAllAttributeRefs() {
-        Set<AttributeRef> allAttrRefs = new HashSet<>();
-        for (List<ConditionAttributeRef> mapping : joinAttributeMap.values()) {
-            for (ConditionAttributeRef attrRef : mapping) {
+        final Set<AttributeRef> allAttrRefs = new HashSet<>();
+        for (final Map.Entry<Integer, List<ConditionAttributeRef>> entry :
+                joinAttributeMap.entrySet()) {
+            // Skip joinAttributeMap for key 0 where there are no join conditions to the left
+            if (entry.getKey() == 0) {
+                continue;
+            }
+            for (final ConditionAttributeRef attrRef : entry.getValue()) {
                 allAttrRefs.add(new AttributeRef(attrRef.leftInputId, attrRef.leftFieldIndex));
                 allAttrRefs.add(new AttributeRef(attrRef.rightInputId, attrRef.rightFieldIndex));
             }
@@ -337,43 +412,70 @@ public class AttributeBasedJoinKeyExtractor implements JoinKeyExtractor, Seriali
         return allAttrRefs;
     }
 
+    /**
+     * Initializes union-find: every attribute is the root of its own set with rank 0.
+     *
+     * <p>Example: attributes {(t1,id1), (t2,user_id2), (t3,user_id3)} start with attributeToRoot[a]
+     * = a.
+     */
     private void initializeDisjointSets(
-            Map<AttributeRef, AttributeRef> parent,
-            Map<AttributeRef, Integer> rank,
-            Set<AttributeRef> allAttrRefs) {
-        for (AttributeRef attrRef : allAttrRefs) {
-            parent.put(attrRef, attrRef);
-            rank.put(attrRef, 0);
+            final Map<AttributeRef, AttributeRef> attributeToRoot,
+            final Map<AttributeRef, Integer> rootRank,
+            final Set<AttributeRef> allAttrRefs) {
+        for (final AttributeRef attrRef : allAttrRefs) {
+            attributeToRoot.put(attrRef, attrRef);
+            rootRank.put(attrRef, 0);
         }
     }
 
-    private void processJoinConditions(
-            Map<AttributeRef, AttributeRef> parent, Map<AttributeRef, Integer> rank) {
-        for (List<ConditionAttributeRef> mapping : joinAttributeMap.values()) {
-            for (ConditionAttributeRef condition : mapping) {
+    /**
+     * Applies all equi-join conditions to union-find by uniting the corresponding attribute sets.
+     *
+     * <p>Example: unite (t2,user_id2) with (t1,id1), then (t3,user_id3) with (t2,user_id2),
+     * yielding one set { (t1,id1), (t2,user_id2), (t3,user_id3) }.
+     */
+    private void findAttributeRoots(
+            final Map<AttributeRef, AttributeRef> attributeToRoot,
+            final Map<AttributeRef, Integer> rootRank) {
+        for (final Map.Entry<Integer, List<ConditionAttributeRef>> entry :
+                joinAttributeMap.entrySet()) {
+            // Skip joinAttributeMap for key 0 where there are no join conditions to the left
+            if (entry.getKey() == 0) {
+                continue;
+            }
+            for (final ConditionAttributeRef condition : entry.getValue()) {
                 unionAttributeSets(
-                        parent,
-                        rank,
+                        attributeToRoot,
+                        rootRank,
                         new AttributeRef(condition.leftInputId, condition.leftFieldIndex),
                         new AttributeRef(condition.rightInputId, condition.rightFieldIndex));
             }
         }
     }
 
+    /** Converts the union-find forest into a map from root → full equivalence set. */
     private Map<AttributeRef, Set<AttributeRef>> buildEquivalenceSets(
-            Map<AttributeRef, AttributeRef> parent, Set<AttributeRef> allAttrRefs) {
-        Map<AttributeRef, Set<AttributeRef>> equivalenceSets = new HashMap<>();
-        for (AttributeRef attrRef : allAttrRefs) {
-            AttributeRef root = findAttributeSet(parent, attrRef);
+            final Map<AttributeRef, AttributeRef> attributeToRoot,
+            final Set<AttributeRef> allAttrRefs) {
+        final Map<AttributeRef, Set<AttributeRef>> equivalenceSets = new HashMap<>();
+        for (final AttributeRef attrRef : allAttrRefs) {
+            final AttributeRef root = findAttributeSet(attributeToRoot, attrRef);
             equivalenceSets.computeIfAbsent(root, k -> new HashSet<>()).add(attrRef);
         }
         return equivalenceSets;
     }
 
+    /**
+     * From all equivalence sets, keep only those that intersect every join step. A set is "common"
+     * only if each step has at least one attribute in the set.
+     *
+     * <p>Example: with steps (t2.user_id2 = t1.id1) and (t3.user_id3 = t2.user_id2), { (t1,id1),
+     * (t2,user_id2), (t3,user_id3) } is kept; a set touching only one step is discarded.
+     */
     private List<Set<AttributeRef>> findCommonConceptualAttributeSets(
-            Map<AttributeRef, Set<AttributeRef>> equivalenceSets) {
-        List<Set<AttributeRef>> commonConceptualAttributeSets = new ArrayList<>();
-        for (Set<AttributeRef> eqSet : equivalenceSets.values()) {
+            final Map<AttributeRef, Set<AttributeRef>> equivalenceSets) {
+        final List<Set<AttributeRef>> commonConceptualAttributeSets = new ArrayList<>();
+        for (final Set<AttributeRef> eqSet : equivalenceSets.values()) {
             if (isCommonConceptualAttributeSet(eqSet)) {
                 commonConceptualAttributeSets.add(eqSet);
             }
@@ -381,18 +483,25 @@ public class AttributeBasedJoinKeyExtractor implements JoinKeyExtractor, Seriali
         return commonConceptualAttributeSets;
     }
 
-    private boolean isCommonConceptualAttributeSet(Set<AttributeRef> eqSet) {
+    /**
+     * Returns true if the given equivalence set intersects every configured join step. For each
+     * step, we check whether the set contains any left or right attribute of that step.
+     *
+     * <p>Example: with steps (t2.user_id2 = t1.id1) and (t3.user_id3 = t2.user_id2): - { (t1,id1),
+     * (t2,user_id2), (t3,user_id3) } → true - { (t1,other), (t2,other) } → false
+     */
+    private boolean isCommonConceptualAttributeSet(final Set<AttributeRef> eqSet) {
         if (joinAttributeMap.isEmpty()) {
             return false;
         }
 
-        for (List<ConditionAttributeRef> conditionsForStep : joinAttributeMap.values()) {
+        for (final List<ConditionAttributeRef> conditionsForStep : joinAttributeMap.values()) {
             if (conditionsForStep.isEmpty()) {
                 return false;
             }
 
             boolean foundInThisStep = false;
-            for (ConditionAttributeRef condition : conditionsForStep) {
+            for (final ConditionAttributeRef condition : conditionsForStep) {
                 if (eqSet.contains(
                                 new AttributeRef(condition.leftInputId, condition.leftFieldIndex))
                         || eqSet.contains(
@@ -409,10 +518,20 @@ public class AttributeBasedJoinKeyExtractor implements JoinKeyExtractor, Seriali
         return true;
     }
 
-    private void processCommonAttributes(List<Set<AttributeRef>> commonConceptualAttributeSets) {
+    /**
+     * For each input, select its attributes that belong to the common sets and initialize
+     * extractors. If any input contributes none, the multi-join is invalid (exception).
+     *
+     * <p>Example: from { (t1,id1), (t2,user_id2), (t3,user_id3) }, input 0 uses id1, input 1 uses
+     * user_id2, input 2 uses user_id3. If some input had none, we would throw an exception.
+     */
+    private void processCommonAttributes(
+            final List<Set<AttributeRef>> commonConceptualAttributeSets,
+            final Map<AttributeRef, AttributeRef> attributeToRoot) {
         for (int currentInputId = 0; currentInputId < inputTypes.size(); currentInputId++) {
             final List<AttributeRef> commonAttrsForThisInput =
-                    findCommonAttributesForInput(currentInputId, commonConceptualAttributeSets);
+                    findCommonAttributesForInput(
+                            currentInputId, commonConceptualAttributeSets, attributeToRoot);
 
             if (commonAttrsForThisInput.isEmpty()) {
                 // This indicates that there is no common join key among all inputs.
@@ -429,11 +548,20 @@ public class AttributeBasedJoinKeyExtractor implements JoinKeyExtractor, Seriali
         }
     }
 
+    /**
+     * For a given input, pick at most one attribute per common set (first match), then sort by
+     * field index. This defines the field order of the common key for that input.
+     *
+     * <p>Example: if input 1 participates in two common sets with fields user_id and account_id,
+     * this returns [account_id, user_id] if account_id's index < user_id's index.
+     */
     private List<AttributeRef> findCommonAttributesForInput(
-            int currentInputId, List<Set<AttributeRef>> commonConceptualAttributeSets) {
-        List<AttributeRef> commonAttrsForThisInput = new ArrayList<>();
-        for (Set<AttributeRef> eqSet : commonConceptualAttributeSets) {
-            for (AttributeRef attrRef : eqSet) {
+            final int currentInputId,
+            final List<Set<AttributeRef>> commonConceptualAttributeSets,
+            final Map<AttributeRef, AttributeRef> attributeToRoot) {
+        final List<AttributeRef> commonAttrsForThisInput = new ArrayList<>();
+        for (final Set<AttributeRef> eqSet : commonConceptualAttributeSets) {
+            for (final AttributeRef attrRef : eqSet) {
                 if (attrRef.inputId == currentInputId) {
                     commonAttrsForThisInput.add(attrRef);
                     break;
@@ -442,8 +570,13 @@ public class AttributeBasedJoinKeyExtractor implements JoinKeyExtractor, Seriali
         }
 
         // Important: ensure a consistent conceptual attribute ordering derived from roots.
+        // The common key fields must have a canonical order across all inputs. This is
+        // achieved by sorting based on the properties of the union-find root attribute
+        // for each conceptual key set. We sort first by the root's field index and then
+        // by the current attribute's field index as a tie-breaker for stability. This
+        // ensures that input 0's attribute order defines the canonical order.
         commonAttrsForThisInput.sort(
-                Comparator.<AttributeRef>comparingInt(a -> parent.get(a).fieldIndex)
+                Comparator.<AttributeRef>comparingInt(a -> attributeToRoot.get(a).fieldIndex)
                         // This is for stable ordering when two roots happen to have the same
                         // fieldIndex
                         .thenComparingInt(a -> a.fieldIndex));
@@ -451,25 +584,29 @@ public class AttributeBasedJoinKeyExtractor implements JoinKeyExtractor, Seriali
         return commonAttrsForThisInput;
     }
 
+    /**
+     * Creates extractor objects and key type metadata for an input. Input 0 defines {@code
+     * commonJoinKeyType} shared across all inputs.
+     *
+     * <p>Example: for input 1 with common attributes [user_id], we create an extractor for that
+     * field and name it "user_id_common" with its logical type.
+     */
     private void processInputCommonAttributes(
-            int currentInputId, List<AttributeRef> commonAttrsForThisInput) {
+            final int currentInputId, final List<AttributeRef> commonAttrsForThisInput) {
         final List<KeyExtractor> extractors = new ArrayList<>();
-        final LogicalType[] keyFieldTypes = new LogicalType[commonAttrsForThisInput.size()];
         final String[] keyFieldNames = new String[commonAttrsForThisInput.size()];
         final RowType originalRowType = inputTypes.get(currentInputId);
 
         for (int i = 0; i < commonAttrsForThisInput.size(); i++) {
             final AttributeRef attr = commonAttrsForThisInput.get(i);
-            validateFieldIndex(currentInputId, attr.fieldIndex, originalRowType);
-            final LogicalType fieldType = originalRowType.getTypeAt(attr.fieldIndex);
-            extractors.add(
-                    new KeyExtractor(currentInputId, attr.fieldIndex, attr.fieldIndex, fieldType));
-            keyFieldTypes[i] = fieldType;
+            extractors.add(createKeyExtractor(attr));
             keyFieldNames[i] = originalRowType.getFieldNames().get(attr.fieldIndex) + "_common";
         }
 
         this.commonJoinKeyExtractors.put(currentInputId, extractors);
 
+        final LogicalType[] keyFieldTypes =
+                extractors.stream().map(e -> e.fieldType).toArray(LogicalType[]::new);
         if (currentInputId == 0 && !extractors.isEmpty()) {
             this.commonJoinKeyType = RowType.of(keyFieldTypes, keyFieldNames);
         }
@@ -477,7 +614,8 @@ public class AttributeBasedJoinKeyExtractor implements JoinKeyExtractor, Seriali
 
     // ==================== Helper Methods ====================
 
-    private void validateFieldIndex(int inputId, int fieldIndex, RowType rowType) {
+    private void validateFieldIndex(
+            final int inputId, final int fieldIndex, final RowType rowType) {
         if (fieldIndex >= rowType.getFieldCount() || fieldIndex < 0) {
             throw new IndexOutOfBoundsException(
                     "joinAttributeMap references field index "
@@ -490,39 +628,152 @@ public class AttributeBasedJoinKeyExtractor implements JoinKeyExtractor, Seriali
     }
 
     private static AttributeRef findAttributeSet(
-            Map<AttributeRef, AttributeRef> parent, AttributeRef item) {
-        if (!parent.get(item).equals(item)) {
-            parent.put(item, findAttributeSet(parent, parent.get(item)));
+            final Map<AttributeRef, AttributeRef> attributeToRoot, final AttributeRef item) {
+        if (!attributeToRoot.get(item).equals(item)) {
+            attributeToRoot.put(item, findAttributeSet(attributeToRoot, attributeToRoot.get(item)));
         }
-        return parent.get(item);
+        return attributeToRoot.get(item);
     }
 
     private static void unionAttributeSets(
-            Map<AttributeRef, AttributeRef> parent,
-            Map<AttributeRef, Integer> rank,
-            AttributeRef a,
-            AttributeRef b) {
-        AttributeRef rootA = findAttributeSet(parent, a);
-        AttributeRef rootB = findAttributeSet(parent, b);
+            final Map<AttributeRef, AttributeRef> attributeToRoot,
+            final Map<AttributeRef, Integer> rootRank,
+            final AttributeRef a,
+            final AttributeRef b) {
+        final AttributeRef rootA = findAttributeSet(attributeToRoot, a);
+        final AttributeRef rootB = findAttributeSet(attributeToRoot, b);
 
+        // Standard union-by-rank implementation to merge sets. The resulting root
+        // depends on the rank of the sets, not on attribute properties like inputId.
+        // A subsequent sorting step establishes a canonical ordering for the common key fields.
+        // Following this logic, the root will be the common join key attributes from input 0
         if (!rootA.equals(rootB)) {
-            if (rank.get(rootA) < rank.get(rootB)) {
-                parent.put(rootA, rootB);
-            } else if (rank.get(rootA) > rank.get(rootB)) {
-                parent.put(rootB, rootA);
+            if (rootRank.get(rootA) < rootRank.get(rootB)) {
+                attributeToRoot.put(rootA, rootB);
+            } else if (rootRank.get(rootA) > rootRank.get(rootB)) {
+                attributeToRoot.put(rootB, rootA);
             } else {
-                parent.put(rootB, rootA);
-                rank.put(rootA, rank.get(rootA) + 1);
+                attributeToRoot.put(rootB, rootA);
+                rootRank.put(rootA, rootRank.get(rootA) + 1);
             }
         }
     }
 
+    // ==================== Validation Methods ====================
+
+    /**
+     * Validates internal key structures for consistency:
+     *
+     * <ol>
+     *   <li>For every input id, the number of left-side extractors equals the number of right-side
+     *       key-field indices.
+     *   <li>If a common join key is defined, then for every input id the number of common key
+     *       extractors equals the number of fields in {@code commonJoinKeyType}.
+     *   <li>If a common join key is defined, each extractor's logical type matches the
+     *       corresponding field type in {@code commonJoinKeyType}.
+     * </ol>
+     *
+     * <p>Throws {@link IllegalStateException} if any inconsistency is found.
+     */
+    public void validateKeyStructures() {
+        final int numInputs = inputTypes == null ? 0 : inputTypes.size();
+
+        // We start at 1 because input 0 has no left-side extractors.
+        for (int inputId = 0; inputId < numInputs; inputId++) {
+            final List<KeyExtractor> leftExtractors = leftKeyExtractorsMap.get(inputId);
+            final List<KeyExtractor> rightExtractors = rightKeyExtractorsMap.get(inputId);
+
+            final int extractorsLength =
+                    validateExtractorsLength(leftExtractors, rightExtractors, inputId);
+
+            for (int j = 0; j < extractorsLength; j++) {
+                final LogicalType leftType = leftExtractors.get(j).fieldType;
+                final LogicalType rightType = rightExtractors.get(j).fieldType;
+
+                if (!Objects.equals(leftType.getTypeRoot(), rightType.getTypeRoot())) {
+                    throw new IllegalStateException(
+                            "Type mismatch for join key field "
+                                    + j
+                                    + " on input "
+                                    + inputId
+                                    + ": left type "
+                                    + leftType.getTypeRoot()
+                                    + " vs right type "
+                                    + rightType.getTypeRoot()
+                                    + ".");
+                }
+            }
+        }
+
+        if (this.commonJoinKeyType != null) {
+            final int expectedCommonFields = this.commonJoinKeyType.getFieldCount();
+
+            for (int inputId = 0; inputId < numInputs; inputId++) {
+                final List<KeyExtractor> commonExtractors = commonJoinKeyExtractors.get(inputId);
+                final int actual = commonExtractors == null ? 0 : commonExtractors.size();
+
+                if (actual != expectedCommonFields) {
+                    throw new IllegalStateException(
+                            "Mismatch in common key counts for input "
+                                    + inputId
+                                    + ": extractors ("
+                                    + actual
+                                    + ") vs commonJoinKeyType fields ("
+                                    + expectedCommonFields
+                                    + ").");
+                }
+
+                for (int i = 0; i < expectedCommonFields; i++) {
+                    final LogicalType extractorType = commonExtractors.get(i).fieldType;
+                    final LogicalType expectedType = this.commonJoinKeyType.getTypeAt(i);
+
+                    if (!Objects.equals(extractorType.getTypeRoot(), expectedType.getTypeRoot())) {
+                        throw new IllegalStateException(
+                                "Type mismatch for common key field "
+                                        + i
+                                        + " on input "
+                                        + inputId
+                                        + ": extractor type "
+                                        + extractorType.getTypeRoot()
+                                        + " vs commonJoinKeyType "
+                                        + expectedType.getTypeRoot()
+                                        + ".");
+                    }
+                }
+            }
+        }
+    }
+
+    private static int validateExtractorsLength(
+            final List<KeyExtractor> leftExtractors,
+            final List<KeyExtractor> rightExtractors,
+            final int inputId) {
+        final int leftSize = leftExtractors == null ? 0 : leftExtractors.size();
+        final int rightSize = rightExtractors == null ? 0 : rightExtractors.size();
+
+        if (leftSize != rightSize) {
+            throw new IllegalStateException(
+                    "Mismatch in key counts for input "
+                            + inputId
+                            + ": left extractors ("
+                            + leftSize
+                            + ") vs right extractors ("
+                            + rightSize
+                            + ").");
+        }
+        return leftSize;
+    }
+
     // ==================== Inner Classes ====================
 
-    /** Helper class to store pre-computed information for extracting a key part. */
-    // TODO we actually need int[] for the indices
-    // because we can have multiple common join keys as fields
-    // this whole file will be refactored in a next ticket
+    /**
+     * Helper class to store pre-computed information for extracting a key part.
+     *
+     * <p>This class uses two separate {@link RowData.FieldGetter} instances because a key extractor
+     * may need to extract a field from the left (already joined) side, which is a wide,
+     * concatenated row, or the right (current input) side, which is a single source row. The field
+     * indices for these two cases are different.
+     */
     private static final class KeyExtractor implements Serializable {
         private static final long serialVersionUID = 1L;
 
@@ -530,41 +781,57 @@ public class AttributeBasedJoinKeyExtractor implements JoinKeyExtractor, Seriali
         private final int fieldIndexInSourceRow;
         private final int absoluteFieldIndex;
         private final LogicalType fieldType;
-        private transient RowData.FieldGetter fieldGetter;
+        private transient RowData.FieldGetter leftFieldGetter;
+        private transient RowData.FieldGetter rightFieldGetter;
 
         public KeyExtractor(
-                int inputIdToAccess,
-                int fieldIndexInSourceRow,
-                int absoluteFieldIndex,
-                LogicalType fieldType) {
+                final int inputIdToAccess,
+                final int fieldIndexInSourceRow,
+                final int absoluteFieldIndex,
+                final LogicalType fieldType) {
             this.inputIdToAccess = inputIdToAccess;
             this.fieldIndexInSourceRow = fieldIndexInSourceRow;
             this.absoluteFieldIndex = absoluteFieldIndex;
             this.fieldType = fieldType;
-            this.fieldGetter =
+            this.rightFieldGetter =
                     RowData.createFieldGetter(this.fieldType, this.fieldIndexInSourceRow);
+            this.leftFieldGetter =
+                    RowData.createFieldGetter(this.fieldType, this.absoluteFieldIndex);
         }
 
-        public Object getRightSideKey(RowData joinedRowData) {
-            if (joinedRowData == null) {
+        /**
+         * Returns the key value from a single input row (right/current side of the current join
+         * step).
+         *
+         * <p>Example: for a step joining t1 (input 0) and t2 (input 1) t1.id1 = t2.user_id2, the
+         * extractor configured for t2 (input 1) returns t2.user_id2 value from the provided t2 row.
+         */
+        public Object getRightSideKey(final RowData row) {
+            if (row == null) {
                 return null;
             }
-            if (this.fieldGetter == null) {
-                this.fieldGetter =
+            if (this.rightFieldGetter == null) {
+                this.rightFieldGetter =
                         RowData.createFieldGetter(this.fieldType, this.fieldIndexInSourceRow);
             }
-            return this.fieldGetter.getFieldOrNull(joinedRowData);
+            return this.rightFieldGetter.getFieldOrNull(row);
         }
 
-        public Object getLeftSideKey(RowData joinedRowData) {
+        /**
+         * Returns the key value from the already-joined row (left side of the current join step).
+         *
+         * <p>Example: for a step joining t1 (input 0) and t2 (input 1) t1.id1 = t2.user_id2, the
+         * extractor configured for t2 (input 1) returns t1.id1 value from the provided t1 row.
+         */
+        public Object getLeftSideKey(final RowData joinedRowData) {
             if (joinedRowData == null) {
                 return null;
             }
-            if (this.fieldGetter == null) {
-                this.fieldGetter =
+            if (this.leftFieldGetter == null) {
+                this.leftFieldGetter =
                         RowData.createFieldGetter(this.fieldType, this.absoluteFieldIndex);
             }
-            return this.fieldGetter.getFieldOrNull(joinedRowData);
+            return this.leftFieldGetter.getFieldOrNull(joinedRowData);
         }
 
         public int getInputIdToAccess() {
@@ -575,12 +842,14 @@ public class AttributeBasedJoinKeyExtractor implements JoinKeyExtractor, Seriali
             return fieldIndexInSourceRow;
         }
 
-        private void readObject(java.io.ObjectInputStream in)
+        private void readObject(final java.io.ObjectInputStream in)
                 throws java.io.IOException, ClassNotFoundException {
             in.defaultReadObject();
             if (this.fieldType != null) {
-                this.fieldGetter =
+                this.rightFieldGetter =
                         RowData.createFieldGetter(this.fieldType, this.fieldIndexInSourceRow);
+                this.leftFieldGetter =
+                        RowData.createFieldGetter(this.fieldType, this.absoluteFieldIndex);
             }
         }
     }
@@ -594,20 +863,20 @@ public class AttributeBasedJoinKeyExtractor implements JoinKeyExtractor, Seriali
             // Default constructor for deserialization
         }
 
-        public AttributeRef(int inputId, int fieldIndex) {
+        public AttributeRef(final int inputId, final int fieldIndex) {
             this.inputId = inputId;
             this.fieldIndex = fieldIndex;
         }
 
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(final Object o) {
             if (this == o) {
                 return true;
             }
             if (o == null || getClass() != o.getClass()) {
                 return false;
             }
-            AttributeRef that = (AttributeRef) o;
+            final AttributeRef that = (AttributeRef) o;
             return inputId == that.inputId && fieldIndex == that.fieldIndex;
         }
 
@@ -634,7 +903,10 @@ public class AttributeBasedJoinKeyExtractor implements JoinKeyExtractor, Seriali
         }
 
         public ConditionAttributeRef(
-                int leftInputId, int leftFieldIndex, int rightInputId, int rightFieldIndex) {
+                final int leftInputId,
+                final int leftFieldIndex,
+                final int rightInputId,
+                final int rightFieldIndex) {
             this.leftInputId = leftInputId;
             this.leftFieldIndex = leftFieldIndex;
             this.rightInputId = rightInputId;
@@ -642,14 +914,14 @@ public class AttributeBasedJoinKeyExtractor implements JoinKeyExtractor, Seriali
         }
 
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(final Object o) {
             if (this == o) {
                 return true;
             }
             if (o == null || getClass() != o.getClass()) {
                 return false;
             }
-            ConditionAttributeRef that = (ConditionAttributeRef) o;
+            final ConditionAttributeRef that = (ConditionAttributeRef) o;
             return leftInputId == that.leftInputId
                     && leftFieldIndex == that.leftFieldIndex
                     && rightInputId == that.rightInputId

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/multijoin/StreamingFourWayMixedOuterJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/multijoin/StreamingFourWayMixedOuterJoinOperatorTest.java
@@ -1182,7 +1182,7 @@ class StreamingFourWayMixedOuterJoinOperatorTest extends StreamingMultiJoinOpera
         String userIdFieldName = String.format("user_id_%d", inputIndex);
         String pkFieldName = String.format("pk_%d", inputIndex); // Generic PK name
 
-        if (inputIndex == 0) { // Users: user_id (VARCHAR), pk (VARCHAR), details (BIGINT)
+        if (inputIndex == 0) { // Users: user_id (CHAR NOT NULL), pk (VARCHAR), details (BIGINT)
             return RowType.of(
                     new LogicalType[] {
                         new CharType(false, 20), VarCharType.STRING_TYPE, new BigIntType()
@@ -1191,7 +1191,7 @@ class StreamingFourWayMixedOuterJoinOperatorTest extends StreamingMultiJoinOpera
                         userIdFieldName, pkFieldName, String.format("details_%d", inputIndex)
                     });
         } else if (inputIndex
-                == 3) { // Shipments: user_id (VARCHAR), pk (VARCHAR), details (BIGINT)
+                == 3) { // Shipments: user_id (CHAR NOT NULL), pk (VARCHAR), details (BIGINT)
             return RowType.of(
                     new LogicalType[] {
                         new CharType(false, 20), VarCharType.STRING_TYPE, new BigIntType()
@@ -1199,7 +1199,8 @@ class StreamingFourWayMixedOuterJoinOperatorTest extends StreamingMultiJoinOpera
                     new String[] {
                         userIdFieldName, pkFieldName, String.format("details_%d", inputIndex)
                     });
-        } else { // Orders (1), Payments (2): user_id (VARCHAR), pk (VARCHAR), details (VARCHAR)
+        } else { // Orders (1), Payments (2): user_id (CHAR NOT NULL), pk (CHAR NOT NULL), details
+            // (VARCHAR)
             return super.createInputTypeInfo(inputIndex);
         }
     }

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/multijoin/StreamingFourWayMixedOuterJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/multijoin/StreamingFourWayMixedOuterJoinOperatorTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.runtime.operators.join.stream.keyselector.Attribut
 import org.apache.flink.table.runtime.operators.join.stream.utils.JoinInputSideSpec;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.CharType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
@@ -1184,7 +1185,7 @@ class StreamingFourWayMixedOuterJoinOperatorTest extends StreamingMultiJoinOpera
         if (inputIndex == 0) { // Users: user_id (VARCHAR), pk (VARCHAR), details (BIGINT)
             return RowType.of(
                     new LogicalType[] {
-                        VarCharType.STRING_TYPE, VarCharType.STRING_TYPE, new BigIntType()
+                        new CharType(false, 20), VarCharType.STRING_TYPE, new BigIntType()
                     },
                     new String[] {
                         userIdFieldName, pkFieldName, String.format("details_%d", inputIndex)
@@ -1193,7 +1194,7 @@ class StreamingFourWayMixedOuterJoinOperatorTest extends StreamingMultiJoinOpera
                 == 3) { // Shipments: user_id (VARCHAR), pk (VARCHAR), details (BIGINT)
             return RowType.of(
                     new LogicalType[] {
-                        VarCharType.STRING_TYPE, VarCharType.STRING_TYPE, new BigIntType()
+                        new CharType(false, 20), VarCharType.STRING_TYPE, new BigIntType()
                     },
                     new String[] {
                         userIdFieldName, pkFieldName, String.format("details_%d", inputIndex)


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The MultiJoin has a JoinKeyExtractor helper that derives keys from AttributeRef mappings in the joinAttributeMap. It describes how attributes from different inputs are equated via equi-join * conditions.

The methods present in the JoinKeyExtractor should always return rows for the join conditions and commonJoinKey in the same order so we have stable a joinKey for state access and key selector for routing. This adds a fix to make sure the order is maintained. 

To make the whole class easier to read, I've also refactored it, added comments and examples.

## Brief change log

- Fix stable ordering issue
- Refactor JoinKeyExtractor for better readability + comments and examples
- Add multiple tests

## Verifying this change

- Added semantic tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
