### PR TITLE
[FLINK-38774] Fixed incorrect handling of hidden directories when obtFixed incorrect handling of hidden directories when obtaining partition structureaining partiti…

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/PartitionPathUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/PartitionPathUtils.java
@@ -341,7 +341,11 @@ public class PartitionPathUtils {
         }
 
         if (fileStatus.isDir()) {
-            for (FileStatus stat : fs.listStatus(fileStatus.getPath())) {
+            FileStatus[] fileStatuses = listStatusWithoutHidden(fs, fileStatus.getPath());
+            if (fileStatuses == null) {
+                return;
+            }
+            for (FileStatus stat : fileStatuses) {
                 listStatusRecursively(fs, stat, level + 1, expectLevel, results);
             }
         }


### PR DESCRIPTION
## What is the purpose of the change

Fixed incorrect handling of hidden directories when obtFixed incorrect handling of hidden directories when obtaining partition structureaining partiti…


## Brief change log
Change fs.listStatus(dir) to listStatusWithoutHidden(fs, fileStatus.getPath())


## Verifying this change

This change added tests and can be verified as follows: PartitionPathUtilsTest.java

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: don't know

## Documentation

  - Does this pull request introduce a new feature? no
