### PR TITLE
[FLINK-38592] Initial Native Flink S3 FileSystem

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/FSDataOutputStream.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FSDataOutputStream.java
@@ -42,6 +42,11 @@ import java.io.OutputStream;
  * Instances of {@code FSDataOutputStream} should not be passed between threads, because there are
  * no guarantees about the order of visibility of operations across threads.
  *
+ * <p><b>Exception:</b> The {@link #close()} method may be called from a thread other than the
+ * writing thread (for example, during task cancellation). Implementations should ensure that {@code
+ * close()} can be safely invoked concurrently with ongoing write operations, typically by guarding
+ * shared mutable state with a lock. See {@link RecoverableFsDataOutputStream} for details.
+ *
  * @see FileSystem
  * @see FSDataInputStream
  */

--- a/flink-core/src/main/java/org/apache/flink/core/fs/RecoverableFsDataOutputStream.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/RecoverableFsDataOutputStream.java
@@ -46,13 +46,19 @@ public abstract class RecoverableFsDataOutputStream extends FSDataOutputStream {
     public abstract Committer closeForCommit() throws IOException;
 
     /**
-     * Closes this stream. Closing the steam releases the local resources that the stream uses, but
+     * Closes this stream. Closing the stream releases the local resources that the stream uses, but
      * does NOT result in durability of previously written data. This method should be interpreted
      * as a "close in order to dispose" or "close on failure".
      *
      * <p>In order to persist all previously written data, one needs to call the {@link
      * #closeForCommit()} method and call {@link Committer#commit()} on the returned committer
      * object.
+     *
+     * <p><b>Thread safety:</b> Unlike other methods on this stream, {@code close()} may be invoked
+     * from a different thread than the one performing writes (for example, during task cancellation
+     * or abort). Implementations must ensure that {@code close()} safely releases local resources
+     * (temp files, streams) without corrupting any already-persisted state, even when called
+     * concurrently with {@link #closeForCommit()} or {@link #persist()}.
      *
      * @throws IOException Thrown if an error occurred during closing.
      */

--- a/flink-filesystems/flink-s3-fs-native/README.md
+++ b/flink-filesystems/flink-s3-fs-native/README.md
@@ -1,0 +1,390 @@
+# Native S3 FileSystem
+
+This module provides a native S3 filesystem implementation for Apache Flink using AWS SDK v2.
+
+## Overview
+
+The Native S3 FileSystem is a direct implementation of Flink's FileSystem interface using AWS SDK v2, without Hadoop dependencies. It provides exactly-once semantics for checkpointing and file sinks through S3 multipart uploads.
+
+## Supported URI Schemes
+
+This module supports both `s3://` and `s3a://` URI schemes:
+
+| Scheme | Description |
+|--------|-------------|
+| `s3://` | Primary scheme for native S3 filesystem |
+| `s3a://` | Hadoop S3A compatibility scheme - allows drop-in replacement for existing Hadoop-based configurations |
+
+Both schemes use the same native AWS SDK v2 implementation and share identical configuration options.
+
+**Example usage with either scheme:**
+
+```java
+// Using s3:// scheme
+env.getCheckpointConfig().setCheckpointStorage("s3://my-bucket/checkpoints");
+
+// Using s3a:// scheme (for Hadoop compatibility)
+env.getCheckpointConfig().setCheckpointStorage("s3a://my-bucket/checkpoints");
+```
+
+## Usage
+
+Add this module to Flink's plugins directory:
+
+```bash
+mkdir -p $FLINK_HOME/plugins/s3-fs-native
+cp flink-s3-fs-native-*.jar $FLINK_HOME/plugins/s3-fs-native/
+```
+
+Configure S3 credentials in `conf/config.yaml`:
+
+```yaml
+s3.access-key: YOUR_ACCESS_KEY
+s3.secret-key: YOUR_SECRET_KEY
+s3.endpoint: https://s3.amazonaws.com  # Optional, defaults to AWS
+```
+
+Use S3 paths in your Flink application:
+
+```java
+env.getCheckpointConfig().setCheckpointStorage("s3://my-bucket/checkpoints");
+
+DataStream<String> input = env.readTextFile("s3://my-bucket/input");
+input.sinkTo(FileSink.forRowFormat(new Path("s3://my-bucket/output"), 
+                                    new SimpleStringEncoder<>()).build());
+```
+
+## Configuration Options
+
+### Core Settings
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| s3.access-key | (none) | AWS access key |
+| s3.secret-key | (none) | AWS secret key |
+| s3.region | (auto-detect) | AWS region (auto-detected via AWS_REGION, ~/.aws/config, EC2 metadata) |
+| s3.endpoint | (none) | Custom S3 endpoint (for MinIO, LocalStack, etc.) |
+| s3.path-style-access | false | Use path-style access (auto-enabled for custom endpoints) |
+| s3.upload.min.part.size | 5242880 | Minimum part size for multipart uploads (5MB) |
+| s3.upload.max.concurrent.uploads | CPU cores | Maximum concurrent uploads per stream |
+| s3.entropy.key | (none) | Key for entropy injection in paths |
+| s3.entropy.length | 4 | Length of entropy string |
+| s3.bulk-copy.enabled | true | Enable bulk copy operations |
+| s3.async.enabled | true | Enable async read/write with TransferManager |
+| s3.read.buffer.size | 262144 (256KB) | Read buffer size per stream (64KB - 4MB) |
+
+### Server-Side Encryption (SSE)
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| s3.sse.type | none | Encryption type: `none`, `sse-s3` (AES256), `sse-kms` (AWS KMS) |
+| s3.sse.kms.key-id | (none) | KMS key ID/ARN/alias for SSE-KMS (uses default aws/s3 key if not specified) |
+
+### IAM Assume Role
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| s3.assume-role.arn | (none) | ARN of the IAM role to assume |
+| s3.assume-role.external-id | (none) | External ID for cross-account access |
+| s3.assume-role.session-name | flink-s3-session | Session name for the assumed role |
+| s3.assume-role.session-duration | 3600 | Session duration in seconds (900-43200) |
+
+## Server-Side Encryption (SSE)
+
+The filesystem supports server-side encryption for data at rest:
+
+### SSE-S3 (S3-Managed Keys)
+
+Amazon S3 manages the encryption keys. Simplest option with no additional configuration.
+
+```yaml
+s3.sse.type: sse-s3
+```
+
+All objects will be encrypted with AES-256 using keys managed by S3.
+
+### SSE-KMS (AWS KMS-Managed Keys)
+
+Use AWS Key Management Service for encryption key management. Provides additional security features like key rotation, audit trails, and fine-grained access control.
+
+**Using the default aws/s3 key:**
+```yaml
+s3.sse.type: sse-kms
+```
+
+**Using a custom KMS key:**
+```yaml
+s3.sse.type: sse-kms
+s3.sse.kms.key-id: arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789abc
+# Or use an alias:
+# s3.sse.kms.key-id: alias/my-s3-encryption-key
+```
+
+**Using encryption context (for fine-grained IAM access control):**
+
+Encryption context allows you to add additional authenticated data (AAD) to KMS encrypt/decrypt operations.
+This enables IAM policies to restrict access based on context values:
+
+```yaml
+s3.sse.type: sse-kms
+s3.sse.kms.key-id: alias/my-key
+# Configure encryption context as key-value pairs
+s3.sse.kms.encryption-context.department: finance
+s3.sse.kms.encryption-context.project: budget-reports
+```
+
+With encryption context, you can create IAM policies like:
+```json
+{
+  "Effect": "Allow",
+  "Action": ["kms:Encrypt", "kms:GenerateDataKey"],
+  "Resource": "arn:aws:kms:region:account:key/key-id",
+  "Condition": {
+    "StringEquals": {
+      "kms:EncryptionContext:department": "finance"
+    }
+  }
+}
+```
+
+See [AWS KMS Encryption Context](https://docs.aws.amazon.com/kms/latest/developerguide/encrypt_context.html) for more details.
+
+**Note:** Ensure the IAM role/user has `kms:Encrypt` and `kms:GenerateDataKey` permissions on the KMS key.
+
+## IAM Assume Role
+
+For cross-account access or temporary elevated permissions, configure an IAM role to assume:
+
+### Basic Assume Role
+
+```yaml
+s3.assume-role.arn: arn:aws:iam::123456789012:role/S3AccessRole
+```
+
+### Cross-Account Access with External ID
+
+For enhanced security when granting access to third parties:
+
+```yaml
+s3.assume-role.arn: arn:aws:iam::123456789012:role/CrossAccountS3Role
+s3.assume-role.external-id: your-secret-external-id
+s3.assume-role.session-name: flink-cross-account-session
+s3.assume-role.session-duration: 3600  # 1 hour
+```
+
+### How It Works
+
+1. Flink uses base credentials (access key, environment, or IAM role) to call STS AssumeRole
+2. STS returns temporary credentials (access key, secret key, session token)
+3. All S3 operations use the assumed role's permissions
+4. Credentials are automatically refreshed before expiration
+
+**IAM Policy Example for the Assumed Role:**
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::my-bucket",
+        "arn:aws:s3:::my-bucket/*"
+      ]
+    }
+  ]
+}
+```
+
+**Trust Policy for Cross-Account Access:**
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::SOURCE_ACCOUNT_ID:root"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "sts:ExternalId": "your-secret-external-id"
+        }
+      }
+    }
+  ]
+}
+```
+
+## MinIO and S3-Compatible Storage
+
+The filesystem auto-detects custom endpoints and configures appropriate settings:
+
+```yaml
+s3.access-key: minioadmin
+s3.secret-key: minioadmin  
+s3.endpoint: http://localhost:9000
+s3.path-style-access: true  # Auto-enabled for custom endpoints
+```
+
+MinIO-specific optimizations are applied automatically:
+- Path-style access enabled
+- Chunked encoding disabled (compatibility)
+- Checksum validation disabled (compatibility)
+
+## Memory Optimization for Large Files
+
+The filesystem is optimized to handle large files without OOM errors:
+
+### Streaming Reads (No Buffering)
+- Files are **streamed** chunk-by-chunk, not loaded into memory
+- Configurable read buffer (default 256KB) prevents memory spikes
+- Only small buffer held in memory at any time
+
+### Configuration for Memory Efficiency
+
+```yaml
+# Read buffer: smaller = less memory, larger = better throughput
+s3.read.buffer.size: 262144  # 256KB (default)
+# For memory-constrained environments: 65536 (64KB)
+# For high-throughput: 1048576 (1MB)
+```
+
+**Memory Calculation Per Parallel Read:**
+- Buffer size × concurrent reads = total memory
+- Example: 256KB buffer × 16 parallel readers = 4MB total
+- This allows processing GB-sized files with MB-sized memory
+
+### OOM Prevention Strategies
+
+1. **Use smaller read buffers** (64-128KB) for very large files
+2. **Reduce parallelism** to limit concurrent S3 readers
+3. **Allocate sufficient JVM heap** for FS operations
+4. **Monitor**: `s3.read.buffer.size` × `parallelism` = peak FS memory
+
+**Important Note on Memory Types:**
+- The filesystem uses **JVM heap memory** for read/write buffers
+- This is separate from RocksDB's **managed native memory** used for state backend
+- Flink's `taskmanager.memory.managed.size` controls RocksDB native memory, NOT filesystem buffers
+- Increase JVM heap (`taskmanager.memory.task.heap.size`) if you see OOM errors during S3 operations
+
+## Async Operations with TransferManager
+
+The filesystem uses AWS SDK's TransferManager for high-performance async read/write operations:
+
+**Benefits:**
+- **Automatic multipart management**: TransferManager automatically handles multipart uploads for large files
+- **Parallel transfers**: Multiple parts uploaded concurrently for maximum throughput  
+- **Progress tracking**: Built-in progress monitoring and retry logic
+- **Resource optimization**: Efficient connection pooling and memory management
+- **Streaming uploads**: Data streamed from disk, not buffered in memory
+
+**Configuration:**
+```yaml
+s3.async.enabled: true  # Default: enabled
+```
+
+When enabled, file uploads automatically use TransferManager for:
+- Large file uploads (automatic multipart handling)
+- Checkpoint data writes
+- Recoverable output stream operations
+
+**Performance Impact:**
+- Up to 10x faster uploads for large files (>100MB)
+- **Reduced memory pressure** through streaming
+- Better utilization of available bandwidth
+- Lower heap requirements for write operations
+
+## Checkpointing
+
+Configure checkpoint storage in `conf/config.yaml`:
+
+```yaml
+state.checkpoints.dir: s3://my-bucket/checkpoints
+execution.checkpointing.interval: 10s
+execution.checkpointing.mode: EXACTLY_ONCE
+```
+
+Or programmatically:
+
+```java
+env.enableCheckpointing(10000);
+env.getCheckpointConfig().setCheckpointStorage("s3://my-bucket/checkpoints");
+```
+
+## Entropy Injection
+
+For high-throughput checkpointing to avoid S3 hot partitions:
+
+```yaml
+s3.entropy.key: _entropy_
+s3.entropy.length: 4
+```
+
+Paths like `s3://bucket/_entropy_/checkpoints` will be expanded to `s3://bucket/af7e/checkpoints` with random characters.
+
+## Implementation Details
+
+The filesystem uses:
+- **AWS SDK v2** for all S3 operations
+- **Multipart uploads** for recoverable writes and large files
+- **S3 Transfer Manager** for bulk copy operations  
+- **Separate sync and async clients** for optimal performance
+
+Key classes:
+- `NativeS3FileSystem` - Main FileSystem implementation
+- `NativeS3RecoverableWriter` - Exactly-once writer using multipart uploads
+- `S3ClientProvider` - Manages S3 client lifecycle
+- `NativeS3AccessHelper` - Low-level S3 operations
+
+## Building
+
+```bash
+mvn clean package
+```
+
+## Testing with MinIO
+
+```bash
+# Start MinIO
+docker run -d -p 9000:9000 -p 9001:9001 \
+  -e "MINIO_ROOT_USER=minioadmin" \
+  -e "MINIO_ROOT_PASSWORD=minioadmin" \
+  minio/minio server /data --console-address ":9001"
+
+# Create bucket
+mc alias set local http://localhost:9000 minioadmin minioadmin
+mc mb local/test-bucket
+
+# Run Flink with MinIO
+export FLINK_HOME=/path/to/flink
+cat > $FLINK_HOME/conf/config.yaml <<EOF
+s3.endpoint: http://localhost:9000
+s3.access-key: minioadmin
+s3.secret-key: minioadmin
+s3.path-style-access: true
+EOF
+
+$FLINK_HOME/bin/flink run YourJob.jar
+```
+
+## Delegation Tokens
+
+The filesystem supports delegation tokens for secure multi-tenant deployments. The delegation token service name is `s3-native` to avoid conflicts with other S3 filesystem implementations.
+
+Configure delegation tokens:
+
+```yaml
+security.delegation.token.provider.s3-native.enabled: true
+security.delegation.token.provider.s3-native.access-key: YOUR_KEY
+security.delegation.token.provider.s3-native.secret-key: YOUR_SECRET
+security.delegation.token.provider.s3-native.region: us-east-1
+```

