### PR TITLE
[FLINK-38477][runtime] Add FINISHED watermark status to support proper watermark aggregation

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/FinishedOnRestoreInput.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/FinishedOnRestoreInput.java
@@ -28,13 +28,16 @@ import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 public class FinishedOnRestoreInput<IN> implements Input<IN> {
     private final RecordWriterOutput<?>[] streamOutputs;
     private final int inputCount;
+    private final String taskName;
 
     private int watermarksSeen = 0;
     private int finishedStatusSeen = 0;
 
-    public FinishedOnRestoreInput(RecordWriterOutput<?>[] streamOutputs, int inputCount) {
+    public FinishedOnRestoreInput(
+            RecordWriterOutput<?>[] streamOutputs, int inputCount, String taskName) {
         this.streamOutputs = streamOutputs;
         this.inputCount = inputCount;
+        this.taskName = taskName;
     }
 
     @Override
@@ -47,8 +50,8 @@ public class FinishedOnRestoreInput<IN> implements Input<IN> {
         if (watermark.getTimestamp() != Watermark.MAX_WATERMARK.getTimestamp()) {
             throw new IllegalStateException(
                     String.format(
-                            "We should not receive any watermarks [%s] other than the MAX_WATERMARK if finished on restore",
-                            watermark));
+                            "We should not receive any watermarks [%s] other than the MAX_WATERMARK if finished on restore. Task: %s",
+                            watermark, taskName));
         }
         if (++watermarksSeen == inputCount) {
             for (RecordWriterOutput<?> streamOutput : streamOutputs) {
@@ -59,22 +62,21 @@ public class FinishedOnRestoreInput<IN> implements Input<IN> {
 
     @Override
     public void processWatermarkStatus(WatermarkStatus watermarkStatus) throws Exception {
-        // Tasks that finished on restore may receive FINISHED watermark status from upstream.
-        // Aggregate FINISHED status from all inputs and emit once all are received, similar to
-        // how MAX_WATERMARK is handled. This ensures proper watermark status propagation.
-        if (watermarkStatus.isFinished()) {
-            if (++finishedStatusSeen == inputCount) {
-                for (RecordWriterOutput<?> streamOutput : streamOutputs) {
-                    streamOutput.emitWatermarkStatus(watermarkStatus);
-                }
-            }
-            return;
+        // A task that finished on restore only ever sees FINISHED from upstream; ACTIVE and IDLE
+        // describe a temporary state that cannot apply to an input which is already complete.
+        if (!watermarkStatus.isFinished()) {
+            throw new IllegalStateException(
+                    String.format(
+                            "Unexpected watermark status [%s] received for finished on restore task. Task: %s",
+                            watermarkStatus, taskName));
         }
-        // Other watermark statuses (ACTIVE, IDLE) should not occur for finished tasks
-        throw new IllegalStateException(
-                String.format(
-                        "Unexpected watermark status [%s] received for finished on restore task",
-                        watermarkStatus));
+        // Aggregate FINISHED across all inputs and forward it once every input has reported,
+        // mirroring how MAX_WATERMARK is handled above.
+        if (++finishedStatusSeen == inputCount) {
+            for (RecordWriterOutput<?> streamOutput : streamOutputs) {
+                streamOutput.emitWatermarkStatus(watermarkStatus);
+            }
+        }
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
@@ -36,7 +36,6 @@ import org.apache.flink.streaming.api.graph.StreamEdge;
 import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.watermark.Watermark;
-import org.apache.flink.streaming.runtime.io.RecordWriterOutput;
 import org.apache.flink.streaming.runtime.io.StreamMultipleInputProcessorFactory;
 import org.apache.flink.streaming.runtime.io.StreamTaskSourceInput;
 import org.apache.flink.streaming.runtime.io.checkpointing.CheckpointBarrierHandler;
@@ -46,7 +45,6 @@ import org.apache.flink.streaming.runtime.metrics.MinWatermarkGauge;
 import org.apache.flink.streaming.runtime.metrics.WatermarkGauge;
 import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
-import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 import org.apache.flink.util.concurrent.FutureUtils;
 
 import javax.annotation.Nullable;
@@ -345,20 +343,6 @@ public class MultipleInputStreamTask<OUT>
 
     @Override
     protected void emitFinishedStatus() {
-        try {
-            if (operatorChain != null) {
-                RecordWriterOutput<?>[] streamOutputs = operatorChain.getStreamOutputs();
-                for (RecordWriterOutput<?> output : streamOutputs) {
-                    output.emitWatermarkStatus(WatermarkStatus.FINISHED);
-                }
-                LOG.debug(
-                        "Successfully emitted FINISHED watermark status via {} outputs",
-                        streamOutputs.length);
-            } else {
-                LOG.warn("Cannot emit FINISHED watermark status: operator chain is null");
-            }
-        } catch (Exception e) {
-            LOG.warn("Failed to emit FINISHED watermark status", e);
-        }
+        emitFinishedStatusToOutputs();
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
@@ -36,6 +36,7 @@ import org.apache.flink.streaming.api.graph.StreamEdge;
 import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.io.RecordWriterOutput;
 import org.apache.flink.streaming.runtime.io.StreamMultipleInputProcessorFactory;
 import org.apache.flink.streaming.runtime.io.StreamTaskSourceInput;
 import org.apache.flink.streaming.runtime.io.checkpointing.CheckpointBarrierHandler;
@@ -45,6 +46,7 @@ import org.apache.flink.streaming.runtime.metrics.MinWatermarkGauge;
 import org.apache.flink.streaming.runtime.metrics.WatermarkGauge;
 import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 import org.apache.flink.util.concurrent.FutureUtils;
 
 import javax.annotation.Nullable;
@@ -338,6 +340,25 @@ public class MultipleInputStreamTask<OUT>
     protected void advanceToEndOfEventTime() throws Exception {
         for (Output<StreamRecord<?>> sourceOutput : operatorChain.getChainedSourceOutputs()) {
             sourceOutput.emitWatermark(Watermark.MAX_WATERMARK);
+        }
+    }
+
+    @Override
+    protected void emitFinishedStatus() {
+        try {
+            if (operatorChain != null) {
+                RecordWriterOutput<?>[] streamOutputs = operatorChain.getStreamOutputs();
+                for (RecordWriterOutput<?> output : streamOutputs) {
+                    output.emitWatermarkStatus(WatermarkStatus.FINISHED);
+                }
+                LOG.debug(
+                        "Successfully emitted FINISHED watermark status via {} outputs",
+                        streamOutputs.length);
+            } else {
+                LOG.warn("Cannot emit FINISHED watermark status: operator chain is null");
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to emit FINISHED watermark status", e);
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
@@ -341,4 +341,9 @@ public class MultipleInputStreamTask<OUT>
             sourceOutput.emitWatermark(Watermark.MAX_WATERMARK);
         }
     }
+
+    @Override
+    protected void emitFinishedStatus() {
+        emitFinishedStatusToOutputs();
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
@@ -187,7 +187,9 @@ public abstract class OperatorChain<OUT, OP extends StreamOperator<OUT>>
         this.finishedOnRestoreInput =
                 this.isTaskDeployedAsFinished()
                         ? new FinishedOnRestoreInput(
-                                streamOutputs, configuration.getInputs(userCodeClassloader).length)
+                                streamOutputs,
+                                configuration.getInputs(userCodeClassloader).length,
+                                containingTask.getName())
                         : null;
 
         // from here on, we need to make sure that the output writers are shut down again on failure

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
@@ -219,6 +219,11 @@ public class SourceOperatorStreamTask<T> extends StreamTask<T, SourceOperator<T,
     }
 
     @Override
+    protected void emitFinishedStatus() {
+        emitFinishedStatusToOutputs();
+    }
+
+    @Override
     protected void declineCheckpoint(long checkpointId) {
         cleanupCheckpoint(checkpointId);
         super.declineCheckpoint(checkpointId);

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
@@ -34,6 +34,7 @@ import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.SourceOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.io.PushingAsyncDataInput.DataOutput;
+import org.apache.flink.streaming.runtime.io.RecordWriterOutput;
 import org.apache.flink.streaming.runtime.io.StreamOneInputProcessor;
 import org.apache.flink.streaming.runtime.io.StreamTaskExternallyInducedSourceInput;
 import org.apache.flink.streaming.runtime.io.StreamTaskInput;
@@ -216,6 +217,25 @@ public class SourceOperatorStreamTask<T> extends StreamTask<T, SourceOperator<T,
     @Override
     protected void advanceToEndOfEventTime() {
         output.emitWatermark(Watermark.MAX_WATERMARK);
+    }
+
+    @Override
+    protected void emitFinishedStatus() {
+        try {
+            if (operatorChain != null) {
+                RecordWriterOutput<?>[] streamOutputs = operatorChain.getStreamOutputs();
+                for (RecordWriterOutput<?> streamOutput : streamOutputs) {
+                    streamOutput.emitWatermarkStatus(WatermarkStatus.FINISHED);
+                }
+                LOG.debug(
+                        "Successfully emitted FINISHED watermark status via {} outputs",
+                        streamOutputs.length);
+            } else {
+                LOG.warn("Cannot emit FINISHED watermark status: operator chain is null");
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to emit FINISHED watermark status", e);
+        }
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
@@ -34,7 +34,6 @@ import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.SourceOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.io.PushingAsyncDataInput.DataOutput;
-import org.apache.flink.streaming.runtime.io.RecordWriterOutput;
 import org.apache.flink.streaming.runtime.io.StreamOneInputProcessor;
 import org.apache.flink.streaming.runtime.io.StreamTaskExternallyInducedSourceInput;
 import org.apache.flink.streaming.runtime.io.StreamTaskInput;
@@ -221,21 +220,7 @@ public class SourceOperatorStreamTask<T> extends StreamTask<T, SourceOperator<T,
 
     @Override
     protected void emitFinishedStatus() {
-        try {
-            if (operatorChain != null) {
-                RecordWriterOutput<?>[] streamOutputs = operatorChain.getStreamOutputs();
-                for (RecordWriterOutput<?> streamOutput : streamOutputs) {
-                    streamOutput.emitWatermarkStatus(WatermarkStatus.FINISHED);
-                }
-                LOG.debug(
-                        "Successfully emitted FINISHED watermark status via {} outputs",
-                        streamOutputs.length);
-            } else {
-                LOG.warn("Cannot emit FINISHED watermark status: operator chain is null");
-            }
-        } catch (Exception e) {
-            LOG.warn("Failed to emit FINISHED watermark status", e);
-        }
+        emitFinishedStatusToOutputs();
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
@@ -180,6 +180,11 @@ public class SourceStreamTask<
     }
 
     @Override
+    protected void emitFinishedStatus() {
+        emitFinishedStatusToOutputs();
+    }
+
+    @Override
     protected void advanceToEndOfEventTime() throws Exception {
         operatorChain.getMainOperatorOutput().emitWatermark(Watermark.MAX_WATERMARK);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
@@ -36,9 +36,7 @@ import org.apache.flink.streaming.api.checkpoint.ExternallyInducedSource;
 import org.apache.flink.streaming.api.functions.source.legacy.SourceFunction;
 import org.apache.flink.streaming.api.operators.StreamSource;
 import org.apache.flink.streaming.api.watermark.Watermark;
-import org.apache.flink.streaming.runtime.io.RecordWriterOutput;
 import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxDefaultAction;
-import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FatalExitExceptionHandler;
 import org.apache.flink.util.FlinkException;
@@ -183,21 +181,7 @@ public class SourceStreamTask<
 
     @Override
     protected void emitFinishedStatus() {
-        try {
-            if (operatorChain != null) {
-                RecordWriterOutput<?>[] streamOutputs = operatorChain.getStreamOutputs();
-                for (RecordWriterOutput<?> output : streamOutputs) {
-                    output.emitWatermarkStatus(WatermarkStatus.FINISHED);
-                }
-                LOG.debug(
-                        "Successfully emitted FINISHED watermark status via {} outputs",
-                        streamOutputs.length);
-            } else {
-                LOG.warn("Cannot emit FINISHED watermark status: operator chain is null");
-            }
-        } catch (Exception e) {
-            LOG.warn("Failed to emit FINISHED watermark status", e);
-        }
+        emitFinishedStatusToOutputs();
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -112,6 +112,7 @@ import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxProcessor;
 import org.apache.flink.streaming.runtime.tasks.mailbox.PeriodTimer;
 import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailbox;
 import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailboxImpl;
+import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FatalExitExceptionHandler;
 import org.apache.flink.util.FlinkException;
@@ -707,6 +708,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
     protected void endData(StopMode mode) throws Exception {
 
         if (mode == StopMode.DRAIN) {
+            emitFinishedStatus();
             advanceToEndOfEventTime();
         }
         // finish all operators in a chain effect way
@@ -722,6 +724,30 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 
     protected void notifyEndOfData() {
         environment.getTaskManagerActions().notifyEndOfData(environment.getExecutionId());
+    }
+
+    /**
+     * Emits FINISHED watermark status to indicate this task has permanently completed and should be
+     * excluded from watermark aggregation in downstream operators. This addresses the issue where
+     * finished tasks with MAX_WATERMARK incorrectly dominate watermark aggregation when other
+     * inputs become idle.
+     */
+    private void emitFinishedStatus() {
+        try {
+            if (operatorChain != null) {
+                RecordWriterOutput<?>[] streamOutputs = operatorChain.getStreamOutputs();
+                for (RecordWriterOutput<?> output : streamOutputs) {
+                    output.emitWatermarkStatus(WatermarkStatus.FINISHED);
+                }
+                LOG.debug(
+                        "Successfully emitted FINISHED watermark status via {} outputs",
+                        streamOutputs.length);
+            } else {
+                LOG.warn("Cannot emit FINISHED watermark status: operator chain is null");
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to emit FINISHED watermark status", e);
+        }
     }
 
     protected void setSynchronousSavepoint(long checkpointId) {

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -112,7 +112,6 @@ import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxProcessor;
 import org.apache.flink.streaming.runtime.tasks.mailbox.PeriodTimer;
 import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailbox;
 import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailboxImpl;
-import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FatalExitExceptionHandler;
 import org.apache.flink.util.FlinkException;
@@ -726,30 +725,6 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
         environment.getTaskManagerActions().notifyEndOfData(environment.getExecutionId());
     }
 
-    /**
-     * Emits FINISHED watermark status to indicate this task has permanently completed and should be
-     * excluded from watermark aggregation in downstream operators. This addresses the issue where
-     * finished tasks with MAX_WATERMARK incorrectly dominate watermark aggregation when other
-     * inputs become idle.
-     */
-    private void emitFinishedStatus() {
-        try {
-            if (operatorChain != null) {
-                RecordWriterOutput<?>[] streamOutputs = operatorChain.getStreamOutputs();
-                for (RecordWriterOutput<?> output : streamOutputs) {
-                    output.emitWatermarkStatus(WatermarkStatus.FINISHED);
-                }
-                LOG.debug(
-                        "Successfully emitted FINISHED watermark status via {} outputs",
-                        streamOutputs.length);
-            } else {
-                LOG.warn("Cannot emit FINISHED watermark status: operator chain is null");
-            }
-        } catch (Exception e) {
-            LOG.warn("Failed to emit FINISHED watermark status", e);
-        }
-    }
-
     protected void setSynchronousSavepoint(long checkpointId) {
         checkState(
                 syncSavepoint == null || syncSavepoint == checkpointId,
@@ -781,6 +756,19 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
      * <p>For tasks other than the source task, this method does nothing.
      */
     protected void advanceToEndOfEventTime() throws Exception {}
+
+    /**
+     * Emits FINISHED watermark status to indicate this task has permanently completed and should be
+     * excluded from watermark aggregation in downstream operators.
+     *
+     * <p>This method is overridden by source tasks to emit FINISHED status directly to downstream
+     * via network outputs. Processing tasks (e.g., OneInputStreamTask, TwoInputStreamTask) do not
+     * override this method because they rely on StatusWatermarkValve to aggregate FINISHED status
+     * from upstream inputs and propagate it downstream automatically.
+     */
+    protected void emitFinishedStatus() {
+        // Empty by default - only source tasks override this method.
+    }
 
     // ------------------------------------------------------------------------
     //  Core work methods of the Stream Task

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -112,6 +112,7 @@ import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxProcessor;
 import org.apache.flink.streaming.runtime.tasks.mailbox.PeriodTimer;
 import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailbox;
 import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailboxImpl;
+import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FatalExitExceptionHandler;
 import org.apache.flink.util.FlinkException;
@@ -768,6 +769,28 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
      */
     protected void emitFinishedStatus() {
         // Empty by default - only source tasks override this method.
+    }
+
+    /**
+     * Helper method to emit FINISHED watermark status to all stream outputs. Subclasses can call
+     * this from their emitFinishedStatus() override if needed.
+     */
+    protected void emitFinishedStatusToOutputs() {
+        try {
+            if (operatorChain != null) {
+                RecordWriterOutput<?>[] streamOutputs = operatorChain.getStreamOutputs();
+                for (RecordWriterOutput<?> output : streamOutputs) {
+                    output.emitWatermarkStatus(WatermarkStatus.FINISHED);
+                }
+                LOG.debug(
+                        "Successfully emitted FINISHED watermark status via {} outputs",
+                        streamOutputs.length);
+            } else {
+                LOG.warn("Cannot emit FINISHED watermark status: operator chain is null");
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to emit FINISHED watermark status", e);
+        }
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -117,6 +117,7 @@ import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxProcessor;
 import org.apache.flink.streaming.runtime.tasks.mailbox.PeriodTimer;
 import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailbox;
 import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailboxImpl;
+import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FatalExitExceptionHandler;
 import org.apache.flink.util.FlinkException;
@@ -758,6 +759,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
     protected void endData(StopMode mode) throws Exception {
 
         if (mode == StopMode.DRAIN) {
+            emitFinishedStatus();
             advanceToEndOfEventTime();
         }
         // finish all operators in a chain effect way
@@ -806,6 +808,41 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
      * <p>For tasks other than the source task, this method does nothing.
      */
     protected void advanceToEndOfEventTime() throws Exception {}
+
+    /**
+     * Emits FINISHED watermark status to indicate this task has permanently completed and should be
+     * excluded from watermark aggregation in downstream operators.
+     *
+     * <p>This method is overridden by source tasks to emit FINISHED status directly to downstream
+     * via network outputs. Processing tasks (e.g., OneInputStreamTask, TwoInputStreamTask) do not
+     * override this method because they rely on StatusWatermarkValve to aggregate FINISHED status
+     * from upstream inputs and propagate it downstream automatically.
+     */
+    protected void emitFinishedStatus() {
+        // Empty by default - only source tasks override this method.
+    }
+
+    /**
+     * Helper method to emit FINISHED watermark status to all stream outputs. Subclasses can call
+     * this from their emitFinishedStatus() override if needed.
+     */
+    protected void emitFinishedStatusToOutputs() {
+        try {
+            if (operatorChain != null) {
+                RecordWriterOutput<?>[] streamOutputs = operatorChain.getStreamOutputs();
+                for (RecordWriterOutput<?> output : streamOutputs) {
+                    output.emitWatermarkStatus(WatermarkStatus.FINISHED);
+                }
+                LOG.debug(
+                        "Successfully emitted FINISHED watermark status via {} outputs",
+                        streamOutputs.length);
+            } else {
+                LOG.warn("Cannot emit FINISHED watermark status: operator chain is null");
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to emit FINISHED watermark status", e);
+        }
+    }
 
     // ------------------------------------------------------------------------
     //  Core work methods of the Stream Task

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/watermark/extension/eventtime/EventTimeWatermarkCombiner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/watermark/extension/eventtime/EventTimeWatermarkCombiner.java
@@ -94,6 +94,18 @@ public class EventTimeWatermarkCombiner extends StatusWatermarkValve implements 
 
         @Override
         public void emitWatermarkStatus(WatermarkStatus watermarkStatus) throws Exception {
+            // The event time extension carries status as a boolean idle flag, so it can express
+            // IDLE and ACTIVE but not FINISHED. Mapping FINISHED through isIdle() would report it
+            // as active, which is the very state that lets a finished input's MAX_WATERMARK
+            // dominate the aggregated minimum. combineWatermark above only ever feeds IDLE or
+            // ACTIVE into the valve, so this is unreachable today; fail loudly rather than
+            // silently downgrade if a FINISHED path is ever added.
+            if (watermarkStatus.isFinished()) {
+                throw new UnsupportedOperationException(
+                        "FINISHED watermark status cannot be represented by "
+                                + "EventTimeExtension.IDLE_STATUS_WATERMARK_DECLARATION, "
+                                + "which is a boolean idle flag.");
+            }
             watermarkEmitter.accept(
                     EventTimeExtension.IDLE_STATUS_WATERMARK_DECLARATION.newWatermark(
                             watermarkStatus.isIdle()));

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/watermarkstatus/StatusWatermarkValve.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/watermarkstatus/StatusWatermarkValve.java
@@ -330,7 +330,7 @@ public class StatusWatermarkValve {
         }
     }
 
-    // Helper to calculate and emit new watermark if it progresses.
+    // Calculate and emit new watermark if it progresses.
     private void tryEmitNewWatermark(DataOutput<?> output) throws Exception {
         Long newWatermark = calculateWatermarkByAggregationRules();
         if (newWatermark != null && newWatermark > lastOutputWatermark) {
@@ -339,7 +339,7 @@ public class StatusWatermarkValve {
         }
     }
 
-    // Calculate and emit new operator-level (global) status
+    // Calculate and emit new operator-level (global) status.
     private void tryEmitNewGlobalWatermarkStatus(DataOutput<?> output) throws Exception {
         WatermarkStatus newGlobalStatus = calculateGlobalWatermarkStatus();
         if (!newGlobalStatus.equals(lastOutputWatermarkStatus)) {

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/watermarkstatus/StatusWatermarkValve.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/watermarkstatus/StatusWatermarkValve.java
@@ -28,6 +28,9 @@ import org.apache.flink.streaming.runtime.io.checkpointing.CheckpointedInputGate
 import org.apache.flink.streaming.runtime.watermarkstatus.HeapPriorityQueue.HeapPriorityQueueElement;
 import org.apache.flink.util.Preconditions;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -46,6 +49,8 @@ import static org.apache.flink.util.Preconditions.checkState;
  */
 @Internal
 public class StatusWatermarkValve {
+
+    private static final Logger LOG = LoggerFactory.getLogger(StatusWatermarkValve.class);
 
     // ------------------------------------------------------------------------
     //	Runtime state for watermark & watermark status output determination
@@ -74,13 +79,13 @@ public class StatusWatermarkValve {
      * watermark-aligned subpartitions, for which the following invariants hold:
      *
      * <ul>
-     *   <li>only active subpartitions can be aligned
+     *   <li>only active subpartitions can be aligned; idle and finished ones never are
      *   <li>the watermark of an aligned subpartition is never smaller than {@link
      *       #lastOutputWatermark}
      *   <li>whenever the queue is non-empty, its minimum watermark equals {@link
-     *       #lastOutputWatermark}; this is maintained by re-deriving the min watermark via {@link
-     *       #findAndOutputNewMinWatermarkAcrossAlignedSubpartitions} after every change to the
-     *       aligned set or to an aligned subpartition's watermark
+     *       #lastOutputWatermark}; this is maintained by re-deriving the watermark via {@link
+     *       #tryEmitNewWatermark} after every change to the aligned set or to an aligned
+     *       subpartition's watermark
      * </ul>
      */
     private final HeapPriorityQueue<SubpartitionStatus> alignedSubpartitionStatuses;
@@ -166,22 +171,37 @@ public class StatusWatermarkValve {
     public void inputWatermark(Watermark watermark, int channelIndex, DataOutput<?> output)
             throws Exception {
         final SubpartitionStatus subpartitionStatus;
+        final int subpartitionIndex;
         if (watermark instanceof InternalWatermark) {
-            int subpartitionStatusIndex = ((InternalWatermark) watermark).getSubpartitionIndex();
-            subpartitionStatus =
-                    subpartitionStatuses.get(channelIndex).get(subpartitionStatusIndex);
+            subpartitionIndex = ((InternalWatermark) watermark).getSubpartitionIndex();
+            subpartitionStatus = subpartitionStatuses.get(channelIndex).get(subpartitionIndex);
         } else {
-            subpartitionStatus =
-                    subpartitionStatuses.get(channelIndex).get(subpartitionIndexes[channelIndex]);
+            subpartitionIndex = subpartitionIndexes[channelIndex];
+            subpartitionStatus = subpartitionStatuses.get(channelIndex).get(subpartitionIndex);
         }
 
-        // ignore the input watermark if its subpartition, or all subpartitions are idle (i.e.
-        // overall the valve is idle).
-        if (lastOutputWatermarkStatus.isActive() && subpartitionStatus.watermarkStatus.isActive()) {
+        WatermarkStatus currentSubpartitionStatus = subpartitionStatus.watermarkStatus;
+
+        // FINISHED subpartitions can only accept Long.MAX_VALUE from upstream to preserve message
+        // ordering
+        if (currentSubpartitionStatus.isFinished()) {
+            if (watermark.getTimestamp() == Long.MAX_VALUE) {
+                subpartitionStatus.watermark = Long.MAX_VALUE;
+                tryEmitNewWatermark(output);
+            } else {
+                // Ignore non-MAX_VALUE watermarks
+                LOG.error(
+                        "Channel {} subpartition {} in FINISHED state received a non-MAX watermark ({})."
+                                + " Ignoring it - only MAX_WATERMARK is expected.",
+                        channelIndex,
+                        subpartitionIndex,
+                        watermark.getTimestamp());
+            }
+        } else if (currentSubpartitionStatus.isActive()) {
             long watermarkMillis = watermark.getTimestamp();
 
             // if the input watermark's value is less than the last received watermark for its
-            // subpartition, ignore it also.
+            // subpartition, ignore it.
             if (watermarkMillis > subpartitionStatus.watermark) {
                 subpartitionStatus.watermark = watermarkMillis;
 
@@ -193,9 +213,20 @@ public class StatusWatermarkValve {
                     markWatermarkAligned(subpartitionStatus);
                 }
 
-                // now, attempt to find a new min watermark across all aligned subpartitions
-                findAndOutputNewMinWatermarkAcrossAlignedSubpartitions(output);
+                tryEmitNewWatermark(output);
             }
+        } else if (currentSubpartitionStatus.isIdle()) {
+            // Ignore watermark if subpartition is IDLE
+            LOG.debug(
+                    "Channel {} subpartition {} is IDLE. Ignoring received watermark ({}).",
+                    channelIndex,
+                    subpartitionIndex,
+                    watermark.getTimestamp());
+        } else {
+            throw new IllegalStateException(
+                    String.format(
+                            "Unknown watermark status for channel %d subpartition %d: %s",
+                            channelIndex, subpartitionIndex, currentSubpartitionStatus));
         }
     }
 
@@ -212,9 +243,17 @@ public class StatusWatermarkValve {
     public void inputWatermarkStatus(
             WatermarkStatus watermarkStatus, int channelIndex, DataOutput<?> output)
             throws Exception {
-        // Shared input channel is only enabled in batch jobs, which do not have watermark status
-        // events.
-        Preconditions.checkState(!isInputChannelShared);
+        // Shared input channel is only enabled in batch jobs. Batch jobs do not perform
+        // watermark-based processing, so watermark status events can be safely ignored.
+        // Note: Tasks may emit FINISHED status on completion regardless of execution mode.
+        if (isInputChannelShared) {
+            LOG.debug(
+                    "Ignoring watermark status {} on channel {} (shared input channels indicate batch mode)",
+                    watermarkStatus,
+                    channelIndex);
+            return;
+        }
+
         SubpartitionStatus subpartitionStatus =
                 subpartitionStatuses.get(channelIndex).get(subpartitionIndexes[channelIndex]);
 
@@ -222,74 +261,196 @@ public class StatusWatermarkValve {
         // consumes multiple subpartitions, so we do not need to map channelIndex into
         // subpartitionStatusIndex for now, like what is done on Watermarks.
 
-        // only account for watermark status inputs that will result in a status change for the
-        // subpartition
-        if (watermarkStatus.isIdle() && subpartitionStatus.watermarkStatus.isActive()) {
-            // handle active -> idle toggle for the subpartition
-            subpartitionStatus.watermarkStatus = WatermarkStatus.IDLE;
+        WatermarkStatus currentSubpartitionStatus = subpartitionStatus.watermarkStatus;
 
-            // the subpartition is now idle, therefore not aligned
-            markWatermarkUnaligned(subpartitionStatus);
+        // Ignore if no change
+        if (watermarkStatus.equals(currentSubpartitionStatus)) {
+            return;
+        }
 
-            // if all subpartitions of the valve are now idle, we need to output an idle stream
-            // status from the valve (this also marks the valve as idle)
-            if (!SubpartitionStatus.hasActiveSubpartitions(subpartitionStatuses)) {
-                // now that all subpartitions are idle and no subpartition will continue to advance
-                // its watermark, we should "flush" all watermarks across all subpartitions;
-                // effectively, this means emitting the max watermark across all subpartitions as
-                // the new watermark, so that the eventual watermark is independent of the order in
-                // which the subpartitions became idle. This also keeps the valve consistent with
-                // the unconditional flush in CombinedWatermarkStatus.
-                findAndOutputMaxWatermarkAcrossAllSubpartitions(output);
+        // Handle all valid status transitions
+        if (currentSubpartitionStatus.isActive()) {
+            if (watermarkStatus.isIdle()) {
+                subpartitionStatus.watermarkStatus = WatermarkStatus.IDLE;
+                markWatermarkUnaligned(subpartitionStatus);
 
-                lastOutputWatermarkStatus = WatermarkStatus.IDLE;
-                output.emitWatermarkStatus(lastOutputWatermarkStatus);
+                // Emit watermark first (final progression before going idle). This is
+                // unconditional: the subpartition just left the aligned set, so the aggregation
+                // may yield a larger watermark even when this subpartition did not hold the
+                // previous minimum. tryEmitNewWatermark only emits on strict advance, so
+                // monotonicity is preserved.
+                tryEmitNewWatermark(output);
+                // Then update and emit global watermark status
+                tryEmitNewGlobalWatermarkStatus(output);
+            } else if (watermarkStatus.isFinished()) {
+                subpartitionStatus.watermarkStatus = WatermarkStatus.FINISHED;
+                markWatermarkUnaligned(subpartitionStatus);
+
+                // Unconditional for the same reason as the idle transition above.
+                tryEmitNewWatermark(output);
+                // Then update and emit global watermark status
+                tryEmitNewGlobalWatermarkStatus(output);
             } else {
-                // the min watermark across the remaining aligned subpartitions may be larger than
-                // the last output watermark, now that the subpartition that just became idle is no
-                // longer part of the aligned set
-                findAndOutputNewMinWatermarkAcrossAlignedSubpartitions(output);
+                throw new IllegalStateException(
+                        "Invalid ACTIVE -> "
+                                + watermarkStatus
+                                + " transition for channel "
+                                + channelIndex
+                                + " subpartition "
+                                + subpartitionIndexes[channelIndex]);
             }
-        } else if (watermarkStatus.isActive() && subpartitionStatus.watermarkStatus.isIdle()) {
-            // handle idle -> active toggle for the subpartition
-            subpartitionStatus.watermarkStatus = WatermarkStatus.ACTIVE;
-
-            // if the last watermark of the subpartition, before it was marked idle, is still
-            // larger than the overall last output watermark of the valve, then we can set the
-            // subpartition to be aligned already.
-            if (subpartitionStatus.watermark >= lastOutputWatermark) {
-                markWatermarkAligned(subpartitionStatus);
+        } else if (currentSubpartitionStatus.isIdle()) {
+            if (watermarkStatus.isActive()) {
+                subpartitionStatus.watermarkStatus = WatermarkStatus.ACTIVE;
+                // Check if watermark has caught up
+                if (subpartitionStatus.watermark >= lastOutputWatermark) {
+                    markWatermarkAligned(subpartitionStatus);
+                }
+                // Update and emit global watermark status
+                tryEmitNewGlobalWatermarkStatus(output);
+                // A subpartition that just realigned may hold the new minimum of the aligned set,
+                // for instance when it is the only aligned subpartition. Its watermark has to be
+                // emitted now, otherwise it stalls until an even larger watermark arrives on that
+                // subpartition. This must follow the ACTIVE status above so downstream inputs do
+                // not drop the watermark while they still consider this input idle.
+                tryEmitNewWatermark(output);
+            } else if (watermarkStatus.isFinished()) {
+                subpartitionStatus.watermarkStatus = WatermarkStatus.FINISHED;
+                markWatermarkUnaligned(subpartitionStatus);
+                // Update and emit global watermark status
+                tryEmitNewGlobalWatermarkStatus(output);
+            } else {
+                throw new IllegalStateException(
+                        "Invalid IDLE -> "
+                                + watermarkStatus
+                                + " transition for channel "
+                                + channelIndex
+                                + " subpartition "
+                                + subpartitionIndexes[channelIndex]);
             }
-
-            // if the valve was previously marked to be idle, mark it as active and output an active
-            // stream status because at least one of the subpartitions is now active
-            if (lastOutputWatermarkStatus.isIdle()) {
-                lastOutputWatermarkStatus = WatermarkStatus.ACTIVE;
-                output.emitWatermarkStatus(lastOutputWatermarkStatus);
-            }
-
-            // the subpartition that just realigned may hold the new min watermark of the aligned
-            // set (e.g. if it is the only aligned subpartition), in which case its watermark must
-            // be emitted now; otherwise it would be stalled until an even larger watermark arrives
-            // on the subpartition. This must happen after the ACTIVE status was emitted, so that
-            // downstream inputs do not drop the watermark while they still consider this input
-            // idle.
-            findAndOutputNewMinWatermarkAcrossAlignedSubpartitions(output);
+        } else if (currentSubpartitionStatus.isFinished()) {
+            LOG.debug(
+                    "Channel {} subpartition {} is in FINISHED state. Ignoring transition to {}.",
+                    channelIndex,
+                    subpartitionIndexes[channelIndex],
+                    watermarkStatus);
+        } else {
+            throw new IllegalStateException(
+                    "Invalid status transition for channel "
+                            + channelIndex
+                            + " subpartition "
+                            + subpartitionIndexes[channelIndex]
+                            + ": currentStatus="
+                            + currentSubpartitionStatus
+                            + ", newStatus="
+                            + watermarkStatus);
         }
     }
 
-    private void findAndOutputNewMinWatermarkAcrossAlignedSubpartitions(DataOutput<?> output)
-            throws Exception {
-        boolean hasAlignedSubpartitions = !alignedSubpartitionStatuses.isEmpty();
-
-        // we acknowledge and output the new overall watermark if it really is aggregated
-        // from some remaining aligned subpartition, and is also larger than the last output
-        // watermark
-        if (hasAlignedSubpartitions
-                && alignedSubpartitionStatuses.peek().watermark > lastOutputWatermark) {
-            lastOutputWatermark = alignedSubpartitionStatuses.peek().watermark;
+    // Calculate and emit new watermark if it progresses.
+    private void tryEmitNewWatermark(DataOutput<?> output) throws Exception {
+        Long newWatermark = calculateWatermarkByAggregationRules();
+        if (newWatermark != null && newWatermark > lastOutputWatermark) {
+            lastOutputWatermark = newWatermark;
             output.emitWatermark(new Watermark(lastOutputWatermark));
         }
+    }
+
+    // Calculate and emit new operator-level (global) status.
+    private void tryEmitNewGlobalWatermarkStatus(DataOutput<?> output) throws Exception {
+        WatermarkStatus newGlobalStatus = calculateGlobalWatermarkStatus();
+        if (!newGlobalStatus.equals(lastOutputWatermarkStatus)) {
+            lastOutputWatermarkStatus = newGlobalStatus;
+            output.emitWatermarkStatus(newGlobalStatus);
+        }
+    }
+
+    /**
+     * Calculates watermark based on the clear aggregation rules.
+     *
+     * <ol>
+     *   <li>If there are ACTIVE subpartitions: watermark = min(active_subpartitions)
+     *   <li>Else if there are IDLE subpartitions: watermark = max(idle_subpartitions)
+     *   <li>Else (all subpartitions FINISHED): watermark = Long.MAX_VALUE if all have received it
+     * </ol>
+     */
+    private Long calculateWatermarkByAggregationRules() {
+        if (SubpartitionStatus.hasActiveSubpartitions(subpartitionStatuses)) {
+            // Rule 1: ACTIVE subpartitions exist -> min(active_subpartitions)
+            return calculateMinWatermarkFromAlignedChannels();
+        } else if (SubpartitionStatus.hasIdleSubpartitions(subpartitionStatuses)) {
+            // Rule 2: Only IDLE subpartitions (no active) -> max(idle_subpartitions)
+            return calculateMaxWatermarkFromNonFinishedChannels();
+        } else {
+            // Rule 3: All subpartitions FINISHED -> emit Long.MAX_VALUE only when all have received
+            // it
+            if (allSubpartitionsFinishedWithMaxValue()) {
+                return Long.MAX_VALUE;
+            } else {
+                return null; // Wait for all subpartitions to receive Long.MAX_VALUE from upstream
+            }
+        }
+    }
+
+    /**
+     * Calculates operator-level (global) watermark status by aggregating subpartition states.
+     *
+     * <ol>
+     *   <li>If there are ACTIVE subpartitions: status = ACTIVE
+     *   <li>Else if there are IDLE subpartitions: status = IDLE
+     *   <li>Else (all subpartitions FINISHED): status = FINISHED
+     * </ol>
+     */
+    private WatermarkStatus calculateGlobalWatermarkStatus() {
+        if (SubpartitionStatus.hasActiveSubpartitions(subpartitionStatuses)) {
+            // Rule 1: At least one ACTIVE subpartition -> operator is ACTIVE
+            return WatermarkStatus.ACTIVE;
+        } else if (SubpartitionStatus.hasIdleSubpartitions(subpartitionStatuses)) {
+            // Rule 2: No ACTIVE, at least one IDLE subpartition -> operator is IDLE
+            return WatermarkStatus.IDLE;
+        } else {
+            // Rule 3: All subpartitions FINISHED -> operator is FINISHED
+            // (Implicitly validated: if not ACTIVE and not IDLE, must be FINISHED)
+            return WatermarkStatus.FINISHED;
+        }
+    }
+
+    // Calculates minimum watermark from aligned (active) subpartitions.
+    private Long calculateMinWatermarkFromAlignedChannels() {
+        boolean hasAlignedSubpartitions = !alignedSubpartitionStatuses.isEmpty();
+        return hasAlignedSubpartitions ? alignedSubpartitionStatuses.peek().watermark : null;
+    }
+
+    // Calculates maximum watermark from non-finished (idle) subpartitions.
+    private Long calculateMaxWatermarkFromNonFinishedChannels() {
+        long maxWatermark = Long.MIN_VALUE;
+        boolean hasNonFinishedChannels = false;
+
+        for (Map<Integer, SubpartitionStatus> map : subpartitionStatuses) {
+            for (SubpartitionStatus subpartitionStatus : map.values()) {
+                if (!subpartitionStatus.watermarkStatus.isFinished()) {
+                    hasNonFinishedChannels = true;
+                    maxWatermark = Math.max(subpartitionStatus.watermark, maxWatermark);
+                }
+            }
+        }
+
+        return hasNonFinishedChannels ? maxWatermark : null;
+    }
+
+    /**
+     * Checks if all subpartitions are FINISHED and have received Long.MAX_VALUE watermark. This is
+     * the condition for emitting Long.MAX_VALUE downstream.
+     */
+    private boolean allSubpartitionsFinishedWithMaxValue() {
+        for (Map<Integer, SubpartitionStatus> map : subpartitionStatuses) {
+            for (SubpartitionStatus status : map.values()) {
+                if (!status.watermarkStatus.isFinished() || status.watermark != Long.MAX_VALUE) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 
     /**
@@ -330,22 +491,6 @@ public class StatusWatermarkValve {
         alignedSubpartitionStatuses.adjustModifiedElement(subpartitionStatus);
     }
 
-    private void findAndOutputMaxWatermarkAcrossAllSubpartitions(DataOutput<?> output)
-            throws Exception {
-        long maxWatermark = Long.MIN_VALUE;
-
-        for (Map<Integer, SubpartitionStatus> map : subpartitionStatuses) {
-            for (SubpartitionStatus subpartitionStatus : map.values()) {
-                maxWatermark = Math.max(subpartitionStatus.watermark, maxWatermark);
-            }
-        }
-
-        if (maxWatermark > lastOutputWatermark) {
-            lastOutputWatermark = maxWatermark;
-            output.emitWatermark(new Watermark(lastOutputWatermark));
-        }
-    }
-
     /**
      * An {@code SubpartitionStatus} keeps track of a subpartition's last watermark, stream status,
      * and whether or not the subpartition's current watermark is aligned with the overall watermark
@@ -383,6 +528,21 @@ public class StatusWatermarkValve {
             for (Map<Integer, SubpartitionStatus> map : subpartitionStatuses) {
                 for (SubpartitionStatus status : map.values()) {
                     if (status.watermarkStatus.isActive()) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        /**
+         * Utility to check if at least one subpartition in a given array of subpartitions is idle.
+         */
+        private static boolean hasIdleSubpartitions(
+                List<Map<Integer, SubpartitionStatus>> subpartitionStatuses) {
+            for (Map<Integer, SubpartitionStatus> map : subpartitionStatuses) {
+                for (SubpartitionStatus status : map.values()) {
+                    if (status.watermarkStatus.isIdle()) {
                         return true;
                     }
                 }

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/watermarkstatus/WatermarkStatus.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/watermarkstatus/WatermarkStatus.java
@@ -81,21 +81,25 @@ public final class WatermarkStatus extends StreamElement {
 
     public static final int IDLE_STATUS = -1;
     public static final int ACTIVE_STATUS = 0;
+    public static final int FINISHED_STATUS = 1;
 
     public static final WatermarkStatus IDLE = new WatermarkStatus(IDLE_STATUS);
     public static final WatermarkStatus ACTIVE = new WatermarkStatus(ACTIVE_STATUS);
+    public static final WatermarkStatus FINISHED = new WatermarkStatus(FINISHED_STATUS);
 
     public final int status;
 
     public WatermarkStatus(int status) {
-        if (status != IDLE_STATUS && status != ACTIVE_STATUS) {
+        if (status != IDLE_STATUS && status != ACTIVE_STATUS && status != FINISHED_STATUS) {
             throw new IllegalArgumentException(
                     "Invalid status value for WatermarkStatus; "
                             + "allowed values are "
                             + ACTIVE_STATUS
-                            + " (for ACTIVE) and "
+                            + " (for ACTIVE), "
                             + IDLE_STATUS
-                            + " (for IDLE).");
+                            + " (for IDLE), and "
+                            + FINISHED_STATUS
+                            + " (for FINISHED).");
         }
 
         this.status = status;
@@ -106,7 +110,11 @@ public final class WatermarkStatus extends StreamElement {
     }
 
     public boolean isActive() {
-        return !isIdle();
+        return this.status == ACTIVE_STATUS;
+    }
+
+    public boolean isFinished() {
+        return this.status == FINISHED_STATUS;
     }
 
     public int getStatus() {
@@ -128,7 +136,20 @@ public final class WatermarkStatus extends StreamElement {
 
     @Override
     public String toString() {
-        String statusStr = (status == ACTIVE_STATUS) ? "ACTIVE" : "IDLE";
+        String statusStr;
+        switch (status) {
+            case ACTIVE_STATUS:
+                statusStr = "ACTIVE";
+                break;
+            case IDLE_STATUS:
+                statusStr = "IDLE";
+                break;
+            case FINISHED_STATUS:
+                statusStr = "FINISHED";
+                break;
+            default:
+                statusStr = "UNKNOWN";
+        }
         return "WatermarkStatus(" + statusStr + ")";
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/watermarkstatus/WatermarkStatus.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/watermarkstatus/WatermarkStatus.java
@@ -28,15 +28,16 @@ import org.apache.flink.streaming.runtime.tasks.StreamTask;
 
 /**
  * A Watermark Status element informs stream tasks whether or not they should continue to expect
- * watermarks from the input stream that sent them. There are 2 kinds of status, namely {@link
- * WatermarkStatus#IDLE} and {@link WatermarkStatus#ACTIVE}. Watermark Status elements are generated
- * at the sources, and may be propagated through the tasks of the topology. They directly infer the
- * current status of the emitting task; a {@link SourceStreamTask} or {@link StreamTask} emits a
- * {@link WatermarkStatus#IDLE} if it will temporarily halt to emit any watermarks (i.e. is idle),
- * and emits a {@link WatermarkStatus#ACTIVE} once it resumes to do so (i.e. is active). Tasks are
- * responsible for propagating their status further downstream once they toggle between being idle
- * and active. The cases that source tasks and downstream tasks are considered either idle or active
- * is explained below:
+ * watermarks from the input stream that sent them. There are 3 kinds of status, namely {@link
+ * WatermarkStatus#IDLE}, {@link WatermarkStatus#ACTIVE} and {@link WatermarkStatus#FINISHED}.
+ * Watermark Status elements are generated at the sources, and may be propagated through the tasks
+ * of the topology. They directly infer the current status of the emitting task; a {@link
+ * SourceStreamTask} or {@link StreamTask} emits a {@link WatermarkStatus#IDLE} if it will
+ * temporarily halt to emit any watermarks (i.e. is idle), and emits a {@link
+ * WatermarkStatus#ACTIVE} once it resumes to do so (i.e. is active). Tasks are responsible for
+ * propagating their status further downstream once they toggle between being idle and active. The
+ * cases that source tasks and downstream tasks are considered either idle or active is explained
+ * below:
  *
  * <ul>
  *   <li>Source tasks: A source task is considered to be idle if its head operator, i.e. a {@link
@@ -71,10 +72,14 @@ import org.apache.flink.streaming.runtime.tasks.StreamTask;
  *       advance the watermark and propagated through the operator chain.
  * </ul>
  *
- * <p>Note that to notify downstream tasks that a source task is permanently closed and will no
- * longer send any more elements, the source should still send a {@link Watermark#MAX_WATERMARK}
- * instead of {@link WatermarkStatus#IDLE}. Watermark Status elements only serve as markers for
- * temporary status.
+ * <p>{@link WatermarkStatus#IDLE} and {@link WatermarkStatus#ACTIVE} describe a temporary condition
+ * that a task can toggle between. {@link WatermarkStatus#FINISHED} is terminal: a source task emits
+ * it when it is permanently closed and will send no further elements, alongside the {@link
+ * Watermark#MAX_WATERMARK} it already emits so that downstream timers fire. Marking such an input
+ * IDLE would be wrong, because an idle input is still expected to resume, while leaving it ACTIVE
+ * lets its {@link Watermark#MAX_WATERMARK} dominate the aggregated minimum once every other input
+ * goes idle. A finished input is therefore excluded from watermark aggregation until every input is
+ * finished, at which point the aggregation yields {@link Watermark#MAX_WATERMARK}.
  */
 @Internal
 public final class WatermarkStatus extends StreamElement {

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/watermarkstatus/StatusWatermarkValveTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/watermarkstatus/StatusWatermarkValveTest.java
@@ -431,6 +431,277 @@ class StatusWatermarkValveTest {
         assertThat(valveOutput.popLastSeenOutput()).isNull();
     }
 
+    /**
+     * Tests that FINISHED channels are excluded from min watermark calculation, allowing remaining
+     * channels to advance the watermark.
+     */
+    @Test
+    void testFinishedChannelExcludedFromMinWatermark() throws Exception {
+        StatusWatermarkValve valve = new StatusWatermarkValve(2);
+        StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
+
+        valve.inputWatermark(new Watermark(5), 0, valveOutput);
+        valve.inputWatermark(new Watermark(10), 1, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(5));
+
+        // Mark channel 0's subpartition as FINISHED - should exclude it from min calculation
+        valve.inputWatermarkStatus(WatermarkStatus.FINISHED, 0, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput())
+                .isEqualTo(new Watermark(10)); // Now min is 10, not 5
+
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+    }
+
+    /**
+     * Tests that FINISHED channels are excluded from max watermark calculation when all other
+     * channels become IDLE.
+     */
+    @Test
+    void testFinishedExcludedFromIdleMaxCalculation() throws Exception {
+        StatusWatermarkValve valve = new StatusWatermarkValve(3);
+        StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
+
+        valve.inputWatermark(new Watermark(10), 0, valveOutput);
+        valve.inputWatermark(new Watermark(20), 1, valveOutput);
+        valve.inputWatermark(new Watermark(5), 2, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(5));
+
+        // Mark channel 1's subpartition (watermark 20) as FINISHED
+        valve.inputWatermarkStatus(WatermarkStatus.FINISHED, 1, valveOutput);
+        // No watermark change since min of remaining subpartitions (10,5) is still 5
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+
+        // Mark remaining subpartitions as IDLE
+        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 0, valveOutput);
+        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 2, valveOutput);
+
+        // Should emit max of non-FINISHED subpartitions (10,5) = 10, not including FINISHED
+        // subpartition (20)
+        assertThat(valveOutput.popLastSeenOutput())
+                .isEqualTo(new Watermark(10)); // max(10,5) = 10, excludes 20
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(WatermarkStatus.IDLE);
+
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+    }
+
+    /**
+     * Tests that FINISHED channels reject non-MAX_VALUE watermarks, accept Long.MAX_VALUE, and
+     * properly aggregate across channels to emit Long.MAX_VALUE once when all FINISHED channels
+     * receive it.
+     */
+    @Test
+    void testFinishedChannelWatermarkHandling() throws Exception {
+        StatusWatermarkValve valve = new StatusWatermarkValve(2);
+        StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
+
+        // Setup: both channels active with watermarks
+        valve.inputWatermark(new Watermark(100), 0, valveOutput);
+        valve.inputWatermark(new Watermark(200), 1, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(100));
+
+        // Mark both channels as FINISHED
+        valve.inputWatermarkStatus(WatermarkStatus.FINISHED, 0, valveOutput);
+        // FINISHED status does NOT change watermark - remains at 200
+        // FINISHED status should NOT modify the channel's watermark
+        // Watermark remains unchanged until Long.MAX_VALUE flows from upstream
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(200));
+        // Channel should be marked as unaligned
+        assertThat(valve.getSubpartitionStatus(0).isWatermarkAligned).isFalse();
+
+        valve.inputWatermarkStatus(WatermarkStatus.FINISHED, 1, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(WatermarkStatus.FINISHED);
+        // No watermark emitted. Long.MAX_VALUE will come via inputWatermark() to preserve message
+        // ordering
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+
+        // FINISHED channels ignore non-MAX_VALUE watermarks (preserve message ordering)
+        valve.inputWatermark(new Watermark(150), 0, valveOutput);
+        valve.inputWatermark(new Watermark(250), 1, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isNull(); // Both ignored
+        assertThat(valve.getSubpartitionStatus(0).watermark).isEqualTo(100L); // Unchanged
+        assertThat(valve.getSubpartitionStatus(1).watermark).isEqualTo(200L); // Unchanged
+
+        // Channel 0 receives Long.MAX_VALUE from upstream
+        valve.inputWatermark(new Watermark(Long.MAX_VALUE), 0, valveOutput);
+        assertThat(valve.getSubpartitionStatus(0).watermark).isEqualTo(Long.MAX_VALUE);
+        assertThat(valveOutput.popLastSeenOutput()).isNull(); // Not all channels have it yet
+
+        // Channel 1 receives Long.MAX_VALUE from upstream
+        valve.inputWatermark(new Watermark(Long.MAX_VALUE), 1, valveOutput);
+        assertThat(valve.getSubpartitionStatus(1).watermark).isEqualTo(Long.MAX_VALUE);
+
+        // Now ALL FINISHED channels have Long.MAX_VALUE - emit once
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(Long.MAX_VALUE));
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+
+        // Duplicate Long.MAX_VALUE should NOT emit again
+        valve.inputWatermark(new Watermark(Long.MAX_VALUE), 0, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+    }
+
+    /**
+     * Tests that FINISHED is a terminal state and channels cannot transition from FINISHED back to
+     * ACTIVE or IDLE.
+     */
+    @Test
+    void testFinishedIsTerminalState() throws Exception {
+        StatusWatermarkValve valve = new StatusWatermarkValve(1);
+        StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
+
+        valve.inputWatermarkStatus(WatermarkStatus.FINISHED, 0, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(WatermarkStatus.FINISHED);
+
+        // Attempt FINISHED -> ACTIVE (should be ignored)
+        valve.inputWatermarkStatus(WatermarkStatus.ACTIVE, 0, valveOutput);
+        assertThat(valve.getSubpartitionStatus(0).watermarkStatus.isFinished()).isTrue();
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+
+        // Attempt FINISHED -> IDLE (should be ignored)
+        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 0, valveOutput);
+        assertThat(valve.getSubpartitionStatus(0).watermarkStatus.isFinished()).isTrue();
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+    }
+
+    /**
+     * Tests ACTIVE to IDLE and ACTIVE to FINISHED transitions in various configurations, including
+     * global status changes.
+     */
+    @Test
+    void testActiveTransitions() throws Exception {
+        StatusWatermarkValve valve = new StatusWatermarkValve(4);
+        StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
+
+        valve.inputWatermark(new Watermark(10), 0, valveOutput);
+        valve.inputWatermark(new Watermark(20), 1, valveOutput);
+        valve.inputWatermark(new Watermark(15), 2, valveOutput);
+        valve.inputWatermark(new Watermark(12), 3, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(10));
+
+        // Case 1: ACTIVE → IDLE when other ACTIVE channels exist (global stays ACTIVE)
+        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 0, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(12));
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+
+        // Case 2: ACTIVE → FINISHED when other ACTIVE channels exist (global stays ACTIVE)
+        valve.inputWatermarkStatus(WatermarkStatus.FINISHED, 3, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(15));
+        assertThat(valve.getSubpartitionStatus(3).isWatermarkAligned).isFalse();
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+
+        // Case 3: Last ACTIVE → IDLE (global becomes IDLE)
+        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 1, valveOutput);
+        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 2, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(20));
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(WatermarkStatus.IDLE);
+
+        // Setup for next case: bring one channel back to ACTIVE
+        valve.inputWatermarkStatus(WatermarkStatus.ACTIVE, 1, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(WatermarkStatus.ACTIVE);
+
+        // Case 4: Last ACTIVE → FINISHED when IDLE channels exist (global becomes IDLE)
+        valve.inputWatermarkStatus(WatermarkStatus.FINISHED, 1, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(WatermarkStatus.IDLE);
+        assertThat(valve.getSubpartitionStatus(1).isWatermarkAligned).isFalse();
+
+        // Case 5: All IDLE → FINISHED (global becomes FINISHED)
+        valve.inputWatermarkStatus(WatermarkStatus.FINISHED, 0, valveOutput);
+        valve.inputWatermarkStatus(WatermarkStatus.FINISHED, 2, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(WatermarkStatus.FINISHED);
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+    }
+
+    /**
+     * Tests IDLE to ACTIVE transitions with both aligned and unaligned watermarks, verifying
+     * realignment behavior.
+     */
+    @Test
+    void testIdleToActiveTransition() throws Exception {
+        StatusWatermarkValve valve = new StatusWatermarkValve(3);
+        StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
+
+        valve.inputWatermark(new Watermark(10), 0, valveOutput);
+        valve.inputWatermark(new Watermark(20), 1, valveOutput);
+        valve.inputWatermark(new Watermark(15), 2, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(10));
+
+        // All channels go IDLE
+        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 0, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput())
+                .isEqualTo(new Watermark(15)); // min of remaining active (Ch1=20, Ch2=15)
+        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 1, valveOutput);
+        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 2, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(20)); // max of all idle
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(WatermarkStatus.IDLE);
+
+        // Case 1: IDLE -> ACTIVE when already caught up (watermark >= lastOutput)
+        valve.inputWatermarkStatus(WatermarkStatus.ACTIVE, 1, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput())
+                .isEqualTo(WatermarkStatus.ACTIVE); // Global becomes ACTIVE
+        assertThat(valve.getSubpartitionStatus(1).isWatermarkAligned)
+                .isTrue(); // 20 >= 20, aligned immediately
+
+        // Case 2: IDLE -> ACTIVE when behind (watermark < lastOutput)
+        valve.inputWatermarkStatus(WatermarkStatus.ACTIVE, 0, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isNull(); // No status change (already ACTIVE)
+        assertThat(valve.getSubpartitionStatus(0).isWatermarkAligned)
+                .isFalse(); // 10 < 20, unaligned
+
+        // Verify unaligned channel doesn't affect min watermark
+        valve.inputWatermark(new Watermark(25), 1, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput())
+                .isEqualTo(new Watermark(25)); // Only Ch1 aligned
+
+        // Ch0 catches up and becomes aligned (but min doesn't change, so no watermark emission)
+        valve.inputWatermark(new Watermark(26), 0, valveOutput);
+        assertThat(valve.getSubpartitionStatus(0).isWatermarkAligned).isTrue();
+        assertThat(valveOutput.popLastSeenOutput()).isNull(); // min still 25, no progression
+    }
+
+    /**
+     * Tests IDLE to FINISHED transitions in various configurations, verifying global status changes
+     * and watermark progression.
+     */
+    @Test
+    void testIdleToFinishedTransition() throws Exception {
+        StatusWatermarkValve valve = new StatusWatermarkValve(3);
+        StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
+
+        valve.inputWatermark(new Watermark(10), 0, valveOutput);
+        valve.inputWatermark(new Watermark(15), 1, valveOutput);
+        valve.inputWatermark(new Watermark(12), 2, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(10));
+
+        // Ch0 goes IDLE
+        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 0, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(12));
+
+        // Case 1: IDLE -> FINISHED when ACTIVE channels exist (global stays ACTIVE)
+        valve.inputWatermarkStatus(WatermarkStatus.FINISHED, 0, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isNull(); // No watermark, no status change
+        assertThat(valve.getSubpartitionStatus(0).watermarkStatus.isFinished()).isTrue();
+        assertThat(valve.getSubpartitionStatus(0).isWatermarkAligned).isFalse();
+
+        // Ch1 goes IDLE (no watermark change since Ch2 still has min=12)
+        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 1, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+
+        // Ch2 goes IDLE (all non-FINISHED are IDLE, emit max of idle channels, then global becomes
+        // IDLE)
+        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 2, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput())
+                .isEqualTo(new Watermark(15)); // max of idle (Ch1=15, Ch2=12)
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(WatermarkStatus.IDLE);
+
+        // Case 2: IDLE -> FINISHED when other IDLE channels exist (global stays IDLE)
+        valve.inputWatermarkStatus(WatermarkStatus.FINISHED, 1, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isNull(); // Global stays IDLE (Ch2 still IDLE)
+
+        // Case 3: IDLE -> FINISHED as last channel (global becomes FINISHED)
+        valve.inputWatermarkStatus(WatermarkStatus.FINISHED, 2, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(WatermarkStatus.FINISHED);
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+    }
+
     private static class StatusWatermarkOutput implements PushingAsyncDataInput.DataOutput {
 
         private BlockingQueue<StreamElement> allOutputs = new LinkedBlockingQueue<>();

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/watermarkstatus/StatusWatermarkValveTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/watermarkstatus/StatusWatermarkValveTest.java
@@ -485,9 +485,15 @@ class StatusWatermarkValveTest {
     }
 
     /**
-     * Tests that FINISHED channels reject non-MAX_VALUE watermarks, accept Long.MAX_VALUE, and
-     * properly aggregate across channels to emit Long.MAX_VALUE once when all FINISHED channels
-     * receive it.
+     * Comprehensive test for FINISHED channels.
+     *
+     * <ol>
+     *   <li>Reject non-MAX_VALUE watermarks
+     *   <li>Accept MAX_VALUE
+     *   <li>Aggregate across channels to emit Long.MAX_VALUE once when all FINISHED channels
+     *       receive it
+     *   <li>Prevent duplicate emissions
+     * </ol>
      */
     @Test
     void testFinishedChannelWatermarkHandling() throws Exception {
@@ -565,6 +571,14 @@ class StatusWatermarkValveTest {
     /**
      * Tests ACTIVE to IDLE and ACTIVE to FINISHED transitions in various configurations, including
      * global status changes.
+     *
+     * <ol>
+     *   <li>ACTIVE → IDLE when other ACTIVE channels exist (global stays ACTIVE)
+     *   <li>ACTIVE → FINISHED when other ACTIVE channels exist (global stays ACTIVE)
+     *   <li>Last ACTIVE → IDLE (global becomes IDLE)
+     *   <li>Last ACTIVE → FINISHED when IDLE channels exist (global becomes IDLE)
+     *   <li>All IDLE → FINISHED (global becomes FINISHED)
+     * </ol>
      */
     @Test
     void testActiveTransitions() throws Exception {
@@ -613,6 +627,11 @@ class StatusWatermarkValveTest {
     /**
      * Tests IDLE to ACTIVE transitions with both aligned and unaligned watermarks, verifying
      * realignment behavior.
+     *
+     * <ol>
+     *   <li>IDLE → ACTIVE when already caught up (watermark >= lastOutput)
+     *   <li>IDLE → ACTIVE when behind (watermark < lastOutput)
+     * </ol>
      */
     @Test
     void testIdleToActiveTransition() throws Exception {
@@ -660,6 +679,12 @@ class StatusWatermarkValveTest {
     /**
      * Tests IDLE to FINISHED transitions in various configurations, verifying global status changes
      * and watermark progression.
+     *
+     * <ol>
+     *   <li>IDLE → FINISHED when ACTIVE channels exist (global stays ACTIVE)
+     *   <li>IDLE → FINISHED when other IDLE channels exist (global stays IDLE)
+     *   <li>IDLE → FINISHED as last channel (global becomes FINISHED)
+     * </ol>
      */
     @Test
     void testIdleToFinishedTransition() throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/watermarkstatus/StatusWatermarkValveTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/watermarkstatus/StatusWatermarkValveTest.java
@@ -337,53 +337,6 @@ class StatusWatermarkValveTest {
     }
 
     /**
-     * Tests that the max watermark across all channels is flushed once all inputs become idle, even
-     * when the last channel to become idle is unaligned, i.e. it went idle, resumed being active,
-     * and only partially caught up to the last output watermark. The eventual watermark advancement
-     * result must be independent of the order in which the inputs become idle (FLINK-7728).
-     */
-    @Test
-    void testMultipleInputFlushMaxWatermarkOnceAllInputsBecomeIdleWithUnalignedLastChannel()
-            throws Exception {
-        StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
-        StatusWatermarkValve valve = new StatusWatermarkValve(3);
-
-        valve.inputWatermark(new Watermark(100), 0, valveOutput);
-        valve.inputWatermark(new Watermark(50), 1, valveOutput);
-        valve.inputWatermark(new Watermark(70), 2, valveOutput);
-        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(50));
-        assertThat(valveOutput.popLastSeenOutput()).isNull();
-
-        // channel 1 becomes idle; the new min watermark is computed from channels 0 and 2
-        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 1, valveOutput);
-        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(70));
-        assertThat(valveOutput.popLastSeenOutput()).isNull();
-
-        // channel 1 resumes being active, but stays unaligned since its watermark (50) has not
-        // caught up to the last output watermark (70)
-        valve.inputWatermarkStatus(WatermarkStatus.ACTIVE, 1, valveOutput);
-        assertThat(valve.getSubpartitionStatus(1).isWatermarkAligned).isFalse();
-        assertThat(valveOutput.popLastSeenOutput()).isNull();
-
-        // channel 1 partially catches up; its watermark is recorded but it remains unaligned
-        valve.inputWatermark(new Watermark(60), 1, valveOutput);
-        assertThat(valve.getSubpartitionStatus(1).watermark).isEqualTo(60);
-        assertThat(valve.getSubpartitionStatus(1).isWatermarkAligned).isFalse();
-        assertThat(valveOutput.popLastSeenOutput()).isNull();
-
-        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 0, valveOutput);
-        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 2, valveOutput);
-        assertThat(valveOutput.popLastSeenOutput()).isNull();
-
-        // the unaligned channel 1 is the last channel to become idle; the max watermark across
-        // all channels must still be flushed
-        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 1, valveOutput);
-        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(100));
-        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(WatermarkStatus.IDLE);
-        assertThat(valveOutput.popLastSeenOutput()).isNull();
-    }
-
-    /**
      * Tests that when idle channels become active again, they need to "catch up" with the latest
      * watermark before they are considered for min watermark computation again.
      */
@@ -475,6 +428,349 @@ class StatusWatermarkValveTest {
 
         // make channel 0 idle again
         valve.inputWatermarkStatus(WatermarkStatus.IDLE, 0, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+    }
+
+    /**
+     * Tests that FINISHED channels are excluded from min watermark calculation, allowing remaining
+     * channels to advance the watermark.
+     */
+    @Test
+    void testFinishedChannelExcludedFromMinWatermark() throws Exception {
+        StatusWatermarkValve valve = new StatusWatermarkValve(2);
+        StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
+
+        valve.inputWatermark(new Watermark(5), 0, valveOutput);
+        valve.inputWatermark(new Watermark(10), 1, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(5));
+
+        // Mark channel 0's subpartition as FINISHED - should exclude it from min calculation
+        valve.inputWatermarkStatus(WatermarkStatus.FINISHED, 0, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput())
+                .isEqualTo(new Watermark(10)); // Now min is 10, not 5
+
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+    }
+
+    /**
+     * Tests that FINISHED channels are excluded from max watermark calculation when all other
+     * channels become IDLE.
+     */
+    @Test
+    void testFinishedExcludedFromIdleMaxCalculation() throws Exception {
+        StatusWatermarkValve valve = new StatusWatermarkValve(3);
+        StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
+
+        valve.inputWatermark(new Watermark(10), 0, valveOutput);
+        valve.inputWatermark(new Watermark(20), 1, valveOutput);
+        valve.inputWatermark(new Watermark(5), 2, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(5));
+
+        // Mark channel 1's subpartition (watermark 20) as FINISHED
+        valve.inputWatermarkStatus(WatermarkStatus.FINISHED, 1, valveOutput);
+        // No watermark change since min of remaining subpartitions (10,5) is still 5
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+
+        // Mark remaining subpartitions as IDLE
+        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 0, valveOutput);
+        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 2, valveOutput);
+
+        // Should emit max of non-FINISHED subpartitions (10,5) = 10, not including FINISHED
+        // subpartition (20)
+        assertThat(valveOutput.popLastSeenOutput())
+                .isEqualTo(new Watermark(10)); // max(10,5) = 10, excludes 20
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(WatermarkStatus.IDLE);
+
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+    }
+
+    /**
+     * Comprehensive test for FINISHED channels.
+     *
+     * <ol>
+     *   <li>Reject non-MAX_VALUE watermarks
+     *   <li>Accept MAX_VALUE
+     *   <li>Aggregate across channels to emit Long.MAX_VALUE once when all FINISHED channels
+     *       receive it
+     *   <li>Prevent duplicate emissions
+     * </ol>
+     */
+    @Test
+    void testFinishedChannelWatermarkHandling() throws Exception {
+        StatusWatermarkValve valve = new StatusWatermarkValve(2);
+        StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
+
+        // Setup: both channels active with watermarks
+        valve.inputWatermark(new Watermark(100), 0, valveOutput);
+        valve.inputWatermark(new Watermark(200), 1, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(100));
+
+        // Mark both channels as FINISHED
+        valve.inputWatermarkStatus(WatermarkStatus.FINISHED, 0, valveOutput);
+        // FINISHED status does NOT change watermark - remains at 200
+        // FINISHED status should NOT modify the channel's watermark
+        // Watermark remains unchanged until Long.MAX_VALUE flows from upstream
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(200));
+        // Channel should be marked as unaligned
+        assertThat(valve.getSubpartitionStatus(0).isWatermarkAligned).isFalse();
+
+        valve.inputWatermarkStatus(WatermarkStatus.FINISHED, 1, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(WatermarkStatus.FINISHED);
+        // No watermark emitted. Long.MAX_VALUE will come via inputWatermark() to preserve message
+        // ordering
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+
+        // FINISHED channels ignore non-MAX_VALUE watermarks (preserve message ordering)
+        valve.inputWatermark(new Watermark(150), 0, valveOutput);
+        valve.inputWatermark(new Watermark(250), 1, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isNull(); // Both ignored
+        assertThat(valve.getSubpartitionStatus(0).watermark).isEqualTo(100L); // Unchanged
+        assertThat(valve.getSubpartitionStatus(1).watermark).isEqualTo(200L); // Unchanged
+
+        // Channel 0 receives Long.MAX_VALUE from upstream
+        valve.inputWatermark(new Watermark(Long.MAX_VALUE), 0, valveOutput);
+        assertThat(valve.getSubpartitionStatus(0).watermark).isEqualTo(Long.MAX_VALUE);
+        assertThat(valveOutput.popLastSeenOutput()).isNull(); // Not all channels have it yet
+
+        // Channel 1 receives Long.MAX_VALUE from upstream
+        valve.inputWatermark(new Watermark(Long.MAX_VALUE), 1, valveOutput);
+        assertThat(valve.getSubpartitionStatus(1).watermark).isEqualTo(Long.MAX_VALUE);
+
+        // Now ALL FINISHED channels have Long.MAX_VALUE - emit once
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(Long.MAX_VALUE));
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+
+        // Duplicate Long.MAX_VALUE should NOT emit again
+        valve.inputWatermark(new Watermark(Long.MAX_VALUE), 0, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+    }
+
+    /**
+     * Tests that FINISHED is a terminal state and channels cannot transition from FINISHED back to
+     * ACTIVE or IDLE.
+     */
+    @Test
+    void testFinishedIsTerminalState() throws Exception {
+        StatusWatermarkValve valve = new StatusWatermarkValve(1);
+        StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
+
+        valve.inputWatermarkStatus(WatermarkStatus.FINISHED, 0, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(WatermarkStatus.FINISHED);
+
+        // Attempt FINISHED -> ACTIVE (should be ignored)
+        valve.inputWatermarkStatus(WatermarkStatus.ACTIVE, 0, valveOutput);
+        assertThat(valve.getSubpartitionStatus(0).watermarkStatus.isFinished()).isTrue();
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+
+        // Attempt FINISHED -> IDLE (should be ignored)
+        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 0, valveOutput);
+        assertThat(valve.getSubpartitionStatus(0).watermarkStatus.isFinished()).isTrue();
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+    }
+
+    /**
+     * Tests ACTIVE to IDLE and ACTIVE to FINISHED transitions in various configurations, including
+     * global status changes.
+     *
+     * <ol>
+     *   <li>ACTIVE → IDLE when other ACTIVE channels exist (global stays ACTIVE)
+     *   <li>ACTIVE → FINISHED when other ACTIVE channels exist (global stays ACTIVE)
+     *   <li>Last ACTIVE → IDLE (global becomes IDLE)
+     *   <li>Last ACTIVE → FINISHED when IDLE channels exist (global becomes IDLE)
+     *   <li>All IDLE → FINISHED (global becomes FINISHED)
+     * </ol>
+     */
+    @Test
+    void testActiveTransitions() throws Exception {
+        StatusWatermarkValve valve = new StatusWatermarkValve(4);
+        StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
+
+        valve.inputWatermark(new Watermark(10), 0, valveOutput);
+        valve.inputWatermark(new Watermark(20), 1, valveOutput);
+        valve.inputWatermark(new Watermark(15), 2, valveOutput);
+        valve.inputWatermark(new Watermark(12), 3, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(10));
+
+        // Case 1: ACTIVE → IDLE when other ACTIVE channels exist (global stays ACTIVE)
+        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 0, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(12));
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+
+        // Case 2: ACTIVE → FINISHED when other ACTIVE channels exist (global stays ACTIVE)
+        valve.inputWatermarkStatus(WatermarkStatus.FINISHED, 3, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(15));
+        assertThat(valve.getSubpartitionStatus(3).isWatermarkAligned).isFalse();
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+
+        // Case 3: Last ACTIVE → IDLE (global becomes IDLE)
+        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 1, valveOutput);
+        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 2, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(20));
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(WatermarkStatus.IDLE);
+
+        // Setup for next case: bring one channel back to ACTIVE
+        valve.inputWatermarkStatus(WatermarkStatus.ACTIVE, 1, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(WatermarkStatus.ACTIVE);
+
+        // Case 4: Last ACTIVE → FINISHED when IDLE channels exist (global becomes IDLE)
+        valve.inputWatermarkStatus(WatermarkStatus.FINISHED, 1, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(WatermarkStatus.IDLE);
+        assertThat(valve.getSubpartitionStatus(1).isWatermarkAligned).isFalse();
+
+        // Case 5: All IDLE → FINISHED (global becomes FINISHED)
+        valve.inputWatermarkStatus(WatermarkStatus.FINISHED, 0, valveOutput);
+        valve.inputWatermarkStatus(WatermarkStatus.FINISHED, 2, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(WatermarkStatus.FINISHED);
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+    }
+
+    /**
+     * Tests IDLE to ACTIVE transitions with both aligned and unaligned watermarks, verifying
+     * realignment behavior.
+     *
+     * <ol>
+     *   <li>IDLE → ACTIVE when already caught up (watermark >= lastOutput)
+     *   <li>IDLE → ACTIVE when behind (watermark < lastOutput)
+     * </ol>
+     */
+    @Test
+    void testIdleToActiveTransition() throws Exception {
+        StatusWatermarkValve valve = new StatusWatermarkValve(3);
+        StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
+
+        valve.inputWatermark(new Watermark(10), 0, valveOutput);
+        valve.inputWatermark(new Watermark(20), 1, valveOutput);
+        valve.inputWatermark(new Watermark(15), 2, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(10));
+
+        // All channels go IDLE
+        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 0, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput())
+                .isEqualTo(new Watermark(15)); // min of remaining active (Ch1=20, Ch2=15)
+        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 1, valveOutput);
+        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 2, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(20)); // max of all idle
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(WatermarkStatus.IDLE);
+
+        // Case 1: IDLE -> ACTIVE when already caught up (watermark >= lastOutput)
+        valve.inputWatermarkStatus(WatermarkStatus.ACTIVE, 1, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput())
+                .isEqualTo(WatermarkStatus.ACTIVE); // Global becomes ACTIVE
+        assertThat(valve.getSubpartitionStatus(1).isWatermarkAligned)
+                .isTrue(); // 20 >= 20, aligned immediately
+
+        // Case 2: IDLE -> ACTIVE when behind (watermark < lastOutput)
+        valve.inputWatermarkStatus(WatermarkStatus.ACTIVE, 0, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isNull(); // No status change (already ACTIVE)
+        assertThat(valve.getSubpartitionStatus(0).isWatermarkAligned)
+                .isFalse(); // 10 < 20, unaligned
+
+        // Verify unaligned channel doesn't affect min watermark
+        valve.inputWatermark(new Watermark(25), 1, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput())
+                .isEqualTo(new Watermark(25)); // Only Ch1 aligned
+
+        // Ch0 catches up and becomes aligned (but min doesn't change, so no watermark emission)
+        valve.inputWatermark(new Watermark(26), 0, valveOutput);
+        assertThat(valve.getSubpartitionStatus(0).isWatermarkAligned).isTrue();
+        assertThat(valveOutput.popLastSeenOutput()).isNull(); // min still 25, no progression
+    }
+
+    /**
+     * Tests IDLE to FINISHED transitions in various configurations, verifying global status changes
+     * and watermark progression.
+     *
+     * <ol>
+     *   <li>IDLE → FINISHED when ACTIVE channels exist (global stays ACTIVE)
+     *   <li>IDLE → FINISHED when other IDLE channels exist (global stays IDLE)
+     *   <li>IDLE → FINISHED as last channel (global becomes FINISHED)
+     * </ol>
+     */
+    @Test
+    void testIdleToFinishedTransition() throws Exception {
+        StatusWatermarkValve valve = new StatusWatermarkValve(3);
+        StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
+
+        valve.inputWatermark(new Watermark(10), 0, valveOutput);
+        valve.inputWatermark(new Watermark(15), 1, valveOutput);
+        valve.inputWatermark(new Watermark(12), 2, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(10));
+
+        // Ch0 goes IDLE
+        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 0, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(12));
+
+        // Case 1: IDLE -> FINISHED when ACTIVE channels exist (global stays ACTIVE)
+        valve.inputWatermarkStatus(WatermarkStatus.FINISHED, 0, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isNull(); // No watermark, no status change
+        assertThat(valve.getSubpartitionStatus(0).watermarkStatus.isFinished()).isTrue();
+        assertThat(valve.getSubpartitionStatus(0).isWatermarkAligned).isFalse();
+
+        // Ch1 goes IDLE (no watermark change since Ch2 still has min=12)
+        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 1, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+
+        // Ch2 goes IDLE (all non-FINISHED are IDLE, emit max of idle channels, then global becomes
+        // IDLE)
+        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 2, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput())
+                .isEqualTo(new Watermark(15)); // max of idle (Ch1=15, Ch2=12)
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(WatermarkStatus.IDLE);
+
+        // Case 2: IDLE -> FINISHED when other IDLE channels exist (global stays IDLE)
+        valve.inputWatermarkStatus(WatermarkStatus.FINISHED, 1, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isNull(); // Global stays IDLE (Ch2 still IDLE)
+
+        // Case 3: IDLE -> FINISHED as last channel (global becomes FINISHED)
+        valve.inputWatermarkStatus(WatermarkStatus.FINISHED, 2, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(WatermarkStatus.FINISHED);
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+    }
+
+    /**
+     * Tests that the max watermark across all channels is flushed once all inputs become idle, even
+     * when the last channel to become idle is unaligned, i.e. it went idle, resumed being active,
+     * and only partially caught up to the last output watermark. The eventual watermark advancement
+     * result must be independent of the order in which the inputs become idle (FLINK-7728).
+     */
+    @Test
+    void testMultipleInputFlushMaxWatermarkOnceAllInputsBecomeIdleWithUnalignedLastChannel()
+            throws Exception {
+        StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
+        StatusWatermarkValve valve = new StatusWatermarkValve(3);
+
+        valve.inputWatermark(new Watermark(100), 0, valveOutput);
+        valve.inputWatermark(new Watermark(50), 1, valveOutput);
+        valve.inputWatermark(new Watermark(70), 2, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(50));
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+
+        // channel 1 becomes idle; the new min watermark is computed from channels 0 and 2
+        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 1, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(70));
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+
+        // channel 1 resumes being active, but stays unaligned since its watermark (50) has not
+        // caught up to the last output watermark (70)
+        valve.inputWatermarkStatus(WatermarkStatus.ACTIVE, 1, valveOutput);
+        assertThat(valve.getSubpartitionStatus(1).isWatermarkAligned).isFalse();
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+
+        // channel 1 partially catches up; its watermark is recorded but it remains unaligned
+        valve.inputWatermark(new Watermark(60), 1, valveOutput);
+        assertThat(valve.getSubpartitionStatus(1).watermark).isEqualTo(60);
+        assertThat(valve.getSubpartitionStatus(1).isWatermarkAligned).isFalse();
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+
+        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 0, valveOutput);
+        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 2, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+
+        // the unaligned channel 1 is the last channel to become idle; the max watermark across
+        // all channels must still be flushed
+        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 1, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(100));
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(WatermarkStatus.IDLE);
         assertThat(valveOutput.popLastSeenOutput()).isNull();
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/watermarkstatus/WatermarkStatusTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/watermarkstatus/WatermarkStatusTest.java
@@ -36,14 +36,22 @@ class WatermarkStatusTest {
     void testEquals() {
         WatermarkStatus idleStatus = new WatermarkStatus(WatermarkStatus.IDLE_STATUS);
         WatermarkStatus activeStatus = new WatermarkStatus(WatermarkStatus.ACTIVE_STATUS);
+        WatermarkStatus finishedStatus = new WatermarkStatus(WatermarkStatus.FINISHED_STATUS);
 
         assertThat(idleStatus).isEqualTo(WatermarkStatus.IDLE);
         assertThat(idleStatus.isIdle()).isTrue();
         assertThat(idleStatus.isActive()).isFalse();
+        assertThat(idleStatus.isFinished()).isFalse();
 
         assertThat(activeStatus).isEqualTo(WatermarkStatus.ACTIVE);
         assertThat(activeStatus.isActive()).isTrue();
         assertThat(activeStatus.isIdle()).isFalse();
+        assertThat(activeStatus.isFinished()).isFalse();
+
+        assertThat(finishedStatus).isEqualTo(WatermarkStatus.FINISHED);
+        assertThat(finishedStatus.isFinished()).isTrue();
+        assertThat(finishedStatus.isActive()).isFalse();
+        assertThat(finishedStatus.isIdle()).isFalse();
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/util/TestHarnessUtil.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/util/TestHarnessUtil.java
@@ -21,6 +21,7 @@ package org.apache.flink.streaming.util;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -29,6 +30,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -46,6 +48,23 @@ public class TestHarnessUtil {
             }
         }
         return resultElements;
+    }
+
+    /**
+     * Filters out {@link WatermarkStatus} elements from the output queue.
+     *
+     * <p>This is useful for tests that focus on data processing or event handling behavior and
+     * should not be affected by task lifecycle signals. {@link WatermarkStatus#FINISHED} is an
+     * implementation detail emitted by tasks when they finish, and is not part of the core feature
+     * being tested in most cases.
+     *
+     * @param output the output queue to filter
+     * @return a new queue with all {@link WatermarkStatus} elements removed
+     */
+    public static ConcurrentLinkedQueue<Object> filterOutWatermarkStatus(Queue<Object> output) {
+        return output.stream()
+                .filter(o -> !(o instanceof WatermarkStatus))
+                .collect(Collectors.toCollection(ConcurrentLinkedQueue::new));
     }
 
     /**

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskChainedSourcesCheckpointingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskChainedSourcesCheckpointingTest.java
@@ -40,8 +40,9 @@ import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.api.StopMode;
 import org.apache.flink.runtime.io.network.api.writer.RecordOrEventCollectingResultPartitionWriter;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
-import org.apache.flink.runtime.io.network.partition.PartitionTestUtils;
+import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
 import org.apache.flink.runtime.io.network.partition.ResultPartition;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionBuilder;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
@@ -380,7 +381,10 @@ class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
         try {
             for (int i = 0; i < partitionWriters.length; ++i) {
                 partitionWriters[i] =
-                        PartitionTestUtils.createPartition(ResultPartitionType.PIPELINED_BOUNDED);
+                        new ResultPartitionBuilder()
+                                .setResultPartitionType(ResultPartitionType.PIPELINED_BOUNDED)
+                                .setNetworkBufferPool(new NetworkBufferPool(10, 128))
+                                .build();
                 partitionWriters[i].setup();
             }
 
@@ -456,9 +460,10 @@ class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
                 assertThat(testHarness.getTaskStateManager().getReportedCheckpointId())
                         .isEqualTo(4);
 
-                // Each result partition should have emitted 2 barriers and 1 EndOfUserRecordsEvent.
+                // Each result partition should have emitted 2 barriers, 1 WatermarkStatus.FINISHED
+                // and 1 EndOfUserRecordsEvent.
                 for (ResultPartition resultPartition : partitionWriters) {
-                    assertThat(resultPartition.getNumberOfQueuedBuffers()).isEqualTo(3);
+                    assertThat(resultPartition.getNumberOfQueuedBuffers()).isEqualTo(4);
                 }
             }
         } finally {
@@ -519,7 +524,10 @@ class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
             assertThat(output).isEmpty();
             testHarness.waitForTaskCompletion();
             assertThat(output)
-                    .containsExactly(Watermark.MAX_WATERMARK, new EndOfData(StopMode.DRAIN));
+                    .containsExactly(
+                            WatermarkStatus.FINISHED,
+                            Watermark.MAX_WATERMARK,
+                            new EndOfData(StopMode.DRAIN));
 
             for (StreamOperatorWrapper<?, ?> wrapper :
                     testHarness.getStreamTask().operatorChain.getAllOperators()) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
@@ -61,8 +61,9 @@ import org.apache.flink.runtime.io.network.api.StopMode;
 import org.apache.flink.runtime.io.network.api.writer.RecordOrEventCollectingResultPartitionWriter;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriterWithAvailabilityHelper;
-import org.apache.flink.runtime.io.network.partition.PartitionTestUtils;
+import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
 import org.apache.flink.runtime.io.network.partition.ResultPartition;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionBuilder;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.metrics.MetricNames;
@@ -176,7 +177,10 @@ class MultipleInputStreamTaskTest {
             testHarness.endInput();
             testHarness.waitForTaskCompletion();
 
-            assertThat(testHarness.getOutput()).containsExactlyInAnyOrderElementsOf(expectedOutput);
+            // Filter out WatermarkStatus (e.g., FINISHED watermark status when task finishes),
+            // which is a task lifecycle signal, not part of the feature being tested.
+            assertThat(TestHarnessUtil.filterOutWatermarkStatus(testHarness.getOutput()))
+                    .containsExactlyInAnyOrderElementsOf(expectedOutput);
         }
     }
 
@@ -392,7 +396,10 @@ class MultipleInputStreamTaskTest {
                     1);
 
             testHarness.waitForTaskCompletion();
-            assertThat(testHarness.getOutput()).containsExactlyElementsOf(expectedOutput);
+            // Filter out WatermarkStatus (e.g., FINISHED watermark status when task finishes),
+            // which is a task lifecycle signal, not part of the feature being tested.
+            assertThat(TestHarnessUtil.filterOutWatermarkStatus(testHarness.getOutput()))
+                    .containsExactlyElementsOf(expectedOutput);
         }
     }
 
@@ -999,7 +1006,10 @@ class MultipleInputStreamTaskTest {
         try {
             for (int i = 0; i < partitionWriters.length; ++i) {
                 partitionWriters[i] =
-                        PartitionTestUtils.createPartition(ResultPartitionType.PIPELINED_BOUNDED);
+                        new ResultPartitionBuilder()
+                                .setResultPartitionType(ResultPartitionType.PIPELINED_BOUNDED)
+                                .setNetworkBufferPool(new NetworkBufferPool(10, 128))
+                                .build();
                 partitionWriters[i].setup();
             }
 
@@ -1067,9 +1077,10 @@ class MultipleInputStreamTaskTest {
                 assertThat(testHarness.getTaskStateManager().getReportedCheckpointId())
                         .isEqualTo(6);
 
-                // Each result partition should have emitted 3 barriers and 1 EndOfUserRecordsEvent.
+                // Each result partition should have emitted 3 barriers, 1 WatermarkStatus.FINISHED
+                // and 1 EndOfUserRecordsEvent.
                 for (ResultPartition resultPartition : partitionWriters) {
-                    assertThat(resultPartition.getNumberOfQueuedBuffers()).isEqualTo(4);
+                    assertThat(resultPartition.getNumberOfQueuedBuffers()).isEqualTo(5);
                 }
             }
         } finally {
@@ -1108,7 +1119,10 @@ class MultipleInputStreamTaskTest {
             testHarness.processElement(Watermark.MAX_WATERMARK, 2);
             testHarness.waitForTaskCompletion();
             assertThat(testHarness.getOutput())
-                    .containsExactly(Watermark.MAX_WATERMARK, new EndOfData(StopMode.DRAIN));
+                    .containsExactly(
+                            Watermark.MAX_WATERMARK,
+                            WatermarkStatus.FINISHED,
+                            new EndOfData(StopMode.DRAIN));
         }
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTaskTest.java
@@ -58,6 +58,7 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElementSerializer;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.LifeCycleMonitor.LifeCyclePhase;
+import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 import org.apache.flink.util.SerializedValue;
 
 import org.assertj.core.api.Assertions;
@@ -132,7 +133,9 @@ class SourceOperatorStreamTaskTest extends SourceStreamTaskTestBase {
                             CheckpointStorageLocationReference.getDefault());
             triggerCheckpointWaitForFinish(testHarness, checkpointId, checkpointOptions);
 
+            // Source tasks emit FINISHED status before MAX_WATERMARK when completing with drain
             Queue<Object> expectedOutput = new LinkedList<>();
+            expectedOutput.add(WatermarkStatus.FINISHED);
             expectedOutput.add(Watermark.MAX_WATERMARK);
             expectedOutput.add(new EndOfData(StopMode.DRAIN));
             expectedOutput.add(
@@ -148,7 +151,9 @@ class SourceOperatorStreamTaskTest extends SourceStreamTaskTestBase {
             testHarness.processAll();
             testHarness.finishProcessing();
 
+            // Source tasks emit FINISHED status before MAX_WATERMARK when completing with drain
             Queue<Object> expectedOutput = new LinkedList<>();
+            expectedOutput.add(WatermarkStatus.FINISHED);
             expectedOutput.add(Watermark.MAX_WATERMARK);
             expectedOutput.add(new EndOfData(StopMode.DRAIN));
             assertThat(testHarness.getOutput()).containsExactlyElementsOf(expectedOutput);
@@ -277,11 +282,15 @@ class SourceOperatorStreamTaskTest extends SourceStreamTaskTestBase {
                         .finish()
                         .build()) {
 
-            testHarness.getStreamTask().invoke(); // should result in end-of-input and task closing
-            testHarness.processAll(); // no-op
+            testHarness.getStreamTask().invoke();
+            testHarness.processAll();
             testHarness.cleanUp(); // close output writer
+            // Source tasks emit FINISHED status before MAX_WATERMARK when completing with drain
             assertThat(output)
-                    .containsExactly(Watermark.MAX_WATERMARK, new EndOfData(StopMode.DRAIN));
+                    .containsExactly(
+                            WatermarkStatus.FINISHED,
+                            Watermark.MAX_WATERMARK,
+                            new EndOfData(StopMode.DRAIN));
 
             LifeCycleMonitorSourceReader sourceReader =
                     (LifeCycleMonitorSourceReader)

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceTaskTerminationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceTaskTerminationTest.java
@@ -106,8 +106,8 @@ class SourceTaskTerminationTest {
                             ::isDone);
 
             if (shouldTerminate) {
-                // if we are in TERMINATE mode, we expect the source task
-                // to emit FINISHED status and then MAX_WM before the SYNC_SAVEPOINT barrier.
+                // if we are in TERMINATE mode, we expect the source task to emit FINISHED status
+                // and then MAX_WM before the SYNC_SAVEPOINT barrier.
                 verifyWatermarkStatus(srcTaskTestHarness.getOutput(), WatermarkStatus.FINISHED);
                 verifyWatermark(srcTaskTestHarness.getOutput(), Watermark.MAX_WATERMARK);
             }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceTaskTerminationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceTaskTerminationTest.java
@@ -106,8 +106,8 @@ class SourceTaskTerminationTest {
                             ::isDone);
 
             if (shouldTerminate) {
-                // if we are in TERMINATE mode, we expect the source task to emit FINISHED status
-                // and then MAX_WM before the SYNC_SAVEPOINT barrier.
+                // if we are in TERMINATE mode, we expect the source task to emit FINISHED
+                // status and then MAX_WM before the SYNC_SAVEPOINT barrier.
                 verifyWatermarkStatus(srcTaskTestHarness.getOutput(), WatermarkStatus.FINISHED);
                 verifyWatermark(srcTaskTestHarness.getOutput(), Watermark.MAX_WATERMARK);
             }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceTaskTerminationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceTaskTerminationTest.java
@@ -34,6 +34,7 @@ import org.apache.flink.streaming.api.functions.source.legacy.SourceFunction;
 import org.apache.flink.streaming.api.operators.StreamSource;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -106,7 +107,8 @@ class SourceTaskTerminationTest {
 
             if (shouldTerminate) {
                 // if we are in TERMINATE mode, we expect the source task
-                // to emit MAX_WM before the SYNC_SAVEPOINT barrier.
+                // to emit FINISHED status and then MAX_WM before the SYNC_SAVEPOINT barrier.
+                verifyWatermarkStatus(srcTaskTestHarness.getOutput(), WatermarkStatus.FINISHED);
                 verifyWatermark(srcTaskTestHarness.getOutput(), Watermark.MAX_WATERMARK);
             }
 
@@ -168,6 +170,14 @@ class SourceTaskTerminationTest {
         Object next = output.remove();
         assertThat(next).as("next element is not an event").isInstanceOf(Watermark.class);
         assertThat(next).as("wrong watermark").isEqualTo(expectedWatermark);
+    }
+
+    private void verifyWatermarkStatus(Queue<Object> output, WatermarkStatus expectedStatus) {
+        Object next = output.remove();
+        assertThat(next)
+                .as("next element is not a watermark status")
+                .isInstanceOf(WatermarkStatus.class);
+        assertThat(next).as("wrong watermark status").isEqualTo(expectedStatus);
     }
 
     private void verifyEvent(Queue<Object> output, AbstractEvent expectedEvent) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMultipleInputSelectiveReadingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMultipleInputSelectiveReadingTest.java
@@ -171,8 +171,7 @@ class StreamTaskMultipleInputSelectiveReadingTest {
             testHarness.waitForTaskCompletion();
 
             // Filter out WatermarkStatus (e.g., FINISHED watermark status when task finishes) -
-            // this
-            // test focuses on selective reading behavior.
+            // this test focuses on selective reading behavior.
             Queue<Object> filteredOutput =
                     TestHarnessUtil.filterOutWatermarkStatus(testHarness.getOutput());
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMultipleInputSelectiveReadingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMultipleInputSelectiveReadingTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.TestAnyModeMultipleInputStreamOperator;
 import org.apache.flink.streaming.util.TestAnyModeMultipleInputStreamOperator.ToStringInput;
+import org.apache.flink.streaming.util.TestHarnessUtil;
 import org.apache.flink.streaming.util.TestSequentialMultipleInputStreamOperator;
 
 import org.junit.jupiter.api.Test;
@@ -169,11 +170,15 @@ class StreamTaskMultipleInputSelectiveReadingTest {
             }
             testHarness.waitForTaskCompletion();
 
+            // Filter out WatermarkStatus (e.g., FINISHED watermark status when task finishes) -
+            // this test focuses on selective reading behavior.
+            Queue<Object> filteredOutput =
+                    TestHarnessUtil.filterOutWatermarkStatus(testHarness.getOutput());
+
             if (orderedCheck) {
-                assertThat(testHarness.getOutput()).containsExactlyElementsOf(expectedOutput);
+                assertThat(filteredOutput).containsExactlyElementsOf(expectedOutput);
             } else {
-                assertThat(testHarness.getOutput())
-                        .containsExactlyInAnyOrderElementsOf(expectedOutput);
+                assertThat(filteredOutput).containsExactlyInAnyOrderElementsOf(expectedOutput);
             }
         }
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMultipleInputSelectiveReadingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMultipleInputSelectiveReadingTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.TestAnyModeMultipleInputStreamOperator;
 import org.apache.flink.streaming.util.TestAnyModeMultipleInputStreamOperator.ToStringInput;
+import org.apache.flink.streaming.util.TestHarnessUtil;
 import org.apache.flink.streaming.util.TestSequentialMultipleInputStreamOperator;
 
 import org.junit.jupiter.api.Test;
@@ -169,11 +170,16 @@ class StreamTaskMultipleInputSelectiveReadingTest {
             }
             testHarness.waitForTaskCompletion();
 
+            // Filter out WatermarkStatus (e.g., FINISHED watermark status when task finishes) -
+            // this
+            // test focuses on selective reading behavior.
+            Queue<Object> filteredOutput =
+                    TestHarnessUtil.filterOutWatermarkStatus(testHarness.getOutput());
+
             if (orderedCheck) {
-                assertThat(testHarness.getOutput()).containsExactlyElementsOf(expectedOutput);
+                assertThat(filteredOutput).containsExactlyElementsOf(expectedOutput);
             } else {
-                assertThat(testHarness.getOutput())
-                        .containsExactlyInAnyOrderElementsOf(expectedOutput);
+                assertThat(filteredOutput).containsExactlyInAnyOrderElementsOf(expectedOutput);
             }
         }
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTest.java
@@ -430,8 +430,15 @@ class TwoInputStreamTaskTest {
 
             testHarness.processAll();
 
+            // Filter out WatermarkStatus (e.g., FINISHED watermark status when task finishes),
+            // which is a task lifecycle signal (an implementation detail emitted by tasks when they
+            // finish), not part of the feature being tested. This test focuses on checkpoint
+            // barrier handling.
+            ConcurrentLinkedQueue<Object> actualOutput =
+                    TestHarnessUtil.filterOutWatermarkStatus(testHarness.getOutput());
+
             TestHarnessUtil.assertOutputEquals(
-                    "Output was not correct.", expectedOutput, testHarness.getOutput());
+                    "Output was not correct.", expectedOutput, actualOutput);
 
             // Then give the earlier barrier, these should be ignored
             testHarness.processEvent(
@@ -452,8 +459,12 @@ class TwoInputStreamTaskTest {
 
             testHarness.waitForTaskCompletion();
 
+            // Filter again for final comparison
+            ConcurrentLinkedQueue<Object> finalOutput =
+                    TestHarnessUtil.filterOutWatermarkStatus(testHarness.getOutput());
+
             TestHarnessUtil.assertOutputEquals(
-                    "Output was not correct.", expectedOutput, testHarness.getOutput());
+                    "Output was not correct.", expectedOutput, finalOutput);
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes a watermark aggregation bug that can cause zero output from time-based operators (e.g., IntervalJoin) when some upstream subtasks finish while others later become temporarily idle.

Details of the issue are described in [FLINK-38477](https://issues.apache.org/jira/browse/FLINK-38477).

**Root cause**:
Flink currently allows finished subtasks to dominate watermark aggregation by emitting Long.MAX_VALUE instead of being excluded like idle inputs. This prematurely advances downstream watermarks to infinity (Long.MAX_VALUE), halting event-time progress and eliminating output.

## Brief change log
**Goal:**  Ensure a finished input is **excluded** from operator watermark aggregation, just like an idle input. This prevents `Long.MAX_VALUE` from dominating aggregation when some channels are finished and others are idle.

### Implementation

- Introduced a **new watermark status: `FINISHED`**.  
- When an operator finishes, it emits:
  - `status = FINISHED`  
  - `watermark = Long.MAX_VALUE` if the watermarks of all input channels are already Long.MAX_VALUE.
- Adjusted aggregation rules:
  - If there are **active channels** → `status = ACTIVE`, `watermark = min(all active channel watermarks)`.
  - Else if there are **idle channels** → `status = IDLE`, `watermark = max(all idle channel watermarks)`.
  - Else (**all channels finished**) → `status = FINISHED`, `watermark = Long.MAX_VALUE`.

This ensures finished inputs are ignored during aggregation until every input has completed, at which point the operator watermark correctly advances to `Long.MAX_VALUE`.

### Core issues identified

- **Current state model:** `ACTIVE` ←→ `IDLE`  
  - Cannot distinguish between:
    - `IDLE` = “temporarily no data, may resume”  
    - `FINISHED` = “permanently done, never resuming”  

- **Rejected approach:** treating finished as idle.  
  - **Issue 1: IDLE status gets overwritten**  
    - `StreamTask.endData()` emits `WatermarkStatus.IDLE` when a source finishs.  
    - Then `operatorChain.finishOperators()` calls `WatermarkAssignerOperator.processWatermark()`.  
    - When `WatermarkAssignerOperator` receives `Long.MAX_VALUE`, it forcibly emits `WatermarkStatus.ACTIVE`.  
    - Result: finished channels are incorrectly marked as ACTIVE, so the finished tasks still participate in watermark aggregation.  

  - **Issue 2: Incorrect aggregation when all channels are IDLE**  
    - Even if Issue 1 is fixed, when all channels become IDLE (including finished tasks whose watermark is `Long.MAX_VALUE`):  
    - `StatusWatermarkValve` calls `findAndOutputMaxWatermarkAcrossAllChannels()`.  
    - This still emits a `Long.MAX_VALUE` watermark.  
    - It cannot distinguish between “all temporarily idle” vs. “all permanently finished.”  

**Conclusion:**  
- Introducing the explicit `FINISHED` status is necessary to create a **three-state WatermarkStatus (ACTIVE / IDLE / FINISHED)** that properly distinguishes temporary idleness from permanent completion.

### Long-term refactoring (future follow-up)

This PR fixes the immediate bug, but the broader problem is **fragmented watermark lifecycle management**.

#### Current problems
- **Multiple, conflicting emission points:** For example:
```
StreamTask.endData():
  ├─ advanceToEndOfEventTime()
  │   └─ emits Long.MAX_VALUE watermark
  │
  └─ operatorChain.finishOperators():
      ├─ ContinuousFileReaderOperator.finish()
      │   └─ emits Long.MAX_VALUE (deprecated?)
      │
      ├─ WatermarkAssignerOperator.finish()
      │    ├─ switches IDLE → ACTIVE if idleness enabled 
      │    └─ emits Long.MAX_VALUE watermark
      └─ ...
```
- Wrapper operators interfere with completion semantics.  
- Sources don’t fully control their own lifecycle, at least from the perspective of watermark and watermark status handling.  

#### Proposed long-term direction
- **Source-owned completion and embedded watermark strategy:**  
Sources should declare when they are active, idle, or finished, and emit both status and watermark atomically. Wrapper operators should not override this behavior.  

  - *Current Architecture:*  
    ```
    Source → WatermarkAssignerOperator (wrapper) → Downstream
             ↑ Adds watermark strategy
             ↑ Can conflict with source completion
    ```
  - *Benefits:*  
    - No wrapper operator to conflict with source status.  
    - Source and watermark strategy have consistent lifecycle.  
    - Table API can configure watermark strategy at source creation, not via wrapper. 

This refactoring would prevent the entire class of bugs we've been fixing and make watermark completion semantics clear and maintainable.

## Verifying this change

### Unit tests (new)
- Test that FINISHED channels are excluded from min watermark calculation, allowing remaining channels to advance the watermark.
- Test that FINISHED channels are excluded from max watermark calculation when all other channels become IDLE.
- Test that FINISHED channels reject non-MAX_VALUE watermarks, accept Long.MAX_VALUE, and properly aggregate across channels to emit Long.MAX_VALUE once when all FINISHED channels receive it.
- Test that FINISHED is a terminal state and channels cannot transition from FINISHED back to ACTIVE or IDLE.
- Tests ACTIVE to IDLE and ACTIVE to FINISHED transitions in various configurations, including global status changes
- Tests IDLE to ACTIVE transitions with both aligned and unaligned watermarks, verifying realignment behavior
- Tests IDLE to FINISHED transitions in various configurations, verifying global status changes and watermark progression.
- Aggregation rule selection verified:
  - Active → min(active watermarks).  
  - Idle (with no active) → idle status; finished excluded.  
  - All finished → operator watermark = `Long.MAX_VALUE`.  

### Manual/e2e tests
1. Set job parallelism greater than Kafka partitions; disable dynamic partition discovery.  
2. Some subtasks finish immediately, others keep running.  
3. Stall the running subtasks until they become idle (`table.exec.source.idle-timeout=10s`).  
4. **Before fix:** operator watermark = `Long.MAX_VALUE`, all records dropped → no output.  
   **After fix:** watermark does not jump; resumed records are processed correctly.

## Does this pull request potentially affect one of the following parts:
- Dependencies: **no**  
- Public API (`@Public(Evolving)`): **no**  
- Serializers: **no**  
- Runtime per-record code paths: **yes** (watermark aggregation; minimal guarded changes)  
- Deployment/recovery (JM, checkpointing, K8s/Yarn, ZooKeeper): **no**  
- S3 file system connector: **no**

## Documentation
- New feature: **no** (bug fix only; introduces internal `FINISHED` watermark status)  
- Documentation: *not applicable*
