### PR TITLE
[FLINK-38946][flink-metrics] Allow AWS PrivateLink/GCP Cloud Private Service Connect for Datadog integration

### DIFF
--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpClient.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpClient.java
@@ -41,9 +41,9 @@ public class DatadogHttpClient {
     private static final Logger LOGGER = LoggerFactory.getLogger(DatadogHttpClient.class);
 
     private static final String SERIES_URL_FORMAT =
-            "https://app.datadoghq.%s/api/v1/series?api_key=%s";
+            "https://api.datadoghq.%s/api/v1/series?api_key=%s";
     private static final String VALIDATE_URL_FORMAT =
-            "https://app.datadoghq.%s/api/v1/validate?api_key=%s";
+            "https://api.datadoghq.%s/api/v1/validate?api_key=%s";
     private static final MediaType MEDIA_TYPE = MediaType.parse("application/json; charset=utf-8");
     private static final int TIMEOUT = 3;
     private static final ObjectMapper MAPPER = new ObjectMapper();


### PR DESCRIPTION
## What is the purpose of the change

It aligns the Flink integration with Datadog's supported API host standards, unblocking usage of private networking support in Clouds providers, such as [AWS PrivateLink](https://docs.datadoghq.com/agent/guide/private-link/?tab=crossregionprivatelinkendpoints) and [GCP Private Service Connect Documentation](https://docs.datadoghq.com/agent/guide/gcp-private-service-connect/?site=eu),

## Brief change log

In DatadogHttpClient.java, the base URLs should be updated from: `https://app.datadoghq.%s/...` to `https://api.datadoghq.%s/`

## Verifying this change


*(example:)*
  - TODO: *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no