--- a/flink-filesystems/flink-s3-fs-native/pom.xml
+++ b/flink-filesystems/flink-s3-fs-native/pom.xml
@@ -1,0 +1,226 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.apache.flink</groupId>
+		<artifactId>flink-filesystems</artifactId>
+		<version>2.3-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>flink-s3-fs-native</artifactId>
+	<name>Flink : FileSystems : S3 FS Native</name>
+	<packaging>jar</packaging>
+
+	<properties>
+		<fs.s3.aws.sdk.version>2.41.34</fs.s3.aws.sdk.version>
+		<japicmp.skip>true</japicmp.skip>
+		<surefire.module.config>--add-opens=java.base/java.util=ALL-UNNAMED</surefire.module.config>
+	</properties>
+
+	<dependencies>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-core</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-architecture-tests-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>s3</artifactId>
+			<version>${fs.s3.aws.sdk.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
+		</dependency>
+
+		<!-- S3 Transfer Manager for async/high-throughput transfers -->
+		<dependency>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>s3-transfer-manager</artifactId>
+			<version>${fs.s3.aws.sdk.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>sts</artifactId>
+			<version>${fs.s3.aws.sdk.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
+		</dependency>
+
+		<!-- Netty async HTTP client (required for Transfer Manager) -->
+		<dependency>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>netty-nio-client</artifactId>
+			<version>${fs.s3.aws.sdk.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
+		</dependency>
+
+		<!-- Apache HTTP client for sync operations -->
+		<dependency>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>apache-client</artifactId>
+			<version>${fs.s3.aws.sdk.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-runtime</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-runtime</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.curator</groupId>
+			<artifactId>curator-test</artifactId>
+			<version>${curator.version}</version>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>com.google.guava</groupId>
+					<artifactId>guava</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>testcontainers</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>shade-flink</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<artifactSet>
+								<includes>
+									<include>software.amazon.awssdk:*</include>
+									<include>org.apache.httpcomponents:*</include>
+									<include>commons-logging:*</include>
+									<include>org.reactivestreams:*</include>
+									<include>io.netty:*</include>
+									<include>com.typesafe.netty:*</include>
+								</includes>
+							</artifactSet>
+							<relocations>
+								<relocation>
+									<pattern>software.amazon.awssdk</pattern>
+									<shadedPattern>org.apache.flink.fs.s3native.shaded.software.amazon.awssdk</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.apache.http</pattern>
+									<shadedPattern>org.apache.flink.fs.s3native.shaded.org.apache.http</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.apache.commons.logging</pattern>
+									<shadedPattern>org.apache.flink.fs.s3native.shaded.org.apache.commons.logging</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>io.netty</pattern>
+									<shadedPattern>org.apache.flink.fs.s3native.shaded.io.netty</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>com.typesafe.netty</pattern>
+									<shadedPattern>org.apache.flink.fs.s3native.shaded.com.typesafe.netty</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.reactivestreams</pattern>
+									<shadedPattern>org.apache.flink.fs.s3native.shaded.org.reactivestreams</shadedPattern>
+								</relocation>
+							</relocations>
+							<filters>
+								<filter>
+									<artifact>*:*</artifact>
+									<excludes>
+										<exclude>META-INF/*.SF</exclude>
+										<exclude>META-INF/*.DSA</exclude>
+										<exclude>META-INF/*.RSA</exclude>
+										<!-- Exclude execution.interceptors files that reference unshaded classes -->
+										<exclude>**/execution.interceptors</exclude>
+									</excludes>
+								</filter>
+							</filters>
+							<transformers>
+								<!-- Merge and relocate service provider files -->
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+								<!-- Handle AWS SDK execution interceptors -->
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"/>
+							</transformers>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>test-jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>
+

--- a/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/NativeS3AFileSystemFactory.java
+++ b/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/NativeS3AFileSystemFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.s3native;
+
+/**
+ * Factory for the native S3 file system registered for the {@code s3a://} scheme.
+ *
+ * <p>This provides compatibility with applications that use the Hadoop S3A scheme ({@code s3a://})
+ * while using Flink's native S3 implementation built on AWS SDK v2.
+ *
+ * <p>All configuration options are the same as for the {@code s3://} scheme. See {@link
+ * NativeS3FileSystemFactory} for available options.
+ */
+public class NativeS3AFileSystemFactory extends NativeS3FileSystemFactory {
+
+    @Override
+    public String getScheme() {
+        return "s3a";
+    }
+}

--- a/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/NativeS3BulkCopyHelper.java
+++ b/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/NativeS3BulkCopyHelper.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.s3native;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.core.fs.ICloseableRegistry;
+import org.apache.flink.core.fs.PathsCopyingFileSystem;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.transfer.s3.S3TransferManager;
+import software.amazon.awssdk.transfer.s3.model.CompletedCopy;
+import software.amazon.awssdk.transfer.s3.model.DownloadFileRequest;
+import software.amazon.awssdk.transfer.s3.model.FileDownload;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Helper class for performing bulk S3 to local file system copies using S3TransferManager.
+ *
+ * <p><b>Concurrency Model:</b> Uses batch-based concurrency control with {@code
+ * maxConcurrentCopies} to limit parallel downloads. The current implementation waits for each batch
+ * to complete before starting the next batch. A future enhancement could use a bounded thread pool
+ * (e.g., {@link java.util.concurrent.Semaphore} or bounded executor) to allow continuous submission
+ * of new downloads as slots become available, which would provide better throughput by avoiding the
+ * "slowest task in batch" bottleneck.
+ *
+ * <p><b>Retry Handling:</b> Relies on the S3TransferManager's built-in retry mechanism for
+ * transient failures. If a download fails after retries:
+ *
+ * <ul>
+ *   <li>The entire bulk copy operation fails with an IOException
+ *   <li>Successfully downloaded files are NOT cleaned up (they remain on disk)
+ *   <li>Partial downloads may leave incomplete files that should be cleaned up by the caller
+ * </ul>
+ *
+ * <p><b>Cleanup:</b> No automatic cleanup is performed on failure. Callers are responsible for
+ * cleaning up destination files if the bulk copy fails. Consider wrapping in a try-finally or using
+ * a temp directory that can be deleted on failure.
+ *
+ * <p><b>TODO:</b> Consider extracting URI parsing logic to a shared S3UriUtils utility class to
+ * consolidate S3 URI handling across the codebase.
+ */
+@Internal
+class NativeS3BulkCopyHelper {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NativeS3BulkCopyHelper.class);
+
+    private final S3TransferManager transferManager;
+    private final int maxConcurrentCopies;
+
+    public NativeS3BulkCopyHelper(S3TransferManager transferManager, int maxConcurrentCopies) {
+        this.transferManager = transferManager;
+        this.maxConcurrentCopies = maxConcurrentCopies;
+    }
+
+    /**
+     * Copies files from S3 to local filesystem in batches.
+     *
+     * <p><b>Error Handling:</b> If an unsupported URI scheme is encountered, all already-started
+     * copy operations are awaited to completion before throwing the exception. This ensures that no
+     * background copy tasks are left running when the method returns, allowing the caller to safely
+     * manage cleanup and resource lifecycle.
+     *
+     * @param requests List of copy requests (source S3 path to destination local path)
+     * @param closeableRegistry Registry for cleanup (currently unused, reserved for future use)
+     * @throws IOException if any copy operation fails or if an unsupported URI scheme is
+     *     encountered
+     */
+    public void copyFiles(
+            List<PathsCopyingFileSystem.CopyRequest> requests, ICloseableRegistry closeableRegistry)
+            throws IOException {
+
+        if (requests.isEmpty()) {
+            return;
+        }
+
+        LOG.info("Starting bulk copy of {} files using S3TransferManager", requests.size());
+
+        List<CompletableFuture<CompletedCopy>> copyFutures = new ArrayList<>();
+
+        try {
+            for (int i = 0; i < requests.size(); i++) {
+                PathsCopyingFileSystem.CopyRequest request = requests.get(i);
+                String sourceUri = request.getSource().toUri().toString();
+                if (sourceUri.startsWith("s3://") || sourceUri.startsWith("s3a://")) {
+                    copyFutures.add(copyS3ToLocal(request));
+                } else {
+                    throw new UnsupportedOperationException(
+                            "Only S3 to local copies are currently supported: " + sourceUri);
+                }
+
+                if (copyFutures.size() >= maxConcurrentCopies || i == requests.size() - 1) {
+                    waitForCopies(copyFutures);
+                    copyFutures.clear();
+                }
+            }
+
+            LOG.info("Completed bulk copy of {} files", requests.size());
+        } catch (Exception e) {
+            if (!copyFutures.isEmpty()) {
+                LOG.warn(
+                        "Error during bulk copy, waiting for {} in-flight operations to complete",
+                        copyFutures.size());
+                try {
+                    waitForCopies(copyFutures);
+                } catch (IOException waitError) {
+                    LOG.warn(
+                            "Error waiting for in-flight copy operations: {}",
+                            waitError.getMessage());
+                    e.addSuppressed(waitError);
+                }
+            }
+            if (e instanceof IOException) {
+                throw (IOException) e;
+            } else {
+                throw new IOException(e);
+            }
+        }
+    }
+
+    /**
+     * Initiates an async S3 to local file copy.
+     *
+     * @param request The copy request containing source S3 path and destination local path
+     * @return A CompletableFuture that completes when the download finishes
+     * @throws IOException if the destination directory cannot be created
+     */
+    private CompletableFuture<CompletedCopy> copyS3ToLocal(
+            PathsCopyingFileSystem.CopyRequest request) throws IOException {
+
+        String sourceUri = request.getSource().toUri().toString();
+        String bucket = extractBucket(sourceUri);
+        String key = extractKey(sourceUri);
+        File destFile = new File(request.getDestination().getPath());
+
+        Files.createDirectories(destFile.getParentFile().toPath());
+
+        DownloadFileRequest downloadRequest =
+                DownloadFileRequest.builder()
+                        .getObjectRequest(req -> req.bucket(bucket).key(key))
+                        .destination(destFile.toPath())
+                        .build();
+
+        FileDownload download = transferManager.downloadFile(downloadRequest);
+
+        return download.completionFuture()
+                .thenApply(
+                        completed -> {
+                            LOG.debug("Successfully copied {} to {}", sourceUri, destFile);
+                            return null;
+                        });
+    }
+
+    private void waitForCopies(List<CompletableFuture<CompletedCopy>> futures) throws IOException {
+        try {
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Bulk copy interrupted", e);
+        } catch (ExecutionException e) {
+            throw new IOException("Bulk copy failed", e.getCause());
+        }
+    }
+
+    /**
+     * Extracts the bucket name from an S3 URI.
+     *
+     * <p>Supports both s3:// and s3a:// schemes (s3a is normalized to s3).
+     *
+     * @param s3Uri the S3 URI
+     * @return the bucket name
+     */
+    String extractBucket(String s3Uri) {
+        String uri = s3Uri.replaceFirst("s3a://", "s3://");
+        int bucketStart = uri.indexOf("://") + 3;
+        int bucketEnd = uri.indexOf("/", bucketStart);
+        if (bucketEnd == -1) {
+            return uri.substring(bucketStart);
+        }
+        return uri.substring(bucketStart, bucketEnd);
+    }
+
+    /**
+     * Extracts the object key from an S3 URI.
+     *
+     * <p>Supports both s3:// and s3a:// schemes (s3a is normalized to s3).
+     *
+     * @param s3Uri the S3 URI
+     * @return the object key (empty string if no key in URI)
+     */
+    String extractKey(String s3Uri) {
+        String uri = s3Uri.replaceFirst("s3a://", "s3://");
+        int bucketStart = uri.indexOf("://") + 3;
+        int keyStart = uri.indexOf("/", bucketStart);
+        if (keyStart == -1) {
+            return "";
+        }
+        return uri.substring(keyStart + 1);
+    }
+}

--- a/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/NativeS3FileSystem.java
+++ b/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/NativeS3FileSystem.java
@@ -1,0 +1,581 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.s3native;
+
+import org.apache.flink.core.fs.BlockLocation;
+import org.apache.flink.core.fs.EntropyInjectingFileSystem;
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.core.fs.FSDataOutputStream;
+import org.apache.flink.core.fs.FileStatus;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.fs.PathsCopyingFileSystem;
+import org.apache.flink.core.fs.RecoverableWriter;
+import org.apache.flink.fs.s3native.writer.NativeS3AccessHelper;
+import org.apache.flink.fs.s3native.writer.NativeS3RecoverableWriter;
+import org.apache.flink.util.AutoCloseableAsync;
+import org.apache.flink.util.StringUtils;
+import org.apache.flink.util.concurrent.FutureUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+import javax.annotation.Nullable;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Native S3 FileSystem implementation using AWS SDK v2.
+ *
+ * <p>This file system uses an {@link AtomicBoolean} guard ({@code closed}) checked at the start of
+ * every public operation via {@link #checkNotClosed()}. The close lifecycle works as follows:
+ *
+ * <ul>
+ *   <li>New operations started after {@link #closeAsync()} will throw {@link
+ *       IllegalStateException}.
+ *   <li>Operations already past the {@code checkNotClosed()} barrier are allowed to complete
+ *       naturally. There is a small race window where an operation may pass the check just before
+ *       {@code closeAsync()} sets the flag. In this case, the operation either completes normally
+ *       (the underlying clients have not been torn down yet) or fails with an {@link IOException}
+ *       from the AWS SDK, which callers are already expected to handle.
+ *   <li>The {@link #closeAsync()} teardown sequence (bulkCopyHelper, transferManager, asyncClient,
+ *       syncClient) provides a natural grace period bounded by {@link #CLOSE_TIMEOUT_SECONDS}.
+ * </ul>
+ *
+ * <p>A thread-pool-routed approach would provide stricter guarantees but introduces latency
+ * overhead on every call and risks deadlocks from nested filesystem calls (e.g., {@code create()}
+ * calling {@code exists()} calling {@code getFileStatus()}).
+ *
+ * <p><b>Permission Considerations:</b> Some operations require specific IAM permissions:
+ *
+ * <ul>
+ *   <li>{@link #getFileStatus}: Returns 403 for non-existent objects if ListBucket permission is
+ *       not granted (to prevent object enumeration)
+ *   <li>{@link #listStatus}: Requires ListBucket permission
+ *   <li>{@link #delete}: With only DeleteObject permission, deleting non-existent objects may
+ *       return errors
+ * </ul>
+ */
+class NativeS3FileSystem extends FileSystem
+        implements EntropyInjectingFileSystem, PathsCopyingFileSystem, AutoCloseableAsync {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NativeS3FileSystem.class);
+
+    /** Timeout in seconds for closing the filesystem. */
+    private static final long CLOSE_TIMEOUT_SECONDS = 60;
+
+    private final S3ClientProvider clientProvider;
+    private final URI uri;
+    private final String bucketName;
+
+    @Nullable private final String entropyInjectionKey;
+    private final int entropyLength;
+
+    @Nullable private final NativeS3AccessHelper s3AccessHelper;
+    private final long s3uploadPartSize;
+    private final int maxConcurrentUploadsPerStream;
+    private final String localTmpDir;
+
+    @Nullable private final NativeS3BulkCopyHelper bulkCopyHelper;
+    private final boolean useAsyncOperations;
+    private final int readBufferSize;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    public NativeS3FileSystem(
+            S3ClientProvider clientProvider,
+            URI uri,
+            @Nullable String entropyInjectionKey,
+            int entropyLength,
+            String localTmpDir,
+            long s3uploadPartSize,
+            int maxConcurrentUploadsPerStream,
+            @Nullable NativeS3BulkCopyHelper bulkCopyHelper,
+            boolean useAsyncOperations,
+            int readBufferSize) {
+        this.clientProvider = clientProvider;
+        this.uri = uri;
+        this.bucketName = uri.getHost();
+        this.entropyInjectionKey = entropyInjectionKey;
+        this.entropyLength = entropyLength;
+        this.localTmpDir = localTmpDir;
+        this.s3uploadPartSize = s3uploadPartSize;
+        this.maxConcurrentUploadsPerStream = maxConcurrentUploadsPerStream;
+        this.useAsyncOperations = useAsyncOperations;
+        this.readBufferSize = readBufferSize;
+        this.s3AccessHelper =
+                new NativeS3AccessHelper(
+                        clientProvider.getS3Client(),
+                        clientProvider.getTransferManager(),
+                        bucketName,
+                        useAsyncOperations,
+                        clientProvider.getEncryptionConfig());
+        this.bulkCopyHelper = bulkCopyHelper;
+
+        if (entropyInjectionKey != null && entropyLength <= 0) {
+            throw new IllegalArgumentException(
+                    "Entropy length must be >= 0 when entropy injection key is set");
+        }
+
+        LOG.info(
+                "Created Native S3 FileSystem for bucket: {}, entropy injection: {}, bulk copy: {}, read buffer: {} KB",
+                bucketName,
+                entropyInjectionKey != null,
+                bulkCopyHelper != null,
+                readBufferSize / 1024);
+    }
+
+    @Override
+    public URI getUri() {
+        return uri;
+    }
+
+    @Override
+    public Path getWorkingDirectory() {
+        return new Path(uri);
+    }
+
+    @Override
+    public Path getHomeDirectory() {
+        return new Path(uri);
+    }
+
+    @Override
+    public FileStatus getFileStatus(Path path) throws IOException {
+        checkNotClosed();
+        final String key = NativeS3AccessHelper.extractKey(path);
+        final S3Client s3Client = clientProvider.getS3Client();
+
+        LOG.debug("Getting file status for s3://{}/{}", bucketName, key);
+
+        try {
+            final HeadObjectRequest request =
+                    HeadObjectRequest.builder().bucket(bucketName).key(key).build();
+
+            final HeadObjectResponse response = s3Client.headObject(request);
+            final Long contentLength = response.contentLength();
+
+            // In S3, a successful HeadObject with null/zero contentLength means
+            // this is a directory marker (prefix), not an actual file
+            if (contentLength == null || contentLength == 0) {
+                LOG.debug(
+                        "HeadObject returned null/zero content length, verifying if directory: {}",
+                        key);
+                return getDirectoryStatus(s3Client, key, path);
+            }
+
+            final long size = contentLength;
+            final long modificationTime =
+                    (response.lastModified() != null)
+                            ? response.lastModified().toEpochMilli()
+                            : System.currentTimeMillis();
+
+            LOG.trace(
+                    "HeadObject successful for {} - size: {}, lastModified: {}",
+                    key,
+                    size,
+                    response.lastModified());
+
+            return S3FileStatus.withFile(size, modificationTime, path);
+        } catch (NoSuchKeyException e) {
+            LOG.debug("Object not found, checking if directory: {}", key);
+            return getDirectoryStatus(s3Client, key, path);
+        } catch (S3Exception e) {
+            LOG.error(
+                    "S3 error getting file status for s3://{}/{} - StatusCode: {}, ErrorCode: {}, Message: {}",
+                    bucketName,
+                    key,
+                    e.statusCode(),
+                    S3ExceptionUtils.errorCode(e),
+                    S3ExceptionUtils.errorMessage(e));
+            if (e.statusCode() == 403) {
+                // Note: S3 returns 403 (not 404) for non-existent objects when the
+                // caller lacks s3:ListBucket permission, to prevent key enumeration.
+                // This 403 is therefore ambiguous: it may indicate a genuine access
+                // denial OR that the object simply does not exist.
+                // See: https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html
+                // See:
+                // https://docs.aws.amazon.com/AmazonS3/latest/userguide/troubleshoot-403-errors.html
+                LOG.error(
+                        "Access denied (403) for s3://{}/{}. This may indicate invalid"
+                                + " credentials/bucket policy, OR the object may not exist and"
+                                + " s3:ListBucket permission is not granted (S3 returns 403"
+                                + " instead of 404 to prevent key enumeration).",
+                        bucketName,
+                        key);
+            } else if (e.statusCode() == 404) {
+                LOG.debug("Object not found (404) for s3://{}/{}", bucketName, key);
+            }
+
+            throw S3ExceptionUtils.toIOException(
+                    String.format("Failed to get file status for s3://%s/%s", bucketName, key), e);
+        }
+    }
+
+    /**
+     * Checks if the given key represents a directory by listing objects with that prefix. Returns a
+     * directory {@link FileStatus} if objects exist under the prefix, otherwise throws {@link
+     * FileNotFoundException}.
+     */
+    private FileStatus getDirectoryStatus(S3Client s3Client, String key, Path path)
+            throws FileNotFoundException {
+        final String prefix = key.endsWith("/") ? key : key + "/";
+        final ListObjectsV2Request listRequest =
+                ListObjectsV2Request.builder().bucket(bucketName).prefix(prefix).maxKeys(1).build();
+        final ListObjectsV2Response listResponse = s3Client.listObjectsV2(listRequest);
+
+        if (listResponse.contents().isEmpty() && !listResponse.hasCommonPrefixes()) {
+            throw new FileNotFoundException("File not found: " + path);
+        }
+
+        LOG.debug("Path is a directory: {}", key);
+        return S3FileStatus.withDirectory(path);
+    }
+
+    @Override
+    public BlockLocation[] getFileBlockLocations(FileStatus file, long start, long len) {
+        return new BlockLocation[] {
+            new S3BlockLocation(new String[] {"localhost"}, 0, file.getLen())
+        };
+    }
+
+    @Override
+    public FSDataInputStream open(Path path, int bufferSize) throws IOException {
+        checkNotClosed();
+        final String key = NativeS3AccessHelper.extractKey(path);
+        final S3Client s3Client = clientProvider.getS3Client();
+        final long fileSize = getFileStatus(path).getLen();
+        return new NativeS3InputStream(s3Client, bucketName, key, fileSize, bufferSize);
+    }
+
+    @Override
+    public FSDataInputStream open(Path path) throws IOException {
+        checkNotClosed();
+        final String key = NativeS3AccessHelper.extractKey(path);
+        final S3Client s3Client = clientProvider.getS3Client();
+        final long fileSize = getFileStatus(path).getLen();
+        return new NativeS3InputStream(s3Client, bucketName, key, fileSize, readBufferSize);
+    }
+
+    /**
+     * Lists the contents of a directory.
+     *
+     * <p><b>Retry Behavior:</b> This method relies on the AWS SDK's built-in retry mechanism. If a
+     * pagination request fails after SDK retries are exhausted:
+     *
+     * <ul>
+     *   <li>The entire operation fails with an IOException
+     *   <li>Partial results from previous pages are NOT returned
+     *   <li>The caller should retry the entire listStatus operation
+     * </ul>
+     *
+     * <p>This behavior is consistent with atomic semantics - either the full listing succeeds or
+     * the operation fails completely.
+     */
+    @Override
+    public FileStatus[] listStatus(Path path) throws IOException {
+        checkNotClosed();
+        String key = NativeS3AccessHelper.extractKey(path);
+        if (!key.isEmpty() && !key.endsWith("/")) {
+            key = key + "/";
+        }
+
+        final S3Client s3Client = clientProvider.getS3Client();
+        final List<FileStatus> results = new ArrayList<>();
+        String continuationToken = null;
+
+        do {
+            ListObjectsV2Request.Builder requestBuilder =
+                    ListObjectsV2Request.builder().bucket(bucketName).prefix(key).delimiter("/");
+
+            if (continuationToken != null) {
+                requestBuilder.continuationToken(continuationToken);
+            }
+
+            final ListObjectsV2Response response = s3Client.listObjectsV2(requestBuilder.build());
+
+            for (S3Object s3Object : response.contents()) {
+                if (!s3Object.key().equals(key)) {
+                    final Path objectPath =
+                            new Path(uri.getScheme(), uri.getHost(), "/" + s3Object.key());
+                    results.add(
+                            S3FileStatus.withFile(
+                                    s3Object.size(),
+                                    s3Object.lastModified().toEpochMilli(),
+                                    objectPath));
+                }
+            }
+
+            for (software.amazon.awssdk.services.s3.model.CommonPrefix prefix :
+                    response.commonPrefixes()) {
+                final Path prefixPath =
+                        new Path(uri.getScheme(), uri.getHost(), "/" + prefix.prefix());
+                results.add(S3FileStatus.withDirectory(prefixPath));
+            }
+
+            continuationToken = response.nextContinuationToken();
+        } while (continuationToken != null);
+
+        return results.toArray(new FileStatus[0]);
+    }
+
+    @Override
+    public boolean delete(Path path, boolean recursive) throws IOException {
+        checkNotClosed();
+        final String key = NativeS3AccessHelper.extractKey(path);
+        final S3Client s3Client = clientProvider.getS3Client();
+
+        try {
+            final FileStatus status = getFileStatus(path);
+
+            if (!status.isDir()) {
+                final DeleteObjectRequest request =
+                        DeleteObjectRequest.builder().bucket(bucketName).key(key).build();
+
+                s3Client.deleteObject(request);
+                return true;
+            } else {
+                if (!recursive) {
+                    throw new IOException("Directory not empty and recursive = false");
+                }
+
+                final FileStatus[] contents = listStatus(path);
+                for (FileStatus file : contents) {
+                    delete(file.getPath(), true);
+                }
+
+                return true;
+            }
+        } catch (FileNotFoundException e) {
+            return false;
+        } catch (S3Exception e) {
+            throw new IOException("Failed to delete: " + path, e);
+        }
+    }
+
+    /**
+     * Creates a directory at the specified path.
+     *
+     * <p><b>S3 Behavior:</b> S3 is a flat object store and doesn't have true directories. Directory
+     * semantics are simulated through key prefixes. This method always returns true because:
+     *
+     * <ul>
+     *   <li>S3 doesn't require directories to exist before creating objects with that prefix
+     *   <li>Creating an empty "directory marker" object (key ending with /) is optional
+     *   <li>Most S3 implementations don't create these markers for consistency with Hadoop FS
+     * </ul>
+     *
+     * <p>If explicit directory markers are needed, consider using a custom implementation.
+     *
+     * @return always returns true (S3 doesn't require explicit directory creation)
+     */
+    @Override
+    public boolean mkdirs(Path path) throws IOException {
+        checkNotClosed();
+        LOG.debug("mkdirs called for {} - S3 doesn't require explicit directory creation", path);
+        return true;
+    }
+
+    @Override
+    public FSDataOutputStream create(Path path, WriteMode overwriteMode) throws IOException {
+        checkNotClosed();
+        if (overwriteMode == WriteMode.NO_OVERWRITE) {
+            try {
+                if (exists(path)) {
+                    throw new IOException("File already exists: " + path);
+                }
+            } catch (FileNotFoundException ignored) {
+            }
+        } else {
+            try {
+                delete(path, false);
+            } catch (FileNotFoundException ignored) {
+            }
+        }
+
+        final String key = NativeS3AccessHelper.extractKey(path);
+        return new NativeS3OutputStream(
+                clientProvider.getS3Client(),
+                bucketName,
+                key,
+                localTmpDir,
+                clientProvider.getEncryptionConfig());
+    }
+
+    /**
+     * Renames a single file from {@code src} to {@code dst}.
+     *
+     * <p><b>Directory rename is not supported.</b>
+     *
+     * @throws UnsupportedOperationException if {@code src} is a directory
+     */
+    @Override
+    public boolean rename(Path src, Path dst) throws IOException {
+        checkNotClosed();
+        final String srcKey = NativeS3AccessHelper.extractKey(src);
+        final String dstKey = NativeS3AccessHelper.extractKey(dst);
+        final S3Client s3Client = clientProvider.getS3Client();
+
+        final FileStatus srcStatus = getFileStatus(src);
+        if (srcStatus.isDir()) {
+            throw new UnsupportedOperationException(
+                    "NativeS3FileSystem does not support renaming directories: " + src);
+        }
+
+        try {
+            final CopyObjectRequest copyRequest =
+                    CopyObjectRequest.builder()
+                            .sourceBucket(bucketName)
+                            .sourceKey(srcKey)
+                            .destinationBucket(bucketName)
+                            .destinationKey(dstKey)
+                            .build();
+            s3Client.copyObject(copyRequest);
+            final DeleteObjectRequest deleteRequest =
+                    DeleteObjectRequest.builder().bucket(bucketName).key(srcKey).build();
+            s3Client.deleteObject(deleteRequest);
+            return true;
+        } catch (S3Exception e) {
+            throw new IOException("Failed to rename " + src + " to " + dst, e);
+        }
+    }
+
+    @Override
+    public boolean isDistributedFS() {
+        return true;
+    }
+
+    @Nullable
+    @Override
+    public String getEntropyInjectionKey() {
+        return entropyInjectionKey;
+    }
+
+    @Override
+    public String generateEntropy() {
+        return StringUtils.generateRandomAlphanumericString(
+                ThreadLocalRandom.current(), entropyLength);
+    }
+
+    @Override
+    public boolean canCopyPaths(Path source, Path destination) {
+        return bulkCopyHelper != null;
+    }
+
+    @Override
+    public void copyFiles(
+            List<CopyRequest> requests,
+            org.apache.flink.core.fs.ICloseableRegistry closeableRegistry)
+            throws IOException {
+        checkNotClosed();
+        if (bulkCopyHelper == null) {
+            throw new UnsupportedOperationException(
+                    "Bulk copy not enabled. Set s3.bulk-copy.enabled=true");
+        }
+        bulkCopyHelper.copyFiles(requests, closeableRegistry);
+    }
+
+    @Override
+    public RecoverableWriter createRecoverableWriter() throws IOException {
+        checkNotClosed();
+        if (s3AccessHelper == null) {
+            throw new UnsupportedOperationException("Recoverable writer not available");
+        }
+        return NativeS3RecoverableWriter.writer(
+                s3AccessHelper, localTmpDir, s3uploadPartSize, maxConcurrentUploadsPerStream);
+    }
+
+    @Override
+    public CompletableFuture<Void> closeAsync() {
+        if (!closed.compareAndSet(false, true)) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        LOG.info("Starting async close of Native S3 FileSystem for bucket: {}", bucketName);
+        CompletableFuture<Void> closeFuture =
+                CompletableFuture.runAsync(
+                                () ->
+                                        LOG.info(
+                                                "Native S3 FileSystem closed for bucket: {}",
+                                                bucketName))
+                        .thenCompose(
+                                ignored -> {
+                                    if (clientProvider != null) {
+                                        return clientProvider
+                                                .closeAsync()
+                                                .whenComplete(
+                                                        (result, error) -> {
+                                                            if (error != null) {
+                                                                LOG.warn(
+                                                                        "Error closing S3 client provider",
+                                                                        error);
+                                                            } else {
+                                                                LOG.debug(
+                                                                        "S3 client provider closed");
+                                                            }
+                                                        });
+                                    }
+                                    return CompletableFuture.completedFuture(null);
+                                })
+                        .orTimeout(CLOSE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                        .whenComplete(
+                                (result, error) -> {
+                                    if (error != null) {
+                                        LOG.error(
+                                                "FileSystem close timed out after {} seconds for bucket: {}",
+                                                CLOSE_TIMEOUT_SECONDS,
+                                                bucketName,
+                                                error);
+                                    }
+                                });
+        FutureUtils.assertNoException(closeFuture);
+        return closeFuture;
+    }
+
+    /**
+     * Verifies that the filesystem has not been closed.
+     *
+     * @throws IllegalStateException if the filesystem has been closed
+     */
+    private void checkNotClosed() {
+        if (closed.get()) {
+            throw new IllegalStateException(
+                    "FileSystem has been closed for bucket: "
+                            + bucketName
+                            + ". Operations are no longer permitted.");
+        }
+    }
+}

--- a/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/NativeS3FileSystemFactory.java
+++ b/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/NativeS3FileSystemFactory.java
@@ -1,0 +1,338 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.s3native;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ConfigurationUtils;
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.FileSystemFactory;
+import org.apache.flink.util.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+
+public class NativeS3FileSystemFactory implements FileSystemFactory {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NativeS3FileSystemFactory.class);
+
+    private static final String INVALID_ENTROPY_KEY_CHARS = "^.*[~#@*+%{}<>\\[\\]|\"\\\\].*$";
+
+    public static final long S3_MULTIPART_MIN_PART_SIZE = 5L << 20;
+
+    public static final ConfigOption<String> ACCESS_KEY =
+            ConfigOptions.key("s3.access-key")
+                    .stringType()
+                    .noDefaultValue()
+                    .withFallbackKeys("s3.access.key")
+                    .withDescription("AWS access key");
+
+    public static final ConfigOption<String> SECRET_KEY =
+            ConfigOptions.key("s3.secret-key")
+                    .stringType()
+                    .noDefaultValue()
+                    .withFallbackKeys("s3.secret.key")
+                    .withDescription("AWS secret key");
+
+    public static final ConfigOption<String> REGION =
+            ConfigOptions.key("s3.region")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "AWS region. If not specified, the region will be automatically detected using AWS SDK's "
+                                    + "DefaultAwsRegionProviderChain, which checks (in order): AWS_REGION env var, "
+                                    + "~/.aws/config, EC2 instance metadata, and bucket location API.");
+
+    public static final ConfigOption<String> ENDPOINT =
+            ConfigOptions.key("s3.endpoint")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Custom S3 endpoint");
+
+    public static final ConfigOption<Boolean> PATH_STYLE_ACCESS =
+            ConfigOptions.key("s3.path-style-access")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withFallbackKeys("s3.path.style.access")
+                    .withDescription("Use path-style access for S3 (for S3-compatible storage)");
+
+    public static final ConfigOption<Long> PART_UPLOAD_MIN_SIZE =
+            ConfigOptions.key("s3.upload.min.part.size")
+                    .longType()
+                    .defaultValue(S3_MULTIPART_MIN_PART_SIZE)
+                    .withDescription(
+                            "Minimum size of data buffered locally before sending to S3 (5MB to 5GB)");
+
+    public static final ConfigOption<Integer> MAX_CONCURRENT_UPLOADS =
+            ConfigOptions.key("s3.upload.max.concurrent.uploads")
+                    .intType()
+                    .defaultValue(Runtime.getRuntime().availableProcessors())
+                    .withDescription("Maximum number of concurrent part uploads per stream");
+
+    public static final ConfigOption<String> ENTROPY_INJECT_KEY_OPTION =
+            ConfigOptions.key("s3.entropy.key")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Key to be replaced by random entropy for sharding optimization");
+
+    public static final ConfigOption<Integer> ENTROPY_INJECT_LENGTH_OPTION =
+            ConfigOptions.key("s3.entropy.length")
+                    .intType()
+                    .defaultValue(4)
+                    .withDescription("Number of random characters for entropy injection");
+
+    public static final ConfigOption<Boolean> BULK_COPY_ENABLED =
+            ConfigOptions.key("s3.bulk-copy.enabled")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription("Enable bulk copy operations using S3TransferManager");
+
+    public static final ConfigOption<Integer> BULK_COPY_MAX_CONCURRENT =
+            ConfigOptions.key("s3.bulk-copy.max-concurrent")
+                    .intType()
+                    .defaultValue(16)
+                    .withDescription("Maximum number of concurrent copy operations");
+
+    public static final ConfigOption<Boolean> USE_ASYNC_OPERATIONS =
+            ConfigOptions.key("s3.async.enabled")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Enable async read/write operations using S3TransferManager for improved performance");
+
+    public static final ConfigOption<Integer> READ_BUFFER_SIZE =
+            ConfigOptions.key("s3.read.buffer.size")
+                    .intType()
+                    .defaultValue(256 * 1024) // 256KB default
+                    .withDescription(
+                            "Read buffer size in bytes for S3 input streams. "
+                                    + "Larger buffers improve throughput but consume more memory. "
+                                    + "Range: 64KB - 4MB. Default: 256KB");
+
+    // Server-Side Encryption (SSE) Configuration
+    public static final ConfigOption<String> SSE_TYPE =
+            ConfigOptions.key("s3.sse.type")
+                    .stringType()
+                    .defaultValue("none")
+                    .withDescription(
+                            "Server-side encryption type. Valid values: "
+                                    + "'none' (no encryption), "
+                                    + "'sse-s3' or 'AES256' (S3-managed keys), "
+                                    + "'sse-kms' or 'aws:kms' (KMS-managed keys)");
+
+    public static final ConfigOption<String> SSE_KMS_KEY_ID =
+            ConfigOptions.key("s3.sse.kms.key-id")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "KMS key ID, ARN, or alias for SSE-KMS encryption. "
+                                    + "If not specified with SSE-KMS, the default AWS-managed key (aws/s3) is used. "
+                                    + "Example: 'arn:aws:kms:us-east-1:123456789:key/12345678-1234-1234-1234-123456789abc' "
+                                    + "or 'alias/my-s3-key'");
+
+    // IAM Assume Role Configuration
+    public static final ConfigOption<String> ASSUME_ROLE_ARN =
+            ConfigOptions.key("s3.assume-role.arn")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "ARN of the IAM role to assume for S3 access. "
+                                    + "Enables cross-account access or temporary elevated permissions. "
+                                    + "Example: 'arn:aws:iam::123456789012:role/S3AccessRole'");
+
+    public static final ConfigOption<String> ASSUME_ROLE_EXTERNAL_ID =
+            ConfigOptions.key("s3.assume-role.external-id")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "External ID for assume role (required for cross-account access with external ID condition)");
+
+    public static final ConfigOption<String> ASSUME_ROLE_SESSION_NAME =
+            ConfigOptions.key("s3.assume-role.session-name")
+                    .stringType()
+                    .defaultValue("flink-s3-session")
+                    .withDescription("Session name for the assumed role session");
+
+    public static final ConfigOption<Integer> ASSUME_ROLE_SESSION_DURATION_SECONDS =
+            ConfigOptions.key("s3.assume-role.session-duration")
+                    .intType()
+                    .defaultValue(3600) // 1 hour default
+                    .withDescription(
+                            "Duration in seconds for the assumed role session (900-43200 seconds, default: 3600)");
+
+    public static final ConfigOption<Integer> MAX_RETRIES =
+            ConfigOptions.key("s3.retry.max-num-retries")
+                    .intType()
+                    .defaultValue(3)
+                    .withDescription(
+                            "Maximum number of retry attempts for failed S3 requests. "
+                                    + "Uses the AWS SDK's default retry strategy (exponential backoff with jitter). "
+                                    + "Set to 0 to disable retries.");
+
+    public static final ConfigOption<String> AWS_CREDENTIALS_PROVIDER =
+            ConfigOptions.key("fs.s3.aws.credentials.provider")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Comma-separated list of AWS credentials provider class names. "
+                                    + "Providers are tried in order; the first one that returns credentials is used. "
+                                    + "Supports fully-qualified AWS SDK v2 class names "
+                                    + "(e.g. 'software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider') "
+                                    + "or simple names from the SDK auth package "
+                                    + "(e.g. 'AnonymousCredentialsProvider', 'DefaultCredentialsProvider'). "
+                                    + "When not set, the default chain is used: delegation tokens -> "
+                                    + "static credentials (if configured) -> DefaultCredentialsProvider.");
+
+    private Configuration flinkConfig;
+
+    @Override
+    public String getScheme() {
+        return "s3";
+    }
+
+    // setting to least priority so that it is not used by default
+    @Override
+    public int getPriority() {
+        return -1;
+    }
+
+    @Override
+    public void configure(Configuration config) {
+        this.flinkConfig = config;
+    }
+
+    @Override
+    public FileSystem create(URI fsUri) throws IOException {
+        Configuration config = this.flinkConfig;
+        if (config == null) {
+            config = new Configuration();
+        }
+
+        String accessKey = config.get(ACCESS_KEY);
+        String secretKey = config.get(SECRET_KEY);
+        String region = config.get(REGION);
+        String endpoint = config.get(ENDPOINT);
+        boolean pathStyleAccess = config.get(PATH_STYLE_ACCESS);
+
+        if (endpoint != null && !pathStyleAccess) {
+            pathStyleAccess = true;
+        }
+
+        S3EncryptionConfig encryptionConfig =
+                S3EncryptionConfig.fromConfig(config.get(SSE_TYPE), config.get(SSE_KMS_KEY_ID));
+        String entropyInjectionKey = config.get(ENTROPY_INJECT_KEY_OPTION);
+        int numEntropyChars = -1;
+        if (entropyInjectionKey != null) {
+            if (entropyInjectionKey.matches(INVALID_ENTROPY_KEY_CHARS)) {
+                throw new IllegalConfigurationException(
+                        "Invalid character in entropy injection key: " + entropyInjectionKey);
+            }
+            numEntropyChars = config.get(ENTROPY_INJECT_LENGTH_OPTION);
+            if (numEntropyChars <= 0) {
+                throw new IllegalConfigurationException(
+                        ENTROPY_INJECT_LENGTH_OPTION.key() + " must be > 0");
+            }
+        }
+
+        final String[] localTmpDirectories = ConfigurationUtils.parseTempDirectories(config);
+        Preconditions.checkArgument(
+                localTmpDirectories.length > 0,
+                "No temporary directories configured. "
+                        + "Please configure at least one temp directory via 'io.tmp.dirs' or similar.");
+        final String localTmpDirectory = localTmpDirectories[0];
+
+        final long s3minPartSize = config.get(PART_UPLOAD_MIN_SIZE);
+        final int maxConcurrentUploads = config.get(MAX_CONCURRENT_UPLOADS);
+
+        // Validate part size: S3 requires minimum 5MB and maximum 5GB per part
+        Preconditions.checkArgument(
+                s3minPartSize >= S3_MULTIPART_MIN_PART_SIZE,
+                "%s must be at least 5MB (5242880 bytes), but was %d bytes",
+                PART_UPLOAD_MIN_SIZE.key(),
+                s3minPartSize);
+        Preconditions.checkArgument(
+                s3minPartSize <= 5L * 1024 * 1024 * 1024,
+                "%s must not exceed 5GB (5368709120 bytes), but was %d bytes",
+                PART_UPLOAD_MIN_SIZE.key(),
+                s3minPartSize);
+        Preconditions.checkArgument(
+                maxConcurrentUploads > 0,
+                "%s must be positive, but was %d",
+                MAX_CONCURRENT_UPLOADS.key(),
+                maxConcurrentUploads);
+
+        boolean useAsyncOperations = config.get(USE_ASYNC_OPERATIONS);
+
+        // Validate and clamp read buffer size to sensible range [64KB, 4MB]
+        // We clip rather than throw to provide flexibility while preventing extreme values
+        int configuredReadBufferSize = config.get(READ_BUFFER_SIZE);
+        int readBufferSize =
+                Math.max(64 * 1024, Math.min(configuredReadBufferSize, 4 * 1024 * 1024));
+        if (readBufferSize != configuredReadBufferSize) {
+            LOG.warn(
+                    "{} value {} was outside valid range [64KB, 4MB]. Using {} instead.",
+                    READ_BUFFER_SIZE.key(),
+                    configuredReadBufferSize,
+                    readBufferSize);
+        }
+
+        S3ClientProvider clientProvider =
+                S3ClientProvider.builder()
+                        .accessKey(accessKey)
+                        .secretKey(secretKey)
+                        .region(region)
+                        .endpoint(endpoint)
+                        .pathStyleAccess(pathStyleAccess)
+                        .assumeRoleArn(config.get(ASSUME_ROLE_ARN))
+                        .assumeRoleExternalId(config.get(ASSUME_ROLE_EXTERNAL_ID))
+                        .assumeRoleSessionName(config.get(ASSUME_ROLE_SESSION_NAME))
+                        .assumeRoleSessionDurationSeconds(
+                                config.get(ASSUME_ROLE_SESSION_DURATION_SECONDS))
+                        .maxRetries(config.get(MAX_RETRIES))
+                        .credentialsProviderClasses(config.get(AWS_CREDENTIALS_PROVIDER))
+                        .encryptionConfig(encryptionConfig)
+                        .build();
+
+        NativeS3BulkCopyHelper bulkCopyHelper = null;
+        if (config.get(BULK_COPY_ENABLED)) {
+            bulkCopyHelper =
+                    new NativeS3BulkCopyHelper(
+                            clientProvider.getTransferManager(),
+                            config.get(BULK_COPY_MAX_CONCURRENT));
+        }
+
+        return new NativeS3FileSystem(
+                clientProvider,
+                fsUri,
+                entropyInjectionKey,
+                numEntropyChars,
+                localTmpDirectory,
+                s3minPartSize,
+                maxConcurrentUploads,
+                bulkCopyHelper,
+                useAsyncOperations,
+                readBufferSize);
+    }
+}

--- a/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/NativeS3InputStream.java
+++ b/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/NativeS3InputStream.java
@@ -1,0 +1,362 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.s3native;
+
+import org.apache.flink.core.fs.FSDataInputStream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * S3 input stream with configurable read-ahead buffer, range-based requests for seek operations,
+ * automatic stream reopening on errors, and lazy initialization to minimize memory footprint.
+ *
+ * <p><b>Thread Safety:</b> Internal state is guarded by a lock to ensure safe concurrent access and
+ * resource cleanup.
+ */
+class NativeS3InputStream extends FSDataInputStream {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NativeS3InputStream.class);
+
+    /** Default read-ahead buffer size: 256KB. */
+    private static final int DEFAULT_READ_BUFFER_SIZE = 256 * 1024;
+
+    /** Maximum buffer size for very large sequential reads. */
+    private static final int MAX_READ_BUFFER_SIZE = 4 * 1024 * 1024; // 4MB
+
+    private final ReentrantLock lock = new ReentrantLock();
+
+    private final S3Client s3Client;
+    private final String bucketName;
+    private final String key;
+    private final long contentLength;
+    private final int readBufferSize;
+
+    private ResponseInputStream<GetObjectResponse> currentStream;
+    private BufferedInputStream bufferedStream;
+    private long position;
+    private volatile boolean closed;
+
+    public NativeS3InputStream(
+            S3Client s3Client, String bucketName, String key, long contentLength) {
+        this(s3Client, bucketName, key, contentLength, DEFAULT_READ_BUFFER_SIZE);
+    }
+
+    public NativeS3InputStream(
+            S3Client s3Client,
+            String bucketName,
+            String key,
+            long contentLength,
+            int readBufferSize) {
+        this.s3Client = s3Client;
+        this.bucketName = bucketName;
+        this.key = key;
+        this.contentLength = contentLength;
+        this.readBufferSize = Math.min(readBufferSize, MAX_READ_BUFFER_SIZE);
+        this.position = 0;
+        this.closed = false;
+
+        LOG.debug(
+                "Created S3 input stream - bucket: {}, key: {}, size: {} bytes, buffer: {} KB",
+                bucketName,
+                key,
+                contentLength,
+                this.readBufferSize / 1024);
+    }
+
+    private void lazyInitialize() throws IOException {
+        if (currentStream == null && !closed) {
+            openStreamAtCurrentPosition();
+        }
+    }
+
+    /**
+     * Opens (or reopens) the S3 stream at the current position.
+     *
+     * <p>This method:
+     *
+     * <ul>
+     *   <li>Closes any existing stream
+     *   <li>Opens a new stream starting at {@link #position}
+     *   <li>Uses HTTP range requests for non-zero positions
+     * </ul>
+     */
+    private void openStreamAtCurrentPosition() throws IOException {
+        lock.lock();
+        try {
+            if (bufferedStream != null) {
+                try {
+                    bufferedStream.close();
+                } catch (IOException e) {
+                    LOG.warn("Error closing buffered stream for {}/{}", bucketName, key, e);
+                } finally {
+                    bufferedStream = null;
+                }
+            }
+            if (currentStream != null) {
+                try {
+                    currentStream.close();
+                } catch (IOException e) {
+                    LOG.warn("Error closing S3 response stream for {}/{}", bucketName, key, e);
+                } finally {
+                    currentStream = null;
+                }
+            }
+
+            try {
+                GetObjectRequest.Builder requestBuilder =
+                        GetObjectRequest.builder().bucket(bucketName).key(key);
+
+                if (position > 0) {
+                    requestBuilder.range(String.format("bytes=%d-", position));
+                    LOG.debug(
+                            "Opening S3 stream with range: bytes={}-{}",
+                            position,
+                            contentLength - 1);
+                } else {
+                    LOG.debug("Opening S3 stream for full object: {} bytes", contentLength);
+                }
+                currentStream = s3Client.getObject(requestBuilder.build());
+                bufferedStream = new BufferedInputStream(currentStream, readBufferSize);
+            } catch (Exception e) {
+                if (bufferedStream != null) {
+                    try {
+                        bufferedStream.close();
+                    } catch (IOException ignored) {
+                    }
+                    bufferedStream = null;
+                }
+                if (currentStream != null) {
+                    try {
+                        currentStream.close();
+                    } catch (IOException ignored) {
+                    }
+                    currentStream = null;
+                }
+                throw new IOException("Failed to open S3 stream for " + bucketName + "/" + key, e);
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void seek(long desired) throws IOException {
+        lock();
+        try {
+            if (closed) {
+                throw new IOException("Stream is closed");
+            }
+            if (desired < 0) {
+                throw new IOException("Cannot seek to negative position: " + desired);
+            }
+
+            if (desired != position) {
+                position = desired;
+                if (currentStream != null) {
+                    openStreamAtCurrentPosition();
+                }
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public long getPos() throws IOException {
+        lock();
+        try {
+            return position;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public int read() throws IOException {
+        lock();
+        try {
+            if (closed) {
+                throw new IOException("Stream is closed");
+            }
+            lazyInitialize();
+            if (position >= contentLength) {
+                return -1;
+            }
+            int data = bufferedStream.read();
+            if (data != -1) {
+                position++;
+            }
+            return data;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        if (b == null) {
+            throw new NullPointerException("Read buffer must not be null");
+        }
+        if (off < 0 || len < 0 || len > b.length - off) {
+            throw new IndexOutOfBoundsException(
+                    String.format(
+                            "Range [off=%d, len=%d] out of bounds for buffer of length %d",
+                            off, len, b.length));
+        }
+        if (len == 0) {
+            return 0;
+        }
+        lock();
+        try {
+            if (closed) {
+                throw new IOException("Stream is closed");
+            }
+            lazyInitialize();
+            if (position >= contentLength) {
+                return -1;
+            }
+            long remaining = contentLength - position;
+            int toRead = (int) Math.min(len, remaining);
+            int bytesRead = bufferedStream.read(b, off, toRead);
+            if (bytesRead > 0) {
+                position += bytesRead;
+            }
+            return bytesRead;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private void lock() throws IOException {
+        try {
+            lock.lockInterruptibly();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while acquiring lock", e);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        lock.lock();
+        try {
+            if (closed) {
+                return;
+            }
+
+            closed = true;
+            IOException exception = null;
+
+            if (bufferedStream != null) {
+                try {
+                    bufferedStream.close();
+                } catch (IOException e) {
+                    exception = e;
+                    LOG.warn("Error closing buffered stream for {}/{}", bucketName, key, e);
+                } finally {
+                    bufferedStream = null;
+                }
+            }
+
+            if (currentStream != null) {
+                try {
+                    currentStream.close();
+                } catch (IOException e) {
+                    if (exception == null) {
+                        exception = e;
+                    } else {
+                        exception.addSuppressed(e);
+                    }
+                    LOG.warn("Error closing S3 response stream for {}/{}", bucketName, key, e);
+                } finally {
+                    currentStream = null;
+                }
+            }
+
+            LOG.debug(
+                    "Closed S3 input stream - bucket: {}, key: {}, final position: {}/{}",
+                    bucketName,
+                    key,
+                    position,
+                    contentLength);
+            if (exception != null) {
+                throw exception;
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Returns an estimate of the number of bytes that can be read without blocking.
+     *
+     * <p>This implementation returns the remaining bytes in the object based on content length and
+     * current position. Note that actual reads may still block due to network I/O, but this
+     * indicates how much data is logically available.
+     *
+     * @return the number of remaining bytes (capped at Integer.MAX_VALUE)
+     * @throws IOException if the stream has been closed
+     */
+    @Override
+    public int available() throws IOException {
+        lock();
+        try {
+            if (closed) {
+                throw new IOException("Stream is closed");
+            }
+            long remaining = contentLength - position;
+            return (int) Math.min(remaining, Integer.MAX_VALUE);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+        lock();
+        try {
+            if (closed) {
+                throw new IOException("Stream is closed");
+            }
+            if (n <= 0) {
+                return 0;
+            }
+            long newPos = Math.min(position + n, contentLength);
+            long skipped = newPos - position;
+            if (newPos != position) {
+                position = newPos;
+                if (currentStream != null) {
+                    openStreamAtCurrentPosition();
+                }
+            }
+            return skipped;
+        } finally {
+            lock.unlock();
+        }
+    }
+}

--- a/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/NativeS3OutputStream.java
+++ b/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/NativeS3OutputStream.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.s3native;
+
+import org.apache.flink.core.fs.FSDataOutputStream;
+
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import javax.annotation.Nullable;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.util.UUID;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * S3 output stream for non-recoverable S3 writes.
+ *
+ * <p><b>Thread Safety:</b> The lock guards write, flush, sync, and close so that {@link #close()}
+ * can be safely invoked from another thread (e.g. during task cancellation) per {@link
+ * org.apache.flink.core.fs.FSDataOutputStream} contract.
+ */
+public class NativeS3OutputStream extends FSDataOutputStream {
+
+    private static final int BUFFER_SIZE = 64 * 1024;
+
+    private final S3Client s3Client;
+    private final String bucketName;
+    private final String key;
+    private final File tmpFile;
+    private final OutputStream bufferedStream;
+    private final S3EncryptionConfig encryptionConfig;
+
+    private final ReentrantLock lock = new ReentrantLock();
+
+    private long position;
+
+    /** Flag to ensure upload happens exactly once. */
+    private boolean fileUploaded = false;
+
+    public NativeS3OutputStream(
+            S3Client s3Client, String bucketName, String key, String localTmpDir)
+            throws IOException {
+        this(s3Client, bucketName, key, localTmpDir, null);
+    }
+
+    public NativeS3OutputStream(
+            S3Client s3Client,
+            String bucketName,
+            String key,
+            String localTmpDir,
+            @Nullable S3EncryptionConfig encryptionConfig)
+            throws IOException {
+        this.s3Client = s3Client;
+        this.bucketName = bucketName;
+        this.key = key;
+        this.encryptionConfig =
+                encryptionConfig != null ? encryptionConfig : S3EncryptionConfig.none();
+
+        File tmpDir = new File(localTmpDir);
+        if (!tmpDir.exists()) {
+            tmpDir.mkdirs();
+        }
+
+        this.tmpFile = new File(tmpDir, "s3-upload-" + UUID.randomUUID());
+        this.bufferedStream = new BufferedOutputStream(new FileOutputStream(tmpFile), BUFFER_SIZE);
+        this.position = 0;
+    }
+
+    @Override
+    public long getPos() throws IOException {
+        lock.lock();
+        try {
+            return position;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        lock.lock();
+        try {
+            if (fileUploaded) {
+                throw new IOException("Stream is closed");
+            }
+            bufferedStream.write(b);
+            position++;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        if (b == null) {
+            throw new NullPointerException();
+        }
+        if (off < 0 || len < 0 || len > b.length - off) {
+            throw new IndexOutOfBoundsException();
+        }
+        lock.lock();
+        try {
+            if (fileUploaded) {
+                throw new IOException("Stream is closed");
+            }
+            bufferedStream.write(b, off, len);
+            position += len;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void flush() throws IOException {
+        lock.lock();
+        try {
+            if (fileUploaded) {
+                throw new IOException("Stream is closed");
+            }
+            bufferedStream.flush();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Flushes all buffered data and uploads the file to S3.
+     *
+     * @throws IOException if upload fails
+     */
+    @Override
+    public void sync() throws IOException {
+        lock.lock();
+        try {
+            if (!fileUploaded) {
+                fileUploaded = true;
+                uploadToS3();
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Closes this output stream and uploads the file to S3.
+     *
+     * @throws IOException if upload fails
+     */
+    @Override
+    public void close() throws IOException {
+        lock.lock();
+        try {
+            if (!fileUploaded) {
+                fileUploaded = true;
+                uploadToS3();
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /** Uploads the temp file to S3 and cleans up local resources. */
+    private void uploadToS3() throws IOException {
+        try {
+            bufferedStream.flush();
+            bufferedStream.close();
+
+            PutObjectRequest.Builder putRequestBuilder =
+                    PutObjectRequest.builder().bucket(bucketName).key(key);
+
+            // Apply encryption settings
+            if (encryptionConfig.isEnabled()) {
+                putRequestBuilder.serverSideEncryption(encryptionConfig.getServerSideEncryption());
+                if (encryptionConfig.getEncryptionType()
+                                == S3EncryptionConfig.EncryptionType.SSE_KMS
+                        && encryptionConfig.getKmsKeyId() != null) {
+                    putRequestBuilder.ssekmsKeyId(encryptionConfig.getKmsKeyId());
+                }
+            }
+
+            s3Client.putObject(putRequestBuilder.build(), RequestBody.fromFile(tmpFile));
+        } finally {
+            if (tmpFile.exists()) {
+                Files.delete(tmpFile.toPath());
+            }
+        }
+    }
+}

--- a/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/S3BlockLocation.java
+++ b/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/S3BlockLocation.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.s3native;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.core.fs.BlockLocation;
+
+@Internal
+public class S3BlockLocation implements BlockLocation {
+
+    private final String[] hosts;
+    private final long offset;
+    private final long length;
+
+    public S3BlockLocation(String[] hosts, long offset, long length) {
+        this.hosts = hosts;
+        this.offset = offset;
+        this.length = length;
+    }
+
+    @Override
+    public String[] getHosts() {
+        return hosts;
+    }
+
+    @Override
+    public long getOffset() {
+        return offset;
+    }
+
+    @Override
+    public long getLength() {
+        return length;
+    }
+
+    @Override
+    public int compareTo(BlockLocation o) {
+        return Long.compare(this.offset, o.getOffset());
+    }
+}

--- a/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/S3ClientProvider.java
+++ b/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/S3ClientProvider.java
@@ -1,0 +1,480 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.s3native;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.fs.s3native.token.DynamicTemporaryAWSCredentialsProvider;
+import org.apache.flink.util.AutoCloseableAsync;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.retry.RetryPolicy;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+import software.amazon.awssdk.transfer.s3.S3TransferManager;
+import software.amazon.awssdk.utils.SdkAutoCloseable;
+
+import javax.annotation.Nullable;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.net.URI;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+/**
+ * Provider for S3 clients (sync and async). Handles credential management, delegation tokens, and
+ * connection configuration.
+ *
+ * <p><b>Thread Safety:</b> This class is thread-safe. All fields are immutable or safely guarded by
+ * atomic operations ({@link AtomicBoolean}).
+ */
+@Internal
+class S3ClientProvider implements AutoCloseableAsync {
+
+    private static final Logger LOG = LoggerFactory.getLogger(S3ClientProvider.class);
+
+    /** Timeout in seconds for closing S3 clients. */
+    private static final long CLIENT_CLOSE_TIMEOUT_SECONDS = 30;
+
+    private final S3Client s3Client;
+    private final S3TransferManager transferManager;
+    private final S3EncryptionConfig encryptionConfig;
+    @Nullable private final AwsCredentialsProvider credentialsProvider;
+    @Nullable private final StsClient stsClient;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    private S3ClientProvider(
+            S3Client s3Client,
+            S3TransferManager transferManager,
+            S3EncryptionConfig encryptionConfig,
+            @Nullable AwsCredentialsProvider credentialsProvider,
+            @Nullable StsClient stsClient) {
+        this.s3Client = s3Client;
+        this.transferManager = transferManager;
+        this.encryptionConfig =
+                encryptionConfig != null ? encryptionConfig : S3EncryptionConfig.none();
+        this.credentialsProvider = credentialsProvider;
+        this.stsClient = stsClient;
+    }
+
+    public S3Client getS3Client() {
+        checkNotClosed();
+        return s3Client;
+    }
+
+    public S3TransferManager getTransferManager() {
+        checkNotClosed();
+        return transferManager;
+    }
+
+    /** Returns the encryption configuration for S3 operations. */
+    public S3EncryptionConfig getEncryptionConfig() {
+        return encryptionConfig;
+    }
+
+    @VisibleForTesting
+    AwsCredentialsProvider getCredentialsProvider() {
+        return credentialsProvider;
+    }
+
+    @Override
+    public CompletableFuture<Void> closeAsync() {
+        if (!closed.compareAndSet(false, true)) {
+            return CompletableFuture.completedFuture(null);
+        }
+        return CompletableFuture.runAsync(
+                        () -> {
+                            if (transferManager != null) {
+                                try {
+                                    transferManager.close();
+                                } catch (Exception e) {
+                                    LOG.warn("Error closing S3 TransferManager", e);
+                                }
+                            }
+                            if (s3Client != null) {
+                                try {
+                                    s3Client.close();
+                                } catch (Exception e) {
+                                    LOG.warn("Error closing S3 sync client", e);
+                                }
+                            }
+                            if (getCredentialsProvider() instanceof SdkAutoCloseable) {
+                                try {
+                                    ((SdkAutoCloseable) getCredentialsProvider()).close();
+                                } catch (Exception e) {
+                                    LOG.warn("Error closing credentials provider", e);
+                                }
+                            }
+                            if (stsClient != null) {
+                                try {
+                                    stsClient.close();
+                                } catch (Exception e) {
+                                    LOG.warn("Error closing STS client", e);
+                                }
+                            }
+                        })
+                .orTimeout(CLIENT_CLOSE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .exceptionally(
+                        ex -> {
+                            LOG.error(
+                                    "S3 client close timed out after {} seconds",
+                                    CLIENT_CLOSE_TIMEOUT_SECONDS,
+                                    ex);
+                            return null;
+                        });
+    }
+
+    private void checkNotClosed() {
+        if (closed.get()) {
+            throw new IllegalStateException("S3ClientProvider has been closed");
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String accessKey;
+        private String secretKey;
+        private String region;
+        private String endpoint;
+        private boolean pathStyleAccess = false;
+        private int maxConnections = 50;
+        private Duration connectionTimeout = Duration.ofSeconds(60);
+        private Duration socketTimeout = Duration.ofSeconds(60);
+        private boolean disableCertCheck = false;
+        private int maxRetries = 3;
+
+        // AssumeRole configuration
+        private String assumeRoleArn;
+        private String assumeRoleExternalId;
+        private String assumeRoleSessionName = "flink-s3-session";
+        private int assumeRoleSessionDurationSeconds = 3600;
+
+        // Encryption configuration
+        private S3EncryptionConfig encryptionConfig;
+
+        // Custom credentials provider class names (comma-separated)
+        @Nullable private String credentialsProviderClasses;
+
+        public Builder accessKey(@Nullable String accessKey) {
+            this.accessKey = accessKey;
+            return this;
+        }
+
+        public Builder secretKey(@Nullable String secretKey) {
+            this.secretKey = secretKey;
+            return this;
+        }
+
+        public Builder region(@Nullable String region) {
+            this.region = region;
+            return this;
+        }
+
+        public Builder endpoint(@Nullable String endpoint) {
+            this.endpoint = endpoint;
+            return this;
+        }
+
+        public Builder pathStyleAccess(boolean pathStyleAccess) {
+            this.pathStyleAccess = pathStyleAccess;
+            return this;
+        }
+
+        public Builder maxConnections(int maxConnections) {
+            this.maxConnections = maxConnections;
+            return this;
+        }
+
+        public Builder connectionTimeout(Duration connectionTimeout) {
+            this.connectionTimeout = connectionTimeout;
+            return this;
+        }
+
+        public Builder socketTimeout(Duration socketTimeout) {
+            this.socketTimeout = socketTimeout;
+            return this;
+        }
+
+        public Builder disableCertCheck(boolean disableCertCheck) {
+            this.disableCertCheck = disableCertCheck;
+            return this;
+        }
+
+        public Builder maxRetries(int maxRetries) {
+            this.maxRetries = maxRetries;
+            return this;
+        }
+
+        public Builder assumeRoleArn(@Nullable String assumeRoleArn) {
+            this.assumeRoleArn = assumeRoleArn;
+            return this;
+        }
+
+        public Builder assumeRoleExternalId(@Nullable String assumeRoleExternalId) {
+            this.assumeRoleExternalId = assumeRoleExternalId;
+            return this;
+        }
+
+        public Builder assumeRoleSessionName(@Nullable String assumeRoleSessionName) {
+            if (assumeRoleSessionName != null) {
+                this.assumeRoleSessionName = assumeRoleSessionName;
+            }
+            return this;
+        }
+
+        public Builder assumeRoleSessionDurationSeconds(int assumeRoleSessionDurationSeconds) {
+            this.assumeRoleSessionDurationSeconds = assumeRoleSessionDurationSeconds;
+            return this;
+        }
+
+        public Builder encryptionConfig(@Nullable S3EncryptionConfig encryptionConfig) {
+            this.encryptionConfig = encryptionConfig;
+            return this;
+        }
+
+        public Builder credentialsProviderClasses(@Nullable String credentialsProviderClasses) {
+            this.credentialsProviderClasses = credentialsProviderClasses;
+            return this;
+        }
+
+        public S3ClientProvider build() {
+            if (endpoint == null) {
+                endpoint = System.getProperty("s3.endpoint");
+            }
+            String pathStyleProp = System.getProperty("s3.path.style.access");
+            if (pathStyleProp != null) {
+                pathStyleAccess = Boolean.parseBoolean(pathStyleProp);
+            }
+
+            URI endpointUri = (endpoint != null) ? URI.create(endpoint) : null;
+            boolean isS3Compatible = endpointUri != null;
+
+            if (isS3Compatible && !pathStyleAccess) {
+                pathStyleAccess = true;
+            }
+            if (isS3Compatible && "http".equalsIgnoreCase(endpointUri.getScheme())) {
+                disableCertCheck = true;
+            }
+
+            Region awsRegion = resolveRegion(region);
+            StsClient stsClient = null;
+            AwsCredentialsProvider credentialsProvider;
+
+            AwsCredentialsProvider baseProvider = buildBaseCredentialsProvider();
+            if (assumeRoleArn != null && !assumeRoleArn.isEmpty()) {
+                stsClient = buildStsClient(baseProvider, awsRegion);
+                credentialsProvider = buildAssumeRoleProvider(stsClient);
+            } else {
+                credentialsProvider = baseProvider;
+            }
+
+            S3Configuration.Builder s3ConfigBuilder =
+                    S3Configuration.builder().pathStyleAccessEnabled(pathStyleAccess);
+            if (isS3Compatible) {
+                s3ConfigBuilder.chunkedEncodingEnabled(false).checksumValidationEnabled(false);
+            }
+            S3Configuration s3Config = s3ConfigBuilder.build();
+
+            ClientOverrideConfiguration overrideConfig =
+                    ClientOverrideConfiguration.builder()
+                            .retryPolicy(RetryPolicy.builder().numRetries(maxRetries).build())
+                            .build();
+
+            ApacheHttpClient.Builder httpClientBuilder =
+                    ApacheHttpClient.builder()
+                            .maxConnections(maxConnections)
+                            .connectionTimeout(connectionTimeout)
+                            .socketTimeout(socketTimeout)
+                            .tcpKeepAlive(true)
+                            .connectionMaxIdleTime(Duration.ofSeconds(60));
+
+            S3ClientBuilder clientBuilder =
+                    S3Client.builder()
+                            .credentialsProvider(credentialsProvider)
+                            .region(awsRegion)
+                            .serviceConfiguration(s3Config)
+                            .httpClientBuilder(httpClientBuilder)
+                            .overrideConfiguration(overrideConfig);
+            if (endpointUri != null) {
+                clientBuilder.endpointOverride(endpointUri);
+            }
+            S3Client s3Client = clientBuilder.build();
+            S3TransferManager transferManager =
+                    S3TransferManager.builder()
+                            .s3Client(
+                                    S3AsyncClient.builder()
+                                            .credentialsProvider(credentialsProvider)
+                                            .region(awsRegion)
+                                            .serviceConfiguration(s3Config)
+                                            .httpClientBuilder(
+                                                    NettyNioAsyncHttpClient.builder()
+                                                            .maxConcurrency(maxConnections)
+                                                            .connectionTimeout(connectionTimeout)
+                                                            .readTimeout(socketTimeout))
+                                            .overrideConfiguration(overrideConfig)
+                                            .endpointOverride(endpointUri)
+                                            .build())
+                            .build();
+
+            return new S3ClientProvider(
+                    s3Client, transferManager, encryptionConfig, credentialsProvider, stsClient);
+        }
+
+        private AwsCredentialsProvider buildBaseCredentialsProvider() {
+            List<AwsCredentialsProvider> chain = new ArrayList<>();
+
+            if (credentialsProviderClasses != null
+                    && !credentialsProviderClasses.trim().isEmpty()) {
+                for (String name : credentialsProviderClasses.split(",")) {
+                    String trimmed = name.trim();
+                    if (!trimmed.isEmpty()) {
+                        chain.add(instantiateCredentialsProvider(trimmed));
+                    }
+                }
+                if (chain.isEmpty()) {
+                    throw new IllegalArgumentException(
+                            "fs.s3.aws.credentials.provider is set but contains no valid provider class names");
+                }
+            }
+
+            if (accessKey != null && secretKey != null) {
+                chain.add(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(accessKey, secretKey)));
+            }
+
+            chain.add(new DynamicTemporaryAWSCredentialsProvider());
+            chain.add(DefaultCredentialsProvider.builder().build());
+
+            LOG.info(
+                    "Using credentials provider chain: {}",
+                    chain.stream()
+                            .map(p -> p.getClass().getSimpleName())
+                            .collect(Collectors.joining(" -> ")));
+
+            return AwsCredentialsProviderChain.builder().credentialsProviders(chain).build();
+        }
+
+        /**
+         * Instantiates an {@link AwsCredentialsProvider} from a class name. Accepts fully-qualified
+         * SDK v2 class names or simple names resolved from the {@code
+         * software.amazon.awssdk.auth.credentials} package (e.g. {@code
+         * AnonymousCredentialsProvider}).
+         */
+        private AwsCredentialsProvider instantiateCredentialsProvider(String className) {
+            String resolvedClassName = resolveProviderClassName(className);
+            try {
+                Class<?> clazz = Class.forName(resolvedClassName);
+                if (!AwsCredentialsProvider.class.isAssignableFrom(clazz)) {
+                    throw new IllegalArgumentException(
+                            "Class "
+                                    + resolvedClassName
+                                    + " does not implement AwsCredentialsProvider");
+                }
+
+                try {
+                    Method createMethod = clazz.getMethod("create");
+                    if (Modifier.isStatic(createMethod.getModifiers())
+                            && AwsCredentialsProvider.class.isAssignableFrom(
+                                    createMethod.getReturnType())) {
+                        return (AwsCredentialsProvider) createMethod.invoke(null);
+                    }
+                } catch (NoSuchMethodException ignored) {
+                }
+
+                return (AwsCredentialsProvider) clazz.getDeclaredConstructor().newInstance();
+            } catch (Exception e) {
+                throw new IllegalArgumentException(
+                        "Failed to instantiate credentials provider: " + resolvedClassName, e);
+            }
+        }
+
+        private static String resolveProviderClassName(String className) {
+            if (!className.contains(".")) {
+                return "software.amazon.awssdk.auth.credentials." + className;
+            }
+            return className;
+        }
+
+        private StsClient buildStsClient(AwsCredentialsProvider baseProvider, Region awsRegion) {
+            return StsClient.builder().region(awsRegion).credentialsProvider(baseProvider).build();
+        }
+
+        private AwsCredentialsProvider buildAssumeRoleProvider(StsClient stsClient) {
+            AssumeRoleRequest.Builder requestBuilder =
+                    AssumeRoleRequest.builder()
+                            .roleArn(assumeRoleArn)
+                            .roleSessionName(assumeRoleSessionName)
+                            .durationSeconds(assumeRoleSessionDurationSeconds);
+
+            if (assumeRoleExternalId != null && !assumeRoleExternalId.isEmpty()) {
+                requestBuilder.externalId(assumeRoleExternalId);
+            }
+
+            return StsAssumeRoleCredentialsProvider.builder()
+                    .stsClient(stsClient)
+                    .refreshRequest(requestBuilder.build())
+                    .build();
+        }
+
+        private Region resolveRegion(@Nullable String explicitRegion) {
+            if (explicitRegion != null && !explicitRegion.isEmpty()) {
+                LOG.info("Using configured AWS region: {}", explicitRegion);
+                return Region.of(explicitRegion);
+            }
+
+            try {
+                Region region = DefaultAwsRegionProviderChain.builder().build().getRegion();
+                LOG.info("Auto-detected AWS region: {}", region.id());
+                return region;
+            } catch (Exception e) {
+                // Fall through to error
+            }
+
+            throw new IllegalArgumentException(
+                    "AWS region could not be determined. Set 's3.region' in Flink configuration, "
+                            + "AWS_REGION environment variable, or configure ~/.aws/config");
+        }
+    }
+}

--- a/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/S3EncryptionConfig.java
+++ b/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/S3EncryptionConfig.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.s3native;
+
+import org.apache.flink.annotation.Internal;
+
+import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Configuration for S3 server-side encryption (SSE).
+ *
+ * <p>Supported encryption types:
+ *
+ * <ul>
+ *   <li><b>SSE-S3</b>: Server-side encryption with Amazon S3-managed keys
+ *   <li><b>SSE-KMS</b>: Server-side encryption with AWS KMS-managed keys
+ * </ul>
+ *
+ * <p><b>Encryption Context (SSE-KMS only):</b> For SSE-KMS, you can optionally provide an
+ * encryption context - a set of key-value pairs that provide additional authenticated data (AAD).
+ * This allows for more granular permission control in IAM policies. See <a
+ * href="https://docs.aws.amazon.com/kms/latest/developerguide/encrypt_context.html">AWS KMS
+ * Encryption Context</a> for details.
+ */
+@Internal
+public class S3EncryptionConfig implements Serializable {
+
+    private static final long serialVersionUID = 2L;
+
+    /** Encryption types supported by this configuration. */
+    public enum EncryptionType {
+        /** No encryption. */
+        NONE,
+        /** Server-side encryption with Amazon S3-managed keys (SSE-S3). */
+        SSE_S3,
+        /** Server-side encryption with AWS KMS-managed keys (SSE-KMS). */
+        SSE_KMS
+    }
+
+    private final EncryptionType encryptionType;
+    @Nullable private final String kmsKeyId;
+
+    /**
+     * Optional encryption context for SSE-KMS. Provides additional authenticated data for KMS
+     * encrypt/decrypt operations and can be used for fine-grained IAM policy conditions.
+     */
+    private final Map<String, String> encryptionContext;
+
+    private S3EncryptionConfig(EncryptionType encryptionType, @Nullable String kmsKeyId) {
+        this(encryptionType, kmsKeyId, Collections.emptyMap());
+    }
+
+    private S3EncryptionConfig(
+            EncryptionType encryptionType,
+            @Nullable String kmsKeyId,
+            Map<String, String> encryptionContext) {
+        this.encryptionType = encryptionType;
+        this.kmsKeyId = kmsKeyId;
+        this.encryptionContext =
+                encryptionContext != null
+                        ? Collections.unmodifiableMap(new HashMap<>(encryptionContext))
+                        : Collections.emptyMap();
+    }
+
+    /** Creates a config with no encryption. */
+    public static S3EncryptionConfig none() {
+        return new S3EncryptionConfig(EncryptionType.NONE, null);
+    }
+
+    /** Creates a config for SSE-S3 encryption (S3-managed keys). */
+    public static S3EncryptionConfig sseS3() {
+        return new S3EncryptionConfig(EncryptionType.SSE_S3, null);
+    }
+
+    /**
+     * Creates a config for SSE-KMS encryption with the default KMS key.
+     *
+     * <p>Uses the AWS-managed KMS key (aws/s3) for the S3 bucket.
+     */
+    public static S3EncryptionConfig sseKms() {
+        return new S3EncryptionConfig(EncryptionType.SSE_KMS, null);
+    }
+
+    /**
+     * Creates a config for SSE-KMS encryption with a specific KMS key.
+     *
+     * @param kmsKeyId The KMS key ID, ARN, or alias (e.g., "arn:aws:kms:region:account:key/key-id"
+     *     or "alias/my-key")
+     */
+    public static S3EncryptionConfig sseKms(String kmsKeyId) {
+        return new S3EncryptionConfig(EncryptionType.SSE_KMS, kmsKeyId);
+    }
+
+    /**
+     * Creates a config for SSE-KMS encryption with a specific KMS key and encryption context.
+     *
+     * <p>The encryption context is a set of key-value pairs that:
+     *
+     * <ul>
+     *   <li>Provides additional authenticated data (AAD) for encryption
+     *   <li>Can be used in IAM policy conditions for fine-grained access control
+     *   <li>Is logged in AWS CloudTrail for auditing
+     * </ul>
+     *
+     * <p>Example: You might include context like {"department": "finance", "project": "budget"} to
+     * restrict which principals can encrypt/decrypt based on these values.
+     *
+     * @param kmsKeyId The KMS key ID, ARN, or alias
+     * @param encryptionContext The encryption context key-value pairs
+     * @see <a href="https://docs.aws.amazon.com/kms/latest/developerguide/encrypt_context.html">AWS
+     *     KMS Encryption Context</a>
+     */
+    public static S3EncryptionConfig sseKms(
+            String kmsKeyId, Map<String, String> encryptionContext) {
+        return new S3EncryptionConfig(EncryptionType.SSE_KMS, kmsKeyId, encryptionContext);
+    }
+
+    /**
+     * Creates an encryption config from configuration strings.
+     *
+     * @param encryptionTypeStr The encryption type: "none", "sse-s3", "sse-kms", or "SSE_S3",
+     *     "SSE_KMS"
+     * @param kmsKeyId The KMS key ID (required for SSE-KMS, ignored for other types)
+     * @return The encryption configuration
+     * @throws IllegalArgumentException if the encryption type is invalid
+     */
+    public static S3EncryptionConfig fromConfig(
+            @Nullable String encryptionTypeStr, @Nullable String kmsKeyId) {
+        if (encryptionTypeStr == null
+                || encryptionTypeStr.isEmpty()
+                || "none".equalsIgnoreCase(encryptionTypeStr)) {
+            return none();
+        }
+
+        String normalizedType = encryptionTypeStr.toUpperCase().replace("-", "_").replace(":", "_");
+
+        switch (normalizedType) {
+            case "SSE_S3":
+            case "AES256":
+                return sseS3();
+            case "SSE_KMS":
+            case "AWS_KMS":
+                return kmsKeyId != null && !kmsKeyId.isEmpty() ? sseKms(kmsKeyId) : sseKms();
+            default:
+                throw new IllegalArgumentException(
+                        "Unknown encryption type: "
+                                + encryptionTypeStr
+                                + ". Supported values: none, sse-s3, sse-kms");
+        }
+    }
+
+    public EncryptionType getEncryptionType() {
+        return encryptionType;
+    }
+
+    @Nullable
+    public String getKmsKeyId() {
+        return kmsKeyId;
+    }
+
+    /**
+     * Gets the encryption context for SSE-KMS.
+     *
+     * @return The encryption context map (never null, may be empty)
+     */
+    public Map<String, String> getEncryptionContext() {
+        return encryptionContext;
+    }
+
+    /**
+     * Checks if encryption context is configured.
+     *
+     * @return true if encryption context has entries
+     */
+    public boolean hasEncryptionContext() {
+        return !encryptionContext.isEmpty();
+    }
+
+    public boolean isEnabled() {
+        return encryptionType != EncryptionType.NONE;
+    }
+
+    /**
+     * Gets the AWS SDK ServerSideEncryption enum value for this configuration.
+     *
+     * @return The ServerSideEncryption value, or null if encryption is disabled
+     */
+    @Nullable
+    public ServerSideEncryption getServerSideEncryption() {
+        switch (encryptionType) {
+            case SSE_S3:
+                return ServerSideEncryption.AES256;
+            case SSE_KMS:
+                return ServerSideEncryption.AWS_KMS;
+            default:
+                return null;
+        }
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder("S3EncryptionConfig{type=").append(encryptionType);
+        if (kmsKeyId != null) {
+            sb.append(", kmsKeyId=").append(kmsKeyId);
+        }
+        if (!encryptionContext.isEmpty()) {
+            sb.append(", encryptionContext=").append(encryptionContext.keySet());
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+}

--- a/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/S3ExceptionUtils.java
+++ b/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/S3ExceptionUtils.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.s3native;
+
+import org.apache.flink.annotation.Internal;
+
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import java.io.IOException;
+
+/** Utilities for consistent handling of {@link S3Exception} across the native S3 connector. */
+@Internal
+public final class S3ExceptionUtils {
+
+    private S3ExceptionUtils() {}
+
+    /**
+     * Wraps an {@link S3Exception} into an {@link IOException} with a contextual message that
+     * includes HTTP status code and AWS error details when available.
+     */
+    public static IOException toIOException(String context, S3Exception e) {
+        return new IOException(
+                String.format("%s (HTTP %d: %s)", context, e.statusCode(), errorMessage(e)), e);
+    }
+
+    public static String errorMessage(S3Exception e) {
+        AwsErrorDetails details = e.awsErrorDetails();
+        if (details != null && details.errorMessage() != null) {
+            return details.errorMessage();
+        }
+        return e.getMessage() != null ? e.getMessage() : "Unknown S3 error";
+    }
+
+    public static String errorCode(S3Exception e) {
+        AwsErrorDetails details = e.awsErrorDetails();
+        if (details != null && details.errorCode() != null) {
+            return details.errorCode();
+        }
+        return "Unknown";
+    }
+}

--- a/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/S3FileStatus.java
+++ b/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/S3FileStatus.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.s3native;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.core.fs.FileStatus;
+import org.apache.flink.core.fs.Path;
+
+@Internal
+public class S3FileStatus implements FileStatus {
+
+    private final long length;
+    private final long blockSize;
+    private final long modificationTime;
+    private final long accessTime;
+    private final boolean isDir;
+    private final Path path;
+
+    /** Creates a FileStatus for an S3 file with the given size and modification time. */
+    public static S3FileStatus withFile(long size, long modificationTime, Path path) {
+        return new S3FileStatus(size, size, modificationTime, 0, false, path);
+    }
+
+    /** Creates a FileStatus for an S3 directory (prefix). */
+    public static S3FileStatus withDirectory(Path path) {
+        return new S3FileStatus(0, 0, 0, 0, true, path);
+    }
+
+    S3FileStatus(
+            long length,
+            long blockSize,
+            long modificationTime,
+            long accessTime,
+            boolean isDir,
+            Path path) {
+        this.length = length;
+        this.blockSize = blockSize;
+        this.modificationTime = modificationTime;
+        this.accessTime = accessTime;
+        this.isDir = isDir;
+        this.path = path;
+    }
+
+    @Override
+    public long getLen() {
+        return length;
+    }
+
+    @Override
+    public long getBlockSize() {
+        return blockSize;
+    }
+
+    @Override
+    public short getReplication() {
+        return 1;
+    }
+
+    @Override
+    public long getModificationTime() {
+        return modificationTime;
+    }
+
+    @Override
+    public long getAccessTime() {
+        return accessTime;
+    }
+
+    @Override
+    public boolean isDir() {
+        return isDir;
+    }
+
+    @Override
+    public Path getPath() {
+        return path;
+    }
+}

--- a/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/token/DynamicTemporaryAWSCredentialsProvider.java
+++ b/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/token/DynamicTemporaryAWSCredentialsProvider.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.s3native.token;
+
+import org.apache.flink.annotation.Internal;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.services.sts.model.Credentials;
+
+@Internal
+public class DynamicTemporaryAWSCredentialsProvider implements AwsCredentialsProvider {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(DynamicTemporaryAWSCredentialsProvider.class);
+
+    @Override
+    public AwsCredentials resolveCredentials() {
+        Credentials credentials = NativeS3DelegationTokenReceiver.getCredentials();
+        if (credentials == null) {
+            // AWS SDK chain expects an exception when provider doesn't have credentials.
+            // This signals the chain to try the next provider in the chain.
+            LOG.debug(
+                    "No delegation token credentials available - "
+                            + "AWS SDK will try next provider in chain");
+            throw new CredentialsNotAvailableException(
+                    "No delegation token credentials available - proceeding to next provider in chain");
+        }
+        LOG.debug(
+                "Using delegation token credentials with access key: {}",
+                credentials.accessKeyId());
+        return AwsSessionCredentials.create(
+                credentials.accessKeyId(),
+                credentials.secretAccessKey(),
+                credentials.sessionToken());
+    }
+
+    /**
+     * Exception thrown when delegation token credentials are not available. This is caught by the
+     * AwsCredentialsProviderChain to proceed to the next provider.
+     */
+    public static class CredentialsNotAvailableException extends RuntimeException {
+        public CredentialsNotAvailableException(String message) {
+            super(message);
+        }
+    }
+}

--- a/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/token/NativeS3DelegationTokenProvider.java
+++ b/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/token/NativeS3DelegationTokenProvider.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.s3native.token;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.GlobalConfiguration;
+import org.apache.flink.core.security.token.DelegationTokenProvider;
+import org.apache.flink.util.InstantiationUtil;
+import org.apache.flink.util.StringUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.model.Credentials;
+import software.amazon.awssdk.services.sts.model.GetSessionTokenRequest;
+import software.amazon.awssdk.services.sts.model.GetSessionTokenResponse;
+
+import java.util.Optional;
+
+/** Provider for AWS S3 delegation tokens using STS session credentials. */
+@Internal
+public class NativeS3DelegationTokenProvider implements DelegationTokenProvider {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(NativeS3DelegationTokenProvider.class);
+
+    /**
+     * Pattern for basic validation of AWS region values. Uses a permissive pattern (alphanumeric +
+     * hyphens).
+     */
+    private static final java.util.regex.Pattern REGION_PATTERN =
+            java.util.regex.Pattern.compile("^[a-z0-9]([a-z0-9\\-]*[a-z0-9])?$");
+
+    private volatile String region;
+    private volatile String accessKey;
+    private volatile String secretKey;
+
+    /**
+     * Using unique service name. Avoids conflict with s3-fs-hadoop plugin. Both plugins can coexist
+     * with different service names
+     *
+     * @return ServiceName
+     */
+    @Override
+    public String serviceName() {
+        return "s3-native";
+    }
+
+    @Override
+    public void init(Configuration configuration) {
+        String configPrefix = String.format("%s.%s", CONFIG_PREFIX, serviceName());
+
+        region = configuration.getString(configPrefix + ".region", null);
+        if (!StringUtils.isNullOrWhitespaceOnly(region)) {
+            if (!REGION_PATTERN.matcher(region).matches()) {
+                LOG.warn(
+                        "Region '{}' contains invalid characters. "
+                                + "Expected only lowercase alphanumeric characters and hyphens (e.g., us-east-1, cn-north-1)",
+                        region);
+            }
+            LOG.debug("Region: {}", region);
+        }
+
+        accessKey = configuration.getString(configPrefix + ".access-key", null);
+        if (!StringUtils.isNullOrWhitespaceOnly(accessKey)) {
+            LOG.debug("Access key configured");
+        }
+
+        secretKey = configuration.getString(configPrefix + ".secret-key", null);
+        if (!StringUtils.isNullOrWhitespaceOnly(secretKey)) {
+            LOG.debug("Secret key: {} (sensitive information)", GlobalConfiguration.HIDDEN_CONTENT);
+        }
+    }
+
+    @Override
+    public boolean delegationTokensRequired() {
+        if (StringUtils.isNullOrWhitespaceOnly(region)
+                || StringUtils.isNullOrWhitespaceOnly(accessKey)
+                || StringUtils.isNullOrWhitespaceOnly(secretKey)) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public ObtainedDelegationTokens obtainDelegationTokens() throws Exception {
+        LOG.info("Obtaining session credentials token with access key: {}", accessKey);
+        StsClient stsClient =
+                StsClient.builder()
+                        .region(Region.of(region))
+                        .credentialsProvider(
+                                StaticCredentialsProvider.create(
+                                        AwsBasicCredentials.create(accessKey, secretKey)))
+                        .build();
+        try {
+            GetSessionTokenRequest request = GetSessionTokenRequest.builder().build();
+            GetSessionTokenResponse response = stsClient.getSessionToken(request);
+            Credentials credentials = response.credentials();
+
+            LOG.info(
+                    "Session credentials obtained successfully with access key: {}, expiration: {}",
+                    credentials.accessKeyId(),
+                    credentials.expiration());
+            return new ObtainedDelegationTokens(
+                    InstantiationUtil.serializeObject(credentials),
+                    Optional.of(credentials.expiration().toEpochMilli()));
+        } finally {
+            stsClient.close();
+        }
+    }
+}

--- a/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/token/NativeS3DelegationTokenReceiver.java
+++ b/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/token/NativeS3DelegationTokenReceiver.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.s3native.token;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.security.token.DelegationTokenProvider;
+import org.apache.flink.core.security.token.DelegationTokenReceiver;
+import org.apache.flink.util.InstantiationUtil;
+import org.apache.flink.util.StringUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.sts.model.Credentials;
+
+import javax.annotation.Nullable;
+
+/**
+ * Receiver for AWS S3 delegation tokens that stores credentials for use by the file system.
+ *
+ * <ul>
+ *   <li>{@link #getRegion()} must be called <b>after</b> {@link #init(Configuration)} to get a
+ *       non-null region value. Calling it before init will return null.
+ *   <li>{@link #getCredentials()} must be called <b>after</b> {@link #onNewTokensObtained(byte[])}
+ *       to get valid credentials. Calling it before tokens are obtained will return null.
+ *   <li>The volatile modifier ensures visibility across threads, but callers should be prepared to
+ *       handle null values if methods are called before their prerequisites.
+ *   <li>If multiple calls to {@link #onNewTokensObtained(byte[])} occur concurrently, the final
+ *       credential value is non-deterministic, but this is acceptable as tokens are typically
+ *       refreshed periodically with sufficient spacing.
+ * </ul>
+ */
+@Internal
+public class NativeS3DelegationTokenReceiver implements DelegationTokenReceiver {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(NativeS3DelegationTokenReceiver.class);
+
+    /**
+     * The current session credentials. Will be null until {@link #onNewTokensObtained(byte[])} is
+     * called.
+     */
+    @VisibleForTesting @Nullable static volatile Credentials credentials;
+
+    /**
+     * The AWS region. Will be null until {@link #init(Configuration)} is called with a configured
+     * region.
+     */
+    @VisibleForTesting @Nullable static volatile String region;
+
+    @Override
+    public String serviceName() {
+        return "s3-native";
+    }
+
+    @Override
+    public void init(Configuration configuration) {
+        region =
+                configuration.getString(
+                        String.format(
+                                "%s.%s.region",
+                                DelegationTokenProvider.CONFIG_PREFIX, serviceName()),
+                        null);
+        if (!StringUtils.isNullOrWhitespaceOnly(region)) {
+            LOG.debug("Region configured: {}", region);
+        }
+    }
+
+    @Override
+    public void onNewTokensObtained(byte[] tokens) throws Exception {
+        LOG.info("Updating session credentials");
+        credentials =
+                InstantiationUtil.deserializeObject(
+                        tokens, NativeS3DelegationTokenReceiver.class.getClassLoader());
+        LOG.info(
+                "Session credentials updated successfully with access key: {}, expiration: {}",
+                credentials.accessKeyId(),
+                credentials.expiration());
+    }
+
+    @Nullable
+    public static Credentials getCredentials() {
+        return credentials;
+    }
+
+    @Nullable
+    public static String getRegion() {
+        return region;
+    }
+}

--- a/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/writer/NativeS3AccessHelper.java
+++ b/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/writer/NativeS3AccessHelper.java
@@ -1,0 +1,560 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.s3native.writer;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.fs.s3native.S3EncryptionConfig;
+import org.apache.flink.fs.s3native.S3ExceptionUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.core.sync.ResponseTransformer;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.CompletedMultipartUpload;
+import software.amazon.awssdk.services.s3.model.CompletedPart;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchUploadException;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
+import software.amazon.awssdk.services.s3.model.UploadPartResponse;
+import software.amazon.awssdk.transfer.s3.S3TransferManager;
+import software.amazon.awssdk.transfer.s3.model.CompletedFileUpload;
+import software.amazon.awssdk.transfer.s3.model.FileUpload;
+import software.amazon.awssdk.transfer.s3.model.UploadFileRequest;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Helper class for S3 operations including multipart uploads, object storage, and retrieval.
+ *
+ * <p><b>Retry Handling:</b> This class relies on the AWS SDK's built-in retry mechanism which is
+ * configured in {@link org.apache.flink.fs.s3native.S3ClientProvider}. The SDK automatically
+ * handles retries for transient errors including:
+ *
+ * <ul>
+ *   <li>5xx server errors (including S3 throttling which manifests as 503 Service Unavailable)
+ *   <li>Network timeouts and connection errors
+ *   <li>Request timeouts
+ * </ul>
+ *
+ * <p>Terminal (non-retriable) errors include:
+ *
+ * <ul>
+ *   <li>4xx client errors (400 Bad Request, 403 Forbidden, 404 Not Found)
+ *   <li>Authentication/authorization failures
+ *   <li>Invalid bucket or key names
+ * </ul>
+ *
+ * <p><b>Encryption Support:</b> Currently supports SSE-S3 and SSE-KMS encryption modes. The
+ * encryption logic is applied through the {@link S3EncryptionConfig} class. Future enhancements may
+ * include:
+ *
+ * <ul>
+ *   <li>SSE-C (customer-provided keys) via a KeyProvider interface
+ *   <li>Client-side encryption via an EncryptionHandler interface
+ *   <li>Encryption context for SSE-KMS (see HADOOP-19197)
+ * </ul>
+ *
+ * <p><b>S3 URI Handling:</b> The {@link #extractKey(Path)} and {@link #extractBucketName(Path)}
+ * methods expect URIs in the standard {@code s3://bucket/key} format. Other formats like path-style
+ * ({@code https://s3.amazonaws.com/bucket/key}) or virtual-hosted-style ({@code
+ * https://bucket.s3.amazonaws.com/key}) are not currently supported.
+ */
+@Internal
+public class NativeS3AccessHelper {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NativeS3AccessHelper.class);
+
+    private final S3Client s3Client;
+    private final S3TransferManager transferManager;
+    private final String bucketName;
+    private final boolean useAsyncOperations;
+    private final S3EncryptionConfig encryptionConfig;
+
+    public NativeS3AccessHelper(S3Client s3Client, String bucketName) {
+        this(s3Client, null, bucketName, false, null);
+    }
+
+    public NativeS3AccessHelper(
+            S3Client s3Client,
+            S3TransferManager transferManager,
+            String bucketName,
+            boolean useAsyncOperations) {
+        this(s3Client, transferManager, bucketName, useAsyncOperations, null);
+    }
+
+    public NativeS3AccessHelper(
+            S3Client s3Client,
+            S3TransferManager transferManager,
+            String bucketName,
+            boolean useAsyncOperations,
+            S3EncryptionConfig encryptionConfig) {
+        this.s3Client = s3Client;
+        this.transferManager = transferManager;
+        this.bucketName = bucketName;
+        this.useAsyncOperations = useAsyncOperations && transferManager != null;
+        this.encryptionConfig =
+                encryptionConfig != null ? encryptionConfig : S3EncryptionConfig.none();
+    }
+
+    public String startMultiPartUpload(String key) throws IOException {
+        try {
+            CreateMultipartUploadRequest.Builder requestBuilder =
+                    CreateMultipartUploadRequest.builder().bucket(bucketName).key(key);
+            applyEncryption(requestBuilder);
+
+            CreateMultipartUploadResponse response =
+                    s3Client.createMultipartUpload(requestBuilder.build());
+            return response.uploadId();
+        } catch (S3Exception e) {
+            throw new IOException("Failed to start multipart upload for key: " + key, e);
+        }
+    }
+
+    private void applyEncryption(CreateMultipartUploadRequest.Builder requestBuilder) {
+        if (!encryptionConfig.isEnabled()) {
+            return;
+        }
+        requestBuilder.serverSideEncryption(encryptionConfig.getServerSideEncryption());
+        if (encryptionConfig.getEncryptionType() == S3EncryptionConfig.EncryptionType.SSE_KMS) {
+            if (encryptionConfig.getKmsKeyId() != null) {
+                requestBuilder.ssekmsKeyId(encryptionConfig.getKmsKeyId());
+            }
+            if (encryptionConfig.hasEncryptionContext()) {
+                requestBuilder.ssekmsEncryptionContext(
+                        serializeEncryptionContext(encryptionConfig.getEncryptionContext()));
+            }
+        }
+    }
+
+    private void applyEncryption(PutObjectRequest.Builder requestBuilder) {
+        if (!encryptionConfig.isEnabled()) {
+            return;
+        }
+        requestBuilder.serverSideEncryption(encryptionConfig.getServerSideEncryption());
+        if (encryptionConfig.getEncryptionType() == S3EncryptionConfig.EncryptionType.SSE_KMS) {
+            if (encryptionConfig.getKmsKeyId() != null) {
+                requestBuilder.ssekmsKeyId(encryptionConfig.getKmsKeyId());
+            }
+            if (encryptionConfig.hasEncryptionContext()) {
+                requestBuilder.ssekmsEncryptionContext(
+                        serializeEncryptionContext(encryptionConfig.getEncryptionContext()));
+            }
+        }
+    }
+
+    /**
+     * Serializes the encryption context map to a Base64-encoded JSON string as required by S3 API.
+     */
+    private String serializeEncryptionContext(java.util.Map<String, String> context) {
+        StringBuilder json = new StringBuilder("{");
+        boolean first = true;
+        for (java.util.Map.Entry<String, String> entry : context.entrySet()) {
+            if (!first) {
+                json.append(",");
+            }
+            json.append("\"")
+                    .append(escapeJson(entry.getKey()))
+                    .append("\":\"")
+                    .append(escapeJson(entry.getValue()))
+                    .append("\"");
+            first = false;
+        }
+        json.append("}");
+        return java.util.Base64.getEncoder().encodeToString(json.toString().getBytes());
+    }
+
+    private String escapeJson(String value) {
+        return value.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+
+    public UploadPartResult uploadPart(
+            String key, String uploadId, int partNumber, File inputFile, long length)
+            throws IOException {
+        try {
+            UploadPartRequest request =
+                    UploadPartRequest.builder()
+                            .bucket(bucketName)
+                            .key(key)
+                            .uploadId(uploadId)
+                            .partNumber(partNumber)
+                            .build();
+
+            UploadPartResponse response =
+                    s3Client.uploadPart(request, RequestBody.fromFile(inputFile));
+
+            return new UploadPartResult(partNumber, response.eTag());
+        } catch (S3Exception e) {
+            throw new IOException(
+                    String.format(
+                            "Failed to upload part %d for key: %s, uploadId: %s",
+                            partNumber, key, uploadId),
+                    e);
+        }
+    }
+
+    public PutObjectResult putObject(String key, File inputFile) throws IOException {
+        if (useAsyncOperations && transferManager != null) {
+            return putObjectViaTransferManager(key, inputFile);
+        }
+
+        try {
+            PutObjectRequest.Builder requestBuilder =
+                    PutObjectRequest.builder().bucket(bucketName).key(key);
+            applyEncryption(requestBuilder);
+
+            PutObjectResponse response =
+                    s3Client.putObject(requestBuilder.build(), RequestBody.fromFile(inputFile));
+            return new PutObjectResult(response.eTag());
+        } catch (S3Exception e) {
+            throw new IOException("Failed to put object for key: " + key, e);
+        }
+    }
+
+    /**
+     * Uploads an object using the S3TransferManager for better throughput.
+     *
+     * <p>The transfer manager provides optimizations over the basic S3 client:
+     *
+     * <ul>
+     *   <li>Automatic multipart upload handling for large files
+     *   <li>Optimized part sizes and parallelism
+     *   <li>Better memory management through streaming
+     * </ul>
+     *
+     * <p>This method blocks until the upload completes.
+     */
+    private PutObjectResult putObjectViaTransferManager(String key, File inputFile)
+            throws IOException {
+        try {
+            UploadFileRequest uploadRequest =
+                    UploadFileRequest.builder()
+                            .putObjectRequest(
+                                    req -> {
+                                        req.bucket(bucketName).key(key);
+                                        if (encryptionConfig.isEnabled()) {
+                                            req.serverSideEncryption(
+                                                    encryptionConfig.getServerSideEncryption());
+                                            if (encryptionConfig.getEncryptionType()
+                                                    == S3EncryptionConfig.EncryptionType.SSE_KMS) {
+                                                if (encryptionConfig.getKmsKeyId() != null) {
+                                                    req.ssekmsKeyId(encryptionConfig.getKmsKeyId());
+                                                }
+                                                if (encryptionConfig.hasEncryptionContext()) {
+                                                    req.ssekmsEncryptionContext(
+                                                            serializeEncryptionContext(
+                                                                    encryptionConfig
+                                                                            .getEncryptionContext()));
+                                                }
+                                            }
+                                        }
+                                    })
+                            .source(inputFile.toPath())
+                            .build();
+
+            FileUpload fileUpload = transferManager.uploadFile(uploadRequest);
+            CompletedFileUpload completedUpload = fileUpload.completionFuture().join();
+            return new PutObjectResult(completedUpload.response().eTag());
+        } catch (Exception e) {
+            throw new IOException("Failed to async upload object for key: " + key, e);
+        }
+    }
+
+    /**
+     * Completes a multipart upload by assembling previously uploaded parts.
+     *
+     * <p><b>Recovery Scenario:</b> If a {@link NoSuchUploadException} is thrown, this may indicate
+     * that the upload was already completed (possibly by a previous attempt during recovery). In
+     * this case, we check if the object exists and return its metadata. This handles the scenario
+     * where:
+     *
+     * <ol>
+     *   <li>A multipart upload was started and parts were uploaded
+     *   <li>The complete request succeeded but the response was lost (e.g., network issue)
+     *   <li>A retry attempt finds the upload already completed and the object present
+     * </ol>
+     *
+     * <p>The object metadata returned in this recovery path can be trusted as S3 guarantees strong
+     * consistency for read-after-write operations.
+     */
+    public CompleteMultipartUploadResult commitMultiPartUpload(
+            String key, String uploadId, List<UploadPartResult> partResults, long length)
+            throws IOException {
+        try {
+            List<CompletedPart> completedParts =
+                    partResults.stream()
+                            .map(
+                                    result ->
+                                            CompletedPart.builder()
+                                                    .partNumber(result.getPartNumber())
+                                                    .eTag(result.getETag())
+                                                    .build())
+                            .collect(Collectors.toList());
+
+            CompleteMultipartUploadRequest request =
+                    CompleteMultipartUploadRequest.builder()
+                            .bucket(bucketName)
+                            .key(key)
+                            .uploadId(uploadId)
+                            .multipartUpload(
+                                    CompletedMultipartUpload.builder()
+                                            .parts(completedParts)
+                                            .build())
+                            .build();
+
+            CompleteMultipartUploadResponse response = s3Client.completeMultipartUpload(request);
+            return new CompleteMultipartUploadResult(
+                    bucketName, key, response.eTag(), response.location());
+        } catch (NoSuchUploadException e) {
+            try {
+                ObjectMetadata metadata = getObjectMetadata(key);
+                return new CompleteMultipartUploadResult(bucketName, key, metadata.getETag(), null);
+            } catch (IOException checkEx) {
+                throw new IOException("Failed to complete multipart upload for key: " + key, e);
+            }
+        } catch (S3Exception e) {
+            throw new IOException("Failed to complete multipart upload for key: " + key, e);
+        }
+    }
+
+    public void abortMultiPartUpload(String key, String uploadId) throws IOException {
+        try {
+            AbortMultipartUploadRequest request =
+                    AbortMultipartUploadRequest.builder()
+                            .bucket(bucketName)
+                            .key(key)
+                            .uploadId(uploadId)
+                            .build();
+
+            s3Client.abortMultipartUpload(request);
+        } catch (S3Exception e) {
+            throw new IOException(
+                    String.format(
+                            "Failed to abort multipart upload for key: %s, uploadId: %s",
+                            key, uploadId),
+                    e);
+        }
+    }
+
+    /**
+     * Deletes an object from S3.
+     *
+     * <p><b>Permission Considerations:</b> Note that S3 may return different error codes depending
+     * on permissions:
+     *
+     * <ul>
+     *   <li>With ListBucket permission: Returns 404 if object doesn't exist
+     *   <li>Without ListBucket permission: Returns 403 (Access Denied) even for non-existent
+     *       objects (for security reasons, to prevent object enumeration)
+     * </ul>
+     *
+     * <p>This method treats 404 as "object not found" (returns false), while 403 and other errors
+     * are propagated as IOException. If your IAM policy doesn't include ListBucket, be aware that
+     * attempting to delete non-existent objects will throw an exception.
+     *
+     * @param key the S3 object key to delete
+     * @return true if the object was deleted, false if it didn't exist (requires ListBucket
+     *     permission)
+     * @throws IOException if the deletion fails due to permissions, throttling, or other errors
+     */
+    public boolean deleteObject(String key) throws IOException {
+        try {
+            DeleteObjectRequest request =
+                    DeleteObjectRequest.builder().bucket(bucketName).key(key).build();
+
+            s3Client.deleteObject(request);
+            return true;
+        } catch (S3Exception e) {
+            if (e.statusCode() == 404) {
+                LOG.debug("Object not found during delete for key: {}", key);
+                return false;
+            }
+            throw S3ExceptionUtils.toIOException("Failed to delete object for key: " + key, e);
+        }
+    }
+
+    public long getObject(String key, File targetLocation) throws IOException {
+        try {
+            GetObjectRequest request =
+                    GetObjectRequest.builder().bucket(bucketName).key(key).build();
+            ResponseTransformer<GetObjectResponse, GetObjectResponse> responseTransformer =
+                    ResponseTransformer.toFile(targetLocation.toPath());
+            s3Client.getObject(request, responseTransformer);
+            return Files.size(targetLocation.toPath());
+        } catch (S3Exception e) {
+            throw new IOException("Failed to get object for key: " + key, e);
+        }
+    }
+
+    public ObjectMetadata getObjectMetadata(String key) throws IOException {
+        try {
+            HeadObjectRequest request =
+                    HeadObjectRequest.builder().bucket(bucketName).key(key).build();
+            HeadObjectResponse response = s3Client.headObject(request);
+            return new ObjectMetadata(
+                    response.contentLength(), response.eTag(), response.lastModified());
+        } catch (S3Exception e) {
+            throw new IOException("Failed to get metadata for key: " + key, e);
+        }
+    }
+
+    public String getBucketName() {
+        return bucketName;
+    }
+
+    /**
+     * Extracts the S3 object key from a Flink Path.
+     *
+     * <p>Expected URI format: {@code s3://bucket-name/path/to/object}
+     *
+     * <p><b>Limitations:</b> This method only supports the standard S3 URI format. Other URI
+     * formats are NOT supported:
+     *
+     * <ul>
+     *   <li>{@code https://bucket.s3.amazonaws.com/path/to/object} (virtual-hosted style)
+     *   <li>{@code https://s3.amazonaws.com/bucket/path/to/object} (path style)
+     *   <li>{@code s3a://} or {@code s3n://} schemes (Hadoop-specific)
+     * </ul>
+     *
+     * @param path the Flink Path with s3:// scheme
+     * @return the object key (path portion without leading slash)
+     */
+    public static String extractKey(Path path) {
+        String pathStr = path.toUri().getPath();
+        if (pathStr.startsWith("/")) {
+            pathStr = pathStr.substring(1);
+        }
+        return pathStr;
+    }
+
+    /**
+     * Extracts the S3 bucket name from a Flink Path.
+     *
+     * <p>Expected URI format: {@code s3://bucket-name/path/to/object}
+     *
+     * @param path the Flink Path with s3:// scheme
+     * @return the bucket name (host portion of the URI)
+     * @see #extractKey(Path) for URI format limitations
+     */
+    public static String extractBucketName(Path path) {
+        return path.toUri().getHost();
+    }
+
+    public static class UploadPartResult {
+        private final int partNumber;
+        private final String eTag;
+
+        public UploadPartResult(int partNumber, String eTag) {
+            this.partNumber = partNumber;
+            this.eTag = eTag;
+        }
+
+        public int getPartNumber() {
+            return partNumber;
+        }
+
+        public String getETag() {
+            return eTag;
+        }
+    }
+
+    public static class PutObjectResult {
+        private final String eTag;
+
+        public PutObjectResult(String eTag) {
+            this.eTag = eTag;
+        }
+
+        public String getETag() {
+            return eTag;
+        }
+    }
+
+    public static class CompleteMultipartUploadResult {
+        private final String bucketName;
+        private final String key;
+        private final String eTag;
+        private final String location;
+
+        public CompleteMultipartUploadResult(
+                String bucketName, String key, String eTag, String location) {
+            this.bucketName = bucketName;
+            this.key = key;
+            this.eTag = eTag;
+            this.location = location;
+        }
+
+        public String getBucketName() {
+            return bucketName;
+        }
+
+        public String getKey() {
+            return key;
+        }
+
+        public String getETag() {
+            return eTag;
+        }
+
+        public String getLocation() {
+            return location;
+        }
+    }
+
+    public static class ObjectMetadata {
+        private final long contentLength;
+        private final String eTag;
+        private final java.time.Instant lastModified;
+
+        public ObjectMetadata(long contentLength, String eTag, java.time.Instant lastModified) {
+            this.contentLength = contentLength;
+            this.eTag = eTag;
+            this.lastModified = lastModified;
+        }
+
+        public long getContentLength() {
+            return contentLength;
+        }
+
+        public String getETag() {
+            return eTag;
+        }
+
+        public java.time.Instant getLastModified() {
+            return lastModified;
+        }
+    }
+}

--- a/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/writer/NativeS3Committer.java
+++ b/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/writer/NativeS3Committer.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.s3native.writer;
+
+import org.apache.flink.core.fs.RecoverableFsDataOutputStream;
+import org.apache.flink.core.fs.RecoverableWriter;
+
+import java.io.IOException;
+import java.util.stream.Collectors;
+
+/**
+ * Committer for S3 multipart uploads that finalizes the upload when commit is called.
+ *
+ * <p><b>Failure Handling:</b> A commit failure will propagate as an IOException, which typically
+ * causes the Flink job to fail and trigger recovery. This is intentional because:
+ *
+ * <ul>
+ *   <li>S3 requires all multipart uploads to be explicitly committed or aborted
+ *   <li>A failed commit means the file is not finalized and data would be lost
+ *   <li>Flink's checkpoint mechanism will handle recovery from the last successful checkpoint
+ * </ul>
+ *
+ * <p>The "empty parts" check is a defensive measure against programming errors - in normal
+ * operation, a multipart upload should always have at least one part before committing.
+ */
+public class NativeS3Committer implements RecoverableFsDataOutputStream.Committer {
+
+    private final NativeS3AccessHelper s3AccessHelper;
+    private final NativeS3Recoverable recoverable;
+
+    public NativeS3Committer(NativeS3AccessHelper s3AccessHelper, NativeS3Recoverable recoverable) {
+        this.s3AccessHelper = s3AccessHelper;
+        this.recoverable = recoverable;
+    }
+
+    /**
+     * Commits the multipart upload to finalize the S3 object.
+     *
+     * <p><b>Empty Parts Check:</b> Attempting to commit with no parts is considered a programming
+     * error and will throw an IOException. This should not happen in normal operation as at least
+     * one part must be uploaded before committing. If this exception is thrown, it indicates a bug
+     * in the calling code or corruption of the recoverable state.
+     *
+     * @throws IOException if the commit fails or if attempting to commit with no parts
+     */
+    @Override
+    public void commit() throws IOException {
+        if (recoverable.parts().isEmpty()) {
+            throw new IOException(
+                    "Cannot commit empty multipart upload for object: "
+                            + recoverable.getObjectName()
+                            + ". This indicates a programming error - at least one part "
+                            + "must be uploaded before committing.");
+        }
+
+        s3AccessHelper.commitMultiPartUpload(
+                recoverable.getObjectName(),
+                recoverable.uploadId(),
+                recoverable.parts().stream()
+                        .map(
+                                part ->
+                                        new NativeS3AccessHelper.UploadPartResult(
+                                                part.getPartNumber(), part.getETag()))
+                        .collect(Collectors.toList()),
+                recoverable.numBytesInParts());
+    }
+
+    @Override
+    public void commitAfterRecovery() throws IOException {
+        commit();
+    }
+
+    @Override
+    public RecoverableWriter.CommitRecoverable getRecoverable() {
+        return recoverable;
+    }
+}

--- a/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/writer/NativeS3Recoverable.java
+++ b/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/writer/NativeS3Recoverable.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.s3native.writer;
+
+import org.apache.flink.core.fs.RecoverableWriter;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Captures the state of an S3 multipart upload for recovery purposes.
+ *
+ * <p><b>Valid States:</b>
+ *
+ * <ul>
+ *   <li><b>No trailing part:</b> {@code lastPartObject == null} AND {@code lastPartObjectLength} is
+ *       ignored (set to -1). This represents a clean state where all data has been uploaded as
+ *       complete parts.
+ *   <li><b>With trailing part:</b> {@code lastPartObject != null} AND {@code lastPartObjectLength >
+ *       0}. The trailing part is a temporary S3 object holding data that hasn't yet been uploaded
+ *       as a multipart part (smaller than minimum part size or pending flush).
+ * </ul>
+ *
+ * <p><b>Invalid States (rejected by constructor):</b>
+ *
+ * <ul>
+ *   <li>{@code lastPartObject != null} with {@code lastPartObjectLength <= 0} - having a trailing
+ *       object with no content makes no sense
+ *   <li>{@code numBytesInParts < 0} - negative byte count is invalid
+ * </ul>
+ *
+ * <p>The integrity of {@code lastPartObject} and {@code lastPartObjectLength} is maintained by
+ * always updating them together through the recoverable's construction. The {@code lastPartObject}
+ * is final, while {@code lastPartObjectLength} is not (for serialization compatibility), but in
+ * practice both are set once during construction and not modified afterwards.
+ */
+public final class NativeS3Recoverable
+        implements RecoverableWriter.ResumeRecoverable, RecoverableWriter.CommitRecoverable {
+
+    private final String uploadId;
+    private final String objectName;
+    private final List<PartETag> parts;
+
+    /**
+     * The S3 key for a temporary object holding data smaller than the minimum part size. Will be
+     * null if there's no pending data.
+     */
+    @Nullable private final String lastPartObject;
+
+    private final long numBytesInParts;
+
+    /** The length of data in {@link #lastPartObject}. Must be > 0 if lastPartObject is not null. */
+    private final long lastPartObjectLength;
+
+    public NativeS3Recoverable(
+            String objectName, String uploadId, List<PartETag> parts, long numBytesInParts) {
+        this(objectName, uploadId, parts, numBytesInParts, null, -1L);
+    }
+
+    public NativeS3Recoverable(
+            String objectName,
+            String uploadId,
+            List<PartETag> parts,
+            long numBytesInParts,
+            @Nullable String lastPartObject,
+            long lastPartObjectLength) {
+        checkArgument(numBytesInParts >= 0L);
+        checkArgument(lastPartObject == null || lastPartObjectLength > 0L);
+
+        this.objectName = checkNotNull(objectName);
+        this.uploadId = checkNotNull(uploadId);
+        this.parts = new ArrayList<>(checkNotNull(parts));
+        this.numBytesInParts = numBytesInParts;
+        this.lastPartObject = lastPartObject;
+        this.lastPartObjectLength = lastPartObjectLength;
+    }
+
+    public String uploadId() {
+        return uploadId;
+    }
+
+    public String getObjectName() {
+        return objectName;
+    }
+
+    public List<PartETag> parts() {
+        return parts;
+    }
+
+    public long numBytesInParts() {
+        return numBytesInParts;
+    }
+
+    @Nullable
+    public String incompleteObjectName() {
+        return lastPartObject;
+    }
+
+    public long incompleteObjectLength() {
+        return lastPartObjectLength;
+    }
+
+    public static class PartETag {
+        private final int partNumber;
+        private final String eTag;
+
+        public PartETag(int partNumber, String eTag) {
+            this.partNumber = partNumber;
+            this.eTag = eTag;
+        }
+
+        public int getPartNumber() {
+            return partNumber;
+        }
+
+        public String getETag() {
+            return eTag;
+        }
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder buf = new StringBuilder(256);
+        buf.append("NativeS3Recoverable: ");
+        buf.append("key=").append(objectName);
+        buf.append(", uploadId=").append(uploadId);
+        buf.append(", bytesInParts=").append(numBytesInParts);
+        buf.append(", parts=[");
+        int num = 0;
+        for (PartETag part : parts) {
+            if (0 != num++) {
+                buf.append(", ");
+            }
+            buf.append(part.getPartNumber()).append('=').append(part.getETag());
+        }
+        buf.append("], trailingPart=").append(lastPartObject);
+        buf.append(", trailingPartLen=").append(lastPartObjectLength);
+        return buf.toString();
+    }
+}

--- a/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/writer/NativeS3RecoverableFsDataOutputStream.java
+++ b/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/writer/NativeS3RecoverableFsDataOutputStream.java
@@ -1,0 +1,291 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.s3native.writer;
+
+import org.apache.flink.core.fs.RecoverableFsDataOutputStream;
+import org.apache.flink.core.fs.RecoverableWriter;
+import org.apache.flink.fs.s3native.writer.NativeS3Recoverable.PartETag;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * A recoverable output stream writes data to S3 using multipart uploads.
+ *
+ * <p>This class is NOT thread-safe. All write operations ({@link #write}, {@link #flush}, {@link
+ * #persist}, {@link #closeForCommit}) must be called from a single thread (the Flink operator
+ * thread). This is consistent with Flink's {@link RecoverableFsDataOutputStream} contract where
+ * output streams are confined to a single task thread.
+ *
+ * <p>The {@link #close()} method may be called concurrently (e.g., during task cancellation). A
+ * {@link ReentrantLock} guards the critical sections in {@link #close()}, {@link
+ * #closeForCommit()}, and {@link #persist()} to ensure safe cleanup of local resources without
+ * corrupting S3 state.
+ */
+@NotThreadSafe
+public class NativeS3RecoverableFsDataOutputStream extends RecoverableFsDataOutputStream {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(NativeS3RecoverableFsDataOutputStream.class);
+
+    private static final int BUFFER_SIZE = 64 * 1024;
+    private final ReentrantLock lock = new ReentrantLock();
+
+    private final NativeS3AccessHelper s3AccessHelper;
+    private final String key;
+    private final String uploadId;
+    private final String localTmpDir;
+    private final long minPartSize;
+
+    private final List<PartETag> completedParts;
+    private long numBytesInParts;
+
+    private File currentTempFile;
+    private FileOutputStream currentFileStream;
+    private BufferedOutputStream currentOutputStream;
+    private long currentPartSize;
+    private int nextPartNumber;
+
+    private volatile boolean closed;
+
+    public NativeS3RecoverableFsDataOutputStream(
+            NativeS3AccessHelper s3AccessHelper,
+            String key,
+            String uploadId,
+            String localTmpDir,
+            long minPartSize)
+            throws IOException {
+        this(s3AccessHelper, key, uploadId, localTmpDir, minPartSize, new ArrayList<>(), 0L);
+    }
+
+    public NativeS3RecoverableFsDataOutputStream(
+            NativeS3AccessHelper s3AccessHelper,
+            String key,
+            String uploadId,
+            String localTmpDir,
+            long minPartSize,
+            List<PartETag> existingParts,
+            long numBytesInParts)
+            throws IOException {
+        this.s3AccessHelper = s3AccessHelper;
+        this.key = key;
+        this.uploadId = uploadId;
+        this.localTmpDir = localTmpDir;
+        this.minPartSize = minPartSize;
+        this.completedParts = new ArrayList<>(existingParts);
+        this.numBytesInParts = numBytesInParts;
+        this.nextPartNumber = existingParts.size() + 1;
+        this.currentPartSize = 0;
+        this.closed = false;
+
+        createNewTempFile();
+    }
+
+    private void createNewTempFile() throws IOException {
+        File tmpDir = new File(localTmpDir);
+        if (!tmpDir.exists()) {
+            tmpDir.mkdirs();
+        }
+
+        currentTempFile = new File(tmpDir, "s3-part-" + UUID.randomUUID());
+        currentFileStream = new FileOutputStream(currentTempFile);
+        currentOutputStream = new BufferedOutputStream(currentFileStream, BUFFER_SIZE);
+        currentPartSize = 0;
+    }
+
+    @Override
+    public long getPos() throws IOException {
+        return numBytesInParts + currentPartSize;
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        if (closed) {
+            throw new IOException("Stream is closed");
+        }
+
+        currentOutputStream.write(b);
+        currentPartSize++;
+
+        if (currentPartSize >= minPartSize) {
+            uploadCurrentPart();
+            createNewTempFile();
+        }
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        if (closed) {
+            throw new IOException("Stream is closed");
+        }
+        if (b == null) {
+            throw new NullPointerException();
+        }
+        if (off < 0 || len < 0 || len > b.length - off) {
+            throw new IndexOutOfBoundsException();
+        }
+
+        currentOutputStream.write(b, off, len);
+        currentPartSize += len;
+
+        if (currentPartSize >= minPartSize) {
+            uploadCurrentPart();
+            createNewTempFile();
+        }
+    }
+
+    @Override
+    public void flush() throws IOException {
+        if (closed) {
+            throw new IOException("Stream is closed");
+        }
+        currentOutputStream.flush();
+    }
+
+    @Override
+    public void sync() throws IOException {
+        if (closed) {
+            throw new IOException("Stream is closed");
+        }
+        persist();
+    }
+
+    private void uploadCurrentPart() throws IOException {
+        currentOutputStream.close();
+
+        int partNumber = nextPartNumber++;
+        NativeS3AccessHelper.UploadPartResult result =
+                s3AccessHelper.uploadPart(
+                        key, uploadId, partNumber, currentTempFile, currentPartSize);
+
+        completedParts.add(new PartETag(result.getPartNumber(), result.getETag()));
+        numBytesInParts += currentPartSize;
+
+        Files.delete(currentTempFile.toPath());
+    }
+
+    @Override
+    public Committer closeForCommit() throws IOException {
+        lock();
+        try {
+            if (closed) {
+                throw new IOException("Stream is already closed");
+            }
+
+            closed = true;
+            currentOutputStream.close();
+
+            if (currentPartSize > 0) {
+                uploadCurrentPart();
+            } else {
+                Files.delete(currentTempFile.toPath());
+            }
+
+            NativeS3Recoverable recoverable =
+                    new NativeS3Recoverable(
+                            key, uploadId, new ArrayList<>(completedParts), numBytesInParts);
+
+            return new NativeS3Committer(s3AccessHelper, recoverable);
+        } finally {
+            unlock();
+        }
+    }
+
+    @Override
+    public RecoverableWriter.ResumeRecoverable persist() throws IOException {
+        lock();
+        try {
+            flush();
+
+            String incompletePartKey = null;
+            long incompletePartLength = 0;
+
+            if (currentPartSize > 0) {
+                currentOutputStream.flush();
+                incompletePartKey = key + "/.incomplete/" + uploadId + "/" + UUID.randomUUID();
+                s3AccessHelper.putObject(incompletePartKey, currentTempFile);
+                incompletePartLength = currentPartSize;
+            }
+
+            return new NativeS3Recoverable(
+                    key,
+                    uploadId,
+                    new ArrayList<>(completedParts),
+                    numBytesInParts,
+                    incompletePartKey,
+                    incompletePartLength);
+        } finally {
+            unlock();
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        lock();
+        try {
+            if (!closed) {
+                closed = true;
+                if (currentOutputStream != null) {
+                    currentOutputStream.close();
+                }
+                if (currentTempFile != null && currentTempFile.exists()) {
+                    Files.delete(currentTempFile.toPath());
+                }
+
+                try {
+                    s3AccessHelper.abortMultiPartUpload(key, uploadId);
+                } catch (IOException e) {
+                    LOG.warn(
+                            "Multipart upload failed (key={}, uploadId={}). "
+                                    + "S3 lifecycle rules should eventually clean up the incomplete upload.",
+                            key,
+                            uploadId,
+                            e);
+                }
+            }
+        } finally {
+            unlock();
+        }
+    }
+
+    private void lock() throws IOException {
+        try {
+            lock.lockInterruptibly();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("interrupted while acquiring lock", e);
+        }
+    }
+
+    private void unlock() {
+        lock.unlock();
+    }
+}

--- a/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/writer/NativeS3RecoverableSerializer.java
+++ b/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/writer/NativeS3RecoverableSerializer.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.s3native.writer;
+
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.fs.s3native.writer.NativeS3Recoverable.PartETag;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Serializer for {@link NativeS3Recoverable} state used during checkpointing and recovery.
+ *
+ * <p><b>Schema Evolution Strategy:</b> This serializer uses an explicit versioning scheme via
+ * {@link SimpleVersionedSerializer}. The approach is intentionally simple (version-based binary
+ * format) rather than using schema evolution frameworks like Avro or Protobuf because:
+ *
+ * <ul>
+ *   <li>The recoverable state is relatively simple and stable
+ *   <li>Changes are infrequent and typically additive
+ *   <li>The format is internal to the filesystem implementation
+ *   <li>Minimizes external dependencies
+ * </ul>
+ *
+ * <p><b>Version Compatibility Rules:</b>
+ *
+ * <ul>
+ *   <li>New fields should be added at the end of the serialized form
+ *   <li>Use optional markers (like the boolean flag for incomplete parts) for nullable fields
+ *   <li>When bumping the version, add handling for previous versions in {@link #deserialize}
+ *   <li>Never remove or reorder existing fields in the current version
+ * </ul>
+ *
+ * <p><b>Current Format (Version 1):</b>
+ *
+ * <pre>
+ * - objectName: UTF string
+ * - uploadId: UTF string
+ * - numBytesInParts: long
+ * - partsCount: int
+ * - parts[]: { partNumber: int, eTag: UTF string } repeated partsCount times
+ * - hasIncompletePart: boolean
+ * - if hasIncompletePart:
+ *   - incompleteObjectName: UTF string
+ *   - incompleteObjectLength: long
+ * </pre>
+ */
+public class NativeS3RecoverableSerializer
+        implements SimpleVersionedSerializer<NativeS3Recoverable> {
+
+    public static final NativeS3RecoverableSerializer INSTANCE =
+            new NativeS3RecoverableSerializer();
+
+    private static final int CURRENT_VERSION = 1;
+
+    @Override
+    public int getVersion() {
+        return CURRENT_VERSION;
+    }
+
+    @Override
+    public byte[] serialize(NativeS3Recoverable recoverable) throws IOException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(outputStream);
+        out.writeUTF(recoverable.getObjectName());
+        out.writeUTF(recoverable.uploadId());
+        out.writeLong(recoverable.numBytesInParts());
+        List<PartETag> parts = recoverable.parts();
+        out.writeInt(parts.size());
+        for (PartETag part : parts) {
+            out.writeInt(part.getPartNumber());
+            out.writeUTF(part.getETag());
+        }
+        String incompleteObject = recoverable.incompleteObjectName();
+        if (incompleteObject == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            out.writeUTF(incompleteObject);
+            out.writeLong(recoverable.incompleteObjectLength());
+        }
+        out.flush();
+        return outputStream.toByteArray();
+    }
+
+    @Override
+    public NativeS3Recoverable deserialize(int version, byte[] serialized) throws IOException {
+        if (version != CURRENT_VERSION) {
+            throw new IOException("Unsupported version: " + version);
+        }
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(serialized);
+        DataInputStream in = new DataInputStream(inputStream);
+        String objectName = in.readUTF();
+        String uploadId = in.readUTF();
+        long numBytesInParts = in.readLong();
+        int numParts = in.readInt();
+        List<PartETag> parts = new ArrayList<>(numParts);
+        for (int i = 0; i < numParts; i++) {
+            int partNumber = in.readInt();
+            String eTag = in.readUTF();
+            parts.add(new PartETag(partNumber, eTag));
+        }
+        boolean hasIncompletePart = in.readBoolean();
+        String incompleteObjectName = null;
+        long incompleteObjectLength = -1;
+        if (hasIncompletePart) {
+            incompleteObjectName = in.readUTF();
+            incompleteObjectLength = in.readLong();
+        }
+        return new NativeS3Recoverable(
+                objectName,
+                uploadId,
+                parts,
+                numBytesInParts,
+                incompleteObjectName,
+                incompleteObjectLength);
+    }
+}

--- a/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/writer/NativeS3RecoverableWriter.java
+++ b/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/writer/NativeS3RecoverableWriter.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.s3native.writer;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.fs.RecoverableFsDataOutputStream;
+import org.apache.flink.core.fs.RecoverableWriter;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** Recoverable writer for S3 using multipart uploads for exactly-once semantics. */
+@PublicEvolving
+public class NativeS3RecoverableWriter implements RecoverableWriter, AutoCloseable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NativeS3RecoverableWriter.class);
+
+    private final NativeS3AccessHelper s3AccessHelper;
+    private final String localTmpDir;
+    private final long userDefinedMinPartSize;
+    private final int maxConcurrentUploadsPerStream;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    private NativeS3RecoverableWriter(
+            NativeS3AccessHelper s3AccessHelper,
+            String localTmpDir,
+            long userDefinedMinPartSize,
+            int maxConcurrentUploadsPerStream) {
+        this.s3AccessHelper = checkNotNull(s3AccessHelper);
+        this.localTmpDir = checkNotNull(localTmpDir);
+        this.userDefinedMinPartSize = userDefinedMinPartSize;
+        this.maxConcurrentUploadsPerStream = maxConcurrentUploadsPerStream;
+
+        LOG.debug(
+                "Created S3 recoverable writer - minPartSize: {} bytes, tmpDir: {}",
+                userDefinedMinPartSize,
+                localTmpDir);
+    }
+
+    @Override
+    public RecoverableFsDataOutputStream open(Path path) throws IOException {
+        checkNotClosed();
+        String key = NativeS3AccessHelper.extractKey(path);
+        LOG.debug("Opening recoverable stream for key: {}", key);
+
+        String uploadId = s3AccessHelper.startMultiPartUpload(key);
+        LOG.debug("Started multipart upload - key: {}, uploadId: {}", key, uploadId);
+
+        return new NativeS3RecoverableFsDataOutputStream(
+                s3AccessHelper, key, uploadId, localTmpDir, userDefinedMinPartSize);
+    }
+
+    @Override
+    public RecoverableFsDataOutputStream.Committer recoverForCommit(CommitRecoverable recoverable)
+            throws IOException {
+        checkNotClosed();
+        NativeS3Recoverable s3recoverable = castToNativeS3Recoverable(recoverable);
+        return new NativeS3Committer(s3AccessHelper, s3recoverable);
+    }
+
+    @Override
+    public RecoverableFsDataOutputStream recover(ResumeRecoverable recoverable) throws IOException {
+        checkNotClosed();
+        NativeS3Recoverable s3recoverable = castToNativeS3Recoverable(recoverable);
+        return new NativeS3RecoverableFsDataOutputStream(
+                s3AccessHelper,
+                s3recoverable.getObjectName(),
+                s3recoverable.uploadId(),
+                localTmpDir,
+                userDefinedMinPartSize,
+                s3recoverable.parts(),
+                s3recoverable.numBytesInParts());
+    }
+
+    @Override
+    public boolean requiresCleanupOfRecoverableState() {
+        return true;
+    }
+
+    @Override
+    public boolean cleanupRecoverableState(ResumeRecoverable resumable) throws IOException {
+        checkNotClosed();
+        NativeS3Recoverable s3recoverable = castToNativeS3Recoverable(resumable);
+        String smallPartObjectToDelete = s3recoverable.incompleteObjectName();
+        return smallPartObjectToDelete != null
+                && s3AccessHelper.deleteObject(smallPartObjectToDelete);
+    }
+
+    @Override
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public SimpleVersionedSerializer<CommitRecoverable> getCommitRecoverableSerializer() {
+        return (SimpleVersionedSerializer) NativeS3RecoverableSerializer.INSTANCE;
+    }
+
+    @Override
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public SimpleVersionedSerializer<ResumeRecoverable> getResumeRecoverableSerializer() {
+        return (SimpleVersionedSerializer) NativeS3RecoverableSerializer.INSTANCE;
+    }
+
+    @Override
+    public boolean supportsResume() {
+        return true;
+    }
+
+    private static NativeS3Recoverable castToNativeS3Recoverable(CommitRecoverable recoverable) {
+        if (recoverable instanceof NativeS3Recoverable) {
+            return (NativeS3Recoverable) recoverable;
+        }
+        throw new IllegalArgumentException(
+                "Native S3 File System cannot recover recoverable for other file system: "
+                        + recoverable);
+    }
+
+    private static NativeS3Recoverable castToNativeS3Recoverable(ResumeRecoverable recoverable) {
+        if (recoverable instanceof NativeS3Recoverable) {
+            return (NativeS3Recoverable) recoverable;
+        }
+        throw new IllegalArgumentException(
+                "Native S3 File System cannot recover recoverable for other file system: "
+                        + recoverable);
+    }
+
+    @Override
+    public void close() {
+        if (!closed.compareAndSet(false, true)) {
+            return;
+        }
+        LOG.debug("Closing S3 recoverable writer");
+    }
+
+    private void checkNotClosed() {
+        if (closed.get()) {
+            throw new IllegalStateException("RecoverableWriter has been closed");
+        }
+    }
+
+    public static NativeS3RecoverableWriter writer(
+            NativeS3AccessHelper s3AccessHelper,
+            String localTmpDir,
+            long userDefinedMinPartSize,
+            int maxConcurrentUploadsPerStream) {
+
+        return new NativeS3RecoverableWriter(
+                s3AccessHelper, localTmpDir, userDefinedMinPartSize, maxConcurrentUploadsPerStream);
+    }
+}

--- a/flink-filesystems/flink-s3-fs-native/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-native/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,72 @@
+flink-s3-fs-native
+Copyright 2014-2026 The Apache Software Foundation
+
+This project includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+- software.amazon.awssdk:annotations:2.41.34
+- software.amazon.awssdk:apache-client:2.41.34
+- software.amazon.awssdk:arns:2.41.34
+- software.amazon.awssdk:auth:2.41.34
+- software.amazon.awssdk:aws-core:2.41.34
+- software.amazon.awssdk:aws-query-protocol:2.41.34
+- software.amazon.awssdk:aws-xml-protocol:2.41.34
+- software.amazon.awssdk:checksums:2.41.34
+- software.amazon.awssdk:checksums-spi:2.41.34
+- software.amazon.awssdk:crt-core:2.41.34
+- software.amazon.awssdk:endpoints-spi:2.41.34
+- software.amazon.awssdk:http-auth:2.41.34
+- software.amazon.awssdk:http-auth-aws:2.41.34
+- software.amazon.awssdk:http-auth-aws-eventstream:2.41.34
+- software.amazon.awssdk:http-auth-spi:2.41.34
+- software.amazon.awssdk:http-client-spi:2.41.34
+- software.amazon.awssdk:identity-spi:2.41.34
+- software.amazon.awssdk:json-utils:2.41.34
+- software.amazon.awssdk:metrics-spi:2.41.34
+- software.amazon.awssdk:netty-nio-client:2.41.34
+- software.amazon.awssdk:profiles:2.41.34
+- software.amazon.awssdk:protocol-core:2.41.34
+- software.amazon.awssdk:regions:2.41.34
+- software.amazon.awssdk:retries:2.41.34
+- software.amazon.awssdk:retries-spi:2.41.34
+- software.amazon.awssdk:s3:2.41.34
+- software.amazon.awssdk:s3-transfer-manager:2.41.34
+- software.amazon.awssdk:sdk-core:2.41.34
+- software.amazon.awssdk:sts:2.41.34
+- software.amazon.awssdk:third-party-jackson-core:2.41.34
+- software.amazon.awssdk:utils:2.41.34
+- software.amazon.awssdk:utils-lite:2.41.34
+- org.apache.httpcomponents:httpclient:4.5.13
+- org.apache.httpcomponents:httpcore:4.4.14
+- commons-logging:commons-logging:1.1.3
+- io.netty:netty-buffer:4.2.6.Final
+- io.netty:netty-codec:4.2.6.Final
+- io.netty:netty-codec-base:4.2.6.Final
+- io.netty:netty-codec-compression:4.2.6.Final
+- io.netty:netty-codec-http:4.2.6.Final
+- io.netty:netty-codec-http2:4.2.6.Final
+- io.netty:netty-codec-marshalling:4.2.6.Final
+- io.netty:netty-codec-protobuf:4.2.6.Final
+- io.netty:netty-common:4.2.6.Final
+- io.netty:netty-handler:4.2.6.Final
+- io.netty:netty-resolver:4.2.6.Final
+- io.netty:netty-transport:4.2.6.Final
+- io.netty:netty-transport-classes-epoll:4.2.6.Final
+- io.netty:netty-transport-native-unix-common:4.2.6.Final
+
+This project bundles the following dependencies under the MIT License (https://opensource.org/licenses/MIT)
+
+- org.reactivestreams:reactive-streams:1.0.4
+
+===============================================================================
+
+This project does not bundle any code from Hadoop, Presto, or other external file systems.
+
+All S3 operations are performed directly using the AWS SDK for Java 2.x.
+
+This native implementation was created to eliminate dependencies on Hadoop and Presto
+while providing complete feature parity and enhanced performance.
+
+For more information, see the project documentation in README.md.

--- a/flink-filesystems/flink-s3-fs-native/src/main/resources/META-INF/services/org.apache.flink.core.fs.FileSystemFactory
+++ b/flink-filesystems/flink-s3-fs-native/src/main/resources/META-INF/services/org.apache.flink.core.fs.FileSystemFactory
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.fs.s3native.NativeS3FileSystemFactory
+org.apache.flink.fs.s3native.NativeS3AFileSystemFactory

--- a/flink-filesystems/flink-s3-fs-native/src/main/resources/META-INF/services/org.apache.flink.core.security.token.DelegationTokenProvider
+++ b/flink-filesystems/flink-s3-fs-native/src/main/resources/META-INF/services/org.apache.flink.core.security.token.DelegationTokenProvider
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.fs.s3native.token.NativeS3DelegationTokenProvider
+

--- a/flink-filesystems/flink-s3-fs-native/src/main/resources/META-INF/services/org.apache.flink.core.security.token.DelegationTokenReceiver
+++ b/flink-filesystems/flink-s3-fs-native/src/main/resources/META-INF/services/org.apache.flink.core.security.token.DelegationTokenReceiver
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.fs.s3native.token.NativeS3DelegationTokenReceiver
+

--- a/flink-filesystems/flink-s3-fs-native/src/test/java/org/apache/flink/fs/s3native/NativeS3BulkCopyHelperTest.java
+++ b/flink-filesystems/flink-s3-fs-native/src/test/java/org/apache/flink/fs/s3native/NativeS3BulkCopyHelperTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.s3native;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+/** Tests for {@link NativeS3BulkCopyHelper}. */
+class NativeS3BulkCopyHelperTest {
+
+    private static final NativeS3BulkCopyHelper helper = new NativeS3BulkCopyHelper(null, 1);
+
+    @ParameterizedTest
+    @CsvSource({
+        "s3://my-bucket/file.txt,my-bucket",
+        "s3a://my-bucket/file.txt,my-bucket",
+        "s3://bucket-name/path/to/file.txt,bucket-name",
+        "s3://my.bucket.name/file.txt,my.bucket.name",
+        "s3://bucket,bucket",
+        "s3://bucket/,bucket",
+        "s3://a/file,a",
+        "s3://my-bucket//path//to//file.txt,my-bucket",
+    })
+    void testExtractBucket(String uri, String expectedBucket) {
+        assertThat(helper.extractBucket(uri)).isEqualTo(expectedBucket);
+    }
+
+    @Test
+    void testExtractBucketWithNullThrowsException() {
+        assertThatNullPointerException().isThrownBy(() -> helper.extractBucket(null));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "s3://bucket/file.txt,file.txt",
+        "s3a://bucket/file.txt,file.txt",
+        "s3://bucket/path/to/file.txt,path/to/file.txt",
+        "s3://bucket/a/b/c/d/e/file.txt,a/b/c/d/e/file.txt",
+        "s3://bucket//double//slash//path/file.txt,/double//slash//path/file.txt",
+        "s3://bucket/path/to/directory/,path/to/directory/",
+        "s3://bucket/path/file.tar.gz.backup,path/file.tar.gz.backup",
+    })
+    void testExtractKey(String uri, String expectedKey) {
+        assertThat(helper.extractKey(uri)).isEqualTo(expectedKey);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "s3://bucket",
+        "s3://bucket/",
+        "s3a://bucket",
+    })
+    void testExtractKeyReturnsEmptyForBucketOnly(String uri) {
+        assertThat(helper.extractKey(uri)).isEmpty();
+    }
+
+    @Test
+    void testExtractKeyWithNullThrowsException() {
+        assertThatNullPointerException().isThrownBy(() -> helper.extractKey(null));
+    }
+
+    @Test
+    void testBothSchemesYieldSameResult() {
+        assertThat(helper.extractBucket("s3://test-bucket/path/file.txt"))
+                .isEqualTo(helper.extractBucket("s3a://test-bucket/path/file.txt"))
+                .isEqualTo("test-bucket");
+        assertThat(helper.extractKey("s3://bucket/deep/path/file.txt"))
+                .isEqualTo(helper.extractKey("s3a://bucket/deep/path/file.txt"))
+                .isEqualTo("deep/path/file.txt");
+    }
+
+    @Test
+    void testBucketAndKeyRoundTrip() {
+        String uri = "s3://my-bucket/path/to/file.txt";
+        String reconstructed = "s3://" + helper.extractBucket(uri) + "/" + helper.extractKey(uri);
+        assertThat(reconstructed).isEqualTo(uri);
+    }
+
+    @Test
+    void testExtractKeyVeryLongPath() {
+        StringBuilder path = new StringBuilder();
+        for (int i = 0; i < 50; i++) {
+            path.append("level").append(i).append("/");
+        }
+        path.append("file.txt");
+        assertThat(helper.extractKey("s3://bucket/" + path)).isEqualTo(path.toString());
+    }
+}

--- a/flink-filesystems/flink-s3-fs-native/src/test/java/org/apache/flink/fs/s3native/NativeS3FileSystemFactoryTest.java
+++ b/flink-filesystems/flink-s3-fs-native/src/test/java/org/apache/flink/fs/s3native/NativeS3FileSystemFactoryTest.java
@@ -1,0 +1,438 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.s3native;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.core.fs.FileSystem;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link NativeS3FileSystemFactory}. */
+class NativeS3FileSystemFactoryTest {
+
+    @Test
+    void testSchemeReturnsS3() {
+        NativeS3FileSystemFactory factory = new NativeS3FileSystemFactory();
+        assertThat(factory.getScheme()).isEqualTo("s3");
+    }
+
+    @Test
+    void testConfigureAcceptsConfiguration() {
+        NativeS3FileSystemFactory factory = new NativeS3FileSystemFactory();
+        Configuration config = new Configuration();
+        config.setString("s3.access-key", "test-key");
+        config.setString("s3.secret-key", "test-secret");
+
+        // Should not throw
+        factory.configure(config);
+    }
+
+    @Test
+    void testCreateFileSystemWithMinimalConfiguration() throws Exception {
+        NativeS3FileSystemFactory factory = new NativeS3FileSystemFactory();
+        Configuration config = new Configuration();
+        config.setString("s3.access-key", "test-access-key");
+        config.setString("s3.secret-key", "test-secret-key");
+        config.setString("s3.region", "us-east-1");
+        config.setString("io.tmp.dirs", System.getProperty("java.io.tmpdir"));
+
+        factory.configure(config);
+
+        URI fsUri = new URI("s3://test-bucket/");
+        FileSystem fs = factory.create(fsUri);
+
+        assertThat(fs).isNotNull();
+        assertThat(fs).isInstanceOf(NativeS3FileSystem.class);
+        assertThat(fs.getUri()).isEqualTo(fsUri);
+    }
+
+    @Test
+    void testCreateFileSystemWithCustomEndpoint() throws Exception {
+        NativeS3FileSystemFactory factory = new NativeS3FileSystemFactory();
+        Configuration config = new Configuration();
+        config.setString("s3.access-key", "test-access-key");
+        config.setString("s3.secret-key", "test-secret-key");
+        config.setString("s3.endpoint", "http://localhost:9000");
+        config.setString("s3.region", "us-east-1");
+        config.setString("io.tmp.dirs", System.getProperty("java.io.tmpdir"));
+
+        factory.configure(config);
+
+        URI fsUri = new URI("s3://test-bucket/");
+        FileSystem fs = factory.create(fsUri);
+
+        assertThat(fs).isNotNull();
+        assertThat(fs).isInstanceOf(NativeS3FileSystem.class);
+    }
+
+    @Test
+    void testPartSizeTooSmallThrowsException() {
+        NativeS3FileSystemFactory factory = new NativeS3FileSystemFactory();
+        Configuration config = new Configuration();
+        config.setString("s3.access-key", "test-access-key");
+        config.setString("s3.secret-key", "test-secret-key");
+        config.setString("s3.region", "us-east-1");
+        config.set(NativeS3FileSystemFactory.PART_UPLOAD_MIN_SIZE, 1024L); // Too small (< 5MB)
+        config.setString("io.tmp.dirs", System.getProperty("java.io.tmpdir"));
+
+        factory.configure(config);
+
+        URI fsUri = URI.create("s3://test-bucket/");
+        assertThatThrownBy(() -> factory.create(fsUri))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must be at least");
+    }
+
+    @Test
+    void testPartSizeTooLargeThrowsException() {
+        NativeS3FileSystemFactory factory = new NativeS3FileSystemFactory();
+        Configuration config = new Configuration();
+        config.setString("s3.access-key", "test-access-key");
+        config.setString("s3.secret-key", "test-secret-key");
+        config.setString("s3.region", "us-east-1");
+        config.set(
+                NativeS3FileSystemFactory.PART_UPLOAD_MIN_SIZE, 6L * 1024 * 1024 * 1024); // > 5GB
+        config.setString("io.tmp.dirs", System.getProperty("java.io.tmpdir"));
+
+        factory.configure(config);
+
+        URI fsUri = URI.create("s3://test-bucket/");
+        assertThatThrownBy(() -> factory.create(fsUri))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must not exceed 5GB");
+    }
+
+    @Test
+    void testInvalidMaxConcurrentUploadsThrowsException() {
+        NativeS3FileSystemFactory factory = new NativeS3FileSystemFactory();
+        Configuration config = new Configuration();
+        config.setString("s3.access-key", "test-access-key");
+        config.setString("s3.secret-key", "test-secret-key");
+        config.setString("s3.region", "us-east-1");
+        config.set(NativeS3FileSystemFactory.MAX_CONCURRENT_UPLOADS, 0);
+        config.setString("io.tmp.dirs", System.getProperty("java.io.tmpdir"));
+
+        factory.configure(config);
+
+        URI fsUri = URI.create("s3://test-bucket/");
+        assertThatThrownBy(() -> factory.create(fsUri))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must be positive");
+    }
+
+    @Test
+    void testInvalidEntropyKeyThrowsException() {
+        NativeS3FileSystemFactory factory = new NativeS3FileSystemFactory();
+        Configuration config = new Configuration();
+        config.setString("s3.access-key", "test-access-key");
+        config.setString("s3.secret-key", "test-secret-key");
+        config.setString("s3.region", "us-east-1");
+        config.setString("s3.entropy.key", "__INVALID#KEY__"); // Contains #
+        config.setString("io.tmp.dirs", System.getProperty("java.io.tmpdir"));
+
+        factory.configure(config);
+
+        URI fsUri = URI.create("s3://test-bucket/");
+        assertThatThrownBy(() -> factory.create(fsUri))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("Invalid character");
+    }
+
+    @Test
+    void testInvalidEntropyLengthThrowsException() {
+        NativeS3FileSystemFactory factory = new NativeS3FileSystemFactory();
+        Configuration config = new Configuration();
+        config.setString("s3.access-key", "test-access-key");
+        config.setString("s3.secret-key", "test-secret-key");
+        config.setString("s3.region", "us-east-1");
+        config.setString("s3.entropy.key", "__ENTROPY__");
+        config.set(NativeS3FileSystemFactory.ENTROPY_INJECT_LENGTH_OPTION, 0); // Invalid
+        config.setString("io.tmp.dirs", System.getProperty("java.io.tmpdir"));
+
+        factory.configure(config);
+
+        URI fsUri = URI.create("s3://test-bucket/");
+        assertThatThrownBy(() -> factory.create(fsUri))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("must be > 0");
+    }
+
+    @Test
+    void testEntropyInjectionWithValidConfiguration() throws Exception {
+        NativeS3FileSystemFactory factory = new NativeS3FileSystemFactory();
+        Configuration config = new Configuration();
+        config.setString("s3.access-key", "test-access-key");
+        config.setString("s3.secret-key", "test-secret-key");
+        config.setString("s3.region", "us-east-1");
+        config.setString("s3.entropy.key", "__ENTROPY__");
+        config.set(NativeS3FileSystemFactory.ENTROPY_INJECT_LENGTH_OPTION, 4);
+        config.setString("io.tmp.dirs", System.getProperty("java.io.tmpdir"));
+
+        factory.configure(config);
+
+        URI fsUri = URI.create("s3://test-bucket/");
+        FileSystem fs = factory.create(fsUri);
+
+        assertThat(fs).isNotNull();
+        assertThat(fs).isInstanceOf(NativeS3FileSystem.class);
+    }
+
+    @Test
+    void testPathStyleAccessAutoEnabledForCustomEndpoint() throws Exception {
+        NativeS3FileSystemFactory factory = new NativeS3FileSystemFactory();
+        Configuration config = new Configuration();
+        config.setString("s3.access-key", "test-access-key");
+        config.setString("s3.secret-key", "test-secret-key");
+        config.setString("s3.endpoint", "http://minio:9000");
+        config.setString("s3.region", "us-east-1");
+        config.set(NativeS3FileSystemFactory.PATH_STYLE_ACCESS, false); // Explicitly set to false
+        config.setString("io.tmp.dirs", System.getProperty("java.io.tmpdir"));
+
+        factory.configure(config);
+
+        URI fsUri = URI.create("s3://test-bucket/");
+        FileSystem fs = factory.create(fsUri);
+
+        // Should succeed - path-style access is auto-enabled
+        assertThat(fs).isNotNull();
+    }
+
+    @Test
+    void testBulkCopyConfiguration() throws Exception {
+        NativeS3FileSystemFactory factory = new NativeS3FileSystemFactory();
+        Configuration config = new Configuration();
+        config.setString("s3.access-key", "test-access-key");
+        config.setString("s3.secret-key", "test-secret-key");
+        config.setString("s3.region", "us-east-1");
+        config.set(NativeS3FileSystemFactory.BULK_COPY_ENABLED, true);
+        config.set(NativeS3FileSystemFactory.BULK_COPY_MAX_CONCURRENT, 32);
+        config.setString("io.tmp.dirs", System.getProperty("java.io.tmpdir"));
+
+        factory.configure(config);
+
+        URI fsUri = URI.create("s3://test-bucket/");
+        FileSystem fs = factory.create(fsUri);
+
+        assertThat(fs).isNotNull();
+        assertThat(fs).isInstanceOf(NativeS3FileSystem.class);
+    }
+
+    @Test
+    void testExplicitRegionConfiguration() throws Exception {
+        NativeS3FileSystemFactory factory = new NativeS3FileSystemFactory();
+        Configuration config = new Configuration();
+        config.setString("s3.access-key", "test-access-key");
+        config.setString("s3.secret-key", "test-secret-key");
+        config.setString("s3.region", "eu-west-1"); // Explicit non-default region
+        config.setString("io.tmp.dirs", System.getProperty("java.io.tmpdir"));
+
+        factory.configure(config);
+
+        URI fsUri = URI.create("s3://test-bucket/");
+        FileSystem fs = factory.create(fsUri);
+
+        assertThat(fs).isNotNull();
+        assertThat(fs).isInstanceOf(NativeS3FileSystem.class);
+    }
+
+    @Test
+    void testExplicitRegionTakesPriorityOverAutodiscovery() throws Exception {
+        NativeS3FileSystemFactory factory = new NativeS3FileSystemFactory();
+        Configuration config = new Configuration();
+        config.setString("s3.access-key", "test-access-key");
+        config.setString("s3.secret-key", "test-secret-key");
+        config.setString("s3.region", "ap-southeast-1"); // Explicit region
+        config.setString("io.tmp.dirs", System.getProperty("java.io.tmpdir"));
+
+        factory.configure(config);
+
+        URI fsUri = URI.create("s3://test-bucket/");
+        FileSystem fs = factory.create(fsUri);
+
+        // Should succeed with explicit region regardless of environment
+        assertThat(fs).isNotNull();
+        assertThat(fs).isInstanceOf(NativeS3FileSystem.class);
+    }
+
+    @Test
+    void testRegionAutodiscoveryWithoutExplicitConfig() throws Exception {
+        // This test verifies that region autodiscovery works when no explicit region is set.
+        // The test will either succeed (if AWS region can be auto-detected from environment)
+        // or fail with a helpful error message.
+        NativeS3FileSystemFactory factory = new NativeS3FileSystemFactory();
+        Configuration config = new Configuration();
+        config.setString("s3.access-key", "test-access-key");
+        config.setString("s3.secret-key", "test-secret-key");
+        // Intentionally not setting s3.region to test autodiscovery
+        config.setString("io.tmp.dirs", System.getProperty("java.io.tmpdir"));
+
+        factory.configure(config);
+
+        URI fsUri = URI.create("s3://test-bucket/");
+
+        try {
+            FileSystem fs = factory.create(fsUri);
+            assertThat(fs).isNotNull();
+            assertThat(fs).isInstanceOf(NativeS3FileSystem.class);
+        } catch (IllegalArgumentException e) {
+            // If no region can be auto-detected, verify the error message is helpful
+            assertThat(e.getMessage()).contains("AWS region could not be determined");
+            assertThat(e.getMessage()).contains("s3.region");
+            assertThat(e.getMessage()).contains("AWS_REGION");
+        }
+    }
+
+    @Test
+    void testRegionAutodiscoveryWithCustomEndpoint() throws Exception {
+        NativeS3FileSystemFactory factory = new NativeS3FileSystemFactory();
+        Configuration config = new Configuration();
+        config.setString("s3.access-key", "test-access-key");
+        config.setString("s3.secret-key", "test-secret-key");
+        config.setString("s3.endpoint", "http://localhost:9000");
+        // Intentionally not setting s3.region with custom endpoint
+        config.setString("io.tmp.dirs", System.getProperty("java.io.tmpdir"));
+
+        factory.configure(config);
+
+        URI fsUri = URI.create("s3://test-bucket/");
+
+        try {
+            FileSystem fs = factory.create(fsUri);
+            assertThat(fs).isNotNull();
+            assertThat(fs).isInstanceOf(NativeS3FileSystem.class);
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage()).contains("AWS region could not be determined");
+            assertThat(e.getMessage()).contains("AWS_REGION");
+            assertThat(e.getMessage()).contains("~/.aws/config");
+        }
+    }
+
+    @Test
+    void testEmptyRegionFallsBackToAutodiscovery() throws Exception {
+        NativeS3FileSystemFactory factory = new NativeS3FileSystemFactory();
+        Configuration config = new Configuration();
+        config.setString("s3.access-key", "test-access-key");
+        config.setString("s3.secret-key", "test-secret-key");
+        config.setString("s3.region", ""); // Empty region should trigger autodiscovery
+        config.setString("io.tmp.dirs", System.getProperty("java.io.tmpdir"));
+
+        factory.configure(config);
+
+        URI fsUri = URI.create("s3://test-bucket/");
+
+        try {
+            FileSystem fs = factory.create(fsUri);
+            assertThat(fs).isNotNull();
+            assertThat(fs).isInstanceOf(NativeS3FileSystem.class);
+        } catch (IllegalArgumentException e) {
+            // If no region can be auto-detected, verify the error message is helpful
+            assertThat(e.getMessage()).contains("AWS region could not be determined");
+        }
+    }
+
+    @Test
+    void testS3ASchemeReturnsS3A() {
+        NativeS3AFileSystemFactory factory = new NativeS3AFileSystemFactory();
+        assertThat(factory.getScheme()).isEqualTo("s3a");
+    }
+
+    @Test
+    void testS3ACreateFileSystemWithMinimalConfiguration() throws Exception {
+        NativeS3AFileSystemFactory factory = new NativeS3AFileSystemFactory();
+        Configuration config = new Configuration();
+        config.setString("s3.access-key", "test-access-key");
+        config.setString("s3.secret-key", "test-secret-key");
+        config.setString("s3.region", "us-east-1");
+        config.setString("io.tmp.dirs", System.getProperty("java.io.tmpdir"));
+
+        factory.configure(config);
+
+        URI fsUri = URI.create("s3a://test-bucket/");
+        FileSystem fs = factory.create(fsUri);
+
+        assertThat(fs).isNotNull();
+        assertThat(fs).isInstanceOf(NativeS3FileSystem.class);
+    }
+
+    @Test
+    void testS3ACreateFileSystemWithCustomEndpoint() throws Exception {
+        NativeS3AFileSystemFactory factory = new NativeS3AFileSystemFactory();
+        Configuration config = new Configuration();
+        config.setString("s3.access-key", "test-access-key");
+        config.setString("s3.secret-key", "test-secret-key");
+        config.setString("s3.endpoint", "http://localhost:9000");
+        config.setString("s3.region", "us-east-1");
+        config.setString("io.tmp.dirs", System.getProperty("java.io.tmpdir"));
+
+        factory.configure(config);
+
+        URI fsUri = URI.create("s3a://test-bucket/path/to/file");
+        FileSystem fs = factory.create(fsUri);
+
+        assertThat(fs).isNotNull();
+        assertThat(fs).isInstanceOf(NativeS3FileSystem.class);
+    }
+
+    @Test
+    void testS3AInheritsAllS3Configuration() throws Exception {
+        NativeS3AFileSystemFactory factory = new NativeS3AFileSystemFactory();
+        Configuration config = new Configuration();
+        config.setString("s3.access-key", "test-access-key");
+        config.setString("s3.secret-key", "test-secret-key");
+        config.setString("s3.region", "eu-west-1");
+        config.setString("s3.entropy.key", "__ENTROPY__");
+        config.set(NativeS3FileSystemFactory.ENTROPY_INJECT_LENGTH_OPTION, 6);
+        config.set(NativeS3FileSystemFactory.BULK_COPY_ENABLED, true);
+        config.set(NativeS3FileSystemFactory.USE_ASYNC_OPERATIONS, true);
+        config.setString("io.tmp.dirs", System.getProperty("java.io.tmpdir"));
+
+        factory.configure(config);
+
+        URI fsUri = URI.create("s3a://test-bucket/");
+        FileSystem fs = factory.create(fsUri);
+
+        assertThat(fs).isNotNull();
+        assertThat(fs).isInstanceOf(NativeS3FileSystem.class);
+    }
+
+    @Test
+    void testS3AWithSSEConfiguration() throws Exception {
+        NativeS3AFileSystemFactory factory = new NativeS3AFileSystemFactory();
+        Configuration config = new Configuration();
+        config.setString("s3.access-key", "test-access-key");
+        config.setString("s3.secret-key", "test-secret-key");
+        config.setString("s3.region", "us-east-1");
+        config.setString("s3.sse.type", "sse-s3");
+        config.setString("io.tmp.dirs", System.getProperty("java.io.tmpdir"));
+
+        factory.configure(config);
+
+        URI fsUri = URI.create("s3a://test-bucket/");
+        FileSystem fs = factory.create(fsUri);
+
+        assertThat(fs).isNotNull();
+        assertThat(fs).isInstanceOf(NativeS3FileSystem.class);
+    }
+}

--- a/flink-filesystems/flink-s3-fs-native/src/test/java/org/apache/flink/fs/s3native/S3ClientProviderTest.java
+++ b/flink-filesystems/flink-s3-fs-native/src/test/java/org/apache/flink/fs/s3native/S3ClientProviderTest.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.s3native;
+
+import org.apache.flink.fs.s3native.token.DynamicTemporaryAWSCredentialsProvider;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests that user configuration intents are correctly mapped into the credentials chain. */
+class S3ClientProviderTest {
+
+    private static final String DUMMY_ENDPOINT = "http://localhost:9000";
+    private static final String DUMMY_REGION = "us-east-1";
+
+    @Test
+    void testMinimalChainWithoutStaticOrCustom() throws Exception {
+        S3ClientProvider provider =
+                S3ClientProvider.builder().endpoint(DUMMY_ENDPOINT).region(DUMMY_REGION).build();
+
+        List<AwsCredentialsProvider> chain = extractChain(provider.getCredentialsProvider());
+
+        assertThat(chain).hasSize(2);
+        assertThat(chain.get(0)).isInstanceOf(DynamicTemporaryAWSCredentialsProvider.class);
+        assertThat(chain.get(1)).isInstanceOf(DefaultCredentialsProvider.class);
+    }
+
+    @Test
+    void testChainWithStaticCredentials() throws Exception {
+        S3ClientProvider provider =
+                S3ClientProvider.builder()
+                        .accessKey("test-key")
+                        .secretKey("test-secret")
+                        .endpoint(DUMMY_ENDPOINT)
+                        .region(DUMMY_REGION)
+                        .build();
+
+        List<AwsCredentialsProvider> chain = extractChain(provider.getCredentialsProvider());
+
+        assertThat(chain).hasSize(3);
+        AwsCredentials creds = chain.get(0).resolveCredentials();
+        assertThat(creds).isInstanceOf(AwsBasicCredentials.class);
+        assertThat(creds.accessKeyId()).isEqualTo("test-key");
+        assertThat(creds.secretAccessKey()).isEqualTo("test-secret");
+        assertThat(chain.get(1)).isInstanceOf(DynamicTemporaryAWSCredentialsProvider.class);
+        assertThat(chain.get(2)).isInstanceOf(DefaultCredentialsProvider.class);
+    }
+
+    @Test
+    void testCustomProviderPrependedToChain() throws Exception {
+        S3ClientProvider provider =
+                S3ClientProvider.builder()
+                        .endpoint(DUMMY_ENDPOINT)
+                        .region(DUMMY_REGION)
+                        .credentialsProviderClasses("AnonymousCredentialsProvider")
+                        .build();
+
+        List<AwsCredentialsProvider> chain = extractChain(provider.getCredentialsProvider());
+
+        assertThat(chain).hasSize(3);
+        assertThat(chain.get(0)).isInstanceOf(AnonymousCredentialsProvider.class);
+        assertThat(chain.get(1)).isInstanceOf(DynamicTemporaryAWSCredentialsProvider.class);
+        assertThat(chain.get(2)).isInstanceOf(DefaultCredentialsProvider.class);
+    }
+
+    @Test
+    void testAllFourTiersActive() throws Exception {
+        S3ClientProvider provider =
+                S3ClientProvider.builder()
+                        .accessKey("my-key")
+                        .secretKey("my-secret")
+                        .endpoint(DUMMY_ENDPOINT)
+                        .region(DUMMY_REGION)
+                        .credentialsProviderClasses("AnonymousCredentialsProvider")
+                        .build();
+
+        List<AwsCredentialsProvider> chain = extractChain(provider.getCredentialsProvider());
+
+        assertThat(chain).hasSize(4);
+        assertThat(chain.get(0)).isInstanceOf(AnonymousCredentialsProvider.class);
+        AwsCredentials creds = chain.get(1).resolveCredentials();
+        assertThat(creds.accessKeyId()).isEqualTo("my-key");
+        assertThat(chain.get(2)).isInstanceOf(DynamicTemporaryAWSCredentialsProvider.class);
+        assertThat(chain.get(3)).isInstanceOf(DefaultCredentialsProvider.class);
+    }
+
+    @Test
+    void testCustomProviderChainWithMultipleEntries() throws Exception {
+        S3ClientProvider provider =
+                S3ClientProvider.builder()
+                        .endpoint(DUMMY_ENDPOINT)
+                        .region(DUMMY_REGION)
+                        .credentialsProviderClasses(
+                                "AnonymousCredentialsProvider,EnvironmentVariableCredentialsProvider")
+                        .build();
+
+        List<AwsCredentialsProvider> chain = extractChain(provider.getCredentialsProvider());
+
+        assertThat(chain).hasSize(4);
+        assertThat(chain.get(0)).isInstanceOf(AnonymousCredentialsProvider.class);
+        assertThat(chain.get(1).getClass().getSimpleName())
+                .isEqualTo("EnvironmentVariableCredentialsProvider");
+        assertThat(chain.get(2)).isInstanceOf(DynamicTemporaryAWSCredentialsProvider.class);
+        assertThat(chain.get(3)).isInstanceOf(DefaultCredentialsProvider.class);
+    }
+
+    @Test
+    void testAssumeRoleWrapsChain() {
+        S3ClientProvider provider =
+                S3ClientProvider.builder()
+                        .accessKey("test-key")
+                        .secretKey("test-secret")
+                        .endpoint(DUMMY_ENDPOINT)
+                        .region(DUMMY_REGION)
+                        .assumeRoleArn("arn:aws:iam::123456789012:role/TestRole")
+                        .build();
+
+        assertThat(provider.getCredentialsProvider())
+                .isInstanceOf(StsAssumeRoleCredentialsProvider.class);
+    }
+
+    @Test
+    void testTokenProviderAlwaysPresentWithCustomConfig() throws Exception {
+        S3ClientProvider provider =
+                S3ClientProvider.builder()
+                        .endpoint(DUMMY_ENDPOINT)
+                        .region(DUMMY_REGION)
+                        .credentialsProviderClasses("AnonymousCredentialsProvider")
+                        .build();
+
+        List<AwsCredentialsProvider> chain = extractChain(provider.getCredentialsProvider());
+
+        assertThat(chain).anyMatch(p -> p instanceof DynamicTemporaryAWSCredentialsProvider);
+    }
+
+    @Test
+    void testDefaultProviderAlwaysTail() throws Exception {
+        S3ClientProvider provider =
+                S3ClientProvider.builder()
+                        .accessKey("key")
+                        .secretKey("secret")
+                        .endpoint(DUMMY_ENDPOINT)
+                        .region(DUMMY_REGION)
+                        .credentialsProviderClasses("AnonymousCredentialsProvider")
+                        .build();
+
+        List<AwsCredentialsProvider> chain = extractChain(provider.getCredentialsProvider());
+
+        assertThat(chain.get(chain.size() - 1)).isInstanceOf(DefaultCredentialsProvider.class);
+    }
+
+    @Test
+    void testInvalidProviderClassThrows() {
+        assertThatThrownBy(
+                        () ->
+                                S3ClientProvider.builder()
+                                        .endpoint(DUMMY_ENDPOINT)
+                                        .region(DUMMY_REGION)
+                                        .credentialsProviderClasses("com.nonexistent.FakeProvider")
+                                        .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Failed to instantiate credentials provider");
+    }
+
+    @Test
+    void testEmptyProviderStringThrows() {
+        assertThatThrownBy(
+                        () ->
+                                S3ClientProvider.builder()
+                                        .endpoint(DUMMY_ENDPOINT)
+                                        .region(DUMMY_REGION)
+                                        .credentialsProviderClasses("  ,  , ")
+                                        .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("no valid provider class names");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<AwsCredentialsProvider> extractChain(AwsCredentialsProvider provider)
+            throws Exception {
+        assertThat(provider).isInstanceOf(AwsCredentialsProviderChain.class);
+        Field field = AwsCredentialsProviderChain.class.getDeclaredField("credentialsProviders");
+        field.setAccessible(true);
+        return (List<AwsCredentialsProvider>) field.get(provider);
+    }
+}

--- a/flink-filesystems/flink-s3-fs-native/src/test/java/org/apache/flink/fs/s3native/writer/NativeS3RecoverableSerializerTest.java
+++ b/flink-filesystems/flink-s3-fs-native/src/test/java/org/apache/flink/fs/s3native/writer/NativeS3RecoverableSerializerTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.s3native.writer;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link NativeS3RecoverableSerializer}. */
+class NativeS3RecoverableSerializerTest {
+
+    @Test
+    void testSerializeAndDeserializeWithParts() throws IOException {
+        NativeS3RecoverableSerializer serializer = NativeS3RecoverableSerializer.INSTANCE;
+
+        List<NativeS3Recoverable.PartETag> parts = new ArrayList<>();
+        parts.add(new NativeS3Recoverable.PartETag(1, "etag1"));
+        parts.add(new NativeS3Recoverable.PartETag(2, "etag2"));
+        parts.add(new NativeS3Recoverable.PartETag(3, "etag3"));
+
+        NativeS3Recoverable original =
+                new NativeS3Recoverable("test-object-key", "test-upload-id", parts, 12345L);
+
+        byte[] serialized = serializer.serialize(original);
+        assertThat(serialized).isNotNull();
+        assertThat(serialized.length).isGreaterThan(0);
+
+        NativeS3Recoverable deserialized =
+                serializer.deserialize(serializer.getVersion(), serialized);
+
+        assertThat(deserialized.getObjectName()).isEqualTo(original.getObjectName());
+        assertThat(deserialized.uploadId()).isEqualTo(original.uploadId());
+        assertThat(deserialized.numBytesInParts()).isEqualTo(original.numBytesInParts());
+        assertThat(deserialized.parts()).hasSize(original.parts().size());
+        assertThat(deserialized.incompleteObjectName()).isNull();
+
+        for (int i = 0; i < parts.size(); i++) {
+            assertThat(deserialized.parts().get(i).getPartNumber())
+                    .isEqualTo(original.parts().get(i).getPartNumber());
+            assertThat(deserialized.parts().get(i).getETag())
+                    .isEqualTo(original.parts().get(i).getETag());
+        }
+    }
+
+    @Test
+    void testSerializeAndDeserializeWithIncompleteObject() throws IOException {
+        NativeS3RecoverableSerializer serializer = NativeS3RecoverableSerializer.INSTANCE;
+
+        List<NativeS3Recoverable.PartETag> parts = new ArrayList<>();
+        parts.add(new NativeS3Recoverable.PartETag(1, "etag1"));
+
+        NativeS3Recoverable original =
+                new NativeS3Recoverable(
+                        "test-object-key",
+                        "test-upload-id",
+                        parts,
+                        5242880L,
+                        "incomplete-object-key",
+                        1024L);
+
+        byte[] serialized = serializer.serialize(original);
+        NativeS3Recoverable deserialized =
+                serializer.deserialize(serializer.getVersion(), serialized);
+
+        assertThat(deserialized.getObjectName()).isEqualTo(original.getObjectName());
+        assertThat(deserialized.uploadId()).isEqualTo(original.uploadId());
+        assertThat(deserialized.numBytesInParts()).isEqualTo(original.numBytesInParts());
+        assertThat(deserialized.incompleteObjectName()).isEqualTo(original.incompleteObjectName());
+    }
+
+    @Test
+    void testSerializeAndDeserializeEmptyParts() throws IOException {
+        NativeS3RecoverableSerializer serializer = NativeS3RecoverableSerializer.INSTANCE;
+
+        NativeS3Recoverable original =
+                new NativeS3Recoverable("test-object-key", "test-upload-id", new ArrayList<>(), 0L);
+
+        byte[] serialized = serializer.serialize(original);
+        NativeS3Recoverable deserialized =
+                serializer.deserialize(serializer.getVersion(), serialized);
+
+        assertThat(deserialized.getObjectName()).isEqualTo(original.getObjectName());
+        assertThat(deserialized.uploadId()).isEqualTo(original.uploadId());
+        assertThat(deserialized.numBytesInParts()).isEqualTo(0L);
+        assertThat(deserialized.parts()).isEmpty();
+    }
+
+    @Test
+    void testVersionIsConsistent() {
+        NativeS3RecoverableSerializer serializer = NativeS3RecoverableSerializer.INSTANCE;
+        assertThat(serializer.getVersion()).isGreaterThanOrEqualTo(1);
+    }
+}

--- a/flink-filesystems/pom.xml
+++ b/flink-filesystems/pom.xml
@@ -43,6 +43,7 @@ under the License.
 		<module>flink-s3-fs-base</module>
 		<module>flink-s3-fs-hadoop</module>
 		<module>flink-s3-fs-presto</module>
+		<module>flink-s3-fs-native</module>
 		<module>flink-oss-fs-hadoop</module>
 		<module>flink-azure-fs-hadoop</module>
 		<module>flink-gs-fs-hadoop</module>


### PR DESCRIPTION
## DESCRIPTION 

# Native S3 FileSystem

This module provides a native S3 filesystem implementation for Apache Flink using AWS SDK v2.

## Overview

The Native S3 FileSystem is a direct implementation of Flink's FileSystem interface using AWS SDK v2, without Hadoop dependencies. It provides exactly-once semantics for checkpointing and file sinks through S3 multipart uploads.

## Usage

Add this module to Flink's plugins directory:

```bash
mkdir -p $FLINK_HOME/plugins/s3-fs-native
cp flink-s3-fs-native-*.jar $FLINK_HOME/plugins/s3-fs-native/
```

Configure S3 credentials in `conf/config.yaml`:

```yaml
s3.access-key: YOUR_ACCESS_KEY
s3.secret-key: YOUR_SECRET_KEY
s3.endpoint: https://s3.amazonaws.com  # Optional, defaults to AWS
```

Use S3 paths in your Flink application:

```java
env.getCheckpointConfig().setCheckpointStorage("s3://my-bucket/checkpoints");

DataStream<String> input = env.readTextFile("s3://my-bucket/input");
input.sinkTo(FileSink.forRowFormat(new Path("s3://my-bucket/output"), 
                                    new SimpleStringEncoder<>()).build());
```

## Configuration Options

### Core Settings

| Key | Default | Description |
|-----|---------|-------------|
| s3.access-key | (none) | AWS access key |
| s3.secret-key | (none) | AWS secret key |
| s3.region | (auto-detect) | AWS region (auto-detected via AWS_REGION, ~/.aws/config, EC2 metadata) |
| s3.endpoint | (none) | Custom S3 endpoint (for MinIO, LocalStack, etc.) |
| s3.path-style-access | false | Use path-style access (auto-enabled for custom endpoints) |
| s3.upload.min.part.size | 5242880 | Minimum part size for multipart uploads (5MB) |
| s3.upload.max.concurrent.uploads | CPU cores | Maximum concurrent uploads per stream |
| s3.entropy.key | (none) | Key for entropy injection in paths |
| s3.entropy.length | 4 | Length of entropy string |
| s3.bulk-copy.enabled | true | Enable bulk copy operations |
| s3.async.enabled | true | Enable async read/write with TransferManager |
| s3.read.buffer.size | 262144 (256KB) | Read buffer size per stream (64KB - 4MB) |

### Server-Side Encryption (SSE)

| Key | Default | Description |
|-----|---------|-------------|
| s3.sse.type | none | Encryption type: `none`, `sse-s3` (AES256), `sse-kms` (AWS KMS) |
| s3.sse.kms.key-id | (none) | KMS key ID/ARN/alias for SSE-KMS (uses default aws/s3 key if not specified) |

### IAM Assume Role

| Key | Default | Description |
|-----|---------|-------------|
| s3.assume-role.arn | (none) | ARN of the IAM role to assume |
| s3.assume-role.external-id | (none) | External ID for cross-account access |
| s3.assume-role.session-name | flink-s3-session | Session name for the assumed role |
| s3.assume-role.session-duration | 3600 | Session duration in seconds (900-43200) |

## Server-Side Encryption (SSE)

The filesystem supports server-side encryption for data at rest:

### SSE-S3 (S3-Managed Keys)

Amazon S3 manages the encryption keys. Simplest option with no additional configuration.

```yaml
s3.sse.type: sse-s3
```

All objects will be encrypted with AES-256 using keys managed by S3.

### SSE-KMS (AWS KMS-Managed Keys)

Use AWS Key Management Service for encryption key management. Provides additional security features like key rotation, audit trails, and fine-grained access control.

**Using the default aws/s3 key:**
```yaml
s3.sse.type: sse-kms
```

**Using a custom KMS key:**
```yaml
s3.sse.type: sse-kms
s3.sse.kms.key-id: arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789abc
# Or use an alias:
# s3.sse.kms.key-id: alias/my-s3-encryption-key
```

**Note:** Ensure the IAM role/user has `kms:Encrypt` and `kms:GenerateDataKey` permissions on the KMS key.

## IAM Assume Role

For cross-account access or temporary elevated permissions, configure an IAM role to assume:

### Basic Assume Role

```yaml
s3.assume-role.arn: arn:aws:iam::123456789012:role/S3AccessRole
```

### Cross-Account Access with External ID

For enhanced security when granting access to third parties:

```yaml
s3.assume-role.arn: arn:aws:iam::123456789012:role/CrossAccountS3Role
s3.assume-role.external-id: your-secret-external-id
s3.assume-role.session-name: flink-cross-account-session
s3.assume-role.session-duration: 3600  # 1 hour
```

### How It Works

1. Flink uses base credentials (access key, environment, or IAM role) to call STS AssumeRole
2. STS returns temporary credentials (access key, secret key, session token)
3. All S3 operations use the assumed role's permissions
4. Credentials are automatically refreshed before expiration

**IAM Policy Example for the Assumed Role:**

```json
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Action": [
        "s3:GetObject",
        "s3:PutObject",
        "s3:DeleteObject",
        "s3:ListBucket"
      ],
      "Resource": [
        "arn:aws:s3:::my-bucket",
        "arn:aws:s3:::my-bucket/*"
      ]
    }
  ]
}
```

**Trust Policy for Cross-Account Access:**

```json
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Principal": {
        "AWS": "arn:aws:iam::SOURCE_ACCOUNT_ID:root"
      },
      "Action": "sts:AssumeRole",
      "Condition": {
        "StringEquals": {
          "sts:ExternalId": "your-secret-external-id"
        }
      }
    }
  ]
}
```

## MinIO and S3-Compatible Storage

The filesystem auto-detects custom endpoints and configures appropriate settings:

```yaml
s3.access-key: minioadmin
s3.secret-key: minioadmin  
s3.endpoint: http://localhost:9000
s3.path-style-access: true  # Auto-enabled for custom endpoints
```

MinIO-specific optimizations are applied automatically:
- Path-style access enabled
- Chunked encoding disabled (compatibility)
- Checksum validation disabled (compatibility)

## Memory Optimization for Large Files

The filesystem is optimized to handle large files without OOM errors:

### Streaming Reads (No Buffering)
- Files are **streamed** chunk-by-chunk, not loaded into memory
- Configurable read buffer (default 256KB) prevents memory spikes
- Only small buffer held in memory at any time

### Configuration for Memory Efficiency

```yaml
# Read buffer: smaller = less memory, larger = better throughput
s3.read.buffer.size: 262144  # 256KB (default)
# For memory-constrained environments: 65536 (64KB)
# For high-throughput: 1048576 (1MB)
```

**Memory Calculation Per Parallel Read:**
- Buffer size × concurrent reads = total memory
- Example: 256KB buffer × 16 parallel readers = 4MB total
- This allows processing GB-sized files with MB-sized memory

### OOM Prevention Strategies

1. **Use smaller read buffers** (64-128KB) for very large files
2. **Reduce parallelism** to limit concurrent S3 readers
3. **Enable managed memory** for Flink state backend
4. **Monitor**: `s3.read.buffer.size` × `parallelism` = peak memory

**Configuration:**
```yaml
s3.async.enabled: true  # Default: enabled
```

When enabled, file uploads automatically use TransferManager for:
- Large file uploads (automatic multipart handling)
- Checkpoint data writes
- Recoverable output stream operations


## Checkpointing

Configure checkpoint storage in `conf/config.yaml`:

```yaml
state.checkpoints.dir: s3://my-bucket/checkpoints
execution.checkpointing.interval: 10s
execution.checkpointing.mode: EXACTLY_ONCE
```

Or programmatically:

```java
env.enableCheckpointing(10000);
env.getCheckpointConfig().setCheckpointStorage("s3://my-bucket/checkpoints");
```

## Entropy Injection

For high-throughput checkpointing to avoid S3 hot partitions:

```yaml
s3.entropy.key: _entropy_
s3.entropy.length: 4
```

Paths like `s3://bucket/_entropy_/checkpoints` will be expanded to `s3://bucket/af7e/checkpoints` with random characters.

## Implementation Details

The filesystem uses:
- **AWS SDK v2** for all S3 operations
- **Multipart uploads** for recoverable writes and large files
- **S3 Transfer Manager** for bulk copy operations  
- **Separate sync and async clients** for optimal performance

Key classes:
- `NativeS3FileSystem` - Main FileSystem implementation
- `NativeS3RecoverableWriter` - Exactly-once writer using multipart uploads
- `S3ClientProvider` - Manages S3 client lifecycle
- `NativeS3AccessHelper` - Low-level S3 operations

## Building

```bash
mvn clean package
```

## Testing with MinIO

```bash
# Start MinIO
docker run -d -p 9000:9000 -p 9001:9001 \
  -e "MINIO_ROOT_USER=minioadmin" \
  -e "MINIO_ROOT_PASSWORD=minioadmin" \
  minio/minio server /data --console-address ":9001"

# Create bucket
mc alias set local http://localhost:9000 minioadmin minioadmin
mc mb local/test-bucket

# Run Flink with MinIO
export FLINK_HOME=/path/to/flink
cat > $FLINK_HOME/conf/config.yaml <<EOF
s3.endpoint: http://localhost:9000
s3.access-key: minioadmin
s3.secret-key: minioadmin
s3.path-style-access: true
EOF

$FLINK_HOME/bin/flink run YourJob.jar
```

## Delegation Tokens

The filesystem supports delegation tokens for secure multi-tenant deployments. The delegation token service name is `s3-native` to avoid conflicts with other S3 filesystem implementations.

Configure delegation tokens:

```yaml
security.delegation.token.provider.s3-native.enabled: true
security.delegation.token.provider.s3-native.access-key: YOUR_KEY
security.delegation.token.provider.s3-native.secret-key: YOUR_SECRET
security.delegation.token.provider.s3-native.region: us-east-1
```





## TESTING 

### Setup And Testing Details 

1. POC is tested properly with s3 bucket and minio setup in local docker setup.
2. Used the wordCount Application to read from the s3 input bucket and write to s3 output bucket.
3. Used streaming mode and enabled checkpointing to the MinIO bucket 

### Callout :
1. Very minimal Unit test added in the patch. 
2. Only tested with the WordCount Application. 

### Log Snippet from testing 

#### Reading the input data 

```
2025-11-09 13:53:15,111 INFO  LocalityAwareSplitAssigner - Assigning local split to requesting host 'localhost': FileSourceSplit: s3://flink-wordcount-test-1762676252/input/wordcount_test_30mb.txt [0, 31465656)
2025-11-09 13:53:15,113 INFO  StaticFileSplitEnumerator - Assigned split to subtask 4 : FileSourceSplit: s3://flink-wordcount-test-1762676252/input/wordcount_test_30mb.txt [0, 31465656)
```
#### Small File Async Upload (< 5MB)

```
2025-11-09 13:53:19,314 INFO  NativeS3AccessHelper - Starting async upload with TransferManager - key: output/wordcount_results/2025-11-09--13/part-8aff2425-e334-474d-b75c-5ae914972b52-1/.incomplete/.../04c8cbcd-de95-46ae-871e-b40178fc1819, size: 550505 bytes
2025-11-09 13:53:20,732 INFO  NativeS3AccessHelper - Async upload completed successfully - key: ..., eTag: "390b8dc43a25b579dc4299cd6cef5246"
```

#### Async upload completed in ~1.4 seconds for 550KB file

```
2025-11-09 13:53:19,797 INFO  NativeS3AccessHelper - Starting async upload with TransferManager - key: output/wordcount_results/2025-11-09--13/part-57ab617d-596c-47d1-989f-e8578b217202-1/.incomplete/.../7dd5f82d-676d-472a-a0f9-8a94c2a91404, size: 184842 bytes
2025-11-09 13:53:20,860 INFO  NativeS3AccessHelper - Async upload completed successfully - key: ..., eTag: "623fd4e5e820b0774d88838dc8e218f0"
```

#### Multipart Upload Operations (Large Files)

```
2025-11-09 13:53:22,640 INFO  NativeS3AccessHelper - Completing multipart upload - key: output/wordcount_results/2025-11-09--13/part-57ab617d-596c-47d1-989f-e8578b217202-0, parts: 1, size: 1048580 bytes
2025-11-09 13:53:22,868 INFO  NativeS3AccessHelper - Multipart upload completed - key: output/wordcount_results/2025-11-09--13/part-57ab617d-596c-47d1-989f-e8578b217202-0, eTag: "a15f5433e6cab5aabc4825f03dbe23c0-1"
```

#### Checkpoint Multipart Uploads to S3

```
2025-11-09 13:53:22,438 INFO  NativeS3AccessHelper - Completing multipart upload - key: checkpoints/762fa149908c89d1195f73b565722b64/chk-1/_metadata, parts: 1, size: 105667 bytes
2025-11-09 13:53:22,633 INFO  NativeS3AccessHelper - Multipart upload completed - key: checkpoints/762fa149908c89d1195f73b565722b64/chk-1/_metadata, eTag: "a789024af1446d2c797e223c34c86617-1"

2025-11-09 13:53:33,221 INFO  NativeS3AccessHelper - Completing multipart upload - key: checkpoints/762fa149908c89d1195f73b565722b64/chk-2/_metadata, parts: 1, size: 122489 bytes
2025-11-09 13:53:33,401 INFO  NativeS3AccessHelper - Multipart upload completed - key: checkpoints/762fa149908c89d1195f73b565722b64/chk-2/_metadata, eTag: "f5c2377f17dc7aee80622371d190be9c-1"
```


### Outcome

#### Final Output Results
```
$ aws s3 ls s3://flink-wordcount-test-1762676252/output/wordcount_results/ --recursive | wc -l
65
$ aws s3 ls s3://flink-wordcount-test-1762676252/output/wordcount_results/ --recursive | awk '{sum+=$3} END {print "Total size:", sum/1024/1024 "MB"}'
Total size: 61.24 MB
```

Able to verify read, write and checkpointing using the native-s3-filesystem

Jobmanager log: https://drive.google.com/file/d/1lfEJRn9F-r72YgU_uyyQFlEg2VAN_3qJ/view?usp=sharing

TaskManager log : 
[taskmanager-1.log](https://github.com/user-attachments/files/23292642/taskmanager-1.log)

<img width="1439" height="442" alt="Screenshot 2025-11-09 at 2 46 39 PM" src="https://github.com/user-attachments/assets/6279185d-a9a9-437a-9f99-10dc89c14757" />
<img width="1438" height="408" alt="Screenshot 2025-11-09 at 2 46 50 PM" src="https://github.com/user-attachments/assets/5fc45ad4-5617-4771-9e3b-b6930039e3c7" />
<img width="1440" height="721" alt="Screenshot 2025-11-09 at 2 47 15 PM" src="https://github.com/user-attachments/assets/b5aaa6b5-ba53-45a4-821c-d7482c8c95c0" />


<img width="1512" height="868" alt="Screenshot 2025-11-03 at 1 19 35 AM" src="https://github.com/user-attachments/assets/8faaff1d-50ee-4aa7-86ef-4ccccae13c9e" />
<img width="1512" height="916" alt="Screenshot 2025-11-03 at 1 19 59 AM" src="https://github.com/user-attachments/assets/0f0f6443-3cbb-47fa-9369-8ece3a525240" />
<img width="1512" height="883" alt="Screenshot 2025-11-03 at 1 20 43 AM" src="https://github.com/user-attachments/assets/6e6070c3-f184-4d94-a82d-739d03eb309e" />

<img width="1490" height="849" alt="Screenshot 2025-11-03 at 1 20 52 AM" src="https://github.com/user-attachments/assets/cc93579c-ce2c-4122-a8d0-d16ed6e51ea4" />
<img width="1512" height="857" alt="Screenshot 2025-11-03 at 1 21 10 AM" src="https://github.com/user-attachments/assets/dde3487c-1354-41d1-8370-6be759c0aa32" />
<img width="1503" height="867" alt="Screenshot 2025-11-03 at 1 22 27 AM" src="https://github.com/user-attachments/assets/ba20c473-d784-455b-8b90-8159b7b04961" />
