### PR TITLE
[FLINK-38987] Add RRSA (RAM Roles for Service Accounts) support for Flink OSS FileSystem

### DIFF
--- a/flink-filesystems/flink-oss-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-oss-fs-hadoop/pom.xml
@@ -181,6 +181,10 @@ under the License.
 								<includes>
 									<include>*:*</include>
 								</includes>
+								<excludes>
+									<!-- jaxb-api is provided separately and contains GPL license headers -->
+									<exclude>javax.xml.bind:jaxb-api</exclude>
+								</excludes>
 							</artifactSet>
 							<relocations>
 								<!-- shade Flink's Hadoop FS adapter classes, forces plugin classloader for them -->
@@ -201,6 +205,11 @@ under the License.
 										<exclude>.gitkeep</exclude>
 										<exclude>mime.types</exclude>
 										<exclude>mozilla/**</exclude>
+										<!-- Exclude jaxb-api files with GPL license headers -->
+										<exclude>com/sun/xml/bind/**</exclude>
+										<exclude>javax/xml/bind/**</exclude>
+										<!-- Exclude unexpected NOTICE files -->
+										<exclude>okhttp3/internal/publicsuffix/NOTICE</exclude>
 									</excludes>
 								</filter>
 							</filters>

--- a/flink-filesystems/flink-oss-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-oss-fs-hadoop/pom.xml
@@ -111,6 +111,17 @@ under the License.
 			<artifactId>credentials-java</artifactId>
 			<version>${aliyun.credentials.version}</version>
 			<optional>${flink.markBundledAsOptional}</optional>
+			<exclusions>
+				<!-- Exclude JAXB implementation JARs with GPL license headers -->
+				<exclusion>
+					<groupId>com.sun.xml.bind</groupId>
+					<artifactId>jaxb-core</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.sun.xml.bind</groupId>
+					<artifactId>jaxb-impl</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>

--- a/flink-filesystems/flink-oss-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-oss-fs-hadoop/pom.xml
@@ -30,6 +30,11 @@ under the License.
 
 	<properties>
 		<fs.oss.sdk.version>3.17.4</fs.oss.sdk.version>
+		<aliyun.credentials.version>0.3.2</aliyun.credentials.version>
+		<aliyun.tea.version>1.2.1</aliyun.tea.version>
+		<junit-pioneer.version>2.3.0</junit-pioneer.version>
+		<!-- JUnit Pioneer @SetEnvironmentVariable/@ClearEnvironmentVariable -->
+		<surefire.module.config>--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED</surefire.module.config>
 	</properties>
 
 	<dependencies>
@@ -102,6 +107,20 @@ under the License.
 		</dependency>
 
 		<dependency>
+			<groupId>com.aliyun</groupId>
+			<artifactId>credentials-java</artifactId>
+			<version>${aliyun.credentials.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>com.aliyun</groupId>
+			<artifactId>tea</artifactId>
+			<version>${aliyun.tea.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
+		</dependency>
+
+		<dependency>
 			<!-- Hadoop requires jaxb-api for javax.xml.bind.JAXBException -->
 			<groupId>javax.xml.bind</groupId>
 			<artifactId>jaxb-api</artifactId>
@@ -134,11 +153,18 @@ under the License.
 			<scope>test</scope>
 			<type>test-jar</type>
 		</dependency>
+
+		<!-- for environment variable testing in RRSA tests -->
+		<dependency>
+			<groupId>org.junit-pioneer</groupId>
+			<artifactId>junit-pioneer</artifactId>
+			<version>${junit-pioneer.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>
 		<plugins>
-
 			<!-- Relocate all OSS related classes -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/flink-filesystems/flink-oss-fs-hadoop/src/main/java/org/apache/flink/fs/osshadoop/RRSACredentialsProvider.java
+++ b/flink-filesystems/flink-oss-fs-hadoop/src/main/java/org/apache/flink/fs/osshadoop/RRSACredentialsProvider.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.osshadoop;
+
+import org.apache.flink.annotation.Internal;
+
+import com.aliyun.credentials.models.CredentialModel;
+import com.aliyun.credentials.provider.OIDCRoleArnCredentialProvider;
+import com.aliyun.oss.common.auth.BasicCredentials;
+import com.aliyun.oss.common.auth.Credentials;
+import com.aliyun.oss.common.auth.CredentialsProvider;
+import com.aliyun.oss.common.auth.InvalidCredentialsException;
+import org.apache.hadoop.conf.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+/**
+ * RRSA (RAM Roles for Service Accounts) credentials provider for OSS.
+ *
+ * <p>This provider enables Flink applications running in Alibaba Cloud Kubernetes (ACK) to
+ * authenticate with OSS using OIDC-based service account credentials. RRSA eliminates the need for
+ * hard-coded access keys by allowing pods to assume specific RAM roles.
+ *
+ * <p>RRSA requires the following environment variables to be set (automatically injected by ACK):
+ *
+ * <ul>
+ *   <li>ALIBABA_CLOUD_OIDC_PROVIDER_ARN - The OIDC provider ARN
+ *   <li>ALIBABA_CLOUD_ROLE_ARN - The RAM role ARN to assume
+ *   <li>ALIBABA_CLOUD_OIDC_TOKEN_FILE - Path to the OIDC token file (service account token)
+ * </ul>
+ *
+ * <p>For more information, see: <a
+ * href="https://www.alibabacloud.com/help/en/ack/ack-managed-and-ack-dedicated/user-guide/use-rrsa-to-authorize-pods-to-access-different-cloud-services">RRSA
+ * Documentation</a>
+ */
+@Internal
+public class RRSACredentialsProvider implements CredentialsProvider {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RRSACredentialsProvider.class);
+
+    public static final String OIDC_PROVIDER_ARN_ENV = "ALIBABA_CLOUD_OIDC_PROVIDER_ARN";
+    public static final String ROLE_ARN_ENV = "ALIBABA_CLOUD_ROLE_ARN";
+    public static final String OIDC_TOKEN_FILE_ENV = "ALIBABA_CLOUD_OIDC_TOKEN_FILE";
+
+    @Nullable private OIDCRoleArnCredentialProvider oidcProvider;
+
+    /** Default constructor required by Hadoop's credential provider mechanism. */
+    public RRSACredentialsProvider() {}
+
+    /**
+     * Constructor that accepts Hadoop configuration. Required by some Hadoop filesystem
+     * implementations.
+     */
+    public RRSACredentialsProvider(Configuration conf) {
+        // Configuration not used for RRSA as it relies on environment variables
+    }
+
+    /**
+     * Checks if RRSA environment variables are present.
+     *
+     * @return true if all required RRSA environment variables are set
+     */
+    public static boolean isRrsaEnvironmentAvailable() {
+        String oidcProviderArn = System.getenv(OIDC_PROVIDER_ARN_ENV);
+        String roleArn = System.getenv(ROLE_ARN_ENV);
+        String oidcTokenFile = System.getenv(OIDC_TOKEN_FILE_ENV);
+
+        boolean available =
+                !isNullOrEmpty(oidcProviderArn)
+                        && !isNullOrEmpty(roleArn)
+                        && !isNullOrEmpty(oidcTokenFile);
+
+        if (available) {
+            LOG.info(
+                    "RRSA environment detected: OIDC Provider ARN={}, Role ARN={}, Token File={}",
+                    oidcProviderArn,
+                    roleArn,
+                    oidcTokenFile);
+        }
+
+        return available;
+    }
+
+    @Override
+    public void setCredentials(Credentials credentials) {
+        // Not used for RRSA - credentials are obtained from OIDC provider
+    }
+
+    @Override
+    public Credentials getCredentials() {
+        try {
+            // Lazy initialization of OIDC provider
+            if (oidcProvider == null) {
+                synchronized (this) {
+                    if (oidcProvider == null) {
+                        if (!isRrsaEnvironmentAvailable()) {
+                            throw new InvalidCredentialsException(
+                                    "RRSA environment variables are not available");
+                        }
+                        LOG.info("Initializing RRSA OIDC credential provider");
+                        oidcProvider = OIDCRoleArnCredentialProvider.builder().build();
+                    }
+                }
+            }
+
+            // Get credentials from OIDC provider (automatically cached and refreshed)
+            LOG.debug("Fetching credentials using RRSA");
+            CredentialModel credModel = oidcProvider.getCredentials();
+
+            // Convert to OSS BasicCredentials
+            long expirationSeconds = 0;
+            if (credModel.getExpiration() > 0) {
+                expirationSeconds = (credModel.getExpiration() - System.currentTimeMillis()) / 1000;
+                LOG.debug("RRSA credentials obtained, expires in {} seconds", expirationSeconds);
+            }
+
+            return new BasicCredentials(
+                    credModel.getAccessKeyId(),
+                    credModel.getAccessKeySecret(),
+                    credModel.getSecurityToken(),
+                    expirationSeconds);
+
+        } catch (Exception e) {
+            LOG.error("Failed to get RRSA credentials", e);
+            throw new InvalidCredentialsException(
+                    "Failed to get RRSA credentials: " + e.getMessage(), e);
+        }
+    }
+
+    private static boolean isNullOrEmpty(String str) {
+        return str == null || str.trim().isEmpty();
+    }
+}

