### PR TITLE
[hotfix] re-enable unit tests test_kafka.py for pyflink

### DIFF
--- a/flink-python/pyflink/datastream/connectors/tests/test_kafka.py
+++ b/flink-python/pyflink/datastream/connectors/tests/test_kafka.py
@@ -16,7 +16,6 @@
 # limitations under the License.
 ################################################################################
 import json
-import unittest
 from typing import Dict
 
 import pyflink.datastream.data_stream as data_stream
@@ -43,10 +42,8 @@ from pyflink.testing.test_case_utils import (
 from pyflink.util.java_utils import to_jarray, is_instance_of, get_field_value
 
 
-@unittest.skip("Disable due to Kafka connector need to release a new version 2.0")
 class KafkaSourceTests(PyFlinkStreamingTestCase):
 
-    @unittest.skip("Disabled due to cyclic dependencies: Should be removed with Flink 2.0")
     def test_legacy_kafka_connector(self):
         source_topic = 'test_source_topic'
         sink_topic = 'test_sink_topic'
@@ -422,7 +419,6 @@ class KafkaSourceTests(PyFlinkStreamingTestCase):
         return Configuration(j_configuration=j_configuration)
 
 
-@unittest.skip("Disable due to Kafka connector need to release a new version 2.0")
 class KafkaSinkTests(PyFlinkStreamingTestCase):
 
     def test_compile(self):
@@ -512,7 +508,6 @@ class KafkaSinkTests(PyFlinkStreamingTestCase):
             .build()
 
 
-@unittest.skip("Disable due to Kafka connector need to release a new version 2.0")
 class KafkaRecordSerializationSchemaTests(PyFlinkTestCase):
 
     def test_set_topic(self):
@@ -536,7 +531,6 @@ class KafkaRecordSerializationSchemaTests(PyFlinkTestCase):
         self.assertIsNone(j_record.key())
         self.assertEqual(j_record.value(), b'{"f0":"test"}')
 
-    @unittest.skip("Disable due to Kafka connector need to release a new version 2.0")
     def test_set_topic_selector(self):
         def _select(data):
             data = data[0]


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
