### PR TITLE
[FLINK-38462] Introduce state backend type identifier

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/state/KeyedStateStore.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/KeyedStateStore.java
@@ -338,4 +338,11 @@ public interface KeyedStateStore {
                             org.apache.flink.api.common.state.v2.AggregatingStateDescriptor<
                                             IN, ACC, OUT>
                                     stateProperties);
+
+    /**
+     * @return fixed lower-case string identifying the type of the underlying state backend, e.g.
+     *     rocksdb, hashmap, forst, batch.
+     */
+    @Experimental
+    String getBackendTypeIdentifier();
 }

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/utils/TestSharedBuffer.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/utils/TestSharedBuffer.java
@@ -287,6 +287,11 @@ public class TestSharedBuffer<V> extends SharedBuffer<V> {
             throw new UnsupportedOperationException();
         }
 
+        @Override
+        public String getBackendTypeIdentifier() {
+            return "mock";
+        }
+
         private class CountingIterator<T> implements Iterator<T> {
 
             private final Iterator<T> iterator;

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/input/MultiStateKeyIteratorTest.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/input/MultiStateKeyIteratorTest.java
@@ -324,6 +324,11 @@ public class MultiStateKeyIteratorTest {
                     "Operations other than getKeys() are not supported on this testing StateBackend.");
         }
 
+        @Override
+        public String getBackendTypeIdentifier() {
+            return "test";
+        }
+
         @Nonnull
         @Override
         public SavepointResources<Integer> savepoint() throws UnsupportedOperationException {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AsyncKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AsyncKeyedStateBackend.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.state;
 
+import org.apache.flink.annotation.Experimental;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.state.InternalCheckpointListener;
 import org.apache.flink.api.common.state.v2.State;
@@ -140,4 +141,11 @@ public interface AsyncKeyedStateBackend<K>
 
     @Override
     void dispose();
+
+    /**
+     * @return fixed lower-case string identifying the type of the underlying state backend, e.g.
+     *     rocksdb, hashmap, or unknown.
+     */
+    @Experimental
+    String getBackendTypeIdentifier();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultKeyedStateStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultKeyedStateStore.java
@@ -219,6 +219,15 @@ public class DefaultKeyedStateStore implements KeyedStateStore {
         }
     }
 
+    @Override
+    public String getBackendTypeIdentifier() {
+        if (keyedStateBackend != null) {
+            return keyedStateBackend.getBackendTypeIdentifier();
+        } else {
+            return asyncKeyedStateBackend.getBackendTypeIdentifier();
+        }
+    }
+
     protected <S extends org.apache.flink.api.common.state.v2.State, SV> S getPartitionedState(
             org.apache.flink.api.common.state.v2.StateDescriptor<SV> stateDescriptor)
             throws Exception {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateBackend.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.state;
 
+import org.apache.flink.annotation.Experimental;
 import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -165,6 +166,13 @@ public interface KeyedStateBackend<K>
     default boolean isSafeToReuseKVState() {
         return false;
     }
+
+    /**
+     * @return fixed lower-case string identifying the type of the underlying state backend, e.g.
+     *     rocksdb, hashmap, forst, batch.
+     */
+    @Experimental
+    String getBackendTypeIdentifier();
 
     /** Listener is given a callback when {@link #setCurrentKey} is called (key context changes). */
     @FunctionalInterface

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
@@ -46,6 +46,7 @@ import org.apache.flink.runtime.state.SnapshotExecutionType;
 import org.apache.flink.runtime.state.SnapshotResult;
 import org.apache.flink.runtime.state.SnapshotStrategy;
 import org.apache.flink.runtime.state.SnapshotStrategyRunner;
+import org.apache.flink.runtime.state.StateBackendLoader;
 import org.apache.flink.runtime.state.StateEntry;
 import org.apache.flink.runtime.state.StateSnapshotRestore;
 import org.apache.flink.runtime.state.StateSnapshotTransformer.StateSnapshotTransformFactory;
@@ -404,6 +405,11 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
         final StateSnapshotRestore stateSnapshotRestore = registeredKVStates.get(state);
         StateTable<K, N, ?> table = (StateTable<K, N, ?>) stateSnapshotRestore;
         return table.getKeysAndNamespaces();
+    }
+
+    @Override
+    public String getBackendTypeIdentifier() {
+        return StateBackendLoader.HASHMAP_STATE_BACKEND_NAME;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/adaptor/AsyncKeyedStateBackendAdaptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/adaptor/AsyncKeyedStateBackendAdaptor.java
@@ -133,6 +133,11 @@ public class AsyncKeyedStateBackendAdaptor<K> implements AsyncKeyedStateBackend<
     public void dispose() {}
 
     @Override
+    public String getBackendTypeIdentifier() {
+        return keyedStateBackend.getBackendTypeIdentifier();
+    }
+
+    @Override
     public void close() throws IOException {}
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionKeyedStateBackend.java
@@ -229,6 +229,11 @@ public class BatchExecutionKeyedStateBackend<K> implements CheckpointableKeyedSt
         return keySelectionListeners.remove(listener);
     }
 
