### PR TITLE
[FLINK-38848] [table] Supports to pass the required privilege when catalog manager gets the table

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableImpl.java
@@ -45,6 +45,7 @@ import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.SchemaTranslator;
+import org.apache.flink.table.catalog.TableWritePrivilege;
 import org.apache.flink.table.catalog.UnresolvedIdentifier;
 import org.apache.flink.table.expressions.ApiExpressionUtils;
 import org.apache.flink.table.expressions.Expression;
@@ -62,6 +63,8 @@ import org.apache.flink.table.operations.utils.OperationExpressionsUtils;
 import org.apache.flink.table.operations.utils.OperationExpressionsUtils.CategorizedExpressions;
 import org.apache.flink.table.operations.utils.OperationTreeBuilder;
 
+import org.apache.flink.shaded.guava33.com.google.common.collect.Sets;
+
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
@@ -69,6 +72,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -443,8 +447,9 @@ public class TableImpl implements Table {
                 tableEnvironment.getParser().parseIdentifier(tablePath);
         ObjectIdentifier objectIdentifier =
                 tableEnvironment.getCatalogManager().qualifyIdentifier(unresolvedIdentifier);
+        Set<TableWritePrivilege> privileges = Sets.newHashSet(TableWritePrivilege.INSERT);
         ContextResolvedTable contextResolvedTable =
-                tableEnvironment.getCatalogManager().getTableOrError(objectIdentifier);
+                tableEnvironment.getCatalogManager().getTableOrError(objectIdentifier, privileges);
         return insertInto(contextResolvedTable, conflictStrategy, overwrite);
     }
 

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/api/internal/TableImplTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/api/internal/TableImplTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api.internal;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.TableDescriptor;
+import org.apache.flink.table.api.TablePipeline;
+import org.apache.flink.table.catalog.CatalogBaseTable;
+import org.apache.flink.table.catalog.CatalogManager;
+import org.apache.flink.table.catalog.CatalogStoreHolder;
+import org.apache.flink.table.catalog.GenericInMemoryCatalog;
+import org.apache.flink.table.catalog.GenericInMemoryCatalogStore;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.TableWritePrivilege;
+import org.apache.flink.table.catalog.exceptions.TableNotExistException;
+import org.apache.flink.table.operations.SinkModifyOperation;
+import org.apache.flink.table.utils.CatalogManagerMocks;
+import org.apache.flink.table.utils.TableEnvironmentMock;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link TableImpl}. */
+class TableImplTest {
+
+    private static final Schema TEST_SCHEMA =
+            Schema.newBuilder().column("id", DataTypes.INT()).build();
+
+    private TableEnvironmentMock tEnv;
+    private CompletableFuture<Set<TableWritePrivilege>> capturedPrivileges;
+
+    @BeforeEach
+    void setUp() {
+        capturedPrivileges = new CompletableFuture<>();
+
+        // Create a custom catalog that captures privileges
+        GenericInMemoryCatalog testCatalog =
+                new GenericInMemoryCatalog(
+                        CatalogManagerMocks.DEFAULT_CATALOG, CatalogManagerMocks.DEFAULT_DATABASE) {
+                    @Override
+                    public CatalogBaseTable getTable(
+                            ObjectPath tablePath, Set<TableWritePrivilege> privileges)
+                            throws TableNotExistException {
+                        capturedPrivileges.complete(privileges);
+                        return super.getTable(tablePath);
+                    }
+                };
+
+        CatalogManager catalogManager =
+                CatalogManager.newBuilder()
+                        .classLoader(TableImplTest.class.getClassLoader())
+                        .config(new Configuration())
+                        .defaultCatalog(CatalogManagerMocks.DEFAULT_CATALOG, testCatalog)
+                        .catalogStoreHolder(
+                                CatalogStoreHolder.newBuilder()
+                                        .catalogStore(new GenericInMemoryCatalogStore())
+                                        .config(new Configuration())
+                                        .classloader(TableImplTest.class.getClassLoader())
+                                        .build())
+                        .build();
+
+        tEnv = TableEnvironmentMock.getStreamingInstance(catalogManager);
+    }
+
+    @Test
+    void testInsertIntoPassesInsertPrivilege() throws Exception {
+        // Create a source and sink table
+        tEnv.createTable(
+                "source_table", TableDescriptor.forConnector("fake").schema(TEST_SCHEMA).build());
+        tEnv.createTable(
+                "sink_table", TableDescriptor.forConnector("fake").schema(TEST_SCHEMA).build());
+
+        // Get a Table from source
+        Table sourceTable = tEnv.from("source_table");
+
+        // Call insertInto with table path
+        TablePipeline pipeline = sourceTable.insertInto("sink_table");
+
+        // Verify that INSERT privilege was passed
+        Set<TableWritePrivilege> privileges = capturedPrivileges.get(10, TimeUnit.SECONDS);
+        assertThat(privileges).containsExactly(TableWritePrivilege.INSERT);
+
+        // Verify the returned pipeline
+        assertThat(pipeline).isNotNull();
+        assertThat(pipeline).isInstanceOf(TablePipelineImpl.class);
+        SinkModifyOperation sinkOp =
+                (SinkModifyOperation) ((TablePipelineImpl) pipeline).getOperation();
+        assertThat(sinkOp.getContextResolvedTable().getIdentifier().getObjectName())
+                .isEqualTo("sink_table");
+    }
+}

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/TableEnvironmentMock.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/TableEnvironmentMock.java
@@ -72,9 +72,18 @@ public class TableEnvironmentMock extends TableEnvironmentImpl {
         return getInstance(false);
     }
 
