### PR TITLE
[FLINK-38387][build] Disable spotless for java 25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1205,6 +1205,41 @@ under the License.
 		</profile>
 
 		<profile>
+			<id>java25</id>
+			<activation>
+				<jdk>[25,)</jdk>
+			</activation>
+
+			<build>
+				<pluginManagement>
+					<plugins>
+						<plugin>
+							<groupId>org.apache.maven.plugins</groupId>
+							<artifactId>maven-surefire-plugin</artifactId>
+							<configuration>
+								<excludedGroups>
+									${surefire.excludedGroups.github-actions},
+									${surefire.excludedGroups.adaptive-scheduler},
+									${surefire.excludedGroups.jdk},
+								</excludedGroups>
+							</configuration>
+						</plugin>
+						<plugin>
+							<groupId>com.diffplug.spotless</groupId>
+							<artifactId>spotless-maven-plugin</artifactId>
+							<configuration>
+								<!-- Current google format does not run on Java 25.
+									 Don't upgrade it in this profile because it formats code differently.
+									 Re-evaluate once support for Java 11 is dropped. -->
+								<skip>true</skip>
+							</configuration>
+						</plugin>
+					</plugins>
+				</pluginManagement>
+			</build>
+		</profile>
+
+		<profile>
 			<id>fast</id>
 			<activation>
 				<property>


### PR DESCRIPTION
## What is the purpose of the change

The problem with spotless in jdk25 is that we still use google-java-format 1.24.0 which still supports jdk11.
The first google-java-format supporting jdk25 is 1.28.0 however it already requires jdk17 as minimum and doesn't support jdk11. So there is no way for now to support 11, 17, 21 and 25.  Moreover updating of google-java-format will also trigger a bit different format for some edge cases. Thus the approach is as before: disable it for jdk25 for now

## Brief change log
pom

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
