### PR TITLE
[FLINK-38809][Tests] Upgrade Testcontainers to 2.0.3

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/ExternalResource.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/ExternalResource.java
@@ -16,18 +16,26 @@
  * limitations under the License.
  */
 
-package org.apache.flink.tests.util.cache;
+package org.apache.flink.tests.util;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
+/**
+ * Resource lifecycle interface for end-to-end tests.
+ *
+ * <p>This interface provides hooks for resource setup and cleanup, allowing resources to
+ * differentiate between successful and failed tests in their cleanup methods.
+ *
+ * <p>This is a JUnit5-compatible version that does not extend TestRule.
+ */
+public interface ExternalResource {
 
-/** A {@link DownloadCacheFactory} for the {@link LolCache}. */
-public final class LolCacheFactory implements DownloadCacheFactory {
+    /** Called before the test execution. */
+    void before() throws Exception;
 
-    @Override
-    public DownloadCache create() throws IOException {
-        final Path tempDirectory = Files.createTempDirectory("flink-lol-cache-");
-        return new LolCache(tempDirectory);
+    /** Called after successful test execution. */
+    void afterTestSuccess();
+
+    /** Called after failed test execution. Defaults to calling {@link #afterTestSuccess()}. */
+    default void afterTestFailure() {
+        afterTestSuccess();
     }
 }

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/activation/OperatingSystemRestriction.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/activation/OperatingSystemRestriction.java
@@ -20,8 +20,8 @@ package org.apache.flink.tests.util.activation;
 
 import org.apache.flink.util.OperatingSystem;
 
-import org.junit.Assume;
-import org.junit.AssumptionViolatedException;
+import org.junit.jupiter.api.Assumptions;
+import org.opentest4j.TestAbortedException;
 
 import java.util.Arrays;
 import java.util.EnumSet;
@@ -39,12 +39,13 @@ public enum OperatingSystemRestriction {
      *
      * @param reason reason for the restriction
      * @param operatingSystems allowed operating systems
-     * @throws AssumptionViolatedException if this method is called on a forbidden operating system
+     * @throws TestAbortedException if this method is called on a forbidden operating system
      */
     public static void restrictTo(final String reason, final OperatingSystem... operatingSystems)
-            throws AssumptionViolatedException {
+            throws TestAbortedException {
         final EnumSet<OperatingSystem> allowed = EnumSet.copyOf(Arrays.asList(operatingSystems));
-        Assume.assumeTrue(reason, allowed.contains(OperatingSystem.getCurrentOperatingSystem()));
+        Assumptions.assumeTrue(
+                allowed.contains(OperatingSystem.getCurrentOperatingSystem()), reason);
     }
 
     /**
@@ -52,13 +53,13 @@ public enum OperatingSystemRestriction {
      *
      * @param reason reason for the restriction
      * @param forbiddenSystems forbidden operating systems
-     * @throws AssumptionViolatedException if this method is called on a forbidden operating system
+     * @throws TestAbortedException if this method is called on a forbidden operating system
      */
     public static void forbid(final String reason, final OperatingSystem... forbiddenSystems)
-            throws AssumptionViolatedException {
+            throws TestAbortedException {
         final OperatingSystem os = OperatingSystem.getCurrentOperatingSystem();
         for (final OperatingSystem forbiddenSystem : forbiddenSystems) {
-            Assume.assumeTrue(reason, os != forbiddenSystem);
+            Assumptions.assumeTrue(os != forbiddenSystem, reason);
         }
     }
 }

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/cache/DownloadCache.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/cache/DownloadCache.java
@@ -18,8 +18,8 @@
 
 package org.apache.flink.tests.util.cache;
 
+import org.apache.flink.tests.util.ExternalResource;
 import org.apache.flink.tests.util.util.FactoryUtils;
-import org.apache.flink.util.ExternalResource;
 
 import java.io.IOException;
 import java.nio.file.Path;

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/cache/LolCache.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/cache/LolCache.java
@@ -18,8 +18,10 @@
 
 package org.apache.flink.tests.util.cache;
 
-import org.junit.rules.TemporaryFolder;
+import org.apache.flink.util.FileUtils;
 
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -31,16 +33,20 @@ import java.util.regex.Pattern;
 public final class LolCache extends AbstractDownloadCache {
 
     private static final Pattern CACHE_FILE_NAME_PATTERN = Pattern.compile(".*");
-    private final TemporaryFolder folder;
+    private final Path tempDirectory;
 
-    public LolCache(TemporaryFolder folder) {
-        super(folder.getRoot().toPath());
-        this.folder = folder;
+    public LolCache(Path tempDirectory) {
+        super(tempDirectory);
+        this.tempDirectory = tempDirectory;
     }
 
     @Override
     public void afterTestSuccess() {
-        folder.delete();
+        try {
+            FileUtils.deleteDirectory(tempDirectory.toFile());
+        } catch (IOException e) {
+            // Ignore cleanup failures
+        }
     }
 
     @Override

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/FlinkResource.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/FlinkResource.java
@@ -19,8 +19,8 @@
 package org.apache.flink.tests.util.flink;
 
 import org.apache.flink.test.util.JobSubmission;
+import org.apache.flink.tests.util.ExternalResource;
 import org.apache.flink.tests.util.util.FactoryUtils;
-import org.apache.flink.util.ExternalResource;
 
 import java.io.IOException;
 import java.time.Duration;

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/test/java/org/apache/flink/tests/util/TestUtilsTest.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/test/java/org/apache/flink/tests/util/TestUtilsTest.java
@@ -21,23 +21,23 @@ import org.apache.flink.tests.util.activation.OperatingSystemRestriction;
 import org.apache.flink.util.OperatingSystem;
 import org.apache.flink.util.TestLogger;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 /** Tests for {@link TestUtils}. */
 public class TestUtilsTest extends TestLogger {
 
-    @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @TempDir Path temporaryFolder;
 
-    @BeforeClass
+    @BeforeAll
     public static void setupClass() {
         OperatingSystemRestriction.forbid(
                 "Symbolic links usually require special permissions on Windows.",
@@ -50,7 +50,7 @@ public class TestUtilsTest extends TestLogger {
             Paths.get("file1"), Paths.get("dir1", "file2"),
         };
 
-        Path source = temporaryFolder.newFolder("source").toPath();
+        Path source = Files.createDirectory(temporaryFolder.resolve("source"));
         for (Path file : files) {
             Files.createDirectories(source.resolve(file).getParent());
             Files.createFile(source.resolve(file));
@@ -63,7 +63,7 @@ public class TestUtilsTest extends TestLogger {
         TestUtils.copyDirectory(symbolicLink, target);
 
         for (Path file : files) {
-            Assert.assertTrue(Files.exists(target.resolve(file)));
+            assertTrue(Files.exists(target.resolve(file)));
         }
     }
 }

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/test/java/org/apache/flink/tests/util/util/FileUtilsTest.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/test/java/org/apache/flink/tests/util/util/FileUtilsTest.java
@@ -20,11 +20,9 @@ package org.apache.flink.tests.util.util;
 import org.apache.flink.test.util.FileUtils;
 import org.apache.flink.util.TestLogger;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -34,18 +32,20 @@ import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 /** Tests for {@link FileUtils}. */
 public class FileUtilsTest extends TestLogger {
 
-    @ClassRule public static final TemporaryFolder TMP = new TemporaryFolder();
+    @TempDir static Path tempDir;
 
     private static final List<String> ORIGINAL_LINES =
             Collections.unmodifiableList(Arrays.asList("line1", "line2", "line3"));
     private Path testFile;
 
-    @Before
+    @BeforeEach
     public void setupFile() throws IOException {
-        Path path = TMP.newFile().toPath();
+        Path path = Files.createTempFile(tempDir, null, null);
 
         Files.write(path, ORIGINAL_LINES);
 
@@ -56,7 +56,7 @@ public class FileUtilsTest extends TestLogger {
     public void replaceSingleMatch() throws IOException {
         FileUtils.replace(testFile, Pattern.compile("line1"), matcher -> "removed");
 
-        Assert.assertEquals(
+        assertEquals(
                 Arrays.asList("removed", ORIGINAL_LINES.get(1), ORIGINAL_LINES.get(2)),
                 Files.readAllLines(testFile));
     }
@@ -65,14 +65,14 @@ public class FileUtilsTest extends TestLogger {
     public void replaceMultipleMatch() throws IOException {
         FileUtils.replace(testFile, Pattern.compile("line(.*)"), matcher -> matcher.group(1));
 
-        Assert.assertEquals(Arrays.asList("1", "2", "3"), Files.readAllLines(testFile));
+        assertEquals(Arrays.asList("1", "2", "3"), Files.readAllLines(testFile));
     }
 
     @Test
     public void replaceWithEmptyLine() throws IOException {
         FileUtils.replace(testFile, Pattern.compile("line2"), matcher -> "");
 
-        Assert.assertEquals(
+        assertEquals(
                 Arrays.asList(ORIGINAL_LINES.get(0), "", ORIGINAL_LINES.get(2)),
                 Files.readAllLines(testFile));
     }

--- a/flink-end-to-end-tests/flink-sql-client-test/pom.xml
+++ b/flink-end-to-end-tests/flink-sql-client-test/pom.xml
@@ -73,7 +73,7 @@ under the License.
 		</dependency>
 		<dependency>
 			<groupId>org.testcontainers</groupId>
-			<artifactId>kafka</artifactId>
+			<artifactId>testcontainers-kafka</artifactId>
 			<scope>test</scope>
 		</dependency>
 

--- a/flink-end-to-end-tests/flink-sql-client-test/src/test/java/SqlClientITCase.java
+++ b/flink-end-to-end-tests/flink-sql-client-test/src/test/java/SqlClientITCase.java
@@ -42,11 +42,11 @@ import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import java.io.File;
@@ -80,7 +80,9 @@ public class SqlClientITCase {
 
     @Container
     public static final KafkaContainer KAFKA =
-            new KafkaContainer(DockerImageName.parse(DockerImageVersions.KAFKA))
+            new KafkaContainer(
+                            DockerImageName.parse(DockerImageVersions.KAFKA)
+                                    .asCompatibleSubstituteFor("apache/kafka"))
                     .withNetwork(NETWORK)
                     .withNetworkAliases(INTER_CONTAINER_KAFKA_ALIAS)
                     .withLogConsumer(LOG_CONSUMER);

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@ under the License.
 		<beam.version>2.54.0</beam.version>
 		<protoc.version>4.32.1</protoc.version>
 		<okhttp.version>3.14.9</okhttp.version>
-		<testcontainers.version>1.20.2</testcontainers.version>
+		<testcontainers.version>2.0.3</testcontainers.version>
 		<lz4.version>1.8.0</lz4.version>
 		<commons.io.version>2.15.1</commons.io.version>
 		<japicmp.skip>false</japicmp.skip>
@@ -293,7 +293,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.testcontainers</groupId>
-			<artifactId>junit-jupiter</artifactId>
+			<artifactId>testcontainers-junit-jupiter</artifactId>
 			<scope>test</scope>
 		</dependency>
 


### PR DESCRIPTION
## What is the purpose of the change

* Update testcontainers to latest version (2.0.3) to avoid Docker API Client compatibility problems

## Brief change log

* Refactored flink-end-to-end-tests-common from JUnit4 to JUnit5. Created local ExternalResource interface to be fully JUnit5-compatible with minimum code changes.
* Updated dependencies and imports

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
