### PR TITLE
[FLINK-36456] feat: Add support to pass Datadog API Key as environment variable

### DIFF
--- a/docs/content.zh/docs/deployment/metric_reporters.md
+++ b/docs/content.zh/docs/deployment/metric_reporters.md
@@ -286,7 +286,7 @@ metrics.reporter.stsd.interval: 60 SECONDS
 
 参数:
 
-- `apikey` - Datadog 的 API KEY。
+- `apikey` - Datadog 的 API KEY。（或者设置环境变量 `DD_API_KEY` 来覆盖配置）
 - `proxyHost` - （可选的）发送到 Datadog 时使用的代理主机。
 - `proxyPort` - （可选的）发送到 Datadog 时使用的代理端口，默认为 8080。
 - `dataCenter` - （可选的）要连接的数据中心（`EU`/`US`），默认为 `US`。

--- a/docs/content/docs/deployment/metric_reporters.md
+++ b/docs/content/docs/deployment/metric_reporters.md
@@ -270,7 +270,7 @@ In contrast to Datadog-provided Histograms the reported aggregations are not com
 
 Parameters:
 
-- `apikey` - the Datadog API key
+- `apikey` - the Datadog API key (or set environment variable `DD_API_KEY` to override)
 - `proxyHost` - (optional) The proxy host to use when sending to Datadog.
 - `proxyPort` - (optional) The proxy port to use when sending to Datadog, defaults to 8080.
 - `dataCenter` - (optional) The data center (`EU`/`US`) to connect to, defaults to `US`.

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporterFactory.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporterFactory.java
@@ -32,6 +32,7 @@ public class DatadogHttpReporterFactory implements MetricReporterFactory {
     private static final Logger LOG = LoggerFactory.getLogger(DatadogHttpReporterFactory.class);
 
     private static final String API_KEY = "apikey";
+    private static final String API_KEY_ENV_VAR = "DATADOG_API_KEY";
     private static final String PROXY_HOST = "proxyHost";
     private static final String PROXY_PORT = "proxyPort";
     private static final String DATA_CENTER = "dataCenter";
@@ -41,7 +42,7 @@ public class DatadogHttpReporterFactory implements MetricReporterFactory {
 
     @Override
     public MetricReporter createMetricReporter(Properties config) {
-        final String apiKey = config.getProperty(API_KEY, null);
+        final String apiKey = getApiKey(config);
         final String proxyHost = config.getProperty(PROXY_HOST, null);
         final int proxyPort = Integer.valueOf(config.getProperty(PROXY_PORT, "8080"));
         final String rawDataCenter = config.getProperty(DATA_CENTER, "US");
@@ -64,5 +65,23 @@ public class DatadogHttpReporterFactory implements MetricReporterFactory {
                 dataCenter,
                 tags,
                 useLogicalIdentifier);
+    }
+
+    /**
+     * Retrieves the Datadog API key from configuration or environment variable.
+     *
+     * <p>The API key is resolved in the following order:
+     * 1. Configuration property "apikey"
+     * 2. Environment variable "DATADOG_API_KEY"
+     *
+     * @param config the configuration properties
+     * @return the Datadog API key, or null if not found in either location
+     */
+    private String getApiKey(Properties config) {
+        String apiKey = config.getProperty(API_KEY, null);
+        if (apiKey != null && !apiKey.isEmpty()) {
+            return apiKey;
+        }
+        return System.getenv(API_KEY_ENV_VAR);
     }
 }

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporterFactory.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporterFactory.java
@@ -71,8 +71,11 @@ public class DatadogHttpReporterFactory implements MetricReporterFactory {
      * Retrieves the Datadog API key from configuration or environment variable.
      *
      * <p>The API key is resolved in the following order:
-     * 1. Configuration property "apikey"
-     * 2. Environment variable "DATADOG_API_KEY"
+     *
+     * <ol>
+     *   <li>Configuration property "apikey"
+     *   <li>Environment variable "DATADOG_API_KEY"
+     * </ol>
      *
      * @param config the configuration properties
      * @return the Datadog API key, or null if not found in either location

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporterFactory.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporterFactory.java
@@ -32,7 +32,7 @@ public class DatadogHttpReporterFactory implements MetricReporterFactory {
     private static final Logger LOG = LoggerFactory.getLogger(DatadogHttpReporterFactory.class);
 
     private static final String API_KEY = "apikey";
-    private static final String API_KEY_ENV_VAR = "DATADOG_API_KEY";
+    private static final String API_KEY_ENV_VAR = "DD_API_KEY";
     private static final String PROXY_HOST = "proxyHost";
     private static final String PROXY_PORT = "proxyPort";
     private static final String DATA_CENTER = "dataCenter";
@@ -68,23 +68,27 @@ public class DatadogHttpReporterFactory implements MetricReporterFactory {
     }
 
     /**
-     * Retrieves the Datadog API key from configuration or environment variable.
-     *
-     * <p>The API key is resolved in the following order:
-     *
-     * <ol>
-     *   <li>Configuration property "apikey"
-     *   <li>Environment variable "DATADOG_API_KEY"
-     * </ol>
+    * Retrieves the Datadog API key from environment variable or configuration.
+    *
+    * <p>The API key is resolved in the following order:
+    *
+    * <ol>
+    *   <li>Environment variable "DD_API_KEY"
+    *   <li>Configuration property "apikey"
+    * </ol>
      *
      * @param config the configuration properties
      * @return the Datadog API key, or null if not found in either location
      */
     private String getApiKey(Properties config) {
+        final String envApiKey = System.getenv(API_KEY_ENV_VAR);
+        if (envApiKey != null && !envApiKey.isEmpty()) {
+            return envApiKey;
+        }
         String apiKey = config.getProperty(API_KEY, null);
         if (apiKey != null && !apiKey.isEmpty()) {
             return apiKey;
         }
-        return System.getenv(API_KEY_ENV_VAR);
+        return null;
     }
 }

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporterFactory.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporterFactory.java
@@ -68,14 +68,14 @@ public class DatadogHttpReporterFactory implements MetricReporterFactory {
     }
 
     /**
-    * Retrieves the Datadog API key from environment variable or configuration.
-    *
-    * <p>The API key is resolved in the following order:
-    *
-    * <ol>
-    *   <li>Environment variable "DD_API_KEY"
-    *   <li>Configuration property "apikey"
-    * </ol>
+     * Retrieves the Datadog API key from environment variable or configuration.
+     *
+     * <p>The API key is resolved in the following order:
+     *
+     * <ol>
+     *   <li>Environment variable "DD_API_KEY"
+     *   <li>Configuration property "apikey"
+     * </ol>
      *
      * @param config the configuration properties
      * @return the Datadog API key, or null if not found in either location

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporterFactory.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporterFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.metrics.datadog;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.metrics.reporter.MetricReporterFactory;
 
@@ -25,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Properties;
+import java.util.function.Function;
 
 /** {@link MetricReporterFactory} for {@link DatadogHttpReporter}. */
 public class DatadogHttpReporterFactory implements MetricReporterFactory {
@@ -42,7 +44,7 @@ public class DatadogHttpReporterFactory implements MetricReporterFactory {
 
     @Override
     public MetricReporter createMetricReporter(Properties config) {
-        final String apiKey = getApiKey(config);
+        final String apiKey = getApiKey(config, System::getenv);
         final String proxyHost = config.getProperty(PROXY_HOST, null);
         final int proxyPort = Integer.valueOf(config.getProperty(PROXY_PORT, "8080"));
         final String rawDataCenter = config.getProperty(DATA_CENTER, "US");
@@ -78,10 +80,12 @@ public class DatadogHttpReporterFactory implements MetricReporterFactory {
      * </ol>
      *
      * @param config the configuration properties
+     * @param envLookup function used to read environment variables (injectable for tests)
      * @return the Datadog API key, or null if not found in either location
      */
-    private String getApiKey(Properties config) {
-        final String envApiKey = System.getenv(API_KEY_ENV_VAR);
+    @VisibleForTesting
+    String getApiKey(Properties config, Function<String, String> envLookup) {
+        final String envApiKey = envLookup.apply(API_KEY_ENV_VAR);
         if (envApiKey != null && !envApiKey.isEmpty()) {
             return envApiKey;
         }

--- a/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DatadogHttpReporterFactoryTest.java
+++ b/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DatadogHttpReporterFactoryTest.java
@@ -91,8 +91,7 @@ class DatadogHttpReporterFactoryTest {
             newEnv.put("DATADOG_API_KEY", envApiKey);
             CommonTestUtils.setEnv(newEnv, true);
 
-            final String resolvedApiKey =
-                    getApiKeyViaReflection(createConfig("apikey", ""));
+            final String resolvedApiKey = getApiKeyViaReflection(createConfig("apikey", ""));
             assertThat(resolvedApiKey).isEqualTo(envApiKey);
         } finally {
             CommonTestUtils.setEnv(originalEnv, true);

--- a/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DatadogHttpReporterFactoryTest.java
+++ b/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DatadogHttpReporterFactoryTest.java
@@ -21,13 +21,10 @@ package org.apache.flink.metrics.datadog;
 import org.apache.flink.metrics.util.MetricReporterTestUtils;
 
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
 
 import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.when;
 
 /** Tests for the {@link DatadogHttpReporterFactory}. */
 class DatadogHttpReporterFactoryTest {
@@ -45,42 +42,17 @@ class DatadogHttpReporterFactoryTest {
     }
 
     @Test
-    void testApiKeyFromEnvironmentVariable() throws Exception {
-        final String apiKey = "test-api-key-from-env";
-
-        try (MockedStatic<System> systemMock = mockStatic(System.class)) {
-            systemMock.when(System::getenv).thenReturn(java.util.Map.of("DATADOG_API_KEY", apiKey));
-            when(System.getenv("DATADOG_API_KEY")).thenReturn(apiKey);
-
-            final String resolvedApiKey = getApiKeyViaReflection(createConfig());
-            assertThat(resolvedApiKey).isEqualTo(apiKey);
-        }
+    void testEmptyConfigurationPropertyReturnsNull() throws Exception {
+        final String resolvedApiKey = getApiKeyViaReflection(createConfig("apikey", ""));
+        // When config is empty, it falls back to System.getenv which returns null if not set
+        assertThat(resolvedApiKey).isNull();
     }
 
     @Test
-    void testConfigurationPropertyTakesPrecedenceOverEnvironmentVariable() throws Exception {
-        final String configApiKey = "test-api-key-from-config";
-        final String envApiKey = "test-api-key-from-env";
-
-        try (MockedStatic<System> systemMock = mockStatic(System.class)) {
-            when(System.getenv("DATADOG_API_KEY")).thenReturn(envApiKey);
-
-            final String resolvedApiKey =
-                    getApiKeyViaReflection(createConfig("apikey", configApiKey));
-            assertThat(resolvedApiKey).isEqualTo(configApiKey);
-        }
-    }
-
-    @Test
-    void testEmptyConfigurationPropertyFallsBackToEnvironmentVariable() throws Exception {
-        final String envApiKey = "test-api-key-from-env";
-
-        try (MockedStatic<System> systemMock = mockStatic(System.class)) {
-            when(System.getenv("DATADOG_API_KEY")).thenReturn(envApiKey);
-
-            final String resolvedApiKey = getApiKeyViaReflection(createConfig("apikey", ""));
-            assertThat(resolvedApiKey).isEqualTo(envApiKey);
-        }
+    void testNoConfigurationPropertyReturnsNull() throws Exception {
+        final String resolvedApiKey = getApiKeyViaReflection(createConfig());
+        // When no config is provided, it falls back to System.getenv which returns null if not set
+        assertThat(resolvedApiKey).isNull();
     }
 
     private Properties createConfig(String key, String value) {

--- a/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DatadogHttpReporterFactoryTest.java
+++ b/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DatadogHttpReporterFactoryTest.java
@@ -18,15 +18,143 @@
 
 package org.apache.flink.metrics.datadog;
 
+import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.metrics.util.MetricReporterTestUtils;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for the {@link DatadogHttpReporterFactory}. */
 class DatadogHttpReporterFactoryTest {
 
+    private DatadogHttpReporterFactory factory;
+
+    @BeforeEach
+    void setUp() {
+        factory = new DatadogHttpReporterFactory();
+    }
+
     @Test
     void testMetricReporterSetupViaSPI() {
         MetricReporterTestUtils.testMetricReporterSetupViaSPI(DatadogHttpReporterFactory.class);
+    }
+
+    @Test
+    void testApiKeyFromConfiguration() {
+        Properties config = new Properties();
+        config.setProperty("apikey", "test-api-key-from-config");
+        config.setProperty("dataCenter", "US");
+
+        MetricReporter reporter = factory.createMetricReporter(config);
+
+        assertThat(reporter).isNotNull().isInstanceOf(DatadogHttpReporter.class);
+    }
+
+    @Test
+    void testApiKeyFromEnvironmentVariable() {
+        Properties config = new Properties();
+        config.setProperty("dataCenter", "US");
+
+        // Store original environment variable
+        String originalEnv = System.getenv("DATADOG_API_KEY");
+        
+        try {
+            // Set environment variable via system property approach
+            // Note: This tests that the factory attempts to use the environment variable
+            // In actual deployment, the OS would set DATADOG_API_KEY before JVM startup
+            MetricReporter reporter = factory.createMetricReporter(config);
+
+            // If an API key is found (either from config or env), reporter should be created
+            // This test validates the code path doesn't fail when env var is expected
+            assertThat(reporter).isNotNull();
+        } finally {
+            // Clean up - restoration would happen via OS environment
+        }
+    }
+
+    @Test
+    void testConfigurationApiKeyTakesPrecedenceOverEnvironmentVariable() {
+        Properties config = new Properties();
+        config.setProperty("apikey", "test-api-key-from-config");
+        config.setProperty("dataCenter", "US");
+
+        MetricReporter reporter = factory.createMetricReporter(config);
+
+        assertThat(reporter).isNotNull().isInstanceOf(DatadogHttpReporter.class);
+    }
+
+    @Test
+    void testDefaultProxyPort() {
+        Properties config = new Properties();
+        config.setProperty("apikey", "test-api-key");
+        config.setProperty("dataCenter", "US");
+
+        MetricReporter reporter = factory.createMetricReporter(config);
+
+        assertThat(reporter).isNotNull().isInstanceOf(DatadogHttpReporter.class);
+    }
+
+    @Test
+    void testCustomProxySettings() {
+        Properties config = new Properties();
+        config.setProperty("apikey", "test-api-key");
+        config.setProperty("proxyHost", "proxy.example.com");
+        config.setProperty("proxyPort", "9090");
+        config.setProperty("dataCenter", "US");
+
+        MetricReporter reporter = factory.createMetricReporter(config);
+
+        assertThat(reporter).isNotNull().isInstanceOf(DatadogHttpReporter.class);
+    }
+
+    @Test
+    void testDataCenterConfiguration() {
+        Properties config = new Properties();
+        config.setProperty("apikey", "test-api-key");
+        config.setProperty("dataCenter", "EU");
+
+        MetricReporter reporter = factory.createMetricReporter(config);
+
+        assertThat(reporter).isNotNull().isInstanceOf(DatadogHttpReporter.class);
+    }
+
+    @Test
+    void testMaxMetricsPerRequestConfiguration() {
+        Properties config = new Properties();
+        config.setProperty("apikey", "test-api-key");
+        config.setProperty("maxMetricsPerRequest", "5000");
+        config.setProperty("dataCenter", "US");
+
+        MetricReporter reporter = factory.createMetricReporter(config);
+
+        assertThat(reporter).isNotNull().isInstanceOf(DatadogHttpReporter.class);
+    }
+
+    @Test
+    void testTagsConfiguration() {
+        Properties config = new Properties();
+        config.setProperty("apikey", "test-api-key");
+        config.setProperty("tags", "env:test,version:1.0");
+        config.setProperty("dataCenter", "US");
+
+        MetricReporter reporter = factory.createMetricReporter(config);
+
+        assertThat(reporter).isNotNull().isInstanceOf(DatadogHttpReporter.class);
+    }
+
+    @Test
+    void testUseLogicalIdentifierConfiguration() {
+        Properties config = new Properties();
+        config.setProperty("apikey", "test-api-key");
+        config.setProperty("useLogicalIdentifier", "true");
+        config.setProperty("dataCenter", "US");
+
+        MetricReporter reporter = factory.createMetricReporter(config);
+
+        assertThat(reporter).isNotNull().isInstanceOf(DatadogHttpReporter.class);
     }
 }

--- a/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DatadogHttpReporterFactoryTest.java
+++ b/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DatadogHttpReporterFactoryTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.metrics.util.MetricReporterTestUtils;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
 import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DatadogHttpReporterFactoryTest.java
+++ b/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DatadogHttpReporterFactoryTest.java
@@ -124,9 +124,11 @@ class DatadogHttpReporterFactoryTest {
                 } else {
                     env.put(key, value);
                 }
-                java.lang.reflect.Field theCaseInsensitiveEnvironmentField = pe.getDeclaredField("theCaseInsensitiveEnvironment");
+                java.lang.reflect.Field theCaseInsensitiveEnvironmentField =
+                        pe.getDeclaredField("theCaseInsensitiveEnvironment");
                 theCaseInsensitiveEnvironmentField.setAccessible(true);
-                Map<String, String> cienv = (Map<String, String>) theCaseInsensitiveEnvironmentField.get(null);
+                Map<String, String> cienv =
+                        (Map<String, String>) theCaseInsensitiveEnvironmentField.get(null);
                 if (value == null) {
                     cienv.remove(key);
                 } else {

--- a/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DatadogHttpReporterFactoryTest.java
+++ b/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DatadogHttpReporterFactoryTest.java
@@ -22,13 +22,17 @@ import org.apache.flink.metrics.util.MetricReporterTestUtils;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.Map;
 import java.util.Properties;
+import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for the {@link DatadogHttpReporterFactory}. */
 class DatadogHttpReporterFactoryTest {
+
+    private static final String API_KEY_ENV_VAR = "DD_API_KEY";
+
+    private final DatadogHttpReporterFactory factory = new DatadogHttpReporterFactory();
 
     @Test
     void testMetricReporterSetupViaSPI() {
@@ -36,108 +40,41 @@ class DatadogHttpReporterFactoryTest {
     }
 
     @Test
-    void testApiKeyFromConfigurationProperty() throws Exception {
+    void testApiKeyFromConfigurationProperty() {
         final String apiKey = "test-api-key-from-config";
-        final String resolvedApiKey = getApiKeyViaReflection(createConfig("apikey", apiKey));
-        assertThat(resolvedApiKey).isEqualTo(apiKey);
+        assertThat(factory.getApiKey(configWithApiKey(apiKey), envOf(null))).isEqualTo(apiKey);
     }
 
     @Test
-    void testEmptyConfigurationPropertyReturnsNull() throws Exception {
-        final String resolvedApiKey = getApiKeyViaReflection(createConfig("apikey", ""));
-        // When config is empty, it falls back to System.getenv which returns null if not set
-        assertThat(resolvedApiKey).isNull();
+    void testEmptyConfigurationPropertyReturnsNull() {
+        assertThat(factory.getApiKey(configWithApiKey(""), envOf(null))).isNull();
     }
 
     @Test
-    void testNoConfigurationPropertyReturnsNull() throws Exception {
-        final String resolvedApiKey = getApiKeyViaReflection(createConfig());
-        // When no config is provided, it falls back to System.getenv which returns null if not set
-        assertThat(resolvedApiKey).isNull();
+    void testNoConfigurationPropertyReturnsNull() {
+        assertThat(factory.getApiKey(new Properties(), envOf(null))).isNull();
     }
 
     @Test
-    void testApiKeyFromEnvironmentVariable() throws Exception {
+    void testApiKeyFromEnvironmentVariable() {
         final String envKey = "env-api-key";
-        setEnv("DD_API_KEY", envKey);
-        try {
-            final String resolvedApiKey = getApiKeyViaReflection(createConfig());
-            assertThat(resolvedApiKey).isEqualTo(envKey);
-        } finally {
-            setEnv("DD_API_KEY", null);
-        }
+        assertThat(factory.getApiKey(new Properties(), envOf(envKey))).isEqualTo(envKey);
     }
 
     @Test
-    void testEnvironmentVariableTakesPrecedenceOverConfiguration() throws Exception {
+    void testEnvironmentVariableTakesPrecedenceOverConfiguration() {
         final String envKey = "env-api-key";
         final String configKey = "config-api-key";
-        setEnv("DD_API_KEY", envKey);
-        try {
-            final String resolvedApiKey = getApiKeyViaReflection(createConfig("apikey", configKey));
-            assertThat(resolvedApiKey).isEqualTo(envKey);
-        } finally {
-            setEnv("DD_API_KEY", null);
-        }
+        assertThat(factory.getApiKey(configWithApiKey(configKey), envOf(envKey))).isEqualTo(envKey);
     }
 
-    private Properties createConfig(String key, String value) {
+    private static Properties configWithApiKey(String value) {
         Properties config = new Properties();
-        config.setProperty(key, value);
+        config.setProperty("apikey", value);
         return config;
     }
 
-    private Properties createConfig() {
-        return new Properties();
-    }
-
-    private String getApiKeyViaReflection(Properties config) throws Exception {
-        DatadogHttpReporterFactory factory = new DatadogHttpReporterFactory();
-        // Use reflection to call the private getApiKey method
-        java.lang.reflect.Method getApiKeyMethod =
-                DatadogHttpReporterFactory.class.getDeclaredMethod("getApiKey", Properties.class);
-        getApiKeyMethod.setAccessible(true);
-        return (String) getApiKeyMethod.invoke(factory, config);
-    }
-
-    @SuppressWarnings("unchecked")
-    private void setEnv(String key, String value) throws Exception {
-        try {
-            Map<String, String> env = System.getenv();
-            Class<?> cl = env.getClass();
-            java.lang.reflect.Field field = cl.getDeclaredField("m");
-            field.setAccessible(true);
-            Map<String, String> writableEnv = (Map<String, String>) field.get(env);
-            if (value == null) {
-                writableEnv.remove(key);
-            } else {
-                writableEnv.put(key, value);
-            }
-        } catch (NoSuchFieldException e) {
-            // Fallback for other JVM implementations
-            try {
-                Class<?> pe = Class.forName("java.lang.ProcessEnvironment");
-                java.lang.reflect.Field theEnvironmentField = pe.getDeclaredField("theEnvironment");
-                theEnvironmentField.setAccessible(true);
-                Map<String, String> env = (Map<String, String>) theEnvironmentField.get(null);
-                if (value == null) {
-                    env.remove(key);
-                } else {
-                    env.put(key, value);
-                }
-                java.lang.reflect.Field theCaseInsensitiveEnvironmentField =
-                        pe.getDeclaredField("theCaseInsensitiveEnvironment");
-                theCaseInsensitiveEnvironmentField.setAccessible(true);
-                Map<String, String> cienv =
-                        (Map<String, String>) theCaseInsensitiveEnvironmentField.get(null);
-                if (value == null) {
-                    cienv.remove(key);
-                } else {
-                    cienv.put(key, value);
-                }
-            } catch (ClassNotFoundException | NoSuchFieldException ex) {
-                // ignore; best-effort environment mutation for tests
-            }
-        }
+    private static Function<String, String> envOf(String ddApiKeyValue) {
+        return name -> API_KEY_ENV_VAR.equals(name) ? ddApiKeyValue : null;
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds support for passing the Datadog API Key via an environment variable (`DD_API_KEY`) instead of only through configuration properties. This enables secure credential management in containerized and cloud-native deployments where environment variables are commonly used.

**Why:** We utilize a GitOps workflow with ArgoCD to deploy the Flink operator and applications. Since we cannot commit sensitive data like the Datadog API key to our repository, injecting it during deployment has proven difficult.

This simplifies our secret management by allowing us to use the External Secrets Operator. We can now sync the API key to a Kubernetes Secret and inject it securely into the application using `envFrom`.

## Brief change log

- Add `DD_API_KEY` environment variable support in `DatadogHttpReporterFactory`
- The environment variable takes precedence over the `apikey` configuration property, so operators can override config at runtime without modifying the (often read-only) config file
- Add a test suite covering environment variable support, configuration property fallback, and precedence behavior
- Update English and Chinese metric-reporter docs to mention the new environment variable

Resolves [FLINK-36456](https://issues.apache.org/jira/browse/FLINK-36456) — see also related [FLINK-33994](https://issues.apache.org/jira/browse/FLINK-33994).

Related PRs:
- https://github.com/apache/flink/pull/19684
- https://github.com/apache/flink/pull/25470

## API Key Resolution Order

The API key is resolved in the following priority order:
1. Environment variable `DD_API_KEY` (if set and non-empty) — wins so operators can override config at runtime
2. Configuration property `apikey` (if set and non-empty)
3. `null` (if neither is provided)

## Verifying this change

This change is covered by 6 tests in `DatadogHttpReporterFactoryTest`:

- `testMetricReporterSetupViaSPI` — verifies the reporter is wired via SPI
- `testApiKeyFromConfigurationProperty` — API key resolves from the config property when no env var is set
- `testEmptyConfigurationPropertyReturnsNull` — empty config property and no env var returns null
- `testNoConfigurationPropertyReturnsNull` — missing config property and no env var returns null
- `testApiKeyFromEnvironmentVariable` — API key resolves from `DD_API_KEY` when no config property is set
- `testEnvironmentVariableTakesPrecedenceOverConfiguration` — env var wins over config when both are set

Tests use neither Mockito nor reflection. `DatadogHttpReporterFactory#getApiKey` is package-private (`@VisibleForTesting`) and takes a `Function<String, String>` env-lookup, so each test passes a small lambda for the desired `DD_API_KEY` value — no process-environment mutation, and no JDK 17 module-access workarounds are required.

The change is backward compatible: existing configurations that set only `apikey` continue to work unchanged.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): **no**
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
- The serializers: **no**
- The runtime per-record code paths (performance sensitive): **no**
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
- The S3 file system connector: **no**

## Documentation

- Does this pull request introduce a new feature? **yes**
- If yes, how is the feature documented?
  - English and Chinese metric-reporter docs mention the `DD_API_KEY` environment variable
  - `DatadogHttpReporterFactory#getApiKey` JavaDoc documents the resolution order
