### PR TITLE
[FLINK-38793][table] Reuse result of functions if ther are used multiple times as input for other functions

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/utils/FlinkRelUtil.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/utils/FlinkRelUtil.java
@@ -24,19 +24,25 @@ import org.apache.calcite.rel.core.Filter;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexLocalRef;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexProgram;
 import org.apache.calcite.rex.RexProgramBuilder;
 import org.apache.calcite.rex.RexSlot;
 import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.rex.RexVisitorImpl;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlKind;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /** Utilities for {@link RelNode}. */
@@ -93,6 +99,9 @@ public class FlinkRelUtil {
         final int[] topInputRefCounter =
                 initializeArray(topProject.getInput().getRowType().getFieldCount(), 0);
 
+        if (functionResultShouldBeReused(topProject, bottomProject)) {
+            return false;
+        }
         return mergeable(topInputRefCounter, topProject.getProjects(), bottomProject.getProjects());
     }
 
@@ -104,6 +113,10 @@ public class FlinkRelUtil {
     public static boolean isMergeable(Calc topCalc, Calc bottomCalc) {
         final RexProgram topProgram = topCalc.getProgram();
         final RexProgram bottomProgram = bottomCalc.getProgram();
+        if (functionResultShouldBeReused(topProgram, bottomProgram)) {
+            return false;
+        }
+
         final int[] topInputRefCounter =
                 initializeArray(topCalc.getInput().getRowType().getFieldCount(), 0);
 
@@ -120,6 +133,84 @@ public class FlinkRelUtil {
         }
 
         return mergeable(topInputRefCounter, topInputRefs, bottomProjects);
+    }
+
+    private static boolean functionResultShouldBeReused(Project topProject, Project bottomProject) {
+        Set<Integer> indexSet = new HashSet<>();
+        List<RexNode> bottomProjectList = bottomProject.getProjects();
+        for (int i = 0; i < bottomProjectList.size(); i++) {
+            RexNode project = bottomProjectList.get(i);
+            if (project instanceof RexCall
+                    //        && SqlKind.FUNCTION.contains(((RexCall) project).op.getKind())
+                    && ((RexCall) project).op.isDeterministic()) {
+                indexSet.add(i);
+            }
+        }
+        if (indexSet.isEmpty()) {
+            return false;
+        }
+
+        Set<RexNode> rexNodes = new HashSet<>();
+        List<RexNode> topProjectList = topProject.getProjects();
+        for (RexNode rex : topProjectList) {
+            if (!(rex instanceof RexCall)) {
+                continue;
+            }
+            RexCall rCall = (RexCall) rex;
+            if (!(rCall.op instanceof SqlFunction)) {
+                continue;
+            }
+            List<RexNode> operands = rCall.operands;
+            for (RexNode op : operands) {
+                if (op instanceof RexSlot) {
+                    if (indexSet.contains(((RexSlot) op).getIndex()) && !rexNodes.add(op)) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static boolean functionResultShouldBeReused(
+            RexProgram topProgram, RexProgram bottomProgram) {
+        Set<Integer> indexSet = new HashSet<>();
+        List<RexLocalRef> bottomProjectList = bottomProgram.getProjectList();
+        for (int i = 0; i < bottomProjectList.size(); i++) {
+            int index = bottomProjectList.get(i).getIndex();
+            RexNode rexNode = bottomProgram.getExprList().get(index);
+            if (rexNode instanceof RexCall
+                    && SqlKind.FUNCTION.contains(((RexCall) rexNode).op.getKind())
+                    && ((RexCall) rexNode).op.isDeterministic()) {
+                indexSet.add(i);
+            }
+        }
+        if (indexSet.isEmpty()) {
+            return false;
+        }
+
+        Set<RexNode> rexNodes = new HashSet<>();
+        List<RexNode> topExprList = topProgram.getExprList();
+        for (RexNode rex : topExprList) {
+            if (!(rex instanceof RexCall)) {
+                continue;
+            }
+            RexCall rCall = (RexCall) rex;
+            if (!(rCall.op instanceof SqlFunction)) {
+                continue;
+            }
+            List<RexNode> operands = rCall.operands;
+            for (RexNode op : operands) {
+                if (op instanceof RexSlot) {
+                    if (indexSet.contains(((RexSlot) op).getIndex()) && !rexNodes.add(op)) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/utils/JavaUserDefinedScalarFunctions.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/utils/JavaUserDefinedScalarFunctions.java
@@ -141,6 +141,26 @@ public class JavaUserDefinedScalarFunctions {
         }
     }
 
+    /** Deterministic scalar function. */
+    public static class DeterministicUdf extends ScalarFunction {
+        public int eval() {
+            return 0;
+        }
+
+        public int eval(@DataTypeHint("INT") int v) {
+            return v;
+        }
+
+        public String eval(String v) {
+            return v;
+        }
+
+        @Override
+        public boolean isDeterministic() {
+            return true;
+        }
+    }
+
     /** Test for Python Scalar Function. */
     public static class PythonScalarFunction extends ScalarFunction implements PythonFunction {
         private final String name;

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/CalcTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/CalcTest.xml
@@ -681,6 +681,44 @@ Calc(select=[a AS EXPR$0])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testReusedFunctionInProject">
+    <Resource name="sql">
+      <![CDATA[SELECT LTRIM(q), RTRIM(q) FROM (SELECT TRIM(c) as q FROM MyTable) t]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(EXPR$0=[LTRIM($0)], EXPR$1=[RTRIM($0)])
++- LogicalProject(q=[TRIM(FLAG(BOTH), _UTF-16LE' ', $2)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[LTRIM(q) AS EXPR$0, RTRIM(q) AS EXPR$1])
++- Calc(select=[TRIM(BOTH, ' ', c) AS q])
+   +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testReusedFunctionInProjectWithDeterministicUdf">
+    <Resource name="sql">
+      <![CDATA[SELECT JSON_VALUE(json_data, '$.id'), JSON_VALUE(json_data, '$.name') FROM (SELECT deterministic_udf(c) as json_data FROM MyTable) t]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(EXPR$0=[JSON_VALUE($0, _UTF-16LE'$.id')], EXPR$1=[JSON_VALUE($0, _UTF-16LE'$.name')])
++- LogicalProject(json_data=[deterministic_udf($2)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[JSON_VALUE(json_data, '$.id') AS EXPR$0, JSON_VALUE(json_data, '$.name') AS EXPR$1])
++- Calc(select=[deterministic_udf(c) AS json_data])
+   +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testRowType">
     <Resource name="sql">
       <![CDATA[SELECT ROW(1, 'Hi', a) FROM MyTable]]>


### PR DESCRIPTION
## What is the purpose of the change

It should reuse result of functions as input for other functions

## Brief change log

projections rules

## Verifying this change

There are tests in CalcTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
