### PR TITLE
[FLINK-38349][runtime] Address SpillingThread Zero-Division During Channel Merging Operations

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/SpillingThreadTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/SpillingThreadTest.java
@@ -18,6 +18,9 @@
 
 package org.apache.flink.runtime.operators.sort;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.IntComparator;
@@ -30,7 +33,6 @@ import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.util.MutableObjectIterator;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -41,9 +43,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class SpillingThreadTest {
 
@@ -107,25 +106,9 @@ class SpillingThreadTest {
     }
 
     /**
-     * Provides test cases for problematic maxFanIn and channelIDs.size() combinations.
-     *
-     * <p>The divide-by-zero occurs when channelIDs.size() equals a power of maxFanIn. This can
-     * happen in two scenarios:
-     *
-     * <ul>
-     *   <li>Exact powers: channelIDs.size() == maxFanIn^n - triggers divide-by-zero in first
-     *       iteration
-     *   <li>Greater than powers: channelIDs.size() > maxFanIn^n - may reduce to an exact power in a
-     *       later iteration, triggering divide-by-zero
-     * </ul>
-     *
-     * <p>For example, with maxFanIn=18:
-     *
-     * <ul>
-     *   <li>5832 (18^3) triggers divide-by-zero immediately
-     *   <li>7055 reduces to 5832 in first iteration, then triggers divide-by-zero in second
-     *       iteration
-     * </ul>
+     * Provides test cases for problematic maxFanIn and channelIDs.size() combinations (namely those
+     * that could result in a floating-point based miscalculation that can occur when the channel
+     * count is greater than or equal to a power of maxFanIn (channelCount ≥ maxFanIn<sup>i</sup>).
      */
     private static Stream<Arguments> maxFanInChannelCountConfigurations() {
         return Stream.of(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/SpillingThreadTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/SpillingThreadTest.java
@@ -1,0 +1,314 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.operators.sort;
+
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.IntComparator;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.runtime.io.disk.iomanager.BlockChannelWriter;
+import org.apache.flink.runtime.io.disk.iomanager.ChannelWriterOutputView;
+import org.apache.flink.runtime.io.disk.iomanager.FileIOChannel;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
+import org.apache.flink.runtime.memory.MemoryAllocationException;
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
+import org.apache.flink.runtime.operators.testutils.DummyInvokable;
+import org.apache.flink.util.MutableObjectIterator;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SpillingThreadTest {
+
+    private static final int PAGE_SIZE = 4 * 1024;
+    private static final int NUM_PAGES = 100;
+
+    private MemoryManager memoryManager;
+    private IOManager ioManager;
+    private final TypeSerializer<Integer> serializer = IntSerializer.INSTANCE;
+    private final TypeComparator<Integer> comparator = new IntComparator(true);
+
+    @BeforeEach
+    void beforeEach() {
+        this.memoryManager =
+                MemoryManagerBuilder.newBuilder()
+                        .setMemorySize(NUM_PAGES * PAGE_SIZE)
+                        .setPageSize(PAGE_SIZE)
+                        .build();
+        this.ioManager = new IOManagerAsync();
+    }
+
+    @AfterEach
+    void afterTest() throws Exception {
+        ioManager.close();
+        if (memoryManager != null) {
+            assertThat(memoryManager.verifyEmpty())
+                    .withFailMessage(
+                            "Memory leak: not all segments have been returned to the memory manager.")
+                    .isTrue();
+            memoryManager.shutdown();
+            memoryManager = null;
+        }
+    }
+
+    @ParameterizedTest(name = "Trigger zero-based division with maxFanIn: {0}, channelCount: {1}")
+    @MethodSource("maxFanInChannelCountConfigurations")
+    void testMergeChannelListDivideByZero(int maxFanIn, int channelCount) throws Exception {
+        // Allocate minimal memory for SpillingThread
+        DummyInvokable owner = new DummyInvokable();
+        List<MemorySegment> sortReadMemory = memoryManager.allocatePages(owner, 5);
+        List<MemorySegment> writeMemory = memoryManager.allocatePages(owner, 5);
+        // Allocate at least maxFanIn read buffers to ensure each channel gets at least 1 segment
+        // channelsToMergePerStep can be up to maxFanIn, so we need at least that many buffers
+        List<MemorySegment> readBuffers = memoryManager.allocatePages(owner, maxFanIn);
+        List<MemorySegment> writeBuffers = memoryManager.allocatePages(owner, 10);
+
+        SpillChannelManager spillChannelManager = null;
+        try {
+            SpillingThread<Integer> spillingThread =
+                    createSpillingThread(maxFanIn, sortReadMemory, writeMemory);
+
+            // Get the SpillChannelManager to clean it up later
+            spillChannelManager = getSpillChannelManager(spillingThread);
+
+            // Create channelIDs list with the specified size
+            // Note: These channels are registered with SpillChannelManager for cleanup
+            // Files are created so the code can proceed to the divide-by-zero point
+            List<ChannelWithBlockCount> channelIDs =
+                    createChannelList(channelCount, spillChannelManager);
+
+            // Use reflection to call the private mergeChannelList method
+            Method mergeChannelListMethod =
+                    SpillingThread.class.getDeclaredMethod(
+                            "mergeChannelList", List.class, List.class, List.class);
+            mergeChannelListMethod.setAccessible(true);
+
+            // This should throw ArithmeticException: / by zero
+            // The original issue specifically mentions maxFanIn=18, channelCount=7055 as
+            // problematic.
+            // Even if the initial calculation doesn't show channelsToMergePerStep=0, floating-point
+            // precision issues or edge cases in the calculation may cause it to become 0, or the
+            // divide-by-zero may occur in a different code path (e.g., when numMerges=0).
+            assertThatThrownBy(
+                            () ->
+                                    mergeChannelListMethod.invoke(
+                                            spillingThread, channelIDs, readBuffers, writeBuffers))
+                    .hasRootCauseInstanceOf(ArithmeticException.class)
+                    .hasRootCauseMessage("/ by zero");
+        } finally {
+            // Clean up SpillChannelManager to remove any temporary files
+            if (spillChannelManager != null) {
+                try {
+                    spillChannelManager.close();
+                } catch (Exception ignored) {
+                    // Ignore cleanup errors
+                }
+            }
+            // Clean up all allocated memory
+            memoryManager.release(sortReadMemory);
+            memoryManager.release(writeMemory);
+            memoryManager.release(readBuffers);
+            memoryManager.release(writeBuffers);
+        }
+    }
+
+    /**
+     * Provides test cases for problematic maxFanIn and channelIDs.size() combinations that align
+     * with configuration values where the channelIDs.size() greater than or equal to some power of
+     * the maxFanIn value:
+     *
+     * <p>(channelSize) >= (maxFanIn^3)
+     *
+     * <p>(channelSize) >= (maxFanIn^5)
+     *
+     * <p>...
+     */
+    private static Stream<Arguments> maxFanInChannelCountConfigurations() {
+        return Stream.of(
+                // maxFanIn = 5, channelIDs.size() = 125 (5^3)
+                Arguments.of(5, 125),
+                // maxFanIn = 6, channelIDs.size() = 216 (6^3)
+                Arguments.of(6, 216),
+                // maxFanIn = 18, channelIDs.size() = 5832 (18^3)
+                Arguments.of(18, 5832),
+                // maxFanIn = 25, channelIDs.size() = 15625 (25^3)
+                Arguments.of(25, 15625),
+                // maxFanIn = 36, channelIDs.size() = 46656 (36^3)
+                Arguments.of(36, 46656),
+                // maxFanIn = 7, channelIDs.size() = 16807 (7^5)
+                Arguments.of(7, 16807));
+    }
+
+    /**
+     * Uses reflection to get the SpillChannelManager from a SpillingThread instance for cleanup.
+     */
+    private SpillChannelManager getSpillChannelManager(SpillingThread<Integer> spillingThread)
+            throws Exception {
+        java.lang.reflect.Field field =
+                SpillingThread.class.getDeclaredField("spillChannelManager");
+        field.setAccessible(true);
+        return (SpillChannelManager) field.get(spillingThread);
+    }
+
+    /**
+     * Creates a simple SpillingThread instance for testing.
+     *
+     * @param maxFanIn the maximum fan-in value to use
+     * @param sortReadMemory memory segments for sort reading (will be stored in SpillingThread)
+     * @param writeMemory memory segments for writing (will be stored in SpillingThread)
+     * @return a SpillingThread instance
+     */
+    private SpillingThread<Integer> createSpillingThread(
+            int maxFanIn, List<MemorySegment> sortReadMemory, List<MemorySegment> writeMemory) {
+
+        // Create simple mock implementations
+        StageRunner.StageMessageDispatcher<Integer> dispatcher = createMockDispatcher();
+        SpillChannelManager spillChannelManager = new SpillChannelManager();
+        SpillingThread.SpillingBehaviour<Integer> spillingBehaviour =
+                new SpillingThread.SpillingBehaviour<>() {
+                    @Override
+                    public void spillBuffer(
+                            CircularElement<Integer> element,
+                            org.apache.flink.runtime.io.disk.iomanager.ChannelWriterOutputView
+                                    output,
+                            LargeRecordHandler<Integer> largeRecordHandler) {}
+
+                    @Override
+                    public void mergeRecords(
+                            MergeIterator<Integer> mergeIterator,
+                            org.apache.flink.runtime.io.disk.iomanager.ChannelWriterOutputView
+                                    output) {}
+                };
+
+        return new SpillingThread<>(
+                null,
+                dispatcher,
+                memoryManager,
+                ioManager,
+                serializer,
+                comparator,
+                sortReadMemory,
+                writeMemory,
+                maxFanIn,
+                spillChannelManager,
+                null,
+                spillingBehaviour,
+                1,
+                10);
+    }
+
+    /**
+     * Creates a mock StageMessageDispatcher that does nothing.
+     *
+     * @return a mock dispatcher
+     */
+    private StageRunner.StageMessageDispatcher<Integer> createMockDispatcher() {
+        return new StageRunner.StageMessageDispatcher<>() {
+            @Override
+            public void send(StageRunner.SortStage stage, CircularElement<Integer> element) {
+                // No-op for testing
+            }
+
+            @Override
+            public CircularElement<Integer> take(StageRunner.SortStage stage)
+                    throws InterruptedException {
+                // Return EOF marker to signal end
+                return CircularElement.endMarker();
+            }
+
+            @Override
+            public CircularElement<Integer> poll(StageRunner.SortStage stage) {
+                return null;
+            }
+
+            @Override
+            public void sendResult(MutableObjectIterator<Integer> result) {
+                // No-op for testing
+            }
+
+            @Override
+            public void close() {
+                // No-op for testing
+            }
+        };
+    }
+
+    /**
+     * Creates a list of ChannelWithBlockCount instances for testing.
+     *
+     * @param count the number of channels to create
+     * @param spillChannelManager the channel manager to register channels with for cleanup
+     * @return a list of ChannelWithBlockCount instances
+     */
+    private List<ChannelWithBlockCount> createChannelList(
+            int count, SpillChannelManager spillChannelManager)
+            throws IOException, MemoryAllocationException {
+        List<ChannelWithBlockCount> channels = new ArrayList<>(count);
+        FileIOChannel.Enumerator enumerator = ioManager.createChannelEnumerator();
+
+        // Allocate minimal memory for writing channel files
+        DummyInvokable owner = new DummyInvokable();
+        List<MemorySegment> writeMemory = memoryManager.allocatePages(owner, 1);
+
+        try {
+            for (int i = 0; i < count; i++) {
+                FileIOChannel.ID channel = enumerator.next();
+                // Register channel for cleanup
+                spillChannelManager.registerChannelToBeRemovedAtShutdown(channel);
+
+                // Create a writer and write minimal valid data to the channel
+                // This ensures the file has the proper header format expected by
+                // ChannelReaderInputView
+                BlockChannelWriter<MemorySegment> writer =
+                        ioManager.createBlockChannelWriter(channel);
+                spillChannelManager.registerOpenChannelToBeRemovedAtShutdown(writer);
+
+                ChannelWriterOutputView output =
+                        new ChannelWriterOutputView(
+                                writer, writeMemory, memoryManager.getPageSize());
+
+                final int blockCount = output.getBlockCount();
+
+                spillChannelManager.unregisterOpenChannelToBeRemovedAtShutdown(writer);
+
+                // Create a channel with the actual block count
+                channels.add(new ChannelWithBlockCount(channel, blockCount));
+            }
+        } finally {
+            memoryManager.release(writeMemory);
+        }
+
+        return channels;
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This pull request addresses the issue detailed in [FLINK-38349](https://issues.apache.org/jira/browse/FLINK-38349) which describes scenarios in which certain edge-case values for `maxFanIn` and `channelIDs.size()` could result in floating-point errors that resulted in thrown `ArithmeticException` exceptions (specifically division by zero). This adds the appropriate safeguards to prevent these issues.

The originating JIRA ticket provides detailed examples illustrating how the floating-point errors were reproduced. In summary, **the issue occurs whenever the channel count (`channelIDs.size()`) is greater than or equal to a power of `maxFanIn`:**
```
channelIDs.size() ≥ maxFanInⁿ
```

The overall change not only addresses the floating-point issues but also **improves scaling calculation performance by 3-4x on average** (see chart below).

## Brief change log
- Updated the scaling logic that occurs within `SpillingThread.mergeChannelList()` by replacing the previous `Math.log()`-based calculations, which could result in floating point errors, in favor of an iterative, exponential search.
  - Added a private `computeMergeScaleForChannelSize()` function to encapsulate and document the updated scaling calculations.
- Added a new `SpillingThreadTest` file with an associated, parameterized `testMergeChannelListDivideByZeroSafety` test that was used to reproduce the original issue and was later adjusted to confirm the fix.

## Verifying this change

This change added tests and can be verified as follows:

  - Added new `SpillingThreadTest.testMergeChannelListDivideByZeroSafety` which originally reproduced the issue by creating a series of parameterized tests founds within the originating JIRA ticket.
  - Ensured all previous test suites within the related areas were passing as expected.
  
### Verifying Performance
In addition to these tests related to reproduction, I performed a series of manual tests to verify performance between the previous `Math.log()`-based approach (prone to floating-point error) and the newer iterative, exponential approach.

Iterations | Old Approach (ns/call) | New Approach (ns/call) | Improvement
-- | -- | -- | --
1,000 | 33.07 | 17.68 | 1.87x
10,000 | 28.62 | 8.6 | 3.33x
100,000 | 8.94 | 4.42 | 2.02x
1,000,000 | 6.2 | 1.78 | 3.48x
100,000,000 | 5.66 | 1.28 | 4.42x

You can [see the full gist here](https://gist.github.com/rionmonster/38d1e99ee0078ae1d2659986bbef8534) with all of the necessary code comparing the older and newer approaches (elected not to commit as it was purely for demonstration purposes).

### Verifying Correctness
In addition to the above performance tests, I also performed a similar equivalence test comparing the generated results between the previous and new approaches to ensure parity (sans floating-point errors) for many of the common and edge case values presented earlier:

<img width="710" height="364" alt="image" src="https://github.com/user-attachments/assets/71bec00d-173e-414c-8416-bef6dd7febb8" />

You can find [a related gist containing these tests](https://gist.github.com/rionmonster/394b743d51d5085c3ac4ceb627d9d57c) as well.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **yes / don't know**
  - Anything that affects deployment or recovery: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**