### PR TITLE
[FLINK-37155] [Runtime/Coordination] Implementing FLIP-505 for Flink History Server scalability improvements to decouple local and remote storage

### DIFF
--- a/docs/layouts/shortcodes/generated/history_server_configuration.html
+++ b/docs/layouts/shortcodes/generated/history_server_configuration.html
@@ -9,6 +9,12 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>historyserver.archive.cached-retained-jobs</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Integer</td>
+            <td>The maximum number of n latest jobs to retain in the local directory defined by `historyserver.web.tmpdir`. If this configuration is provided, the remote and local storage of job archives will be decoupled.If set to `0` or less than `-1` HistoryServer will throw an <code class="highlighter-rouge">IllegalConfigurationException</code>. </td>
+        </tr>
+        <tr>
             <td><h5>historyserver.archive.clean-expired-applications</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
@@ -31,6 +37,12 @@
             <td style="word-wrap: break-word;">10 s</td>
             <td>Duration</td>
             <td>Interval for refreshing the archived job directories.</td>
+        </tr>
+        <tr>
+            <td><h5>historyserver.archive.num-cached-most-recently-viewed-jobs</h5></td>
+            <td style="word-wrap: break-word;">1</td>
+            <td>Integer</td>
+            <td>The maximum number of jobs to retain in the local cache defined by `historyserver.web.tmpdir` which stores the job archives that are fetched from the remote storage. This limit is distinct from the number of most recent jobs which will in the cache.The total cache size is a combination of the number of remote cache jobs and the number of remote fetch cached jobs and retained cache jobs.If set to less than `0` HistoryServer will throw an <code class="highlighter-rouge">IllegalConfigurationException</code>. </td>
         </tr>
         <tr>
             <td><h5>historyserver.archive.retained-applications</h5></td>

--- a/docs/layouts/shortcodes/generated/python_configuration.html
+++ b/docs/layouts/shortcodes/generated/python_configuration.html
@@ -21,12 +21,6 @@
             <td>The path of the Python interpreter used to launch the Python process when submitting the Python jobs via "flink run" or compiling the Java/Scala jobs containing Python UDFs. Equivalent to the command line option "-pyclientexec" or the environment variable PYFLINK_CLIENT_EXECUTABLE. The priority is as following: <br />1. the configuration 'python.client.executable' defined in the source code(Only used in Flink Java SQL/Table API job call Python UDF);<br />2. the command line option "-pyclientexec";<br />3. the configuration 'python.client.executable' defined in config.yaml<br />4. the environment variable PYFLINK_CLIENT_EXECUTABLE;</td>
         </tr>
         <tr>
-            <td><h5>python.logging.default.level</h5></td>
-            <td style="word-wrap: break-word;">"INFO"</td>
-            <td>String</td>
-            <td>Controls the default log level of python loggers, available values: OFF, ERROR, WARN, INFO, DEBUG, TRACE.</td>
-        </tr>
-        <tr>
             <td><h5>python.executable</h5></td>
             <td style="word-wrap: break-word;">"python"</td>
             <td>String</td>
@@ -67,6 +61,12 @@
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
             <td>If set, the Python worker will configure itself to use the managed memory budget of the task slot. Otherwise, it will use the Off-Heap Memory of the task slot. In this case, users should set the Task Off-Heap Memory using the configuration key taskmanager.memory.task.off-heap.size.</td>
+        </tr>
+        <tr>
+            <td><h5>python.logging.default.level</h5></td>
+            <td style="word-wrap: break-word;">"INFO"</td>
+            <td>String</td>
+            <td>Controls the default log level of python loggers, available values: OFF, ERROR, WARN, INFO, DEBUG, TRACE.</td>
         </tr>
         <tr>
             <td><h5>python.logging.level.overrides</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/HistoryServerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/HistoryServerOptions.java
@@ -145,6 +145,23 @@ public class HistoryServerOptions {
                                     .text(LEGACY_NOTE_MESSAGE)
                                     .build());
 
+    public static final ConfigOption<Integer> HISTORY_SERVER_CACHED_JOBS =
+            key("historyserver.archive.cached-retained-jobs")
+                    .intType()
+                    .noDefaultValue()
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            String.format(
+                                                    "The maximum number of n latest jobs to retain in the local directory defined by `%s`. ",
+                                                    HISTORY_SERVER_WEB_DIR.key()))
+                                    .text(
+                                            "If this configuration is provided, the remote and local storage of job archives will be decoupled.")
+                                    .text(
+                                            "If set to `0` or less than `-1` HistoryServer will throw an %s. ",
+                                            code("IllegalConfigurationException"))
+                                    .build());
+
     public static final ConfigOption<Integer> HISTORY_SERVER_RETAINED_JOBS =
             key(HISTORY_SERVER_RETAINED_JOBS_KEY)
                     .intType()
