### PR TITLE
[FLINK-38870] Uninformative error message when job is suspended due to JobManager leadership loss

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobResult.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobResult.java
@@ -75,8 +75,8 @@ public class JobResult implements Serializable {
 
         checkArgument(netRuntime >= 0, "netRuntime must be greater than or equals 0");
         checkArgument(
-                jobStatus == null || jobStatus.isGloballyTerminalState(),
-                "jobStatus must be globally terminal or unknow(null)");
+                jobStatus == null || jobStatus.isTerminalState(),
+                "jobStatus must be terminal or unknown(null)");
 
         this.jobId = requireNonNull(jobId);
         this.jobStatus = jobStatus;
@@ -147,11 +147,22 @@ public class JobResult implements Serializable {
                 exception = new JobExecutionException(jobId, "Job execution failed.", cause);
             } else if (jobStatus == JobStatus.CANCELED) {
                 exception = new JobCancellationException(jobId, "Job was cancelled.", cause);
+            } else if (jobStatus == JobStatus.SUSPENDED) {
+                exception =
+                        new JobExecutionException(
+                                jobId,
+                                "Job is in state SUSPENDED. This commonly happens when the "
+                                        + "JobManager lost leadership. The job may recover "
+                                        + "automatically if High Availability and a persistent "
+                                        + "job store are configured. If recovery is not possible "
+                                        + "(e.g., non-persistent ExecutionPlanStore), the job "
+                                        + "needs to be resubmitted.",
+                                cause);
             } else {
                 exception =
                         new JobExecutionException(
                                 jobId,
-                                "Job completed with illegal status: " + jobStatus + '.',
+                                "Job completed with unexpected status: " + jobStatus + '.',
                                 cause);
             }
 
@@ -234,7 +245,8 @@ public class JobResult implements Serializable {
         final JobResult.Builder builder = new JobResult.Builder();
         builder.jobId(jobId);
 
-        builder.jobStatus(jobStatus.isGloballyTerminalState() ? jobStatus : null);
+        // Store the actual terminal status (including locally terminal states like SUSPENDED)
+        builder.jobStatus(jobStatus);
 
         final long netRuntime =
                 accessExecutionGraph.getStatusTimestamp(jobStatus)
@@ -249,6 +261,12 @@ public class JobResult implements Serializable {
             checkNotNull(errorInfo, "No root cause is found for the job failure.");
 
             builder.serializedThrowable(errorInfo.getException());
+        } else if (jobStatus == JobStatus.SUSPENDED) {
+            // SUSPENDED jobs may or may not have a failure cause
+            final ErrorInfo errorInfo = accessExecutionGraph.getFailureInfo();
+            if (errorInfo != null) {
+                builder.serializedThrowable(errorInfo.getException());
+            }
         }
 
         return builder.build();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobResult.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobResult.java
@@ -76,7 +76,7 @@ public class JobResult implements Serializable {
         checkArgument(netRuntime >= 0, "netRuntime must be greater than or equals 0");
         checkArgument(
                 jobStatus == null || jobStatus.isTerminalState(),
-                "jobStatus must be terminal or unknown(null)");
+                "jobStatus must be terminal or null");
 
         this.jobId = requireNonNull(jobId);
         this.jobStatus = jobStatus;
@@ -159,11 +159,15 @@ public class JobResult implements Serializable {
                                         + "needs to be resubmitted.",
                                 cause);
             } else {
-                exception =
-                        new JobExecutionException(
-                                jobId,
-                                "Job completed with unexpected status: " + jobStatus + '.',
-                                cause);
+                final String statusMessage =
+                        jobStatus != null
+                                ? "Job completed with unexpected status: " + jobStatus
+                                : "Job completed with unknown status";
+                final String message =
+                        cause != null
+                                ? statusMessage + "."
+                                : statusMessage + " (no cause provided).";
+                exception = new JobExecutionException(jobId, message, cause);
             }
 
             throw exception;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/json/JobResultSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/json/JobResultSerializer.java
@@ -47,6 +47,8 @@ public class JobResultSerializer extends StdSerializer<JobResult> {
 
     static final String FIELD_NAME_APPLICATION_STATUS = "application-status";
 
+    static final String FIELD_NAME_JOB_STATUS = "job-status";
+
     static final String FIELD_NAME_NET_RUNTIME = "net-runtime";
 
     static final String FIELD_NAME_ACCUMULATOR_RESULTS = "accumulator-results";
@@ -82,6 +84,12 @@ public class JobResultSerializer extends StdSerializer<JobResult> {
         // use application status to maintain backward compatibility
         gen.writeFieldName(FIELD_NAME_APPLICATION_STATUS);
         gen.writeString(ApplicationStatus.fromJobStatus(result.getJobStatus().orElse(null)).name());
+
+        // also include the actual job status for precise state information (e.g., SUSPENDED)
+        if (result.getJobStatus().isPresent()) {
+            gen.writeFieldName(FIELD_NAME_JOB_STATUS);
+            gen.writeString(result.getJobStatus().get().name());
+        }
 
         gen.writeFieldName(FIELD_NAME_ACCUMULATOR_RESULTS);
         gen.writeStartObject();


### PR DESCRIPTION
This PR fixes [FLINK-38870](https://issues.apache.org/jira/browse/FLINK-38870).

### Problem

  When a JobManager loses leadership, jobs enter SUSPENDED state. The old error message "Job completed with illegal status: null" was uninformative and confusing.

### Solution

  My approach improves on the JIRA proposal by:
  1. Preserving the actual SUSPENDED JobStatus instead of losing it (the proposal only added a field but kept setting it to null)
  2. Adding serialization support to preserve SUSPENDED state across REST API calls
  3. Maintaining backward compatibility with older clients

### Files Modified

  1. JobResult.java

  - Constructor validation: Changed from requiring "globally terminal" to just "terminal" states, allowing SUSPENDED
  - createFrom(): Now stores actual JobStatus including SUSPENDED (was setting null for non-globally-terminal states)
  - toJobExecutionResult(): Added specific handling for SUSPENDED with detailed error message:
  Job is in state SUSPENDED. This commonly happens when the JobManager lost leadership.
  The job may recover automatically if High Availability and a persistent job store are configured.
  If recovery is not possible (e.g., non-persistent ExecutionPlanStore), the job needs to be resubmitted.

  2. JobResultSerializer.java

  - Added new job-status field to preserve actual JobStatus in JSON (alongside existing application-status for backward compatibility)

  3. JobResultDeserializer.java

  - Reads new job-status field if present (takes priority)
  - Falls back to application-status for backward compatibility with older messages

  4. Tests Added

  - JobResultTest: 3 new tests for SUSPENDED state handling
  - JobResultDeserializerTest: 3 new tests for serialization with SUSPENDED state

### Test Results

```
  Tests run: 17, Failures: 0, Errors: 0, Skipped: 0
  BUILD SUCCESS
```
### Error Message Comparison

  Before:
```
  Job completed with illegal status: null.
```

  After:
```
  Job is in state SUSPENDED. This commonly happens when the JobManager lost leadership.
  The job may recover automatically if High Availability and a persistent job store are configured.
  If recovery is not possible (e.g., non-persistent ExecutionPlanStore), the job needs to be resubmitted.
```