### PR TITLE
[FLINK-38825][streaming] Add ordered async batch support for AsyncBatchWaitOperator

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/AsyncDataStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/AsyncDataStream.java
@@ -26,9 +26,11 @@ import org.apache.flink.streaming.api.functions.async.AsyncRetryStrategy;
 import org.apache.flink.streaming.api.operators.async.AsyncBatchWaitOperatorFactory;
 import org.apache.flink.streaming.api.operators.async.AsyncWaitOperator;
 import org.apache.flink.streaming.api.operators.async.AsyncWaitOperatorFactory;
+import org.apache.flink.streaming.api.operators.async.OrderedAsyncBatchWaitOperatorFactory;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.Utils;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.streaming.util.retryable.AsyncRetryStrategies.NO_RETRY_STRATEGY;
@@ -399,6 +401,81 @@ public class AsyncDataStream {
         return in.transform("async batch wait operator", outTypeInfo, operatorFactory);
     }
 
-    // TODO: Add orderedWaitBatch in follow-up PR
+    /**
+     * Adds an AsyncBatchWaitOperator to process elements in batches with ordered output. The order
+     * of output stream records is guaranteed to be the same as input order.
+     *
+     * <p>This method is particularly useful for high-latency inference workloads where batching can
+     * significantly improve throughput while maintaining ordering guarantees, such as machine
+     * learning model inference with order-sensitive downstream processing.
+     *
+     * <p>The operator buffers incoming elements and triggers the async batch function when either:
+     *
+     * <ul>
+     *   <li>The buffer reaches {@code maxBatchSize}
+     *   <li>The {@code maxWaitTime} has elapsed since the first buffered element
+     * </ul>
+     *
+     * <p>Results are buffered and emitted in the original input order, regardless of async
+     * completion order.
+     *
+     * @param in Input {@link DataStream}
+     * @param func {@link AsyncBatchFunction} to process batches of elements
+     * @param maxBatchSize Maximum number of elements to batch before triggering async invocation
+     * @param maxWaitTime Maximum duration to wait before flushing a partial batch; Duration.ZERO or
+     *     negative means timeout is disabled
+     * @param <IN> Type of input record
+     * @param <OUT> Type of output record
+     * @return A new {@link SingleOutputStreamOperator}
+     */
+    public static <IN, OUT> SingleOutputStreamOperator<OUT> orderedWaitBatch(
+            DataStream<IN> in,
+            AsyncBatchFunction<IN, OUT> func,
+            int maxBatchSize,
+            Duration maxWaitTime) {
+        Preconditions.checkArgument(maxBatchSize > 0, "maxBatchSize must be greater than 0");
+        Preconditions.checkNotNull(maxWaitTime, "maxWaitTime must not be null");
+
+        long batchTimeoutMs = maxWaitTime.toMillis();
+
+        TypeInformation<OUT> outTypeInfo =
+                TypeExtractor.getUnaryOperatorReturnType(
+                        func,
+                        AsyncBatchFunction.class,
+                        0,
+                        1,
+                        new int[] {1, 0},
+                        in.getType(),
+                        Utils.getCallLocationName(),
+                        true);
+
+        // create transform
+        OrderedAsyncBatchWaitOperatorFactory<IN, OUT> operatorFactory =
+                new OrderedAsyncBatchWaitOperatorFactory<>(
+                        in.getExecutionEnvironment().clean(func), maxBatchSize, batchTimeoutMs);
+
+        return in.transform("ordered async batch wait operator", outTypeInfo, operatorFactory);
+    }
+
+    /**
+     * Adds an AsyncBatchWaitOperator to process elements in batches with ordered output. The order
+     * of output stream records is guaranteed to be the same as input order.
+     *
+     * <p>This overload disables timeout-based batching. Batches are only flushed when the buffer
+     * reaches {@code maxBatchSize} or when the input ends.
+     *
+     * @param in Input {@link DataStream}
+     * @param func {@link AsyncBatchFunction} to process batches of elements
+     * @param maxBatchSize Maximum number of elements to batch before triggering async invocation
+     * @param <IN> Type of input record
+     * @param <OUT> Type of output record
+     * @return A new {@link SingleOutputStreamOperator}
+     */
+    public static <IN, OUT> SingleOutputStreamOperator<OUT> orderedWaitBatch(
+            DataStream<IN> in, AsyncBatchFunction<IN, OUT> func, int maxBatchSize) {
+        return orderedWaitBatch(in, func, maxBatchSize, Duration.ZERO);
+    }
+
     // TODO: Add event-time based batching support in follow-up PR
