### PR TITLE
[FLINK-38770][runtime] Fix parallelism overrides ignored in Application Mode

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -33,7 +33,6 @@ import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.configuration.HighAvailabilityOptions;
-import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.core.execution.CheckpointType;
 import org.apache.flink.core.execution.SavepointFormatType;
@@ -73,9 +72,7 @@ import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.JobResultEntry;
 import org.apache.flink.runtime.highavailability.JobResultStore;
 import org.apache.flink.runtime.highavailability.JobResultStoreOptions;
-import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobResourceRequirements;
-import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobmanager.ApplicationStoreEntry;
 import org.apache.flink.runtime.jobmanager.ApplicationWriter;
@@ -1268,10 +1265,6 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId>
     }
 
     private CompletableFuture<Acknowledge> internalSubmitJob(ExecutionPlan executionPlan) {
-        if (executionPlan instanceof JobGraph) {
-            applyParallelismOverrides((JobGraph) executionPlan);
-        }
-
         final JobID jobId = executionPlan.getJobID();
         final String jobName = executionPlan.getName();
         final ApplicationID applicationId = executionPlan.getApplicationId().orElse(null);
@@ -2529,25 +2522,6 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId>
 
     public CompletableFuture<Void> onRemovedExecutionPlan(JobID jobId) {
         return CompletableFuture.runAsync(() -> terminateJob(jobId), getMainThreadExecutor(jobId));
-    }
-
-    private void applyParallelismOverrides(JobGraph jobGraph) {
-        Map<String, String> overrides = new HashMap<>();
-        overrides.putAll(configuration.get(PipelineOptions.PARALLELISM_OVERRIDES));
-        overrides.putAll(jobGraph.getJobConfiguration().get(PipelineOptions.PARALLELISM_OVERRIDES));
-        for (JobVertex vertex : jobGraph.getVertices()) {
-            String override = overrides.get(vertex.getID().toHexString());
-            if (override != null) {
-                int currentParallelism = vertex.getParallelism();
-                int overrideParallelism = Integer.parseInt(override);
-                log.info(
-                        "Changing job vertex {} parallelism from {} to {}",
-                        vertex.getID(),
-                        currentParallelism,
-                        overrideParallelism);
-                vertex.setParallelism(overrideParallelism);
-            }
-        }
     }
 
     private Executor getIoExecutor(JobID jobID) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
@@ -95,6 +95,9 @@ public class DefaultSchedulerFactory implements SchedulerNGFactory {
                     "Unsupported execution plan " + executionPlan.getClass().getCanonicalName());
         }
 
+        // Apply parallelism overrides after StreamGraph -> JobGraph conversion
+        ParallelismOverrideUtil.applyParallelismOverrides(jobGraph, jobMasterConfiguration);
+
         final SlotPool slotPool =
                 slotPoolService
                         .castInto(SlotPool.class)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ParallelismOverrideUtil.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ParallelismOverrideUtil.java