+    public static TableEnvironmentMock getStreamingInstance(CatalogManager catalogManager) {
+        return getInstance(catalogManager, true);
+    }
+
     private static TableEnvironmentMock getInstance(boolean isStreamingMode) {
-        final TableConfig tableConfig = TableConfig.getDefault();
         final CatalogManager catalogManager = CatalogManagerMocks.createEmptyCatalogManager();
+        return getInstance(catalogManager, isStreamingMode);
+    }
+
+    private static TableEnvironmentMock getInstance(
+            CatalogManager catalogManager, boolean isStreamingMode) {
+        final TableConfig tableConfig = TableConfig.getDefault();
         final ModuleManager moduleManager = new ModuleManager();
         final ResourceManager resourceManager =
                 ResourceManager.createResourceManager(

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
@@ -51,6 +51,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -280,6 +281,23 @@ public interface Catalog {
         throw new UnsupportedOperationException(
                 String.format(
                         "getTable(ObjectPath, long) is not implemented for %s.", this.getClass()));
+    }
+
+    /**
+     * Returns a {@link CatalogTable} or {@link CatalogView} with specific write privileges
+     * identified by the given {@link ObjectPath}. The framework will resolve the metadata objects
+     * when necessary.
+     *
+     * @param tablePath Path of the table or view
+     * @param writePrivileges specific write privileges for the table
+     * @return The requested table or view
+     * @throws TableNotExistException if the target does not exist
+     * @throws CatalogException in case of any runtime exception
+     */
+    default CatalogBaseTable getTable(
+            ObjectPath tablePath, Set<TableWritePrivilege> writePrivileges)
+            throws TableNotExistException, CatalogException {
+        return getTable(tablePath);
     }
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/TableWritePrivilege.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/TableWritePrivilege.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/** The table writing privileges that will be provided when loading a table. */
+@PublicEvolving
+public enum TableWritePrivilege {
+    /** The privilege of adding rows to the table. */
+    INSERT,
+
+    /** The privilege for changing existing rows in the table. */
+    UPDATE,
+
+    /** The privilege for deleting rows from the table. */
+    DELETE
+}


### PR DESCRIPTION
## What is the purpose of the change

For custom catalogs that have access control, read and write permissions can be different. However, currently Flink always call Catalog#getTable to look up the table, no matter it's for read or write.

This PR adds a variant of getTable that indicates the required write privileges. All the write commands will call this new method to look up tables instead. This new method has a default implementation that just calls getTable, so there is no breaking change.

Apache Spark also has similar interfaces. It helps catalog to implementation access control feature better.
More details, you can see https://github.com/apache/spark/pull/47772

## Brief change log

I added interfaces getTable with required privileges for `CatalogManager` and `Catalog`.

I added TableWritePrivileges, include insert, update, delete.

I passed the write privileges in the `TableImpl.java` and `SqlNodeToOperationConversion.java`.

## Verifying this change

Run the existing tests to verify that this change won't break compatibility.
I also run the `flink-sql-client` to verify the sql `insert`, `update`, `delete` using a custom catalog service (Apache Gravitino). It takes effect.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: Yes, I added the enum `TableWritePrivileges` and modified some `Catalog` interfaces. They are compatible changes.
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented?  not applicable
