### PR TITLE
[optimize] Add isWarnEnabled guard for expensive log construction

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/io/BinaryInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/BinaryInputFormat.java
@@ -129,10 +129,12 @@ public abstract class BinaryInputFormat<T> extends FileInputFormat<T>
         }
 
         if (inputSplits.size() < minNumSplits) {
-            LOG.warn(
-                    String.format(
-                            "With the given block size %d, the files %s cannot be split into %d blocks. Filling up with empty splits...",
-                            blockSize, Arrays.toString(getFilePaths()), minNumSplits));
+            if (LOG.isWarnEnabled()){
+                LOG.warn(
+                        String.format(
+                                "With the given block size %d, the files %s cannot be split into %d blocks. Filling up with empty splits...",
+                                blockSize, Arrays.toString(getFilePaths()), minNumSplits));
+            }
             FileStatus last = files.get(files.size() - 1);
             final BlockLocation[] blocks =
                     last.getPath().getFileSystem().getFileBlockLocations(last, 0, last.getLen());


### PR DESCRIPTION
Avoids expensive string formatting and array-to-string conversion in `LOG.warn` when the logging level is not enabled. This improves performance by skipping the argument construction for the file splitting log message.