@@ -60,14 +60,19 @@ public class ParallelismOverrideUtil {
         Map<String, String> overrides = new HashMap<>();
 
         // Add overrides from job master configuration
-        overrides.putAll(jobMasterConfiguration.get(PipelineOptions.PARALLELISM_OVERRIDES));
+        Map<String, String> masterConfigOverrides =
+                jobMasterConfiguration.get(PipelineOptions.PARALLELISM_OVERRIDES);
+        overrides.putAll(masterConfigOverrides);
 
         // Add overrides from job configuration (these take precedence)
-        overrides.putAll(jobGraph.getJobConfiguration().get(PipelineOptions.PARALLELISM_OVERRIDES));
+        Map<String, String> jobConfigOverrides =
+                jobGraph.getJobConfiguration().get(PipelineOptions.PARALLELISM_OVERRIDES);
+        overrides.putAll(jobConfigOverrides);
 
         // Apply overrides to each vertex
         for (JobVertex vertex : jobGraph.getVertices()) {
-            String override = overrides.get(vertex.getID().toHexString());
+            String vertexIdHex = vertex.getID().toHexString();
+            String override = overrides.get(vertexIdHex);
             if (override != null) {
                 int currentParallelism = vertex.getParallelism();
                 int overrideParallelism = Integer.parseInt(override);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ParallelismOverrideUtil.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ParallelismOverrideUtil.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.PipelineOptions;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Utility class for applying parallelism overrides from configuration to JobGraph vertices.
+ *
+ * <p>This utility must be called after converting StreamGraph to JobGraph in all SchedulerNGFactory
+ * implementations to ensure parallelism overrides are respected in Application Mode (where
+ * StreamGraph is submitted directly).
+ */
+@Internal
+public class ParallelismOverrideUtil {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ParallelismOverrideUtil.class);
+
+    /**
+     * Applies parallelism overrides from configuration to the JobGraph.
+     *
+     * <p>Overrides are taken from two sources (in order of precedence):
+     *
+     * <ol>
+     *   <li>JobGraph configuration (higher precedence)
+     *   <li>Job master configuration (lower precedence)
+     * </ol>
+     *
+     * @param jobGraph the JobGraph to modify
+     * @param jobMasterConfiguration the job master configuration containing potential overrides
+     */
+    public static void applyParallelismOverrides(
+            JobGraph jobGraph, Configuration jobMasterConfiguration) {
+        Map<String, String> overrides = new HashMap<>();
+
+        // Add overrides from job master configuration
+        overrides.putAll(jobMasterConfiguration.get(PipelineOptions.PARALLELISM_OVERRIDES));
+
+        // Add overrides from job configuration (these take precedence)
+        overrides.putAll(jobGraph.getJobConfiguration().get(PipelineOptions.PARALLELISM_OVERRIDES));
+
+        // Apply overrides to each vertex
+        for (JobVertex vertex : jobGraph.getVertices()) {
+            String override = overrides.get(vertex.getID().toHexString());
+            if (override != null) {
+                int currentParallelism = vertex.getParallelism();
+                int overrideParallelism = Integer.parseInt(override);
+                LOG.info(
+                        "Applying parallelism override for job vertex {} ({}): {} -> {}",
+                        vertex.getName(),
+                        vertex.getID(),
+                        currentParallelism,
+                        overrideParallelism);
+                vertex.setParallelism(overrideParallelism);
+            }
+        }
+    }
+
+    private ParallelismOverrideUtil() {
+        // Utility class, not meant to be instantiated
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ParallelismOverrideUtil.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ParallelismOverrideUtil.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.streaming.api.graph.ExecutionPlan;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,16 +32,65 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Utility class for applying parallelism overrides from configuration to JobGraph vertices.
+ * Utility for applying {@link PipelineOptions#PARALLELISM_OVERRIDES} to a {@link JobGraph}.
  *
- * <p>This utility must be called after converting StreamGraph to JobGraph in all SchedulerNGFactory
- * implementations to ensure parallelism overrides are respected in Application Mode (where
- * StreamGraph is submitted directly).
+ * <p>Parallelism overrides let operators change the parallelism of specific job vertices without
+ * modifying the job code. Each entry maps a {@link JobVertex#getID() JobVertexID} hex string to the
+ * desired parallelism.
+ *
+ * <p>Overrides can be configured in two places, merged in this order of precedence:
+ *
+ * <ol>
+ *   <li>{@link JobGraph#getJobConfiguration() Job configuration} (higher precedence — set by the
+ *       job author or the client)
+ *   <li>Job master configuration (lower precedence — set on the cluster side, e.g. {@code
+ *       flink-conf.yaml})
+ * </ol>
+ *
+ * <p>This utility is called by scheduler factories ({@link
+ * org.apache.flink.runtime.scheduler.DefaultSchedulerFactory}, {@link
+ * org.apache.flink.runtime.scheduler.adaptive.AdaptiveSchedulerFactory}, and {@link
+ * org.apache.flink.runtime.scheduler.adaptivebatch.AdaptiveBatchSchedulerFactory}) after {@link
+ * org.apache.flink.streaming.api.graph.StreamGraph StreamGraph} has been converted to a {@link
+ * JobGraph}. This ensures overrides apply uniformly in both Session Mode (JobGraph submission) and
+ * Application Mode (StreamGraph submission).
+ *
+ * <p>The adaptive-batch StreamGraph path is handled separately by {@link
+ * org.apache.flink.runtime.scheduler.adaptivebatch.DefaultAdaptiveExecutionHandler}, which checks
+ * overrides per-vertex in {@code getInitialParallelism} as the JobGraph is built incrementally.
  */
 @Internal
 public class ParallelismOverrideUtil {
 
     private static final Logger LOG = LoggerFactory.getLogger(ParallelismOverrideUtil.class);
+
+    /**
+     * Applies parallelism overrides to the given execution plan if it is a {@link JobGraph}.
+     *
+     * <p>This overload lets scheduler factories that accept either a {@link JobGraph} or a {@link
+     * org.apache.flink.streaming.api.graph.StreamGraph} call the utility unconditionally, keeping
+     * the call site structurally consistent with factories that always work on a {@code JobGraph}.
+     *
+     * <p>For a {@link JobGraph} input, this delegates to {@link
+     * #applyParallelismOverrides(JobGraph, Configuration)}.
+     *
+     * <p>For a {@link org.apache.flink.streaming.api.graph.StreamGraph} input, this is a no-op: the
+     * adaptive-batch StreamGraph path builds the JobGraph incrementally, so overrides cannot be
+     * applied upfront. They are applied per-vertex by {@link
+     * org.apache.flink.runtime.scheduler.adaptivebatch.DefaultAdaptiveExecutionHandler} in {@code
+     * getInitialParallelism} as each vertex becomes ready.
+     *
+     * @param executionPlan the execution plan; overrides are applied only when this is a {@link
+     *     JobGraph}
+     * @param jobMasterConfiguration the job master configuration containing potential overrides
+     * @throws IllegalArgumentException if an override value is not a positive integer
+     */
+    public static void applyParallelismOverridesIfApplicable(
+            ExecutionPlan executionPlan, Configuration jobMasterConfiguration) {
+        if (executionPlan instanceof JobGraph) {
+            applyParallelismOverrides((JobGraph) executionPlan, jobMasterConfiguration);
+        }
+    }
 
     /**
      * Applies parallelism overrides from configuration to the JobGraph.
@@ -54,6 +104,7 @@ public class ParallelismOverrideUtil {
      *
      * @param jobGraph the JobGraph to modify
      * @param jobMasterConfiguration the job master configuration containing potential overrides
+     * @throws IllegalArgumentException if an override value is not a positive integer
      */
     public static void applyParallelismOverrides(
             JobGraph jobGraph, Configuration jobMasterConfiguration) {
@@ -75,7 +126,7 @@ public class ParallelismOverrideUtil {
             String override = overrides.get(vertexIdHex);
             if (override != null) {
                 int currentParallelism = vertex.getParallelism();
-                int overrideParallelism = Integer.parseInt(override);
+                int overrideParallelism = parseParallelism(vertexIdHex, override);
                 LOG.info(
                         "Applying parallelism override for job vertex {} ({}): {} -> {}",
                         vertex.getName(),
@@ -85,6 +136,26 @@ public class ParallelismOverrideUtil {
                 vertex.setParallelism(overrideParallelism);
             }
         }
+    }
+
+    private static int parseParallelism(String vertexIdHex, String override) {
+        final int parallelism;
+        try {
+            parallelism = Integer.parseInt(override);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Invalid parallelism override for job vertex %s: '%s' is not a valid integer.",
+                            vertexIdHex, override),
+                    e);
+        }
+        if (parallelism <= 0) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Invalid parallelism override for job vertex %s: parallelism must be positive, got %d.",
+                            vertexIdHex, parallelism));
+        }
+        return parallelism;
     }
 
     private ParallelismOverrideUtil() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerFactory.java
@@ -42,6 +42,7 @@ import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.scheduler.DefaultExecutionGraphFactory;
 import org.apache.flink.runtime.scheduler.ExecutionGraphFactory;
+import org.apache.flink.runtime.scheduler.ParallelismOverrideUtil;
 import org.apache.flink.runtime.scheduler.SchedulerNG;
 import org.apache.flink.runtime.scheduler.SchedulerNGFactory;
 import org.apache.flink.runtime.scheduler.adaptive.allocator.SlotSharingSlotAllocator;
@@ -98,6 +99,9 @@ public class AdaptiveSchedulerFactory implements SchedulerNGFactory {
             throw new FlinkException(
                     "Unsupported execution plan " + executionPlan.getClass().getCanonicalName());
         }
+
+        // Apply parallelism overrides after StreamGraph -> JobGraph conversion
+        ParallelismOverrideUtil.applyParallelismOverrides(jobGraph, jobMasterConfiguration);
 
         final DeclarativeSlotPool declarativeSlotPool =
                 slotPoolService

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchSchedulerFactory.java
@@ -285,7 +285,8 @@ public class AdaptiveBatchSchedulerFactory implements SchedulerNGFactory {
                         executionPlan,
                         jobRecoveryHandler instanceof DefaultBatchJobRecoveryHandler,
                         userCodeLoader,
-                        futureExecutor);
+                        futureExecutor,
+                        jobMasterConfiguration);
 
         return new AdaptiveBatchScheduler(
                 log,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchSchedulerFactory.java
@@ -60,6 +60,7 @@ import org.apache.flink.runtime.scheduler.ExecutionGraphFactory;
 import org.apache.flink.runtime.scheduler.ExecutionOperations;
 import org.apache.flink.runtime.scheduler.ExecutionSlotAllocatorFactory;
 import org.apache.flink.runtime.scheduler.ExecutionVertexVersioner;
+import org.apache.flink.runtime.scheduler.ParallelismOverrideUtil;
 import org.apache.flink.runtime.scheduler.SchedulerNG;
 import org.apache.flink.runtime.scheduler.SchedulerNGFactory;
 import org.apache.flink.runtime.scheduler.SimpleExecutionSlotAllocator;
@@ -122,17 +123,22 @@ public class AdaptiveBatchSchedulerFactory implements SchedulerNGFactory {
             Collection<FailureEnricher> failureEnrichers,
             BlocklistOperations blocklistOperations)
             throws Exception {
-        ExecutionConfig executionConfig;
+        final JobGraph jobGraph;
+        final ExecutionConfig executionConfig;
 
         if (executionPlan instanceof JobGraph) {
+            jobGraph = (JobGraph) executionPlan;
             executionConfig =
                     executionPlan.getSerializedExecutionConfig().deserializeValue(userCodeLoader);
         } else if (executionPlan instanceof StreamGraph) {
+            jobGraph = ((StreamGraph) executionPlan).getJobGraph(userCodeLoader);
             executionConfig = ((StreamGraph) executionPlan).getExecutionConfig();
         } else {
             throw new FlinkException(
                     "Unsupported execution plan " + executionPlan.getClass().getCanonicalName());
         }
+
+        ParallelismOverrideUtil.applyParallelismOverrides(jobGraph, jobMasterConfiguration);
 
         final SlotPool slotPool =
                 slotPoolService
@@ -175,7 +181,7 @@ public class AdaptiveBatchSchedulerFactory implements SchedulerNGFactory {
 
         return createScheduler(
                 log,
-                executionPlan,
+                jobGraph,
                 executionConfig,
                 ioExecutor,
                 jobMasterConfiguration,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchSchedulerFactory.java
@@ -123,22 +123,19 @@ public class AdaptiveBatchSchedulerFactory implements SchedulerNGFactory {
             Collection<FailureEnricher> failureEnrichers,
             BlocklistOperations blocklistOperations)
             throws Exception {
-        final JobGraph jobGraph;
         final ExecutionConfig executionConfig;
 
         if (executionPlan instanceof JobGraph) {
-            jobGraph = (JobGraph) executionPlan;
             executionConfig =
                     executionPlan.getSerializedExecutionConfig().deserializeValue(userCodeLoader);
+            ParallelismOverrideUtil.applyParallelismOverrides(
+                    (JobGraph) executionPlan, jobMasterConfiguration);
         } else if (executionPlan instanceof StreamGraph) {
-            jobGraph = ((StreamGraph) executionPlan).getJobGraph(userCodeLoader);
             executionConfig = ((StreamGraph) executionPlan).getExecutionConfig();
         } else {
             throw new FlinkException(
                     "Unsupported execution plan " + executionPlan.getClass().getCanonicalName());
         }
-
-        ParallelismOverrideUtil.applyParallelismOverrides(jobGraph, jobMasterConfiguration);
 
         final SlotPool slotPool =
                 slotPoolService
@@ -181,7 +178,7 @@ public class AdaptiveBatchSchedulerFactory implements SchedulerNGFactory {
 
         return createScheduler(
                 log,
-                jobGraph,
+                executionPlan,
                 executionConfig,
                 ioExecutor,
                 jobMasterConfiguration,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchSchedulerFactory.java
@@ -125,11 +125,12 @@ public class AdaptiveBatchSchedulerFactory implements SchedulerNGFactory {
             throws Exception {
         final ExecutionConfig executionConfig;
 
+        ParallelismOverrideUtil.applyParallelismOverridesIfApplicable(
+                executionPlan, jobMasterConfiguration);
+
         if (executionPlan instanceof JobGraph) {
             executionConfig =
                     executionPlan.getSerializedExecutionConfig().deserializeValue(userCodeLoader);
-            ParallelismOverrideUtil.applyParallelismOverrides(
-                    (JobGraph) executionPlan, jobMasterConfiguration);
         } else if (executionPlan instanceof StreamGraph) {
             executionConfig = ((StreamGraph) executionPlan).getExecutionConfig();
         } else {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveExecutionHandlerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveExecutionHandlerFactory.java
@@ -73,7 +73,10 @@ public class AdaptiveExecutionHandlerFactory {
                 return new NonAdaptiveExecutionHandler(jobGraph);
             } else {
                 return new DefaultAdaptiveExecutionHandler(
-                        userClassLoader, (StreamGraph) executionPlan, serializationExecutor);
+                        userClassLoader,
+                        (StreamGraph) executionPlan,
+                        serializationExecutor,
+                        jobMasterConfiguration);
             }
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/DefaultAdaptiveExecutionHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/DefaultAdaptiveExecutionHandler.java
@@ -19,6 +19,8 @@
 package org.apache.flink.runtime.scheduler.adaptivebatch;
 
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
@@ -35,6 +37,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
@@ -59,8 +62,14 @@ public class DefaultAdaptiveExecutionHandler implements AdaptiveExecutionHandler
 
     private final StreamGraphOptimizer streamGraphOptimizer;
 
+    /** Merged parallelism overrides: master config first, job config wins. */
+    private final Map<String, String> parallelismOverrides;
+
     public DefaultAdaptiveExecutionHandler(
-            ClassLoader userClassloader, StreamGraph streamGraph, Executor serializationExecutor)
+            ClassLoader userClassloader,
+            StreamGraph streamGraph,
+            Executor serializationExecutor,
+            Configuration jobMasterConfiguration)
             throws DynamicCodeLoadingException {
         this.adaptiveGraphManager =
                 new AdaptiveGraphManager(userClassloader, streamGraph, serializationExecutor);
@@ -69,6 +78,14 @@ public class DefaultAdaptiveExecutionHandler implements AdaptiveExecutionHandler
                 new StreamGraphOptimizer(streamGraph.getJobConfiguration(), userClassloader);
         this.streamGraphOptimizer.initializeStrategies(
                 adaptiveGraphManager.getStreamGraphContext());
+
+        // Merge overrides: master config first, job config wins (same precedence as
+        // ParallelismOverrideUtil)
+        Map<String, String> overrides = new HashMap<>();
+        overrides.putAll(jobMasterConfiguration.get(PipelineOptions.PARALLELISM_OVERRIDES));
+        overrides.putAll(
+                streamGraph.getJobConfiguration().get(PipelineOptions.PARALLELISM_OVERRIDES));
+        this.parallelismOverrides = overrides;
     }
 
     @Override
@@ -150,6 +167,10 @@ public class DefaultAdaptiveExecutionHandler implements AdaptiveExecutionHandler
 
     @Override
     public int getInitialParallelism(JobVertexID jobVertexId) {
+        String override = parallelismOverrides.get(jobVertexId.toHexString());
+        if (override != null) {
+            return Integer.parseInt(override);
+        }
         JobVertex jobVertex = adaptiveGraphManager.getJobGraph().findVertexByID(jobVertexId);
         int vertexInitialParallelism = jobVertex.getParallelism();
         StreamNodeForwardGroup forwardGroup =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -1352,7 +1352,7 @@ public class DispatcherTest extends AbstractDispatcherTest {
     }
 
     @Test
-    public void testOverridingJobVertexParallelisms() throws Exception {
+    public void testDispatcherDoesNotOverrideJobVertexParallelisms() throws Exception {
         JobVertex v1 = new JobVertex("v1");
         v1.setParallelism(1);
         JobVertex v2 = new JobVertex("v2");
@@ -1395,9 +1395,11 @@ public class DispatcherTest extends AbstractDispatcherTest {
 
         dispatcherGateway.submitJob(jobGraph, TIMEOUT).get();
 
-        assertEquals(jobGraph.findVertexByID(v1.getID()).getParallelism(), 10);
+        // Verify that Dispatcher does NOT apply parallelism overrides directly
+        // Overrides are applied in scheduler factories, not in Dispatcher
+        assertEquals(jobGraph.findVertexByID(v1.getID()).getParallelism(), 1);
         assertEquals(jobGraph.findVertexByID(v2.getID()).getParallelism(), 2);
-        assertEquals(jobGraph.findVertexByID(v3.getID()).getParallelism(), 42);
+        assertEquals(jobGraph.findVertexByID(v3.getID()).getParallelism(), 3);
     }
 
     private JobManagerRunner runningJobManagerRunnerWithJobStatus(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/ParallelismOverrideUtilTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/ParallelismOverrideUtilTest.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.PipelineOptions;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link ParallelismOverrideUtil}. */
+class ParallelismOverrideUtilTest {
+
+    @Test
+    void testApplyOverridesFromJobMasterConfiguration() {
+        JobVertex vertex1 = new JobVertex("vertex1");
+        vertex1.setParallelism(1);
+        JobVertex vertex2 = new JobVertex("vertex2");
+        vertex2.setParallelism(2);
+
+        JobGraph jobGraph = JobGraphTestUtils.streamingJobGraph(vertex1, vertex2);
+
+        Configuration jobMasterConfig = new Configuration();
+        Map<String, String> overrides = new HashMap<>();
+        overrides.put(vertex1.getID().toHexString(), "10");
+        overrides.put(vertex2.getID().toHexString(), "20");
+        jobMasterConfig.set(PipelineOptions.PARALLELISM_OVERRIDES, overrides);
+
+        ParallelismOverrideUtil.applyParallelismOverrides(jobGraph, jobMasterConfig);
+
+        assertThat(vertex1.getParallelism()).isEqualTo(10);
+        assertThat(vertex2.getParallelism()).isEqualTo(20);
+    }
+
+    @Test
+    void testApplyOverridesFromJobGraphConfiguration() {
+        JobVertex vertex1 = new JobVertex("vertex1");
+        vertex1.setParallelism(1);
+        JobVertex vertex2 = new JobVertex("vertex2");
+        vertex2.setParallelism(2);
+
+        JobGraph jobGraph = JobGraphTestUtils.streamingJobGraph(vertex1, vertex2);
+
+        Map<String, String> overrides = new HashMap<>();
+        overrides.put(vertex1.getID().toHexString(), "10");
+        overrides.put(vertex2.getID().toHexString(), "20");
+        jobGraph.getJobConfiguration().set(PipelineOptions.PARALLELISM_OVERRIDES, overrides);
+
+        ParallelismOverrideUtil.applyParallelismOverrides(jobGraph, new Configuration());
+
+        assertThat(vertex1.getParallelism()).isEqualTo(10);
+        assertThat(vertex2.getParallelism()).isEqualTo(20);
+    }
+
+    @Test
+    void testJobGraphConfigurationTakesPrecedenceOverJobMasterConfiguration() {
+        JobVertex vertex = new JobVertex("vertex");
+        vertex.setParallelism(1);
+
+        JobGraph jobGraph = JobGraphTestUtils.streamingJobGraph(vertex);
+
+        // Set override in job master configuration
+        Configuration jobMasterConfig = new Configuration();
+        jobMasterConfig.set(
+                PipelineOptions.PARALLELISM_OVERRIDES, Map.of(vertex.getID().toHexString(), "10"));
+
+        // Set different override in job graph configuration (should win)
+        jobGraph.getJobConfiguration()
+                .set(
+                        PipelineOptions.PARALLELISM_OVERRIDES,
+                        Map.of(vertex.getID().toHexString(), "20"));
+
+        ParallelismOverrideUtil.applyParallelismOverrides(jobGraph, jobMasterConfig);
+
+        assertThat(vertex.getParallelism()).isEqualTo(20);
+    }
+
+    @Test
+    void testPartialOverrides() {
+        JobVertex vertex1 = new JobVertex("vertex1");
+        vertex1.setParallelism(1);
+        JobVertex vertex2 = new JobVertex("vertex2");
+        vertex2.setParallelism(2);
+
+        JobGraph jobGraph = JobGraphTestUtils.streamingJobGraph(vertex1, vertex2);
+
+        // Only override vertex1, not vertex2
+        Configuration jobMasterConfig = new Configuration();
+        jobMasterConfig.set(
+                PipelineOptions.PARALLELISM_OVERRIDES, Map.of(vertex1.getID().toHexString(), "10"));
+
+        ParallelismOverrideUtil.applyParallelismOverrides(jobGraph, jobMasterConfig);
+
+        assertThat(vertex1.getParallelism()).isEqualTo(10);
+        assertThat(vertex2.getParallelism()).isEqualTo(2); // unchanged
+    }
+
+    @Test
+    void testUnknownVertexIdIgnored() {
+        JobVertex vertex = new JobVertex("vertex");
+        vertex.setParallelism(1);
+
+        JobGraph jobGraph = JobGraphTestUtils.streamingJobGraph(vertex);
+
+        Configuration jobMasterConfig = new Configuration();
+        Map<String, String> overrides = new HashMap<>();
+        overrides.put("non-existent-vertex-id", "10");
+        overrides.put(vertex.getID().toHexString(), "20");
+        jobMasterConfig.set(PipelineOptions.PARALLELISM_OVERRIDES, overrides);
+
+        ParallelismOverrideUtil.applyParallelismOverrides(jobGraph, jobMasterConfig);
+
+        // Should apply known vertex and ignore unknown one without error
+        assertThat(vertex.getParallelism()).isEqualTo(20);
+    }
+
+    @Test
+    void testNoOverridesWhenEmpty() {
+        JobVertex vertex = new JobVertex("vertex");
+        vertex.setParallelism(5);
+
+        JobGraph jobGraph = JobGraphTestUtils.streamingJobGraph(vertex);
+
+        ParallelismOverrideUtil.applyParallelismOverrides(jobGraph, new Configuration());
+
+        assertThat(vertex.getParallelism()).isEqualTo(5); // unchanged
+    }
+
+    @Test
+    void testMultipleVerticesWithMixedOverrides() {
+        JobVertex vertex1 = new JobVertex("vertex1");
+        vertex1.setParallelism(1);
+        JobVertex vertex2 = new JobVertex("vertex2");
+        vertex2.setParallelism(2);
+        JobVertex vertex3 = new JobVertex("vertex3");
+        vertex3.setParallelism(3);
+
+        JobGraph jobGraph = JobGraphTestUtils.streamingJobGraph(vertex1, vertex2, vertex3);
+
+        // Set some overrides in job master config
+        Configuration jobMasterConfig = new Configuration();
+        Map<String, String> masterOverrides = new HashMap<>();
+        masterOverrides.put(vertex1.getID().toHexString(), "10");
+        masterOverrides.put(vertex2.getID().toHexString(), "20");
+        jobMasterConfig.set(PipelineOptions.PARALLELISM_OVERRIDES, masterOverrides);
+
+        // Set some overrides in job config (vertex2 should be overridden by this)
+        Map<String, String> jobOverrides = new HashMap<>();
+        jobOverrides.put(vertex2.getID().toHexString(), "200");
+        jobOverrides.put(vertex3.getID().toHexString(), "30");
+        jobGraph.getJobConfiguration().set(PipelineOptions.PARALLELISM_OVERRIDES, jobOverrides);
+
+        ParallelismOverrideUtil.applyParallelismOverrides(jobGraph, jobMasterConfig);
+
+        assertThat(vertex1.getParallelism()).isEqualTo(10); // from job master config
+        assertThat(vertex2.getParallelism()).isEqualTo(200); // job config wins
+        assertThat(vertex3.getParallelism()).isEqualTo(30); // from job config
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/ParallelismOverrideUtilTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/ParallelismOverrideUtilTest.java
@@ -18,11 +18,16 @@
 
 package org.apache.flink.runtime.scheduler;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
 import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
+import org.apache.flink.streaming.api.environment.CheckpointConfig;
+import org.apache.flink.streaming.api.graph.ExecutionPlan;
+import org.apache.flink.streaming.api.graph.StreamGraph;
 
 import org.junit.jupiter.api.Test;
 
@@ -30,6 +35,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link ParallelismOverrideUtil}. */
 class ParallelismOverrideUtilTest {
@@ -178,5 +184,79 @@ class ParallelismOverrideUtilTest {
         assertThat(vertex1.getParallelism()).isEqualTo(10); // from job master config
         assertThat(vertex2.getParallelism()).isEqualTo(200); // job config wins
         assertThat(vertex3.getParallelism()).isEqualTo(30); // from job config
+    }
+
+    @Test
+    void testNonNumericOverrideThrowsIllegalArgument() {
+        JobVertex vertex = new JobVertex("vertex");
+        vertex.setParallelism(1);
+
+        JobGraph jobGraph = JobGraphTestUtils.streamingJobGraph(vertex);
+
+        Configuration jobMasterConfig = new Configuration();
+        jobMasterConfig.set(
+                PipelineOptions.PARALLELISM_OVERRIDES,
+                Map.of(vertex.getID().toHexString(), "not-a-number"));
+
+        assertThatThrownBy(
+                        () ->
+                                ParallelismOverrideUtil.applyParallelismOverrides(
+                                        jobGraph, jobMasterConfig))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("not a valid integer")
+                .hasMessageContaining(vertex.getID().toHexString());
+    }
+
+    @Test
+    void testApplyIfApplicableAppliesForJobGraph() {
+        JobVertex vertex = new JobVertex("vertex");
+        vertex.setParallelism(1);
+
+        JobGraph jobGraph = JobGraphTestUtils.streamingJobGraph(vertex);
+
+        Configuration jobMasterConfig = new Configuration();
+        jobMasterConfig.set(
+                PipelineOptions.PARALLELISM_OVERRIDES, Map.of(vertex.getID().toHexString(), "7"));
+
+        ExecutionPlan executionPlan = jobGraph;
+        ParallelismOverrideUtil.applyParallelismOverridesIfApplicable(
+                executionPlan, jobMasterConfig);
+
+        assertThat(vertex.getParallelism()).isEqualTo(7);
+    }
+
+    @Test
+    void testApplyIfApplicableNoOpsForStreamGraph() {
+        StreamGraph streamGraph =
+                new StreamGraph(
+                        new Configuration(),
+                        new ExecutionConfig(),
+                        new CheckpointConfig(),
+                        SavepointRestoreSettings.none());
+
+        Configuration jobMasterConfig = new Configuration();
+        jobMasterConfig.set(PipelineOptions.PARALLELISM_OVERRIDES, Map.of("some-vertex-id", "42"));
+
+        // Should not throw — StreamGraph path handles overrides elsewhere.
+        ParallelismOverrideUtil.applyParallelismOverridesIfApplicable(streamGraph, jobMasterConfig);
+    }
+
+    @Test
+    void testNonPositiveOverrideThrowsIllegalArgument() {
+        JobVertex vertex = new JobVertex("vertex");
+        vertex.setParallelism(1);
+
+        JobGraph jobGraph = JobGraphTestUtils.streamingJobGraph(vertex);
+
+        Configuration jobMasterConfig = new Configuration();
+        jobMasterConfig.set(
+                PipelineOptions.PARALLELISM_OVERRIDES, Map.of(vertex.getID().toHexString(), "0"));
+
+        assertThatThrownBy(
+                        () ->
+                                ParallelismOverrideUtil.applyParallelismOverrides(
+                                        jobGraph, jobMasterConfig))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must be positive");
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveExecutionPlanSchedulingContextTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveExecutionPlanSchedulingContextTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.scheduler.adaptivebatch;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSet;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
@@ -158,6 +159,7 @@ class AdaptiveExecutionPlanSchedulingContextTest {
         return new DefaultAdaptiveExecutionHandler(
                 Thread.currentThread().getContextClassLoader(),
                 streamGraph,
-                EXECUTOR_RESOURCE.getExecutor());
+                EXECUTOR_RESOURCE.getExecutor(),
+                new Configuration());
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/DefaultAdaptiveExecutionHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/DefaultAdaptiveExecutionHandlerTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.scheduler.adaptivebatch;
 
 import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobmaster.event.ExecutionJobVertexFinishedEvent;
@@ -250,7 +251,10 @@ class DefaultAdaptiveExecutionHandlerTest {
             throws DynamicCodeLoadingException {
         DefaultAdaptiveExecutionHandler handler =
                 new DefaultAdaptiveExecutionHandler(
-                        getClass().getClassLoader(), streamGraph, EXECUTOR_RESOURCE.getExecutor());
+                        getClass().getClassLoader(),
+                        streamGraph,
+                        EXECUTOR_RESOURCE.getExecutor(),
+                        new Configuration());
         handler.registerJobGraphUpdateListener(listener);
 
         return handler;

--- a/flink-tests/src/test/java/org/apache/flink/test/scheduling/AdaptiveSchedulerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/scheduling/AdaptiveSchedulerITCase.java
@@ -655,8 +655,7 @@ class AdaptiveSchedulerITCase {
         overrides.put(vertex.getID().toHexString(), "2");
         jobGraph.getJobConfiguration().set(PipelineOptions.PARALLELISM_OVERRIDES, overrides);
 
-        final RestClusterClient<?> restClusterClient =
-                miniClusterResource.getRestClusterClient();
+        var restClusterClient = miniClusterResource.getRestClusterClient();
         restClusterClient.submitJob(jobGraph).join();
         JobID jobId = jobGraph.getJobID();
 

--- a/flink-tests/src/test/java/org/apache/flink/test/scheduling/AdaptiveSchedulerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/scheduling/AdaptiveSchedulerITCase.java
@@ -20,6 +20,8 @@ package org.apache.flink.test.scheduling;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.api.common.functions.OpenContext;
+import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.common.state.CheckpointListener;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
@@ -89,6 +91,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.core.testutils.FlinkAssertions.assertThatFuture;
@@ -104,6 +107,9 @@ class AdaptiveSchedulerITCase {
     private static final int NUMBER_TASK_MANAGERS = 2;
     private static final int NUMBER_SLOTS_PER_TASK_MANAGER = 2;
     private static final int PARALLELISM = NUMBER_SLOTS_PER_TASK_MANAGER * NUMBER_TASK_MANAGERS;
+
+    /** Used to capture the actual parallelism at runtime in Application Mode tests. */
+    private static final AtomicInteger CAPTURED_PARALLELISM = new AtomicInteger(0);
 
     private static final Configuration configuration = getConfiguration();
 
@@ -125,6 +131,7 @@ class AdaptiveSchedulerITCase {
 
     @BeforeEach
     void createMiniCluster() throws Exception {
+        CAPTURED_PARALLELISM.set(0);
         miniClusterResource =
                 new MiniClusterWithClientResource(
                         new MiniClusterResourceConfiguration.Builder()
@@ -649,7 +656,7 @@ class AdaptiveSchedulerITCase {
         jobGraph.getJobConfiguration().set(PipelineOptions.PARALLELISM_OVERRIDES, overrides);
 
         final RestClusterClient<?> restClusterClient =
-                MINI_CLUSTER_WITH_CLIENT_RESOURCE.getRestClusterClient();
+                miniClusterResource.getRestClusterClient();
         restClusterClient.submitJob(jobGraph).join();
         JobID jobId = jobGraph.getJobID();
 
@@ -685,6 +692,69 @@ class AdaptiveSchedulerITCase {
             assertThat(actualParallelism).as("Parallelism override should be applied").isEqualTo(2);
         } finally {
             restClusterClient.cancel(jobId).join();
+        }
+    }
+
+    /**
+     * Tests parallelism overrides in Application Mode with Adaptive Scheduler. This verifies the
+     * fix for FLINK-38770 works in Application Mode by ensuring a job with overrides configured
+     * completes successfully. The test uses a small bounded job that completes quickly and verifies
+     * the parallelism override was applied.
+     */
+    @Test
+    public void testParallelismOverridesInApplicationMode() throws Exception {
+        Configuration discoveryConfig = new Configuration();
+        StreamExecutionEnvironment discoveryEnv =
+                StreamExecutionEnvironment.getExecutionEnvironment(discoveryConfig);
+        discoveryEnv.setParallelism(1);
+        discoveryEnv.disableOperatorChaining();
+        discoveryEnv
+                .fromSequence(1, 10)
+                .map(new ParallelismCapturingMapFunction())
+                .name("test-map");
+
+        JobGraph discoveryJobGraph = discoveryEnv.getStreamGraph().getJobGraph();
+        JobVertex mapVertex = null;
+        for (JobVertex vertex : discoveryJobGraph.getVertices()) {
+            if (vertex.getName().contains("test-map")) {
+                mapVertex = vertex;
+                break;
+            }
+        }
+        assertThat(mapVertex).as("Map vertex should exist").isNotNull();
+        final JobVertexID mapVertexId = mapVertex.getID();
+
+        Configuration config = new Configuration();
+        Map<String, String> overrides = new HashMap<>();
+        overrides.put(mapVertexId.toHexString(), "2");
+        config.set(PipelineOptions.PARALLELISM_OVERRIDES, overrides);
+
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment(config);
+        env.setParallelism(1);
+        env.disableOperatorChaining();
+        env.fromSequence(1, 10)
+                .map(new ParallelismCapturingMapFunction())
+                .name("test-map")
+                .addSink(new DiscardingSink<>());
+
+        env.execute();
+
+        assertThat(CAPTURED_PARALLELISM.get())
+                .as("Parallelism override should be applied (expected 2, not 1)")
+                .isEqualTo(2);
+    }
+
+    private static class ParallelismCapturingMapFunction extends RichMapFunction<Long, Long> {
+
+        @Override
+        public void open(OpenContext openContext) throws Exception {
+            int parallelism = getRuntimeContext().getTaskInfo().getNumberOfParallelSubtasks();
+            CAPTURED_PARALLELISM.set(parallelism);
+        }
+
+        @Override
+        public Long map(Long value) throws Exception {
+            return value * 2;
         }
     }
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/scheduling/AdaptiveSchedulerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/scheduling/AdaptiveSchedulerITCase.java
@@ -27,12 +27,15 @@ import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HeartbeatManagerOptions;
 import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.core.execution.CheckpointingMode;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobGraphBuilder;
+import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
@@ -44,10 +47,12 @@ import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.JobExceptionsHeaders;
 import org.apache.flink.runtime.rest.messages.JobExceptionsInfoWithHistory;
 import org.apache.flink.runtime.rest.messages.JobExceptionsInfoWithHistory.RootExceptionInfo;
+import org.apache.flink.runtime.rest.messages.job.JobDetailsInfo;
 import org.apache.flink.runtime.rest.messages.job.JobExceptionsMessageParameters;
 import org.apache.flink.runtime.scheduler.stopwithsavepoint.StopWithSavepointStoppingException;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.runtime.testtasks.BlockingNoOpInvokable;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
@@ -78,7 +83,9 @@ import java.io.File;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -621,6 +628,63 @@ class AdaptiveSchedulerITCase {
         @Override
         public void notifyCheckpointComplete(long checkpointId) throws Exception {
             throw new RuntimeException("Test exception.");
+        }
+    }
+
+    /**
+     * Tests that parallelism overrides work correctly with the Adaptive scheduler. This verifies
+     * the fix for FLINK-38770.
+     */
+    @Test
+    public void testParallelismOverridesWithAdaptiveScheduler() throws Exception {
+        JobVertex vertex = new JobVertex("test-vertex");
+        vertex.setParallelism(1);
+        vertex.setInvokableClass(BlockingNoOpInvokable.class);
+
+        JobGraph jobGraph = JobGraphTestUtils.streamingJobGraph(vertex);
+
+        // Configure parallelism override to change parallelism from 1 to 2
+        Map<String, String> overrides = new HashMap<>();
+        overrides.put(vertex.getID().toHexString(), "2");
+        jobGraph.getJobConfiguration().set(PipelineOptions.PARALLELISM_OVERRIDES, overrides);
+
+        final RestClusterClient<?> restClusterClient =
+                MINI_CLUSTER_WITH_CLIENT_RESOURCE.getRestClusterClient();
+        restClusterClient.submitJob(jobGraph).join();
+        JobID jobId = jobGraph.getJobID();
+
+        try {
+            // Wait for job to be running with 2 tasks
+            CommonTestUtils.waitUntilCondition(
+                    () -> {
+                        JobDetailsInfo jobDetails = restClusterClient.getJobDetails(jobId).join();
+                        int runningTasks =
+                                jobDetails.getJobVertexInfos().stream()
+                                        .map(JobDetailsInfo.JobVertexDetailsInfo::getTasksPerState)
+                                        .map(
+                                                tasksPerState ->
+                                                        tasksPerState.get(ExecutionState.RUNNING))
+                                        .mapToInt(Integer::intValue)
+                                        .sum();
+                        return runningTasks == 2;
+                    });
+
+            // Verify actual parallelism is 2, not 1
+            JobDetailsInfo jobDetails = restClusterClient.getJobDetails(jobId).join();
+            int actualParallelism =
+                    jobDetails.getJobVertexInfos().stream()
+                            .filter(v -> v.getJobVertexID().equals(vertex.getID()))
+                            .findFirst()
+                            .map(JobDetailsInfo.JobVertexDetailsInfo::getParallelism)
+                            .orElseThrow(
+                                    () ->
+                                            new AssertionError(
+                                                    "Vertex "
+                                                            + vertex.getID()
+                                                            + " not found in job details"));
+            assertThat(actualParallelism).as("Parallelism override should be applied").isEqualTo(2);
+        } finally {
+            restClusterClient.cancel(jobId).join();
         }
     }
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/scheduling/ParallelismOverridesITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/scheduling/ParallelismOverridesITCase.java
@@ -1,0 +1,259 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.scheduling;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.client.program.rest.RestClusterClient;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.PipelineOptions;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.runtime.rest.messages.job.JobDetailsInfo;
+import org.apache.flink.runtime.testtasks.BlockingNoOpInvokable;
+import org.apache.flink.runtime.testutils.CommonTestUtils;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.test.junit5.InjectClusterClient;
+import org.apache.flink.test.junit5.InjectMiniCluster;
+import org.apache.flink.test.junit5.MiniClusterExtension;
+import org.apache.flink.util.TestLoggerExtension;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for parallelism overrides via {@code pipeline.jobvertex-parallelism-overrides}
+ * configuration.
+ *
+ * <p>These tests verify that the fix for FLINK-38770 works correctly across different scheduler
+ * types and submission modes.
+ */
+@ExtendWith(TestLoggerExtension.class)
+public class ParallelismOverridesITCase {
+
+    private static final int NUMBER_OF_SLOTS = 8;
+
+    @RegisterExtension
+    private static final MiniClusterExtension MINI_CLUSTER_EXTENSION =
+            new MiniClusterExtension(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setConfiguration(createConfiguration())
+                            .setNumberSlotsPerTaskManager(NUMBER_OF_SLOTS)
+                            .build());
+
+    private static Configuration createConfiguration() {
+        Configuration configuration = new Configuration();
+        configuration.set(JobManagerOptions.SCHEDULER, JobManagerOptions.SchedulerType.Default);
+        return configuration;
+    }
+
+    private RestClusterClient<?> restClusterClient;
+    private MiniCluster miniCluster;
+
+    @BeforeEach
+    void beforeEach(
+            @InjectClusterClient RestClusterClient<?> restClusterClient,
+            @InjectMiniCluster MiniCluster miniCluster) {
+        this.restClusterClient = restClusterClient;
+        this.miniCluster = miniCluster;
+    }
+
+    /**
+     * Tests parallelism overrides with the Default scheduler. This verifies that JobGraph
+     * submission (Session Mode scenario) correctly applies overrides.
+     */
+    @Test
+    void testParallelismOverridesWithDefaultScheduler() throws Exception {
+        JobVertex vertex = new JobVertex("test-vertex");
+        vertex.setParallelism(1);
+        vertex.setInvokableClass(BlockingNoOpInvokable.class);
+
+        JobGraph jobGraph = JobGraphTestUtils.streamingJobGraph(vertex);
+
+        // Configure parallelism override to change parallelism from 1 to 4
+        Map<String, String> overrides = new HashMap<>();
+        overrides.put(vertex.getID().toHexString(), "4");
+        jobGraph.getJobConfiguration().set(PipelineOptions.PARALLELISM_OVERRIDES, overrides);
+
+        try {
+            restClusterClient.submitJob(jobGraph).join();
+            JobID jobId = jobGraph.getJobID();
+
+            // Wait for job to be running with 4 tasks
+            waitForRunningTasks(restClusterClient, jobId, 4);
+
+            // Verify actual parallelism is 4, not 1
+            int actualParallelism = getVertexParallelism(restClusterClient, jobId, vertex.getID());
+            assertThat(actualParallelism).as("Parallelism override should be applied").isEqualTo(4);
+        } finally {
+            restClusterClient.cancel(jobGraph.getJobID()).join();
+        }
+    }
+
+    /**
+     * Tests that job-level configuration takes precedence over cluster-level configuration for
+     * parallelism overrides.
+     */
+    @Test
+    void testJobConfigurationTakesPrecedenceOverClusterConfiguration() throws Exception {
+        JobVertex vertex = new JobVertex("test-vertex");
+        vertex.setParallelism(1);
+        vertex.setInvokableClass(BlockingNoOpInvokable.class);
+
+        JobGraph jobGraph = JobGraphTestUtils.streamingJobGraph(vertex);
+
+        // Set different override in job configuration
+        Map<String, String> jobOverrides = new HashMap<>();
+        jobOverrides.put(vertex.getID().toHexString(), "4");
+        jobGraph.getJobConfiguration().set(PipelineOptions.PARALLELISM_OVERRIDES, jobOverrides);
+
+        try {
+            restClusterClient.submitJob(jobGraph).join();
+            JobID jobId = jobGraph.getJobID();
+
+            // Wait for job to be running
+            waitForRunningTasks(restClusterClient, jobId, 4);
+
+            // Verify parallelism is 4 (from job config)
+            int actualParallelism = getVertexParallelism(restClusterClient, jobId, vertex.getID());
+            assertThat(actualParallelism).isEqualTo(4);
+        } finally {
+            restClusterClient.cancel(jobGraph.getJobID()).join();
+        }
+    }
+
+    /**
+     * Tests that partial overrides work correctly - only specified vertices are modified, others
+     * keep their original parallelism.
+     */
+    @Test
+    void testPartialParallelismOverrides() throws Exception {
+        JobVertex vertex1 = new JobVertex("vertex1");
+        vertex1.setParallelism(1);
+        vertex1.setInvokableClass(BlockingNoOpInvokable.class);
+
+        JobVertex vertex2 = new JobVertex("vertex2");
+        vertex2.setParallelism(2);
+        vertex2.setInvokableClass(BlockingNoOpInvokable.class);
+
+        JobGraph jobGraph = JobGraphTestUtils.streamingJobGraph(vertex1, vertex2);
+
+        // Only override vertex1, not vertex2
+        Map<String, String> overrides = new HashMap<>();
+        overrides.put(vertex1.getID().toHexString(), "4");
+        jobGraph.getJobConfiguration().set(PipelineOptions.PARALLELISM_OVERRIDES, overrides);
+
+        try {
+            restClusterClient.submitJob(jobGraph).join();
+            JobID jobId = jobGraph.getJobID();
+
+            // Wait for job to be running (4 + 2 = 6 tasks total)
+            waitForRunningTasks(restClusterClient, jobId, 6);
+
+            // Verify vertex1 has parallelism 4 (overridden)
+            int parallelism1 = getVertexParallelism(restClusterClient, jobId, vertex1.getID());
+            assertThat(parallelism1).isEqualTo(4);
+
+            // Verify vertex2 has parallelism 2 (unchanged)
+            int parallelism2 = getVertexParallelism(restClusterClient, jobId, vertex2.getID());
+            assertThat(parallelism2).isEqualTo(2);
+        } finally {
+            restClusterClient.cancel(jobGraph.getJobID()).join();
+        }
+    }
+
+    /**
+     * Tests parallelism overrides work correctly when overrides come from multiple sources (cluster
+     * config and job config), verifying that job config takes precedence.
+     */
+    @Test
+    void testOverridePrecedenceFromMultipleSources() throws Exception {
+        JobVertex vertex1 = new JobVertex("vertex1");
+        vertex1.setParallelism(1);
+        vertex1.setInvokableClass(BlockingNoOpInvokable.class);
+
+        JobVertex vertex2 = new JobVertex("vertex2");
+        vertex2.setParallelism(1);
+        vertex2.setInvokableClass(BlockingNoOpInvokable.class);
+
+        JobGraph jobGraph = JobGraphTestUtils.streamingJobGraph(vertex1, vertex2);
+
+        // Set overrides in job configuration for both vertices
+        Map<String, String> jobOverrides = new HashMap<>();
+        jobOverrides.put(vertex1.getID().toHexString(), "3");
+        jobOverrides.put(vertex2.getID().toHexString(), "2");
+        jobGraph.getJobConfiguration().set(PipelineOptions.PARALLELISM_OVERRIDES, jobOverrides);
+
+        try {
+            restClusterClient.submitJob(jobGraph).join();
+            JobID jobId = jobGraph.getJobID();
+
+            // Wait for job to be running (3 + 2 = 5 tasks total)
+            waitForRunningTasks(restClusterClient, jobId, 5);
+
+            // Verify both vertices have their overridden parallelism
+            int parallelism1 = getVertexParallelism(restClusterClient, jobId, vertex1.getID());
+            assertThat(parallelism1).isEqualTo(3);
+
+            int parallelism2 = getVertexParallelism(restClusterClient, jobId, vertex2.getID());
+            assertThat(parallelism2).isEqualTo(2);
+        } finally {
+            restClusterClient.cancel(jobGraph.getJobID()).join();
+        }
+    }
+
+    private static int getVertexParallelism(
+            RestClusterClient<?> client, JobID jobId, JobVertexID vertexId) {
+        JobDetailsInfo jobDetails = client.getJobDetails(jobId).join();
+        return jobDetails.getJobVertexInfos().stream()
+                .filter(v -> v.getJobVertexID().equals(vertexId))
+                .findFirst()
+                .map(JobDetailsInfo.JobVertexDetailsInfo::getParallelism)
+                .orElseThrow(
+                        () ->
+                                new AssertionError(
+                                        "Vertex " + vertexId + " not found in job details"));
+    }
+
+    private static void waitForRunningTasks(
+            RestClusterClient<?> client, JobID jobId, int expectedRunningTasks) throws Exception {
+        CommonTestUtils.waitUntilCondition(
+                () -> getNumberRunningTasks(client, jobId) == expectedRunningTasks);
+    }
+
+    private static int getNumberRunningTasks(RestClusterClient<?> client, JobID jobId) {
+        JobDetailsInfo jobDetails = client.getJobDetails(jobId).join();
+        return jobDetails.getJobVertexInfos().stream()
+                .map(JobDetailsInfo.JobVertexDetailsInfo::getTasksPerState)
+                .map(tasksPerState -> tasksPerState.get(ExecutionState.RUNNING))
+                .mapToInt(Integer::intValue)
+                .sum();
+    }
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/scheduling/ParallelismOverridesITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/scheduling/ParallelismOverridesITCase.java
@@ -67,6 +67,13 @@ public class ParallelismOverridesITCase {
     /** Used to capture the actual parallelism at runtime in Application Mode tests. */
     private static final AtomicInteger CAPTURED_PARALLELISM = new AtomicInteger(0);
 
+    /**
+     * Reserved vertex ID used exclusively by the cluster-vs-job override conflict test. The cluster
+     * configuration defines an override for this ID, so tests that use random IDs are unaffected.
+     */
+    private static final JobVertexID CLUSTER_OVERRIDE_VERTEX_ID =
+            JobVertexID.fromHexString("cafecafecafecafecafecafecafecafe");
+
     @RegisterExtension
     private static final MiniClusterExtension MINI_CLUSTER_EXTENSION =
             new MiniClusterExtension(
@@ -78,6 +85,9 @@ public class ParallelismOverridesITCase {
     private static Configuration createConfiguration() {
         Configuration configuration = new Configuration();
         configuration.set(JobManagerOptions.SCHEDULER, JobManagerOptions.SchedulerType.Default);
+        Map<String, String> clusterOverrides = new HashMap<>();
+        clusterOverrides.put(CLUSTER_OVERRIDE_VERTEX_ID.toHexString(), "2");
+        configuration.set(PipelineOptions.PARALLELISM_OVERRIDES, clusterOverrides);
         return configuration;
     }
 
@@ -152,6 +162,39 @@ public class ParallelismOverridesITCase {
             // Verify parallelism is 4 (from job config)
             int actualParallelism = getVertexParallelism(restClusterClient, jobId, vertex.getID());
             assertThat(actualParallelism).isEqualTo(4);
+        } finally {
+            restClusterClient.cancel(jobGraph.getJobID()).join();
+        }
+    }
+
+    /**
+     * Tests that when both cluster-level and job-level overrides exist for the same vertex, the
+     * job-level override wins. The cluster-level override (parallelism 2) is configured in {@link
+     * #createConfiguration()}; this test sets a job-level override (parallelism 4) for the same
+     * vertex ID and verifies the job-level value is applied.
+     */
+    @Test
+    void testJobOverrideTakesPrecedenceOverClusterOverride() throws Exception {
+        JobVertex vertex = new JobVertex("test-vertex", CLUSTER_OVERRIDE_VERTEX_ID);
+        vertex.setParallelism(1);
+        vertex.setInvokableClass(BlockingNoOpInvokable.class);
+
+        JobGraph jobGraph = JobGraphTestUtils.streamingJobGraph(vertex);
+
+        Map<String, String> jobOverrides = new HashMap<>();
+        jobOverrides.put(CLUSTER_OVERRIDE_VERTEX_ID.toHexString(), "4");
+        jobGraph.getJobConfiguration().set(PipelineOptions.PARALLELISM_OVERRIDES, jobOverrides);
+
+        try {
+            restClusterClient.submitJob(jobGraph).join();
+            JobID jobId = jobGraph.getJobID();
+
+            waitForRunningTasks(restClusterClient, jobId, 4);
+
+            int actualParallelism = getVertexParallelism(restClusterClient, jobId, vertex.getID());
+            assertThat(actualParallelism)
+                    .as("Job-level override (4) should win over cluster-level override (2)")
+                    .isEqualTo(4);
         } finally {
             restClusterClient.cancel(jobGraph.getJobID()).join();
         }


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes a bug where `pipeline.jobvertex-parallelism-overrides` configuration was completely ignored when running jobs in Application Mode with Flink 2.0+. This broke the Flink Kubernetes Operator's autoscaler functionality.

## Brief change log

- Created `ParallelismOverrideUtil` to centralize override application logic
- Modified all scheduler factories (DefaultScheduler, AdaptiveScheduler, AdaptiveBatchScheduler) to apply overrides after StreamGraph→JobGraph conversion
- Removed duplicate override logic from Dispatcher.java
- Ensured correct configuration precedence: job config > job master config

## Verifying this change

This change added tests and can be verified as follows:

- Added 7 unit tests in `ParallelismOverrideUtilTest` covering all override scenarios
- Added 4 integration tests in `ParallelismOverridesITCase` verifying end-to-end behavior across different scheduler types
- Modified existing integration tests in `AdaptiveBatchSchedulerITCase` and `AdaptiveSchedulerITCase` to include parallelism override tests

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes (JobManager scheduler factories)
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable