### PR TITLE
[FLINK-38369][runtime] Fix flaky RestClientTest

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestClientTest.java
@@ -77,7 +77,8 @@ class RestClientTest {
     private static final TestExecutorExtension<ScheduledExecutorService> EXECUTOR_EXTENSION =
             TestingUtils.defaultExecutorExtension();
 
-    private static final String unroutableIp = "240.0.0.0";
+    // Part of TEST-NET-1 block described in RFC 5737 that should never be routed.
+    private static final String unroutableIp = "192.0.2.1";
 
     private static final long TIMEOUT = 10L;
 


### PR DESCRIPTION
## What is the purpose of the change

`RestClientTest` has failed a few times in the past with exception `Network is unreachable: /240.0.0.0:80` instead of connection timeout. By changing the test IP to an address of TEST-NET-1, which is reserved for "Documentation", hopefully we will have more reliable test results than using `240.0.0.0`, which has undefined behavior on some network devices.

## Brief change log

- Update unroutableIp to `192.0.2.1` which is part of TEST-NET-1 in RFC 5737

## Verifying this change

Could not reproduce the issue locally in either way, so I did not have a reliable way to verify this.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
