### PR TITLE
FLINK-38872: waitForAllTaskRunning Hang Indefinitely

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/CommonTestUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/CommonTestUtilsTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.testutils;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link CommonTestUtils}. */
+class CommonTestUtilsTest {
+
+    @Test
+    void testWaitUntilConditionWithTimeoutSucceeds() throws Exception {
+        AtomicInteger counter = new AtomicInteger(0);
+
+        CommonTestUtils.waitUntilCondition(
+                () -> counter.incrementAndGet() >= 3, Duration.ofSeconds(10));
+
+        assertThat(counter.get()).isGreaterThanOrEqualTo(3);
+    }
+
+    @Test
+    void testWaitUntilConditionWithTimeoutThrowsOnTimeout() {
+        assertThatThrownBy(
+                        () ->
+                                CommonTestUtils.waitUntilCondition(
+                                        () -> false, Duration.ofMillis(100)))
+                .isInstanceOf(TimeoutException.class)
+                .hasMessageContaining("Condition was not met within the timeout");
+    }
+
+    @Test
+    void testWaitUntilConditionWithRetryIntervalAndTimeout() throws Exception {
+        AtomicInteger counter = new AtomicInteger(0);
+
+        CommonTestUtils.waitUntilCondition(
+                () -> counter.incrementAndGet() >= 3,
+                Duration.ofMillis(10),
+                Duration.ofSeconds(10));
+
+        assertThat(counter.get()).isGreaterThanOrEqualTo(3);
+    }
+
+    @Test
+    void testWaitUntilConditionWithRetryIntervalAndTimeoutThrowsOnTimeout() {
+        assertThatThrownBy(
+                        () ->
+                                CommonTestUtils.waitUntilCondition(
+                                        () -> false, Duration.ofMillis(10), Duration.ofMillis(100)))
+                .isInstanceOf(TimeoutException.class)
+                .hasMessageContaining("Condition was not met within the timeout");
+    }
+}


### PR DESCRIPTION
This PR fixes [FLINK-38872](https://issues.apache.org/jira/browse/FLINK-38872).



### Issue: 
CommonTestUtils.waitForAllTaskRunning() could hang indefinitely if the job is lost, cancelled, or enters an unexpected terminal state.


### Changes Made:
Added timeout parameters to waitUntilCondition and waitForAllTaskRunning methods.


  1. CommonTestUtils.java (flink-runtime/src/test/java/org/apache/flink/runtime/testutils/)

  Added:
  - DEFAULT_WAIT_FOR_TASKS_TIMEOUT constant (5 minutes) at line 75
  - New overload waitUntilCondition(condition, Duration timeout) at lines 161-165
  - New overload waitUntilCondition(condition, Duration retryInterval, Duration timeout) at lines 167-180 - throws TimeoutException when deadline is exceeded
  - New overload waitForAllTaskRunning(MiniCluster, JobID, boolean, Duration) at lines 211-215
  - New overload waitForAllTaskRunning(SupplierWithException<AccessExecutionGraph>, boolean, Duration) at lines 230-269
  - New overload waitForAllTaskRunning(SupplierWithException<JobDetailsInfo>, Duration) at lines 276-298

  Backward compatibility: Existing methods without timeout parameters now delegate to the new timeout-aware versions using DEFAULT_WAIT_FOR_TASKS_TIMEOUT.

  2. CommonTestUtilsTest.java (new file)

  Created unit tests to verify the timeout functionality:
  - testWaitUntilConditionWithTimeoutSucceeds - verifies successful completion
  - testWaitUntilConditionWithTimeoutThrowsOnTimeout - verifies TimeoutException is thrown
  - testWaitUntilConditionWithRetryIntervalAndTimeout - tests with custom retry interval
  - testWaitUntilConditionWithRetryIntervalAndTimeoutThrowsOnTimeout - verifies timeout with custom interval
