### PR TITLE
[FLINK-39148] [Build] Update flink-connector-kafka & flink-sql-connector-kafka to 4.0.1-2.0

### DIFF
--- a/flink-end-to-end-tests/flink-confluent-schema-registry/pom.xml
+++ b/flink-end-to-end-tests/flink-confluent-schema-registry/pom.xml
@@ -51,7 +51,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-kafka</artifactId>
-			<version>3.0.0-1.17</version>
+			<version>4.0.1-2.0</version>
 		</dependency>
 		<!-- Make sure that Shaded Guava matches the one used in the flink-connector-kafka,
 		 or remove when FLINK-32462 is resolved -->

--- a/flink-end-to-end-tests/flink-confluent-schema-registry/pom.xml
+++ b/flink-end-to-end-tests/flink-confluent-schema-registry/pom.xml
@@ -51,7 +51,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-kafka</artifactId>
-			<version>4.0.1-2.0</version>
+			<version>${flink.connector.kafka.version}</version>
 		</dependency>
 		<!-- Make sure that Shaded Guava matches the one used in the flink-connector-kafka,
 		 or remove when FLINK-32462 is resolved -->

--- a/flink-end-to-end-tests/flink-sql-client-test/pom.xml
+++ b/flink-end-to-end-tests/flink-sql-client-test/pom.xml
@@ -61,7 +61,7 @@ under the License.
 			<!-- Used by maven-dependency-plugin -->
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-sql-connector-kafka</artifactId>
-			<version>3.0.0-1.17</version>
+			<version>${flink.connector.kafka.version}</version>
 			<scope>provided</scope>
 		</dependency>
 
@@ -138,7 +138,7 @@ under the License.
 								<artifactItem>
 									<groupId>org.apache.flink</groupId>
 									<artifactId>flink-sql-connector-kafka</artifactId>
-									<version>3.0.0-1.17</version>
+									<version>${flink.connector.kafka.version}</version>
 									<type>jar</type>
 								</artifactItem>
 								<artifactItem>

--- a/flink-examples/flink-examples-streaming/pom.xml
+++ b/flink-examples/flink-examples-streaming/pom.xml
@@ -67,7 +67,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-kafka</artifactId>
-			<version>3.0.0-1.17</version>
+			<version>4.0.1-2.0</version>
 		</dependency>
 
 		<dependency>

--- a/flink-examples/flink-examples-streaming/pom.xml
+++ b/flink-examples/flink-examples-streaming/pom.xml
@@ -67,7 +67,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-kafka</artifactId>
-			<version>4.0.1-2.0</version>
+			<version>${flink.connector.kafka.version}</version>
 		</dependency>
 
 		<dependency>

--- a/flink-python/pom.xml
+++ b/flink-python/pom.xml
@@ -289,7 +289,7 @@ under the License.
 			<!-- Indirectly accessed in pyflink_gateway_server -->
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-sql-connector-kafka</artifactId>
-			<version>4.0.1-2.0</version>
+			<version>${flink.connector.kafka.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
@@ -74,7 +74,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-kafka</artifactId>
-			<version>4.0.1-2.0</version>
+			<version>${flink.connector.kafka.version}</version>
 		</dependency>
 		-->
 

--- a/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
@@ -74,7 +74,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-kafka</artifactId>
-			<version>3.0.0-1.17</version>
+			<version>4.0.1-2.0</version>
 		</dependency>
 		-->
 

--- a/flink-walkthroughs/flink-walkthrough-datastream-java/src/main/resources/archetype-resources/pom.xml
+++ b/flink-walkthroughs/flink-walkthrough-datastream-java/src/main/resources/archetype-resources/pom.xml
@@ -79,7 +79,7 @@ under the License.
 		<dependency>
 		    <groupId>org.apache.flink</groupId>
 		    <artifactId>flink-connector-kafka</artifactId>
-		    <version>4.0.1-2.0</version>
+			<version>${flink.connector.kafka.version}</version>
 		</dependency>
 		-->
 

--- a/flink-walkthroughs/flink-walkthrough-datastream-java/src/main/resources/archetype-resources/pom.xml
+++ b/flink-walkthroughs/flink-walkthrough-datastream-java/src/main/resources/archetype-resources/pom.xml
@@ -79,7 +79,7 @@ under the License.
 		<dependency>
 		    <groupId>org.apache.flink</groupId>
 		    <artifactId>flink-connector-kafka</artifactId>
-		    <version>3.0.0-1.17</version>
+		    <version>4.0.1-2.0</version>
 		</dependency>
 		-->
 

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,7 @@ under the License.
 		<flink.shaded.version>21.0</flink.shaded.version>
 		<flink.shaded.jackson.version>2.20.1</flink.shaded.jackson.version>
 		<flink.shaded.jsonpath.version>2.10.0</flink.shaded.jsonpath.version>
+		<flink.connector.kafka.version>4.0.1-2.0</flink.connector.kafka.version>
 		<flink.markBundledAsOptional>true</flink.markBundledAsOptional>
 		<source.java.version>11</source.java.version>
 		<target.java.version>17</target.java.version>


### PR DESCRIPTION
## What is the purpose of the change

flink-connector-kafka 3.0.0-1.17 contains the following CVEs:
* CVE-2025-27819
* CVE-2025-27818
* CVE-2025-27817
* CVE-2024-56128
* CVE-2024-31141
* CVE-2023-44981

Upgrading to 4.0.1-2.0 resolves all above CVEs

## Brief change log

- Update flink-connector-kafka to 4.0.1-2.0
- Update flink-sql-connector-kafka to 4.0.1-2.0
- Use a variable for flink-connector-kafka version

## Verifying this change

Passes CI tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
