### PR TITLE
[FLINK-38470] Make CreateMaterializedTableOperation return ResolvedCatalogMaterializedTable

### DIFF
--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/materializedtable/MaterializedTableManager.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/materializedtable/MaterializedTableManager.java
@@ -197,7 +197,7 @@ public class MaterializedTableManager {
             OperationExecutor operationExecutor,
             OperationHandle handle,
             CreateMaterializedTableOperation createMaterializedTableOperation) {
-        CatalogMaterializedTable materializedTable =
+        ResolvedCatalogMaterializedTable materializedTable =
                 createMaterializedTableOperation.getCatalogMaterializedTable();
         if (CatalogMaterializedTable.RefreshMode.CONTINUOUS == materializedTable.getRefreshMode()) {
             createMaterializedTableInContinuousMode(
@@ -220,7 +220,7 @@ public class MaterializedTableManager {
 
         ObjectIdentifier materializedTableIdentifier =
                 createMaterializedTableOperation.getTableIdentifier();
-        CatalogMaterializedTable catalogMaterializedTable =
+        ResolvedCatalogMaterializedTable catalogMaterializedTable =
                 createMaterializedTableOperation.getCatalogMaterializedTable();
 
         try {
@@ -257,7 +257,7 @@ public class MaterializedTableManager {
 
         ObjectIdentifier materializedTableIdentifier =
                 createMaterializedTableOperation.getTableIdentifier();
-        CatalogMaterializedTable catalogMaterializedTable =
+        ResolvedCatalogMaterializedTable catalogMaterializedTable =
                 createMaterializedTableOperation.getCatalogMaterializedTable();
 
         // convert duration to cron expression

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateMaterializedTable.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateMaterializedTable.java
@@ -124,7 +124,7 @@ public class SqlCreateMaterializedTable extends SqlCreate {
         return Optional.ofNullable(tableConstraint);
     }
 
-    public SqlDistribution getDistribution() {
+    public @Nullable SqlDistribution getDistribution() {
         return distribution;
     }
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/materializedtable/CreateMaterializedTableOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/materializedtable/CreateMaterializedTableOperation.java
@@ -21,7 +21,6 @@ package org.apache.flink.table.operations.materializedtable;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.api.internal.TableResultImpl;
 import org.apache.flink.table.api.internal.TableResultInternal;
-import org.apache.flink.table.catalog.CatalogMaterializedTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ResolvedCatalogMaterializedTable;
 import org.apache.flink.table.operations.Operation;
@@ -38,7 +37,7 @@ public class CreateMaterializedTableOperation
         implements CreateOperation, MaterializedTableOperation {
 
     private final ObjectIdentifier tableIdentifier;
-    private final CatalogMaterializedTable materializedTable;
+    private final ResolvedCatalogMaterializedTable materializedTable;
 
     public CreateMaterializedTableOperation(
             ObjectIdentifier tableIdentifier, ResolvedCatalogMaterializedTable materializedTable) {
@@ -57,7 +56,7 @@ public class CreateMaterializedTableOperation
         return tableIdentifier;
     }
 
-    public CatalogMaterializedTable getCatalogMaterializedTable() {
+    public ResolvedCatalogMaterializedTable getCatalogMaterializedTable() {
         return materializedTable;
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlMaterializedTableNodeToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlMaterializedTableNodeToOperationConverterTest.java
@@ -126,8 +126,7 @@ public class SqlMaterializedTableNodeToOperationConverterTest
         assertThat(operation).isInstanceOf(CreateMaterializedTableOperation.class);
 
         CreateMaterializedTableOperation op = (CreateMaterializedTableOperation) operation;
-        CatalogMaterializedTable materializedTable = op.getCatalogMaterializedTable();
-        assertThat(materializedTable).isInstanceOf(ResolvedCatalogMaterializedTable.class);
+        ResolvedCatalogMaterializedTable materializedTable = op.getCatalogMaterializedTable();
 
         Map<String, String> options = new HashMap<>();
         options.put("connector", "filesystem");
@@ -152,8 +151,7 @@ public class SqlMaterializedTableNodeToOperationConverterTest
                         .definitionQuery("SELECT *\n" + "FROM `builtin`.`default`.`t1`")
                         .build();
 
-        assertThat(((ResolvedCatalogMaterializedTable) materializedTable).getOrigin())
-                .isEqualTo(expected);
+        assertThat(materializedTable.getOrigin()).isEqualTo(expected);
     }
 
     @Test
@@ -202,8 +200,7 @@ public class SqlMaterializedTableNodeToOperationConverterTest
         assertThat(operation).isInstanceOf(CreateMaterializedTableOperation.class);
 
         CreateMaterializedTableOperation op = (CreateMaterializedTableOperation) operation;
-        CatalogMaterializedTable materializedTable = op.getCatalogMaterializedTable();
-        assertThat(materializedTable).isInstanceOf(ResolvedCatalogMaterializedTable.class);
+        ResolvedCatalogMaterializedTable materializedTable = op.getCatalogMaterializedTable();
 
         assertThat(materializedTable.getLogicalRefreshMode())
                 .isEqualTo(CatalogMaterializedTable.LogicalRefreshMode.AUTOMATIC);
@@ -220,8 +217,7 @@ public class SqlMaterializedTableNodeToOperationConverterTest
         assertThat(operation2).isInstanceOf(CreateMaterializedTableOperation.class);
 
         CreateMaterializedTableOperation op2 = (CreateMaterializedTableOperation) operation2;
-        CatalogMaterializedTable materializedTable2 = op2.getCatalogMaterializedTable();
-        assertThat(materializedTable2).isInstanceOf(ResolvedCatalogMaterializedTable.class);
+        ResolvedCatalogMaterializedTable materializedTable2 = op2.getCatalogMaterializedTable();
 
         assertThat(materializedTable2.getLogicalRefreshMode())
                 .isEqualTo(CatalogMaterializedTable.LogicalRefreshMode.CONTINUOUS);
@@ -240,8 +236,7 @@ public class SqlMaterializedTableNodeToOperationConverterTest
         assertThat(operation).isInstanceOf(CreateMaterializedTableOperation.class);
 
         CreateMaterializedTableOperation op = (CreateMaterializedTableOperation) operation;
-        CatalogMaterializedTable materializedTable = op.getCatalogMaterializedTable();
-        assertThat(materializedTable).isInstanceOf(ResolvedCatalogMaterializedTable.class);
+        ResolvedCatalogMaterializedTable materializedTable = op.getCatalogMaterializedTable();
 
         assertThat(materializedTable.getLogicalRefreshMode())
                 .isEqualTo(CatalogMaterializedTable.LogicalRefreshMode.AUTOMATIC);
@@ -258,8 +253,7 @@ public class SqlMaterializedTableNodeToOperationConverterTest
         assertThat(operation2).isInstanceOf(CreateMaterializedTableOperation.class);
 
         CreateMaterializedTableOperation op2 = (CreateMaterializedTableOperation) operation2;
-        CatalogMaterializedTable materializedTable2 = op2.getCatalogMaterializedTable();
-        assertThat(materializedTable2).isInstanceOf(ResolvedCatalogMaterializedTable.class);
+        ResolvedCatalogMaterializedTable materializedTable2 = op2.getCatalogMaterializedTable();
 
         assertThat(materializedTable2.getLogicalRefreshMode())
                 .isEqualTo(CatalogMaterializedTable.LogicalRefreshMode.FULL);


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes a type inconsistency in `CreateMaterializedTableOperation` where the getter method returns the parent type `CatalogMaterializedTable` instead of the actual stored type `ResolvedCatalogMaterializedTable`. This creates unnecessary type loss and is inconsistent with similar operations like `CreateTableOperation` which correctly returns `ResolvedCatalogTable`.

## Brief change log

- Changed `CreateMaterializedTableOperation.getCatalogMaterializedTable()` return type from `CatalogMaterializedTable` to `ResolvedCatalogMaterializedTable` to match the field type and align with the pattern used in `CreateTableOperation`

## Verifying this change

This change is already covered by existing tests, such as:
- All existing tests continue to pass since `ResolvedCatalogMaterializedTable` implements `CatalogMaterializedTable` (safe covariant return type change)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no (class is `@Internal`)
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable