### PR TITLE
[FLINK-38557][FileSystems] Bumped presto version from 0.272 to 0.295

### DIFF
--- a/flink-filesystems/flink-s3-fs-presto/pom.xml
+++ b/flink-filesystems/flink-s3-fs-presto/pom.xml
@@ -32,7 +32,7 @@ under the License.
 	<packaging>jar</packaging>
 
 	<properties>
-		<presto.version>0.272</presto.version>
+		<presto.version>0.295</presto.version>
 		<surefire.module.config> <!--
 			S5CmdOnPrestoS3FileSystemITCase uses ArraysAsListSerializer indirectly
 			-->--add-opens=java.base/java.util=ALL-UNNAMED

--- a/flink-filesystems/flink-s3-fs-presto/pom.xml
+++ b/flink-filesystems/flink-s3-fs-presto/pom.xml
@@ -562,6 +562,8 @@ under the License.
 										<exclude>mime.types</exclude>
 										<exclude>mozilla/**</exclude>
 										<exclude>META-INF/LICENSE.txt</exclude>
+										<exclude>/LICENSE.txt</exclude>
+										<exclude>/LICENSE</exclude>
 									</excludes>
 								</filter>
 								<filter>

--- a/flink-filesystems/flink-s3-fs-presto/pom.xml
+++ b/flink-filesystems/flink-s3-fs-presto/pom.xml
@@ -32,7 +32,7 @@ under the License.
 	<packaging>jar</packaging>
 
 	<properties>
-		<presto.version>0.272</presto.version>
+		<presto.version>0.295</presto.version>
 		<surefire.module.config> <!--
 			S5CmdOnPrestoS3FileSystemITCase uses ArraysAsListSerializer indirectly
 			-->--add-opens=java.base/java.util=ALL-UNNAMED
@@ -604,4 +604,3 @@ under the License.
 	</build>
 
 </project>
-

--- a/flink-filesystems/flink-s3-fs-presto/pom.xml
+++ b/flink-filesystems/flink-s3-fs-presto/pom.xml
@@ -32,7 +32,7 @@ under the License.
 	<packaging>jar</packaging>
 
 	<properties>
-		<presto.version>0.295</presto.version>
+		<presto.version>0.272</presto.version>
 		<surefire.module.config> <!--
 			S5CmdOnPrestoS3FileSystemITCase uses ArraysAsListSerializer indirectly
 			-->--add-opens=java.base/java.util=ALL-UNNAMED
@@ -604,3 +604,4 @@ under the License.
 	</build>
 
 </project>
+

--- a/flink-filesystems/flink-s3-fs-presto/pom.xml
+++ b/flink-filesystems/flink-s3-fs-presto/pom.xml
@@ -562,8 +562,9 @@ under the License.
 										<exclude>mime.types</exclude>
 										<exclude>mozilla/**</exclude>
 										<exclude>META-INF/LICENSE.txt</exclude>
-										<exclude>/LICENSE.txt</exclude>
-										<exclude>/LICENSE</exclude>
+										<!-- flink-s3-fs-presto-2.2 jar contains LICENSE files in the root folder -->
+										<exclude>LICENSE.txt</exclude>
+										<exclude>LICENSE</exclude>
 									</excludes>
 								</filter>
 								<filter>

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
@@ -16,10 +16,10 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.facebook.airlift:log:0.201
 - com.facebook.airlift:stats:0.201
 - com.facebook.presto.hadoop:hadoop-apache2:2.7.4-9
-- com.facebook.presto:presto-common:0.272
-- com.facebook.presto:presto-hive-common:0.272
-- com.facebook.presto:presto-hive-metastore:0.272
-- com.facebook.presto:presto-hive:0.272
+- com.facebook.presto:presto-common:0.295
+- com.facebook.presto:presto-hive-common:0.295
+- com.facebook.presto:presto-hive-metastore:0.295
+- com.facebook.presto:presto-hive:0.295
 - com.fasterxml.jackson.core:jackson-annotations:2.18.2
 - com.fasterxml.jackson.core:jackson-core:2.18.2
 - com.fasterxml.jackson.core:jackson-databind:2.18.2

--- a/tools/ci/flink-ci-tools/src/main/java/org/apache/flink/tools/ci/licensecheck/JarFileChecker.java
+++ b/tools/ci/flink-ci-tools/src/main/java/org/apache/flink/tools/ci/licensecheck/JarFileChecker.java
@@ -206,9 +206,9 @@ public class JarFileChecker {
                     // dual-licensed under GPL 2 and CDDL 1.1
                     // contained in hadoop/presto S3 FS and flink-dist
                     .filter(path -> !pathStartsWith(path, "/META-INF/versions/11/javax/xml/bind"))
-                    //contained in flink-s3-fs-presto
+                    // contained in flink-s3-fs-presto
                     .filter(path -> !pathStartsWith(path, "/com/sun/el"))
-                    //contained in flink-s3-fs-presto
+                    // contained in flink-s3-fs-presto
                     .filter(path -> !pathStartsWith(path, "/META-INF/LGPL2.1"))
                     .filter(path -> !isJavaxManifest(jar, path))
                     .filter(

--- a/tools/ci/flink-ci-tools/src/main/java/org/apache/flink/tools/ci/licensecheck/JarFileChecker.java
+++ b/tools/ci/flink-ci-tools/src/main/java/org/apache/flink/tools/ci/licensecheck/JarFileChecker.java
@@ -206,6 +206,10 @@ public class JarFileChecker {
                     // dual-licensed under GPL 2 and CDDL 1.1
                     // contained in hadoop/presto S3 FS and flink-dist
                     .filter(path -> !pathStartsWith(path, "/META-INF/versions/11/javax/xml/bind"))
+                    //contained in flink-s3-fs-presto
+                    .filter(path -> !pathStartsWith(path, "/com/sun/el"))
+                    //contained in flink-s3-fs-presto
+                    .filter(path -> !pathStartsWith(path, "/META-INF/LGPL2.1"))
                     .filter(path -> !isJavaxManifest(jar, path))
                     .filter(
                             path ->


### PR DESCRIPTION
## What is the purpose of the change

* Bumps the version of presto to reduce the vulnerabilities present in the previous version


## Brief change log

  - *Updated the version in pom.xml*
  - *Excluded the LICENSE files present in the root directory of flink-s3-fs-presto-2.2 jar*
  - *Updated JarFileChecker to ignore the license files containing forbidden patterns*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes 
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: yes

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
