### PR TITLE
[FLINK-38488][tests] Use 'throws Exception' instead of try-catch-fail…

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeWindowCheckpointingITCase.java
@@ -76,7 +76,6 @@ import java.util.stream.Collectors;
 import static org.apache.flink.test.checkpointing.EventTimeWindowCheckpointingITCase.StateBackendEnum.ROCKSDB_INCREMENTAL_ZK;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * This verifies that checkpointing works correctly with event time windows. This is more strict
@@ -308,435 +307,405 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
     // ------------------------------------------------------------------------
 
     @Test
-    public void testTumblingTimeWindow() {
+    public void testTumblingTimeWindow() throws Exception {
         final int numElementsPerKey = numElementsPerKey();
         final int windowSize = windowSize();
         final int numKeys = numKeys();
 
-        try {
-            StreamExecutionEnvironment env =
-                    StreamExecutionEnvironment.getExecutionEnvironment(configuration);
-            env.setParallelism(PARALLELISM);
-            env.enableCheckpointing(100);
-            RestartStrategyUtils.configureFixedDelayRestartStrategy(env, 1, 0L);
-            env.getConfig().setUseSnapshotCompression(true);
+        StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(configuration);
+        env.setParallelism(PARALLELISM);
+        env.enableCheckpointing(100);
+        RestartStrategyUtils.configureFixedDelayRestartStrategy(env, 1, 0L);
+        env.getConfig().setUseSnapshotCompression(true);
 
-            env.addSource(
-                            new FailingSource(
-                                    new KeyedEventTimeGenerator(numKeys, windowSize),
-                                    numElementsPerKey))
-                    .rebalance()
-                    .keyBy(x -> x.f0)
-                    .window(TumblingEventTimeWindows.of(Duration.ofMillis(windowSize)))
-                    .apply(
-                            new RichWindowFunction<
-                                    Tuple2<Long, IntType>,
-                                    Tuple4<Long, Long, Long, IntType>,
-                                    Long,
-                                    TimeWindow>() {
+        env.addSource(
+                        new FailingSource(
+                                new KeyedEventTimeGenerator(numKeys, windowSize),
+                                numElementsPerKey))
+                .rebalance()
+                .keyBy(x -> x.f0)
+                .window(TumblingEventTimeWindows.of(Duration.ofMillis(windowSize)))
+                .apply(
+                        new RichWindowFunction<
+                                Tuple2<Long, IntType>,
+                                Tuple4<Long, Long, Long, IntType>,
+                                Long,
+                                TimeWindow>() {
 
-                                private boolean open = false;
+                            private boolean open = false;
 
-                                @Override
-                                public void open(OpenContext openContext) {
-                                    assertEquals(
-                                            PARALLELISM,
-                                            getRuntimeContext()
-                                                    .getTaskInfo()
-                                                    .getNumberOfParallelSubtasks());
-                                    open = true;
+                            @Override
+                            public void open(OpenContext openContext) {
+                                assertEquals(
+                                        PARALLELISM,
+                                        getRuntimeContext()
+                                                .getTaskInfo()
+                                                .getNumberOfParallelSubtasks());
+                                open = true;
+                            }
+
+                            @Override
+                            public void apply(
+                                    Long l,
+                                    TimeWindow window,
+                                    Iterable<Tuple2<Long, IntType>> values,
+                                    Collector<Tuple4<Long, Long, Long, IntType>> out) {
+
+                                // validate that the function has been opened properly
+                                assertTrue(open);
+
+                                int sum = 0;
+                                long key = -1;
+
+                                for (Tuple2<Long, IntType> value : values) {
+                                    sum += value.f1.value;
+                                    key = value.f0;
                                 }
 
-                                @Override
-                                public void apply(
-                                        Long l,
-                                        TimeWindow window,
-                                        Iterable<Tuple2<Long, IntType>> values,
-                                        Collector<Tuple4<Long, Long, Long, IntType>> out) {
+                                final Tuple4<Long, Long, Long, IntType> result =
+                                        new Tuple4<>(
+                                                key,
+                                                window.getStart(),
+                                                window.getEnd(),
+                                                new IntType(sum));
+                                out.collect(result);
+                            }
+                        })
+                .addSink(
+                        new ValidatingSink<>(
+                                new SinkValidatorUpdateFun(numElementsPerKey),
+                                new SinkValidatorCheckFun(numKeys, numElementsPerKey, windowSize)))
+                .setParallelism(1);
 
-                                    // validate that the function has been opened properly
-                                    assertTrue(open);
-
-                                    int sum = 0;
-                                    long key = -1;
-
-                                    for (Tuple2<Long, IntType> value : values) {
-                                        sum += value.f1.value;
-                                        key = value.f0;
-                                    }
-
-                                    final Tuple4<Long, Long, Long, IntType> result =
-                                            new Tuple4<>(
-                                                    key,
-                                                    window.getStart(),
-                                                    window.getEnd(),
-                                                    new IntType(sum));
-                                    out.collect(result);
-                                }
-                            })
-                    .addSink(
-                            new ValidatingSink<>(
-                                    new SinkValidatorUpdateFun(numElementsPerKey),
-                                    new SinkValidatorCheckFun(
-                                            numKeys, numElementsPerKey, windowSize)))
-                    .setParallelism(1);
-
-            env.execute("Tumbling Window Test");
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        }
+        env.execute("Tumbling Window Test");
     }
 
     @Test
-    public void testTumblingTimeWindowWithKVStateMinMaxParallelism() {
+    public void testTumblingTimeWindowWithKVStateMinMaxParallelism() throws Exception {
         doTestTumblingTimeWindowWithKVState(PARALLELISM);
     }
 
     @Test
-    public void testTumblingTimeWindowWithKVStateMaxMaxParallelism() {
+    public void testTumblingTimeWindowWithKVStateMaxMaxParallelism() throws Exception {
         doTestTumblingTimeWindowWithKVState(1 << 15);
     }
 
-    public void doTestTumblingTimeWindowWithKVState(int maxParallelism) {
+    public void doTestTumblingTimeWindowWithKVState(int maxParallelism) throws Exception {
         final int numElementsPerKey = numElementsPerKey();
         final int windowSize = windowSize();
         final int numKeys = numKeys();
 
-        try {
-            StreamExecutionEnvironment env =
-                    StreamExecutionEnvironment.getExecutionEnvironment(configuration);
-            env.setParallelism(PARALLELISM);
-            env.setMaxParallelism(maxParallelism);
-            env.enableCheckpointing(100);
-            RestartStrategyUtils.configureFixedDelayRestartStrategy(env, 1, 0L);
-            env.getConfig().setUseSnapshotCompression(true);
+        StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(configuration);
+        env.setParallelism(PARALLELISM);
+        env.setMaxParallelism(maxParallelism);
+        env.enableCheckpointing(100);
+        RestartStrategyUtils.configureFixedDelayRestartStrategy(env, 1, 0L);
+        env.getConfig().setUseSnapshotCompression(true);
 
-            env.addSource(
-                            new FailingSource(
-                                    new KeyedEventTimeGenerator(numKeys, windowSize),
-                                    numElementsPerKey))
-                    .rebalance()
-                    .keyBy(x -> x.f0)
-                    .window(TumblingEventTimeWindows.of(Duration.ofMillis(windowSize)))
-                    .apply(
-                            new RichWindowFunction<
-                                    Tuple2<Long, IntType>,
-                                    Tuple4<Long, Long, Long, IntType>,
-                                    Long,
-                                    TimeWindow>() {
+        env.addSource(
+                        new FailingSource(
+                                new KeyedEventTimeGenerator(numKeys, windowSize),
+                                numElementsPerKey))
+                .rebalance()
+                .keyBy(x -> x.f0)
+                .window(TumblingEventTimeWindows.of(Duration.ofMillis(windowSize)))
+                .apply(
+                        new RichWindowFunction<
+                                Tuple2<Long, IntType>,
+                                Tuple4<Long, Long, Long, IntType>,
+                                Long,
+                                TimeWindow>() {
 
-                                private boolean open = false;
+                            private boolean open = false;
 
-                                private ValueState<Integer> count;
+                            private ValueState<Integer> count;
 
-                                @Override
-                                public void open(OpenContext openContext) {
-                                    assertEquals(
-                                            PARALLELISM,
-                                            getRuntimeContext()
-                                                    .getTaskInfo()
-                                                    .getNumberOfParallelSubtasks());
-                                    open = true;
-                                    count =
-                                            getRuntimeContext()
-                                                    .getState(
-                                                            new ValueStateDescriptor<>(
-                                                                    "count", Integer.class, 0));
+                            @Override
+                            public void open(OpenContext openContext) {
+                                assertEquals(
+                                        PARALLELISM,
+                                        getRuntimeContext()
+                                                .getTaskInfo()
+                                                .getNumberOfParallelSubtasks());
+                                open = true;
+                                count =
+                                        getRuntimeContext()
+                                                .getState(
+                                                        new ValueStateDescriptor<>(
+                                                                "count", Integer.class, 0));
+                            }
+
+                            @Override
+                            public void apply(
+                                    Long l,
+                                    TimeWindow window,
+                                    Iterable<Tuple2<Long, IntType>> values,
+                                    Collector<Tuple4<Long, Long, Long, IntType>> out)
+                                    throws Exception {
+
+                                // the window count state starts with the key, so that we get
+                                // different count results for each key
+                                if (count.value() == 0) {
+                                    count.update(l.intValue());
                                 }
 
-                                @Override
-                                public void apply(
-                                        Long l,
-                                        TimeWindow window,
-                                        Iterable<Tuple2<Long, IntType>> values,
-                                        Collector<Tuple4<Long, Long, Long, IntType>> out)
-                                        throws Exception {
+                                // validate that the function has been opened properly
+                                assertTrue(open);
 
-                                    // the window count state starts with the key, so that we get
-                                    // different count results for each key
-                                    if (count.value() == 0) {
-                                        count.update(l.intValue());
-                                    }
+                                count.update(count.value() + 1);
+                                out.collect(
+                                        new Tuple4<>(
+                                                l,
+                                                window.getStart(),
+                                                window.getEnd(),
+                                                new IntType(count.value())));
+                            }
+                        })
+                .addSink(
+                        new ValidatingSink<>(
+                                new CountingSinkValidatorUpdateFun(),
+                                new SinkValidatorCheckFun(numKeys, numElementsPerKey, windowSize)))
+                .setParallelism(1);
 
-                                    // validate that the function has been opened properly
-                                    assertTrue(open);
-
-                                    count.update(count.value() + 1);
-                                    out.collect(
-                                            new Tuple4<>(
-                                                    l,
-                                                    window.getStart(),
-                                                    window.getEnd(),
-                                                    new IntType(count.value())));
-                                }
-                            })
-                    .addSink(
-                            new ValidatingSink<>(
-                                    new CountingSinkValidatorUpdateFun(),
-                                    new SinkValidatorCheckFun(
-                                            numKeys, numElementsPerKey, windowSize)))
-                    .setParallelism(1);
-
-            env.execute("Tumbling Window Test");
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        }
+        env.execute("Tumbling Window Test");
     }
 
     @Test
-    public void testSlidingTimeWindow() {
+    public void testSlidingTimeWindow() throws Exception {
         final int numElementsPerKey = numElementsPerKey();
         final int windowSize = windowSize();
         final int windowSlide = windowSlide();
         final int numKeys = numKeys();
 
-        try {
-            StreamExecutionEnvironment env =
-                    StreamExecutionEnvironment.getExecutionEnvironment(configuration);
-            env.setMaxParallelism(2 * PARALLELISM);
-            env.setParallelism(PARALLELISM);
-            env.enableCheckpointing(100);
-            RestartStrategyUtils.configureFixedDelayRestartStrategy(env, 1, 0L);
-            env.getConfig().setUseSnapshotCompression(true);
+        StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(configuration);
+        env.setMaxParallelism(2 * PARALLELISM);
+        env.setParallelism(PARALLELISM);
+        env.enableCheckpointing(100);
+        RestartStrategyUtils.configureFixedDelayRestartStrategy(env, 1, 0L);
+        env.getConfig().setUseSnapshotCompression(true);
 
-            env.addSource(
-                            new FailingSource(
-                                    new KeyedEventTimeGenerator(numKeys, windowSlide),
-                                    numElementsPerKey))
-                    .rebalance()
-                    .keyBy(x -> x.f0)
-                    .window(
-                            SlidingEventTimeWindows.of(
-                                    Duration.ofMillis(windowSize), Duration.ofMillis(windowSlide)))
-                    .apply(
-                            new RichWindowFunction<
-                                    Tuple2<Long, IntType>,
-                                    Tuple4<Long, Long, Long, IntType>,
-                                    Long,
-                                    TimeWindow>() {
+        env.addSource(
+                        new FailingSource(
+                                new KeyedEventTimeGenerator(numKeys, windowSlide),
+                                numElementsPerKey))
+                .rebalance()
+                .keyBy(x -> x.f0)
+                .window(
+                        SlidingEventTimeWindows.of(
+                                Duration.ofMillis(windowSize), Duration.ofMillis(windowSlide)))
+                .apply(
+                        new RichWindowFunction<
+                                Tuple2<Long, IntType>,
+                                Tuple4<Long, Long, Long, IntType>,
+                                Long,
+                                TimeWindow>() {
 
-                                private boolean open = false;
+                            private boolean open = false;
 
-                                @Override
-                                public void open(OpenContext openContext) {
-                                    assertEquals(
-                                            PARALLELISM,
-                                            getRuntimeContext()
-                                                    .getTaskInfo()
-                                                    .getNumberOfParallelSubtasks());
-                                    open = true;
+                            @Override
+                            public void open(OpenContext openContext) {
+                                assertEquals(
+                                        PARALLELISM,
+                                        getRuntimeContext()
+                                                .getTaskInfo()
+                                                .getNumberOfParallelSubtasks());
+                                open = true;
+                            }
+
+                            @Override
+                            public void apply(
+                                    Long l,
+                                    TimeWindow window,
+                                    Iterable<Tuple2<Long, IntType>> values,
+                                    Collector<Tuple4<Long, Long, Long, IntType>> out) {
+
+                                // validate that the function has been opened properly
+                                assertTrue(open);
+
+                                int sum = 0;
+                                long key = -1;
+
+                                for (Tuple2<Long, IntType> value : values) {
+                                    sum += value.f1.value;
+                                    key = value.f0;
                                 }
+                                final Tuple4<Long, Long, Long, IntType> output =
+                                        new Tuple4<>(
+                                                key,
+                                                window.getStart(),
+                                                window.getEnd(),
+                                                new IntType(sum));
+                                out.collect(output);
+                            }
+                        })
+                .addSink(
+                        new ValidatingSink<>(
+                                new SinkValidatorUpdateFun(numElementsPerKey),
+                                new SinkValidatorCheckFun(numKeys, numElementsPerKey, windowSlide)))
+                .setParallelism(1);
 
-                                @Override
-                                public void apply(
-                                        Long l,
-                                        TimeWindow window,
-                                        Iterable<Tuple2<Long, IntType>> values,
-                                        Collector<Tuple4<Long, Long, Long, IntType>> out) {
+        env.execute("Tumbling Window Test");
+    }
 
-                                    // validate that the function has been opened properly
-                                    assertTrue(open);
+    @Test
+    public void testPreAggregatedTumblingTimeWindow() throws Exception {
+        final int numElementsPerKey = numElementsPerKey();
+        final int windowSize = windowSize();
+        final int numKeys = numKeys();
 
-                                    int sum = 0;
-                                    long key = -1;
+        StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(configuration);
+        env.setParallelism(PARALLELISM);
+        env.enableCheckpointing(100);
+        RestartStrategyUtils.configureFixedDelayRestartStrategy(env, 1, 0L);
+        env.getConfig().setUseSnapshotCompression(true);
 
-                                    for (Tuple2<Long, IntType> value : values) {
-                                        sum += value.f1.value;
-                                        key = value.f0;
-                                    }
+        env.addSource(
+                        new FailingSource(
+                                new KeyedEventTimeGenerator(numKeys, windowSize),
+                                numElementsPerKey))
+                .rebalance()
+                .keyBy(x -> x.f0)
+                .window(TumblingEventTimeWindows.of(Duration.ofMillis(windowSize)))
+                .reduce(
+                        new ReduceFunction<Tuple2<Long, IntType>>() {
+
+                            @Override
+                            public Tuple2<Long, IntType> reduce(
+                                    Tuple2<Long, IntType> a, Tuple2<Long, IntType> b) {
+                                return new Tuple2<>(a.f0, new IntType(a.f1.value + b.f1.value));
+                            }
+                        },
+                        new RichWindowFunction<
+                                Tuple2<Long, IntType>,
+                                Tuple4<Long, Long, Long, IntType>,
+                                Long,
+                                TimeWindow>() {
+
+                            private boolean open = false;
+
+                            @Override
+                            public void open(OpenContext openContext) {
+                                assertEquals(
+                                        PARALLELISM,
+                                        getRuntimeContext()
+                                                .getTaskInfo()
+                                                .getNumberOfParallelSubtasks());
+                                open = true;
+                            }
+
+                            @Override
+                            public void apply(
+                                    Long l,
+                                    TimeWindow window,
+                                    Iterable<Tuple2<Long, IntType>> input,
+                                    Collector<Tuple4<Long, Long, Long, IntType>> out) {
+
+                                // validate that the function has been opened properly
+                                assertTrue(open);
+
+                                for (Tuple2<Long, IntType> in : input) {
                                     final Tuple4<Long, Long, Long, IntType> output =
                                             new Tuple4<>(
-                                                    key,
+                                                    in.f0,
                                                     window.getStart(),
                                                     window.getEnd(),
-                                                    new IntType(sum));
+                                                    in.f1);
                                     out.collect(output);
                                 }
-                            })
-                    .addSink(
-                            new ValidatingSink<>(
-                                    new SinkValidatorUpdateFun(numElementsPerKey),
-                                    new SinkValidatorCheckFun(
-                                            numKeys, numElementsPerKey, windowSlide)))
-                    .setParallelism(1);
+                            }
+                        })
+                .addSink(
+                        new ValidatingSink<>(
+                                new SinkValidatorUpdateFun(numElementsPerKey),
+                                new SinkValidatorCheckFun(numKeys, numElementsPerKey, windowSize)))
+                .setParallelism(1);
 
-            env.execute("Tumbling Window Test");
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        }
+        env.execute("Tumbling Window Test");
     }
 
     @Test
-    public void testPreAggregatedTumblingTimeWindow() {
-        final int numElementsPerKey = numElementsPerKey();
-        final int windowSize = windowSize();
-        final int numKeys = numKeys();
-
-        try {
-            StreamExecutionEnvironment env =
-                    StreamExecutionEnvironment.getExecutionEnvironment(configuration);
-            env.setParallelism(PARALLELISM);
-            env.enableCheckpointing(100);
-            RestartStrategyUtils.configureFixedDelayRestartStrategy(env, 1, 0L);
-            env.getConfig().setUseSnapshotCompression(true);
-
-            env.addSource(
-                            new FailingSource(
-                                    new KeyedEventTimeGenerator(numKeys, windowSize),
-                                    numElementsPerKey))
-                    .rebalance()
-                    .keyBy(x -> x.f0)
-                    .window(TumblingEventTimeWindows.of(Duration.ofMillis(windowSize)))
-                    .reduce(
-                            new ReduceFunction<Tuple2<Long, IntType>>() {
-
-                                @Override
-                                public Tuple2<Long, IntType> reduce(
-                                        Tuple2<Long, IntType> a, Tuple2<Long, IntType> b) {
-                                    return new Tuple2<>(a.f0, new IntType(a.f1.value + b.f1.value));
-                                }
-                            },
-                            new RichWindowFunction<
-                                    Tuple2<Long, IntType>,
-                                    Tuple4<Long, Long, Long, IntType>,
-                                    Long,
-                                    TimeWindow>() {
-
-                                private boolean open = false;
-
-                                @Override
-                                public void open(OpenContext openContext) {
-                                    assertEquals(
-                                            PARALLELISM,
-                                            getRuntimeContext()
-                                                    .getTaskInfo()
-                                                    .getNumberOfParallelSubtasks());
-                                    open = true;
-                                }
-
-                                @Override
-                                public void apply(
-                                        Long l,
-                                        TimeWindow window,
-                                        Iterable<Tuple2<Long, IntType>> input,
-                                        Collector<Tuple4<Long, Long, Long, IntType>> out) {
-
-                                    // validate that the function has been opened properly
-                                    assertTrue(open);
-
-                                    for (Tuple2<Long, IntType> in : input) {
-                                        final Tuple4<Long, Long, Long, IntType> output =
-                                                new Tuple4<>(
-                                                        in.f0,
-                                                        window.getStart(),
-                                                        window.getEnd(),
-                                                        in.f1);
-                                        out.collect(output);
-                                    }
-                                }
-                            })
-                    .addSink(
-                            new ValidatingSink<>(
-                                    new SinkValidatorUpdateFun(numElementsPerKey),
-                                    new SinkValidatorCheckFun(
-                                            numKeys, numElementsPerKey, windowSize)))
-                    .setParallelism(1);
-
-            env.execute("Tumbling Window Test");
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        }
-    }
-
-    @Test
-    public void testPreAggregatedSlidingTimeWindow() {
+    public void testPreAggregatedSlidingTimeWindow() throws Exception {
         final int numElementsPerKey = numElementsPerKey();
         final int windowSize = windowSize();
         final int windowSlide = windowSlide();
         final int numKeys = numKeys();
 
-        try {
-            StreamExecutionEnvironment env =
-                    StreamExecutionEnvironment.getExecutionEnvironment(configuration);
-            env.setParallelism(PARALLELISM);
-            env.enableCheckpointing(100);
-            RestartStrategyUtils.configureFixedDelayRestartStrategy(env, 1, 0L);
-            env.getConfig().setUseSnapshotCompression(true);
+        StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(configuration);
+        env.setParallelism(PARALLELISM);
+        env.enableCheckpointing(100);
+        RestartStrategyUtils.configureFixedDelayRestartStrategy(env, 1, 0L);
+        env.getConfig().setUseSnapshotCompression(true);
 
-            env.addSource(
-                            new FailingSource(
-                                    new KeyedEventTimeGenerator(numKeys, windowSlide),
-                                    numElementsPerKey))
-                    .rebalance()
-                    .keyBy(x -> x.f0)
-                    .window(
-                            SlidingEventTimeWindows.of(
-                                    Duration.ofMillis(windowSize), Duration.ofMillis(windowSlide)))
-                    .reduce(
-                            new ReduceFunction<Tuple2<Long, IntType>>() {
+        env.addSource(
+                        new FailingSource(
+                                new KeyedEventTimeGenerator(numKeys, windowSlide),
+                                numElementsPerKey))
+                .rebalance()
+                .keyBy(x -> x.f0)
+                .window(
+                        SlidingEventTimeWindows.of(
+                                Duration.ofMillis(windowSize), Duration.ofMillis(windowSlide)))
+                .reduce(
+                        new ReduceFunction<Tuple2<Long, IntType>>() {
 
-                                @Override
-                                public Tuple2<Long, IntType> reduce(
-                                        Tuple2<Long, IntType> a, Tuple2<Long, IntType> b) {
+                            @Override
+                            public Tuple2<Long, IntType> reduce(
+                                    Tuple2<Long, IntType> a, Tuple2<Long, IntType> b) {
 
-                                    // validate that the function has been opened properly
-                                    return new Tuple2<>(a.f0, new IntType(a.f1.value + b.f1.value));
+                                // validate that the function has been opened properly
+                                return new Tuple2<>(a.f0, new IntType(a.f1.value + b.f1.value));
+                            }
+                        },
+                        new RichWindowFunction<
+                                Tuple2<Long, IntType>,
+                                Tuple4<Long, Long, Long, IntType>,
+                                Long,
+                                TimeWindow>() {
+
+                            private boolean open = false;
+
+                            @Override
+                            public void open(OpenContext openContext) {
+                                assertEquals(
+                                        PARALLELISM,
+                                        getRuntimeContext()
+                                                .getTaskInfo()
+                                                .getNumberOfParallelSubtasks());
+                                open = true;
+                            }
+
+                            @Override
+                            public void apply(
+                                    Long l,
+                                    TimeWindow window,
+                                    Iterable<Tuple2<Long, IntType>> input,
+                                    Collector<Tuple4<Long, Long, Long, IntType>> out) {
+
+                                // validate that the function has been opened properly
+                                assertTrue(open);
+
+                                for (Tuple2<Long, IntType> in : input) {
+                                    out.collect(
+                                            new Tuple4<>(
+                                                    in.f0,
+                                                    window.getStart(),
+                                                    window.getEnd(),
+                                                    in.f1));
                                 }
-                            },
-                            new RichWindowFunction<
-                                    Tuple2<Long, IntType>,
-                                    Tuple4<Long, Long, Long, IntType>,
-                                    Long,
-                                    TimeWindow>() {
+                            }
+                        })
+                .addSink(
+                        new ValidatingSink<>(
+                                new SinkValidatorUpdateFun(numElementsPerKey),
+                                new SinkValidatorCheckFun(numKeys, numElementsPerKey, windowSlide)))
+                .setParallelism(1);
 
-                                private boolean open = false;
-
-                                @Override
-                                public void open(OpenContext openContext) {
-                                    assertEquals(
-                                            PARALLELISM,
-                                            getRuntimeContext()
-                                                    .getTaskInfo()
-                                                    .getNumberOfParallelSubtasks());
-                                    open = true;
-                                }
-
-                                @Override
-                                public void apply(
-                                        Long l,
-                                        TimeWindow window,
-                                        Iterable<Tuple2<Long, IntType>> input,
-                                        Collector<Tuple4<Long, Long, Long, IntType>> out) {
-
-                                    // validate that the function has been opened properly
-                                    assertTrue(open);
-
-                                    for (Tuple2<Long, IntType> in : input) {
-                                        out.collect(
-                                                new Tuple4<>(
-                                                        in.f0,
-                                                        window.getStart(),
-                                                        window.getEnd(),
-                                                        in.f1));
-                                    }
-                                }
-                            })
-                    .addSink(
-                            new ValidatingSink<>(
-                                    new SinkValidatorUpdateFun(numElementsPerKey),
-                                    new SinkValidatorCheckFun(
-                                            numKeys, numElementsPerKey, windowSlide)))
-                    .setParallelism(1);
-
-            env.execute("Tumbling Window Test");
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        }
+        env.execute("Tumbling Window Test");
     }
 
     // ------------------------------------------------------------------------

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RegionFailoverITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RegionFailoverITCase.java
@@ -141,16 +141,11 @@ public class RegionFailoverITCase extends TestLogger {
      * completed checkpoint's.
      */
     @Test(timeout = 60000)
-    public void testMultiRegionFailover() {
-        try {
-            JobGraph jobGraph = createJobGraph();
-            ClusterClient<?> client = cluster.getClusterClient();
-            submitJobAndWaitForResult(client, jobGraph, getClass().getClassLoader());
-            verifyAfterJobExecuted();
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail(e.getMessage());
-        }
+    public void testMultiRegionFailover() throws Exception {
+        JobGraph jobGraph = createJobGraph();
+        ClusterClient<?> client = cluster.getClusterClient();
+        submitJobAndWaitForResult(client, jobGraph, getClass().getClassLoader());
+        verifyAfterJobExecuted();
     }
 
     private void verifyAfterJobExecuted() {

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/TimestampedFileInputSplitTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/TimestampedFileInputSplitTest.java
@@ -87,16 +87,10 @@ public class TimestampedFileInputSplitTest extends TestLogger {
         Assert.assertTrue(richThirdSplit.compareTo(richForthSplit) < 0);
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testIllegalArgument() {
-        try {
-            new TimestampedFileInputSplit(
-                    -10, 2, new Path("test"), 0, 100, null); // invalid modification time
-        } catch (Exception e) {
-            if (!(e instanceof IllegalArgumentException)) {
-                Assert.fail(e.getMessage());
-            }
-        }
+        new TimestampedFileInputSplit(
+                -10, 2, new Path("test"), 0, 100, null); // invalid modification time
     }
 
     @Test

--- a/flink-tests/src/test/java/org/apache/flink/test/example/client/LocalExecutorITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/client/LocalExecutorITCase.java
@@ -36,7 +36,6 @@ import org.apache.flink.test.testdata.WordCountData;
 import org.apache.flink.test.testfunctions.Tokenizer;
 import org.apache.flink.util.TestLogger;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -67,31 +66,25 @@ public class LocalExecutorITCase extends TestLogger {
     }
 
     @Test(timeout = 60_000)
-    public void testLocalExecutorWithWordCount() throws InterruptedException {
-        try {
-            // set up the files
-            File inFile = File.createTempFile("wctext", ".in");
-            File outFile = File.createTempFile("wctext", ".out");
-            inFile.deleteOnExit();
-            outFile.deleteOnExit();
+    public void testLocalExecutorWithWordCount() throws Exception {
+        // set up the files
+        File inFile = File.createTempFile("wctext", ".in");
+        File outFile = File.createTempFile("wctext", ".out");
+        inFile.deleteOnExit();
+        outFile.deleteOnExit();
 
-            try (FileWriter fw = new FileWriter(inFile)) {
-                fw.write(WordCountData.TEXT);
-            }
-
-            final Configuration config = new Configuration();
-            config.set(CoreOptions.FILESYTEM_DEFAULT_OVERRIDE, true);
-            config.set(DeploymentOptions.ATTACHED, true);
-
-            StreamGraph wcStreamGraph = getWordCountStreamGraph(inFile, outFile, parallelism);
-            JobClient jobClient =
-                    executor.execute(wcStreamGraph, config, ClassLoader.getSystemClassLoader())
-                            .get();
-            jobClient.getJobExecutionResult().get();
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail(e.getMessage());
+        try (FileWriter fw = new FileWriter(inFile)) {
+            fw.write(WordCountData.TEXT);
         }
+
+        final Configuration config = new Configuration();
+        config.set(CoreOptions.FILESYTEM_DEFAULT_OVERRIDE, true);
+        config.set(DeploymentOptions.ATTACHED, true);
+
+        StreamGraph wcStreamGraph = getWordCountStreamGraph(inFile, outFile, parallelism);
+        JobClient jobClient =
+                executor.execute(wcStreamGraph, config, ClassLoader.getSystemClassLoader()).get();
+        jobClient.getJobExecutionResult().get();
 
         assertThat(miniCluster.isRunning(), is(false));
     }

--- a/flink-tests/src/test/java/org/apache/flink/test/io/InputOutputITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/io/InputOutputITCase.java
@@ -24,8 +24,6 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.legacy.OutputFormatSinkFunction;
 import org.apache.flink.test.util.JavaProgramTestBaseJUnit4;
 
-import static org.junit.Assert.fail;
-
 /**
  * Tests for non rich DataSource and DataSink input output formats being correctly used at runtime.
  */
@@ -38,12 +36,7 @@ public class InputOutputITCase extends JavaProgramTestBaseJUnit4 {
         TestNonRichOutputFormat output = new TestNonRichOutputFormat();
         env.createInput(new TestNonRichInputFormat())
                 .addSink(new OutputFormatSinkFunction<>(output));
-        try {
-            env.execute();
-        } catch (Exception e) {
-            // we didn't break anything by making everything rich.
-            e.printStackTrace();
-            fail(e.getMessage());
-        }
+        env.execute();
+        // we didn't break anything by making everything rich.
     }
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/misc/CustomSerializationITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/misc/CustomSerializationITCase.java
@@ -40,7 +40,6 @@ import java.io.IOException;
 
 import static org.apache.flink.util.ExceptionUtils.findThrowable;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * Test for proper error messages in case user-defined serialization is broken and detected in the
@@ -67,7 +66,7 @@ public class CustomSerializationITCase extends TestLogger {
     }
 
     @Test
-    public void testIncorrectSerializer1() {
+    public void testIncorrectSerializer1() throws Exception {
         try {
             StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
             env.setParallelism(PARLLELISM);
@@ -93,14 +92,11 @@ public class CustomSerializationITCase extends TestLogger {
                                                     .getMessage()
                                                     .contains("broken serialization."))
                             .isPresent());
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail(e.getMessage());
         }
     }
 
     @Test
-    public void testIncorrectSerializer2() {
+    public void testIncorrectSerializer2() throws Exception {
         try {
             StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
             env.setParallelism(PARLLELISM);
@@ -126,14 +122,11 @@ public class CustomSerializationITCase extends TestLogger {
                                                     .getMessage()
                                                     .contains("broken serialization."))
                             .isPresent());
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail(e.getMessage());
         }
     }
 
     @Test
-    public void testIncorrectSerializer3() {
+    public void testIncorrectSerializer3() throws Exception {
         try {
             StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
             env.setParallelism(PARLLELISM);
@@ -159,14 +152,11 @@ public class CustomSerializationITCase extends TestLogger {
                                                     .getMessage()
                                                     .contains("broken serialization."))
                             .isPresent());
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail(e.getMessage());
         }
     }
 
     @Test
-    public void testIncorrectSerializer4() {
+    public void testIncorrectSerializer4() throws Exception {
         try {
             StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
             env.setParallelism(PARLLELISM);
@@ -192,9 +182,6 @@ public class CustomSerializationITCase extends TestLogger {
                                                     .getMessage()
                                                     .contains("broken serialization."))
                             .isPresent());
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail(e.getMessage());
         }
     }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
@@ -226,13 +226,11 @@ abstract class AbstractTaskManagerProcessFailureRecoveryTest {
 
             // all seems well :-)
         } catch (Exception e) {
-            e.printStackTrace();
             printProcessLog("TaskManager 1", taskManagerProcess1);
             printProcessLog("TaskManager 2", taskManagerProcess2);
             printProcessLog("TaskManager 3", taskManagerProcess3);
-            fail(e.getMessage());
+            throw e;
         } catch (Error e) {
-            e.printStackTrace();
             printProcessLog("TaskManager 1", taskManagerProcess1);
             printProcessLog("TaskManager 2", taskManagerProcess2);
             printProcessLog("TaskManager 3", taskManagerProcess3);

--- a/flink-tests/src/test/java/org/apache/flink/test/state/StateHandleSerializationTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/StateHandleSerializationTest.java
@@ -36,22 +36,17 @@ import static org.junit.Assert.fail;
 public class StateHandleSerializationTest {
 
     @Test
-    public void ensureStateHandlesHaveSerialVersionUID() {
-        try {
-            Reflections reflections = new Reflections("org.apache.flink");
+    public void ensureStateHandlesHaveSerialVersionUID() throws Exception {
+        Reflections reflections = new Reflections("org.apache.flink");
 
-            // check all state handles
+        // check all state handles
 
-            @SuppressWarnings("unchecked")
-            Set<Class<?>> stateHandleImplementations =
-                    (Set<Class<?>>) (Set<?>) reflections.getSubTypesOf(StateObject.class);
+        @SuppressWarnings("unchecked")
+        Set<Class<?>> stateHandleImplementations =
+                (Set<Class<?>>) (Set<?>) reflections.getSubTypesOf(StateObject.class);
 
-            for (Class<?> clazz : stateHandleImplementations) {
-                validataSerialVersionUID(clazz);
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail(e.getMessage());
+        for (Class<?> clazz : stateHandleImplementations) {
+            validataSerialVersionUID(clazz);
         }
     }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/PartitionerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/PartitionerITCase.java
@@ -80,7 +80,7 @@ public class PartitionerITCase extends AbstractTestBaseJUnit4 {
     }
 
     @Test
-    public void partitionerTest() {
+    public void partitionerTest() throws Exception {
 
         TestListResultSink<Tuple2<Integer, String>> hashPartitionResultSink =
                 new TestListResultSink<Tuple2<Integer, String>>();
@@ -145,12 +145,7 @@ public class PartitionerITCase extends AbstractTestBaseJUnit4 {
         // partition global
         src.global().map(new SubtaskIndexAssigner()).addSink(globalPartitionResultSink);
 
-        try {
-            env.execute();
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        }
+        env.execute();
 
         List<Tuple2<Integer, String>> hashPartitionResult = hashPartitionResultSink.getResult();
         List<Tuple2<Integer, String>> customPartitionResult = customPartitionResultSink.getResult();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/FLINK-38488

Currently we have some tests using following patter:
```java
try {
  doTestSomething();
  ...
} catch (Exception e) {
  e.printStackTrace();
  fail(e.getMessage());
}
```
This can be replaced by just throwing Exceptions in test and let JUnit handles the failure along with exception stack trace. The existing code loses stack trace information in test reports, and we need to look around in the stdout to guess.

As we can see other tests in Flink uses the "throws Exception" model:

  - The framework provides better formatting and integration with IDEs and CI systems
  - Test runners can distinguish between assertion failures and unexpected exceptions
 - Test logic is more readable without exception handling noise