### PR TITLE
[FLINK-38418][python] Support pickling Instants when collecting TIMESTAMP_LTZ types in PyFlink

### DIFF
--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -18,6 +18,7 @@
 import datetime
 import decimal
 import sys
+import time
 import unittest
 
 from py4j.protocol import Py4JJavaError
@@ -700,6 +701,7 @@ class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
                                1.98932, bytearray(b'pyflink'), 'pyflink',
                                datetime.date(2014, 9, 13), datetime.time(12, 0, 0, 123000),
                                datetime.datetime(2018, 3, 11, 3, 0, 0, 123000),
+                               datetime.datetime(2025, 9, 26, 1, 2, 3, 123000),
                                [['a', 'b'], ['c', 'd'], ['e', 'f']],
                                [Row('pyflink'), Row('pyflink'), Row('pyflink')],
                                {1: Row('flink'), 2: Row('pyflink')},
@@ -712,6 +714,7 @@ class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
               datetime.date(2014, 9, 13), datetime.time(hour=12, minute=0, second=0,
                                                         microsecond=123000),
               datetime.datetime(2018, 3, 11, 3, 0, 0, 123000),
+              datetime.datetime(2025, 9, 26, 1, 2, 3, 123000),
               [['a', 'b'], ['c', 'd'], ['e', 'f']],
               [Row('pyflink'), Row('pyflink'), Row('pyflink')],
               {1: Row('flink'), 2: Row('pyflink')},
@@ -733,20 +736,21 @@ class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
                  DataTypes.FIELD("k", DataTypes.DATE()),
                  DataTypes.FIELD("l", DataTypes.TIME()),
                  DataTypes.FIELD("m", DataTypes.TIMESTAMP(3)),
-                 DataTypes.FIELD("n", DataTypes.ARRAY(DataTypes.ARRAY(DataTypes.STRING()))),
+                 DataTypes.FIELD("n", DataTypes.TIMESTAMP_LTZ(3)),
+                 DataTypes.FIELD("o", DataTypes.ARRAY(DataTypes.ARRAY(DataTypes.STRING()))),
                  DataTypes.FIELD(
-                     "o",
+                     "p",
                      DataTypes.ARRAY(
                          DataTypes.ROW([DataTypes.FIELD("ss2", DataTypes.STRING())])
                      )),
                  DataTypes.FIELD(
-                     "p",
+                     "q",
                      DataTypes.MAP(
                          DataTypes.BIGINT(),
                          DataTypes.ROW([DataTypes.FIELD("ss", DataTypes.STRING())]),
                      )),
                  DataTypes.FIELD(
-                     "q",
+                     "r",
                      DataTypes.ARRAY(
                          DataTypes.ROW(
                              [
@@ -774,8 +778,8 @@ class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
                              ]
                          )
                      )),
-                 DataTypes.FIELD("r", DataTypes.DECIMAL(38, 18)),
-                 DataTypes.FIELD("s", DataTypes.DECIMAL(38, 18))
+                 DataTypes.FIELD("s", DataTypes.DECIMAL(38, 18)),
+                 DataTypes.FIELD("t", DataTypes.DECIMAL(38, 18))
                  ]
             )
         )
@@ -785,6 +789,35 @@ class StreamTableEnvironmentTests(PyFlinkStreamTableTestCase):
             for i in result:
                 collected_result.append(i)
             self.assertEqual(expected_result, collected_result)
