### PR TITLE
[FLINK-38783][runtime] Improved TieredStorageResourceRegistry Thread-Safety/Concurrency

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TieredStorageResourceRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TieredStorageResourceRegistry.java
@@ -20,10 +20,9 @@ package org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage;
 
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageDataIdentifier;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * A registry that maintains local or remote resources that correspond to a certain set of data in
@@ -31,8 +30,9 @@ import java.util.Map;
  */
 public class TieredStorageResourceRegistry {
 
-    private final Map<TieredStorageDataIdentifier, List<TieredStorageResource>>
-            registeredResources = new HashMap<>();
+    private final ConcurrentHashMap<
+                    TieredStorageDataIdentifier, CopyOnWriteArrayList<TieredStorageResource>>
+            registeredResources = new ConcurrentHashMap<>();
 
     /**
      * Register a new resource for the given owner.
@@ -43,7 +43,7 @@ public class TieredStorageResourceRegistry {
     public void registerResource(
             TieredStorageDataIdentifier owner, TieredStorageResource tieredStorageResource) {
         registeredResources
-                .computeIfAbsent(owner, (ignore) -> new ArrayList<>())
+                .computeIfAbsent(owner, (ignore) -> new CopyOnWriteArrayList<>())
                 .add(tieredStorageResource);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TieredStorageResourceRegistryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TieredStorageResourceRegistryTest.java
@@ -66,11 +66,11 @@ class TieredStorageResourceRegistryTest {
     void testConcurrentRegisterResourceWithDifferentOwners() throws Exception {
         AtomicInteger successfulRegistrations = new AtomicInteger(0);
 
+        // Run multiple concurrent threads to simulate concurrent registration (with
+        // different owners)
         runConcurrentTask(
                 threadId -> {
                     for (int i = 0; i < NUM_OPERATIONS_PER_THREAD; i++) {
-                        // Each thread uses unique owners to maximize contention
-                        // on HashMap.computeIfAbsent()
                         TestingDataIdentifier owner =
                                 new TestingDataIdentifier(threadId * NUM_OPERATIONS_PER_THREAD + i);
                         registry.registerResource(owner, () -> {});
@@ -78,7 +78,7 @@ class TieredStorageResourceRegistryTest {
                     }
                 });
 
-        assertNoExceptions("concurrent registerResource() calls");
+        assertNoExceptions("Concurrent registerResource() calls");
         assertThat(successfulRegistrations.get())
                 .isEqualTo(NUM_THREADS * NUM_OPERATIONS_PER_THREAD);
     }
@@ -92,6 +92,7 @@ class TieredStorageResourceRegistryTest {
             owners[i] = new TestingDataIdentifier(i);
         }
 
+        // Run multiple concurrent threads to simulate concurrent registration/clearing
         runConcurrentTask(
                 threadId -> {
                     for (int i = 0; i < NUM_OPERATIONS_PER_THREAD; i++) {
@@ -107,7 +108,8 @@ class TieredStorageResourceRegistryTest {
                     }
                 });
 
-        assertNoExceptions("concurrent register/clear calls");
+        // Verify there were no exceptions during concurrent registration/clear operations
+        assertNoExceptions("Concurrent registration/clearing calls");
     }
 
     @RepeatedTest(10)
@@ -128,12 +130,9 @@ class TieredStorageResourceRegistryTest {
         // Clear resources and verify all were registered
         registry.clearResourceFor(sharedOwner);
 
-        // Due to potential race conditions in ArrayList.add(), the actual count
-        // may be less than expected if the bug exists
+        // Verify that all registered resources were successfully release
         assertThat(releaseCount.get())
-                .as(
-                        "All registered resources should be released. "
-                                + "If fewer were released, ArrayList concurrent modification may have lost some entries.")
+                .as("All registered resources should be released.")
                 .isEqualTo(NUM_THREADS * NUM_OPERATIONS_PER_THREAD);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TieredStorageResourceRegistryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TieredStorageResourceRegistryTest.java
@@ -1,0 +1,229 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage;
+
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageDataIdentifier;
+
+import org.junit.jupiter.api.RepeatedTest;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link TieredStorageResourceRegistry}. */
+class TieredStorageResourceRegistryTest {
+
+    private static final int NUM_THREADS = 10;
+    private static final int NUM_OPERATIONS_PER_THREAD = 100;
+
+    @RepeatedTest(10)
+    void testConcurrentRegisterResourceWithDifferentOwners() throws Exception {
+        TieredStorageResourceRegistry registry = new TieredStorageResourceRegistry();
+        ExecutorService executor = Executors.newFixedThreadPool(NUM_THREADS);
+        CyclicBarrier barrier = new CyclicBarrier(NUM_THREADS);
+        CountDownLatch completionLatch = new CountDownLatch(NUM_THREADS);
+        List<Throwable> exceptions = Collections.synchronizedList(new ArrayList<>());
+        AtomicInteger successfulRegistrations = new AtomicInteger(0);
+
+        for (int t = 0; t < NUM_THREADS; t++) {
+            final int threadId = t;
+            executor.submit(
+                    () -> {
+                        try {
+                            // Wait for all threads to be ready
+                            barrier.await();
+
+                            for (int i = 0; i < NUM_OPERATIONS_PER_THREAD; i++) {
+                                // Each thread uses unique owners to maximize contention
+                                // on HashMap.computeIfAbsent()
+                                TestingDataIdentifier owner =
+                                        new TestingDataIdentifier(
+                                                threadId * NUM_OPERATIONS_PER_THREAD + i);
+                                registry.registerResource(owner, () -> {});
+                                successfulRegistrations.incrementAndGet();
+                            }
+                        } catch (Throwable e) {
+                            exceptions.add(e);
+                        } finally {
+                            completionLatch.countDown();
+                        }
+                    });
+        }
+
+        completionLatch.await(30, TimeUnit.SECONDS);
+        executor.shutdown();
+        executor.awaitTermination(10, TimeUnit.SECONDS);
+
+        // If the bug exists, we expect ConcurrentModificationException
+        // If fixed, all registrations should succeed
+        assertThat(exceptions)
+                .as(
+                        "Expected no exceptions during concurrent registerResource() calls. "
+                                + "Found: %s",
+                        exceptions)
+                .isEmpty();
+        assertThat(successfulRegistrations.get())
+                .isEqualTo(NUM_THREADS * NUM_OPERATIONS_PER_THREAD);
+    }
+
+    @RepeatedTest(10)
+    void testConcurrentRegisterAndClear() throws Exception {
+        TieredStorageResourceRegistry registry = new TieredStorageResourceRegistry();
+        ExecutorService executor = Executors.newFixedThreadPool(NUM_THREADS);
+        CyclicBarrier barrier = new CyclicBarrier(NUM_THREADS);
+        CountDownLatch completionLatch = new CountDownLatch(NUM_THREADS);
+        List<Throwable> exceptions = Collections.synchronizedList(new ArrayList<>());
+
+        // Use few owners to maximize contention on the same keys across threads
+        final int numOwners = 5;
+        TestingDataIdentifier[] owners = new TestingDataIdentifier[numOwners];
+        for (int i = 0; i < owners.length; i++) {
+            owners[i] = new TestingDataIdentifier(i);
+        }
+
+        for (int t = 0; t < NUM_THREADS; t++) {
+            executor.submit(
+                    () -> {
+                        try {
+                            barrier.await();
+
+                            for (int i = 0; i < NUM_OPERATIONS_PER_THREAD; i++) {
+                                // All threads compete for the same small set of owners
+                                TestingDataIdentifier owner = owners[i % numOwners];
+
+                                // Alternate between register and clear to maximize
+                                // concurrent modification chances
+                                if (i % 2 == 0) {
+                                    registry.registerResource(owner, () -> {});
+                                } else {
+                                    registry.clearResourceFor(owner);
+                                }
+                            }
+                        } catch (Throwable e) {
+                            exceptions.add(e);
+                        } finally {
+                            completionLatch.countDown();
+                        }
+                    });
+        }
+
+        completionLatch.await(30, TimeUnit.SECONDS);
+        executor.shutdown();
+        executor.awaitTermination(10, TimeUnit.SECONDS);
+
+        assertThat(exceptions)
+                .as(
+                        "Expected no exceptions during concurrent register/clear calls. "
+                                + "Found: %s",
+                        exceptions)
+                .isEmpty();
+    }
+
+    @RepeatedTest(10)
+    void testConcurrentRegisterResourceWithSameOwner() throws Exception {
+        TieredStorageResourceRegistry registry = new TieredStorageResourceRegistry();
+        ExecutorService executor = Executors.newFixedThreadPool(NUM_THREADS);
+        CyclicBarrier barrier = new CyclicBarrier(NUM_THREADS);
+        CountDownLatch completionLatch = new CountDownLatch(NUM_THREADS);
+        List<Throwable> exceptions = Collections.synchronizedList(new ArrayList<>());
+        AtomicInteger releaseCount = new AtomicInteger(0);
+
+        // Single owner shared across all threads
+        TestingDataIdentifier sharedOwner = new TestingDataIdentifier(0);
+
+        for (int t = 0; t < NUM_THREADS; t++) {
+            executor.submit(
+                    () -> {
+                        try {
+                            barrier.await();
+
+                            for (int i = 0; i < NUM_OPERATIONS_PER_THREAD; i++) {
+                                registry.registerResource(
+                                        sharedOwner, () -> releaseCount.incrementAndGet());
+                            }
+                        } catch (Throwable e) {
+                            exceptions.add(e);
+                        } finally {
+                            completionLatch.countDown();
+                        }
+                    });
+        }
+
+        completionLatch.await(30, TimeUnit.SECONDS);
+        executor.shutdown();
+        executor.awaitTermination(10, TimeUnit.SECONDS);
+
+        assertThat(exceptions)
+                .as(
+                        "Expected no exceptions during concurrent registerResource() calls "
+                                + "with same owner. Found: %s",
+                        exceptions)
+                .isEmpty();
+
+        // Clear resources and verify all were registered
+        registry.clearResourceFor(sharedOwner);
+
+        // Due to potential race conditions in ArrayList.add(), the actual count
+        // may be less than expected if the bug exists
+        assertThat(releaseCount.get())
+                .as(
+                        "All registered resources should be released. "
+                                + "If fewer were released, ArrayList concurrent modification may have lost some entries.")
+                .isEqualTo(NUM_THREADS * NUM_OPERATIONS_PER_THREAD);
+    }
+
+    /** Simple implementation of TieredStorageDataIdentifier for testing. */
+    private static class TestingDataIdentifier implements TieredStorageDataIdentifier {
+        private final int id;
+
+        TestingDataIdentifier(int id) {
+            this.id = id;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            TestingDataIdentifier that = (TestingDataIdentifier) o;
+            return id == that.id;
+        }
+
+        @Override
+        public int hashCode() {
+            return Integer.hashCode(id);
+        }
+
+        @Override
+        public String toString() {
+            return "TestingDataIdentifier{id=" + id + "}";
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TieredStorageResourceRegistryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TieredStorageResourceRegistryTest.java
@@ -18,8 +18,11 @@
 
 package org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage;
 
-import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageDataIdentifier;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageDataIdentifier;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.RepeatedTest;
 
 import java.util.ArrayList;
@@ -32,72 +35,56 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 /** Tests for {@link TieredStorageResourceRegistry}. */
 class TieredStorageResourceRegistryTest {
 
     private static final int NUM_THREADS = 10;
     private static final int NUM_OPERATIONS_PER_THREAD = 100;
 
-    @RepeatedTest(10)
-    void testConcurrentRegisterResourceWithDifferentOwners() throws Exception {
-        TieredStorageResourceRegistry registry = new TieredStorageResourceRegistry();
-        ExecutorService executor = Executors.newFixedThreadPool(NUM_THREADS);
-        CyclicBarrier barrier = new CyclicBarrier(NUM_THREADS);
-        CountDownLatch completionLatch = new CountDownLatch(NUM_THREADS);
-        List<Throwable> exceptions = Collections.synchronizedList(new ArrayList<>());
-        AtomicInteger successfulRegistrations = new AtomicInteger(0);
+    private TieredStorageResourceRegistry registry;
+    private ExecutorService executor;
+    private CyclicBarrier barrier;
+    private CountDownLatch completionLatch;
+    private List<Throwable> exceptions;
 
-        for (int t = 0; t < NUM_THREADS; t++) {
-            final int threadId = t;
-            executor.submit(
-                    () -> {
-                        try {
-                            // Wait for all threads to be ready
-                            barrier.await();
+    @BeforeEach
+    void setUp() {
+        registry = new TieredStorageResourceRegistry();
+        executor = Executors.newFixedThreadPool(NUM_THREADS);
+        barrier = new CyclicBarrier(NUM_THREADS);
+        completionLatch = new CountDownLatch(NUM_THREADS);
+        exceptions = Collections.synchronizedList(new ArrayList<>());
+    }
 
-                            for (int i = 0; i < NUM_OPERATIONS_PER_THREAD; i++) {
-                                // Each thread uses unique owners to maximize contention
-                                // on HashMap.computeIfAbsent()
-                                TestingDataIdentifier owner =
-                                        new TestingDataIdentifier(
-                                                threadId * NUM_OPERATIONS_PER_THREAD + i);
-                                registry.registerResource(owner, () -> {});
-                                successfulRegistrations.incrementAndGet();
-                            }
-                        } catch (Throwable e) {
-                            exceptions.add(e);
-                        } finally {
-                            completionLatch.countDown();
-                        }
-                    });
-        }
-
-        completionLatch.await(30, TimeUnit.SECONDS);
+    @AfterEach
+    void tearDown() throws Exception {
         executor.shutdown();
         executor.awaitTermination(10, TimeUnit.SECONDS);
+    }
 
-        // If the bug exists, we expect ConcurrentModificationException
-        // If fixed, all registrations should succeed
-        assertThat(exceptions)
-                .as(
-                        "Expected no exceptions during concurrent registerResource() calls. "
-                                + "Found: %s",
-                        exceptions)
-                .isEmpty();
+    @RepeatedTest(10)
+    void testConcurrentRegisterResourceWithDifferentOwners() throws Exception {
+        AtomicInteger successfulRegistrations = new AtomicInteger(0);
+
+        runConcurrentTask(
+                threadId -> {
+                    for (int i = 0; i < NUM_OPERATIONS_PER_THREAD; i++) {
+                        // Each thread uses unique owners to maximize contention
+                        // on HashMap.computeIfAbsent()
+                        TestingDataIdentifier owner =
+                                new TestingDataIdentifier(threadId * NUM_OPERATIONS_PER_THREAD + i);
+                        registry.registerResource(owner, () -> {});
+                        successfulRegistrations.incrementAndGet();
+                    }
+                });
+
+        assertNoExceptions("concurrent registerResource() calls");
         assertThat(successfulRegistrations.get())
                 .isEqualTo(NUM_THREADS * NUM_OPERATIONS_PER_THREAD);
     }
 
     @RepeatedTest(10)
     void testConcurrentRegisterAndClear() throws Exception {
-        TieredStorageResourceRegistry registry = new TieredStorageResourceRegistry();
-        ExecutorService executor = Executors.newFixedThreadPool(NUM_THREADS);
-        CyclicBarrier barrier = new CyclicBarrier(NUM_THREADS);
-        CountDownLatch completionLatch = new CountDownLatch(NUM_THREADS);
-        List<Throwable> exceptions = Collections.synchronizedList(new ArrayList<>());
-
         // Use few owners to maximize contention on the same keys across threads
         final int numOwners = 5;
         TestingDataIdentifier[] owners = new TestingDataIdentifier[numOwners];
@@ -105,84 +92,38 @@ class TieredStorageResourceRegistryTest {
             owners[i] = new TestingDataIdentifier(i);
         }
 
-        for (int t = 0; t < NUM_THREADS; t++) {
-            executor.submit(
-                    () -> {
-                        try {
-                            barrier.await();
+        runConcurrentTask(
+                threadId -> {
+                    for (int i = 0; i < NUM_OPERATIONS_PER_THREAD; i++) {
+                        // All threads compete for the same small set of owners
+                        TestingDataIdentifier owner = owners[i % numOwners];
 
-                            for (int i = 0; i < NUM_OPERATIONS_PER_THREAD; i++) {
-                                // All threads compete for the same small set of owners
-                                TestingDataIdentifier owner = owners[i % numOwners];
-
-                                // Alternate between register and clear to maximize
-                                // concurrent modification chances
-                                if (i % 2 == 0) {
-                                    registry.registerResource(owner, () -> {});
-                                } else {
-                                    registry.clearResourceFor(owner);
-                                }
-                            }
-                        } catch (Throwable e) {
-                            exceptions.add(e);
-                        } finally {
-                            completionLatch.countDown();
+                        // Alternate between register and clear to maximize entropy
+                        if (i % 2 == 0) {
+                            registry.registerResource(owner, () -> {});
+                        } else {
+                            registry.clearResourceFor(owner);
                         }
-                    });
-        }
+                    }
+                });
 
-        completionLatch.await(30, TimeUnit.SECONDS);
-        executor.shutdown();
-        executor.awaitTermination(10, TimeUnit.SECONDS);
-
-        assertThat(exceptions)
-                .as(
-                        "Expected no exceptions during concurrent register/clear calls. "
-                                + "Found: %s",
-                        exceptions)
-                .isEmpty();
+        assertNoExceptions("concurrent register/clear calls");
     }
 
     @RepeatedTest(10)
     void testConcurrentRegisterResourceWithSameOwner() throws Exception {
-        TieredStorageResourceRegistry registry = new TieredStorageResourceRegistry();
-        ExecutorService executor = Executors.newFixedThreadPool(NUM_THREADS);
-        CyclicBarrier barrier = new CyclicBarrier(NUM_THREADS);
-        CountDownLatch completionLatch = new CountDownLatch(NUM_THREADS);
-        List<Throwable> exceptions = Collections.synchronizedList(new ArrayList<>());
         AtomicInteger releaseCount = new AtomicInteger(0);
-
-        // Single owner shared across all threads
         TestingDataIdentifier sharedOwner = new TestingDataIdentifier(0);
 
-        for (int t = 0; t < NUM_THREADS; t++) {
-            executor.submit(
-                    () -> {
-                        try {
-                            barrier.await();
+        runConcurrentTask(
+                threadId -> {
+                    for (int i = 0; i < NUM_OPERATIONS_PER_THREAD; i++) {
+                        registry.registerResource(
+                                sharedOwner, () -> releaseCount.incrementAndGet());
+                    }
+                });
 
-                            for (int i = 0; i < NUM_OPERATIONS_PER_THREAD; i++) {
-                                registry.registerResource(
-                                        sharedOwner, () -> releaseCount.incrementAndGet());
-                            }
-                        } catch (Throwable e) {
-                            exceptions.add(e);
-                        } finally {
-                            completionLatch.countDown();
-                        }
-                    });
-        }
-
-        completionLatch.await(30, TimeUnit.SECONDS);
-        executor.shutdown();
-        executor.awaitTermination(10, TimeUnit.SECONDS);
-
-        assertThat(exceptions)
-                .as(
-                        "Expected no exceptions during concurrent registerResource() calls "
-                                + "with same owner. Found: %s",
-                        exceptions)
-                .isEmpty();
+        assertNoExceptions("concurrent registerResource() calls with same owner");
 
         // Clear resources and verify all were registered
         registry.clearResourceFor(sharedOwner);
@@ -194,6 +135,35 @@ class TieredStorageResourceRegistryTest {
                         "All registered resources should be released. "
                                 + "If fewer were released, ArrayList concurrent modification may have lost some entries.")
                 .isEqualTo(NUM_THREADS * NUM_OPERATIONS_PER_THREAD);
+    }
+
+    private void runConcurrentTask(ThrowingIntConsumer task) throws Exception {
+        for (int t = 0; t < NUM_THREADS; t++) {
+            final int threadId = t;
+            executor.submit(
+                    () -> {
+                        try {
+                            barrier.await();
+                            task.accept(threadId);
+                        } catch (Throwable e) {
+                            exceptions.add(e);
+                        } finally {
+                            completionLatch.countDown();
+                        }
+                    });
+        }
+        completionLatch.await(30, TimeUnit.SECONDS);
+    }
+
+    private void assertNoExceptions(String operationDescription) {
+        assertThat(exceptions)
+                .as("Expected no exceptions during %s. Found: %s", operationDescription, exceptions)
+                .isEmpty();
+    }
+
+    @FunctionalInterface
+    private interface ThrowingIntConsumer {
+        void accept(int value) throws Exception;
     }
 
     /** Simple implementation of TieredStorageDataIdentifier for testing. */


### PR DESCRIPTION
## What is the purpose of the change

This pull request addresses the issue detailed in [FLINK-38783](https://issues.apache.org/jira/browse/FLINK-38783) which detailed how the registration process within `TieredStorageResourceRegistry` was not properly handling concurrent operations and as such could throw a `ConcurrentModificationException` under concurrent load.

## Brief change log

- Replaced the previous `registeredResources` general-purpose hash map (`Map<..., List<...>>`) with corresponding thread-safe structures (`ConcurrentHashMap<..., CopyOnWriteArrayList<...>>`) to better handle concurrent operations.

## Verifying this change

This change added a series of tests in `TieredStorageResourceRegistryTest` to originally reproduce the issue and later confirm the fix worked as expected including:

- `testConcurrentRegisterResource` to test concurrent resource registration across separate threads (10 total with same owner/identifier)
- `testConcurrentRegisterResourceWithDifferentOwners` to test concurrent registration across separate threads (10 total with different owners/identifiers)
- `testConcurrentRegisterAndClear` to test concurrent registration _and_ clearing across separate threads

### Example Tests

<img width="828" height="344" alt="image" src="https://github.com/user-attachments/assets/2b33eeae-b874-4360-bb1e-924634c3f2a8" />

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: **no/don't know**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
