### PR TITLE
[hotfix][metrics] Fix NullArgumentException when calculating checkpoint statistics with empty data

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/DescriptiveStatisticsHistogramStatistics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/DescriptiveStatisticsHistogramStatistics.java
@@ -172,7 +172,7 @@ public class DescriptiveStatisticsHistogramStatistics extends HistogramStatistic
             if (percentilesImpl == null) {
                 percentilesImpl = new Percentile().withNaNStrategy(NaNStrategy.FIXED);
             }
-            if (data != null) {
+            if (data != null && data.length > 0) {
                 percentilesImpl.setData(data);
             } else {
                 percentilesImpl.setData(new double[] {0.0});


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

When a Flink job starts without any checkpoint data, the DescriptiveStatisticsHistogramStatistics
may be initialized with an empty array. The maybeInitPercentile() method only checked for null but not for empty arrays, causing Apache Commons Math's Percentile.evaluate() to throw a NullArgumentException when accessing the checkpoint statistics page in the Web UI.

``` java
org.apache.commons.math3.exception.NullArgumentException: input array
	at org.apache.commons.math3.util.MathArrays.verifyValues(MathArrays.java:1753) ~[commons-math3-3.6.1.jar:3.6.1]
	at org.apache.commons.math3.stat.descriptive.AbstractUnivariateStatistic.test(AbstractUnivariateStatistic.java:158) ~[commons-math3-3.6.1.jar:3.6.1]
	at org.apache.commons.math3.stat.descriptive.rank.Percentile.evaluate(Percentile.java:272) ~[commons-math3-3.6.1.jar:3.6.1]
	at org.apache.commons.math3.stat.descriptive.rank.Percentile.evaluate(Percentile.java:241) ~[commons-math3-3.6.1.jar:3.6.1]
	at org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogramStatistics$CommonMetricsSnapshot.getPercentile(DescriptiveStatisticsHistogramStatistics.java:163) ~[classes/:?]
	at org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogramStatistics.getQuantile(DescriptiveStatisticsHistogramStatistics.java:57) ~[classes/:?]
	at org.apache.flink.runtime.checkpoint.StatsSummarySnapshot.getQuantile(StatsSummarySnapshot.java:108) ~[classes/:?]
	at org.apache.flink.runtime.rest.messages.checkpoints.StatsSummaryDto.valueOf(StatsSummaryDto.java:81) ~[classes/:?]
	at org.apache.flink.runtime.rest.handler.job.checkpoints.CheckpointingStatisticsHandler.createCheckpointingStatistics(CheckpointingStatisticsHandler.java:128) ~[classes/:?]
	at org.apache.flink.runtime.rest.handler.job.checkpoints.CheckpointingStatisticsHandler.handleCheckpointStatsRequest(CheckpointingStatisticsHandler.java:85) ~[classes/:?]
	at org.apache.flink.runtime.rest.handler.job.checkpoints.CheckpointingStatisticsHandler.handleCheckpointStatsRequest(CheckpointingStatisticsHandler.java:59) ~[classes/:?]
	at org.apache.flink.runtime.rest.handler.job.checkpoints.AbstractCheckpointStatsHandler.lambda$handleRequest$1(AbstractCheckpointStatsHandler.java:89) ~[classes/:?]
	at java.util.concurrent.CompletableFuture.uniApply(CompletableFuture.java:616) [?:1.8.0_432]
	at java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:591) [?:1.8.0_432]
	at java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:456) [?:1.8.0_432]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:1.8.0_432]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:1.8.0_432]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180) [?:1.8.0_432]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293) [?:1.8.0_432]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_432]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_432]
	at java.lang.Thread.run(Thread.java:750) [?:1.8.0_432]
```




## Brief change log

This commit adds an additional check for empty arrays in the maybeInitPercentile() method. When the data array is null or empty, it now uses a default array {0.0} to avoid the exception while maintaining reasonable default values for all percentile calculations.


## Verifying this change


This change is already covered by existing tests, such as:
- `DescriptiveStatisticsHistogramTest` - Tests the histogram statistics calculation with various data scenarios
- The existing tests continue to pass with this change, and the fix prevents the `NullArgumentException` in production scenarios

**Manual Verification:**
- Started a Flink cluster with a streaming job that has no checkpoint configured
- Accessed the checkpoint statistics page in Web UI (`http://localhost:8081/#/job/<job-id>/checkpoints`)
- Verified that the page loads successfully without throwing `NullArgumentException`
- After enabling checkpoints and completing some checkpoints, verified that real statistics are calculated correctly


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)