+    @Override
+    public String getBackendTypeIdentifier() {
+        return "batch";
+    }
+
     @Nonnull
     @Override
     public <N, SV, SEV, S extends State, IS extends S> IS createOrUpdateInternalState(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestUtils.java
@@ -172,6 +172,11 @@ public class StateBackendTestUtils {
         }
 
         @Override
+        public String getBackendTypeIdentifier() {
+            return "test";
+        }
+
+        @Override
         public void close() {
             // do nothing
         }
@@ -326,6 +331,11 @@ public class StateBackendTestUtils {
                 public void dispose() {
                     super.dispose();
                     delegatedKeyedStateBackend.dispose();
+                }
+
+                @Override
+                public String getBackendTypeIdentifier() {
+                    return "test";
                 }
 
                 @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackend.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackend.java
@@ -236,6 +236,11 @@ public class MockKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
                                                                 (N) namespace.getKey())));
     }
 
+    @Override
+    public String getBackendTypeIdentifier() {
+        return "mock";
+    }
+
     @Nonnull
     @Override
     public RunnableFuture<SnapshotResult<KeyedStateHandle>> snapshot(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AbstractKeyedStateTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AbstractKeyedStateTestBase.java
@@ -213,6 +213,11 @@ public class AbstractKeyedStateTestBase {
                 public void dispose() {
                     // do nothing
                 }
+
+                @Override
+                public String getBackendTypeIdentifier() {
+                    return "test";
+                }
             };
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/tasks/TestStateBackend.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/tasks/TestStateBackend.java
@@ -176,6 +176,11 @@ public class TestStateBackend extends AbstractStateBackend {
             throw new UnsupportedOperationException();
         }
 
+        @Override
+        public String getBackendTypeIdentifier() {
+            return "test";
+        }
+
         @Nonnull
         @Override
         public <N, SV, SEV, S extends State, IS extends S> IS createOrUpdateInternalState(

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
@@ -623,6 +623,11 @@ public class ChangelogKeyedStateBackend<K>
         return keyedStateBackend.isSafeToReuseKVState();
     }
 
+    @Override
+    public String getBackendTypeIdentifier() {
+        return keyedStateBackend.getBackendTypeIdentifier();
+    }
+
     @Nonnull
     @Override
     public SavepointResources<K> savepoint() throws Exception {

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/restore/ChangelogMigrationRestoreTarget.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/restore/ChangelogMigrationRestoreTarget.java
@@ -299,6 +299,11 @@ public class ChangelogMigrationRestoreTarget<K> implements ChangelogRestoreTarge
                 keyedStateBackend.dispose();
                 changelogStateFactory.dispose();
             }
+
+            @Override
+            public String getBackendTypeIdentifier() {
+                return keyedStateBackend.getBackendTypeIdentifier();
+            }
         };
     }
 }

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackend.java
@@ -47,6 +47,7 @@ import org.apache.flink.runtime.state.PriorityQueueSetFactory;
 import org.apache.flink.runtime.state.SerializedCompositeKeyBuilder;
 import org.apache.flink.runtime.state.SnapshotResult;
 import org.apache.flink.runtime.state.SnapshotStrategyRunner;
