### PR TITLE
[FLINK-38825] Introduce AsyncBatchFunction and AsyncBatchWaitOperator

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/AsyncBatchFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/AsyncBatchFunction.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.functions.async;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.functions.Function;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * A function to trigger Async I/O operations in batches.
+ *
+ * <p>For each batch of inputs, an async I/O operation can be triggered via {@link
+ * #asyncInvokeBatch}, and once it has been done, the results can be collected by calling {@link
+ * ResultFuture#complete}. This is particularly useful for high-latency inference workloads where
+ * batching can significantly improve throughput.
+ *
+ * <p>Unlike {@link AsyncFunction} which processes one element at a time, this interface allows
+ * processing multiple elements together, which is beneficial for scenarios like:
+ *
+ * <ul>
+ *   <li>Machine learning model inference where batching improves GPU utilization
+ *   <li>External service calls that support batch APIs
+ *   <li>Database queries that can be batched for efficiency
+ * </ul>
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * public class BatchInferenceFunction implements AsyncBatchFunction<String, String> {
+ *
+ *   public void asyncInvokeBatch(List<String> inputs, ResultFuture<String> resultFuture) {
+ *     // Submit batch inference request
+ *     CompletableFuture.supplyAsync(() -> {
+ *         List<String> results = modelService.batchInference(inputs);
+ *         return results;
+ *     }).thenAccept(results -> resultFuture.complete(results));
+ *   }
+ * }
+ * }</pre>
+ *
+ * @param <IN> The type of the input elements.
+ * @param <OUT> The type of the returned elements.
+ */
+@PublicEvolving
+public interface AsyncBatchFunction<IN, OUT> extends Function, Serializable {
+
+    /**
+     * Trigger async operation for a batch of stream inputs.
+     *
+     * <p>The implementation should process all inputs in the batch and complete the result future
+     * with all corresponding outputs. The number of outputs does not need to match the number of
+     * inputs - it depends on the specific use case.
+     *
+     * @param inputs a batch of elements coming from upstream tasks
+     * @param resultFuture to be completed with the result data for the entire batch
+     * @throws Exception in case of a user code error. An exception will make the task fail and
+     *     trigger fail-over process.
+     */
+    void asyncInvokeBatch(List<IN> inputs, ResultFuture<OUT> resultFuture) throws Exception;
+
+    // TODO: Add timeout handling in follow-up PR
+    // TODO: Add open/close lifecycle methods in follow-up PR
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncBatchWaitOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncBatchWaitOperator.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.async;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.operators.MailboxExecutor;
+import org.apache.flink.streaming.api.functions.async.AsyncBatchFunction;
+import org.apache.flink.streaming.api.functions.async.CollectionSupplier;
+import org.apache.flink.streaming.api.functions.async.ResultFuture;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.BoundedOneInput;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nonnull;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * The {@link AsyncBatchWaitOperator} batches incoming stream records and invokes the {@link
+ * AsyncBatchFunction} when the batch size reaches the configured maximum.
+ *
+ * <p>This operator implements unordered semantics only - results are emitted as soon as they are
+ * available, regardless of input order. This is suitable for AI inference workloads where order
+ * does not matter.
+ *
+ * <p>Key behaviors:
+ *
+ * <ul>
+ *   <li>Buffer incoming records until batch size is reached
+ *   <li>Flush remaining records when end of input is signaled
+ *   <li>Emit all results from the batch function to downstream
+ * </ul>
+ *
+ * <p>This is a minimal implementation for the first PR. Future enhancements may include:
+ *
+ * <ul>
+ *   <li>Ordered mode support
+ *   <li>Time-based batching with timers
+ *   <li>Timeout handling
+ *   <li>Retry logic
+ *   <li>Metrics
+ * </ul>
+ *
+ * @param <IN> Input type for the operator.
+ * @param <OUT> Output type for the operator.
+ */
+@Internal
+public class AsyncBatchWaitOperator<IN, OUT> extends AbstractStreamOperator<OUT>
+        implements OneInputStreamOperator<IN, OUT>, BoundedOneInput {
+
+    private static final long serialVersionUID = 1L;
+
+    /** The async batch function to invoke. */
+    private final AsyncBatchFunction<IN, OUT> asyncBatchFunction;
+
+    /** Maximum batch size before triggering async invocation. */
+    private final int maxBatchSize;
+
+    /** Buffer for incoming stream records. */
+    private transient List<IN> buffer;
+
+    /** Mailbox executor for processing async results on the main thread. */
+    private final transient MailboxExecutor mailboxExecutor;
+
+    /** Counter for in-flight async operations. */
+    private transient int inFlightCount;
+
+    public AsyncBatchWaitOperator(
+            @Nonnull StreamOperatorParameters<OUT> parameters,
+            @Nonnull AsyncBatchFunction<IN, OUT> asyncBatchFunction,
+            int maxBatchSize,
+            @Nonnull MailboxExecutor mailboxExecutor) {
+        Preconditions.checkArgument(maxBatchSize > 0, "maxBatchSize must be greater than 0");
+        this.asyncBatchFunction = Preconditions.checkNotNull(asyncBatchFunction);
+        this.maxBatchSize = maxBatchSize;
+        this.mailboxExecutor = Preconditions.checkNotNull(mailboxExecutor);
+
+        // Setup the operator using parameters
+        setup(parameters.getContainingTask(), parameters.getStreamConfig(), parameters.getOutput());
+    }
+
+    @Override
+    public void open() throws Exception {
+        super.open();
+        this.buffer = new ArrayList<>(maxBatchSize);
+        this.inFlightCount = 0;
+    }
+
+    @Override
+    public void processElement(StreamRecord<IN> element) throws Exception {
+        buffer.add(element.getValue());
+
+        if (buffer.size() >= maxBatchSize) {
+            flushBuffer();
+        }
+    }
+
+    /** Flush the current buffer by invoking the async batch function. */
+    private void flushBuffer() throws Exception {
+        if (buffer.isEmpty()) {
+            return;
+        }
+
+        // Create a copy of the buffer and clear it for new incoming elements
+        List<IN> batch = new ArrayList<>(buffer);
+        buffer.clear();
+
+        // Increment in-flight counter
+        inFlightCount++;
+
+        // Create result handler for this batch
+        BatchResultHandler resultHandler = new BatchResultHandler();
+
+        // Invoke the async batch function
+        asyncBatchFunction.asyncInvokeBatch(batch, resultHandler);
+    }
+
+    @Override
+    public void endInput() throws Exception {
+        // Flush any remaining elements in the buffer
+        flushBuffer();
+
+        // Wait for all in-flight async operations to complete
+        while (inFlightCount > 0) {
+            mailboxExecutor.yield();
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        super.close();
+    }
+
+    /** Returns the current buffer size. Visible for testing. */
+    int getBufferSize() {
+        return buffer != null ? buffer.size() : 0;
+    }
+
+    /** A handler for the results of a batch async invocation. */
+    private class BatchResultHandler implements ResultFuture<OUT> {
+
+        /** Guard against multiple completions. */
+        private final AtomicBoolean completed = new AtomicBoolean(false);
+
+        @Override
+        public void complete(Collection<OUT> results) {
+            Preconditions.checkNotNull(
+                    results, "Results must not be null, use empty collection to emit nothing");
+
+            if (!completed.compareAndSet(false, true)) {
+                return;
+            }
+
+            // Process results in the mailbox thread
+            mailboxExecutor.execute(
+                    () -> processResults(results), "AsyncBatchWaitOperator#processResults");
+        }
+
+        @Override
+        public void completeExceptionally(Throwable error) {
+            if (!completed.compareAndSet(false, true)) {
+                return;
+            }
+
+            // Signal failure through the containing task
+            getContainingTask()
+                    .getEnvironment()
+                    .failExternally(new Exception("Async batch operation failed.", error));
+
+            // Decrement in-flight counter in mailbox thread
+            mailboxExecutor.execute(
+                    () -> inFlightCount--, "AsyncBatchWaitOperator#decrementInFlight");
+        }
+
+        @Override
+        public void complete(CollectionSupplier<OUT> supplier) {
+            Preconditions.checkNotNull(
+                    supplier, "Supplier must not be null, return empty collection to emit nothing");
+
+            if (!completed.compareAndSet(false, true)) {
+                return;
+            }
+
+            mailboxExecutor.execute(
+                    () -> {
+                        try {
+                            processResults(supplier.get());
+                        } catch (Throwable t) {
+                            getContainingTask()
+                                    .getEnvironment()
+                                    .failExternally(
+                                            new Exception("Async batch operation failed.", t));
+                            inFlightCount--;
+                        }
+                    },
+                    "AsyncBatchWaitOperator#processResultsFromSupplier");
+        }
+
+        private void processResults(Collection<OUT> results) {
+            // Emit all results downstream
+            for (OUT result : results) {
+                output.collect(new StreamRecord<>(result));
+            }
+            // Decrement in-flight counter
+            inFlightCount--;
+        }
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncBatchWaitOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncBatchWaitOperatorFactory.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.async;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.streaming.api.functions.async.AsyncBatchFunction;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+import org.apache.flink.streaming.api.operators.legacy.YieldingOperatorFactory;
+
+/**
+ * The factory of {@link AsyncBatchWaitOperator}.
+ *
+ * @param <IN> The input type of the operator
+ * @param <OUT> The output type of the operator
+ */
+@Internal
+public class AsyncBatchWaitOperatorFactory<IN, OUT> extends AbstractStreamOperatorFactory<OUT>
+        implements OneInputStreamOperatorFactory<IN, OUT>, YieldingOperatorFactory<OUT> {
+
+    private static final long serialVersionUID = 1L;
+
+    private final AsyncBatchFunction<IN, OUT> asyncBatchFunction;
+    private final int maxBatchSize;
+
+    public AsyncBatchWaitOperatorFactory(
+            AsyncBatchFunction<IN, OUT> asyncBatchFunction, int maxBatchSize) {
+        this.asyncBatchFunction = asyncBatchFunction;
+        this.maxBatchSize = maxBatchSize;
+        this.chainingStrategy = ChainingStrategy.ALWAYS;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T extends StreamOperator<OUT>> T createStreamOperator(
+            StreamOperatorParameters<OUT> parameters) {
+        AsyncBatchWaitOperator<IN, OUT> operator =
+                new AsyncBatchWaitOperator<>(
+                        parameters, asyncBatchFunction, maxBatchSize, getMailboxExecutor());
+        return (T) operator;
+    }
+
+    @Override
+    public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
+        return AsyncBatchWaitOperator.class;
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncBatchWaitOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncBatchWaitOperatorTest.java
@@ -1,0 +1,306 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.async;
+
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.runtime.operators.testutils.ExpectedTestException;
+import org.apache.flink.streaming.api.functions.async.AsyncBatchFunction;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link AsyncBatchWaitOperator}.
+ *
+ * <p>These tests verify:
+ *
+ * <ul>
+ *   <li>Batch size trigger - elements are batched correctly
+ *   <li>Correct result emission - all outputs are emitted downstream
+ *   <li>Exception propagation - errors fail the operator
+ * </ul>
+ */
+@Timeout(value = 100, unit = TimeUnit.SECONDS)
+class AsyncBatchWaitOperatorTest {
+
+    /**
+     * Test that the operator correctly batches elements based on maxBatchSize.
+     *
+     * <p>Input: 5 records with maxBatchSize = 3
+     *
+     * <p>Expected: 2 batch invocations with sizes [3, 2]
+     */
+    @Test
+    void testBatchSizeTrigger() throws Exception {
+        final int maxBatchSize = 3;
+        final List<Integer> batchSizes = new CopyOnWriteArrayList<>();
+
+        AsyncBatchFunction<Integer, Integer> function =
+                (inputs, resultFuture) -> {
+                    batchSizes.add(inputs.size());
+                    // Return input * 2 for each element
+                    List<Integer> results =
+                            inputs.stream().map(i -> i * 2).collect(Collectors.toList());
+                    resultFuture.complete(results);
+                };
+
+        try (OneInputStreamOperatorTestHarness<Integer, Integer> testHarness =
+                createTestHarness(function, maxBatchSize)) {
+
+            testHarness.open();
+
+            // Process 5 elements
+            testHarness.processElement(new StreamRecord<>(1, 1L));
+            testHarness.processElement(new StreamRecord<>(2, 2L));
+            testHarness.processElement(new StreamRecord<>(3, 3L));
+            // First batch of 3 should be triggered here
+
+            testHarness.processElement(new StreamRecord<>(4, 4L));
+            testHarness.processElement(new StreamRecord<>(5, 5L));
+            // Remaining 2 elements in buffer
+
+            testHarness.endInput();
+            // Second batch of 2 should be triggered on endInput
+
+            // Verify batch sizes
+            assertThat(batchSizes).containsExactly(3, 2);
+        }
+    }
+
+    /** Test that all results from the batch function are correctly emitted downstream. */
+    @Test
+    void testCorrectResultEmission() throws Exception {
+        final int maxBatchSize = 3;
+
+        // Function that doubles each input
+        AsyncBatchFunction<Integer, Integer> function =
+                (inputs, resultFuture) -> {
+                    List<Integer> results =
+                            inputs.stream().map(i -> i * 2).collect(Collectors.toList());
+                    resultFuture.complete(results);
+                };
+
+        try (OneInputStreamOperatorTestHarness<Integer, Integer> testHarness =
+                createTestHarness(function, maxBatchSize)) {
+
+            testHarness.open();
+
+            // Process 5 elements: 1, 2, 3, 4, 5
+            for (int i = 1; i <= 5; i++) {
+                testHarness.processElement(new StreamRecord<>(i, i));
+            }
+
+            testHarness.endInput();
+
+            // Verify outputs: should be 2, 4, 6, 8, 10
+            List<Integer> outputs =
+                    testHarness.getOutput().stream()
+                            .filter(e -> e instanceof StreamRecord)
+                            .map(e -> ((StreamRecord<Integer>) e).getValue())
+                            .collect(Collectors.toList());
+
+            assertThat(outputs).containsExactlyInAnyOrder(2, 4, 6, 8, 10);
+        }
+    }
+
+    /** Test that exceptions from the batch function are properly propagated. */
+    @Test
+    void testExceptionPropagation() throws Exception {
+        final int maxBatchSize = 2;
+
+        AsyncBatchFunction<Integer, Integer> function =
+                (inputs, resultFuture) -> {
+                    resultFuture.completeExceptionally(new ExpectedTestException());
+                };
+
+        try (OneInputStreamOperatorTestHarness<Integer, Integer> testHarness =
+                createTestHarness(function, maxBatchSize)) {
+
+            testHarness.getEnvironment().setExpectedExternalFailureCause(Throwable.class);
+            testHarness.open();
+
+            // Process 2 elements to trigger a batch
+            testHarness.processElement(new StreamRecord<>(1, 1L));
+            testHarness.processElement(new StreamRecord<>(2, 2L));
+
+            // The exception should be propagated - we need to yield to process the async result
+            // In the test harness, the exception is recorded in the environment
+            testHarness.endInput();
+
+            // Verify that the task environment received the exception
+            assertThat(testHarness.getEnvironment().getActualExternalFailureCause())
+                    .isPresent()
+                    .get()
+                    .satisfies(
+                            t ->
+                                    assertThat(t.getCause())
+                                            .isInstanceOf(ExpectedTestException.class));
+        }
+    }
+
+    /** Test async completion using CompletableFuture. */
+    @Test
+    void testAsyncCompletion() throws Exception {
+        final int maxBatchSize = 2;
+        final AtomicInteger invocationCount = new AtomicInteger(0);
+
+        AsyncBatchFunction<Integer, Integer> function =
+                (inputs, resultFuture) -> {
+                    invocationCount.incrementAndGet();
+                    // Simulate async processing
+                    CompletableFuture.supplyAsync(
+                                    () ->
+                                            inputs.stream()
+                                                    .map(i -> i * 3)
+                                                    .collect(Collectors.toList()))
+                            .thenAccept(resultFuture::complete);
+                };
+
+        try (OneInputStreamOperatorTestHarness<Integer, Integer> testHarness =
+                createTestHarness(function, maxBatchSize)) {
+
+            testHarness.open();
+
+            // Process 4 elements: should trigger 2 batches
+            for (int i = 1; i <= 4; i++) {
+                testHarness.processElement(new StreamRecord<>(i, i));
+            }
+
+            testHarness.endInput();
+
+            // Verify invocation count
+            assertThat(invocationCount.get()).isEqualTo(2);
+
+            // Verify outputs: should be 3, 6, 9, 12
+            List<Integer> outputs =
+                    testHarness.getOutput().stream()
+                            .filter(e -> e instanceof StreamRecord)
+                            .map(e -> ((StreamRecord<Integer>) e).getValue())
+                            .collect(Collectors.toList());
+
+            assertThat(outputs).containsExactlyInAnyOrder(3, 6, 9, 12);
+        }
+    }
+
+    /** Test that empty batches are not triggered. */
+    @Test
+    void testEmptyInput() throws Exception {
+        final int maxBatchSize = 3;
+        final AtomicInteger invocationCount = new AtomicInteger(0);
+
+        AsyncBatchFunction<Integer, Integer> function =
+                (inputs, resultFuture) -> {
+                    invocationCount.incrementAndGet();
+                    resultFuture.complete(Collections.emptyList());
+                };
+
+        try (OneInputStreamOperatorTestHarness<Integer, Integer> testHarness =
+                createTestHarness(function, maxBatchSize)) {
+
+            testHarness.open();
+            testHarness.endInput();
+
+            // No invocations should happen for empty input
+            assertThat(invocationCount.get()).isEqualTo(0);
+            assertThat(testHarness.getOutput()).isEmpty();
+        }
+    }
+
+    /** Test that batch function can return fewer or more outputs than inputs. */
+    @Test
+    void testVariableOutputSize() throws Exception {
+        final int maxBatchSize = 3;
+
+        // Function that returns only one output per batch (aggregation-style)
+        AsyncBatchFunction<Integer, Integer> function =
+                (inputs, resultFuture) -> {
+                    int sum = inputs.stream().mapToInt(Integer::intValue).sum();
+                    resultFuture.complete(Collections.singletonList(sum));
+                };
+
+        try (OneInputStreamOperatorTestHarness<Integer, Integer> testHarness =
+                createTestHarness(function, maxBatchSize)) {
+
+            testHarness.open();
+
+            // Process 5 elements: 1, 2, 3, 4, 5
+            for (int i = 1; i <= 5; i++) {
+                testHarness.processElement(new StreamRecord<>(i, i));
+            }
+
+            testHarness.endInput();
+
+            // First batch: 1+2+3 = 6, Second batch: 4+5 = 9
+            List<Integer> outputs =
+                    testHarness.getOutput().stream()
+                            .filter(e -> e instanceof StreamRecord)
+                            .map(e -> ((StreamRecord<Integer>) e).getValue())
+                            .collect(Collectors.toList());
+
+            assertThat(outputs).containsExactlyInAnyOrder(6, 9);
+        }
+    }
+
+    /** Test single element batch (maxBatchSize = 1). */
+    @Test
+    void testSingleElementBatch() throws Exception {
+        final int maxBatchSize = 1;
+        final List<Integer> batchSizes = new CopyOnWriteArrayList<>();
+
+        AsyncBatchFunction<Integer, Integer> function =
+                (inputs, resultFuture) -> {
+                    batchSizes.add(inputs.size());
+                    resultFuture.complete(inputs);
+                };
+
+        try (OneInputStreamOperatorTestHarness<Integer, Integer> testHarness =
+                createTestHarness(function, maxBatchSize)) {
+
+            testHarness.open();
+
+            testHarness.processElement(new StreamRecord<>(1, 1L));
+            testHarness.processElement(new StreamRecord<>(2, 2L));
+            testHarness.processElement(new StreamRecord<>(3, 3L));
+
+            testHarness.endInput();
+
+            // Each element should trigger its own batch
+            assertThat(batchSizes).containsExactly(1, 1, 1);
+        }
+    }
+
+    private static OneInputStreamOperatorTestHarness<Integer, Integer> createTestHarness(
+            AsyncBatchFunction<Integer, Integer> function, int maxBatchSize) throws Exception {
+        return new OneInputStreamOperatorTestHarness<>(
+                new AsyncBatchWaitOperatorFactory<>(function, maxBatchSize),
+                IntSerializer.INSTANCE);
+    }
+}


### PR DESCRIPTION
### Motivation

Flink’s existing `AsyncFunction` processes records one-by-one, which is not optimal for **high-latency inference workloads** such as machine learning model serving, where **batching requests** can significantly improve throughput and resource utilization (e.g. GPU/remote inference services).

Currently, users have to implement batching logic outside of Flink or embed complex buffering logic inside a single-record `AsyncFunction`, which is error-prone and hard to evolve.

This PR introduces a **minimal, batch-oriented async abstraction** as a foundation for future AI / inference-related extensions.

---

### What is proposed in this PR

This PR adds a **small, additive, and backward-compatible** set of building blocks:

1. **`AsyncBatchFunction` (PublicEvolving API)**  
   A new async function interface that allows processing a *batch of input elements* in a single async invocation.

2. **`AsyncBatchWaitOperator` (runtime operator)**  
   A minimal unordered async batch operator that:
   - Buffers incoming records
   - Triggers async invocation when `maxBatchSize` is reached
   - Emits results as soon as the async call completes
   - Flushes remaining elements on end-of-input

3. **Stream API entry point**  
   A new `AsyncDataStream.unorderedWaitBatch(...)` method to wire the operator in the DataStream API.

4. **Unit tests**  
   Tests validating batch triggering, result emission, and exception propagation.

---

### Scope and intentional limitations

This PR is intentionally **minimal** and does **not** include:

- Ordered output mode
- Time-based batching or timers
- Retry / timeout handling
- Metrics
- SQL / Table API integration
- Python integration
- Any changes to existing `AsyncFunction` or `AsyncWaitOperator`

These aspects are expected to be explored incrementally in follow-up PRs once the core abstraction is agreed upon.

---

### Why this approach

- Keeps the initial API surface small and reviewable
- Avoids coupling with existing async internals
- Makes future extensions (timers, retries, Python, SQL) explicit and incremental
- Aligns with Flink’s philosophy of evolving APIs through small, focused changes

---

### Follow-up work (out of scope for this PR)

Potential next steps include:
- Ordered batch async operator
- Time-based batch triggering
- Async retry and timeout strategies
- Metrics and backpressure awareness
- Python / ML inference integrations
- SQL/Table API exposure

---

### Compatibility

- Fully backward-compatible
- Purely additive changes
- No behavior changes to existing async operators

---

## PR Series for FLINK-38825

JIRA: [FLINK-38825](https://issues.apache.org/jira/browse/FLINK-38825) - Introduce an AI-friendly Async Batch Operator for high-latency inference workloads

This feature is implemented incrementally through the following PR series:

| # | PR | Title | Description | Module |
|---|---|---|---|---|
| **1** | [#27355](https://github.com/apache/flink/pull/27355) | Introduce AsyncBatchFunction and AsyncBatchWaitOperator | Core API and runtime operator with unordered semantics and size-based batch triggering | **`flink-streaming-java`** |
| 2 | [#27356](https://github.com/apache/flink/pull/27356) | Add time-based batch triggering | Timeout-based flush to trigger incomplete batches after a configurable duration | `flink-streaming-java` |
| 3 | [#27357](https://github.com/apache/flink/pull/27357) | Add ordered async batch support | Ordered output semantics via OrderedAsyncBatchWaitOperator with sequence numbers | `flink-streaming-java` |
| 4 | [#27358](https://github.com/apache/flink/pull/27358) | Add inference-oriented metrics | Batch size/latency histograms, async call duration, inflight batches, failure counters | `flink-streaming-java` |
| 5 | [#27359](https://github.com/apache/flink/pull/27359) | Implement retry and timeout strategies | Fixed-delay/exponential-backoff retry, fail-on-timeout/allow-partial timeout policies | `flink-streaming-java` |
| 6 | [#27360](https://github.com/apache/flink/pull/27360) | Add SQL/Table API integration | AsyncBatchLookupFunction, AsyncBatchLookupFunctionProvider, lookup join runner | `flink-table` |
| 7 | [#27361](https://github.com/apache/flink/pull/27361) | Add Python DataStream API integration | Python AsyncBatchFunction, async_invoke_batch() API, AsyncDataStream batch methods | `flink-python` |

> **Note**: Each PR builds incrementally on the previous ones. PRs should be reviewed and merged in order.