+    // TODO: Add retry strategies for batch operations in follow-up PR
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/AsyncDataStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/AsyncDataStream.java
@@ -347,7 +347,7 @@ public class AsyncDataStream {
      */
     public static <IN, OUT> SingleOutputStreamOperator<OUT> unorderedWaitBatch(
             DataStream<IN> in, AsyncBatchFunction<IN, OUT> func, int maxBatchSize) {
-        return unorderedWaitBatch(in, func, maxBatchSize, 0L);
+        return unorderedWaitBatch(in, func, maxBatchSize, 0L, TimeUnit.MILLISECONDS);
     }
 
     /**
@@ -370,7 +370,8 @@ public class AsyncDataStream {
      * @param in Input {@link DataStream}
      * @param func {@link AsyncBatchFunction} to process batches of elements
      * @param maxBatchSize Maximum number of elements to batch before triggering async invocation
-     * @param batchTimeoutMs Batch timeout in milliseconds; <= 0 means timeout is disabled
+     * @param timeout Batch timeout duration; <= 0 means timeout is disabled
+     * @param timeUnit The time unit of the timeout argument
      * @param <IN> Type of input record
      * @param <OUT> Type of output record
      * @return A new {@link SingleOutputStreamOperator}
@@ -379,7 +380,8 @@ public class AsyncDataStream {
             DataStream<IN> in,
             AsyncBatchFunction<IN, OUT> func,
             int maxBatchSize,
-            long batchTimeoutMs) {
+            long timeout,
+            TimeUnit timeUnit) {
         Preconditions.checkArgument(maxBatchSize > 0, "maxBatchSize must be greater than 0");
 
         TypeInformation<OUT> outTypeInfo =
@@ -396,7 +398,9 @@ public class AsyncDataStream {
         // create transform
         AsyncBatchWaitOperatorFactory<IN, OUT> operatorFactory =
                 new AsyncBatchWaitOperatorFactory<>(
-                        in.getExecutionEnvironment().clean(func), maxBatchSize, batchTimeoutMs);
+                        in.getExecutionEnvironment().clean(func),
+                        maxBatchSize,
+                        timeUnit.toMillis(timeout));
 
         return in.transform("async batch wait operator", outTypeInfo, operatorFactory);
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/AsyncBatchFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/AsyncBatchFunction.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.functions.async;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.functions.Function;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * A function to trigger Async I/O operations in batches.
+ *
+ * <p>For each batch of inputs, an async I/O operation can be triggered via {@link
+ * #asyncInvokeBatch}, and once it has been done, the results can be collected by calling {@link
+ * ResultFuture#complete}. This is particularly useful for high-latency inference workloads where
+ * batching can significantly improve throughput.
+ *
+ * <p>Unlike {@link AsyncFunction} which processes one element at a time, this interface allows
+ * processing multiple elements together, which is beneficial for scenarios like:
+ *
+ * <ul>
+ *   <li>Machine learning model inference where batching improves GPU utilization
+ *   <li>External service calls that support batch APIs
+ *   <li>Database queries that can be batched for efficiency
+ * </ul>
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * public class BatchInferenceFunction implements AsyncBatchFunction<String, String> {
+ *
+ *   public void asyncInvokeBatch(List<String> inputs, ResultFuture<String> resultFuture) {
+ *     // Submit batch inference request
+ *     CompletableFuture.supplyAsync(() -> {
+ *         List<String> results = modelService.batchInference(inputs);
+ *         return results;
+ *     }).thenAccept(results -> resultFuture.complete(results));
+ *   }
+ * }
+ * }</pre>
+ *
+ * @param <IN> The type of the input elements.
+ * @param <OUT> The type of the returned elements.
+ */
+@PublicEvolving
+public interface AsyncBatchFunction<IN, OUT> extends Function, Serializable {
+
+    /**
+     * Trigger async operation for a batch of stream inputs.
+     *
+     * <p>The implementation should process all inputs in the batch and complete the result future
+     * with all corresponding outputs. The number of outputs does not need to match the number of
+     * inputs - it depends on the specific use case.
+     *
+     * @param inputs a batch of elements coming from upstream tasks
+     * @param resultFuture to be completed with the result data for the entire batch
+     * @throws Exception in case of a user code error. An exception will make the task fail and
+     *     trigger fail-over process.
+     */
+    void asyncInvokeBatch(List<IN> inputs, ResultFuture<OUT> resultFuture) throws Exception;
+
+    // TODO: Add timeout handling in follow-up PR
+    // TODO: Add open/close lifecycle methods in follow-up PR
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncBatchWaitOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncBatchWaitOperator.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.async;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.operators.MailboxExecutor;
+import org.apache.flink.streaming.api.functions.async.AsyncBatchFunction;
+import org.apache.flink.streaming.api.functions.async.CollectionSupplier;
+import org.apache.flink.streaming.api.functions.async.ResultFuture;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.BoundedOneInput;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nonnull;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * The {@link AsyncBatchWaitOperator} batches incoming stream records and invokes the {@link
+ * AsyncBatchFunction} when the batch size reaches the configured maximum.
+ *
+ * <p>This operator implements unordered semantics only - results are emitted as soon as they are
+ * available, regardless of input order. This is suitable for AI inference workloads where order
+ * does not matter.
+ *
+ * <p>Key behaviors:
+ *
+ * <ul>
+ *   <li>Buffer incoming records until batch size is reached
+ *   <li>Flush remaining records when end of input is signaled
+ *   <li>Emit all results from the batch function to downstream
+ * </ul>
+ *
+ * <p>This is a minimal implementation for the first PR. Future enhancements may include:
+ *
+ * <ul>
+ *   <li>Ordered mode support
+ *   <li>Time-based batching with timers
+ *   <li>Timeout handling
+ *   <li>Retry logic
+ *   <li>Metrics
+ * </ul>
+ *
+ * @param <IN> Input type for the operator.
+ * @param <OUT> Output type for the operator.
+ */
+@Internal
+public class AsyncBatchWaitOperator<IN, OUT> extends AbstractStreamOperator<OUT>
+        implements OneInputStreamOperator<IN, OUT>, BoundedOneInput {
+
+    private static final long serialVersionUID = 1L;
+
+    /** The async batch function to invoke. */
+    private final AsyncBatchFunction<IN, OUT> asyncBatchFunction;
+
+    /** Maximum batch size before triggering async invocation. */
+    private final int maxBatchSize;
+
+    /** Buffer for incoming stream records. */
+    private transient List<IN> buffer;
+
+    /** Mailbox executor for processing async results on the main thread. */
+    private final transient MailboxExecutor mailboxExecutor;
+
+    /** Counter for in-flight async operations. */
+    private transient int inFlightCount;
+
+    public AsyncBatchWaitOperator(
+            @Nonnull StreamOperatorParameters<OUT> parameters,
+            @Nonnull AsyncBatchFunction<IN, OUT> asyncBatchFunction,
+            int maxBatchSize,
+            @Nonnull MailboxExecutor mailboxExecutor) {
+        Preconditions.checkArgument(maxBatchSize > 0, "maxBatchSize must be greater than 0");
+        this.asyncBatchFunction = Preconditions.checkNotNull(asyncBatchFunction);
+        this.maxBatchSize = maxBatchSize;
+        this.mailboxExecutor = Preconditions.checkNotNull(mailboxExecutor);
+
+        // Setup the operator using parameters
+        setup(parameters.getContainingTask(), parameters.getStreamConfig(), parameters.getOutput());
+    }
+
+    @Override
+    public void open() throws Exception {
+        super.open();
+        this.buffer = new ArrayList<>(maxBatchSize);
+        this.inFlightCount = 0;
+    }
+
+    @Override
+    public void processElement(StreamRecord<IN> element) throws Exception {
+        buffer.add(element.getValue());
+
+        if (buffer.size() >= maxBatchSize) {
+            flushBuffer();
+        }
+    }
+
+    /** Flush the current buffer by invoking the async batch function. */
+    private void flushBuffer() throws Exception {
+        if (buffer.isEmpty()) {
+            return;
+        }
+
+        // Create a copy of the buffer and clear it for new incoming elements
+        List<IN> batch = new ArrayList<>(buffer);
+        buffer.clear();
+
+        // Increment in-flight counter
+        inFlightCount++;
+
+        // Create result handler for this batch
+        BatchResultHandler resultHandler = new BatchResultHandler();
+
+        // Invoke the async batch function
+        asyncBatchFunction.asyncInvokeBatch(batch, resultHandler);
+    }
+
+    @Override
+    public void endInput() throws Exception {
+        // Flush any remaining elements in the buffer
+        flushBuffer();
+
+        // Wait for all in-flight async operations to complete
+        while (inFlightCount > 0) {
+            mailboxExecutor.yield();
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        super.close();
+    }
+
+    /** Returns the current buffer size. Visible for testing. */
+    int getBufferSize() {
+        return buffer != null ? buffer.size() : 0;
+    }
+
+    /** A handler for the results of a batch async invocation. */
+    private class BatchResultHandler implements ResultFuture<OUT> {
+
+        /** Guard against multiple completions. */
+        private final AtomicBoolean completed = new AtomicBoolean(false);
+
+        @Override
+        public void complete(Collection<OUT> results) {
+            Preconditions.checkNotNull(
+                    results, "Results must not be null, use empty collection to emit nothing");
+
+            if (!completed.compareAndSet(false, true)) {
+                return;
+            }
+
+            // Process results in the mailbox thread
+            mailboxExecutor.execute(
+                    () -> processResults(results), "AsyncBatchWaitOperator#processResults");
+        }
+
+        @Override
+        public void completeExceptionally(Throwable error) {
+            if (!completed.compareAndSet(false, true)) {
+                return;
+            }
+
+            // Signal failure through the containing task
+            getContainingTask()
+                    .getEnvironment()
+                    .failExternally(new Exception("Async batch operation failed.", error));
+
+            // Decrement in-flight counter in mailbox thread
+            mailboxExecutor.execute(
+                    () -> inFlightCount--, "AsyncBatchWaitOperator#decrementInFlight");
+        }
+
+        @Override
+        public void complete(CollectionSupplier<OUT> supplier) {
+            Preconditions.checkNotNull(
+                    supplier, "Supplier must not be null, return empty collection to emit nothing");
+
+            if (!completed.compareAndSet(false, true)) {
+                return;
+            }
+
+            mailboxExecutor.execute(
+                    () -> {
+                        try {
+                            processResults(supplier.get());
+                        } catch (Throwable t) {
+                            getContainingTask()
+                                    .getEnvironment()
+                                    .failExternally(
+                                            new Exception("Async batch operation failed.", t));
+                            inFlightCount--;
+                        }
+                    },
+                    "AsyncBatchWaitOperator#processResultsFromSupplier");
+        }
+
+        private void processResults(Collection<OUT> results) {
+            // Emit all results downstream
+            for (OUT result : results) {
+                output.collect(new StreamRecord<>(result));
+            }
+            // Decrement in-flight counter
+            inFlightCount--;
+        }
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncBatchWaitOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncBatchWaitOperator.java
@@ -67,7 +67,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * <p>Future enhancements may include:
  *
  * <ul>
- *   <li>Ordered mode support
  *   <li>Event-time based batching
  *   <li>Multiple inflight batches
  *   <li>Retry logic
@@ -84,32 +83,28 @@ public class AsyncBatchWaitOperator<IN, OUT> extends AbstractStreamOperator<OUT>
     private static final long serialVersionUID = 1L;
 
     /** Constant indicating timeout is disabled. */
-    private static final long NO_TIMEOUT = 0L;
+    protected static final long NO_TIMEOUT = 0L;
 
     /** The async batch function to invoke. */
-    private final AsyncBatchFunction<IN, OUT> asyncBatchFunction;
+    protected final AsyncBatchFunction<IN, OUT> asyncBatchFunction;
 
     /** Maximum batch size before triggering async invocation. */
-    private final int maxBatchSize;
+    protected final int maxBatchSize;
 
     /**
      * Batch timeout in milliseconds. When positive, a timer is registered to flush the batch after
      * this duration since the first buffered element. A value <= 0 disables timeout-based batching.
      */
-    private final long batchTimeoutMs;
+    protected final long batchTimeoutMs;
 
     /** Buffer for incoming stream records. */
-    private transient List<IN> buffer;
+    protected transient List<IN> buffer;
 
     /** Mailbox executor for processing async results on the main thread. */
-    private final transient MailboxExecutor mailboxExecutor;
+    protected final transient MailboxExecutor mailboxExecutor;
 
     /** Counter for in-flight async operations. */
-    private transient int inFlightCount;
-
-    // ================================================================================
-    //  Timer state fields for timeout-based batching
-    // ================================================================================
+    protected transient int inFlightCount;
 
     /**
      * The processing time when the current batch started (i.e., when first element was added to
@@ -157,7 +152,6 @@ public class AsyncBatchWaitOperator<IN, OUT> extends AbstractStreamOperator<OUT>
         this.batchTimeoutMs = batchTimeoutMs;
         this.mailboxExecutor = Preconditions.checkNotNull(mailboxExecutor);
 
-        // Setup the operator using parameters
         setup(parameters.getContainingTask(), parameters.getStreamConfig(), parameters.getOutput());
     }
 
@@ -172,7 +166,6 @@ public class AsyncBatchWaitOperator<IN, OUT> extends AbstractStreamOperator<OUT>
 
     @Override
     public void processElement(StreamRecord<IN> element) throws Exception {
-        // If buffer is empty and timeout is enabled, record batch start time and register timer
         if (buffer.isEmpty() && isTimeoutEnabled()) {
             currentBatchStartTime = getProcessingTimeService().getCurrentProcessingTime();
             registerBatchTimer();
@@ -180,57 +173,51 @@ public class AsyncBatchWaitOperator<IN, OUT> extends AbstractStreamOperator<OUT>
 
         buffer.add(element.getValue());
 
-        // Size-triggered flush: cancel pending timer and flush
         if (buffer.size() >= maxBatchSize) {
             flushBuffer();
         }
     }
 
-    /**
-     * Callback when processing time timer fires. Flushes the buffer if non-empty.
-     *
-     * @param timestamp The timestamp for which the timer was registered
-     */
     @Override
     public void onProcessingTime(long timestamp) throws Exception {
-        // Timer fired - clear timer state first
         timerRegistered = false;
 
-        // Flush buffer if non-empty (timeout-triggered flush)
         if (!buffer.isEmpty()) {
             flushBuffer();
         }
     }
 
     /** Flush the current buffer by invoking the async batch function. */
-    private void flushBuffer() throws Exception {
+    protected void flushBuffer() throws Exception {
         if (buffer.isEmpty()) {
             return;
         }
 
-        // Clear timer state since we're flushing the batch
         clearTimerState();
 
-        // Create a copy of the buffer and clear it for new incoming elements
         List<IN> batch = new ArrayList<>(buffer);
         buffer.clear();
 
-        // Increment in-flight counter
         inFlightCount++;
 
-        // Create result handler for this batch
-        BatchResultHandler resultHandler = new BatchResultHandler();
+        asyncBatchFunction.asyncInvokeBatch(batch, createResultHandler(batch));
+    }
 
-        // Invoke the async batch function
-        asyncBatchFunction.asyncInvokeBatch(batch, resultHandler);
+    /**
+     * Create a result handler for the given batch. Subclasses can override this to provide custom
+     * result handling (e.g., ordered emission).
+     *
+     * @param batch The batch of input elements
+     * @return A ResultFuture to handle async results
+     */
+    protected ResultFuture<OUT> createResultHandler(List<IN> batch) {
+        return new BatchResultHandler();
     }
 
     @Override
     public void endInput() throws Exception {
-        // Flush any remaining elements in the buffer
         flushBuffer();
 
-        // Wait for all in-flight async operations to complete
         while (inFlightCount > 0) {
             mailboxExecutor.yield();
         }
@@ -241,12 +228,8 @@ public class AsyncBatchWaitOperator<IN, OUT> extends AbstractStreamOperator<OUT>
         super.close();
     }
 
-    // ================================================================================
-    //  Timer management methods
-    // ================================================================================
-
     /** Check if timeout-based batching is enabled. */
-    private boolean isTimeoutEnabled() {
+    protected boolean isTimeoutEnabled() {
         return batchTimeoutMs > NO_TIMEOUT;
     }
 
@@ -277,7 +260,6 @@ public class AsyncBatchWaitOperator<IN, OUT> extends AbstractStreamOperator<OUT>
     /** A handler for the results of a batch async invocation. */
     private class BatchResultHandler implements ResultFuture<OUT> {
 
-        /** Guard against multiple completions. */
         private final AtomicBoolean completed = new AtomicBoolean(false);
 
         @Override
@@ -289,7 +271,6 @@ public class AsyncBatchWaitOperator<IN, OUT> extends AbstractStreamOperator<OUT>
                 return;
             }
 
-            // Process results in the mailbox thread
             mailboxExecutor.execute(
                     () -> processResults(results), "AsyncBatchWaitOperator#processResults");
         }
@@ -300,12 +281,10 @@ public class AsyncBatchWaitOperator<IN, OUT> extends AbstractStreamOperator<OUT>
                 return;
             }
 
-            // Signal failure through the containing task
             getContainingTask()
                     .getEnvironment()
                     .failExternally(new Exception("Async batch operation failed.", error));
 
-            // Decrement in-flight counter in mailbox thread
             mailboxExecutor.execute(
                     () -> inFlightCount--, "AsyncBatchWaitOperator#decrementInFlight");
         }
@@ -335,11 +314,9 @@ public class AsyncBatchWaitOperator<IN, OUT> extends AbstractStreamOperator<OUT>
         }
 
         private void processResults(Collection<OUT> results) {
-            // Emit all results downstream
             for (OUT result : results) {
                 output.collect(new StreamRecord<>(result));
             }
-            // Decrement in-flight counter
             inFlightCount--;
         }
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncBatchWaitOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncBatchWaitOperator.java
@@ -146,13 +146,12 @@ public class AsyncBatchWaitOperator<IN, OUT> extends AbstractStreamOperator<OUT>
             int maxBatchSize,
             long batchTimeoutMs,
             @Nonnull MailboxExecutor mailboxExecutor) {
+        super(parameters);
         Preconditions.checkArgument(maxBatchSize > 0, "maxBatchSize must be greater than 0");
         this.asyncBatchFunction = Preconditions.checkNotNull(asyncBatchFunction);
         this.maxBatchSize = maxBatchSize;
         this.batchTimeoutMs = batchTimeoutMs;
         this.mailboxExecutor = Preconditions.checkNotNull(mailboxExecutor);
-
-        setup(parameters.getContainingTask(), parameters.getStreamConfig(), parameters.getOutput());
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncBatchWaitOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncBatchWaitOperatorFactory.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.async;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.streaming.api.functions.async.AsyncBatchFunction;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+import org.apache.flink.streaming.api.operators.legacy.YieldingOperatorFactory;
+
+/**
+ * The factory of {@link AsyncBatchWaitOperator}.
+ *
+ * @param <IN> The input type of the operator
+ * @param <OUT> The output type of the operator
+ */
+@Internal
+public class AsyncBatchWaitOperatorFactory<IN, OUT> extends AbstractStreamOperatorFactory<OUT>
+        implements OneInputStreamOperatorFactory<IN, OUT>, YieldingOperatorFactory<OUT> {
+
+    private static final long serialVersionUID = 1L;
+
+    private final AsyncBatchFunction<IN, OUT> asyncBatchFunction;
+    private final int maxBatchSize;
+
+    public AsyncBatchWaitOperatorFactory(
+            AsyncBatchFunction<IN, OUT> asyncBatchFunction, int maxBatchSize) {
+        this.asyncBatchFunction = asyncBatchFunction;
+        this.maxBatchSize = maxBatchSize;
+        this.chainingStrategy = ChainingStrategy.ALWAYS;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T extends StreamOperator<OUT>> T createStreamOperator(
+            StreamOperatorParameters<OUT> parameters) {
+        AsyncBatchWaitOperator<IN, OUT> operator =
+                new AsyncBatchWaitOperator<>(
+                        parameters, asyncBatchFunction, maxBatchSize, getMailboxExecutor());
+        return (T) operator;
+    }
+
+    @Override
+    public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
+        return AsyncBatchWaitOperator.class;
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncBatchWaitOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncBatchWaitOperatorFactory.java
@@ -39,13 +39,36 @@ public class AsyncBatchWaitOperatorFactory<IN, OUT> extends AbstractStreamOperat
 
     private static final long serialVersionUID = 1L;
 
+    /** Constant indicating timeout is disabled. */
+    private static final long NO_TIMEOUT = 0L;
+
     private final AsyncBatchFunction<IN, OUT> asyncBatchFunction;
     private final int maxBatchSize;
+    private final long batchTimeoutMs;
 
+    /**
+     * Creates a factory with size-based batching only (no timeout).
+     *
+     * @param asyncBatchFunction The async batch function
+     * @param maxBatchSize Maximum batch size before triggering async invocation
+     */
     public AsyncBatchWaitOperatorFactory(
             AsyncBatchFunction<IN, OUT> asyncBatchFunction, int maxBatchSize) {
+        this(asyncBatchFunction, maxBatchSize, NO_TIMEOUT);
+    }
+
+    /**
+     * Creates a factory with size-based and optional timeout-based batching.
+     *
+     * @param asyncBatchFunction The async batch function
+     * @param maxBatchSize Maximum batch size before triggering async invocation
+     * @param batchTimeoutMs Batch timeout in milliseconds; <= 0 means disabled
+     */
+    public AsyncBatchWaitOperatorFactory(
+            AsyncBatchFunction<IN, OUT> asyncBatchFunction, int maxBatchSize, long batchTimeoutMs) {
         this.asyncBatchFunction = asyncBatchFunction;
         this.maxBatchSize = maxBatchSize;
+        this.batchTimeoutMs = batchTimeoutMs;
         this.chainingStrategy = ChainingStrategy.ALWAYS;
     }
 
@@ -55,7 +78,11 @@ public class AsyncBatchWaitOperatorFactory<IN, OUT> extends AbstractStreamOperat
             StreamOperatorParameters<OUT> parameters) {
         AsyncBatchWaitOperator<IN, OUT> operator =
                 new AsyncBatchWaitOperator<>(
-                        parameters, asyncBatchFunction, maxBatchSize, getMailboxExecutor());
+                        parameters,
+                        asyncBatchFunction,
+                        maxBatchSize,
+                        batchTimeoutMs,
+                        getMailboxExecutor());
         return (T) operator;
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/OrderedAsyncBatchWaitOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/OrderedAsyncBatchWaitOperator.java
@@ -1,0 +1,432 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.async;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.operators.MailboxExecutor;
+import org.apache.flink.api.common.operators.ProcessingTimeService.ProcessingTimeCallback;
+import org.apache.flink.streaming.api.functions.async.AsyncBatchFunction;
+import org.apache.flink.streaming.api.functions.async.CollectionSupplier;
+import org.apache.flink.streaming.api.functions.async.ResultFuture;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.BoundedOneInput;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nonnull;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * The {@link OrderedAsyncBatchWaitOperator} batches incoming stream records and invokes the {@link
+ * AsyncBatchFunction} when the batch size reaches the configured maximum or when the batch timeout
+ * is reached.
+ *
+ * <p>This operator implements <b>ordered semantics</b> - output records are emitted in the same
+ * order as input records, even though async batch invocations may complete out-of-order internally.
+ *
+ * <p>Ordering is achieved by:
+ *
+ * <ul>
+ *   <li>Assigning a monotonic sequence number to each batch
+ *   <li>Buffering completed batch results in a pending results map
+ *   <li>Emitting results strictly in sequence order
+ * </ul>
+ *
+ * <p>Key behaviors:
+ *
+ * <ul>
+ *   <li>Buffer incoming records until batch size is reached OR timeout expires
+ *   <li>Flush remaining records when end of input is signaled
+ *   <li>Wait for all batches to complete and emit in order before finishing
+ * </ul>
+ *
+ * <p>Timer lifecycle (when batchTimeoutMs > 0):
+ *
+ * <ul>
+ *   <li>Timer is registered when first element is added to an empty buffer
+ *   <li>Timer fires at: currentBatchStartTime + batchTimeoutMs
+ *   <li>Timer is cleared when batch is flushed (by size, timeout, or end-of-input)
+ *   <li>At most one timer is active at any time
+ * </ul>
+ *
+ * <p>Future enhancements may include:
+ *
+ * <ul>
+ *   <li>Event-time or watermark-based ordering
+ *   <li>Multiple inflight batches concurrency control
+ *   <li>Retry logic
+ *   <li>Metrics
+ * </ul>
+ *
+ * @param <IN> Input type for the operator.
+ * @param <OUT> Output type for the operator.
+ */
+@Internal
+public class OrderedAsyncBatchWaitOperator<IN, OUT> extends AbstractStreamOperator<OUT>
+        implements OneInputStreamOperator<IN, OUT>, BoundedOneInput, ProcessingTimeCallback {
+
+    private static final long serialVersionUID = 1L;
+
+    /** Constant indicating timeout is disabled. */
+    private static final long NO_TIMEOUT = 0L;
+
+    /** The async batch function to invoke. */
+    private final AsyncBatchFunction<IN, OUT> asyncBatchFunction;
+
+    /** Maximum batch size before triggering async invocation. */
+    private final int maxBatchSize;
+
+    /**
+     * Batch timeout in milliseconds. When positive, a timer is registered to flush the batch after
+     * this duration since the first buffered element. A value <= 0 disables timeout-based batching.
+     */
+    private final long batchTimeoutMs;
+
+    /** Buffer for incoming stream records. */
+    private transient List<IN> buffer;
+
+    /** Mailbox executor for processing async results on the main thread. */
+    private final transient MailboxExecutor mailboxExecutor;
+
+    /** Counter for in-flight async operations. */
+    private transient int inFlightCount;
+
+    // ================================================================================
+    //  Timer state fields for timeout-based batching
+    // ================================================================================
+
+    /**
+     * The processing time when the current batch started (i.e., when first element was added to
+     * empty buffer). Used to calculate timer fire time.
+     */
+    private transient long currentBatchStartTime;
+
+    /** Whether a timer is currently registered for the current batch. */
+    private transient boolean timerRegistered;
+
+    // ================================================================================
+    //  Ordered emission state fields
+    // ================================================================================
+
+    /**
+     * The sequence number to assign to the next batch. Monotonically increasing, starting from 0.
+     */
+    private transient long nextBatchSequenceNumber;
+
+    /**
+     * The sequence number of the next batch whose results should be emitted. Used to ensure
+     * strictly ordered output emission.
+     */
+    private transient long nextExpectedSequenceNumber;
+
+    /**
+     * Pending results buffer. Maps batch sequence number to completed results. Results are held
+     * here until all preceding batches have been emitted.
+     */
+    private transient Map<Long, Collection<OUT>> pendingResults;
+
+    /**
+     * Creates an OrderedAsyncBatchWaitOperator with size-based batching only (no timeout).
+     *
+     * @param parameters Stream operator parameters
+     * @param asyncBatchFunction The async batch function to invoke
+     * @param maxBatchSize Maximum batch size before triggering async invocation
+     * @param mailboxExecutor Mailbox executor for processing async results
+     */
+    public OrderedAsyncBatchWaitOperator(
+            @Nonnull StreamOperatorParameters<OUT> parameters,
+            @Nonnull AsyncBatchFunction<IN, OUT> asyncBatchFunction,
+            int maxBatchSize,
+            @Nonnull MailboxExecutor mailboxExecutor) {
+        this(parameters, asyncBatchFunction, maxBatchSize, NO_TIMEOUT, mailboxExecutor);
+    }
+
+    /**
+     * Creates an OrderedAsyncBatchWaitOperator with size-based and optional timeout-based batching.
+     *
+     * @param parameters Stream operator parameters
+     * @param asyncBatchFunction The async batch function to invoke
+     * @param maxBatchSize Maximum batch size before triggering async invocation
+     * @param batchTimeoutMs Batch timeout in milliseconds; <= 0 means disabled
+     * @param mailboxExecutor Mailbox executor for processing async results
+     */
+    public OrderedAsyncBatchWaitOperator(
+            @Nonnull StreamOperatorParameters<OUT> parameters,
+            @Nonnull AsyncBatchFunction<IN, OUT> asyncBatchFunction,
+            int maxBatchSize,
+            long batchTimeoutMs,
+            @Nonnull MailboxExecutor mailboxExecutor) {
+        Preconditions.checkArgument(maxBatchSize > 0, "maxBatchSize must be greater than 0");
+        this.asyncBatchFunction = Preconditions.checkNotNull(asyncBatchFunction);
+        this.maxBatchSize = maxBatchSize;
+        this.batchTimeoutMs = batchTimeoutMs;
+        this.mailboxExecutor = Preconditions.checkNotNull(mailboxExecutor);
+
+        // Setup the operator using parameters
+        setup(parameters.getContainingTask(), parameters.getStreamConfig(), parameters.getOutput());
+    }
+
+    @Override
+    public void open() throws Exception {
+        super.open();
+        this.buffer = new ArrayList<>(maxBatchSize);
+        this.inFlightCount = 0;
+        this.currentBatchStartTime = 0L;
+        this.timerRegistered = false;
+
+        // Initialize ordered emission state
+        this.nextBatchSequenceNumber = 0L;
+        this.nextExpectedSequenceNumber = 0L;
+        this.pendingResults = new TreeMap<>();
+    }
+
+    @Override
+    public void processElement(StreamRecord<IN> element) throws Exception {
+        // If buffer is empty and timeout is enabled, record batch start time and register timer
+        if (buffer.isEmpty() && isTimeoutEnabled()) {
+            currentBatchStartTime = getProcessingTimeService().getCurrentProcessingTime();
+            registerBatchTimer();
+        }
+
+        buffer.add(element.getValue());
+
+        // Size-triggered flush: cancel pending timer and flush
+        if (buffer.size() >= maxBatchSize) {
+            flushBuffer();
+        }
+    }
+
+    /**
+     * Callback when processing time timer fires. Flushes the buffer if non-empty.
+     *
+     * @param timestamp The timestamp for which the timer was registered
+     */
+    @Override
+    public void onProcessingTime(long timestamp) throws Exception {
+        // Timer fired - clear timer state first
+        timerRegistered = false;
+
+        // Flush buffer if non-empty (timeout-triggered flush)
+        if (!buffer.isEmpty()) {
+            flushBuffer();
+        }
+    }
+
+    /** Flush the current buffer by invoking the async batch function. */
+    private void flushBuffer() throws Exception {
+        if (buffer.isEmpty()) {
+            return;
+        }
+
+        // Clear timer state since we're flushing the batch
+        clearTimerState();
+
+        // Create a copy of the buffer and clear it for new incoming elements
+        List<IN> batch = new ArrayList<>(buffer);
+        buffer.clear();
+
+        // Assign sequence number to this batch and increment counter
+        long batchSequenceNumber = nextBatchSequenceNumber++;
+
+        // Increment in-flight counter
+        inFlightCount++;
+
+        // Create result handler for this batch with its sequence number
+        OrderedBatchResultHandler resultHandler =
+                new OrderedBatchResultHandler(batchSequenceNumber);
+
+        // Invoke the async batch function
+        asyncBatchFunction.asyncInvokeBatch(batch, resultHandler);
+    }
+
+    @Override
+    public void endInput() throws Exception {
+        // Flush any remaining elements in the buffer
+        flushBuffer();
+
+        // Wait for all in-flight async operations to complete and emit results in order
+        while (inFlightCount > 0 || !pendingResults.isEmpty()) {
+            mailboxExecutor.yield();
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        super.close();
+    }
+
+    // ================================================================================
+    //  Timer management methods
+    // ================================================================================
+
+    /** Check if timeout-based batching is enabled. */
+    private boolean isTimeoutEnabled() {
+        return batchTimeoutMs > NO_TIMEOUT;
+    }
+
+    /** Register a processing time timer for the current batch. */
+    private void registerBatchTimer() {
+        if (!timerRegistered && isTimeoutEnabled()) {
+            long fireTime = currentBatchStartTime + batchTimeoutMs;
+            getProcessingTimeService().registerTimer(fireTime, this);
+            timerRegistered = true;
+        }
+    }
+
+    /**
+     * Clear timer state. Note: We don't explicitly cancel the timer because: 1. The timer callback
+     * checks buffer state before flushing 2. Cancelling timers has overhead 3. Timer will be
+     * ignored if buffer is empty when it fires
+     */
+    private void clearTimerState() {
+        timerRegistered = false;
+        currentBatchStartTime = 0L;
+    }
+
+    // ================================================================================
+    //  Ordered emission methods
+    // ================================================================================
+
+    /**
+     * Try to emit results in order. Called when a batch completes. Emits all consecutive completed
+     * batches starting from nextExpectedSequenceNumber.
+     */
+    private void tryEmitInOrder() {
+        // Emit results in strict sequence order
+        while (pendingResults.containsKey(nextExpectedSequenceNumber)) {
+            Collection<OUT> results = pendingResults.remove(nextExpectedSequenceNumber);
+
+            // Emit all results from this batch
+            for (OUT result : results) {
+                output.collect(new StreamRecord<>(result));
+            }
+
+            // Move to next expected sequence number
+            nextExpectedSequenceNumber++;
+        }
+    }
+
+    /** Returns the current buffer size. Visible for testing. */
+    int getBufferSize() {
+        return buffer != null ? buffer.size() : 0;
+    }
+
+    /** Returns the number of pending result batches. Visible for testing. */
+    int getPendingResultsCount() {
+        return pendingResults != null ? pendingResults.size() : 0;
+    }
+
+    /**
+     * A handler for the results of a batch async invocation that maintains ordering.
+     *
+     * <p>Results are stored in the pending results buffer and emitted in sequence order.
+     */
+    private class OrderedBatchResultHandler implements ResultFuture<OUT> {
+
+        /** Guard against multiple completions. */
+        private final AtomicBoolean completed = new AtomicBoolean(false);
+
+        /** The sequence number of this batch. */
+        private final long batchSequenceNumber;
+
+        OrderedBatchResultHandler(long batchSequenceNumber) {
+            this.batchSequenceNumber = batchSequenceNumber;
+        }
+
+        @Override
+        public void complete(Collection<OUT> results) {
+            Preconditions.checkNotNull(
+                    results, "Results must not be null, use empty collection to emit nothing");
+
+            if (!completed.compareAndSet(false, true)) {
+                return;
+            }
+
+            // Process results in the mailbox thread
+            mailboxExecutor.execute(
+                    () -> processResultsOrdered(results),
+                    "OrderedAsyncBatchWaitOperator#processResultsOrdered");
+        }
+
+        @Override
+        public void completeExceptionally(Throwable error) {
+            if (!completed.compareAndSet(false, true)) {
+                return;
+            }
+
+            // Signal failure through the containing task
+            getContainingTask()
+                    .getEnvironment()
+                    .failExternally(new Exception("Async batch operation failed.", error));
+
+            // Decrement in-flight counter in mailbox thread
+            mailboxExecutor.execute(
+                    () -> inFlightCount--, "OrderedAsyncBatchWaitOperator#decrementInFlight");
+        }
+
+        @Override
+        public void complete(CollectionSupplier<OUT> supplier) {
+            Preconditions.checkNotNull(
+                    supplier, "Supplier must not be null, return empty collection to emit nothing");
+
+            if (!completed.compareAndSet(false, true)) {
+                return;
+            }
+
+            mailboxExecutor.execute(
+                    () -> {
+                        try {
+                            processResultsOrdered(supplier.get());
+                        } catch (Throwable t) {
+                            getContainingTask()
+                                    .getEnvironment()
+                                    .failExternally(
+                                            new Exception("Async batch operation failed.", t));
+                            inFlightCount--;
+                        }
+                    },
+                    "OrderedAsyncBatchWaitOperator#processResultsFromSupplier");
+        }
+
+        /**
+         * Process results with ordering guarantee.
+         *
+         * <p>Results are added to the pending buffer and then we try to emit all consecutive
+         * completed batches in order.
+         */
+        private void processResultsOrdered(Collection<OUT> results) {
+            // Store results in pending buffer keyed by sequence number
+            pendingResults.put(batchSequenceNumber, new ArrayList<>(results));
+
+            // Try to emit all consecutive completed batches
+            tryEmitInOrder();
+
+            // Decrement in-flight counter
+            inFlightCount--;
+        }
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/OrderedAsyncBatchWaitOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/OrderedAsyncBatchWaitOperator.java
@@ -215,7 +215,13 @@ public class OrderedAsyncBatchWaitOperator<IN, OUT> extends AsyncBatchWaitOperat
                     .failExternally(new Exception("Async batch operation failed.", error));
 
             mailboxExecutor.execute(
-                    () -> inFlightCount--, "OrderedAsyncBatchWaitOperator#completeExceptionally");
+                    () -> {
+                        // Mark slot as done with empty results so the queue can be drained
+                        slot.complete(new ArrayList<>());
+                        drainInOrder();
+                        inFlightCount--;
+                    },
+                    "OrderedAsyncBatchWaitOperator#completeExceptionally");
         }
 
         @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/OrderedAsyncBatchWaitOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/OrderedAsyncBatchWaitOperator.java
@@ -20,41 +20,32 @@ package org.apache.flink.streaming.api.operators.async;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.operators.MailboxExecutor;
-import org.apache.flink.api.common.operators.ProcessingTimeService.ProcessingTimeCallback;
 import org.apache.flink.streaming.api.functions.async.AsyncBatchFunction;
 import org.apache.flink.streaming.api.functions.async.CollectionSupplier;
 import org.apache.flink.streaming.api.functions.async.ResultFuture;
-import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
-import org.apache.flink.streaming.api.operators.BoundedOneInput;
-import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nonnull;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Deque;
 import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
- * The {@link OrderedAsyncBatchWaitOperator} batches incoming stream records and invokes the {@link
- * AsyncBatchFunction} when the batch size reaches the configured maximum or when the batch timeout
- * is reached.
+ * The {@link OrderedAsyncBatchWaitOperator} extends {@link AsyncBatchWaitOperator} with ordered
+ * output semantics.
  *
- * <p>This operator implements <b>ordered semantics</b> - output records are emitted in the same
- * order as input records, even though async batch invocations may complete out-of-order internally.
+ * <p>Output records are emitted in the same order as input records, even though async batch
+ * invocations may complete out-of-order internally.
  *
- * <p>Ordering is achieved by:
- *
- * <ul>
- *   <li>Assigning a monotonic sequence number to each batch
- *   <li>Buffering completed batch results in a pending results map
- *   <li>Emitting results strictly in sequence order
- * </ul>
+ * <p>Ordering is achieved by maintaining a FIFO queue of pending result slots. Each slot is
+ * pre-allocated when a batch is flushed. When a batch completes, it fills its slot and a drain pass
+ * emits all consecutive head-of-queue completed slots in order.
  *
  * <p>Key behaviors:
  *
@@ -64,90 +55,19 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *   <li>Wait for all batches to complete and emit in order before finishing
  * </ul>
  *
- * <p>Timer lifecycle (when batchTimeoutMs > 0):
- *
- * <ul>
- *   <li>Timer is registered when first element is added to an empty buffer
- *   <li>Timer fires at: currentBatchStartTime + batchTimeoutMs
- *   <li>Timer is cleared when batch is flushed (by size, timeout, or end-of-input)
- *   <li>At most one timer is active at any time
- * </ul>
- *
- * <p>Future enhancements may include:
- *
- * <ul>
- *   <li>Event-time or watermark-based ordering
- *   <li>Multiple inflight batches concurrency control
- *   <li>Retry logic
- *   <li>Metrics
- * </ul>
- *
  * @param <IN> Input type for the operator.
  * @param <OUT> Output type for the operator.
  */
 @Internal
-public class OrderedAsyncBatchWaitOperator<IN, OUT> extends AbstractStreamOperator<OUT>
-        implements OneInputStreamOperator<IN, OUT>, BoundedOneInput, ProcessingTimeCallback {
+public class OrderedAsyncBatchWaitOperator<IN, OUT> extends AsyncBatchWaitOperator<IN, OUT> {
 
     private static final long serialVersionUID = 1L;
 
-    /** Constant indicating timeout is disabled. */
-    private static final long NO_TIMEOUT = 0L;
-
-    /** The async batch function to invoke. */
-    private final AsyncBatchFunction<IN, OUT> asyncBatchFunction;
-
-    /** Maximum batch size before triggering async invocation. */
-    private final int maxBatchSize;
-
     /**
-     * Batch timeout in milliseconds. When positive, a timer is registered to flush the batch after
-     * this duration since the first buffered element. A value <= 0 disables timeout-based batching.
+     * FIFO queue of result slots. Each slot is added to the tail when a batch is dispatched and
+     * removed from the head when results are drained in order.
      */
-    private final long batchTimeoutMs;
-
-    /** Buffer for incoming stream records. */
-    private transient List<IN> buffer;
-
-    /** Mailbox executor for processing async results on the main thread. */
-    private final transient MailboxExecutor mailboxExecutor;
-
-    /** Counter for in-flight async operations. */
-    private transient int inFlightCount;
-
-    // ================================================================================
-    //  Timer state fields for timeout-based batching
-    // ================================================================================
-
-    /**
-     * The processing time when the current batch started (i.e., when first element was added to
-     * empty buffer). Used to calculate timer fire time.
-     */
-    private transient long currentBatchStartTime;
-
-    /** Whether a timer is currently registered for the current batch. */
-    private transient boolean timerRegistered;
-
-    // ================================================================================
-    //  Ordered emission state fields
-    // ================================================================================
-
-    /**
-     * The sequence number to assign to the next batch. Monotonically increasing, starting from 0.
-     */
-    private transient long nextBatchSequenceNumber;
-
-    /**
-     * The sequence number of the next batch whose results should be emitted. Used to ensure
-     * strictly ordered output emission.
-     */
-    private transient long nextExpectedSequenceNumber;
-
-    /**
-     * Pending results buffer. Maps batch sequence number to completed results. Results are held
-     * here until all preceding batches have been emitted.
-     */
-    private transient Map<Long, Collection<OUT>> pendingResults;
+    private transient Deque<ResultSlot<OUT>> resultQueue;
 
     /**
      * Creates an OrderedAsyncBatchWaitOperator with size-based batching only (no timeout).
@@ -180,181 +100,90 @@ public class OrderedAsyncBatchWaitOperator<IN, OUT> extends AbstractStreamOperat
             int maxBatchSize,
             long batchTimeoutMs,
             @Nonnull MailboxExecutor mailboxExecutor) {
-        Preconditions.checkArgument(maxBatchSize > 0, "maxBatchSize must be greater than 0");
-        this.asyncBatchFunction = Preconditions.checkNotNull(asyncBatchFunction);
-        this.maxBatchSize = maxBatchSize;
-        this.batchTimeoutMs = batchTimeoutMs;
-        this.mailboxExecutor = Preconditions.checkNotNull(mailboxExecutor);
-
-        // Setup the operator using parameters
-        setup(parameters.getContainingTask(), parameters.getStreamConfig(), parameters.getOutput());
+        super(parameters, asyncBatchFunction, maxBatchSize, batchTimeoutMs, mailboxExecutor);
     }
 
     @Override
     public void open() throws Exception {
         super.open();
-        this.buffer = new ArrayList<>(maxBatchSize);
-        this.inFlightCount = 0;
-        this.currentBatchStartTime = 0L;
-        this.timerRegistered = false;
-
-        // Initialize ordered emission state
-        this.nextBatchSequenceNumber = 0L;
-        this.nextExpectedSequenceNumber = 0L;
-        this.pendingResults = new TreeMap<>();
+        this.resultQueue = new ArrayDeque<>();
     }
 
     @Override
-    public void processElement(StreamRecord<IN> element) throws Exception {
-        // If buffer is empty and timeout is enabled, record batch start time and register timer
-        if (buffer.isEmpty() && isTimeoutEnabled()) {
-            currentBatchStartTime = getProcessingTimeService().getCurrentProcessingTime();
-            registerBatchTimer();
-        }
-
-        buffer.add(element.getValue());
-
-        // Size-triggered flush: cancel pending timer and flush
-        if (buffer.size() >= maxBatchSize) {
-            flushBuffer();
-        }
-    }
-
-    /**
-     * Callback when processing time timer fires. Flushes the buffer if non-empty.
-     *
-     * @param timestamp The timestamp for which the timer was registered
-     */
-    @Override
-    public void onProcessingTime(long timestamp) throws Exception {
-        // Timer fired - clear timer state first
-        timerRegistered = false;
-
-        // Flush buffer if non-empty (timeout-triggered flush)
-        if (!buffer.isEmpty()) {
-            flushBuffer();
-        }
-    }
-
-    /** Flush the current buffer by invoking the async batch function. */
-    private void flushBuffer() throws Exception {
-        if (buffer.isEmpty()) {
-            return;
-        }
-
-        // Clear timer state since we're flushing the batch
-        clearTimerState();
-
-        // Create a copy of the buffer and clear it for new incoming elements
-        List<IN> batch = new ArrayList<>(buffer);
-        buffer.clear();
-
-        // Assign sequence number to this batch and increment counter
-        long batchSequenceNumber = nextBatchSequenceNumber++;
-
-        // Increment in-flight counter
-        inFlightCount++;
-
-        // Create result handler for this batch with its sequence number
-        OrderedBatchResultHandler resultHandler =
-                new OrderedBatchResultHandler(batchSequenceNumber);
-
-        // Invoke the async batch function
-        asyncBatchFunction.asyncInvokeBatch(batch, resultHandler);
+    protected ResultFuture<OUT> createResultHandler(List<IN> batch) {
+        ResultSlot<OUT> slot = new ResultSlot<>();
+        resultQueue.addLast(slot);
+        return new OrderedBatchResultHandler(slot);
     }
 
     @Override
     public void endInput() throws Exception {
-        // Flush any remaining elements in the buffer
         flushBuffer();
 
-        // Wait for all in-flight async operations to complete and emit results in order
-        while (inFlightCount > 0 || !pendingResults.isEmpty()) {
+        while (inFlightCount > 0 || !resultQueue.isEmpty()) {
             mailboxExecutor.yield();
         }
     }
 
-    @Override
-    public void close() throws Exception {
-        super.close();
-    }
-
-    // ================================================================================
-    //  Timer management methods
-    // ================================================================================
-
-    /** Check if timeout-based batching is enabled. */
-    private boolean isTimeoutEnabled() {
-        return batchTimeoutMs > NO_TIMEOUT;
-    }
-
-    /** Register a processing time timer for the current batch. */
-    private void registerBatchTimer() {
-        if (!timerRegistered && isTimeoutEnabled()) {
-            long fireTime = currentBatchStartTime + batchTimeoutMs;
-            getProcessingTimeService().registerTimer(fireTime, this);
-            timerRegistered = true;
-        }
-    }
-
     /**
-     * Clear timer state. Note: We don't explicitly cancel the timer because: 1. The timer callback
-     * checks buffer state before flushing 2. Cancelling timers has overhead 3. Timer will be
-     * ignored if buffer is empty when it fires
+     * Drain all consecutive completed slots from the head of the queue and emit their results. Runs
+     * on the mailbox thread.
      */
-    private void clearTimerState() {
-        timerRegistered = false;
-        currentBatchStartTime = 0L;
-    }
-
-    // ================================================================================
-    //  Ordered emission methods
-    // ================================================================================
-
-    /**
-     * Try to emit results in order. Called when a batch completes. Emits all consecutive completed
-     * batches starting from nextExpectedSequenceNumber.
-     */
-    private void tryEmitInOrder() {
-        // Emit results in strict sequence order
-        while (pendingResults.containsKey(nextExpectedSequenceNumber)) {
-            Collection<OUT> results = pendingResults.remove(nextExpectedSequenceNumber);
-
-            // Emit all results from this batch
-            for (OUT result : results) {
+    private void drainInOrder() {
+        while (!resultQueue.isEmpty()) {
+            ResultSlot<OUT> head = resultQueue.peekFirst();
+            if (!head.isDone()) {
+                break;
+            }
+            resultQueue.pollFirst();
+            for (OUT result : head.getResults()) {
                 output.collect(new StreamRecord<>(result));
             }
-
-            // Move to next expected sequence number
-            nextExpectedSequenceNumber++;
         }
     }
 
-    /** Returns the current buffer size. Visible for testing. */
-    int getBufferSize() {
-        return buffer != null ? buffer.size() : 0;
+    /** Returns the number of pending result slots. Visible for testing. */
+    int getPendingResultsCount() {
+        return resultQueue != null ? resultQueue.size() : 0;
     }
 
-    /** Returns the number of pending result batches. Visible for testing. */
-    int getPendingResultsCount() {
-        return pendingResults != null ? pendingResults.size() : 0;
+    // ================================================================================
+    //  Internal classes
+    // ================================================================================
+
+    /**
+     * A pre-allocated slot in the result FIFO queue. The slot transitions from "pending" to "done"
+     * exactly once when the batch completes.
+     */
+    private static class ResultSlot<OUT> {
+        private Collection<OUT> results;
+        private boolean done = false;
+
+        void complete(Collection<OUT> results) {
+            this.results = results;
+            this.done = true;
+        }
+
+        boolean isDone() {
+            return done;
+        }
+
+        Collection<OUT> getResults() {
+            return results;
+        }
     }
 
     /**
-     * A handler for the results of a batch async invocation that maintains ordering.
-     *
-     * <p>Results are stored in the pending results buffer and emitted in sequence order.
+     * A {@link ResultFuture} implementation that fills a {@link ResultSlot} and triggers in-order
+     * emission.
      */
     private class OrderedBatchResultHandler implements ResultFuture<OUT> {
 
-        /** Guard against multiple completions. */
         private final AtomicBoolean completed = new AtomicBoolean(false);
+        private final ResultSlot<OUT> slot;
 
-        /** The sequence number of this batch. */
-        private final long batchSequenceNumber;
-
-        OrderedBatchResultHandler(long batchSequenceNumber) {
-            this.batchSequenceNumber = batchSequenceNumber;
+        OrderedBatchResultHandler(ResultSlot<OUT> slot) {
+            this.slot = slot;
         }
 
         @Override
@@ -366,10 +195,13 @@ public class OrderedAsyncBatchWaitOperator<IN, OUT> extends AbstractStreamOperat
                 return;
             }
 
-            // Process results in the mailbox thread
             mailboxExecutor.execute(
-                    () -> processResultsOrdered(results),
-                    "OrderedAsyncBatchWaitOperator#processResultsOrdered");
+                    () -> {
+                        slot.complete(new ArrayList<>(results));
+                        drainInOrder();
+                        inFlightCount--;
+                    },
+                    "OrderedAsyncBatchWaitOperator#complete");
         }
 
         @Override
@@ -378,14 +210,12 @@ public class OrderedAsyncBatchWaitOperator<IN, OUT> extends AbstractStreamOperat
                 return;
             }
 
-            // Signal failure through the containing task
             getContainingTask()
                     .getEnvironment()
                     .failExternally(new Exception("Async batch operation failed.", error));
 
-            // Decrement in-flight counter in mailbox thread
             mailboxExecutor.execute(
-                    () -> inFlightCount--, "OrderedAsyncBatchWaitOperator#decrementInFlight");
+                    () -> inFlightCount--, "OrderedAsyncBatchWaitOperator#completeExceptionally");
         }
 
         @Override
@@ -400,7 +230,9 @@ public class OrderedAsyncBatchWaitOperator<IN, OUT> extends AbstractStreamOperat
             mailboxExecutor.execute(
                     () -> {
                         try {
-                            processResultsOrdered(supplier.get());
+                            slot.complete(new ArrayList<>(supplier.get()));
+                            drainInOrder();
+                            inFlightCount--;
                         } catch (Throwable t) {
                             getContainingTask()
                                     .getEnvironment()
@@ -409,24 +241,7 @@ public class OrderedAsyncBatchWaitOperator<IN, OUT> extends AbstractStreamOperat
                             inFlightCount--;
                         }
                     },
-                    "OrderedAsyncBatchWaitOperator#processResultsFromSupplier");
-        }
-
-        /**
-         * Process results with ordering guarantee.
-         *
-         * <p>Results are added to the pending buffer and then we try to emit all consecutive
-         * completed batches in order.
-         */
-        private void processResultsOrdered(Collection<OUT> results) {
-            // Store results in pending buffer keyed by sequence number
-            pendingResults.put(batchSequenceNumber, new ArrayList<>(results));
-
-            // Try to emit all consecutive completed batches
-            tryEmitInOrder();
-
-            // Decrement in-flight counter
-            inFlightCount--;
+                    "OrderedAsyncBatchWaitOperator#completeFromSupplier");
         }
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/OrderedAsyncBatchWaitOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/OrderedAsyncBatchWaitOperatorFactory.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.async;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.streaming.api.functions.async.AsyncBatchFunction;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+import org.apache.flink.streaming.api.operators.legacy.YieldingOperatorFactory;
+
+/**
+ * The factory of {@link OrderedAsyncBatchWaitOperator}.
+ *
+ * <p>This factory creates operators that maintain ordering guarantees - output records are emitted
+ * in the same order as input records, regardless of async completion order.
+ *
+ * @param <IN> The input type of the operator
+ * @param <OUT> The output type of the operator
+ */
+@Internal
+public class OrderedAsyncBatchWaitOperatorFactory<IN, OUT>
+        extends AbstractStreamOperatorFactory<OUT>
+        implements OneInputStreamOperatorFactory<IN, OUT>, YieldingOperatorFactory<OUT> {
+
+    private static final long serialVersionUID = 1L;
+
+    /** Constant indicating timeout is disabled. */
+    private static final long NO_TIMEOUT = 0L;
+
+    private final AsyncBatchFunction<IN, OUT> asyncBatchFunction;
+    private final int maxBatchSize;
+    private final long batchTimeoutMs;
+
+    /**
+     * Creates a factory with size-based batching only (no timeout).
+     *
+     * @param asyncBatchFunction The async batch function
+     * @param maxBatchSize Maximum batch size before triggering async invocation
+     */
+    public OrderedAsyncBatchWaitOperatorFactory(
+            AsyncBatchFunction<IN, OUT> asyncBatchFunction, int maxBatchSize) {
+        this(asyncBatchFunction, maxBatchSize, NO_TIMEOUT);
+    }
+
+    /**
+     * Creates a factory with size-based and optional timeout-based batching.
+     *
+     * @param asyncBatchFunction The async batch function
+     * @param maxBatchSize Maximum batch size before triggering async invocation
+     * @param batchTimeoutMs Batch timeout in milliseconds; <= 0 means disabled
+     */
+    public OrderedAsyncBatchWaitOperatorFactory(
+            AsyncBatchFunction<IN, OUT> asyncBatchFunction, int maxBatchSize, long batchTimeoutMs) {
+        this.asyncBatchFunction = asyncBatchFunction;
+        this.maxBatchSize = maxBatchSize;
+        this.batchTimeoutMs = batchTimeoutMs;
+        this.chainingStrategy = ChainingStrategy.ALWAYS;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T extends StreamOperator<OUT>> T createStreamOperator(
+            StreamOperatorParameters<OUT> parameters) {
+        OrderedAsyncBatchWaitOperator<IN, OUT> operator =
+                new OrderedAsyncBatchWaitOperator<>(
+                        parameters,
+                        asyncBatchFunction,
+                        maxBatchSize,
+                        batchTimeoutMs,
+                        getMailboxExecutor());
+        return (T) operator;
+    }
+
+    @Override
+    public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
+        return OrderedAsyncBatchWaitOperator.class;
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncBatchWaitOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncBatchWaitOperatorTest.java
@@ -1,0 +1,305 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.async;
+
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.runtime.operators.testutils.ExpectedTestException;
+import org.apache.flink.streaming.api.functions.async.AsyncBatchFunction;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link AsyncBatchWaitOperator}.
+ *
+ * <p>These tests verify:
+ *
+ * <ul>
+ *   <li>Batch size trigger - elements are batched correctly
+ *   <li>Correct result emission - all outputs are emitted downstream
+ *   <li>Exception propagation - errors fail the operator
+ * </ul>
+ */
+@Timeout(value = 100, unit = TimeUnit.SECONDS)
+class AsyncBatchWaitOperatorTest {
+
+    /**
+     * Test that the operator correctly batches elements based on maxBatchSize.
+     *
+     * <p>Input: 5 records with maxBatchSize = 3
+     *
+     * <p>Expected: 2 batch invocations with sizes [3, 2]
+     */
+    @Test
+    void testBatchSizeTrigger() throws Exception {
+        final int maxBatchSize = 3;
+        final List<Integer> batchSizes = new CopyOnWriteArrayList<>();
+
+        AsyncBatchFunction<Integer, Integer> function =
+                (inputs, resultFuture) -> {
+                    batchSizes.add(inputs.size());
+                    // Return input * 2 for each element
+                    List<Integer> results =
+                            inputs.stream().map(i -> i * 2).collect(Collectors.toList());
+                    resultFuture.complete(results);
+                };
+
+        try (OneInputStreamOperatorTestHarness<Integer, Integer> testHarness =
+                createTestHarness(function, maxBatchSize)) {
+
+            testHarness.open();
+
+            // Process 5 elements
+            testHarness.processElement(new StreamRecord<>(1, 1L));
+            testHarness.processElement(new StreamRecord<>(2, 2L));
+            testHarness.processElement(new StreamRecord<>(3, 3L));
+            // First batch of 3 should be triggered here
+
+            testHarness.processElement(new StreamRecord<>(4, 4L));
+            testHarness.processElement(new StreamRecord<>(5, 5L));
+            // Remaining 2 elements in buffer
+
+            testHarness.endInput();
+            // Second batch of 2 should be triggered on endInput
+
+            // Verify batch sizes
+            assertThat(batchSizes).containsExactly(3, 2);
+        }
+    }
+
+    /** Test that all results from the batch function are correctly emitted downstream. */
+    @Test
+    void testCorrectResultEmission() throws Exception {
+        final int maxBatchSize = 3;
+
+        // Function that doubles each input
+        AsyncBatchFunction<Integer, Integer> function =
+                (inputs, resultFuture) -> {
+                    List<Integer> results =
+                            inputs.stream().map(i -> i * 2).collect(Collectors.toList());
+                    resultFuture.complete(results);
+                };
+
+        try (OneInputStreamOperatorTestHarness<Integer, Integer> testHarness =
+                createTestHarness(function, maxBatchSize)) {
+
+            testHarness.open();
+
+            // Process 5 elements: 1, 2, 3, 4, 5
+            for (int i = 1; i <= 5; i++) {
+                testHarness.processElement(new StreamRecord<>(i, i));
+            }
+
+            testHarness.endInput();
+
+            // Verify outputs: should be 2, 4, 6, 8, 10
+            List<Integer> outputs =
+                    testHarness.getOutput().stream()
+                            .filter(e -> e instanceof StreamRecord)
+                            .map(e -> ((StreamRecord<Integer>) e).getValue())
+                            .collect(Collectors.toList());
+
+            assertThat(outputs).containsExactlyInAnyOrder(2, 4, 6, 8, 10);
+        }
+    }
+
+    /** Test that exceptions from the batch function are properly propagated. */
+    @Test
+    void testExceptionPropagation() throws Exception {
+        final int maxBatchSize = 2;
+
+        AsyncBatchFunction<Integer, Integer> function =
+                (inputs, resultFuture) -> {
+                    resultFuture.completeExceptionally(new ExpectedTestException());
+                };
+
+        try (OneInputStreamOperatorTestHarness<Integer, Integer> testHarness =
+                createTestHarness(function, maxBatchSize)) {
+
+            testHarness.open();
+
+            // Process 2 elements to trigger a batch
+            testHarness.processElement(new StreamRecord<>(1, 1L));
+            testHarness.processElement(new StreamRecord<>(2, 2L));
+
+            // The exception should be propagated - we need to yield to process the async result
+            // In the test harness, the exception is recorded in the environment
+            testHarness.endInput();
+
+            // Verify that the task environment received the exception
+            assertThat(testHarness.getEnvironment().getActualExternalFailureCause())
+                    .isPresent()
+                    .get()
+                    .satisfies(
+                            t ->
+                                    assertThat(t.getCause())
+                                            .isInstanceOf(ExpectedTestException.class));
+        }
+    }
+
+    /** Test async completion using CompletableFuture. */
+    @Test
+    void testAsyncCompletion() throws Exception {
+        final int maxBatchSize = 2;
+        final AtomicInteger invocationCount = new AtomicInteger(0);
+
+        AsyncBatchFunction<Integer, Integer> function =
+                (inputs, resultFuture) -> {
+                    invocationCount.incrementAndGet();
+                    // Simulate async processing
+                    CompletableFuture.supplyAsync(
+                                    () ->
+                                            inputs.stream()
+                                                    .map(i -> i * 3)
+                                                    .collect(Collectors.toList()))
+                            .thenAccept(resultFuture::complete);
+                };
+
+        try (OneInputStreamOperatorTestHarness<Integer, Integer> testHarness =
+                createTestHarness(function, maxBatchSize)) {
+
+            testHarness.open();
+
+            // Process 4 elements: should trigger 2 batches
+            for (int i = 1; i <= 4; i++) {
+                testHarness.processElement(new StreamRecord<>(i, i));
+            }
+
+            testHarness.endInput();
+
+            // Verify invocation count
+            assertThat(invocationCount.get()).isEqualTo(2);
+
+            // Verify outputs: should be 3, 6, 9, 12
+            List<Integer> outputs =
+                    testHarness.getOutput().stream()
+                            .filter(e -> e instanceof StreamRecord)
+                            .map(e -> ((StreamRecord<Integer>) e).getValue())
+                            .collect(Collectors.toList());
+
+            assertThat(outputs).containsExactlyInAnyOrder(3, 6, 9, 12);
+        }
+    }
+
+    /** Test that empty batches are not triggered. */
+    @Test
+    void testEmptyInput() throws Exception {
+        final int maxBatchSize = 3;
+        final AtomicInteger invocationCount = new AtomicInteger(0);
+
+        AsyncBatchFunction<Integer, Integer> function =
+                (inputs, resultFuture) -> {
+                    invocationCount.incrementAndGet();
+                    resultFuture.complete(Collections.emptyList());
+                };
+
+        try (OneInputStreamOperatorTestHarness<Integer, Integer> testHarness =
+                createTestHarness(function, maxBatchSize)) {
+
+            testHarness.open();
+            testHarness.endInput();
+
+            // No invocations should happen for empty input
+            assertThat(invocationCount.get()).isEqualTo(0);
+            assertThat(testHarness.getOutput()).isEmpty();
+        }
+    }
+
+    /** Test that batch function can return fewer or more outputs than inputs. */
+    @Test
+    void testVariableOutputSize() throws Exception {
+        final int maxBatchSize = 3;
+
+        // Function that returns only one output per batch (aggregation-style)
+        AsyncBatchFunction<Integer, Integer> function =
+                (inputs, resultFuture) -> {
+                    int sum = inputs.stream().mapToInt(Integer::intValue).sum();
+                    resultFuture.complete(Collections.singletonList(sum));
+                };
+
+        try (OneInputStreamOperatorTestHarness<Integer, Integer> testHarness =
+                createTestHarness(function, maxBatchSize)) {
+
+            testHarness.open();
+
+            // Process 5 elements: 1, 2, 3, 4, 5
+            for (int i = 1; i <= 5; i++) {
+                testHarness.processElement(new StreamRecord<>(i, i));
+            }
+
+            testHarness.endInput();
+
+            // First batch: 1+2+3 = 6, Second batch: 4+5 = 9
+            List<Integer> outputs =
+                    testHarness.getOutput().stream()
+                            .filter(e -> e instanceof StreamRecord)
+                            .map(e -> ((StreamRecord<Integer>) e).getValue())
+                            .collect(Collectors.toList());
+
+            assertThat(outputs).containsExactlyInAnyOrder(6, 9);
+        }
+    }
+
+    /** Test single element batch (maxBatchSize = 1). */
+    @Test
+    void testSingleElementBatch() throws Exception {
+        final int maxBatchSize = 1;
+        final List<Integer> batchSizes = new CopyOnWriteArrayList<>();
+
+        AsyncBatchFunction<Integer, Integer> function =
+                (inputs, resultFuture) -> {
+                    batchSizes.add(inputs.size());
+                    resultFuture.complete(inputs);
+                };
+
+        try (OneInputStreamOperatorTestHarness<Integer, Integer> testHarness =
+                createTestHarness(function, maxBatchSize)) {
+
+            testHarness.open();
+
+            testHarness.processElement(new StreamRecord<>(1, 1L));
+            testHarness.processElement(new StreamRecord<>(2, 2L));
+            testHarness.processElement(new StreamRecord<>(3, 3L));
+
+            testHarness.endInput();
+
+            // Each element should trigger its own batch
+            assertThat(batchSizes).containsExactly(1, 1, 1);
+        }
+    }
+
+    private static OneInputStreamOperatorTestHarness<Integer, Integer> createTestHarness(
+            AsyncBatchFunction<Integer, Integer> function, int maxBatchSize) throws Exception {
+        return new OneInputStreamOperatorTestHarness<>(
+                new AsyncBatchWaitOperatorFactory<>(function, maxBatchSize),
+                IntSerializer.INSTANCE);
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncBatchWaitOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncBatchWaitOperatorTest.java
@@ -144,6 +144,7 @@ class AsyncBatchWaitOperatorTest {
         try (OneInputStreamOperatorTestHarness<Integer, Integer> testHarness =
                 createTestHarness(function, maxBatchSize)) {
 
+            testHarness.getEnvironment().setExpectedExternalFailureCause(Throwable.class);
             testHarness.open();
 
             // Process 2 elements to trigger a batch

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/OrderedAsyncBatchWaitOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/OrderedAsyncBatchWaitOperatorTest.java
@@ -1,0 +1,439 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.async;
+
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.runtime.operators.testutils.ExpectedTestException;
+import org.apache.flink.streaming.api.functions.async.AsyncBatchFunction;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link OrderedAsyncBatchWaitOperator}.
+ *
+ * <p>These tests verify:
+ *
+ * <ul>
+ *   <li>Strict ordering guarantee - output order matches input order
+ *   <li>Batch + time trigger interaction with ordering
+ *   <li>Exception propagation
+ * </ul>
+ */
+@Timeout(value = 100, unit = TimeUnit.SECONDS)
+class OrderedAsyncBatchWaitOperatorTest {
+
+    /**
+     * Test strict ordering guarantee even when async results complete out of order.
+     *
+     * <p>Inputs: [1, 2, 3, 4, 5]
+     *
+     * <p>Async batches complete in reverse order (second batch completes before first)
+     *
+     * <p>Output MUST be: [1, 2, 3, 4, 5] (same as input order)
+     */
+    @Test
+    void testStrictOrderingGuarantee() throws Exception {
+        final int maxBatchSize = 3;
+        final List<CompletableFuture<Void>> batchFutures = new CopyOnWriteArrayList<>();
+        final AtomicInteger batchIndex = new AtomicInteger(0);
+
+        AsyncBatchFunction<Integer, Integer> function =
+                (inputs, resultFuture) -> {
+                    int currentBatch = batchIndex.getAndIncrement();
+                    CompletableFuture<Void> future = new CompletableFuture<>();
+                    batchFutures.add(future);
+
+                    // Store input for later completion
+                    List<Integer> inputCopy = new ArrayList<>(inputs);
+
+                    // Complete asynchronously when future is completed externally
+                    future.thenRun(() -> resultFuture.complete(inputCopy));
+                };
+
+        try (OneInputStreamOperatorTestHarness<Integer, Integer> testHarness =
+                createTestHarness(function, maxBatchSize)) {
+
+            testHarness.open();
+
+            // Process 5 elements: batch 0 = [1,2,3], batch 1 = [4,5]
+            for (int i = 1; i <= 5; i++) {
+                testHarness.processElement(new StreamRecord<>(i, i));
+            }
+
+            // Trigger end of input to flush remaining elements
+            // This creates batch 1 with [4, 5]
+            // At this point we have 2 batches pending
+
+            // Wait for batches to be created
+            while (batchFutures.size() < 2) {
+                Thread.sleep(10);
+            }
+
+            // Complete batches in REVERSE order (batch 1 first, then batch 0)
+            // This tests that output is still in original order
+            batchFutures.get(1).complete(null); // Complete batch [4, 5] first
+            Thread.sleep(50); // Give time for async processing
+
+            batchFutures.get(0).complete(null); // Then complete batch [1, 2, 3]
+
+            testHarness.endInput();
+
+            // Verify outputs are in strict input order: [1, 2, 3, 4, 5]
+            List<Integer> outputs =
+                    testHarness.getOutput().stream()
+                            .filter(e -> e instanceof StreamRecord)
+                            .map(e -> ((StreamRecord<Integer>) e).getValue())
+                            .collect(Collectors.toList());
+
+            // MUST be in exact input order, not completion order
+            assertThat(outputs).containsExactly(1, 2, 3, 4, 5);
+        }
+    }
+
+    /** Test ordering with synchronous completions - simple case to verify basic ordering. */
+    @Test
+    void testOrderingWithSynchronousCompletion() throws Exception {
+        final int maxBatchSize = 2;
+
+        // Function that immediately completes with input values
+        AsyncBatchFunction<Integer, Integer> function =
+                (inputs, resultFuture) -> {
+                    resultFuture.complete(inputs);
+                };
+
+        try (OneInputStreamOperatorTestHarness<Integer, Integer> testHarness =
+                createTestHarness(function, maxBatchSize)) {
+
+            testHarness.open();
+
+            // Process 6 elements: 3 batches of 2
+            for (int i = 1; i <= 6; i++) {
+                testHarness.processElement(new StreamRecord<>(i, i));
+            }
+
+            testHarness.endInput();
+
+            // Verify outputs are in strict input order
+            List<Integer> outputs =
+                    testHarness.getOutput().stream()
+                            .filter(e -> e instanceof StreamRecord)
+                            .map(e -> ((StreamRecord<Integer>) e).getValue())
+                            .collect(Collectors.toList());
+
+            assertThat(outputs).containsExactly(1, 2, 3, 4, 5, 6);
+        }
+    }
+
+    /**
+     * Test batch + time trigger interaction with ordering preserved.
+     *
+     * <p>Small batch size with timeout, verify ordering across multiple batches.
+     */
+    @Test
+    void testBatchAndTimeoutTriggerWithOrdering() throws Exception {
+        final int maxBatchSize = 3;
+        final long batchTimeoutMs = 100L;
+
+        AsyncBatchFunction<Integer, Integer> function =
+                (inputs, resultFuture) -> {
+                    resultFuture.complete(inputs);
+                };
+
+        try (OneInputStreamOperatorTestHarness<Integer, Integer> testHarness =
+                createTestHarnessWithTimeout(function, maxBatchSize, batchTimeoutMs)) {
+
+            testHarness.open();
+            testHarness.setProcessingTime(0L);
+
+            // First batch: size-triggered (3 elements)
+            testHarness.processElement(new StreamRecord<>(1, 1L));
+            testHarness.processElement(new StreamRecord<>(2, 2L));
+            testHarness.processElement(new StreamRecord<>(3, 3L));
+
+            // Second batch: timeout-triggered (1 element)
+            testHarness.setProcessingTime(200L);
+            testHarness.processElement(new StreamRecord<>(4, 4L));
+            testHarness.setProcessingTime(301L); // Trigger timeout
+
+            // Third batch: size-triggered (3 elements)
+            testHarness.setProcessingTime(400L);
+            testHarness.processElement(new StreamRecord<>(5, 5L));
+            testHarness.processElement(new StreamRecord<>(6, 6L));
+            testHarness.processElement(new StreamRecord<>(7, 7L));
+
+            testHarness.endInput();
+
+            // Verify outputs are in strict input order
+            List<Integer> outputs =
+                    testHarness.getOutput().stream()
+                            .filter(e -> e instanceof StreamRecord)
+                            .map(e -> ((StreamRecord<Integer>) e).getValue())
+                            .collect(Collectors.toList());
+
+            assertThat(outputs).containsExactly(1, 2, 3, 4, 5, 6, 7);
+        }
+    }
+
+    /** Test exception propagation - exception in batch invocation fails fast. */
+    @Test
+    void testExceptionPropagation() throws Exception {
+        final int maxBatchSize = 2;
+
+        AsyncBatchFunction<Integer, Integer> function =
+                (inputs, resultFuture) -> {
+                    resultFuture.completeExceptionally(new ExpectedTestException());
+                };
+
+        try (OneInputStreamOperatorTestHarness<Integer, Integer> testHarness =
+                createTestHarness(function, maxBatchSize)) {
+
+            testHarness.open();
+
+            // Process 2 elements to trigger a batch
+            testHarness.processElement(new StreamRecord<>(1, 1L));
+            testHarness.processElement(new StreamRecord<>(2, 2L));
+
+            testHarness.endInput();
+
+            // Verify that the task environment received the exception
+            assertThat(testHarness.getEnvironment().getActualExternalFailureCause())
+                    .isPresent()
+                    .get()
+                    .satisfies(
+                            t ->
+                                    assertThat(t.getCause())
+                                            .isInstanceOf(ExpectedTestException.class));
+        }
+    }
+
+    /** Test ordering with delayed async completions simulating real async I/O. */
+    @Test
+    void testOrderingWithDelayedAsyncCompletion() throws Exception {
+        final int maxBatchSize = 2;
+        final List<Integer> completionOrder = new CopyOnWriteArrayList<>();
+
+        AsyncBatchFunction<Integer, Integer> function =
+                (inputs, resultFuture) -> {
+                    List<Integer> inputCopy = new ArrayList<>(inputs);
+                    int firstElement = inputCopy.get(0);
+
+                    // Simulate varying async delays - earlier batches take longer
+                    CompletableFuture.runAsync(
+                            () -> {
+                                try {
+                                    // Batch starting with 1 delays more than batch starting with 3
+                                    int delay = (5 - firstElement) * 20;
+                                    Thread.sleep(delay);
+                                } catch (InterruptedException e) {
+                                    Thread.currentThread().interrupt();
+                                }
+                                completionOrder.add(firstElement);
+                                resultFuture.complete(inputCopy);
+                            });
+                };
+
+        try (OneInputStreamOperatorTestHarness<Integer, Integer> testHarness =
+                createTestHarness(function, maxBatchSize)) {
+
+            testHarness.open();
+
+            // Process 4 elements: batch 0 = [1,2], batch 1 = [3,4]
+            for (int i = 1; i <= 4; i++) {
+                testHarness.processElement(new StreamRecord<>(i, i));
+            }
+
+            testHarness.endInput();
+
+            // Verify outputs are in strict input order regardless of completion order
+            List<Integer> outputs =
+                    testHarness.getOutput().stream()
+                            .filter(e -> e instanceof StreamRecord)
+                            .map(e -> ((StreamRecord<Integer>) e).getValue())
+                            .collect(Collectors.toList());
+
+            assertThat(outputs).containsExactly(1, 2, 3, 4);
+        }
+    }
+
+    /** Test that empty batches are not triggered. */
+    @Test
+    void testEmptyInput() throws Exception {
+        final int maxBatchSize = 3;
+        final AtomicInteger invocationCount = new AtomicInteger(0);
+
+        AsyncBatchFunction<Integer, Integer> function =
+                (inputs, resultFuture) -> {
+                    invocationCount.incrementAndGet();
+                    resultFuture.complete(Collections.emptyList());
+                };
+
+        try (OneInputStreamOperatorTestHarness<Integer, Integer> testHarness =
+                createTestHarness(function, maxBatchSize)) {
+
+            testHarness.open();
+            testHarness.endInput();
+
+            // No invocations should happen for empty input
+            assertThat(invocationCount.get()).isEqualTo(0);
+            assertThat(testHarness.getOutput()).isEmpty();
+        }
+    }
+
+    /** Test single element batch with ordering. */
+    @Test
+    void testSingleElementBatchOrdering() throws Exception {
+        final int maxBatchSize = 1;
+        final List<Integer> batchSizes = new CopyOnWriteArrayList<>();
+
+        AsyncBatchFunction<Integer, Integer> function =
+                (inputs, resultFuture) -> {
+                    batchSizes.add(inputs.size());
+                    resultFuture.complete(inputs);
+                };
+
+        try (OneInputStreamOperatorTestHarness<Integer, Integer> testHarness =
+                createTestHarness(function, maxBatchSize)) {
+
+            testHarness.open();
+
+            testHarness.processElement(new StreamRecord<>(3, 1L));
+            testHarness.processElement(new StreamRecord<>(1, 2L));
+            testHarness.processElement(new StreamRecord<>(2, 3L));
+
+            testHarness.endInput();
+
+            // Each element is its own batch
+            assertThat(batchSizes).containsExactly(1, 1, 1);
+
+            // Verify outputs maintain input order (not value order)
+            List<Integer> outputs =
+                    testHarness.getOutput().stream()
+                            .filter(e -> e instanceof StreamRecord)
+                            .map(e -> ((StreamRecord<Integer>) e).getValue())
+                            .collect(Collectors.toList());
+
+            // Output order should be [3, 1, 2] - same as input order
+            assertThat(outputs).containsExactly(3, 1, 2);
+        }
+    }
+
+    /** Test that batch function can return different number of outputs while maintaining order. */
+    @Test
+    void testVariableOutputSizeWithOrdering() throws Exception {
+        final int maxBatchSize = 2;
+
+        // Function that returns sum of batch (one output per batch)
+        AsyncBatchFunction<Integer, Integer> function =
+                (inputs, resultFuture) -> {
+                    int sum = inputs.stream().mapToInt(Integer::intValue).sum();
+                    resultFuture.complete(Collections.singletonList(sum));
+                };
+
+        try (OneInputStreamOperatorTestHarness<Integer, Integer> testHarness =
+                createTestHarness(function, maxBatchSize)) {
+
+            testHarness.open();
+
+            // Process 4 elements: batch 0 = [1,2] -> 3, batch 1 = [3,4] -> 7
+            for (int i = 1; i <= 4; i++) {
+                testHarness.processElement(new StreamRecord<>(i, i));
+            }
+
+            testHarness.endInput();
+
+            // First batch outputs first (3), then second batch (7)
+            List<Integer> outputs =
+                    testHarness.getOutput().stream()
+                            .filter(e -> e instanceof StreamRecord)
+                            .map(e -> ((StreamRecord<Integer>) e).getValue())
+                            .collect(Collectors.toList());
+
+            // Order should be [3, 7] - first batch result, then second batch result
+            assertThat(outputs).containsExactly(3, 7);
+        }
+    }
+
+    /** Test ordering with many batches to verify sequence number handling. */
+    @Test
+    void testManyBatchesOrdering() throws Exception {
+        final int maxBatchSize = 2;
+        final int totalElements = 20;
+
+        AsyncBatchFunction<Integer, Integer> function =
+                (inputs, resultFuture) -> {
+                    resultFuture.complete(inputs);
+                };
+
+        try (OneInputStreamOperatorTestHarness<Integer, Integer> testHarness =
+                createTestHarness(function, maxBatchSize)) {
+
+            testHarness.open();
+
+            // Process many elements
+            for (int i = 1; i <= totalElements; i++) {
+                testHarness.processElement(new StreamRecord<>(i, i));
+            }
+
+            testHarness.endInput();
+
+            // Verify all outputs are in strict order
+            List<Integer> outputs =
+                    testHarness.getOutput().stream()
+                            .filter(e -> e instanceof StreamRecord)
+                            .map(e -> ((StreamRecord<Integer>) e).getValue())
+                            .collect(Collectors.toList());
+
+            List<Integer> expected = new ArrayList<>();
+            for (int i = 1; i <= totalElements; i++) {
+                expected.add(i);
+            }
+
+            assertThat(outputs).containsExactlyElementsOf(expected);
+        }
+    }
+
+    private static OneInputStreamOperatorTestHarness<Integer, Integer> createTestHarness(
+            AsyncBatchFunction<Integer, Integer> function, int maxBatchSize) throws Exception {
+        return new OneInputStreamOperatorTestHarness<>(
+                new OrderedAsyncBatchWaitOperatorFactory<>(function, maxBatchSize),
+                IntSerializer.INSTANCE);
+    }
+
+    private static OneInputStreamOperatorTestHarness<Integer, Integer> createTestHarnessWithTimeout(
+            AsyncBatchFunction<Integer, Integer> function, int maxBatchSize, long batchTimeoutMs)
+            throws Exception {
+        return new OneInputStreamOperatorTestHarness<>(
+                new OrderedAsyncBatchWaitOperatorFactory<>(function, maxBatchSize, batchTimeoutMs),
+                IntSerializer.INSTANCE);
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/OrderedAsyncBatchWaitOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/OrderedAsyncBatchWaitOperatorTest.java
@@ -213,6 +213,7 @@ class OrderedAsyncBatchWaitOperatorTest {
         try (OneInputStreamOperatorTestHarness<Integer, Integer> testHarness =
                 createTestHarness(function, maxBatchSize)) {
 
+            testHarness.getEnvironment().setExpectedExternalFailureCause(Throwable.class);
             testHarness.open();
 
             // Process 2 elements to trigger a batch

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/OrderedAsyncBatchWaitOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/OrderedAsyncBatchWaitOperatorTest.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -61,22 +62,27 @@ class OrderedAsyncBatchWaitOperatorTest {
      *
      * <p>Output MUST be: [1, 2, 3, 4, 5] (same as input order)
      */
+    /**
+     * Test strict ordering guarantee even when async results complete out of order.
+     *
+     * <p>Inputs: [1, 2, 3, 4] with maxBatchSize=2
+     *
+     * <p>Batch 0=[1,2] and batch 1=[3,4] are both size-triggered. Batch 1 completes first (via
+     * external future completion), but output MUST still be [1, 2, 3, 4].
+     */
     @Test
     void testStrictOrderingGuarantee() throws Exception {
-        final int maxBatchSize = 3;
+        final int maxBatchSize = 2;
         final List<CompletableFuture<Void>> batchFutures = new CopyOnWriteArrayList<>();
-        final AtomicInteger batchIndex = new AtomicInteger(0);
+        // Each size-triggered batch registers a latch entry synchronously during processElement
+        final CountDownLatch batchesRegistered = new CountDownLatch(2);
 
         AsyncBatchFunction<Integer, Integer> function =
                 (inputs, resultFuture) -> {
-                    int currentBatch = batchIndex.getAndIncrement();
                     CompletableFuture<Void> future = new CompletableFuture<>();
                     batchFutures.add(future);
-
-                    // Store input for later completion
+                    batchesRegistered.countDown();
                     List<Integer> inputCopy = new ArrayList<>(inputs);
-
-                    // Complete asynchronously when future is completed externally
                     future.thenRun(() -> resultFuture.complete(inputCopy));
                 };
 
@@ -85,38 +91,28 @@ class OrderedAsyncBatchWaitOperatorTest {
 
             testHarness.open();
 
-            // Process 5 elements: batch 0 = [1,2,3], batch 1 = [4,5]
-            for (int i = 1; i <= 5; i++) {
+            // Both batches are size-triggered synchronously during processElement calls
+            for (int i = 1; i <= 4; i++) {
                 testHarness.processElement(new StreamRecord<>(i, i));
             }
 
-            // Trigger end of input to flush remaining elements
-            // This creates batch 1 with [4, 5]
-            // At this point we have 2 batches pending
+            // Both batches are already registered at this point (size-triggered synchronously)
+            batchesRegistered.await(10, TimeUnit.SECONDS);
 
-            // Wait for batches to be created
-            while (batchFutures.size() < 2) {
-                Thread.sleep(10);
-            }
-
-            // Complete batches in REVERSE order (batch 1 first, then batch 0)
-            // This tests that output is still in original order
-            batchFutures.get(1).complete(null); // Complete batch [4, 5] first
-            Thread.sleep(50); // Give time for async processing
-
-            batchFutures.get(0).complete(null); // Then complete batch [1, 2, 3]
+            // Complete batches in REVERSE order to verify output is still in input order
+            batchFutures.get(1).complete(null); // Complete batch [3, 4] first
+            batchFutures.get(0).complete(null); // Then complete batch [1, 2]
 
             testHarness.endInput();
 
-            // Verify outputs are in strict input order: [1, 2, 3, 4, 5]
+            // Verify outputs are in strict input order: [1, 2, 3, 4]
             List<Integer> outputs =
                     testHarness.getOutput().stream()
                             .filter(e -> e instanceof StreamRecord)
                             .map(e -> ((StreamRecord<Integer>) e).getValue())
                             .collect(Collectors.toList());
 
-            // MUST be in exact input order, not completion order
-            assertThat(outputs).containsExactly(1, 2, 3, 4, 5);
+            assertThat(outputs).containsExactly(1, 2, 3, 4);
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change
This PR adds ordered semantics to the async batch operator, building on top of:
PR1: Size-based batching (AsyncBatchWaitOperator)
PR2: Time-based batching (timeout flush)

For AI inference workloads and other batch-oriented async operations, users may require that output records maintain the same order as input records, even when async batch invocations complete out of order. This is essential for downstream processing that depends on ordering guarantees.

## Brief change log
- Add OrderedAsyncBatchWaitOperator - maintains ordering by assigning monotonic sequence numbers to each batch and emitting results strictly in sequence order
- Add OrderedAsyncBatchWaitOperatorFactory - creates ordered operator instances
- Add AsyncDataStream.orderedWaitBatch() API methods as entry points
- Add comprehensive unit tests in OrderedAsyncBatchWaitOperatorTest

## Verifying this change
This change added tests and can be verified as follows:
- OrderedAsyncBatchWaitOperatorTest#testStrictOrderingGuarantee - verifies batches completing out-of-order still produce ordered output
- OrderedAsyncBatchWaitOperatorTest#testBatchAndTimeoutTriggerWithOrdering - verifies ordering preserved across size and time triggered batches
- OrderedAsyncBatchWaitOperatorTest#testExceptionPropagation - verifies exceptions are propagated correctly
- OrderedAsyncBatchWaitOperatorTest#testDelayedAsyncCompletion - verifies delayed completions are handled correctly
- OrderedAsyncBatchWaitOperatorTest#testManyBatchesOrdering - verifies sequence number handling for many batches

## Does this pull request potentially affect one of the following parts
- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with @Public(Evolving): yes (new API methods)
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: no
- The S3 file system connector: no

## Documentation
- Does this pull request introduce a new feature? yes
- If yes, how is the feature documented? JavaDocs

---

## PR Series for FLINK-38825

JIRA: [FLINK-38825](https://issues.apache.org/jira/browse/FLINK-38825) - Introduce an AI-friendly Async Batch Operator for high-latency inference workloads

This feature is implemented incrementally through the following PR series:

| # | PR | Title | Description | Module |
|---|---|---|---|---|
| 1 | [#27355](https://github.com/apache/flink/pull/27355) | Introduce AsyncBatchFunction and AsyncBatchWaitOperator | Core API and runtime operator with unordered semantics and size-based batch triggering | `flink-streaming-java` |
| 2 | [#27356](https://github.com/apache/flink/pull/27356) | Add time-based batch triggering | Timeout-based flush to trigger incomplete batches after a configurable duration | `flink-streaming-java` |
| **3** | [#27357](https://github.com/apache/flink/pull/27357) | Add ordered async batch support | Ordered output semantics via OrderedAsyncBatchWaitOperator with sequence numbers | **`flink-streaming-java`** |
| 4 | [#27358](https://github.com/apache/flink/pull/27358) | Add inference-oriented metrics | Batch size/latency histograms, async call duration, inflight batches, failure counters | `flink-streaming-java` |
| 5 | [#27359](https://github.com/apache/flink/pull/27359) | Implement retry and timeout strategies | Fixed-delay/exponential-backoff retry, fail-on-timeout/allow-partial timeout policies | `flink-streaming-java` |
| 6 | [#27360](https://github.com/apache/flink/pull/27360) | Add SQL/Table API integration | AsyncBatchLookupFunction, AsyncBatchLookupFunctionProvider, lookup join runner | `flink-table` |
| 7 | [#27361](https://github.com/apache/flink/pull/27361) | Add Python DataStream API integration | Python AsyncBatchFunction, async_invoke_batch() API, AsyncDataStream batch methods | `flink-python` |

> **Note**: Each PR builds incrementally on the previous ones. PRs should be reviewed and merged in order.