+import org.apache.flink.runtime.state.StateBackendLoader;
 import org.apache.flink.runtime.state.heap.HeapPriorityQueueElement;
 import org.apache.flink.runtime.state.heap.HeapPriorityQueueSetFactory;
 import org.apache.flink.runtime.state.heap.HeapPriorityQueueSnapshotRestoreWrapper;
@@ -615,6 +616,11 @@ public class ForStKeyedStateBackend<K> implements AsyncKeyedStateBackend<K> {
             IOUtils.closeQuietly(snapshotStrategy);
             this.disposed = true;
         }
+    }
+
+    @Override
+    public String getBackendTypeIdentifier() {
+        return StateBackendLoader.FORST_STATE_BACKEND_NAME;
     }
 
     @Override

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/sync/ForStSyncKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/sync/ForStSyncKeyedStateBackend.java
@@ -50,6 +50,7 @@ import org.apache.flink.runtime.state.SavepointResources;
 import org.apache.flink.runtime.state.SerializedCompositeKeyBuilder;
 import org.apache.flink.runtime.state.SnapshotResult;
 import org.apache.flink.runtime.state.SnapshotStrategyRunner;
+import org.apache.flink.runtime.state.StateBackendLoader;
 import org.apache.flink.runtime.state.StateSnapshotTransformer.StateSnapshotTransformFactory;
 import org.apache.flink.runtime.state.StreamCompressionDecorator;
 import org.apache.flink.runtime.state.heap.HeapPriorityQueueElement;
@@ -950,6 +951,11 @@ public class ForStSyncKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> 
         ForStOperationUtils.ForStKvStateInfo kvStateInfo =
                 kvStateInformation.get(stateDesc.getName());
         db.compactRange(kvStateInfo.columnFamilyHandle);
+    }
+
+    @Override
+    public String getBackendTypeIdentifier() {
+        return StateBackendLoader.FORST_STATE_BACKEND_NAME;
     }
 
     @Nonnegative

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/state/rocksdb/RocksDBKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/state/rocksdb/RocksDBKeyedStateBackend.java
@@ -50,6 +50,7 @@ import org.apache.flink.runtime.state.SavepointResources;
 import org.apache.flink.runtime.state.SerializedCompositeKeyBuilder;
 import org.apache.flink.runtime.state.SnapshotResult;
 import org.apache.flink.runtime.state.SnapshotStrategyRunner;
+import org.apache.flink.runtime.state.StateBackendLoader;
 import org.apache.flink.runtime.state.StateSnapshotTransformer.StateSnapshotTransformFactory;
 import org.apache.flink.runtime.state.StreamCompressionDecorator;
 import org.apache.flink.runtime.state.heap.HeapPriorityQueueElement;
@@ -1103,6 +1104,11 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
     @Override
     public boolean isSafeToReuseKVState() {
         return true;
+    }
+
+    @Override
+    public String getBackendTypeIdentifier() {
+        return StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME;
     }
 
     /** Rocks DB specific information about the k/v states. */


### PR DESCRIPTION
Add State backend type identifier as proposed in FLIP-544 [discussion](https://lists.apache.org/thread/kq3c5d68gkh0rj55rtcp1n25h6n6opoq).

State backend type identifier can be used by Operators to optimize their execution logic.
For example, 
- choose different thresholds for heap vs rocksdb
- rely on orderliness when using rocksdb