+
+    def test_timestamp_ltz_collection(self):
+        test_cases = [
+            (datetime.datetime(2025, 9, 26, 1, 2, 3, 123000),),
+            (datetime.datetime(2025, 9, 26, 12, 30, 45, 500000),),
+            (datetime.datetime(2025, 12, 31, 23, 59, 59, 999000),),
+        ]
+
+        schema = DataTypes.ROW([
+            DataTypes.FIELD("ts", DataTypes.TIMESTAMP_LTZ(3))
+        ])
+
+        table = self.t_env.from_elements(test_cases, schema=schema)
+        result = list(table.execute().collect())
+
+        self.assertEqual(len(result), 3)
+        for row in result:
+            self.assertIsInstance(row[0], datetime.datetime)
+
+        # Verify epoch preservation: TIMESTAMP_LTZ stores epoch time, not local time
+        test_dt = datetime.datetime(2025, 9, 26, 12, 0, 0, 500000)
+        input_epoch = time.mktime(test_dt.timetuple()) + test_dt.microsecond / 1e6
+
+        table2 = self.t_env.from_elements([(test_dt,)], schema=schema)
+        result2 = list(table2.execute().collect())
+        retrieved = result2[0][0]
+
+        retrieved_epoch = time.mktime(retrieved.timetuple()) + retrieved.microsecond / 1e6
+        self.assertAlmostEqual(input_epoch, retrieved_epoch, places=5)
 
     def test_row_form_consistency_with_elements(self):
         schema = DataTypes.ROW(

--- a/flink-python/pyflink/table/utils.py
+++ b/flink-python/pyflink/table/utils.py
@@ -132,6 +132,8 @@ def pickled_bytes_to_python_converter(data, field_type: DataType):
             return field_type.from_sql_type(data)
         elif isinstance(field_type, TimestampType):
             return field_type.from_sql_type(int(data.timestamp() * 10**6))
+        elif isinstance(field_type, LocalZonedTimestampType):
+            return field_type.from_sql_type(int(data.timestamp() * 10**6))
         elif isinstance(field_type, MapType):
             key_type = field_type.key_type
             value_type = field_type.value_type

--- a/flink-python/src/main/java/org/apache/flink/api/common/python/PythonBridgeUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/api/common/python/PythonBridgeUtils.java
@@ -40,6 +40,7 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.DateType;
 import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.RowType;
@@ -58,6 +59,7 @@ import java.io.IOException;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -163,7 +165,8 @@ public final class PythonBridgeUtils {
         return objs;
     }
 
-    private static Object getPickledBytesFromJavaObject(Object obj, LogicalType dataType)
+    /** Package-private for testing. */
+    static Object getPickledBytesFromJavaObject(Object obj, LogicalType dataType)
             throws IOException {
         Pickler pickler = new Pickler();
         initialize();
@@ -190,6 +193,12 @@ public final class PythonBridgeUtils {
             } else if (dataType instanceof TimestampType) {
                 if (obj instanceof LocalDateTime) {
                     return pickler.dumps(Timestamp.valueOf((LocalDateTime) obj));
+                } else {
+                    return pickler.dumps(obj);
+                }
+            } else if (dataType instanceof LocalZonedTimestampType) {
+                if (obj instanceof Instant) {
+                    return pickler.dumps(Timestamp.from((Instant) obj));
                 } else {
                     return pickler.dumps(obj);
                 }

--- a/flink-python/src/test/java/org/apache/flink/api/common/python/PythonBridgeUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/api/common/python/PythonBridgeUtilsTest.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.python;
+
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.DateType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.TimeType;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.types.Row;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link PythonBridgeUtils}. */
+class PythonBridgeUtilsTest {
+
+    @Test
+    void testPickleNull() throws Exception {
+        Object pickledBytes = PythonBridgeUtils.getPickledBytesFromJavaObject(null, new IntType());
+
+        assertThat(pickledBytes).isInstanceOf(byte[].class);
+        assertThat(((byte[]) pickledBytes).length).isEqualTo(0);
+    }
+
+    @Test
+    void testPickleDate() throws Exception {
+        LocalDate date = LocalDate.of(2025, 9, 26);
+        DateType dateType = new DateType();
+
+        Object pickledBytes = PythonBridgeUtils.getPickledBytesFromJavaObject(date, dateType);
+
+        assertThat(pickledBytes).isNotNull();
+        assertThat(pickledBytes).isInstanceOf(byte[].class);
+        assertThat(((byte[]) pickledBytes).length).isGreaterThan(0);
+    }
+
+    @Test
+    void testPickleTime() throws Exception {
+        LocalTime time = LocalTime.of(12, 30, 45, 123000000);
+        TimeType timeType = new TimeType();
+
+        Object pickledBytes = PythonBridgeUtils.getPickledBytesFromJavaObject(time, timeType);
+
+        assertThat(pickledBytes).isNotNull();
+        assertThat(pickledBytes).isInstanceOf(byte[].class);
+        assertThat(((byte[]) pickledBytes).length).isGreaterThan(0);
+    }
+
+    @Test
+    void testPickleTimestamp() throws Exception {
+        LocalDateTime timestamp = LocalDateTime.of(2025, 9, 26, 12, 30, 45, 123000000);
+        TimestampType timestampType = new TimestampType(6);
+
+        Object pickledBytes =
+                PythonBridgeUtils.getPickledBytesFromJavaObject(timestamp, timestampType);
+
+        assertThat(pickledBytes).isNotNull();
+        assertThat(pickledBytes).isInstanceOf(byte[].class);
+        assertThat(((byte[]) pickledBytes).length).isGreaterThan(0);
+    }
+
+    @Test
+    void testPickleLocalZonedTimestamp() throws Exception {
+        Instant instant = Instant.ofEpochSecond(1727337723L, 123000000L);
+        LocalZonedTimestampType ltzType = new LocalZonedTimestampType(6);
+
+        Object pickledBytes = PythonBridgeUtils.getPickledBytesFromJavaObject(instant, ltzType);
+
+        assertThat(pickledBytes).isNotNull();
+        assertThat(pickledBytes).isInstanceOf(byte[].class);
+        assertThat(((byte[]) pickledBytes).length).isGreaterThan(0);
+    }
+
+    @Test
+    void testPickleLocalZonedTimestampWithDifferentPrecisions() throws Exception {
+        Instant instant = Instant.ofEpochSecond(1727337723L, 123456789L);
+
+        for (int precision = 0; precision <= 9; precision++) {
+            LocalZonedTimestampType ltzType = new LocalZonedTimestampType(precision);
+            Object pickledBytes = PythonBridgeUtils.getPickledBytesFromJavaObject(instant, ltzType);
+
+            assertThat(pickledBytes).isNotNull();
+            assertThat(pickledBytes).isInstanceOf(byte[].class);
+        }
+    }
+
+    @Test
+    void testPickleFloat() throws Exception {
+        float value = 3.14159f;
+        FloatType floatType = new FloatType();
+
+        Object pickledBytes = PythonBridgeUtils.getPickledBytesFromJavaObject(value, floatType);
+
+        assertThat(pickledBytes).isNotNull();
+        assertThat(pickledBytes).isInstanceOf(byte[].class);
+        assertThat(((byte[]) pickledBytes).length).isGreaterThan(0);
+    }
+
+    @Test
+    void testPickleString() throws Exception {
+        String value = "test string";
+        VarCharType varcharType = VarCharType.STRING_TYPE;
+
+        Object pickledBytes = PythonBridgeUtils.getPickledBytesFromJavaObject(value, varcharType);
+
+        assertThat(pickledBytes).isNotNull();
+        assertThat(pickledBytes).isInstanceOf(byte[].class);
+        assertThat(((byte[]) pickledBytes).length).isGreaterThan(0);
+    }
+
+    @Test
+    void testPickleArray() throws Exception {
+        Integer[] array = {1, 2, 3, 4, 5};
+        ArrayType arrayType = new ArrayType(new IntType());
+
+        Object pickledBytes = PythonBridgeUtils.getPickledBytesFromJavaObject(array, arrayType);
+
+        assertThat(pickledBytes).isNotNull();
+        assertThat(pickledBytes).isInstanceOf(byte[].class);
+        assertThat(((byte[]) pickledBytes).length).isGreaterThan(0);
+    }
+
+    @Test
+    void testPickleMap() throws Exception {
+        Map<String, Integer> map = new HashMap<>();
+        map.put("one", 1);
+        map.put("two", 2);
+        map.put("three", 3);
+
+        MapType mapType = new MapType(VarCharType.STRING_TYPE, new IntType());
+
+        Object pickledBytes = PythonBridgeUtils.getPickledBytesFromJavaObject(map, mapType);
+
+        assertThat(pickledBytes).isNotNull();
+        assertThat(pickledBytes).isInstanceOf(byte[].class);
+        assertThat(((byte[]) pickledBytes).length).isGreaterThan(0);
+    }
+
+    @Test
+    void testPickleRow() throws Exception {
+        RowType rowType = RowType.of(new IntType(), VarCharType.STRING_TYPE, new DateType());
+
+        Row row = new Row(3);
+        row.setField(0, 42);
+        row.setField(1, "test");
+        row.setField(2, LocalDate.of(2025, 9, 26));
+
+        Object pickledBytes = PythonBridgeUtils.getPickledBytesFromJavaObject(row, rowType);
+
+        assertThat(pickledBytes).isNotNull();
+        assertThat(pickledBytes).isInstanceOf(List.class);
+        List<?> rowBytes = (List<?>) pickledBytes;
+        assertThat(rowBytes).hasSize(4);
+    }
+
+    @Test
+    void testPickleNestedStructures() throws Exception {
+        ArrayType arrayType = new ArrayType(new IntType());
+        MapType mapType = new MapType(VarCharType.STRING_TYPE, arrayType);
+
+        Map<String, Integer[]> nestedMap = new HashMap<>();
+        nestedMap.put("numbers", new Integer[] {1, 2, 3});
+        nestedMap.put("more", new Integer[] {4, 5, 6});
+
+        Object pickledBytes = PythonBridgeUtils.getPickledBytesFromJavaObject(nestedMap, mapType);
+
+        assertThat(pickledBytes).isNotNull();
+        assertThat(pickledBytes).isInstanceOf(byte[].class);
+        assertThat(((byte[]) pickledBytes).length).isGreaterThan(0);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Currently, when trying to `collect` a `TIMESTAMP_LTZ` value in PyFlink, you get a pickling error:

```
py4j.protocol.Py4JJavaError: An error occurred while calling z:org.apache.flink.api.common.python.PythonBridgeUtils.getPickledBytesFromRow.
: org.apache.flink.api.python.shaded.net.razorvine.pickle.PickleException: couldn't introspect javabean: java.lang.IllegalArgumentException: wrong number of arguments 
```

This is because there is no case to handle pickling `LocalZonedTimestampType` `Instant` values in the pickler, which just defaults to trying to pickle the `Instant` object which fails. This PR adds a clause to handle this (by creating a `Timestamp` value from the `Instant`, similar to how `Timestamp`s are pickled), and adds a handler on the PyFlink side to convert this value to a datetime.

## Brief change log

- Adds case to handle `LocalZonedTimestampType` types in the pickling/unpickling logic during collection.

## Verifying this change

I've added an extra case in the Table API environment type tests to include a test for `TIMESTAMP_LTZ` types insert/collection tests, which before this change fails with the above pickling error.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