@@ -245,6 +262,25 @@ public class HistoryServerOptions {
                                     .list(
                                             text(CONFIGURE_SINGLE_INSTANCE),
                                             text(CONFIGURE_CONSISTENT))
+                                    .build());
+
+    public static final ConfigOption<Integer> HISTORY_SERVER_NUM_CACHED_MOST_RECENTLY_VIEWED_JOBS =
+            key("historyserver.archive.num-cached-most-recently-viewed-jobs")
+                    .intType()
+                    .defaultValue(1)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            String.format(
+                                                    "The maximum number of jobs to retain in the local cache defined by `%s` which "
+                                                            + "stores the job archives that are fetched from the remote storage. This "
+                                                            + "limit is distinct from the number of most recent jobs which will in the cache."
+                                                            + "The total cache size is a combination of the number of remote cache jobs and "
+                                                            + "the number of remote fetch cached jobs and retained cache jobs.",
+                                                    HISTORY_SERVER_WEB_DIR.key()))
+                                    .text(
+                                            "If set to less than `0` HistoryServer will throw an %s. ",
+                                            code("IllegalConfigurationException"))
                                     .build());
 
     private HistoryServerOptions() {}

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerApplicationArchiveFetcher.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerApplicationArchiveFetcher.java
@@ -81,7 +81,16 @@ public class HistoryServerApplicationArchiveFetcher extends HistoryServerArchive
             boolean cleanupExpiredArchives,
             ArchiveRetainedStrategy retainedStrategy)
             throws IOException {
-        super(refreshDirs, webDir, archiveEventListener, cleanupExpiredArchives, retainedStrategy);
+        // Applications don't use caching, so pass default values for cache parameters
+        super(
+                refreshDirs,
+                webDir,
+                archiveEventListener,
+                cleanupExpiredArchives,
+                retainedStrategy,
+                -1, // generalCachedJobSize (disabled)
+                false, // remoteFetchEnabled (disabled for applications)
+                0); // numCachedMostRecentlyViewedJobs (not used)
 
         for (HistoryServer.RefreshLocation refreshDir : refreshDirs) {
             cachedApplicationIdsToJobIds.put(refreshDir.getPath(), new HashMap<>());

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcherTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcherTest.java
@@ -1,0 +1,492 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.webmonitor.history;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.core.fs.FileStatus;
+import org.apache.flink.core.fs.FileSystem;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for the HistoryServerArchiveFetcher. */
+public class HistoryServerArchiveFetcherTest {
+
+    @Test
+    void testMostRecentlyViewedCacheEvictedWhenFull(@TempDir Path tmpDir) throws IOException {
+        final Path webDir = Files.createDirectory(tmpDir.resolve("webDir"));
+        final Path tempDir = Files.createDirectory(tmpDir.resolve("tmpDir"));
+        final org.apache.flink.core.fs.Path tempDirFs =
+                new org.apache.flink.core.fs.Path(tempDir.toUri());
+
+        List<HistoryServer.RefreshLocation> refreshDirs = new ArrayList<>();
+        FileSystem refreshFS = tempDirFs.getFileSystem();
+        refreshDirs.add(new HistoryServer.RefreshLocation(tempDirFs, refreshFS));
+
+        int numJobs = 5;
+        int localCacheSize = 3;
+        int mostRecentlyViewedCacheSize = 1;
+
+        HistoryServerArchiveFetcher archiveFetcher =
+                new HistoryServerArchiveFetcher(
+                        refreshDirs,
+                        webDir.toFile(),
+                        (event) -> {},
+                        true,
+                        (archive, index) -> true, // No retention limit for this test
+                        localCacheSize,
+                        true,
+                        mostRecentlyViewedCacheSize);
+
+        for (int i = 0; i < numJobs; i++) {
+            String jobID = JobID.generate().toString();
+            buildRemoteStorageJobDirectory(tempDir, jobID);
+        }
+
+        Map<Integer, String> jobIdByCreation =
+                retrieveRemoteArchivesByModificationTime(refreshFS, tempDirFs);
+
+        // Fetching the remote archives and storing them in the local cache asynchronously
+        archiveFetcher.fetchArchives();
+
+        // Confirming that the size of the local cache is based on the asynchronous fetch cache
+        // limit
+        assertThat(getNumJobsInGeneralCache(webDir)).isEqualTo(localCacheSize);
+        for (int i = 0; i < localCacheSize; i++) {
+            assertThat(findJobIdInGeneralCache(webDir, jobIdByCreation.get(i))).isTrue();
+        }
+
+        // Fetching the second to last job which was created. It should not be present in the
+        // local cache.
+        archiveFetcher.fetchArchiveByJobId(jobIdByCreation.get(3));
+
+        // Validating that the job has been fetched from the remote job archive and that the
+        // cache is still within the right size of localCacheSize + remoteFetchCacheSize;
+        assertThat(findJobIdInGeneralCache(webDir, jobIdByCreation.get(3))).isTrue();
+        assertThat(getNumJobsInGeneralCache(webDir))
+                .isEqualTo(localCacheSize + mostRecentlyViewedCacheSize);
+
+        // Fetching another job via remote fetch
+        archiveFetcher.fetchArchiveByJobId(jobIdByCreation.get(4));
+
+        // Forcing a background refresh to evict the previously remotely fetched job
+        archiveFetcher.fetchArchives();
+
+        // Validating that the previously remotely fetched job has been evicted and the new
+        // job has taken its place
+        assertThat(findJobIdInGeneralCache(webDir, jobIdByCreation.get(4))).isTrue();
+        assertThat(findJobIdInGeneralCache(webDir, jobIdByCreation.get(3))).isFalse();
+        assertThat(getNumJobsInGeneralCache(webDir))
+                .isEqualTo(localCacheSize + mostRecentlyViewedCacheSize);
+    }
+
+    @Test
+    void testGeneralCacheEviction(@TempDir Path tmpDir) throws IOException, InterruptedException {
+        final Path webDir = Files.createDirectory(tmpDir.resolve("webDir"));
+        final Path tempDir = Files.createDirectory(tmpDir.resolve("tmpDir"));
+        final org.apache.flink.core.fs.Path tempDirFs =
+                new org.apache.flink.core.fs.Path(tempDir.toUri());
+
+        List<HistoryServer.RefreshLocation> refreshDirs = new ArrayList<>();
+        FileSystem refreshFS = tempDirFs.getFileSystem();
+        refreshDirs.add(new HistoryServer.RefreshLocation(tempDirFs, refreshFS));
+
+        int numJobs = 5;
+        int generalCacheSize = 3;
+        int mostRecentlyViewedCacheSize = 1;
+
+        HistoryServerArchiveFetcher archiveFetcher =
+                new HistoryServerArchiveFetcher(
+                        refreshDirs,
+                        webDir.toFile(),
+                        (event) -> {},
+                        true,
+                        (archive, index) -> true, // No retention limit for this test
+                        generalCacheSize,
+                        true,
+                        mostRecentlyViewedCacheSize);
+
+        for (int i = 0; i < numJobs; i++) {
+            String jobID = JobID.generate().toString();
+            buildRemoteStorageJobDirectory(tempDir, jobID);
+        }
+
+        Map<Integer, String> jobIdByCreation =
+                retrieveRemoteArchivesByModificationTime(refreshFS, tempDirFs);
+
+        // Fetching the remote archives and storing them in the local cache
+        archiveFetcher.fetchArchives();
+
+        // Confirming that the size of the local cache is based on the asynchronous fetch cache
+        // limit
+        assertThat(getNumJobsInGeneralCache(webDir)).isEqualTo(generalCacheSize);
+        for (int i = 0; i < generalCacheSize; i++) {
+            assertThat(findJobIdInGeneralCache(webDir, jobIdByCreation.get(i))).isTrue();
+        }
+
+        // Adding another remote directory to indicate a newer job, we sleep for a short period
+        // of time to ensure a more recent timestamp
+        Thread.sleep(1000);
+        String latestJobID = JobID.generate().toString();
+        buildRemoteStorageJobDirectory(tempDir, latestJobID);
+
+        archiveFetcher.fetchArchives();
+
+        // Validating that the cache has not exceeded the async refresh cache limit and that
+        // the new job is cached
+        assertThat(getNumJobsInGeneralCache(webDir)).isEqualTo(generalCacheSize);
+        assertThat(findJobIdInGeneralCache(webDir, latestJobID)).isTrue();
+
+        // Validating that the oldest record was evicted from the cache
+        assertThat(findJobIdInGeneralCache(webDir, jobIdByCreation.get(2))).isFalse();
+    }
+
+    @Test
+    void testMostRecentlyViewedCacheNotEvictedByPeriodicFetch(@TempDir Path tmpDir)
+            throws IOException, InterruptedException {
+        final Path webDir = Files.createDirectory(tmpDir.resolve("webDir"));
+        final Path tempDir = Files.createDirectory(tmpDir.resolve("tmpDir"));
+        final org.apache.flink.core.fs.Path tempDirFs =
+                new org.apache.flink.core.fs.Path(tempDir.toUri());
+
+        List<HistoryServer.RefreshLocation> refreshDirs = new ArrayList<>();
+        FileSystem refreshFS = tempDirFs.getFileSystem();
+        refreshDirs.add(new HistoryServer.RefreshLocation(tempDirFs, refreshFS));
+
+        int numJobs = 5;
+        int generalCacheSize = 3;
+        int mostRecentlyViewedCacheSize = 1;
+
+        HistoryServerArchiveFetcher archiveFetcher =
+                new HistoryServerArchiveFetcher(
+                        refreshDirs,
+                        webDir.toFile(),
+                        (event) -> {},
+                        true,
+                        (archive, index) -> true, // No retention limit for this test
+                        generalCacheSize,
+                        true,
+                        mostRecentlyViewedCacheSize);
+
+        for (int i = 0; i < numJobs; i++) {
+            String jobID = JobID.generate().toString();
+            buildRemoteStorageJobDirectory(tempDir, jobID);
+        }
+
+        Map<Integer, String> jobIdByCreation =
+                retrieveRemoteArchivesByModificationTime(refreshFS, tempDirFs);
+
+        // Fetching the remote archives and storing them in the local cache
+        archiveFetcher.fetchArchives();
+
+        // Confirming that the size of the local cache is based on the asynchronous fetch cache
+        // limit
+        assertThat(getNumJobsInGeneralCache(webDir)).isEqualTo(generalCacheSize);
+        for (int i = 0; i < generalCacheSize; i++) {
+            assertThat(findJobIdInGeneralCache(webDir, jobIdByCreation.get(i))).isTrue();
+        }
+
+        // Adding another remote directory to indicate a newer job, we sleep for a short period
+        // of time to ensure a more recent timestamp
+        Thread.sleep(1000);
+        String latestJobID = JobID.generate().toString();
+        buildRemoteStorageJobDirectory(tempDir, latestJobID);
+
+        // Fetching a job stored in the remote archive
+        archiveFetcher.fetchArchiveByJobId(jobIdByCreation.get(3));
+
+        // triggering an asynchronous fetch to update the cache
+        archiveFetcher.fetchArchives();
+
+        // Validating that the cache has not exceeded the async refresh cache limit and that
+        // the new job is cached and that the most recently viewed job is still present
+        assertThat(getNumJobsInGeneralCache(webDir))
+                .isEqualTo(generalCacheSize + mostRecentlyViewedCacheSize);
+        assertThat(findJobIdInGeneralCache(webDir, latestJobID)).isTrue();
+        assertThat(findJobIdInGeneralCache(webDir, jobIdByCreation.get(3))).isTrue();
+
+        // Validating that the oldest record was evicted from the cache
+        assertThat(findJobIdInGeneralCache(webDir, jobIdByCreation.get(2))).isFalse();
+    }
+
+    @Test
+    void testGeneralAndMostRecentlyViewedCacheEviction(@TempDir Path tmpDir)
+            throws IOException, InterruptedException {
+        final Path webDir = Files.createDirectory(tmpDir.resolve("webDir"));
+        final Path tempDir = Files.createDirectory(tmpDir.resolve("tmpDir"));
+        final org.apache.flink.core.fs.Path tempDirFs =
+                new org.apache.flink.core.fs.Path(tempDir.toUri());
+
+        List<HistoryServer.RefreshLocation> refreshDirs = new ArrayList<>();
+        FileSystem refreshFS = tempDirFs.getFileSystem();
+        refreshDirs.add(new HistoryServer.RefreshLocation(tempDirFs, refreshFS));
+
+        int numJobs = 5;
+        int generalCacheSize = 3;
+        int mostRecentlyViewedCacheSize = 1;
+
+        HistoryServerArchiveFetcher archiveFetcher =
+                new HistoryServerArchiveFetcher(
+                        refreshDirs,
+                        webDir.toFile(),
+                        (event) -> {},
+                        true,
+                        (archive, index) -> true, // No retention limit for this test
+                        generalCacheSize,
+                        true,
+                        mostRecentlyViewedCacheSize);
+
+        for (int i = 0; i < numJobs; i++) {
+            String jobID = JobID.generate().toString();
+            buildRemoteStorageJobDirectory(tempDir, jobID);
+        }
+
+        Map<Integer, String> jobIdByCreation =
+                retrieveRemoteArchivesByModificationTime(refreshFS, tempDirFs);
+
+        // Fetching the remote archives and store them in the local cache
+        archiveFetcher.fetchArchives();
+
+        // Confirming that the size of the local cache is based on the asynchronous fetch cache
+        // limit
+        assertThat(getNumJobsInGeneralCache(webDir)).isEqualTo(generalCacheSize);
+        for (int i = 0; i < generalCacheSize; i++) {
+            assertThat(findJobIdInGeneralCache(webDir, jobIdByCreation.get(i))).isTrue();
+        }
+
+        // Fetching a job stored in the remote archive
+        archiveFetcher.fetchArchiveByJobId(jobIdByCreation.get(3));
+
+        // Validating that the cache size contains both the asynchronous and remote user fetch
+        // records
+        assertThat(getNumJobsInGeneralCache(webDir))
+                .isEqualTo(generalCacheSize + mostRecentlyViewedCacheSize);
+        for (int i = 0; i < generalCacheSize + mostRecentlyViewedCacheSize; i++) {
+            assertThat(findJobIdInGeneralCache(webDir, jobIdByCreation.get(i))).isTrue();
+        }
+
+        // Adding another remote directory to indicate a newer job, we sleep for a short period
+        // of time to ensure a more recent timestamp
+        Thread.sleep(1000);
+        String latestJobID = JobID.generate().toString();
+        buildRemoteStorageJobDirectory(tempDir, latestJobID);
+
+        // We remotely fetch another older archive which will mark the last remote fetch archive
+        // for eviction and trigger an asynchronous fetch which will evict both the out of date
+        // remote fetch job and the oldest asynchronous fetch job
+        archiveFetcher.fetchArchiveByJobId(jobIdByCreation.get(4));
+        archiveFetcher.fetchArchives();
+
+        // Validating that the correct remotely fetched job has been evicted
+        assertThat(findJobIdInGeneralCache(webDir, jobIdByCreation.get(4))).isTrue();
+        assertThat(findJobIdInGeneralCache(webDir, jobIdByCreation.get(3))).isFalse();
+
+        // Validating that the cache does not exceed the total cache limit
+        assertThat(getNumJobsInGeneralCache(webDir))
+                .isEqualTo(generalCacheSize + mostRecentlyViewedCacheSize);
+        assertThat(findJobIdInGeneralCache(webDir, latestJobID)).isTrue();
+
+        // Validating that the oldest record which was not remotely fetched was evicted from the
+        // cache
+        assertThat(findJobIdInGeneralCache(webDir, jobIdByCreation.get(2))).isFalse();
+    }
+
+    @Test
+    void testMostRecentlyViewedCacheUpdatesBasedOnFetchingByIdFromLocalCache(@TempDir Path tmpDir)
+            throws IOException, InterruptedException {
+        final Path webDir = Files.createDirectory(tmpDir.resolve("webDir"));
+        final Path tempDir = Files.createDirectory(tmpDir.resolve("tmpDir"));
+        final org.apache.flink.core.fs.Path tempDirFs =
+                new org.apache.flink.core.fs.Path(tempDir.toUri());
+
+        List<HistoryServer.RefreshLocation> refreshDirs = new ArrayList<>();
+        FileSystem refreshFS = tempDirFs.getFileSystem();
+        refreshDirs.add(new HistoryServer.RefreshLocation(tempDirFs, refreshFS));
+
+        int numJobs = 5;
+        int generalCacheSize = 3;
+        int mostRecentlyViewedCacheSize = 2;
+
+        HistoryServerArchiveFetcher archiveFetcher =
+                new HistoryServerArchiveFetcher(
+                        refreshDirs,
+                        webDir.toFile(),
+                        (event) -> {},
+                        true,
+                        (archive, index) -> true, // No retention limit for this test
+                        generalCacheSize,
+                        true,
+                        mostRecentlyViewedCacheSize);
+
+        for (int i = 0; i < numJobs; i++) {
+            String jobID = JobID.generate().toString();
+            buildRemoteStorageJobDirectory(tempDir, jobID);
+        }
+
+        Map<Integer, String> jobIdByCreation =
+                retrieveRemoteArchivesByModificationTime(refreshFS, tempDirFs);
+
+        // Fetching the remote archives and store them in the local cache
+        archiveFetcher.fetchArchives();
+
+        // Confirming that the size of the local cache is based on the asynchronous fetch cache
+        // limit
+        assertThat(getNumJobsInGeneralCache(webDir)).isEqualTo(generalCacheSize);
+        for (int i = 0; i < generalCacheSize; i++) {
+            assertThat(findJobIdInGeneralCache(webDir, jobIdByCreation.get(i))).isTrue();
+        }
+
+        // Fetching a job stored in the remote archive
+        archiveFetcher.fetchArchiveByJobId(jobIdByCreation.get(3));
+
+        // Fetching a job that is in the local cache via direct request
+        archiveFetcher.fetchArchiveByJobId(jobIdByCreation.get(2));
+
+        // Validating that the cache size contains both the asynchronous and remote user fetch
+        // records
+        assertThat(getNumJobsInGeneralCache(webDir)).isEqualTo(generalCacheSize + 1);
+        for (int i = 0; i < generalCacheSize + 1; i++) {
+            assertThat(findJobIdInGeneralCache(webDir, jobIdByCreation.get(i))).isTrue();
+        }
+
+        // Adding another remote directory to indicate a newer job, we sleep for a short period
+        // of time to ensure a more recent timestamp
+        Thread.sleep(1000);
+        String latestJobID = JobID.generate().toString();
+        buildRemoteStorageJobDirectory(tempDir, latestJobID);
+
+        // Doing asynchronous to retrieve the latest job. Because the job that would have
+        // otherwise would have been evicted was fetched via a user request, it should not
+        // be evicted from the archives
+        archiveFetcher.fetchArchives();
+
+        // Validating that the cache does not exceed the total cache limit and that the
+        // correct jobs are stored in the cache
+        assertThat(getNumJobsInGeneralCache(webDir))
+                .isEqualTo(generalCacheSize + mostRecentlyViewedCacheSize);
+        assertThat(findJobIdInGeneralCache(webDir, latestJobID)).isTrue();
+        for (int i = 0; i < generalCacheSize + 1; i++) {
+            assertThat(findJobIdInGeneralCache(webDir, jobIdByCreation.get(i))).isTrue();
+        }
+    }
+
+    private int getNumJobsInGeneralCache(Path cacheDir) {
+        File f = new File(cacheDir.toFile(), "/jobs");
+        return f.listFiles().length - 1;
+    }
+
+    private boolean findJobIdInGeneralCache(Path cacheDir, String jobID) throws IOException {
+        File jobPath = new File(cacheDir.toFile(), "/jobs/" + jobID + ".json");
+        return jobPath.exists();
+    }
+
+    private void buildRemoteStorageJobDirectory(Path refreshDir, String jobID) throws IOException {
+        String json =
+                "{\n"
+                        + "   \"archive\": [\n"
+                        + "      {\n"
+                        + "         \"path\": \"/jobs/"
+                        + jobID
+                        + "\",\n"
+                        + "         \"json\": \"{\\\"jid\\\":\\\""
+                        + jobID
+                        + "\\\",\\\"name\\\":\\\"WordCount\\\",\\\"isStoppable\\\":false,"
+                        + "\\\"state\\\":\\\"FINISHED\\\",\\\"start-time\\\":1705527079656,\\\"end-time\\\":1705527080059,"
+                        + "\\\"duration\\\":403,\\\"maxParallelism\\\":-1,\\\"now\\\":1705527080104,\\\"timestamps\\\":{\\\"FAILED\\\":"
+                        + "0,\\\"FINISHED\\\":1705527080059,\\\"CANCELLING\\\":0,\\\"CANCELED\\\":0,\\\"INITIALIZING\\\":"
+                        + "1705527079656,\\\"CREATED\\\":1705527079708,\\\"RUNNING\\\":1705527079763,\\\"RESTARTING\\\":"
+                        + "0,\\\"SUSPENDED\\\":0,\\\"FAILING\\\":0,\\\"RECONCILING\\\":0},\\\"vertices\\\":[{\\\"id\\\":"
+                        + "\\\"cbc357ccb763df2852fee8c4fc7d55f2\\\",\\\"name\\\":\\\"Source: in-memory-input -> tokenizer\\\","
+                        + "\\\"maxParallelism\\\":128,\\\"parallelism\\\":1,\\\"status\\\":\\\"FINISHED\\\","
+                        + "\\\"start-time\\\":1705527079881,\\\"end-time\\\":1705527080046,\\\"duration\\\":165,"
+                        + "\\\"tasks\\\":{\\\"CANCELED\\\":0,\\\"FAILED\\\":0,\\\"FINISHED\\\":1,\\\"DEPLOYING\\\":"
+                        + "0,\\\"RUNNING\\\":0,\\\"INITIALIZING\\\":0,\\\"SCHEDULED\\\":0,\\\"CANCELING\\\":0,"
+                        + "\\\"RECONCILING\\\":0,\\\"CREATED\\\":0},\\\"metrics\\\":{\\\"read-bytes\\\":0,"
+                        + "\\\"read-bytes-complete\\\":true,\\\"write-bytes\\\":4047,\\\"write-bytes-complete\\\":true,"
+                        + "\\\"read-records\\\":0,\\\"read-records-complete\\\":true,\\\"write-records\\\":287,"
+                        + "\\\"write-records-complete\\\":true,\\\"accumulated-backpressured-time\\\":0,"
+                        + "\\\"accumulated-idle-time\\\":0,\\\"accumulated-busy-time\\\":\\\"NaN\\\"}},{\\\"id\\\":"
+                        + "\\\""
+                        + jobID
+                        + "\\\",\\\"name\\\":\\\"counter -> Sink: print-sink\\\",\\\"maxParallelism\\\":"
+                        + "128,\\\"parallelism\\\":1,\\\"status\\\":\\\"FINISHED\\\",\\\"start-time\\\":"
+                        + "1705527079885,\\\"end-time\\\":1705527080057,\\\"duration\\\":172,\\\"tasks\\\":{\\\"CANCELED\\\":"
+                        + "0,\\\"FAILED\\\":0,\\\"FINISHED\\\":1,\\\"DEPLOYING\\\":0,\\\"RUNNING\\\":0,\\\"INITIALIZING\\\":"
+                        + "0,\\\"SCHEDULED\\\":0,\\\"CANCELING\\\":0,\\\"RECONCILING\\\":0,\\\"CREATED\\\":0},\\\"metrics\\\":"
+                        + "{\\\"read-bytes\\\":4060,\\\"read-bytes-complete\\\":true,\\\"write-bytes\\\":0,"
+                        + "\\\"write-bytes-complete\\\":true,\\\"read-records\\\":287,\\\"read-records-complete\\\":true,"
+                        + "\\\"write-records\\\":0,\\\"write-records-complete\\\":true,\\\"accumulated-backpressured-time\\\":"
+                        + "0,\\\"accumulated-idle-time\\\":1,\\\"accumulated-busy-time\\\":15.0}}],\\\"status-counts\\\":{\\\"CANCELED\\\":"
+                        + "0,\\\"FAILED\\\":0,\\\"FINISHED\\\":2,\\\"DEPLOYING\\\":0,\\\"RUNNING\\\":0,\\\"INITIALIZING\\\":0,"
+                        + "\\\"SCHEDULED\\\":0,\\\"CANCELING\\\":0,\\\"RECONCILING\\\":0,\\\"CREATED\\\":0},\\\"plan\\\":{\\\"jid\\\":"
+                        + "\\\""
+                        + jobID
+                        + "\\\",\\\"name\\\":\\\"WordCount\\\",\\\"type\\\":\\\"STREAMING\\\",\\\"nodes\\\":[{\\\"id\\\":"
+                        + "\\\""
+                        + jobID
+                        + "\\\",\\\"parallelism\\\":1,\\\"operator\\\":\\\"\\\",\\\"operator_strategy\\\":\\\"\\\","
+                        + "\\\"description\\\":\\\"counter<br/>+- Sink: print-sink<br/>\\\",\\\"inputs\\\":[{\\\"num\\\":0,"
+                        + "\\\"id\\\":\\\"cbc357ccb763df2852fee8c4fc7d55f2\\\",\\\"ship_strategy\\\":\\\"HASH\\\","
+                        + "\\\"exchange\\\":\\\"pipelined_bounded\\\"}],\\\"optimizer_properties\\\":{}},{\\\"id\\\":"
+                        + "\\\"cbc357ccb763df2852fee8c4fc7d55f2\\\",\\\"parallelism\\\":1,\\\"operator\\\":\\\"\\\","
+                        + "\\\"operator_strategy\\\":\\\"\\\",\\\"description\\\":\\\"Source: in-memory-input<br/>+- tokenizer"
+                        + "<br/>\\\",\\\"optimizer_properties\\\":{}}]}\"\n"
+                        + "      }\n"
+                        + "   ]\n"
+                        + "}";
+        Path remoteJobArchive = Files.createFile(refreshDir.resolve(jobID));
+        remoteJobArchive.toFile().setLastModified(System.currentTimeMillis());
+        FileUtils.writeStringToFile(remoteJobArchive.toFile(), json);
+    }
+
+    private Map<Integer, String> retrieveRemoteArchivesByModificationTime(
+            FileSystem refreshFS, org.apache.flink.core.fs.Path tempDirFs) throws IOException {
+        // List archives directly (listArchives was removed, use filesystem directly)
+        FileStatus[] archives = refreshFS.listStatus(tempDirFs);
+        if (archives == null) {
+            return new LinkedHashMap<>();
+        }
+        Arrays.sort(archives, Comparator.comparingLong(FileStatus::getModificationTime).reversed());
+
+        return IntStream.range(0, archives.length)
+                .boxed()
+                .collect(
+                        Collectors.toMap(
+                                i -> i,
+                                i -> archives[i].getPath().getName(),
+                                (a, b) -> b,
+                                LinkedHashMap::new));
+    }
+}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerStaticFileServerHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerStaticFileServerHandlerTest.java
@@ -20,16 +20,22 @@ package org.apache.flink.runtime.webmonitor.history;
 
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.runtime.rest.handler.router.Router;
 import org.apache.flink.runtime.webmonitor.testutils.HttpUtils;
 import org.apache.flink.runtime.webmonitor.utils.WebFrontendBootstrap;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -40,10 +46,34 @@ class HistoryServerStaticFileServerHandlerTest {
     void testRespondWithFile(@TempDir Path tmpDir) throws Exception {
         final Path webDir = Files.createDirectory(tmpDir.resolve("webDir"));
         final Path uploadDir = Files.createDirectory(tmpDir.resolve("uploadDir"));
+        final Path tempDir = Files.createDirectory(tmpDir.resolve("tmpDir"));
+        final org.apache.flink.core.fs.Path tempDirFs =
+                new org.apache.flink.core.fs.Path(tempDir.toUri());
+
+        buildLocalCacheDirectory(webDir, "job123");
+        buildRemoteStorageJobDirectory(tempDir, "jobabc");
+
+        List<HistoryServer.RefreshLocation> refreshDirs = new ArrayList<>();
+        FileSystem refreshFS = tempDirFs.getFileSystem();
+        refreshDirs.add(new HistoryServer.RefreshLocation(tempDirFs, refreshFS));
+
+        HistoryServerArchiveFetcher archiveFetcher =
+                new HistoryServerArchiveFetcher(
+                        refreshDirs,
+                        webDir.toFile(),
+                        (event) -> {},
+                        true,
+                        (archive, index) -> index <= 10, // Retain first 10 archives
+                        5,
+                        true,
+                        3);
 
         Router router =
                 new Router()
-                        .addGet("/:*", new HistoryServerStaticFileServerHandler(webDir.toFile()));
+                        .addGet(
+                                "/:*",
+                                new HistoryServerStaticFileServerHandler(
+                                        webDir.toFile(), true, archiveFetcher));
         WebFrontendBootstrap webUI =
                 new WebFrontendBootstrap(
                         router,
@@ -61,6 +91,23 @@ class HistoryServerStaticFileServerHandlerTest {
                     HttpUtils.getFromHTTP("http://localhost:" + port + "/hello");
             assertThat(notFound404.f0).isEqualTo(404);
             assertThat(notFound404.f1).contains("not found");
+
+            // verify that we are able to fetch job files from the local cache
+            Tuple2<Integer, String> foundFromCache =
+                    HttpUtils.getFromHTTP("http://localhost:" + port + "/jobs/job123");
+            assertThat(foundFromCache.f0).isEqualTo(200);
+
+            // verify that we are able to fetch job files from the remote file system when the
+            // file is not present in the local cache
+            Tuple2<Integer, String> foundFromRemoteCache =
+                    HttpUtils.getFromHTTP("http://localhost:" + port + "/jobs/jobabc");
+            assertThat(foundFromRemoteCache.f0).isEqualTo(200);
+
+            // verify that if a job does not exist either in the remote or local cache
+            // that a 404 message is returned
+            Tuple2<Integer, String> jobNotFound404 =
+                    HttpUtils.getFromHTTP("http://localhost:" + port + "/jobs/jobfoo");
+            assertThat(jobNotFound404.f0).isEqualTo(404);
 
             // verify that a) a file can be loaded using the ClassLoader and b) that the
             // HistoryServer
@@ -91,5 +138,69 @@ class HistoryServerStaticFileServerHandlerTest {
         } finally {
             webUI.shutdown();
         }
+    }
+
+    private void buildLocalCacheDirectory(Path cacheDir, String jobID) throws IOException {
+        File localCachePath = new File(cacheDir.toFile(), "jobs/" + jobID + ".json");
+        localCachePath.getParentFile().mkdirs();
+        Files.createFile(localCachePath.toPath());
+    }
+
+    private void buildRemoteStorageJobDirectory(Path refreshDir, String jobID) throws IOException {
+        String json =
+                "{\n"
+                        + "   \"archive\": [\n"
+                        + "      {\n"
+                        + "         \"path\": \"/jobs/"
+                        + jobID
+                        + "\",\n"
+                        + "         \"json\": \"{\\\"jid\\\":\\\""
+                        + jobID
+                        + "\\\",\\\"name\\\":\\\"WordCount\\\",\\\"isStoppable\\\":false,"
+                        + "\\\"state\\\":\\\"FINISHED\\\",\\\"start-time\\\":1705527079656,\\\"end-time\\\":1705527080059,"
+                        + "\\\"duration\\\":403,\\\"maxParallelism\\\":-1,\\\"now\\\":1705527080104,\\\"timestamps\\\":{\\\"FAILED\\\":"
+                        + "0,\\\"FINISHED\\\":1705527080059,\\\"CANCELLING\\\":0,\\\"CANCELED\\\":0,\\\"INITIALIZING\\\":"
+                        + "1705527079656,\\\"CREATED\\\":1705527079708,\\\"RUNNING\\\":1705527079763,\\\"RESTARTING\\\":"
+                        + "0,\\\"SUSPENDED\\\":0,\\\"FAILING\\\":0,\\\"RECONCILING\\\":0},\\\"vertices\\\":[{\\\"id\\\":"
+                        + "\\\"cbc357ccb763df2852fee8c4fc7d55f2\\\",\\\"name\\\":\\\"Source: in-memory-input -> tokenizer\\\","
+                        + "\\\"maxParallelism\\\":128,\\\"parallelism\\\":1,\\\"status\\\":\\\"FINISHED\\\","
+                        + "\\\"start-time\\\":1705527079881,\\\"end-time\\\":1705527080046,\\\"duration\\\":165,"
+                        + "\\\"tasks\\\":{\\\"CANCELED\\\":0,\\\"FAILED\\\":0,\\\"FINISHED\\\":1,\\\"DEPLOYING\\\":"
+                        + "0,\\\"RUNNING\\\":0,\\\"INITIALIZING\\\":0,\\\"SCHEDULED\\\":0,\\\"CANCELING\\\":0,"
+                        + "\\\"RECONCILING\\\":0,\\\"CREATED\\\":0},\\\"metrics\\\":{\\\"read-bytes\\\":0,"
+                        + "\\\"read-bytes-complete\\\":true,\\\"write-bytes\\\":4047,\\\"write-bytes-complete\\\":true,"
+                        + "\\\"read-records\\\":0,\\\"read-records-complete\\\":true,\\\"write-records\\\":287,"
+                        + "\\\"write-records-complete\\\":true,\\\"accumulated-backpressured-time\\\":0,"
+                        + "\\\"accumulated-idle-time\\\":0,\\\"accumulated-busy-time\\\":\\\"NaN\\\"}},{\\\"id\\\":"
+                        + "\\\""
+                        + jobID
+                        + "\\\",\\\"name\\\":\\\"counter -> Sink: print-sink\\\",\\\"maxParallelism\\\":"
+                        + "128,\\\"parallelism\\\":1,\\\"status\\\":\\\"FINISHED\\\",\\\"start-time\\\":"
+                        + "1705527079885,\\\"end-time\\\":1705527080057,\\\"duration\\\":172,\\\"tasks\\\":{\\\"CANCELED\\\":"
+                        + "0,\\\"FAILED\\\":0,\\\"FINISHED\\\":1,\\\"DEPLOYING\\\":0,\\\"RUNNING\\\":0,\\\"INITIALIZING\\\":"
+                        + "0,\\\"SCHEDULED\\\":0,\\\"CANCELING\\\":0,\\\"RECONCILING\\\":0,\\\"CREATED\\\":0},\\\"metrics\\\":"
+                        + "{\\\"read-bytes\\\":4060,\\\"read-bytes-complete\\\":true,\\\"write-bytes\\\":0,"
+                        + "\\\"write-bytes-complete\\\":true,\\\"read-records\\\":287,\\\"read-records-complete\\\":true,"
+                        + "\\\"write-records\\\":0,\\\"write-records-complete\\\":true,\\\"accumulated-backpressured-time\\\":"
+                        + "0,\\\"accumulated-idle-time\\\":1,\\\"accumulated-busy-time\\\":15.0}}],\\\"status-counts\\\":{\\\"CANCELED\\\":"
+                        + "0,\\\"FAILED\\\":0,\\\"FINISHED\\\":2,\\\"DEPLOYING\\\":0,\\\"RUNNING\\\":0,\\\"INITIALIZING\\\":0,"
+                        + "\\\"SCHEDULED\\\":0,\\\"CANCELING\\\":0,\\\"RECONCILING\\\":0,\\\"CREATED\\\":0},\\\"plan\\\":{\\\"jid\\\":"
+                        + "\\\""
+                        + jobID
+                        + "\\\",\\\"name\\\":\\\"WordCount\\\",\\\"type\\\":\\\"STREAMING\\\",\\\"nodes\\\":[{\\\"id\\\":"
+                        + "\\\""
+                        + jobID
+                        + "\\\",\\\"parallelism\\\":1,\\\"operator\\\":\\\"\\\",\\\"operator_strategy\\\":\\\"\\\","
+                        + "\\\"description\\\":\\\"counter<br/>+- Sink: print-sink<br/>\\\",\\\"inputs\\\":[{\\\"num\\\":0,"
+                        + "\\\"id\\\":\\\"cbc357ccb763df2852fee8c4fc7d55f2\\\",\\\"ship_strategy\\\":\\\"HASH\\\","
+                        + "\\\"exchange\\\":\\\"pipelined_bounded\\\"}],\\\"optimizer_properties\\\":{}},{\\\"id\\\":"
+                        + "\\\"cbc357ccb763df2852fee8c4fc7d55f2\\\",\\\"parallelism\\\":1,\\\"operator\\\":\\\"\\\","
+                        + "\\\"operator_strategy\\\":\\\"\\\",\\\"description\\\":\\\"Source: in-memory-input<br/>+- tokenizer"
+                        + "<br/>\\\",\\\"optimizer_properties\\\":{}}]}\"\n"
+                        + "      }\n"
+                        + "   ]\n"
+                        + "}";
+        Path remoteJobArchive = Files.createFile(refreshDir.resolve(jobID));
+        FileUtils.writeStringToFile(remoteJobArchive.toFile(), json);
     }
 }

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerTest.java
@@ -57,11 +57,14 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.DeserializationFeature;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import javax.annotation.Nullable;
@@ -92,7 +95,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for the HistoryServer. */
 class HistoryServerTest {
-
     private static final JsonFactory JACKSON_FACTORY =
             new JsonFactory()
                     .enable(JsonGenerator.Feature.AUTO_CLOSE_TARGET)
@@ -198,15 +200,14 @@ class HistoryServerTest {
         }
 
         CountDownLatch numArchivesCreatedInitially = new CountDownLatch(numArchivesToKeepInHistory);
-        CountDownLatch numArchivesDeletedInitially =
-                new CountDownLatch(numArchivesToRemoveUponHsStart);
         CountDownLatch numArchivesCreatedTotal =
                 new CountDownLatch(
                         numArchivesBeforeHsStarted
                                 - numArchivesToRemoveUponHsStart
                                 + numArchivesAfterHsStarted);
-        CountDownLatch numArchivesDeletedTotal =
-                new CountDownLatch(numArchivesToRemoveUponHsStart + numArchivesAfterHsStarted);
+        CountDownLatch numArchivesDeletedTotal = new CountDownLatch(numArchivesAfterHsStarted);
+        CountDownLatch numArchivesRemovedInitially =
+                new CountDownLatch(numArchivesToRemoveUponHsStart);
 
         Configuration historyServerConfig =
                 createTestConfiguration(
@@ -223,8 +224,12 @@ class HistoryServerTest {
                                     numArchivesCreatedTotal.countDown();
                                     break;
                                 case DELETED:
-                                    numArchivesDeletedInitially.countDown();
                                     numArchivesDeletedTotal.countDown();
+                                    numArchivesRemovedInitially.countDown();
+                                    break;
+                                case DELETED_FROM_REMOTE:
+                                    numArchivesDeletedTotal.countDown();
+                                    numArchivesRemovedInitially.countDown();
                                     break;
                             }
                         },
@@ -236,7 +241,7 @@ class HistoryServerTest {
             hs.start();
             String baseUrl = "http://localhost:" + hs.getWebPort();
             assertThat(numArchivesCreatedInitially.await(10L, TimeUnit.SECONDS)).isTrue();
-            assertThat(numArchivesDeletedInitially.await(10L, TimeUnit.SECONDS)).isTrue();
+            assertThat(numArchivesRemovedInitially.await(10L, TimeUnit.SECONDS)).isTrue();
             assertThat(getIdsFromJobOverview(baseUrl))
                     .isEqualTo(new HashSet<>(expectedJobIdsToKeep));
 
@@ -275,6 +280,24 @@ class HistoryServerTest {
                 .isInstanceOf(IllegalConfigurationException.class);
     }
 
+    @Test
+    void testFailIfCacheSizeLimitIsZero() throws Exception {
+        assertThatThrownBy(() -> startHistoryServerWithCacheSizeLimit(0))
+                .isInstanceOf(IllegalConfigurationException.class);
+    }
+
+    @Test
+    void testFailIfCacheSizeLimitIsLessThanMinusOne() throws Exception {
+        assertThatThrownBy(() -> startHistoryServerWithCacheSizeLimit(-2))
+                .isInstanceOf(IllegalConfigurationException.class);
+    }
+
+    @Test
+    void testFailIfRemoteCacheSizeLimitIsLessThanOrEqualToZero() throws Exception {
+        assertThatThrownBy(() -> startHistoryServerWithRemoteFetchCacheSizeLimit(0))
+                .isInstanceOf(IllegalConfigurationException.class);
+    }
+
     private void startHistoryServerWithSizeLimit(int maxHistorySize)
             throws IOException, FlinkException, InterruptedException {
         Configuration historyServerConfig =
@@ -284,16 +307,29 @@ class HistoryServerTest {
         new HistoryServer(historyServerConfig).start();
     }
 
-    @Test
-    void testCleanExpiredJob() throws Exception {
-        runArchiveExpirationTest(true);
+    private void startHistoryServerWithCacheSizeLimit(int maxCacheSize)
+            throws IOException, FlinkException, InterruptedException {
+        Configuration historyServerConfig =
+                createTestConfiguration(
+                        HistoryServerOptions.HISTORY_SERVER_CLEANUP_EXPIRED_JOBS.defaultValue());
+        historyServerConfig.set(HistoryServerOptions.HISTORY_SERVER_CACHED_JOBS, maxCacheSize);
+        new HistoryServer(historyServerConfig).start();
     }
 
-    @Test
-    void testRemainExpiredJob() throws Exception {
-        runArchiveExpirationTest(false);
+    private void startHistoryServerWithRemoteFetchCacheSizeLimit(
+            int numCachedMostRecentlyViewedJobs)
+            throws IOException, FlinkException, InterruptedException {
+        Configuration historyServerConfig =
+                createTestConfiguration(
+                        HistoryServerOptions.HISTORY_SERVER_CLEANUP_EXPIRED_JOBS.defaultValue());
+        historyServerConfig.set(HistoryServerOptions.HISTORY_SERVER_CACHED_JOBS, 3);
+        historyServerConfig.set(
+                HistoryServerOptions.HISTORY_SERVER_NUM_CACHED_MOST_RECENTLY_VIEWED_JOBS,
+                numCachedMostRecentlyViewedJobs);
+        new HistoryServer(historyServerConfig).start();
     }
 
+    // FLIP-490: Test for web directory cleanup
     @Test
     void testClearWebDir() throws Exception {
         // Test the path configured by 'historyserver.web.tmpdir' is clean.
@@ -334,20 +370,52 @@ class HistoryServerTest {
         assertThat(new File(historyWebDir, "applications").list()).containsExactly("overview.json");
     }
 
-    private void runArchiveExpirationTest(boolean cleanupExpiredJobs) throws Exception {
+    // FLIP-505: Parameterized test for archive expiration with caching
+    private static Stream<Arguments> archiveExpirationTestSource() {
+        return Stream.of(
+                Arguments.arguments(true, 3, 5, 5, 3),
+                Arguments.arguments(false, 3, 5, 5, 3),
+                Arguments.arguments(true, 3, 5, 1, 1),
+                Arguments.arguments(false, 3, 5, 1, 1),
+                Arguments.arguments(true, 5, 4, -1, 4),
+                Arguments.arguments(false, 3, 1, 5, 1),
+                Arguments.arguments(true, 5, 1, -1, 1),
+                Arguments.arguments(true, 3, 5, 2, 2),
+                Arguments.arguments(true, 4, -1, 3, 3),
+                Arguments.arguments(true, 3, -1, -1, 3),
+                Arguments.arguments(false, 3, -1, -1, 3));
+    }
+
+    @ParameterizedTest
+    @MethodSource("archiveExpirationTestSource")
+    void runArchiveExpirationTest(
+            boolean cleanupExpiredJobs,
+            final int numJobs,
+            final int maxCache,
+            final int maxHistory,
+            final int limitingHistory)
+            throws Exception {
         int numExpiredJobs = cleanupExpiredJobs ? 1 : 0;
-        int numJobs = 3;
         for (int x = 0; x < numJobs; x++) {
             runJob();
         }
         waitForArchivesCreation(numJobs);
 
-        CountDownLatch numExpectedArchivedJobs = new CountDownLatch(numJobs);
-        CountDownLatch firstArchiveExpiredLatch = new CountDownLatch(numExpiredJobs);
-        CountDownLatch allArchivesExpiredLatch =
-                new CountDownLatch(cleanupExpiredJobs ? numJobs : 0);
+        CountDownLatch numExpectedArchivedJobs = new CountDownLatch(limitingHistory);
+        int initialDeletedArchives =
+                (maxHistory > 0 && maxHistory < numJobs) ? numJobs - maxHistory : 0;
+        CountDownLatch numInitialDeletedArchives = new CountDownLatch(initialDeletedArchives);
+
+        CountDownLatch numDeletedArchivesInCache = new CountDownLatch(numExpiredJobs);
+
+        int allDeletedArchives =
+                (maxCache > 0 && maxCache == limitingHistory) ? maxCache : limitingHistory;
+        CountDownLatch allArchivesExpiredLatch;
+        allArchivesExpiredLatch = new CountDownLatch(cleanupExpiredJobs ? allDeletedArchives : 0);
 
         Configuration historyServerConfig = createTestConfiguration(cleanupExpiredJobs);
+        historyServerConfig.set(HistoryServerOptions.HISTORY_SERVER_CACHED_JOBS, maxCache);
+        historyServerConfig.set(HistoryServerOptions.HISTORY_SERVER_RETAINED_JOBS, maxHistory);
 
         HistoryServer hs =
                 new HistoryServer(
@@ -358,8 +426,11 @@ class HistoryServerTest {
                                     numExpectedArchivedJobs.countDown();
                                     break;
                                 case DELETED:
-                                    firstArchiveExpiredLatch.countDown();
+                                    numDeletedArchivesInCache.countDown();
                                     allArchivesExpiredLatch.countDown();
+                                    break;
+                                case DELETED_FROM_REMOTE:
+                                    numInitialDeletedArchives.countDown();
                                     break;
                             }
                         },
@@ -371,12 +442,15 @@ class HistoryServerTest {
             hs.start();
             String baseUrl = "http://localhost:" + hs.getWebPort();
             assertThat(numExpectedArchivedJobs.await(10L, TimeUnit.SECONDS)).isTrue();
+            assertThat(numInitialDeletedArchives.await(10L, TimeUnit.SECONDS)).isTrue();
 
             Collection<JobDetails> jobs = getJobsOverview(baseUrl).getJobs();
-            assertThat(jobs).hasSize(numJobs);
+            assertThat(jobs).hasSize(Math.min(numJobs, limitingHistory));
 
+            int jobCount = jobs.size();
             String jobIdToDelete =
                     jobs.stream()
+                            .skip(jobCount - 1)
                             .findFirst()
                             .map(JobDetails::getJobId)
                             .map(JobID::toString)
@@ -389,40 +463,147 @@ class HistoryServerTest {
             // we fetch again to probabilistically cause a concurrent deletion
             hs.fetchArchives();
             Files.deleteIfExists(jmDirectory.toPath().resolve(jobIdToDelete));
-
-            assertThat(firstArchiveExpiredLatch.await(10L, TimeUnit.SECONDS)).isTrue();
-
+            assertThat(numDeletedArchivesInCache.await(10L, TimeUnit.SECONDS)).isTrue();
             // check that archive is still/no longer present in hs
             Collection<JobDetails> jobsAfterDeletion = getJobsOverview(baseUrl).getJobs();
-            assertThat(jobsAfterDeletion).hasSize(numJobs - numExpiredJobs);
-            assertThat(
-                            jobsAfterDeletion.stream()
-                                    .map(JobDetails::getJobId)
-                                    .map(JobID::toString)
-                                    .filter(jobId -> jobId.equals(jobIdToDelete))
-                                    .count())
-                    .isEqualTo(1 - numExpiredJobs);
 
-            // delete remaining archives from jm and ensure files are cleaned up
-            List<String> remainingJobIds =
-                    jobsAfterDeletion.stream()
-                            .map(JobDetails::getJobId)
-                            .map(JobID::toString)
-                            .collect(Collectors.toList());
-
-            for (String remainingJobId : remainingJobIds) {
-                Files.deleteIfExists(jmDirectory.toPath().resolve(remainingJobId));
+            if (numExpiredJobs != 0) {
+                assertThat(
+                                jobsAfterDeletion.stream()
+                                        .map(JobDetails::getJobId)
+                                        .map(JobID::toString)
+                                        .filter(jobId -> jobId.equals(jobIdToDelete))
+                                        .count())
+                        .isEqualTo(0);
             }
 
+            // delete remaining archives from jm and ensure files are cleaned up
+            FileUtils.cleanDirectory(jmDirectory);
             assertThat(allArchivesExpiredLatch.await(10L, TimeUnit.SECONDS)).isTrue();
-
-            assertFilesCleanedUp(cleanupExpiredJobs);
+            Thread.sleep(3000);
+            assertJobFilesCleanedUp(cleanupExpiredJobs);
         } finally {
             hs.stop();
         }
     }
 
-    private void assertFilesCleanedUp(boolean filesShouldBeDeleted) throws IOException {
+    // FLIP-505: Test for remote and local cache limits
+
+    private static Stream<Arguments> remoteAndLocalCacheSource() {
+        return Stream.of(
+                Arguments.arguments(true, 1, 3, 1),
+                Arguments.arguments(false, 1, 3, 1),
+                Arguments.arguments(true, 3, 1, 1),
+                Arguments.arguments(false, 1, 3, 1),
+                Arguments.arguments(
+                        true,
+                        2,
+                        HistoryServerOptions.HISTORY_SERVER_RETAINED_JOBS.defaultValue(),
+                        2),
+                Arguments.arguments(
+                        false,
+                        2,
+                        HistoryServerOptions.HISTORY_SERVER_RETAINED_JOBS.defaultValue(),
+                        2),
+                Arguments.arguments(true, -1, 2, 2),
+                Arguments.arguments(false, -1, 2, 2));
+    }
+
+    @ParameterizedTest
+    @MethodSource("remoteAndLocalCacheSource")
+    void testRemoveLocalAndRemoteArchiveLimits(
+            final boolean versionLessThan14,
+            final int cacheLimit,
+            final int remoteHistoryLimit,
+            final int limitingStorage)
+            throws Exception {
+
+        final int numRemoteArchivesBeforeHsStarted = 4;
+        final int numRemoteArchivesAfterHsStarted = 2;
+
+        final int numArchivesDeletedAfterHsStarted =
+                numRemoteArchivesAfterHsStarted - limitingStorage;
+
+        final long oneMinuteSinceEpoch = 1000L * 60L;
+        List<String> expectedJobIdsToKeep = new LinkedList<>();
+
+        for (int j = 0; j < numRemoteArchivesBeforeHsStarted; j++) {
+            JobID jobId =
+                    createLegacyArchive(
+                            jmDirectory.toPath(), j * oneMinuteSinceEpoch, versionLessThan14);
+            if (j >= numRemoteArchivesBeforeHsStarted - limitingStorage) {
+                expectedJobIdsToKeep.add(jobId.toString());
+            }
+        }
+
+        CountDownLatch numArchivesCreatedInitially = new CountDownLatch(limitingStorage);
+        CountDownLatch numArchivesCreatedTotal = new CountDownLatch(limitingStorage * 2);
+        CountDownLatch numArchivesDeletedTotal =
+                new CountDownLatch(numArchivesDeletedAfterHsStarted);
+
+        Configuration historyServerConfig =
+                createTestConfiguration(
+                        HistoryServerOptions.HISTORY_SERVER_CLEANUP_EXPIRED_JOBS.defaultValue());
+        if (cacheLimit > 0) {
+            historyServerConfig.set(HistoryServerOptions.HISTORY_SERVER_CACHED_JOBS, cacheLimit);
+        }
+        historyServerConfig.set(
+                HistoryServerOptions.HISTORY_SERVER_RETAINED_JOBS, remoteHistoryLimit);
+
+        HistoryServer hs =
+                new HistoryServer(
+                        historyServerConfig,
+                        (event) -> {
+                            switch (event.getType()) {
+                                case CREATED:
+                                    numArchivesCreatedInitially.countDown();
+                                    numArchivesCreatedTotal.countDown();
+                                    break;
+                                case DELETED:
+                                    numArchivesDeletedTotal.countDown();
+                                    break;
+                                case DELETED_FROM_REMOTE:
+                                    numArchivesDeletedTotal.countDown();
+                                    break;
+                            }
+                        },
+                        (event) -> {}); // Application archive event listener (not used in this
+        // test)
+
+        try {
+            hs.start();
+            String baseUrl = "http://localhost:" + hs.getWebPort();
+            assertThat(numArchivesCreatedInitially.await(10L, TimeUnit.SECONDS)).isTrue();
+            assertThat(getIdsFromJobOverview(baseUrl))
+                    .isEqualTo(
+                            expectedJobIdsToKeep.stream()
+                                    .map(JobID::fromHexString)
+                                    .collect(Collectors.toSet()));
+
+            for (int j = numRemoteArchivesBeforeHsStarted;
+                    j < numRemoteArchivesBeforeHsStarted + numRemoteArchivesAfterHsStarted;
+                    j++) {
+                expectedJobIdsToKeep.remove(0);
+                expectedJobIdsToKeep.add(
+                        createLegacyArchive(
+                                        jmDirectory.toPath(),
+                                        j * oneMinuteSinceEpoch,
+                                        versionLessThan14)
+                                .toString());
+            }
+            assertThat(numArchivesCreatedTotal.await(10L, TimeUnit.SECONDS)).isTrue();
+            assertThat(numArchivesDeletedTotal.await(10L, TimeUnit.SECONDS)).isTrue();
+            assertThat(getIdsFromJobOverview(baseUrl))
+                    .isEqualTo(
+                            expectedJobIdsToKeep.stream()
+                                    .map(JobID::fromHexString)
+                                    .collect(Collectors.toSet()));
+        } finally {
+            hs.stop();
+        }
+    }
+
+    private void assertJobFilesCleanedUp(boolean jobFilesShouldBeDeleted) throws IOException {
         try (Stream<Path> paths = Files.walk(hsDirectory.toPath())) {
             final List<Path> applicationOrJobFiles =
                     paths.filter(path -> !path.equals(hsDirectory.toPath()))
@@ -439,7 +620,7 @@ class HistoryServerTest {
                             .filter(path -> !path.equals(Paths.get("application-overviews")))
                             .collect(Collectors.toList());
 
-            if (filesShouldBeDeleted) {
+            if (jobFilesShouldBeDeleted) {
                 assertThat(applicationOrJobFiles).isEmpty();
             } else {
                 assertThat(applicationOrJobFiles).isNotEmpty();
@@ -471,7 +652,7 @@ class HistoryServerTest {
                 HistoryServerOptions.HISTORY_SERVER_WEB_DIR, hsDirectory.getAbsolutePath());
         historyServerConfig.set(
                 HistoryServerOptions.HISTORY_SERVER_ARCHIVE_REFRESH_INTERVAL,
-                Duration.ofMillis(100L));
+                Duration.ofMillis(1000L));
 
         historyServerConfig.set(
                 HistoryServerOptions.HISTORY_SERVER_CLEANUP_EXPIRED_JOBS, cleanupExpiredJobs);
@@ -690,6 +871,11 @@ class HistoryServerTest {
                                             .DELETED) {
                                 numArchivesDeletedInitially.countDown();
                                 numArchivesDeletedTotal.countDown();
+                            } else if (event.getType()
+                                    == HistoryServerApplicationArchiveFetcher.ArchiveEventType
+                                            .DELETED_FROM_REMOTE) {
+                                numArchivesDeletedInitially.countDown();
+                                numArchivesDeletedTotal.countDown();
                             }
                         });
         try {
@@ -844,7 +1030,7 @@ class HistoryServerTest {
                 deleteApplicationArchiveDir(remainingApplicationId);
             }
             assertThat(allArchivesExpiredLatch.await(10L, TimeUnit.SECONDS)).isTrue();
-            assertFilesCleanedUp(cleanupExpiredApplications);
+            assertJobFilesCleanedUp(cleanupExpiredApplications);
         } finally {
             hs.stop();
         }

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/utils/WebFrontendBootstrapTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/utils/WebFrontendBootstrapTest.java
@@ -20,10 +20,13 @@ package org.apache.flink.runtime.webmonitor.utils;
 
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.runtime.io.network.netty.InboundChannelHandlerFactory;
 import org.apache.flink.runtime.io.network.netty.Prio0InboundChannelHandlerFactory;
 import org.apache.flink.runtime.io.network.netty.Prio1InboundChannelHandlerFactory;
 import org.apache.flink.runtime.rest.handler.router.Router;
+import org.apache.flink.runtime.webmonitor.history.HistoryServer;
+import org.apache.flink.runtime.webmonitor.history.HistoryServerArchiveFetcher;
 import org.apache.flink.runtime.webmonitor.history.HistoryServerStaticFileServerHandler;
 import org.apache.flink.runtime.webmonitor.testutils.HttpUtils;
 import org.apache.flink.testutils.junit.extensions.ContextClassLoaderExtension;
@@ -36,6 +39,8 @@ import org.slf4j.LoggerFactory;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -57,12 +62,35 @@ class WebFrontendBootstrapTest {
     @Test
     void testHandlersMustBeLoaded() throws Exception {
         Path webDir = Files.createDirectories(tmp.resolve("webDir"));
+
+        Path refreshDir = Files.createDirectories(tmp.resolve("refreshDir"));
+        final org.apache.flink.core.fs.Path tempDirFs =
+                new org.apache.flink.core.fs.Path(refreshDir.toUri());
+
+        List<HistoryServer.RefreshLocation> refreshDirs = new ArrayList<>();
+        FileSystem refreshFS = tempDirFs.getFileSystem();
+        refreshDirs.add(new HistoryServer.RefreshLocation(tempDirFs, refreshFS));
+
         Configuration configuration = new Configuration();
         configuration.set(Prio0InboundChannelHandlerFactory.REDIRECT_FROM_URL, "/nonExisting");
         configuration.set(Prio0InboundChannelHandlerFactory.REDIRECT_TO_URL, "/index.html");
+
+        HistoryServerArchiveFetcher archiveFetcher =
+                new HistoryServerArchiveFetcher(
+                        refreshDirs,
+                        webDir.toFile(),
+                        (event) -> {},
+                        true,
+                        (archive, index) -> index <= 10, // Retain first 10 archives
+                        5,
+                        true,
+                        3);
         Router<?> router =
                 new Router<>()
-                        .addGet("/:*", new HistoryServerStaticFileServerHandler(webDir.toFile()));
+                        .addGet(
+                                "/:*",
+                                new HistoryServerStaticFileServerHandler(
+                                        webDir.toFile(), false, archiveFetcher));
         WebFrontendBootstrap webUI =
                 new WebFrontendBootstrap(
                         router,

--- a/flink-runtime-web/web-dashboard/src/app/components/job-list/job-list.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/components/job-list/job-list.component.html
@@ -30,7 +30,7 @@
         <th [nzSortFn]="sortJobNameFn" nzWidth="40%">Job Name</th>
         <th [nzSortFn]="sortStartTimeFn">Start Time</th>
         <th [nzSortFn]="sortDurationFn">Duration</th>
-        <th [nzSortFn]="sortEndTimeFn">End Time</th>
+        <th [nzSortFn]="sortEndTimeFn" [nzSortOrder]="sortOrder">End Time</th>
         <th>Tasks</th>
         <th [nzSortFn]="sortStateFn">Status</th>
       </tr>

--- a/flink-runtime-web/web-dashboard/src/app/components/job-list/job-list.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/components/job-list/job-list.component.ts
@@ -61,6 +61,7 @@ export class JobListComponent implements OnInit, OnDestroy, OnChanges {
   listOfJob: JobsItem[] = [];
   isLoading = true;
   destroy$ = new Subject<void>();
+  sortOrder = 'descend';
   @Input() completed = false;
   @Input() title: string;
   @Input() jobData$: Observable<JobsItem[]>;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/files/StaticFileServerHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/files/StaticFileServerHandler.java
@@ -368,7 +368,7 @@ public class StaticFileServerHandler<T extends RestfulGateway> extends LeaderRet
     public static void checkFileValidity(File file, File rootPath, Logger logger)
             throws IOException, RestHandlerException {
         // this check must be done first to prevent probing for arbitrary files
-        if (!file.getCanonicalFile().toPath().startsWith(rootPath.toPath())) {
+        if (!file.getCanonicalFile().toPath().startsWith(rootPath.getCanonicalFile().toPath())) {
             if (logger.isDebugEnabled()) {
                 logger.debug(
                         "Requested path {} points outside the root directory.",


### PR DESCRIPTION
## All credit to @achang52 as the FLIP-505 implementer and contributor. This is a fork off of https://github.com/apache/flink/pull/26878 as the PR has been abandoned since August 2025.

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Implementing FLIP-505 for Flink History Server scalability improvements by decoupling local job archive caching with a remote store.


## Brief change log

- Adding new configurations for the Flink History Server historyserver.archive.cached-retained-jobs and historyserver.archive.num-cached-most-recently-viewed-jobs
- Enabling decoupling the number of job archives stored from the local cache by enabling remote storage
- Enabling fetching a job archive by jobID


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

This change added tests and can be verified as follows:

- Added new tests for [HistoryServerArchiveFetcherTest.java](https://github.com/apache/flink/compare/master...achang52:flink:FLINK-37155?expand=1#diff-869f7fea48433ce47b78bf3220a8934f55b420eb4b20eda22fc29b55697a8036) for ensuring the validation of how cached jobs are evicted and how the local and remote caches interact
- Added additional test in the HistoryServerTest.java and WebFrontendBootstrapTest to cover local and remote caching behavior
- Manually verified by deploying the Flink History Server locally with test job archives.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

- Does this pull request introduce a new feature? yes
- If yes, how is the feature documented? Documented in JavaDocs as well as in the FLIP-505 - https://cwiki.apache.org/confluence/display/FLINK/FLIP+505%3A+Flink+History+Server+Scability+Improvements%2C+Remote+Data+Store+Fetch+and+Per+Job+Fetch
