### PR TITLE
[FLINK-38689] [flink-protobuf] Add support for protobuf 4.x field name conflict resolution

### DIFF
--- a/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/util/PbFieldConflictResolver.java
+++ b/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/util/PbFieldConflictResolver.java
@@ -1,0 +1,300 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.protobuf.util;
+
+import org.apache.flink.annotation.VisibleForTesting;
+
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.Descriptors.FieldDescriptor;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Protobuf field conflict resolver for Java code generation.
+ *
+ * <p>Implements protoc 4.x field conflict semantics: we derive all potential field accessor names
+ * (base, enum numeric, repeated list/count) and suffix every field base in a conflict group with
+ * its field number when any clash is detected. This covers field conflicts between:
+ *
+ * <ul>
+ *   <li>Any *_value fields vs enum numeric value accessors
+ *   <li>Any *_list / *_count fields vs repeated field list/count accessors
+ * </ul>
+ *
+ * <p>We explicitly mirror only the supported conflict resolution scenarios implemented by the
+ * Protobuf Java compiler to maintain 1:1 compatibility. Quoting the official implementation
+ * (https://github.com/protocolbuffers/protobuf/blob/v32.1/src/google/protobuf/compiler/java/context.cc#L93-L97):
+ * "Well, there are obviously many more conflicting cases, but it probably doesn't worth the effort
+ * to exhaust all of them because they rarely happen and as we are continuing adding new
+ * methods/changing existing methods the number of different conflicting cases will keep growing. We
+ * can just add more cases here when they are found in the real world."
+ *
+ * <p>Note: Only a single cache keyed by {@link Descriptors.Descriptor} is maintained. Public
+ * helpers expose resolved getter variants, repeated count, enum numeric accessors, builder setter
+ * segment derivation, and presence/non-default checks used by Flink's dynamic codegen.
+ */
+public class PbFieldConflictResolver {
+
+    // Accessor mapping implementation
+    public static final class AccessorNames {
+        public final String getter; // getBase or getBaseN
+        public final String enumNumericGetter; // getBaseValue or getBaseNValue
+        public final String repeatedListGetter; // getBaseList or getBaseNList
+        public final String repeatedCountGetter; // getBaseCount or getBaseNCount
+
+        AccessorNames(String g, String e, String rl, String rc) {
+            this.getter = g;
+            this.enumNumericGetter = e;
+            this.repeatedListGetter = rl;
+            this.repeatedCountGetter = rc;
+        }
+    }
+
+    public static final class AccessorMappings {
+        final Map<Integer, AccessorNames> map;
+
+        AccessorMappings(Map<Integer, AccessorNames> map) {
+            this.map = map;
+        }
+
+        public AccessorNames get(FieldDescriptor fd) {
+            return map.get(fd.getNumber());
+        }
+    }
+
+    private static final ConcurrentHashMap<Descriptors.Descriptor, AccessorMappings> CACHE =
+            new ConcurrentHashMap<>();
+
+    public static AccessorMappings getAccessorMappings(Descriptors.Descriptor desc) {
+        return CACHE.computeIfAbsent(desc, PbFieldConflictResolver::buildMappings);
+    }
+
+    private static AccessorMappings buildMappings(Descriptors.Descriptor desc) {
+        // Phase 1: collect potential (unsuffixed) accessor method names per field.
+        Map<Integer, String> baseByFieldNumber = new HashMap<>(desc.getFields().size());
+        Map<String, List<FieldDescriptor>> potentialAccessorToFields = new HashMap<>();
+        for (FieldDescriptor fd : desc.getFields()) {
+            String base = PbFormatUtils.getStrongCamelCaseJsonName(fd.getJsonName());
+            int fieldNumber = fd.getNumber();
+            baseByFieldNumber.put(fieldNumber, base);
+            potentialAccessorToFields.computeIfAbsent("get" + base, k -> new ArrayList<>()).add(fd);
+            if (fd.getJavaType() == FieldDescriptor.JavaType.ENUM) {
+                potentialAccessorToFields
+                        .computeIfAbsent("get" + base + "Value", k -> new ArrayList<>())
+                        .add(fd);
+            }
+            if (fd.isRepeated() && !fd.isMapField()) {
+                potentialAccessorToFields
+                        .computeIfAbsent("get" + base + "List", k -> new ArrayList<>())
+                        .add(fd);
+                potentialAccessorToFields
+                        .computeIfAbsent("get" + base + "Count", k -> new ArrayList<>())
+                        .add(fd);
+            }
+        }
+
+        // Phase 2: detect field conflicts by shared accessor names.
+        Set<String> conflictingBases = new HashSet<>();
+        for (Map.Entry<String, List<FieldDescriptor>> e : potentialAccessorToFields.entrySet()) {
+            if (e.getValue().size() > 1) {
+                for (FieldDescriptor fd : e.getValue()) {
+                    conflictingBases.add(
+                            PbFormatUtils.getStrongCamelCaseJsonName(fd.getJsonName()));
+                }
+            }
+        }
+
+        // Phase 3: build final mappings with suffixes applied to conflicting bases.
+        Map<Integer, AccessorNames> mappings = new HashMap<>();
+        for (FieldDescriptor fd : desc.getFields()) {
+            int fieldNumber = fd.getNumber();
+            String base = baseByFieldNumber.get(fieldNumber);
+            boolean conflict = conflictingBases.contains(base);
+            String effectiveBase = conflict ? base + fieldNumber : base;
+            String getter = "get" + effectiveBase;
+            String enumNumeric = null;
+            String listGetter = null;
+            String countGetter = null;
+            if (fd.getJavaType() == FieldDescriptor.JavaType.ENUM) {
+                enumNumeric = "get" + effectiveBase + "Value";
+            }
+            if (fd.isRepeated() && !fd.isMapField()) {
+                listGetter = "get" + effectiveBase + "List";
+                countGetter = "get" + effectiveBase + "Count";
+            }
+            mappings.put(
+                    fieldNumber, new AccessorNames(getter, enumNumeric, listGetter, countGetter));
+        }
+        return new AccessorMappings(mappings);
+    }
+
+    /**
+     * Resolves the appropriate getter name for the field.
+     *
+     * @param fd field descriptor
+     * @param isList whether caller wants the repeated list accessor for a repeated field
+     * @param m precomputed accessor mappings
+     * @return method name like getField(), getFieldN(), getFieldNList(), getFieldMap()
+     */
+    public static String resolveGetter(FieldDescriptor fd, boolean isList, AccessorMappings m) {
+        AccessorNames names = m.get(fd);
+        if (fd.isMapField()) {
+            String camel = PbFormatUtils.getStrongCamelCaseJsonName(fd.getJsonName());
+            return "get" + camel + "Map"; // map accessor naming
+        }
+        if (isList && names.repeatedListGetter != null) {
+            return names.repeatedListGetter;
+        }
+        if (fd.getJavaType() == FieldDescriptor.JavaType.ENUM) {
+            return names.getter; // caller decides if numeric needed via resolveEnumNumeric
+        }
+        return names.getter;
+    }
+
+    /**
+     * Returns the enum numeric accessor for an enum field, or null for non-enum fields. Returns
+     * get{FieldName}Value (no conflict) or get{FieldName}{FieldNumber}Value (conflict resolution
+     * applied).
+     */
+    public static String resolveEnumNumeric(FieldDescriptor fd, AccessorMappings m) {
+        AccessorNames names = m.get(fd);
+        return names.enumNumericGetter;
+    }
+
+    /**
+     * Returns the repeated count accessor for a repeated non-map field, or null otherwise. Returns
+     * get{FieldName}Count (no conflict) or get{FieldName}{FieldNumber}Count (conflict resolution
+     * applied).
+     */
+    public static String resolveRepeatedCount(FieldDescriptor fd, AccessorMappings m) {
+        AccessorNames names = m.get(fd);
+        return names.repeatedCountGetter;
+    }
+
+    /**
+     * Derives the builder setter segment (without set/addAll prefix) from the resolved getter.
+     * Example: getTags4List() -> Tags4List, getMode13() -> Mode13.
+     */
+    public static String resolveSetterSegment(
+            FieldDescriptor fd, String fieldName, AccessorMappings mappings) {
+        AccessorNames names = mappings.get(fd);
+        String getter = names.getter;
+        if (getter.startsWith("get")) {
+            return getter.substring(3);
+        }
+        return PbFormatUtils.getStrongCamelCaseJsonName(fieldName);
+    }
+
+    /**
+     * Generates a boolean Java expression that determines whether the field is present/non-default.
+     * For repeated/map fields we check count>0; for proto3 scalars without presence we compare
+     * against default value; for enums we check numeric value non-zero.
+     *
+     * @param message variable name of the message instance
+     * @param fd field descriptor
+     * @param strongCamelFieldName camel-cased JSON name (used for hasX / fallback count)
+     * @param isListOrMap whether caller treats field as collection
+     * @param mappings accessor mappings
+     * @return Java expression string evaluating to a boolean
+     */
+    public static String generatePresenceCheck(
+            String message,
+            FieldDescriptor fd,
+            String strongCamelFieldName,
+            boolean isListOrMap,
+            AccessorMappings mappings) {
+
+        if (isListOrMap) {
+            return generateCountCheck(message, fd, strongCamelFieldName, mappings);
+        }
+
+        if (fd.hasPresence()) {
+            return generateHasCheck(message, fd, strongCamelFieldName, mappings);
+        }
+
+        // For fields without explicit presence, check for non-default values
+        return generateNonDefaultCheck(message, fd, strongCamelFieldName, mappings);
+    }
+
+    private static String generateCountCheck(
+            String message,
+            FieldDescriptor fd,
+            String strongCamelFieldName,
+            AccessorMappings mappings) {
+        AccessorNames names = mappings.get(fd);
+        String countGetter =
+                names.repeatedCountGetter != null
+                        ? names.repeatedCountGetter
+                        : ("get" + strongCamelFieldName + "Count");
+        return message + "." + countGetter + "() > 0";
+    }
+
+    private static String generateHasCheck(
+            String message,
+            FieldDescriptor fd,
+            String strongCamelFieldName,
+            AccessorMappings mappings) {
+        // Presence remains based on base camel name; simplified resolver always transforms all
+        // accessors within a field conflict group so hasX remains valid (protoc behavior). We do
+        // not attempt to suffix presence checks here.
+        return message + ".has" + strongCamelFieldName + "()";
+    }
+
+    private static String generateNonDefaultCheck(
+            String message,
+            FieldDescriptor fd,
+            String strongCamelFieldName,
+            AccessorMappings mappings) {
+        AccessorNames names = mappings.get(fd);
+        String getterCall = message + "." + names.getter + "()";
+
+        switch (fd.getJavaType()) {
+            case STRING:
+                return getterCall + ".length() > 0";
+            case INT:
+            case LONG:
+            case FLOAT:
+            case DOUBLE:
+                return getterCall + " != 0";
+            case BOOLEAN:
+                return getterCall;
+            case BYTE_STRING:
+                return getterCall + ".size() > 0";
+            case ENUM:
+                if (fd.getType() == FieldDescriptor.Type.ENUM && !fd.hasPresence()) {
+                    return getterCall + ".getNumber() != 0";
+                }
+                return getterCall + " != 0";
+            default:
+                return getterCall + " != null";
+        }
+    }
+
+    /** Clears internal descriptor->accessor mapping cache (testing / lifecycle). */
+    @VisibleForTesting
+    public static void clearCache() {
+        CACHE.clear();
+    }
+}

--- a/flink-formats/flink-protobuf/src/test/java/org/apache/flink/formats/protobuf/FieldConflictProtoToRowTest.java
+++ b/flink-formats/flink-protobuf/src/test/java/org/apache/flink/formats/protobuf/FieldConflictProtoToRowTest.java
@@ -1,0 +1,307 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.protobuf;
+
+import org.apache.flink.formats.protobuf.testproto.FieldConflictPbMessage;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for protobuf field conflict resolution covering:
+ *
+ * <ul>
+ *   <li>Enum numeric accessor vs *_value field conflicts.
+ *   <li>Repeated field accessor base name vs singular field conflicts.
+ * </ul>
+ */
+public class FieldConflictProtoToRowTest {
+
+    @Test
+    public void testEnumAndValueConflict() throws Exception {
+        FieldConflictPbMessage msg =
+                FieldConflictPbMessage.newBuilder()
+                        .setStatus1(FieldConflictPbMessage.Status.STATUS_ACTIVE)
+                        .setStatusValue2("custom_status")
+                        .setControlField(42)
+                        .setOtherValue("nv")
+                        .build();
+
+        // Normal (string enum) mode
+        RowData row =
+                ProtobufTestHelper.pbBytesToRow(FieldConflictPbMessage.class, msg.toByteArray());
+        // Row schema order now: status, status_value, control_field, tags, tags_list, tags_count,
+        // other_value
+        assertEquals("STATUS_ACTIVE", row.getString(0).toString());
+        assertEquals("custom_status", row.getString(1).toString());
+        assertEquals(42, row.getInt(2));
+        assertEquals("nv", row.getString(6).toString());
+
+        // Int enum mode (numeric values)
+        RowData intEnumRow =
+                ProtobufTestHelper.pbBytesToRow(
+                        FieldConflictPbMessage.class, msg.toByteArray(), true);
+        assertEquals(1, intEnumRow.getInt(0)); // numeric value of STATUS_ACTIVE
+        assertEquals("custom_status", intEnumRow.getString(1).toString());
+        assertEquals(42, intEnumRow.getInt(2));
+        assertEquals("nv", intEnumRow.getString(6).toString());
+    }
+
+    @Test
+    public void testEnumMissingValueFieldPresent() throws Exception {
+        FieldConflictPbMessage msg =
+                FieldConflictPbMessage.newBuilder()
+                        .setStatusValue2("only_value")
+                        .setControlField(7)
+                        .build();
+        RowData row =
+                ProtobufTestHelper.pbBytesToRow(FieldConflictPbMessage.class, msg.toByteArray());
+        assertFalse(row.isNullAt(1)); // status_value present
+        assertEquals("only_value", row.getString(1).toString());
+    }
+
+    @Test
+    public void testRepeatedAndSingularAllPresent() throws Exception {
+        FieldConflictPbMessage msg =
+                FieldConflictPbMessage.newBuilder()
+                        .addTags4("tag1")
+                        .addTags4("tag2")
+                        .setTagsList5("joined_tags")
+                        .setTagsCount6(2)
+                        .setOtherValue("ov")
+                        .build();
+        RowData row =
+                ProtobufTestHelper.pbBytesToRow(FieldConflictPbMessage.class, msg.toByteArray());
+        assertEquals(2, row.getArray(3).size());
+        assertEquals(StringData.fromString("tag1"), row.getArray(3).getString(0));
+        assertEquals(StringData.fromString("tag2"), row.getArray(3).getString(1));
+        assertEquals("joined_tags", row.getString(4).toString());
+        assertEquals(2, row.getInt(5));
+        assertEquals("ov", row.getString(6).toString());
+    }
+
+    @Test
+    public void testOnlyRepeatedPresent() throws Exception {
+        FieldConflictPbMessage msg =
+                FieldConflictPbMessage.newBuilder().addTags4("single_tag").build();
+        RowData row =
+                ProtobufTestHelper.pbBytesToRow(FieldConflictPbMessage.class, msg.toByteArray());
+        assertEquals(1, row.getArray(3).size());
+        assertEquals(StringData.fromString("single_tag"), row.getArray(3).getString(0));
+        // Proto3 implicit presence: absent fields materialize to their default values
+        assertFalse(row.isNullAt(4)); // tags_list
+        assertEquals("", row.getString(4).toString());
+        assertFalse(row.isNullAt(5)); // tags_count
+        assertEquals(0, row.getInt(5));
+    }
+
+    @Test
+    public void testOnlySingularPresent() throws Exception {
+        FieldConflictPbMessage msg =
+                FieldConflictPbMessage.newBuilder().setTagsList5("x").setTagsCount6(1).build();
+
+        RowData row =
+                ProtobufTestHelper.pbBytesToRow(FieldConflictPbMessage.class, msg.toByteArray());
+        assertTrue(row.isNullAt(3)); // tags field should be null
+        assertEquals("x", row.getString(4).toString());
+        assertEquals(1, row.getInt(5));
+    }
+
+    @Test
+    public void testOtherValueOnlyAccessor() throws Exception {
+        FieldConflictPbMessage msg =
+                FieldConflictPbMessage.newBuilder().setOtherValue("abc").build();
+        RowData row =
+                ProtobufTestHelper.pbBytesToRow(FieldConflictPbMessage.class, msg.toByteArray());
+        assertFalse(row.isNullAt(6));
+        assertEquals("abc", row.getString(6).toString());
+    }
+
+    @Test
+    public void testOtherValueDefaultsMaterialization() throws Exception {
+        FieldConflictPbMessage msg =
+                FieldConflictPbMessage.newBuilder()
+                        .setStatus1(FieldConflictPbMessage.Status.STATUS_UNSPECIFIED)
+                        .build();
+        RowData row =
+                ProtobufTestHelper.pbBytesToRow(FieldConflictPbMessage.class, msg.toByteArray());
+        // other_value absent -> proto3 default empty string should materialize (not null)
+        assertFalse(row.isNullAt(6));
+        assertEquals("", row.getString(6).toString());
+    }
+
+    @Test
+    public void testMapFieldNoConflict() throws Exception {
+        FieldConflictPbMessage msg =
+                FieldConflictPbMessage.newBuilder()
+                        .putTagsMap("key1", 10)
+                        .putTagsMap("key2", 20)
+                        .build();
+        RowData row =
+                ProtobufTestHelper.pbBytesToRow(FieldConflictPbMessage.class, msg.toByteArray());
+        // Map field should work correctly without conflicts
+        assertFalse(row.isNullAt(7)); // tags_map at index 7
+        org.apache.flink.table.data.MapData mapData = row.getMap(7);
+        assertEquals(2, mapData.size());
+    }
+
+    @Test
+    public void testBooleanPresence() throws Exception {
+        // Test with boolean fields set
+        FieldConflictPbMessage msg1 =
+                FieldConflictPbMessage.newBuilder().setActive(true).setActiveValue(false).build();
+        RowData row1 =
+                ProtobufTestHelper.pbBytesToRow(FieldConflictPbMessage.class, msg1.toByteArray());
+        assertEquals(true, row1.getBoolean(8)); // active at index 8
+        assertEquals(false, row1.getBoolean(9)); // active_value at index 9
+
+        // Test with boolean fields unset
+        FieldConflictPbMessage msg2 = FieldConflictPbMessage.newBuilder().build();
+        RowData row2 =
+                ProtobufTestHelper.pbBytesToRow(FieldConflictPbMessage.class, msg2.toByteArray());
+        assertEquals(false, row2.getBoolean(8)); // proto3 default for bool
+        assertEquals(false, row2.getBoolean(9)); // proto3 default for bool
+    }
+
+    @Test
+    public void testMultipleEnumConflicts() throws Exception {
+        FieldConflictPbMessage msg =
+                FieldConflictPbMessage.newBuilder()
+                        .setStatus1(FieldConflictPbMessage.Status.STATUS_ACTIVE)
+                        .setStatusValue2("status_str")
+                        .setPriority11(FieldConflictPbMessage.Priority.PRIORITY_HIGH)
+                        .setPriorityValue12(99)
+                        .build();
+        RowData row =
+                ProtobufTestHelper.pbBytesToRow(FieldConflictPbMessage.class, msg.toByteArray());
+        // Both enum/value pairs should work correctly
+        assertEquals("STATUS_ACTIVE", row.getString(0).toString());
+        assertEquals("status_str", row.getString(1).toString());
+        assertEquals("PRIORITY_HIGH", row.getString(10).toString());
+        assertEquals(99, row.getInt(11));
+    }
+
+    @Test
+    public void testNestedMessageFields() throws Exception {
+        FieldConflictPbMessage.NestedMessage nested =
+                FieldConflictPbMessage.NestedMessage.newBuilder()
+                        .setNestedField("nested_value")
+                        .build();
+        FieldConflictPbMessage msg =
+                FieldConflictPbMessage.newBuilder()
+                        .setNested(nested)
+                        .addNestedList(nested)
+                        .addNestedList(nested)
+                        .build();
+        RowData row =
+                ProtobufTestHelper.pbBytesToRow(FieldConflictPbMessage.class, msg.toByteArray());
+        // Nested message fields should not have conflict issues
+        assertFalse(row.isNullAt(14)); // nested
+        assertFalse(row.isNullAt(15)); // nested_list
+        assertEquals(2, row.getArray(15).size());
+    }
+
+    @Test
+    public void testMultipleRepeatedFieldConflicts() throws Exception {
+        FieldConflictPbMessage msg =
+                FieldConflictPbMessage.newBuilder()
+                        .addItems17(100)
+                        .addItems17(200)
+                        .setItemsList18("items_string")
+                        .setItemsCount19(999L)
+                        .build();
+        RowData row =
+                ProtobufTestHelper.pbBytesToRow(FieldConflictPbMessage.class, msg.toByteArray());
+        // Multiple repeated field conflict scenarios in same message
+        assertEquals(2, row.getArray(16).size());
+        assertEquals(100, row.getArray(16).getInt(0));
+        assertEquals(200, row.getArray(16).getInt(1));
+        assertEquals("items_string", row.getString(17).toString());
+        assertEquals(999L, row.getLong(18));
+    }
+
+    @Test
+    public void testEnumEndingWithListConflictsWithRepeatedField() throws Exception {
+        // Repeated field 'data' generates getDataList()
+        // Enum field 'data_list' also tries to generate getDataList()
+        // Resolution: Both get field number suffixes:
+        // - repeated 'data' (field 20) → getData20(), getData20Count()
+        // - enum 'data_list' (field 21) → getDataList21()
+        FieldConflictPbMessage msg =
+                FieldConflictPbMessage.newBuilder()
+                        .addData20("data1")
+                        .addData20("data2")
+                        .setDataList21(FieldConflictPbMessage.DataList.DATA_LIST_JSON)
+                        .build();
+
+        // Normal (string enum) mode
+        RowData row =
+                ProtobufTestHelper.pbBytesToRow(FieldConflictPbMessage.class, msg.toByteArray());
+        // data at index 19, data_list at index 20
+        assertEquals(2, row.getArray(19).size());
+        assertEquals(StringData.fromString("data1"), row.getArray(19).getString(0));
+        assertEquals(StringData.fromString("data2"), row.getArray(19).getString(1));
+        assertEquals("DATA_LIST_JSON", row.getString(20).toString());
+
+        // Int enum mode (numeric values)
+        RowData intEnumRow =
+                ProtobufTestHelper.pbBytesToRow(
+                        FieldConflictPbMessage.class, msg.toByteArray(), true);
+        assertEquals(2, intEnumRow.getArray(19).size());
+        assertEquals(1, intEnumRow.getInt(20)); // numeric value of DATA_LIST_JSON
+    }
+
+    @Test
+    public void testEnumEndingWithCountConflictsWithRepeatedField() throws Exception {
+        // Repeated field 'record' generates getRecordCount()
+        // Enum field 'record_count' also tries to generate getRecordCount()
+        // Resolution: Both get field number suffixes:
+        // - repeated 'record' (field 22) → getRecord22(), getRecord22Count()
+        // - enum 'record_count' (field 23) → getRecordCount23()
+        FieldConflictPbMessage msg =
+                FieldConflictPbMessage.newBuilder()
+                        .addRecord22("record1")
+                        .addRecord22("record2")
+                        .addRecord22("record3")
+                        .setRecordCount23(FieldConflictPbMessage.RecordCount.RECORD_COUNT_LARGE)
+                        .build();
+
+        // Normal (string enum) mode
+        RowData row =
+                ProtobufTestHelper.pbBytesToRow(FieldConflictPbMessage.class, msg.toByteArray());
+        // record at index 21, record_count at index 22
+        assertEquals(3, row.getArray(21).size());
+        assertEquals(StringData.fromString("record1"), row.getArray(21).getString(0));
+        assertEquals(StringData.fromString("record2"), row.getArray(21).getString(1));
+        assertEquals(StringData.fromString("record3"), row.getArray(21).getString(2));
+        assertEquals("RECORD_COUNT_LARGE", row.getString(22).toString());
+
+        // Int enum mode (numeric values)
+        RowData intEnumRow =
+                ProtobufTestHelper.pbBytesToRow(
+                        FieldConflictPbMessage.class, msg.toByteArray(), true);
+        assertEquals(3, intEnumRow.getArray(21).size());
+        assertEquals(2, intEnumRow.getInt(22)); // numeric value of RECORD_COUNT_LARGE
+    }
+}

--- a/flink-formats/flink-protobuf/src/test/java/org/apache/flink/formats/protobuf/FieldConflictRowToProtoTest.java
+++ b/flink-formats/flink-protobuf/src/test/java/org/apache/flink/formats/protobuf/FieldConflictRowToProtoTest.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.protobuf;
+
+import org.apache.flink.formats.protobuf.testproto.FieldConflictPbMessage;
+import org.apache.flink.table.data.GenericRowData;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests serialization (RowData -> Proto bytes) for field conflict scenarios ensuring builder method
+ * suffixes (setStatus1, setStatusValue2, addTags4, setTagsList5, setTagsCount6) are correctly
+ * invoked by generated code.
+ */
+public class FieldConflictRowToProtoTest {
+
+    @Test
+    public void testEnumAndValueConflictSerialization() throws Exception {
+        // Row schema order (zero-based indices):
+        // 0=status, 1=status_value, 2=control_field, 3=tags, 4=tags_list, 5=tags_count,
+        // 6=other_value, 7=tags_map, 8=active, 9=active_value, 10=priority, 11=priority_value,
+        // 12=nested, 13=nested_list, 14=items, 15=items_list, 16=items_count, 17=mode,
+        // 18=mode_value, 19=data, 20=data_list, 21=record, 22=record_count
+        GenericRowData row = new GenericRowData(23);
+        row.setField(0, org.apache.flink.table.data.StringData.fromString("STATUS_ACTIVE"));
+        row.setField(1, org.apache.flink.table.data.StringData.fromString("custom_status"));
+        row.setField(2, 42);
+        // Leave repeated tags empty; supply singular fields and other_value
+        // Empty array for repeated tags: create explicit empty GenericArrayData
+        row.setField(3, new org.apache.flink.table.data.GenericArrayData(new Object[0]));
+        row.setField(4, org.apache.flink.table.data.StringData.fromString("joined_tags"));
+        row.setField(5, 2);
+        row.setField(6, org.apache.flink.table.data.StringData.fromString("nv"));
+        // New fields - set to null/empty for most
+        row.setField(7, null); // tags_map
+        row.setField(8, false); // active
+        row.setField(9, false); // active_value
+        row.setField(10, null); // priority
+        row.setField(11, null); // priority_value
+        row.setField(12, null); // nested
+        row.setField(13, null); // nested_list
+        row.setField(14, null); // items
+        row.setField(15, null); // items_list
+        row.setField(16, null); // items_count
+        row.setField(17, null); // mode
+        row.setField(18, null); // mode_value
+        row.setField(19, null); // data
+        row.setField(20, null); // data_list
+        row.setField(21, null); // record
+        row.setField(22, null); // record_count
+
+        byte[] bytes = ProtobufTestHelper.rowToPbBytes(row, FieldConflictPbMessage.class);
+        FieldConflictPbMessage parsed = FieldConflictPbMessage.parseFrom(bytes);
+        assertEquals(FieldConflictPbMessage.Status.STATUS_ACTIVE, parsed.getStatus1());
+        assertEquals("custom_status", parsed.getStatusValue2());
+        assertEquals(42, parsed.getControlField());
+        assertEquals("joined_tags", parsed.getTagsList5());
+        assertEquals(2, parsed.getTagsCount6());
+        assertEquals("nv", parsed.getOtherValue());
+    }
+
+    @Test
+    public void testRepeatedFieldConflictSerialization() throws Exception {
+        GenericRowData row = new GenericRowData(23);
+        row.setField(0, org.apache.flink.table.data.StringData.fromString("STATUS_ACTIVE"));
+        row.setField(1, org.apache.flink.table.data.StringData.fromString("cs"));
+        row.setField(2, 100);
+        // Provide repeated tags array with two elements
+        org.apache.flink.table.data.StringData[] tagArray =
+                new org.apache.flink.table.data.StringData[] {
+                    org.apache.flink.table.data.StringData.fromString("t1"),
+                    org.apache.flink.table.data.StringData.fromString("t2")
+                };
+        row.setField(3, new org.apache.flink.table.data.GenericArrayData(tagArray));
+        row.setField(4, org.apache.flink.table.data.StringData.fromString("joined"));
+        row.setField(5, 2);
+        row.setField(6, org.apache.flink.table.data.StringData.fromString("ov"));
+        // Fill additional fields with null/defaults
+        row.setField(7, null); // tags_map
+        row.setField(8, false); // active
+        row.setField(9, false); // active_value
+        row.setField(10, null); // priority
+        row.setField(11, null); // priority_value
+        row.setField(12, null); // nested
+        row.setField(13, null); // nested_list
+        row.setField(14, null); // items
+        row.setField(15, null); // items_list
+        row.setField(16, null); // items_count
+        row.setField(17, null); // mode
+        row.setField(18, null); // mode_value
+        row.setField(19, null); // data
+        row.setField(20, null); // data_list
+        row.setField(21, null); // record
+        row.setField(22, null); // record_count
+
+        byte[] bytes = ProtobufTestHelper.rowToPbBytes(row, FieldConflictPbMessage.class);
+        FieldConflictPbMessage parsed = FieldConflictPbMessage.parseFrom(bytes);
+        assertEquals(2, parsed.getTags4Count());
+        assertEquals("t1", parsed.getTags4(0));
+        assertEquals("t2", parsed.getTags4(1));
+        assertEquals("joined", parsed.getTagsList5());
+        assertEquals(2, parsed.getTagsCount6());
+    }
+
+    @Test
+    public void testEnumNumericModeSerialization() throws Exception {
+        GenericRowData row = new GenericRowData(23);
+        // Numeric enum mode: supply integer at position 0
+        row.setField(0, 1); // STATUS_ACTIVE numeric value
+        row.setField(1, org.apache.flink.table.data.StringData.fromString("custom_status"));
+        row.setField(2, 7);
+        row.setField(3, new org.apache.flink.table.data.GenericArrayData(new Object[0]));
+        row.setField(4, org.apache.flink.table.data.StringData.fromString("tags"));
+        row.setField(5, 0);
+        row.setField(6, org.apache.flink.table.data.StringData.fromString("other"));
+        // Fill additional fields with null/defaults
+        row.setField(7, null); // tags_map
+        row.setField(8, false); // active
+        row.setField(9, false); // active_value
+        row.setField(10, null); // priority
+        row.setField(11, null); // priority_value
+        row.setField(12, null); // nested
+        row.setField(13, null); // nested_list
+        row.setField(14, null); // items
+        row.setField(15, null); // items_list
+        row.setField(16, null); // items_count
+        row.setField(17, null); // mode
+        row.setField(18, null); // mode_value
+        row.setField(19, null); // data
+        row.setField(20, null); // data_list
+        row.setField(21, null); // record
+        row.setField(22, null); // record_count
+
+        byte[] bytes = ProtobufTestHelper.rowToPbBytes(row, FieldConflictPbMessage.class, true);
+        FieldConflictPbMessage parsed = FieldConflictPbMessage.parseFrom(bytes);
+        assertEquals(FieldConflictPbMessage.Status.STATUS_ACTIVE, parsed.getStatus1());
+        assertEquals("custom_status", parsed.getStatusValue2());
+        assertEquals(7, parsed.getControlField());
+    }
+
+    @Test
+    public void testEnumListAndCountConflictSerialization() throws Exception {
+        // data (index 19), data_list (20), record (21), record_count (22)
+        GenericRowData row = new GenericRowData(23);
+        // Populate minimal earlier fields to satisfy builder logic
+        row.setField(0, org.apache.flink.table.data.StringData.fromString("STATUS_ACTIVE"));
+        row.setField(1, org.apache.flink.table.data.StringData.fromString("status_val"));
+        row.setField(2, 1); // control_field
+        // Minimal placeholders for intervening indices
+        for (int i = 3; i < 19; i++) {
+            row.setField(i, null);
+        }
+        // Repeated 'data' with two entries via suffixed accessors addData20()
+        org.apache.flink.table.data.StringData[] dataArr =
+                new org.apache.flink.table.data.StringData[] {
+                    org.apache.flink.table.data.StringData.fromString("d1"),
+                    org.apache.flink.table.data.StringData.fromString("d2")
+                };
+        row.setField(19, new org.apache.flink.table.data.GenericArrayData(dataArr));
+        // Enum 'data_list'
+        row.setField(20, org.apache.flink.table.data.StringData.fromString("DATA_LIST_XML"));
+        // Repeated 'record'
+        org.apache.flink.table.data.StringData[] recordArr =
+                new org.apache.flink.table.data.StringData[] {
+                    org.apache.flink.table.data.StringData.fromString("r1"),
+                    org.apache.flink.table.data.StringData.fromString("r2"),
+                    org.apache.flink.table.data.StringData.fromString("r3")
+                };
+        row.setField(21, new org.apache.flink.table.data.GenericArrayData(recordArr));
+        // Enum 'record_count'
+        row.setField(22, org.apache.flink.table.data.StringData.fromString("RECORD_COUNT_SMALL"));
+
+        byte[] bytes = ProtobufTestHelper.rowToPbBytes(row, FieldConflictPbMessage.class);
+        FieldConflictPbMessage parsed = FieldConflictPbMessage.parseFrom(bytes);
+        // Validate repeated field serialization using suffixed builder methods
+        assertEquals(2, parsed.getData20Count());
+        assertEquals("d1", parsed.getData20(0));
+        assertEquals("d2", parsed.getData20(1));
+        assertEquals(FieldConflictPbMessage.DataList.DATA_LIST_XML, parsed.getDataList21());
+        assertEquals(3, parsed.getRecord22Count());
+        assertEquals("r1", parsed.getRecord22(0));
+        assertEquals("r2", parsed.getRecord22(1));
+        assertEquals("r3", parsed.getRecord22(2));
+        assertEquals(
+                FieldConflictPbMessage.RecordCount.RECORD_COUNT_SMALL, parsed.getRecordCount23());
+    }
+}

--- a/flink-formats/flink-protobuf/src/test/proto/test_field_conflict.proto
+++ b/flink-formats/flink-protobuf/src/test/proto/test_field_conflict.proto
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+package org.apache.flink.formats.protobuf.testproto;
+option java_multiple_files = true;
+
+// Proto to test various field conflicts that can occur with protobuf getter generation:
+// 1. Enum numeric accessor vs *_value field conflict
+// 2. Repeated field accessor base name vs singular field conflicts
+// 3. Enum field named *_value conflicting with another enum's numeric accessor (enum-to-enum)
+message FieldConflictPbMessage {
+  // Enum field - generates getStatus() and getStatusValue() accessors
+  enum Status {
+    STATUS_UNSPECIFIED = 0;
+    STATUS_ACTIVE = 1;
+    STATUS_INACTIVE = 2;
+  }
+  Status status = 1;
+  // Field with proto name ending in _value; conflicts with enum numeric accessor
+  string status_value = 2;
+
+  // Control field to ensure no unintended field conflicts
+  int32 control_field = 3;
+
+  // Repeated field - generates getTagsList() / getTagsCount() accessors
+  repeated string tags = 4;
+  // Singular field whose name conflicts with repeated field List accessor
+  string tags_list = 5;
+  // Singular field whose name conflicts with repeated field Count accessor
+  int32 tags_count = 6;
+  // Non-conflicting *_value field in same message to verify mixed conflict/non-conflict generation
+  string other_value = 7;
+
+  // Edge case: Map field (verify no field conflict with map-related accessors)
+  map<string, int32> tags_map = 8;
+
+  // Edge case: Boolean field for presence testing
+  bool active = 9;
+  bool active_value = 10;  // Test boolean with *_value field conflict
+
+  // Edge case: Multiple enum field conflicts in same message
+  enum Priority {
+    PRIORITY_UNSPECIFIED = 0;
+    PRIORITY_LOW = 1;
+    PRIORITY_HIGH = 2;
+  }
+  Priority priority = 11;
+  int32 priority_value = 12;
+
+  // Edge case: Enum-to-enum field conflict (enum field named *_value conflicting with another enum's numeric accessor)
+  // The 'mode' enum generates getModeValue() for its numeric accessor
+  // The 'mode_value' enum field generates getModeValue() for its enum object accessor
+  // These conflict! Protoc should generate getMode13Value() and getModeValue14()
+  enum Mode {
+    MODE_UNSPECIFIED = 0;
+    MODE_MANUAL = 1;
+    MODE_AUTO = 2;
+  }
+  enum ModeValue {
+    MODE_VALUE_UNSPECIFIED = 0;
+    MODE_VALUE_DEFAULT = 1;
+    MODE_VALUE_CUSTOM = 2;
+  }
+  Mode mode = 13;
+  ModeValue mode_value = 14;
+
+  // Edge case: Nested message field
+  message NestedMessage {
+    string nested_field = 1;
+  }
+  NestedMessage nested = 15;
+  repeated NestedMessage nested_list = 16;  // Should not conflict
+
+  // Edge case: Additional repeated field conflict scenario
+  repeated int32 items = 17;
+  string items_list = 18;
+  int64 items_count = 19;
+
+  // Edge case: Enum field ending with _list conflicting with repeated field's List accessor
+  // Repeated field 'data' generates getDataList()
+  // Enum field 'data_list' also tries to generate getDataList()
+  // Protobuf resolves by appending field numbers to BOTH:
+  // - repeated 'data' (field 20) → getData20(), getData20Count(), getData20List()
+  // - enum 'data_list' (field 21) → getDataList21()
+  enum DataList {
+    DATA_LIST_UNSPECIFIED = 0;
+    DATA_LIST_JSON = 1;
+    DATA_LIST_XML = 2;
+  }
+  repeated string data = 20;
+  DataList data_list = 21;
+
+  // Edge case: Enum field ending with _count conflicting with repeated field's Count accessor
+  // Repeated field 'record' generates getRecordCount()
+  // Enum field 'record_count' also tries to generate getRecordCount()
+  // Protobuf resolves by appending field numbers to BOTH:
+  // - repeated 'record' (field 22) → getRecord22(), getRecord22Count(), getRecord22List()
+  // - enum 'record_count' (field 23) → getRecordCount23()
+  enum RecordCount {
+    RECORD_COUNT_UNSPECIFIED = 0;
+    RECORD_COUNT_SMALL = 1;
+    RECORD_COUNT_LARGE = 2;
+  }
+  repeated string record = 22;
+  RecordCount record_count = 23;
+}


### PR DESCRIPTION
## What is the purpose of the change

Flink's protobuf format fails when processing messages compiled with protobuf-java's field naming conflict resolution. When proto schemas contain certain field patterns, protoc appends field number suffixes to accessor methods (e.g., `getStatus1()`, `getTags4List()`), but Flink's codegen assumes canonical names (`getStatus()`, `getTagsList()`). Conflict scenarios:
- Repeated field vs `*_list`/`*_count` fields -> numbered suffixes
- Enum field + `*_value` field -> both get numbered suffixes (protobuf-java 4.30.0+)

This affects users with conflict-prone schemas on protobuf-java 3.x+ (repeated field conflicts) and 4.30.0+ (enum field conflicts).

## Brief change log

- Added `PbFieldConflictResolver` with caching for conflict-aware accessor resolution
- Refactored deserializer/serializer codegen to use conflict-aware accessors

## Verifying this change

This change added tests and can be verified as follows:

- Added `test_field_conflict.proto` with field conflict scenarios
- Generated Java classes with protoc 4.32.1 to verify accessor name matching
- Added `FieldConflictProtoToRowTest` (14 tests) and `FieldConflictRowToProtoTest` (4 tests)
- All tests pass with protobuf-java 4.32.1

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no** (the changes only affect which accessor methods are called during codegen, not the serialization format or behavior)
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
