### PR TITLE
[FLINK-38406][runtime] Fix DefaultSchedulerCheckpointCoordinatorTest failures

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultSchedulerCheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultSchedulerCheckpointCoordinatorTest.java
@@ -19,11 +19,11 @@
 package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.api.common.JobStatus;
-import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.executiongraph.TestingComponentMainThreadExecutor;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobGraphBuilder;
 import org.apache.flink.runtime.jobgraph.JobVertex;
@@ -34,7 +34,6 @@ import org.apache.flink.runtime.scheduler.DefaultScheduler;
 import org.apache.flink.runtime.scheduler.DefaultSchedulerBuilder;
 import org.apache.flink.runtime.scheduler.SchedulerBase;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
-import org.apache.flink.runtime.testutils.DirectScheduledExecutorService;
 import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.testutils.executor.TestExecutorExtension;
 
@@ -57,6 +56,13 @@ class DefaultSchedulerCheckpointCoordinatorTest {
     private static final TestExecutorExtension<ScheduledExecutorService> EXECUTOR_EXTENSION =
             TestingUtils.defaultExecutorExtension();
 
+    @RegisterExtension
+    static final TestingComponentMainThreadExecutor.Extension MAIN_EXECUTOR_RESOURCE =
+            new TestingComponentMainThreadExecutor.Extension();
+
+    private final TestingComponentMainThreadExecutor mainThreadExecutor =
+            MAIN_EXECUTOR_RESOURCE.getComponentMainThreadTestExecutor();
+
     /** Tests that the checkpoint coordinator is shut down if the execution graph is failed. */
     @Test
     void testClosingSchedulerShutsDownCheckpointCoordinatorOnFailedExecutionGraph()
@@ -78,9 +84,14 @@ class DefaultSchedulerCheckpointCoordinatorTest {
         assertThat(checkpointCoordinator).isNotNull();
         assertThat(checkpointCoordinator.isShutdown()).isFalse();
 
-        graph.failJob(new Exception("Test Exception"), System.currentTimeMillis());
-
-        scheduler.closeAsync().get();
+        mainThreadExecutor
+                .execute(
+                        () -> {
+                            graph.failJob(
+                                    new Exception("Test Exception"), System.currentTimeMillis());
+                            return scheduler.closeAsync();
+                        })
+                .get();
 
         assertThat(checkpointCoordinator.isShutdown()).isTrue();
         assertThat(counterShutdownFuture).isCompletedWithValue(JobStatus.FAILED);
@@ -108,9 +119,13 @@ class DefaultSchedulerCheckpointCoordinatorTest {
         assertThat(checkpointCoordinator).isNotNull();
         assertThat(checkpointCoordinator.isShutdown()).isFalse();
 
-        graph.suspend(new Exception("Test Exception"));
-
-        scheduler.closeAsync().get();
+        mainThreadExecutor
+                .execute(
+                        () -> {
+                            graph.suspend(new Exception("Test Exception"));
+                            return scheduler.closeAsync();
+                        })
+                .get();
 
         assertThat(checkpointCoordinator.isShutdown()).isTrue();
         assertThat(counterShutdownFuture).isCompletedWithValue(JobStatus.SUSPENDED);
@@ -138,18 +153,22 @@ class DefaultSchedulerCheckpointCoordinatorTest {
         assertThat(checkpointCoordinator).isNotNull();
         assertThat(checkpointCoordinator.isShutdown()).isFalse();
 
-        scheduler.startScheduling();
-
-        for (ExecutionVertex executionVertex : graph.getAllExecutionVertices()) {
-            final Execution currentExecutionAttempt = executionVertex.getCurrentExecutionAttempt();
-            scheduler.updateTaskExecutionState(
-                    new TaskExecutionState(
-                            currentExecutionAttempt.getAttemptId(), ExecutionState.FINISHED));
-        }
+        mainThreadExecutor.execute(
+                () -> {
+                    scheduler.startScheduling();
+                    for (ExecutionVertex executionVertex : graph.getAllExecutionVertices()) {
+                        final Execution currentExecutionAttempt =
+                                executionVertex.getCurrentExecutionAttempt();
+                        scheduler.updateTaskExecutionState(
+                                new TaskExecutionState(
+                                        currentExecutionAttempt.getAttemptId(),
+                                        ExecutionState.FINISHED));
+                    }
+                });
 
         assertThat(graph.getTerminationFuture()).isCompletedWithValue(JobStatus.FINISHED);
 
-        scheduler.closeAsync().get();
+        mainThreadExecutor.execute(scheduler::closeAsync).get();
 
         assertThat(checkpointCoordinator.isShutdown()).isTrue();
         assertThat(counterShutdownFuture).isCompletedWithValue(JobStatus.FINISHED);
@@ -177,7 +196,7 @@ class DefaultSchedulerCheckpointCoordinatorTest {
         assertThat(checkpointCoordinator).isNotNull();
         assertThat(checkpointCoordinator.isShutdown()).isFalse();
 
-        scheduler.closeAsync().get();
+        mainThreadExecutor.execute(scheduler::closeAsync).get();
 
         assertThat(graph.getState()).isEqualTo(JobStatus.SUSPENDED);
         assertThat(checkpointCoordinator.isShutdown()).isTrue();
@@ -209,11 +228,10 @@ class DefaultSchedulerCheckpointCoordinatorTest {
 
         return new DefaultSchedulerBuilder(
                         jobGraph,
-                        ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                        mainThreadExecutor.getMainThreadExecutor(),
                         EXECUTOR_EXTENSION.getExecutor())
                 .setCheckpointRecoveryFactory(new TestingCheckpointRecoveryFactory(store, counter))
                 .setRpcTimeout(timeout)
-                .setFutureExecutor(new DirectScheduledExecutorService())
                 .build();
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Tasks were failing because they were not run in the main thread. This is related [FLINK-38114](https://issues.apache.org/jira/browse/FLINK-38114), PR https://github.com/apache/flink/pull/26821

## Brief change log

- Update test so that all `ExecutionGraph` operations happen from the main thread

## Verifying this change

Could not reproduce issue after this fix

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
