### PR TITLE
[FLINK-37351][runtime] Ensure Writer/Committer Colocation for Non-Pre-Commit Topologies

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/translators/SinkTransformationTranslator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/translators/SinkTransformationTranslator.java
@@ -277,6 +277,13 @@ public class SinkTransformationTranslator<Input, Output>
                         adjustTransformations(
                                 writerResult, preCommittingSink::addPreCommitTopology, true, false);
             } else {
+                // Default to co-location for sinks without pre-commit topology ensuring
+                // writer and committer run on the same TaskManager.
+                if (transformation.getCoLocationGroupKey() == null) {
+                    transformation.setCoLocationGroupKey(
+                            "sink-writer-committer-" + transformation.getId());
+                }
+
                 precommitted = addWriter(sink, inputStream, committableTypeInformation);
             }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/SinkV2TransformationTranslatorITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/SinkV2TransformationTranslatorITCase.java
@@ -324,4 +324,61 @@ class SinkV2TransformationTranslatorITCase {
     StreamNode findGlobalCommitter(StreamGraph streamGraph) {
         return findNodeName(streamGraph, name -> name.contains("Global Committer"));
     }
+
+    @ParameterizedTest
+    @EnumSource(RuntimeExecutionMode.class)
+    void testWriterAndCommitterColocatedWithoutPreCommitTopology(
+            RuntimeExecutionMode runtimeExecutionMode) {
+        final StreamGraph streamGraph = buildGraph(sinkWithCommitter(), runtimeExecutionMode);
+
+        final StreamNode writerNode = findWriter(streamGraph);
+        final StreamNode committerNode = findCommitter(streamGraph);
+
+        // Writer and committer should be co-located for sinks without pre-commit topology
+        assertThat(writerNode.getCoLocationGroup()).isNotNull();
+        assertThat(committerNode.getCoLocationGroup()).isNotNull();
+        assertThat(writerNode.getCoLocationGroup()).isEqualTo(committerNode.getCoLocationGroup());
+    }
+
+    @ParameterizedTest
+    @EnumSource(RuntimeExecutionMode.class)
+    void testWriterAndCommitterNotColocatedWithPreCommitTopology(
+            RuntimeExecutionMode runtimeExecutionMode) {
+        // Create sink with pre-commit topology
+        Sink<Integer> sinkWithPreCommit =
+                TestSinkV2.<Integer>newBuilder()
+                        .setCommitter(
+                                new TestSinkV2.DefaultCommitter<>(),
+                                TestSinkV2.RecordSerializer::new)
+                        .setWithPreCommitTopology(r -> r)
+                        .build();
+
+        final StreamGraph streamGraph = buildGraph(sinkWithPreCommit, runtimeExecutionMode);
+
+        final StreamNode writerNode = findWriter(streamGraph);
+        final StreamNode committerNode = findCommitter(streamGraph);
+
+        // Pre-commit topology sinks should not be co-located
+        assertThat(writerNode.getCoLocationGroup()).isNull();
+        assertThat(committerNode.getCoLocationGroup()).isNull();
+    }
+
+    @Test
+    void testUserSpecifiedCoLocationGroupIsRespected() {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        final DataStreamSource<Integer> src = env.fromData(1, 2);
+        final DataStreamSink<Integer> dataStreamSink = sinkTo(src, sinkWithCommitter());
+        dataStreamSink.name(NAME);
+
+        // Explicitly set user-specified co-location group
+        dataStreamSink.getTransformation().setCoLocationGroupKey("user-specified-group");
+
+        final StreamGraph streamGraph = env.getStreamGraph();
+        final StreamNode writerNode = findWriter(streamGraph);
+        final StreamNode committerNode = findCommitter(streamGraph);
+
+        // Both writer and sink should have the user-specified co-location group
+        assertThat(writerNode.getCoLocationGroup()).isEqualTo("user-specified-group");
+        assertThat(committerNode.getCoLocationGroup()).isEqualTo("user-specified-group");
+    }
 }


### PR DESCRIPTION
## What is the purpose of the change

This pull request addresses the issue detailed in [FLINK-37351](https://issues.apache.org/jira/browse/FLINK-38783) which aims to ensure writer/committer colocation, specifically for non-pre-commit topologies, which should improve overall performance.

## Brief change log

- Added a process within the existing `SinkTransformationTranslator.addCommittingTopology()` function to detect non-pre-commit topologies and define a colocation-group key for the transformation (via `setCoLocationGroupKey(...)`). 

## Verifying this change

This change added a series of tests in `SinkV2TransformationTranslatorITCase` to verify that colocation wasn't being applied (via a red-green cycle) as well as two other tests to confirm colocation was working for expected cases:

- `testWriterAndCommitterColocatedWithoutPreCommitTopology` to verify writer/committer colocation for non-pre-commit topologies
- `testWriterAndCommitterNotColocatedWithPreCommitTopology` to verify pre-commit sinks are not colocated
- `testUserSpecifiedCoLocationGroupIsRespected` to verify user-specified colocation groups are preserved

### Example Tests

<img width="724" height="434" alt="image" src="https://github.com/user-attachments/assets/87e36fc4-5990-4033-961e-7872899669f5" />

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: **no/don't know**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
  
## Reviewer Requested

@AHeise 
