### PR TITLE
[FLINK-38539][table] Fix integer overflow in AbstractBytesMultiMap wh…

### DIFF
--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/util/collections/binary/AbstractBytesMultiMapBoundaryTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/util/collections/binary/AbstractBytesMultiMapBoundaryTest.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.util.collections.binary;
+
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.core.memory.MemorySegmentSource;
+import org.apache.flink.runtime.io.disk.SimpleCollectingOutputView;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.EOFException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/**
+ * Tests for boundary conditions in {@link AbstractBytesMultiMap}.
+ *
+ * <p>These tests verify that the overflow protection correctly handles offsets around
+ * Integer.MAX_VALUE (~2GB). Since allocating 2GB of memory is impractical in unit tests, we use a
+ * spy on SimpleCollectingOutputView to simulate offsets near the boundary.
+ *
+ * <p>The boundary behavior should be:
+ *
+ * <ul>
+ *   <li>Offset = Integer.MAX_VALUE - 4 (2,147,483,643): Should succeed (pointer fits)
+ *   <li>Offset = Integer.MAX_VALUE - 3 (2,147,483,644): Should fail (pointer would exceed)
+ *   <li>Offset = Integer.MAX_VALUE (2,147,483,647): Should fail
+ *   <li>Offset > Integer.MAX_VALUE: Should fail
+ * </ul>
+ */
+class AbstractBytesMultiMapBoundaryTest {
+
+    private static final int SEGMENT_SIZE = 32 * 1024; // 32KB
+    private static final int POINTER_SIZE = 4; // 4 bytes for int pointer
+
+    /**
+     * Tests that writing a pointer succeeds when the offset is just under the boundary where the
+     * 4-byte pointer would still fit within Integer.MAX_VALUE.
+     *
+     * <p>With offset = Integer.MAX_VALUE - 4, after adding the 4-byte pointer, the total would be
+     * exactly Integer.MAX_VALUE, which should be allowed.
+     */
+    @Test
+    void testWritePointerAtMaxMinusPointerSize() throws Exception {
+        // Create output view with simulated high offset
+        long offsetJustUnderBoundary = (long) Integer.MAX_VALUE - POINTER_SIZE;
+        TestableOutputView outputView =
+                new TestableOutputView(SEGMENT_SIZE, offsetJustUnderBoundary);
+
+        // Use reflection to test the boundary check logic
+        // The check is: if (totalOffset > Integer.MAX_VALUE)
+        // With offset = MAX - 4, totalOffset after skip check = MAX - 4 + 0 = MAX - 4
+        // This should NOT throw since totalOffset <= Integer.MAX_VALUE
+        assertDoesNotThrow(
+                () -> invokeWritePointer(outputView, -1),
+                "Writing pointer at offset Integer.MAX_VALUE - 4 should succeed");
+    }
+
+    /**
+     * Tests that writing a pointer fails when the offset would cause the total to exceed
+     * Integer.MAX_VALUE.
+     *
+     * <p>With offset = Integer.MAX_VALUE - 3, after any alignment skip, the pointer write position
+     * could exceed Integer.MAX_VALUE.
+     */
+    @Test
+    void testWritePointerAtMaxMinusThree() throws Exception {
+        // Create output view with simulated high offset that would overflow
+        long offsetAtBoundary = (long) Integer.MAX_VALUE - 3;
+        TestableOutputView outputView = new TestableOutputView(SEGMENT_SIZE, offsetAtBoundary);
+
+        // Force alignment skip by positioning near end of segment
+        outputView.setPositionInSegment(SEGMENT_SIZE - 2);
+
+        // The check is: if (totalOffset > Integer.MAX_VALUE)
+        // With offset = MAX - 3 and skip = 2 (alignment), totalOffset = MAX - 1
+        // This should still succeed, but let's test with exact MAX
+        assertDoesNotThrow(
+                () -> invokeWritePointer(outputView, -1),
+                "Writing pointer at offset Integer.MAX_VALUE - 3 with 2-byte skip should succeed");
+    }
+
+    /**
+     * Tests that writing a pointer fails when the offset equals Integer.MAX_VALUE.
+     *
+     * <p>When totalOffset > Integer.MAX_VALUE, an EOFException should be thrown.
+     */
+    @Test
+    void testWritePointerAtExactMax() throws Exception {
+        // Create output view with offset at exactly Integer.MAX_VALUE
+        long offsetAtMax = Integer.MAX_VALUE;
+        TestableOutputView outputView = new TestableOutputView(SEGMENT_SIZE, offsetAtMax);
+
+        // The check is: if (totalOffset > Integer.MAX_VALUE)
+        // With offset = MAX and skip = 0, totalOffset = MAX
+        // Since the check is >, not >=, this should NOT throw
+        assertDoesNotThrow(
+                () -> invokeWritePointer(outputView, -1),
+                "Writing pointer at exactly Integer.MAX_VALUE should succeed (boundary is >)");
+    }
+
+    /**
+     * Tests that writing a pointer fails when the offset exceeds Integer.MAX_VALUE.
+     *
+     * <p>When totalOffset > Integer.MAX_VALUE, an EOFException should be thrown.
+     */
+    @Test
+    void testWritePointerOverMax() throws Exception {
+        // Create output view with offset exceeding Integer.MAX_VALUE
+        long offsetOverMax = (long) Integer.MAX_VALUE + 1;
+        TestableOutputView outputView = new TestableOutputView(SEGMENT_SIZE, offsetOverMax);
+
+        // The check is: if (totalOffset > Integer.MAX_VALUE)
+        // With offset = MAX + 1, totalOffset > MAX, so should throw
+        assertThatThrownBy(() -> invokeWritePointer(outputView, -1))
+                .isInstanceOf(EOFException.class);
+    }
+
+    /**
+     * Tests that writing a pointer fails when the offset is well beyond the limit.
+     *
+     * <p>This tests behavior at 2x Integer.MAX_VALUE to ensure the long arithmetic works correctly.
+     */
+    @Test
+    void testWritePointerAtDoubleMax() throws Exception {
+        // Create output view with offset at 2x Integer.MAX_VALUE
+        long offsetDoubleMax = 2L * Integer.MAX_VALUE;
+        TestableOutputView outputView = new TestableOutputView(SEGMENT_SIZE, offsetDoubleMax);
+
+        assertThatThrownBy(() -> invokeWritePointer(outputView, -1))
+                .isInstanceOf(EOFException.class);
+    }
+
+    /**
+     * Invokes the boundary check logic similar to writePointer in AbstractBytesMultiMap.
+     *
+     * <p>Since the actual writePointer method is private and requires full map initialization, we
+     * replicate the boundary checking logic here to verify it works correctly.
+     */
+    private void invokeWritePointer(TestableOutputView outputView, int value) throws Exception {
+        long rawOffset = outputView.getCurrentOffset();
+        int skip = checkSkipWriteForPointer(outputView);
+
+        // This is the boundary check from AbstractBytesMultiMap.writePointer()
+        long totalOffset = rawOffset + skip;
+        if (totalOffset > Integer.MAX_VALUE) {
+            throw new EOFException(
+                    "Cannot write pointer: offset " + totalOffset + " exceeds Integer.MAX_VALUE");
+        }
+
+        // Write would proceed here in actual code
+        outputView.getCurrentSegment().putInt(outputView.getCurrentPositionInSegment(), value);
+        outputView.skipBytesToWrite(POINTER_SIZE);
+    }
+
+    /** Replicates the checkSkipWriteForPointer logic from AbstractBytesMultiMap. */
+    private int checkSkipWriteForPointer(SimpleCollectingOutputView outView) throws Exception {
+        int available = outView.getSegmentSize() - outView.getCurrentPositionInSegment();
+        if (available < POINTER_SIZE) {
+            outView.advance();
+            return available;
+        }
+        return 0;
+    }
+
+    /**
+     * A testable extension of SimpleCollectingOutputView that allows setting a simulated offset.
+     */
+    private static class TestableOutputView extends SimpleCollectingOutputView {
+        private final long simulatedOffset;
+
+        TestableOutputView(int segmentSize, long simulatedOffset) {
+            super(new ArrayList<>(), new TestMemorySegmentSource(segmentSize), segmentSize);
+            this.simulatedOffset = simulatedOffset;
+        }
+
+        @Override
+        public long getCurrentOffset() {
+            return simulatedOffset;
+        }
+
+        void setPositionInSegment(int position) {
+            // Use reflection to set the position
+            try {
+                Method method =
+                        SimpleCollectingOutputView.class
+                                .getSuperclass()
+                                .getDeclaredMethod("seekOutput", MemorySegment.class, int.class);
+                method.setAccessible(true);
+                method.invoke(this, getCurrentSegment(), position);
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to set position", e);
+            }
+        }
+    }
+
+    /** A simple memory segment source for testing. */
+    private static class TestMemorySegmentSource implements MemorySegmentSource {
+        private final int segmentSize;
+
+        TestMemorySegmentSource(int segmentSize) {
+            this.segmentSize = segmentSize;
+        }
+
+        @Override
+        public MemorySegment nextSegment() {
+            return MemorySegmentFactory.allocateUnpooledSegment(segmentSize);
+        }
+    }
+}

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/util/collections/binary/AbstractBytesMultiMapBoundaryTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/util/collections/binary/AbstractBytesMultiMapBoundaryTest.java
@@ -22,209 +22,144 @@ import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.core.memory.MemorySegmentSource;
 import org.apache.flink.runtime.io.disk.SimpleCollectingOutputView;
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.memory.MemoryManagerBuilder;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LogicalType;
 
 import org.junit.jupiter.api.Test;
 
 import java.io.EOFException;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 /**
- * Tests for boundary conditions in {@link AbstractBytesMultiMap}.
+ * Tests for integer overflow protection in {@link AbstractBytesMultiMap#writePointer} and {@link
+ * AbstractBytesMultiMap#skipPointer}.
  *
- * <p>These tests verify that the overflow protection correctly handles offsets around
- * Integer.MAX_VALUE (~2GB). Since allocating 2GB of memory is impractical in unit tests, we use a
- * spy on SimpleCollectingOutputView to simulate offsets near the boundary.
- *
- * <p>The boundary behavior should be:
- *
- * <ul>
- *   <li>Offset = Integer.MAX_VALUE - 4 (2,147,483,643): Should succeed (pointer fits)
- *   <li>Offset = Integer.MAX_VALUE - 3 (2,147,483,644): Should fail (pointer would exceed)
- *   <li>Offset = Integer.MAX_VALUE (2,147,483,647): Should fail
- *   <li>Offset > Integer.MAX_VALUE: Should fail
- * </ul>
+ * <p>Without the overflow fix, offsets exceeding Integer.MAX_VALUE are silently truncated via
+ * {@code (int) longValue}, leading to corrupt pointers. These tests call the actual production
+ * methods via reflection and use a mock output view to simulate large offsets without allocating
+ * 2GB of memory.
  */
 class AbstractBytesMultiMapBoundaryTest {
 
-    private static final int SEGMENT_SIZE = 32 * 1024; // 32KB
-    private static final int POINTER_SIZE = 4; // 4 bytes for int pointer
+    private static final int SEGMENT_SIZE = 32 * 1024;
 
-    /**
-     * Tests that writing a pointer succeeds when the offset is just under the boundary where the
-     * 4-byte pointer would still fit within Integer.MAX_VALUE.
-     *
-     * <p>With offset = Integer.MAX_VALUE - 4, after adding the 4-byte pointer, the total would be
-     * exactly Integer.MAX_VALUE, which should be allowed.
-     */
     @Test
-    void testWritePointerAtMaxMinusPointerSize() throws Exception {
-        // Create output view with simulated high offset
-        long offsetJustUnderBoundary = (long) Integer.MAX_VALUE - POINTER_SIZE;
-        TestableOutputView outputView =
-                new TestableOutputView(SEGMENT_SIZE, offsetJustUnderBoundary);
+    void testWritePointerThrowsOnOverflow() throws Exception {
+        BytesMultiMap map = createMinimalMap();
+        try {
+            long overflowOffset = (long) Integer.MAX_VALUE + 1;
+            SimpleCollectingOutputView outputView = createOutputViewWithOffset(overflowOffset);
 
-        // Use reflection to test the boundary check logic
-        // The check is: if (totalOffset > Integer.MAX_VALUE)
-        // With offset = MAX - 4, totalOffset after skip check = MAX - 4 + 0 = MAX - 4
-        // This should NOT throw since totalOffset <= Integer.MAX_VALUE
-        assertDoesNotThrow(
-                () -> invokeWritePointer(outputView, -1),
-                "Writing pointer at offset Integer.MAX_VALUE - 4 should succeed");
-    }
+            Method writePointer =
+                    AbstractBytesMultiMap.class.getDeclaredMethod(
+                            "writePointer", SimpleCollectingOutputView.class, int.class);
+            writePointer.setAccessible(true);
 
-    /**
-     * Tests that writing a pointer fails when the offset would cause the total to exceed
-     * Integer.MAX_VALUE.
-     *
-     * <p>With offset = Integer.MAX_VALUE - 3, after any alignment skip, the pointer write position
-     * could exceed Integer.MAX_VALUE.
-     */
-    @Test
-    void testWritePointerAtMaxMinusThree() throws Exception {
-        // Create output view with simulated high offset that would overflow
-        long offsetAtBoundary = (long) Integer.MAX_VALUE - 3;
-        TestableOutputView outputView = new TestableOutputView(SEGMENT_SIZE, offsetAtBoundary);
-
-        // Force alignment skip by positioning near end of segment
-        outputView.setPositionInSegment(SEGMENT_SIZE - 2);
-
-        // The check is: if (totalOffset > Integer.MAX_VALUE)
-        // With offset = MAX - 3 and skip = 2 (alignment), totalOffset = MAX - 1
-        // This should still succeed, but let's test with exact MAX
-        assertDoesNotThrow(
-                () -> invokeWritePointer(outputView, -1),
-                "Writing pointer at offset Integer.MAX_VALUE - 3 with 2-byte skip should succeed");
-    }
-
-    /**
-     * Tests that writing a pointer fails when the offset equals Integer.MAX_VALUE.
-     *
-     * <p>When totalOffset > Integer.MAX_VALUE, an EOFException should be thrown.
-     */
-    @Test
-    void testWritePointerAtExactMax() throws Exception {
-        // Create output view with offset at exactly Integer.MAX_VALUE
-        long offsetAtMax = Integer.MAX_VALUE;
-        TestableOutputView outputView = new TestableOutputView(SEGMENT_SIZE, offsetAtMax);
-
-        // The check is: if (totalOffset > Integer.MAX_VALUE)
-        // With offset = MAX and skip = 0, totalOffset = MAX
-        // Since the check is >, not >=, this should NOT throw
-        assertDoesNotThrow(
-                () -> invokeWritePointer(outputView, -1),
-                "Writing pointer at exactly Integer.MAX_VALUE should succeed (boundary is >)");
-    }
-
-    /**
-     * Tests that writing a pointer fails when the offset exceeds Integer.MAX_VALUE.
-     *
-     * <p>When totalOffset > Integer.MAX_VALUE, an EOFException should be thrown.
-     */
-    @Test
-    void testWritePointerOverMax() throws Exception {
-        // Create output view with offset exceeding Integer.MAX_VALUE
-        long offsetOverMax = (long) Integer.MAX_VALUE + 1;
-        TestableOutputView outputView = new TestableOutputView(SEGMENT_SIZE, offsetOverMax);
-
-        // The check is: if (totalOffset > Integer.MAX_VALUE)
-        // With offset = MAX + 1, totalOffset > MAX, so should throw
-        assertThatThrownBy(() -> invokeWritePointer(outputView, -1))
-                .isInstanceOf(EOFException.class);
-    }
-
-    /**
-     * Tests that writing a pointer fails when the offset is well beyond the limit.
-     *
-     * <p>This tests behavior at 2x Integer.MAX_VALUE to ensure the long arithmetic works correctly.
-     */
-    @Test
-    void testWritePointerAtDoubleMax() throws Exception {
-        // Create output view with offset at 2x Integer.MAX_VALUE
-        long offsetDoubleMax = 2L * Integer.MAX_VALUE;
-        TestableOutputView outputView = new TestableOutputView(SEGMENT_SIZE, offsetDoubleMax);
-
-        assertThatThrownBy(() -> invokeWritePointer(outputView, -1))
-                .isInstanceOf(EOFException.class);
-    }
-
-    /**
-     * Invokes the boundary check logic similar to writePointer in AbstractBytesMultiMap.
-     *
-     * <p>Since the actual writePointer method is private and requires full map initialization, we
-     * replicate the boundary checking logic here to verify it works correctly.
-     */
-    private void invokeWritePointer(TestableOutputView outputView, int value) throws Exception {
-        long rawOffset = outputView.getCurrentOffset();
-        int skip = checkSkipWriteForPointer(outputView);
-
-        // This is the boundary check from AbstractBytesMultiMap.writePointer()
-        long totalOffset = rawOffset + skip;
-        if (totalOffset > Integer.MAX_VALUE) {
-            throw new EOFException(
-                    "Cannot write pointer: offset " + totalOffset + " exceeds Integer.MAX_VALUE");
+            assertThatThrownBy(() -> invokeReflective(writePointer, map, outputView, -1))
+                    .isInstanceOf(EOFException.class);
+        } finally {
+            map.free();
         }
-
-        // Write would proceed here in actual code
-        outputView.getCurrentSegment().putInt(outputView.getCurrentPositionInSegment(), value);
-        outputView.skipBytesToWrite(POINTER_SIZE);
     }
 
-    /** Replicates the checkSkipWriteForPointer logic from AbstractBytesMultiMap. */
-    private int checkSkipWriteForPointer(SimpleCollectingOutputView outView) throws Exception {
-        int available = outView.getSegmentSize() - outView.getCurrentPositionInSegment();
-        if (available < POINTER_SIZE) {
-            outView.advance();
-            return available;
+    @Test
+    void testSkipPointerThrowsOnOverflow() throws Exception {
+        BytesMultiMap map = createMinimalMap();
+        try {
+            long overflowOffset = (long) Integer.MAX_VALUE + 1;
+            SimpleCollectingOutputView outputView = createOutputViewWithOffset(overflowOffset);
+
+            Method skipPointer =
+                    AbstractBytesMultiMap.class.getDeclaredMethod(
+                            "skipPointer", SimpleCollectingOutputView.class);
+            skipPointer.setAccessible(true);
+
+            assertThatThrownBy(() -> invokeReflective(skipPointer, map, outputView))
+                    .isInstanceOf(EOFException.class);
+        } finally {
+            map.free();
         }
-        return 0;
     }
 
-    /**
-     * A testable extension of SimpleCollectingOutputView that allows setting a simulated offset.
-     */
-    private static class TestableOutputView extends SimpleCollectingOutputView {
-        private final long simulatedOffset;
+    @Test
+    void testWritePointerSucceedsAtExactMax() throws Exception {
+        BytesMultiMap map = createMinimalMap();
+        try {
+            SimpleCollectingOutputView outputView = createOutputViewWithOffset(Integer.MAX_VALUE);
 
-        TestableOutputView(int segmentSize, long simulatedOffset) {
-            super(new ArrayList<>(), new TestMemorySegmentSource(segmentSize), segmentSize);
-            this.simulatedOffset = simulatedOffset;
+            Method writePointer =
+                    AbstractBytesMultiMap.class.getDeclaredMethod(
+                            "writePointer", SimpleCollectingOutputView.class, int.class);
+            writePointer.setAccessible(true);
+
+            long result = (long) invokeReflective(writePointer, map, outputView, -1);
+            assertThat(result).isEqualTo(Integer.MAX_VALUE);
+        } finally {
+            map.free();
         }
+    }
 
-        @Override
-        public long getCurrentOffset() {
-            return simulatedOffset;
+    @Test
+    void testWritePointerThrowsAtDoubleMax() throws Exception {
+        BytesMultiMap map = createMinimalMap();
+        try {
+            long doubleMax = 2L * Integer.MAX_VALUE;
+            SimpleCollectingOutputView outputView = createOutputViewWithOffset(doubleMax);
+
+            Method writePointer =
+                    AbstractBytesMultiMap.class.getDeclaredMethod(
+                            "writePointer", SimpleCollectingOutputView.class, int.class);
+            writePointer.setAccessible(true);
+
+            assertThatThrownBy(() -> invokeReflective(writePointer, map, outputView, -1))
+                    .isInstanceOf(EOFException.class);
+        } finally {
+            map.free();
         }
+    }
 
-        void setPositionInSegment(int position) {
-            // Use reflection to set the position
-            try {
-                Method method =
-                        SimpleCollectingOutputView.class
-                                .getSuperclass()
-                                .getDeclaredMethod("seekOutput", MemorySegment.class, int.class);
-                method.setAccessible(true);
-                method.invoke(this, getCurrentSegment(), position);
-            } catch (Exception e) {
-                throw new RuntimeException("Failed to set position", e);
+    private Object invokeReflective(Method method, Object target, Object... args) throws Exception {
+        try {
+            return method.invoke(target, args);
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof Exception) {
+                throw (Exception) cause;
             }
+            throw e;
         }
     }
 
-    /** A simple memory segment source for testing. */
+    private BytesMultiMap createMinimalMap() {
+        LogicalType[] keyTypes = new LogicalType[] {new IntType()};
+        LogicalType[] valueTypes = new LogicalType[] {new IntType()};
+        int memorySize = 1024 * 1024 + 64 * 1024;
+        MemoryManager memoryManager =
+                MemoryManagerBuilder.newBuilder().setMemorySize(memorySize).build();
+        return new BytesMultiMap(this, memoryManager, memorySize, keyTypes, valueTypes);
+    }
+
+    private SimpleCollectingOutputView createOutputViewWithOffset(long simulatedOffset) {
+        return new SimpleCollectingOutputView(
+                new ArrayList<>(), new TestMemorySegmentSource(), SEGMENT_SIZE) {
+            @Override
+            public long getCurrentOffset() {
+                return simulatedOffset;
+            }
+        };
+    }
+
     private static class TestMemorySegmentSource implements MemorySegmentSource {
-        private final int segmentSize;
-
-        TestMemorySegmentSource(int segmentSize) {
-            this.segmentSize = segmentSize;
-        }
-
         @Override
         public MemorySegment nextSegment() {
-            return MemorySegmentFactory.allocateUnpooledSegment(segmentSize);
+            return MemorySegmentFactory.allocateUnpooledSegment(SEGMENT_SIZE);
         }
     }
 }


### PR DESCRIPTION
…en data exceeds 2GB


## What is the purpose of the change

  This pull request fixes an IndexOutOfBoundsException in AbstractBytesMultiMap that occurs when window aggregate queries (using TUMBLE TVF with LAST_VALUE aggregations) process large amounts of data with the
  memory state backend. When the value/key area exceeds ~2GB (Integer.MAX_VALUE bytes), casting the long offset to int overflows to a negative value, causing invalid array access.

 ## Brief change log

  - Added bounds checking in writePointer() to validate offset before casting long to int
  - Added bounds checking in skipPointer() to validate offset before casting long to int
  - Added bounds checking in appendRecord() to validate key area offset before casting
  - Removed redundant post-cast checks in appendValue() and appendRecord() since writePointer() now handles validation
  - Ensures EOFException is thrown with a clear warning message before any overflow can occur

 ## Verifying this change

  This change added tests and can be verified as follows:

  - Added testThrowsEOFExceptionWhenFull() test to BytesMultiMapTestBase that verifies EOFException is thrown when the map exceeds capacity (not IndexOutOfBoundsException which occurred before the fix)
  - Existing tests (BytesMultiMapTest, WindowBytesMultiMapTest) continue to pass, verifying the fix doesn't break normal operation

  The fix adds validation that throws EOFException earlier in the code path. The existing EOFException handling in RecordsWindowBuffer.addElement() already properly handles this case by flushing the buffer and
  retrying.

  ##Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with @Public(Evolving): no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no (only adds a comparison before existing cast)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

 ## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable