### PR TITLE
[FLINK-37932] Add UserAgent in GCS requests

### DIFF
--- a/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gs/GSFileSystemFactory.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gs/GSFileSystemFactory.java
@@ -25,7 +25,10 @@ import org.apache.flink.core.fs.FileSystemFactory;
 import org.apache.flink.fs.gs.utils.ConfigUtils;
 import org.apache.flink.util.Preconditions;
 
+import org.apache.flink.shaded.guava33.com.google.common.collect.ImmutableMap;
+
 import com.google.api.gax.retrying.RetrySettings;
+import com.google.api.gax.rpc.FixedHeaderProvider;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.ServiceOptions;
 import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem;
@@ -94,7 +97,17 @@ public class GSFileSystemFactory implements FileSystemFactory {
         this.fileSystemOptions = new GSFileSystemOptions(flinkConfig);
         LOGGER.info("Using file system options {}", fileSystemOptions);
 
-        StorageOptions.Builder storageOptionsBuilder = StorageOptions.newBuilder();
+        String version = GSFileSystemFactory.class.getPackage().getImplementationVersion();
+        if (version == null) {
+            version = "unknown";
+        }
+        String userAgent = "apache-flink/" + version + " (GPN:apache-flink)";
+
+        StorageOptions.Builder storageOptionsBuilder =
+                StorageOptions.newBuilder()
+                        .setHeaderProvider(
+                                FixedHeaderProvider.create(
+                                        ImmutableMap.of("User-agent", userAgent)));
         storageOptionsBuilder.setTransportOptions(getHttpTransportOptions(fileSystemOptions));
         storageOptionsBuilder.setRetrySettings(getRetrySettings(fileSystemOptions));
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds a User-Agent header to all Google Cloud Storage (GCS) requests made by the Flink GCS file system. This allows for better tracking and identification of Flink-originated traffic on the GCS side.


## Brief change log
- In GSFileSystemFactory.java, a User-Agent header is added to the StorageOptions.Builder for the GCS client


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): No
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: No
  - The serializers: No
  - The runtime per-record code paths (performance sensitive): No
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: No
  - The S3 file system connector: No

## Documentation

  - Does this pull request introduce a new feature? No
  - If yes, how is the feature documented? Not applicable
