### PR TITLE
[FLINK-38484][ci] Avoid long command line error

### DIFF
--- a/.github/workflows/community-review.sh
+++ b/.github/workflows/community-review.sh
@@ -116,7 +116,8 @@ main() {
     receivedPullRequests=$(jq '[.[] | select((.node.isDraft = false))]' <<< "$receivedPullRequests")
     printf " %2s PR retained" "$(JSONArrayLength "$receivedPullRequests")"
 
-    pullRequests=$(jq --argjson a1 "$pullRequests" --argjson a2 "$receivedPullRequests" '$a1 + $a2' <<< '{}')
+    # the below line is coded so as to avoid command-line argument limits.
+    pullRequests=$(jq -s '.[0] + .[1]' <(echo "$pullRequests") <(echo "$receivedPullRequests"))
 
     hasNextPage=$(jq  '.data.repository.pullRequests.pageInfo.hasNextPage' <<< "$restResponse")
     cursor=$(jq -r '.data.repository.pullRequests.pageInfo.endCursor' <<< "$restResponse")


### PR DESCRIPTION
## What is the purpose of the change

The community review github action was failing because the command line was too long. 

## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

As is this was no reproducable locally, as there is a different command line  limit. I wrote a script that failed locally with the line of code as is and replaced it with the fixed line and it worked. This reassured me that the change should work. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