--- a/flink-filesystems/flink-oss-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-oss-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -10,7 +10,11 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.aliyun:aliyun-java-sdk-core:4.5.10
 - com.aliyun:aliyun-java-sdk-kms:2.11.0
 - com.aliyun:aliyun-java-sdk-ram:3.1.0
-- com.google.code.gson:gson:2.8.6
+- com.aliyun:credentials-java:0.3.2
+- com.aliyun:tea:1.2.1
+- com.google.code.gson:gson:2.10.1
+- com.squareup.okhttp3:okhttp:3.14.9
+- com.squareup.okio:okio:1.17.2
 - commons-codec:commons-codec:1.15
 - commons-logging:commons-logging:1.1.3
 - io.opentracing:opentracing-api:0.33.0
@@ -23,7 +27,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.ini4j:ini4j:0.5.4
 
 The binary distribution of this product bundles these dependencies under the Eclipse Public License - v 2.0 (https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt)
-- org.jacoco:org.jacoco.agent:runtime:0.8.5
+- org.jacoco:org.jacoco.agent:runtime:0.8.3
 
 This project bundles the following dependencies under the JDOM license.
 See bundled license files for details.

--- a/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/RRSACredentialsProviderTest.java
+++ b/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/RRSACredentialsProviderTest.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.osshadoop;
+
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.ClearEnvironmentVariable;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Unit tests for {@link RRSACredentialsProvider}. */
+class RRSACredentialsProviderTest {
+
+    @Test
+    @ClearEnvironmentVariable(key = RRSACredentialsProvider.OIDC_PROVIDER_ARN_ENV)
+    @ClearEnvironmentVariable(key = RRSACredentialsProvider.ROLE_ARN_ENV)
+    @ClearEnvironmentVariable(key = RRSACredentialsProvider.OIDC_TOKEN_FILE_ENV)
+    void testIsRrsaEnvironmentNotAvailable() {
+        // Verify that RRSA is not available when environment variables are not set
+        assertThat(RRSACredentialsProvider.isRrsaEnvironmentAvailable())
+                .as("RRSA should not be available without environment variables")
+                .isFalse();
+    }
+
+    @Test
+    @SetEnvironmentVariable(
+            key = RRSACredentialsProvider.OIDC_PROVIDER_ARN_ENV,
+            value = "acs:ram::123456789:oidc-provider/ack-rrsa-test")
+    @ClearEnvironmentVariable(key = RRSACredentialsProvider.ROLE_ARN_ENV)
+    @ClearEnvironmentVariable(key = RRSACredentialsProvider.OIDC_TOKEN_FILE_ENV)
+    void testIsRrsaEnvironmentPartiallyAvailableOidcProvider() {
+        // Verify that RRSA is not available when only OIDC provider ARN is set
+        assertThat(RRSACredentialsProvider.isRrsaEnvironmentAvailable())
+                .as("RRSA should not be available with only OIDC provider ARN")
+                .isFalse();
+    }
+
+    @Test
+    @SetEnvironmentVariable(
+            key = RRSACredentialsProvider.OIDC_PROVIDER_ARN_ENV,
+            value = "acs:ram::123456789:oidc-provider/ack-rrsa-test")
+    @SetEnvironmentVariable(
+            key = RRSACredentialsProvider.ROLE_ARN_ENV,
+            value = "acs:ram::123456789:role/test-rrsa-role")
+    @ClearEnvironmentVariable(key = RRSACredentialsProvider.OIDC_TOKEN_FILE_ENV)
+    void testIsRrsaEnvironmentPartiallyAvailableWithoutTokenFile() {
+        // Verify that RRSA is not available when token file is missing
+        assertThat(RRSACredentialsProvider.isRrsaEnvironmentAvailable())
+                .as("RRSA should not be available without OIDC token file")
+                .isFalse();
+    }
+
+    @Test
+    @SetEnvironmentVariable(
+            key = RRSACredentialsProvider.OIDC_PROVIDER_ARN_ENV,
+            value = "acs:ram::123456789:oidc-provider/ack-rrsa-test")
+    @SetEnvironmentVariable(
+            key = RRSACredentialsProvider.ROLE_ARN_ENV,
+            value = "acs:ram::123456789:role/test-rrsa-role")
+    @SetEnvironmentVariable(
+            key = RRSACredentialsProvider.OIDC_TOKEN_FILE_ENV,
+            value = "/tmp/oidc-token")
+    void testIsRrsaEnvironmentAvailable() {
+        // Verify that RRSA is available when all environment variables are set
+        assertThat(RRSACredentialsProvider.isRrsaEnvironmentAvailable())
+                .as("RRSA should be available with all environment variables set")
+                .isTrue();
+    }
+
+    @Test
+    @SetEnvironmentVariable(
+            key = RRSACredentialsProvider.OIDC_PROVIDER_ARN_ENV,
+            value = "acs:ram::123456789:oidc-provider/ack-rrsa-test")
+    @SetEnvironmentVariable(
+            key = RRSACredentialsProvider.ROLE_ARN_ENV,
+            value = "acs:ram::123456789:role/test-rrsa-role")
+    @SetEnvironmentVariable(
+            key = RRSACredentialsProvider.OIDC_TOKEN_FILE_ENV,
+            value = "/tmp/oidc-token")
+    void testGetCredentialsWithMockEnvironment() {
+        // Create provider with RRSA environment variables set
+        RRSACredentialsProvider provider = new RRSACredentialsProvider();
+
+        // With fake credentials, getCredentials should fail when trying to actually fetch tokens
+        // This is expected behavior - we're just testing that the provider is initialized
+        // correctly
+        assertThatThrownBy(provider::getCredentials)
+                .as("Getting credentials with fake RRSA environment should fail")
+                .hasMessageContaining("Failed to get RRSA credentials");
+    }
+
+    @Test
+    @ClearEnvironmentVariable(key = RRSACredentialsProvider.OIDC_PROVIDER_ARN_ENV)
+    @ClearEnvironmentVariable(key = RRSACredentialsProvider.ROLE_ARN_ENV)
+    @ClearEnvironmentVariable(key = RRSACredentialsProvider.OIDC_TOKEN_FILE_ENV)
+    void testGetCredentialsWithoutEnvironment() {
+        // Create provider without RRSA environment variables
+        RRSACredentialsProvider provider = new RRSACredentialsProvider();
+
+        // Should fail immediately when environment is not available
+        assertThatThrownBy(provider::getCredentials)
+                .as("Getting credentials without RRSA environment should fail")
+                .hasMessageContaining("RRSA environment variables are not available");
+    }
+
+    @Test
+    void testSetCredentialsIsNoOp() {
+        // setCredentials should be a no-op for RRSA provider
+        RRSACredentialsProvider provider = new RRSACredentialsProvider();
+        provider.setCredentials(null); // Should not throw
+    }
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This PR adds RRSA (RAM Roles for Service Accounts) support to the Flink OSS FileSystem, enabling Flink applications running in Alibaba Cloud Kubernetes (ACK) to authenticate with OSS using OIDC-based service account credentials.


## Brief change log

  - Added RRSACredentialsProvider class that implements OSS CredentialsProvider interface for RRSA authentication
  - Modified OSSFileSystemFactory to automatically detect RRSA environment variables and prepend RRSACredentialsProvider to the credential provider chain


## Verifying this change

This change added tests and can be verified as follows:
  - Added unit tests (RRSACredentialsProviderTest) that verify:
    - RRSA environment variable detection logic (all, partial, and missing variables)
    - Credential provider initialization and error handling
    - Behavior when RRSA environment is not available
  - Extended integration tests (HadoopOSSFileSystemITCase) that verify:
    - RRSA provider is automatically configured when environment variables are present
    - RRSA provider is correctly prepended to the credential provider chain
    - RRSA provider integrates properly with the OSS filesystem factory
  - Manual verification can be done by:
    - Deploying Flink to Alibaba Cloud ACK with RRSA-enabled service accounts
    - Setting the required environment variables (ALIBABA_CLOUD_OIDC_PROVIDER_ARN, ALIBABA_CLOUD_ROLE_ARN, ALIBABA_CLOUD_OIDC_TOKEN_FILE)
    - Running process that use flink-oss-fs-hadoop to accesses OSS, verifying authentication works without explicit access keys

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes (added aliyun credentials-java, aliyun tea, and junit-pioneer for tests)
  - The public API, i.e., is any changed class annotated with @Public(Evolving): no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no
## Documentation
  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs (comprehensive JavaDoc added to RRSACredentialsProvider explaining the feature, required environment variables, and references to Alibaba Cloud RRSA documentation)