### PR TITLE
Fix the conversion to relational algebra issue in Batch Mode

### DIFF
--- a/flink-examples/flink-examples-table/src/test/java/org/apache/flink/table/examples/java/basics/WatermarkExampleITCase.java
+++ b/flink-examples/flink-examples-table/src/test/java/org/apache/flink/table/examples/java/basics/WatermarkExampleITCase.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.examples.java.basics;
+
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ExecutionOptions;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.TableResult;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for Java Watermark Query in Batch and Streaming mode. */
+class WatermarkExampleITCase {
+    private static final String createTableA =
+            "CREATE TABLE a ("
+                    + "testTime BIGINT NOT NULL, "
+                    + "eventTime AS TO_TIMESTAMP_LTZ(testTime, 3), "
+                    + "WATERMARK FOR eventTime AS eventTime - INTERVAL '5' SECOND"
+                    + ") WITH ("
+                    + "'connector' = 'datagen', "
+                    + "'number-of-rows' = '10'"
+                    + ")";
+    private static final String createTableB =
+            "CREATE TABLE b ("
+                    + "testTime BIGINT NOT NULL, "
+                    + "eventTime TIMESTAMP_LTZ(3), "
+                    + "WATERMARK FOR eventTime AS eventTime - INTERVAL '5' SECOND"
+                    + ") WITH ("
+                    + "'connector' = 'filesystem', "
+                    + "'format' = 'csv', "
+                    + "'path' = '/tmp/'"
+                    + ")";
+    private static final String insertIntoB = "INSERT INTO b SELECT * FROM a";
+    private static final String selectFromB = "SELECT * FROM b";
+    private static final String testTimeStr = "testTime";
+    private static final String eventTimeStr = "eventTime";
+
+    @Test
+    void testWatermarkInBatchMode() {
+        Configuration configuration = new Configuration();
+        configuration.setString(
+                ExecutionOptions.RUNTIME_MODE.key(), RuntimeExecutionMode.BATCH.toString());
+        StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(configuration);
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+
+        tEnv.executeSql(createTableA);
+        tEnv.executeSql(createTableB);
+        tEnv.executeSql(insertIntoB);
+
+        TableResult res = tEnv.executeSql(selectFromB);
+        assertThat(res.getResolvedSchema().toString().contains(testTimeStr)).isTrue();
+        assertThat(res.getResolvedSchema().toString().contains(eventTimeStr)).isTrue();
+    }
+
+    @Test
+    void testWatermarkInStreamingMode() {
+        Configuration configuration = new Configuration();
+        configuration.setString(
+                ExecutionOptions.RUNTIME_MODE.key(), RuntimeExecutionMode.STREAMING.toString());
+        StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(configuration);
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+
+        tEnv.executeSql(createTableA);
+        tEnv.executeSql(createTableB);
+        tEnv.executeSql(insertIntoB);
+
+        TableResult res = tEnv.executeSql(selectFromB);
+        assertThat(res.getResolvedSchema().toString().contains(testTimeStr)).isTrue();
+        assertThat(res.getResolvedSchema().toString().contains(eventTimeStr)).isTrue();
+    }
+}

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/StreamTableEnvironment.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/StreamTableEnvironment.java
@@ -88,7 +88,13 @@ public interface StreamTableEnvironment extends TableEnvironment {
      *     TableEnvironment}.
      */
     static StreamTableEnvironment create(StreamExecutionEnvironment executionEnvironment) {
-        return create(executionEnvironment, EnvironmentSettings.newInstance().build());
+        return create(
+                executionEnvironment,
+                EnvironmentSettings.newInstance()
+                        .withConfiguration(
+                                (org.apache.flink.configuration.Configuration)
+                                        executionEnvironment.getConfiguration())
+                        .build());
     }
 
     /**


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
[FLINK-39014](https://issues.apache.org/jira/browse/FLINK-39014)
When creating a `StreamTableEnvironment` using `StreamTableEnvironment.create(env)` where the `StreamExecutionEnvironment` is configured with `RUNTIME_MODE=BATCH`, the planner was incorrectly created in `STREAMING` mode, causing a mismatch between execution mode and planner mode.

## Brief change log
The fix ensures that `EnvironmentSettings` inherits the configuration from `StreamExecutionEnvironment` by calling `.withConfiguration`(`executionEnvironment.getConfiguration()`) when creating default environment settings. This maintains consistency between the execution mode and planner mode throughout the system. 
  - **StreamTableEnvironment.java**: Modified `create`(`StreamExecutionEnvironment`) to pass the execution environment's configuration to EnvironmentSettings, ensuring the runtime mode is properly inherited          
  - **WatermarkExampleITCase.java**: Added integration test to verify watermark handling works correctly in both batch and streaming execution modes  

## Verifying this change
This change is covered by new integration tests in `WatermarkExampleITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
