### PR TITLE
FLINK-38449: Makes error message for fractional values for MemorySize explicit

### DIFF
--- a/flink-core-api/src/main/java/org/apache/flink/configuration/MemorySize.java
+++ b/flink-core-api/src/main/java/org/apache/flink/configuration/MemorySize.java
@@ -287,6 +287,10 @@ public class MemorySize implements java.io.Serializable, Comparable<MemorySize> 
             throw new NumberFormatException("text does not start with a number");
         }
 
+        if(unit.startsWith(".")) {
+            throw new IllegalArgumentException("Memory size must be an integer value. Fractional values are not supported. Found: " + text);
+        }
+
         final long value;
         try {
             value = Long.parseLong(number); // this throws a NumberFormatException on overflow

--- a/flink-core-api/src/main/java/org/apache/flink/configuration/MemorySize.java
+++ b/flink-core-api/src/main/java/org/apache/flink/configuration/MemorySize.java
@@ -27,6 +27,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.IntStream;
 
 import static org.apache.flink.configuration.MemorySize.MemoryUnit.BYTES;
@@ -287,8 +289,14 @@ public class MemorySize implements java.io.Serializable, Comparable<MemorySize> 
             throw new NumberFormatException("text does not start with a number");
         }
 
-        if(unit.startsWith(".")) {
-            throw new IllegalArgumentException("Memory size must be an integer value. Fractional values are not supported. Found: " + text);
+        String unitsRegex = MemoryUnit.getRegularExpressionForAllUnits();
+        Pattern regexPattern = Pattern.compile("^(\\d+)\\s*" + unitsRegex + "?$");
+        Matcher matcher = regexPattern.matcher(trimmed.toLowerCase(Locale.US));
+
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException(
+                    "Memory size must be an integer value optionally followed by a unit. Found: "
+                            + text);
         }
 
         final long value;
@@ -390,6 +398,21 @@ public class MemorySize implements java.io.Serializable, Comparable<MemorySize> 
                     MEGA_BYTES.getUnits(),
                     GIGA_BYTES.getUnits(),
                     TERA_BYTES.getUnits());
+        }
+
+        public static String getRegularExpressionForAllUnits() {
+            String delimiter = "|";
+            String units =
+                    String.join(
+                            delimiter,
+                            new String[] {
+                                String.join(delimiter, BYTES.getUnits()),
+                                String.join(delimiter, KILO_BYTES.getUnits()),
+                                String.join(delimiter, MEGA_BYTES.getUnits()),
+                                String.join(delimiter, GIGA_BYTES.getUnits()),
+                                String.join(delimiter, TERA_BYTES.getUnits()),
+                            });
+            return "(" + units + ")";
         }
 
         public static boolean hasUnit(String text) {

--- a/flink-core-api/src/test/java/org/apache/flink/configuration/MemorySizeTest.java
+++ b/flink-core-api/src/test/java/org/apache/flink/configuration/MemorySizeTest.java
@@ -179,6 +179,10 @@ class MemorySizeTest {
         // negative number
         assertThatThrownBy(() -> MemorySize.parseBytes("-100 bytes"))
                 .isInstanceOf(IllegalArgumentException.class);
+
+        // fractional number
+        assertThatThrownBy(() -> MemorySize.parseBytes("1.5g"))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
Currently for a fractional value for memory size, like 1.5g, the exception message is generated from failing to parse the string ".5g". Improving the exception handling for this case.


## Verifying this change

Added a change in MemorySizeTest to make sure this is handled as expected.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
