### PR TITLE
[hotfix] Intermittent unit test failures we have hit in ExecutionGraph tests 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,6 @@ tmp
 *.zip
 *.log
 *.pyc
-.metals
 .DS_Store
 build-target
 **/dependency-reduced-pom.xml

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ tmp
 *.zip
 *.log
 *.pyc
+.metals
 .DS_Store
 build-target
 **/dependency-reduced-pom.xml

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
@@ -39,6 +39,7 @@ import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.executiongraph.IOMetrics;
+import org.apache.flink.runtime.executiongraph.JobStatusListener;
 import org.apache.flink.runtime.executiongraph.ResultPartitionBytes;
 import org.apache.flink.runtime.executiongraph.failover.TestRestartBackoffTimeStrategy;
 import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
@@ -105,6 +106,18 @@ public class SchedulerTestingUtils {
             final ScheduledExecutorService executorService)
             throws Exception {
         return new DefaultSchedulerBuilder(jobGraph, mainThreadExecutor, executorService).build();
+    }
+
+    public static DefaultScheduler createScheduler(
+            final JobGraph jobGraph,
+            final ComponentMainThreadExecutor mainThreadExecutor,
+            final ScheduledExecutorService executorService,
+            JobStatusListener jobStatusListener)
+            throws Exception {
+        DefaultSchedulerBuilder builder =
+                new DefaultSchedulerBuilder(jobGraph, mainThreadExecutor, executorService);
+        builder.setJobStatusListener(jobStatusListener);
+        return builder.build();
     }
 
     public static void enableCheckpointing(final JobGraph jobGraph) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/slowtaskdetector/ExecutionTimeBasedSlowTaskDetectorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/slowtaskdetector/ExecutionTimeBasedSlowTaskDetectorTest.java
@@ -261,6 +261,8 @@ class ExecutionTimeBasedSlowTaskDetectorTest {
                 executionGraph.getJobVertex(jobVertex2.getID()).getTaskVertices()[2];
         ev23.setInputBytes(1024);
 
+        // Sleep to ensure that the 3 tasks do actually start
+        Thread.sleep(10);
         ev23.getCurrentExecutionAttempt().markFinished();
 
         final Map<ExecutionVertexID, Collection<ExecutionAttemptID>> slowTasks =


### PR DESCRIPTION
We were getting an intermittent errors in our CI pipeline,
1) ExecutionTimeBasedSlowTaskDetectorTest.testBalancedInput : Expected size: 2 but was: 0
2) ExecutionGraphCoLocationRestartTest.testConstraintsAfterRestart : do not have the symptoms 
3) ExecutionGraphRestartTest.testCancelWhileFailing  expected: RUNNING FAILING
4) ExecutionTimeBasedSlowTaskDetectorTest.testNoFinishedTaskButRatioIsZero: Expected size: 3 but was: 0

The original change was to introduce sleeps in line with the approach the existing test take in this area. This was rightly rejected in the review. I have changed the approach to add job listeners and futures so that the tests continue when they hit the expected state, without using sleeps.
