### PR TITLE
[FLINK-38468][flink-table-planner] When the coalesce parameter contains a function, convert it to case when

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/logical/RemoveUnreachableCoalesceArgumentsRuleTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/logical/RemoveUnreachableCoalesceArgumentsRuleTest.java
@@ -85,6 +85,11 @@ class RemoveUnreachableCoalesceArgumentsRuleTest extends TableTestBase {
     }
 
     @Test
+    void testFunctionCoalesce() {
+        util.verifyRelPlan("SELECT COALESCE(f0, JSON_VALUE('{\"a\": true}', '$.a')) FROM T");
+    }
+
+    @Test
     void testMultipleCoalesces() {
         util.verifyRelPlan(
                 "SELECT COALESCE(1),\n"

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/RemoveUnreachableCoalesceArgumentsRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/RemoveUnreachableCoalesceArgumentsRuleTest.xml
@@ -111,6 +111,23 @@ Calc(select=[f0, f1, f2, f00, f10, f20])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testFunctionCoalesce">
+    <Resource name="sql">
+      <![CDATA[SELECT COALESCE(f0, JSON_VALUE('{"a": true}', '$.a')) FROM T]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(EXPR$0=[COALESCE($0, JSON_VALUE(_UTF-16LE'{"a": true}', _UTF-16LE'$.a'))])
++- LogicalTableScan(table=[[default_catalog, default_database, T]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[CAST(CASE(IS NOT NULL(f0), f0, 'true') AS VARCHAR(2147483647)) AS EXPR$0])
++- TableSourceScan(table=[[default_catalog, default_database, T]], fields=[f0, f1, f2])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testMultipleCoalesces">
     <Resource name="sql">
       <![CDATA[SELECT COALESCE(1),

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/RemoveUnreachableCoalesceArgumentsRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/RemoveUnreachableCoalesceArgumentsRuleTest.xml
@@ -85,6 +85,23 @@ Calc(select=[f0, f1, f2], where=[=(COALESCE(f0, f1), 'abc')])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testFunctionCoalesce">
+    <Resource name="sql">
+      <![CDATA[SELECT COALESCE(f0, JSON_VALUE('{"a": true}', '$.a')) FROM T]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(EXPR$0=[COALESCE($0, JSON_VALUE(_UTF-16LE'{"a": true}', _UTF-16LE'$.a'))])
++- LogicalTableScan(table=[[default_catalog, default_database, T]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[CAST(CASE(IS NOT NULL(f0), f0, 'true') AS VARCHAR(2147483647)) AS EXPR$0])
++- TableSourceScan(table=[[default_catalog, default_database, T]], fields=[f0, f1, f2])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testJoinCoalesce">
     <Resource name="sql">
       <![CDATA[SELECT * FROM T t1 LEFT JOIN T t2 ON COALESCE(t1.f0, '-', t1.f2) = t2.f0]]>
@@ -108,23 +125,6 @@ Calc(select=[f0, f1, f2, f00, f10, f20])
    :     +- TableSourceScan(table=[[default_catalog, default_database, T]], fields=[f0, f1, f2])
    +- Exchange(distribution=[hash[f0]])
       +- TableSourceScan(table=[[default_catalog, default_database, T]], fields=[f0, f1, f2])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testFunctionCoalesce">
-    <Resource name="sql">
-      <![CDATA[SELECT COALESCE(f0, JSON_VALUE('{"a": true}', '$.a')) FROM T]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalProject(EXPR$0=[COALESCE($0, JSON_VALUE(_UTF-16LE'{"a": true}', _UTF-16LE'$.a'))])
-+- LogicalTableScan(table=[[default_catalog, default_database, T]])
-]]>
-    </Resource>
-    <Resource name="optimized rel plan">
-      <![CDATA[
-Calc(select=[CAST(CASE(IS NOT NULL(f0), f0, 'true') AS VARCHAR(2147483647)) AS EXPR$0])
-+- TableSourceScan(table=[[default_catalog, default_database, T]], fields=[f0, f1, f2])
 ]]>
     </Resource>
   </TestCase>


### PR DESCRIPTION
Optimize RemoveUnreachableCoalesceArgumentsRule rule，when including functions, it will fall back to case when

[FLINK-38468](https://issues.apache.org/jira/browse/FLINK-38468)
