### PR TITLE
[FLINK-38473][build] Upgrade ArchUnit to 1.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@ under the License.
 		<jaxb.api.version>2.3.1</jaxb.api.version>
 		<junit4.version>4.13.2</junit4.version>
 		<junit5.version>5.11.4</junit5.version>
-		<archunit.version>1.2.0</archunit.version>
+		<archunit.version>1.4.1</archunit.version>
 		<mockito.version>5.19.0</mockito.version>
 		<hamcrest.version>1.3</hamcrest.version>
 		<assertj.version>3.27.3</assertj.version>


### PR DESCRIPTION

## What is the purpose of the change

The PR bumps archunit to 1.4.1 in order to support jdk25

current issue with jdk25 and Archunit 1.2.0 is that
```
mvn clean install -DskipTests -Dfast -Pjava25-target
mvn verify -pl flink-architecture-tests/flink-architecture-tests-production/ -Darchunit.freeze.store.default.allowStoreUpdate=false
```
fails as 
```
[ERROR] TableApiRules.CONNECTOR_OPTIONS_PACKAGE -- Time elapsed: 0.004 s <<< FAILURE!
java.lang.AssertionError: Rule 'Options for connectors and formats should reside in a consistent package and be public API.' failed to check any classes. This means either that no classes have been passed to the rule at all, or that no classes passed to the rule matched the `that()` clause. To allow rules being evaluated without checking any classes you can either use `ArchRule.allowEmptyShould(true)` on a single rule or set the configuration property `archRule.failOnEmptyShould = false` to change the behavior globally.
	at com.tngtech.archunit.lang.ArchRule$Factory$SimpleArchRule.verifyNoEmptyShouldIfEnabled(ArchRule.java:201)
	at com.tngtech.archunit.lang.ArchRule$Factory$SimpleArchRule.evaluate(ArchRule.java:181)
	at com.tngtech.archunit.library.freeze.FreezingArchRule.evaluate(FreezingArchRule.java:123)
	at com.tngtech.archunit.lang.ArchRule$Assertions.check(ArchRule.java:84)
	at com.tngtech.archunit.library.freeze.FreezingArchRule.check(FreezingArchRule.java:97)
	at com.tngtech.archunit.junit.internal.ArchUnitTestDescriptor$ArchUnitRuleDescriptor.execute(ArchUnitTestDescriptor.java:166)
	at com.tngtech.archunit.junit.internal.ArchUnitTestDescriptor$ArchUnitRuleDescriptor.execute(ArchUnitTestDescriptor.java:149)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)
```
this PR is going to fix it

## Brief change log
pom

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes )
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
