### PR TITLE
[FLINK-34015] fix setting execution.savepoint.ignore-unclaimed-state …

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendITCase.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendITCase.java
@@ -21,6 +21,8 @@ package org.apache.flink.client.cli;
 import org.apache.flink.client.deployment.executors.LocalExecutor;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.PipelineOptions;
+import org.apache.flink.configuration.StateRecoveryOptions;
+import org.apache.flink.core.execution.RecoveryClaimMode;
 import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 
@@ -84,6 +86,23 @@ class CliFrontendITCase {
     }
 
     @Test
+    void configurationRestoreMode() throws Exception {
+        Configuration config = new Configuration();
+        CustomCommandLine commandLine = new DefaultCLI();
+
+        config.set(StateRecoveryOptions.RESTORE_MODE, RecoveryClaimMode.CLAIM);
+
+        CliFrontend cliFrontend = new CliFrontend(config, Collections.singletonList(commandLine));
+
+        cliFrontend.parseAndRun(
+                new String[] {
+                    "run", "-c", TestingJob.class.getName(), CliFrontendTestUtils.getTestJarPath()
+                });
+
+        assertThat(getStdoutString()).contains("Restore mode is CLAIM");
+    }
+
+    @Test
     void commandlineOverridesConfiguration() throws Exception {
         Configuration config = new Configuration();
 
@@ -138,6 +157,9 @@ class CliFrontendITCase {
             StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
             System.out.println(
                     "Watermark interval is " + env.getConfig().getAutoWatermarkInterval());
+            System.out.println(
+                    "Restore mode is "
+                            + env.getConfiguration().get(StateRecoveryOptions.RESTORE_MODE));
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/SavepointRestoreSettings.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/SavepointRestoreSettings.java
@@ -176,14 +176,17 @@ public class SavepointRestoreSettings implements Serializable {
     public static void toConfiguration(
             final SavepointRestoreSettings savepointRestoreSettings,
             final Configuration configuration) {
-        configuration.set(
-                StateRecoveryOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE,
-                savepointRestoreSettings.allowNonRestoredState());
-        configuration.set(
-                StateRecoveryOptions.RESTORE_MODE, savepointRestoreSettings.getRecoveryClaimMode());
-        final String savepointPath = savepointRestoreSettings.getRestorePath();
-        if (savepointPath != null) {
-            configuration.set(StateRecoveryOptions.SAVEPOINT_PATH, savepointPath);
+        if (!savepointRestoreSettings.equals(SavepointRestoreSettings.none())) {
+            configuration.set(
+                    StateRecoveryOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE,
+                    savepointRestoreSettings.allowNonRestoredState());
+            configuration.set(
+                    StateRecoveryOptions.RESTORE_MODE,
+                    savepointRestoreSettings.getRecoveryClaimMode());
+            final String savepointPath = savepointRestoreSettings.getRestorePath();
+            if (savepointPath != null) {
+                configuration.set(StateRecoveryOptions.SAVEPOINT_PATH, savepointPath);
+            }
         }
     }
 


### PR DESCRIPTION
…does not take effect when passing this parameter by dynamic properties

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

fix setting execution.savepoint.ignore-unclaimed-state does not take effect when passing this parameter by dynamic properties.

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

when combining the savepoint restore setting from cli options and dynamic properties, check whether the cli option is none(), if true, just NOT setting it to the configuration.

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

added unit test: org.apache.flink.client.cli.CliFrontendITCase#configurationRestoreMode

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
