### PR TITLE
[FLINK-38584][metrics] Support checkpoint path as Prometheus info-style metric

### DIFF
--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/AbstractPrometheusReporter.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/AbstractPrometheusReporter.java
@@ -196,6 +196,12 @@ public abstract class AbstractPrometheusReporter implements MetricReporter {
     }
 
     private void addMetric(Metric metric, List<String> dimensionValues, Collector collector) {
+        // CheckpointPathInfoCollector doesn't need addChild - it reads directly from the gauge
+        if (collector instanceof CheckpointPathInfoCollector) {
+            // No-op: CheckpointPathInfoCollector reads the value directly in collect()
+            return;
+        }
+
         switch (metric.getMetricType()) {
             case GAUGE:
                 ((io.prometheus.client.Gauge) collector)
@@ -220,6 +226,12 @@ public abstract class AbstractPrometheusReporter implements MetricReporter {
     }
 
     private void removeMetric(Metric metric, List<String> dimensionValues, Collector collector) {
+        // CheckpointPathInfoCollector doesn't need remove - it reads directly from the gauge
+        if (collector instanceof CheckpointPathInfoCollector) {
+            // No-op: CheckpointPathInfoCollector reads the value directly in collect()
+            return;
+        }
+
         switch (metric.getMetricType()) {
             case GAUGE:
                 ((io.prometheus.client.Gauge) collector).remove(toArray(dimensionValues));

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/AbstractPrometheusReporter.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/AbstractPrometheusReporter.java
@@ -61,6 +61,7 @@ public abstract class AbstractPrometheusReporter implements MetricReporter {
 
     @VisibleForTesting static final char SCOPE_SEPARATOR = '_';
     @VisibleForTesting static final String SCOPE_PREFIX = "flink" + SCOPE_SEPARATOR;
+    private static final String CHECKPOINT_PATH_METRIC_NAME = "lastCheckpointExternalPath";
 
     private final Map<String, AbstractMap.SimpleImmutableEntry<Collector, Integer>>
             collectorsWithCountByMetricName = new HashMap<>();
@@ -153,31 +154,43 @@ public abstract class AbstractPrometheusReporter implements MetricReporter {
             String scopedMetricName,
             String helpString) {
         Collector collector;
-        switch (metric.getMetricType()) {
-            case GAUGE:
-            case COUNTER:
-            case METER:
-                collector =
-                        io.prometheus.client.Gauge.build()
-                                .name(scopedMetricName)
-                                .help(helpString)
-                                .labelNames(toArray(dimensionKeys))
-                                .create();
-                break;
-            case HISTOGRAM:
-                collector =
-                        new HistogramSummaryProxy(
-                                (Histogram) metric,
-                                scopedMetricName,
-                                helpString,
-                                dimensionKeys,
-                                dimensionValues);
-                break;
-            default:
-                log.warn(
-                        "Cannot create collector for unknown metric type: {}. This indicates that the metric type is not supported by this reporter.",
-                        metric.getClass().getName());
-                collector = null;
+
+        // Special handling for checkpoint path metric - export as info-style metric
+        if (scopedMetricName.endsWith(CHECKPOINT_PATH_METRIC_NAME)) {
+            // Add _info suffix to follow Prometheus naming convention for info metrics
+            String infoMetricName = scopedMetricName + "_info";
+            @SuppressWarnings("unchecked")
+            Gauge<String> pathGauge = (Gauge<String>) metric;
+            collector =
+                    new CheckpointPathInfoCollector(
+                            pathGauge, infoMetricName, helpString, dimensionKeys, dimensionValues);
+        } else {
+            switch (metric.getMetricType()) {
+                case GAUGE:
+                case COUNTER:
+                case METER:
+                    collector =
+                            io.prometheus.client.Gauge.build()
+                                    .name(scopedMetricName)
+                                    .help(helpString)
+                                    .labelNames(toArray(dimensionKeys))
+                                    .create();
+                    break;
+                case HISTOGRAM:
+                    collector =
+                            new HistogramSummaryProxy(
+                                    (Histogram) metric,
+                                    scopedMetricName,
+                                    helpString,
+                                    dimensionKeys,
+                                    dimensionValues);
+                    break;
+                default:
+                    log.warn(
+                            "Cannot create collector for unknown metric type: {}. This indicates that the metric type is not supported by this reporter.",
+                            metric.getClass().getName());
+                    collector = null;
+            }
         }
         return collector;
     }
@@ -389,5 +402,69 @@ public abstract class AbstractPrometheusReporter implements MetricReporter {
 
     private static String[] toArray(List<String> list) {
         return list.toArray(new String[list.size()]);
+    }
+
+    /**
+     * Collector for checkpoint path metrics that exports them as Prometheus info-style metrics.
+     *
+     * <p>This collector is specifically designed for the lastCheckpointExternalPath metric. Instead
+     * of exporting the path as a metric value (which would be meaningless as a number), it exports
+     * the path as a label value with the metric value always set to 1.0. This follows the
+     * Prometheus convention for info-style metrics.
+     *
+     * <p>Example output: {@code
+     * flink_jobmanager_job_lastCheckpointExternalPath_info{host="...",job_id="...",path="hdfs://..."}
+     * 1.0 }
+     */
+    static class CheckpointPathInfoCollector extends Collector {
+        private final Gauge<String> checkpointPathGauge;
+        private final String metricName;
+        private final String helpString;
+        private final List<String> labelNames;
+        private final List<String> labelValues;
+
+        CheckpointPathInfoCollector(
+                Gauge<String> checkpointPathGauge,
+                String metricName,
+                String helpString,
+                List<String> labelNames,
+                List<String> labelValues) {
+            this.checkpointPathGauge = checkpointPathGauge;
+            this.metricName = metricName;
+            this.helpString = helpString;
+
+            // Add "path" as an additional label
+            this.labelNames = new ArrayList<>(labelNames);
+            this.labelNames.add("path");
+
+            this.labelValues = new ArrayList<>(labelValues);
+        }
+
+        @Override
+        public List<MetricFamilySamples> collect() {
+            // Get the current checkpoint path from the gauge
+            String checkpointPath = checkpointPathGauge.getValue();
+
+            // If path is null or empty, don't export any samples
+            if (checkpointPath == null || checkpointPath.isEmpty()) {
+                return Collections.emptyList();
+            }
+
+            // Create label values including the checkpoint path
+            List<String> sampleLabelValues = new ArrayList<>(labelValues);
+            sampleLabelValues.add(checkpointPath);
+
+            // Create a sample with value 1.0 (info-style metric)
+            MetricFamilySamples.Sample sample =
+                    new MetricFamilySamples.Sample(
+                            metricName, labelNames, sampleLabelValues, 1.0);
+
+            // Create and return the metric family
+            MetricFamilySamples metricFamilySamples =
+                    new MetricFamilySamples(
+                            metricName, Type.GAUGE, helpString, Collections.singletonList(sample));
+
+            return Collections.singletonList(metricFamilySamples);
+        }
     }
 }

--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/CheckpointPathInfoCollectorTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/CheckpointPathInfoCollectorTest.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.metrics.prometheus;
+
+import org.apache.flink.metrics.Gauge;
+
+import io.prometheus.client.Collector;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link AbstractPrometheusReporter.CheckpointPathInfoCollector}. */
+class CheckpointPathInfoCollectorTest {
+
+    @Test
+    void testCheckpointPathExportedAsInfoMetric() {
+        // Given: A checkpoint path gauge
+        final String checkpointPath = "hdfs://namenode:8020/flink/checkpoints/job123/chk-456";
+        Gauge<String> pathGauge = () -> checkpointPath;
+
+        List<String> labelNames = Arrays.asList("host", "job_id");
+        List<String> labelValues = Arrays.asList("localhost", "test_job");
+
+        // When: Creating the collector
+        AbstractPrometheusReporter.CheckpointPathInfoCollector collector =
+                new AbstractPrometheusReporter.CheckpointPathInfoCollector(
+                        pathGauge, "test_metric_info", "Test metric", labelNames, labelValues);
+
+        // Then: Collect samples
+        List<Collector.MetricFamilySamples> samples = collector.collect();
+
+        assertThat(samples).hasSize(1);
+        Collector.MetricFamilySamples family = samples.get(0);
+        assertThat(family.name).isEqualTo("test_metric_info");
+        assertThat(family.type).isEqualTo(Collector.Type.GAUGE);
+        assertThat(family.samples).hasSize(1);
+
+        Collector.MetricFamilySamples.Sample sample = family.samples.get(0);
+        assertThat(sample.name).isEqualTo("test_metric_info");
+        assertThat(sample.value).isEqualTo(1.0);
+
+        // Verify labels include the path
+        assertThat(sample.labelNames).contains("path");
+        assertThat(sample.labelValues).contains(checkpointPath);
+        assertThat(sample.labelNames).contains("host");
+        assertThat(sample.labelValues).contains("localhost");
+        assertThat(sample.labelNames).contains("job_id");
+        assertThat(sample.labelValues).contains("test_job");
+    }
+
+    @Test
+    void testNullCheckpointPathReturnsEmptyList() {
+        // Given: A gauge returning null
+        Gauge<String> pathGauge = () -> null;
+
+        // When: Creating the collector
+        AbstractPrometheusReporter.CheckpointPathInfoCollector collector =
+                new AbstractPrometheusReporter.CheckpointPathInfoCollector(
+                        pathGauge,
+                        "test_metric_info",
+                        "Test metric",
+                        Collections.emptyList(),
+                        Collections.emptyList());
+
+        // Then: Should return empty list
+        List<Collector.MetricFamilySamples> samples = collector.collect();
+        assertThat(samples).isEmpty();
+    }
+
+    @Test
+    void testEmptyCheckpointPathReturnsEmptyList() {
+        // Given: A gauge returning empty string
+        Gauge<String> pathGauge = () -> "";
+
+        // When: Creating the collector
+        AbstractPrometheusReporter.CheckpointPathInfoCollector collector =
+                new AbstractPrometheusReporter.CheckpointPathInfoCollector(
+                        pathGauge,
+                        "test_metric_info",
+                        "Test metric",
+                        Collections.emptyList(),
+                        Collections.emptyList());
+
+        // Then: Should return empty list
+        List<Collector.MetricFamilySamples> samples = collector.collect();
+        assertThat(samples).isEmpty();
+    }
+
+    @Test
+    void testCheckpointPathWithSpecialCharacters() {
+        // Given: A checkpoint path with special characters
+        final String checkpointPath =
+                "s3://my-bucket/flink/checkpoints/job_123/chk-456?version=1";
+        Gauge<String> pathGauge = () -> checkpointPath;
+
+        List<String> labelNames = Arrays.asList("job_name");
+        List<String> labelValues = Arrays.asList("my_job");
+
+        // When: Creating the collector
+        AbstractPrometheusReporter.CheckpointPathInfoCollector collector =
+                new AbstractPrometheusReporter.CheckpointPathInfoCollector(
+                        pathGauge, "test_metric_info", "Test metric", labelNames, labelValues);
+
+        // Then: Path should be preserved as-is in the label
+        List<Collector.MetricFamilySamples> samples = collector.collect();
+        assertThat(samples).hasSize(1);
+
+        Collector.MetricFamilySamples.Sample sample = samples.get(0).samples.get(0);
+        assertThat(sample.labelValues).contains(checkpointPath);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This pull request enhances the Prometheus reporter to export the `lastCheckpointExternalPath` metric as an info-style metric, making it compatible with Prometheus and VictoriaMetrics.

**Current Problem:**
- The `lastCheckpointExternalPath` metric is currently exported as a string-valued Gauge
- Prometheus and VictoriaMetrics only support numeric values, making it impossible to store checkpoint paths
- Users must use additional storage systems (e.g., InfluxDB) to track checkpoint paths, increasing operational complexity

**Solution:**
- Export `lastCheckpointExternalPath` as a Prometheus info-style metric with `_info` suffix
- Store the checkpoint path in a `path` label instead of as a metric value
- Set the metric value to 1.0 (following Prometheus convention for info metrics)

This approach follows Prometheus best practices (similar to `node_uname_info` from node_exporter) and enables users to:
1. Store checkpoint paths directly in Prometheus/VictoriaMetrics
2. Join checkpoint paths with other checkpoint metrics via PromQL
3. Create monitoring dashboards and alerts based on checkpoint paths


## Brief change log

- Added `CHECKPOINT_PATH_METRIC_NAME` constant to identify the checkpoint path metric
- Modified [createCollector()](cci:1://file:///Users/lihaopeng/IdeaProjects/bigdata-hadoop3-flink-src/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/AbstractPrometheusReporter.java:153:4-195:5) method in [AbstractPrometheusReporter](cci:2://file:///Users/lihaopeng/IdeaProjects/bigdata-hadoop3-flink-src/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/AbstractPrometheusReporter.java:53:0-460:1) to detect and handle checkpoint path metrics specially
- Added [CheckpointPathInfoCollector](cci:2://file:///Users/lihaopeng/IdeaProjects/bigdata-hadoop3-flink-src/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/CheckpointPathInfoCollector.java:40:0-91:1) inner class to export checkpoint path as an info-style metric
  - Appends `_info` suffix to the metric name
  - Stores checkpoint path in a `path` label
  - Sets metric value to 1.0
  - Handles null and empty path values gracefully
- Added comprehensive unit tests in [CheckpointPathInfoCollectorTest](cci:2://file:///Users/lihaopeng/IdeaProjects/bigdata-hadoop3-flink-src/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/CheckpointPathInfoCollectorTest.java:44:0-324:1) with 4 test cases


## Verifying this change

This change added tests and can be verified as follows:

**Unit Tests:**
- Added [CheckpointPathInfoCollectorTest](cci:2://file:///Users/lihaopeng/IdeaProjects/bigdata-hadoop3-flink-src/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/CheckpointPathInfoCollectorTest.java:44:0-324:1) with 4 test cases:
  - [testCheckpointPathExportedAsInfoMetric](cci:1://file:///Users/lihaopeng/IdeaProjects/sohurdc/flink/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/CheckpointPathInfoCollectorTest.java:34:4-68:5): Verifies checkpoint path is correctly exported as an info metric with path in label
  - [testNullCheckpointPathReturnsEmptyList](cci:1://file:///Users/lihaopeng/IdeaProjects/bigdata-hadoop3-flink-src/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/CheckpointPathInfoCollectorTest.java:76:4-93:5): Verifies null path values are handled correctly (returns empty list)
  - [testEmptyCheckpointPathReturnsEmptyList](cci:1://file:///Users/lihaopeng/IdeaProjects/bigdata-hadoop3-flink-src/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/CheckpointPathInfoCollectorTest.java:95:4-112:5): Verifies empty string path values are handled correctly
  - [testCheckpointPathWithSpecialCharacters](cci:1://file:///Users/lihaopeng/IdeaProjects/bigdata-hadoop3-flink-src/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/CheckpointPathInfoCollectorTest.java:114:4-138:5): Verifies special characters in paths (e.g., S3 URLs with query parameters) are preserved correctly

**Integration Verification:**
All existing Prometheus reporter tests pass (27/27 tests):
- [PrometheusReporterTest](cci:2://file:///Users/lihaopeng/IdeaProjects/bigdata-hadoop3-flink-src/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java:61:0-417:1): 14 tests
- `PrometheusReporterTaskScopeTest`: 5 tests
- `PrometheusPushGatewayReporterTest`: 4 tests
- [CheckpointPathInfoCollectorTest](cci:2://file:///Users/lihaopeng/IdeaProjects/bigdata-hadoop3-flink-src/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/CheckpointPathInfoCollectorTest.java:44:0-324:1): 4 tests (new)

**Manual Verification:**
The change can be manually verified by:
1. Starting a Flink cluster with Prometheus reporter enabled
2. Running a job with checkpointing enabled
3. Querying the Prometheus metrics endpoint (e.g., `curl http://localhost:9249/metrics`)
4. Verifying the output contains:
   ```
   flink_jobmanager_job_lastCheckpointExternalPath_info{job_id="...",job_name="...",path="hdfs://..."} 1.0
   ```
5. Using PromQL to join with other metrics:
   ```promql
   flink_jobmanager_job_lastCheckpointSize 
     * on(job_id) group_left(path) 
     flink_jobmanager_job_lastCheckpointExternalPath_info
   ```


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no** (only affects metric reporting, not checkpoint functionality)
  - The S3 file system connector: **no**


## Documentation

  - Does this pull request introduce a new feature? **yes**
  - If yes, how is the feature documented? **JavaDocs**
  
**Documentation Details:**
- Comprehensive JavaDoc added to [CheckpointPathInfoCollector](cci:2://file:///Users/lihaopeng/IdeaProjects/bigdata-hadoop3-flink-src/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/CheckpointPathInfoCollector.java:40:0-91:1) class explaining:
  - Purpose: Export checkpoint path as Prometheus info-style metric
  - Behavior: Path stored in label, value always 1.0
  - Example output format
- Inline code comments explaining the special handling logic
- Unit test documentation demonstrating usage patterns

**Additional Documentation (if requested):**
If the community requires, I can add documentation to `docs/content/docs/deployment/metric_reporters.md` explaining:
- The info-style metric format for checkpoint paths
- PromQL query examples for joining with other metrics
- Use cases for monitoring and alerting
```

