### PR TITLE
[FLINK-38841][table] Enforce expected nullability in FamilyArgumentStrategy

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/FamilyArgumentTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/FamilyArgumentTypeStrategy.java
@@ -86,13 +86,16 @@ public final class FamilyArgumentTypeStrategy implements ArgumentTypeStrategy {
         if (Objects.equals(expectedNullability, Boolean.FALSE) && actualType.isNullable()) {
             return callContext.fail(
                     throwOnFailure,
-                    "Unsupported argument type. Expected nullable type of family '%s' but actual type was '%s'.",
+                    "Unsupported argument type. Expected NOT NULL type of family '%s' but actual type was '%s'.",
                     expectedFamily,
                     actualType);
         }
 
         // type is part of the family
         if (actualType.getTypeRoot().getFamilies().contains(expectedFamily)) {
+            if (Objects.equals(expectedNullability, Boolean.TRUE) && !actualType.isNullable()) {
+                return Optional.of(actualDataType.nullable());
+            }
             return Optional.of(actualDataType);
         }
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/InputTypeStrategiesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/InputTypeStrategiesTest.java
@@ -549,23 +549,33 @@ class InputTypeStrategiesTest extends InputTypeStrategiesTestBase {
                                 sequence(
                                         logical(LogicalTypeFamily.CHARACTER_STRING, true),
                                         logical(LogicalTypeFamily.EXACT_NUMERIC),
+                                        logical(LogicalTypeFamily.EXACT_NUMERIC, true),
                                         logical(LogicalTypeFamily.APPROXIMATE_NUMERIC),
                                         logical(LogicalTypeFamily.APPROXIMATE_NUMERIC),
                                         logical(LogicalTypeFamily.APPROXIMATE_NUMERIC, false)))
                         .calledWithArgumentTypes(
                                 DataTypes.NULL(),
                                 DataTypes.TINYINT(),
+                                DataTypes.SMALLINT().notNull(),
                                 DataTypes.INT(),
                                 DataTypes.BIGINT().notNull(),
                                 DataTypes.DECIMAL(10, 2).notNull())
                         .expectSignature(
-                                "f(<CHARACTER_STRING NULL>, <EXACT_NUMERIC>, <APPROXIMATE_NUMERIC>, <APPROXIMATE_NUMERIC>, <APPROXIMATE_NUMERIC NOT NULL>)")
+                                "f(<CHARACTER_STRING NULL>, <EXACT_NUMERIC>, <EXACT_NUMERIC NULL>, <APPROXIMATE_NUMERIC>, <APPROXIMATE_NUMERIC>, <APPROXIMATE_NUMERIC NOT NULL>)")
                         .expectArgumentTypes(
                                 DataTypes.VARCHAR(1),
                                 DataTypes.TINYINT(),
+                                DataTypes.SMALLINT(),
                                 DataTypes.DOUBLE(), // widening with preserved nullability
                                 DataTypes.DOUBLE().notNull(), // widening with preserved nullability
                                 DataTypes.DOUBLE().notNull()),
+                TestSpec.forStrategy(
+                                "Logical type family with invalid nullability",
+                                sequence(logical(LogicalTypeFamily.EXACT_NUMERIC, false)))
+                        .calledWithArgumentTypes(DataTypes.INT())
+                        .expectSignature("f(<EXACT_NUMERIC NOT NULL>)")
+                        .expectErrorMessage(
+                                "Unsupported argument type. Expected NOT NULL type of family 'EXACT_NUMERIC' but actual type was 'INT'."),
                 TestSpec.forStrategy(
                                 "Logical type family with invalid type",
                                 sequence(logical(LogicalTypeFamily.EXACT_NUMERIC)))


### PR DESCRIPTION
## What is the purpose of the change

`FamilyArgumentTypeStrategy` is designed to request an argument of a specific `LogicalTypeFamily` and nullability.
When `expectedNullability` is explicitly set, the input argument should be implicitly cast to match that nullability during type inference. However, the current implementation ignores this requirement and incorrectly yields the original input type as the inferred type.

Consider a built-in function with an argument declared as `logical(EXACT_NUMERIC, true)` (i.e., nullable). If the actual input is `SMALLINT NOT NULL`, the expected inferred type should be `SMALLINT NULL`. However, under the current implementation, it remains `SMALLINT NOT NULL`. Furthermore, If the function's return type inference further depends on the input types (for instance, `nullableIfAllArgs()`), the error propagates.

## Brief change log

- Enforce expected nullability in FamilyArgumentStrategy.
- Fix incorrect error message.

## Verifying this change

- `InputTypeStrategiesTest`
- No built-in functions currently use FamilyArgumentStrategy with explicit nullability requirements, so this change has no impact on the existing public API.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
