### PR TITLE
[FLINK-39030][Table SQL/API] Support emit-only-on-update mode for CUMULATE window TVF to reduce unnecessary outputs

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowAggregateBase.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowAggregateBase.java
@@ -162,6 +162,10 @@ public abstract class StreamExecWindowAggregateBase extends StreamExecAggregateB
             if (offset != null) {
                 assigner = assigner.withOffset(offset);
             }
+            Boolean emitOnlyOnUpdate = ((CumulativeWindowSpec) windowSpec).getEmitOnlyOnUpdate();
+            if (emitOnlyOnUpdate != null && emitOnlyOnUpdate) {
+                assigner = assigner.withEmitOnlyOnUpdate(true);
+            }
             return assigner;
         } else {
             throw new UnsupportedOperationException(windowSpec + " is not supported yet.");

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/WindowUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/WindowUtil.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.planner.plan.utils
 import org.apache.flink.configuration.ReadableConfig
 import org.apache.flink.table.api.{DataTypes, TableConfig, TableException, ValidationException}
 import org.apache.flink.table.api.config.ExecutionConfigOptions
-import org.apache.flink.table.planner.JBigDecimal
+import org.apache.flink.table.planner.{JBigDecimal, JBoolean}
 import org.apache.flink.table.planner.calcite.{FlinkTypeFactory, RexTableArgCall}
 import org.apache.flink.table.planner.functions.sql.{FlinkSqlOperatorTable, SqlWindowTableFunction}
 import org.apache.flink.table.planner.plan.`trait`.RelWindowProperties
@@ -244,8 +244,13 @@ object WindowUtil {
         new HoppingWindowSpec(Duration.ofMillis(size), Duration.ofMillis(slide), offset)
 
       case FlinkSqlOperatorTable.CUMULATE =>
-        val offset = if (windowCall.operands.size() == 5) {
+        val offset = if (windowCall.operands.size() >= 5) {
           Duration.ofMillis(getOperandAsLong(windowCall.operands(4)))
+        } else {
+          null
+        }
+        val emitOnlyOnUpdate = if (windowCall.operands.size() == 6) {
+          getOperandAsBoolean(windowCall.operands(5))
         } else {
           null
         }
@@ -260,7 +265,11 @@ object WindowUtil {
           throw new ValidationException("CUMULATE table function based aggregate requires maxSize " +
             s"must be an integral multiple of step, but got maxSize $maxSize ms and step $step ms.")
         }
-        new CumulativeWindowSpec(Duration.ofMillis(maxSize), Duration.ofMillis(step), offset)
+        new CumulativeWindowSpec(
+          Duration.ofMillis(maxSize),
+          Duration.ofMillis(step),
+          offset,
+          emitOnlyOnUpdate)
       case FlinkSqlOperatorTable.SESSION =>
         val tableArgCall = windowCall.operands(0).asInstanceOf[RexTableArgCall]
         if (!tableArgCall.getOrderKeys.isEmpty) {
@@ -419,6 +428,15 @@ object WindowUtil {
           "Window aggregate only support SECOND, MINUTE, HOUR, DAY as the time unit. " +
             "MONTH and YEAR time unit are not supported yet.")
       case _ => throw new TableException("Only constant window descriptors are supported.")
+    }
+  }
+
+  private def getOperandAsBoolean(operand: RexNode): JBoolean = {
+    operand match {
+      case v: RexLiteral if v.getTypeName.getFamily == SqlTypeFamily.BOOLEAN =>
+        v.getValue.asInstanceOf[JBoolean]
+      case _ =>
+        throw new TableException("Only constant window descriptors are supported.")
     }
   }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/WindowTableFunctionITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/WindowTableFunctionITCase.scala
@@ -491,4 +491,175 @@ class WindowTableFunctionITCase(mode: StateBackendMode) extends StreamingWithSta
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
       .isEqualTo(expected.sorted.mkString("\n"))
   }
+
+  /**
+   * Tests CUMULATE window with emit-only-on-update mode enabled.
+   *
+   * <p>When emit_only_on_update is set to true, the window only emits results when new data arrives
+   * within the step interval. This reduces unnecessary outputs for sparse data streams.
+   */
+  @TestTemplate
+  def testCumulateWindowWithEmitOnlyOnUpdate(): Unit = {
+    val sql =
+      """
+        |SELECT
+        |  sum(`int`),
+        |  window_start,
+        |  window_end
+        |FROM TABLE(
+        |  CUMULATE(
+        |    TABLE T1,
+        |    DESCRIPTOR(rowtime),
+        |    INTERVAL '5' SECOND,
+        |    INTERVAL '15' SECOND,
+        |    INTERVAL '0' SECOND,
+        |    true))
+        |GROUP BY window_start, window_end
+      """.stripMargin
+
+    val sink = new TestingAppendSink
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
+    env.execute()
+
+    // With emit_only_on_update = true, outputs are only emitted when new data arrives
+    // within the step interval. Data in the first window period [00:00:00, 00:00:15):
+    // - [00:00:00, 00:00:05): 1+2+2+5 = 10 (late event hasn't arrived yet)
+    // - [00:00:00, 00:00:10): += 6+3+3+5(late) = 17, total = 27
+    // - [00:00:00, 00:00:15): no new data in this step, skipped due to emitOnlyOnUpdate
+    //
+    // Second window period [00:00:15, 00:00:30):
+    // - [00:00:15, 00:00:20): 4
+    // - [00:00:15, 00:00:25): no new data, skipped
+    // - [00:00:15, 00:00:30): no new data, skipped
+    //
+    // Third window period [00:00:30, 00:00:45):
+    // - [00:00:30, 00:00:35): 7+1 = 8
+    // - [00:00:30, 00:00:40): no new data, skipped
+    // - [00:00:30, 00:00:45): no new data, skipped
+    val expected = Seq(
+      "10,2020-10-10T00:00,2020-10-10T00:00:05",
+      "27,2020-10-10T00:00,2020-10-10T00:00:10",
+      "4,2020-10-10T00:00:15,2020-10-10T00:00:20",
+      "8,2020-10-10T00:00:30,2020-10-10T00:00:35"
+    )
+    assertThat(sink.getAppendResults.sorted.mkString("\n"))
+      .isEqualTo(expected.sorted.mkString("\n"))
+  }
+
+  /**
+   * Tests CUMULATE window with emit-only-on-update mode disabled (default behavior).
+   *
+   * <p>When emit_only_on_update is set to false (or not specified), the window emits results for
+   * every step, even if no new data arrives. This is the default cumulate behavior.
+   */
+  @TestTemplate
+  def testCumulateWindowWithEmitOnlyOnUpdateDisabled(): Unit = {
+    val sql =
+      """
+        |SELECT
+        |  sum(`int`),
+        |  window_start,
+        |  window_end
+        |FROM TABLE(
+        |  CUMULATE(
+        |    TABLE T1,
+        |    DESCRIPTOR(rowtime),
+        |    INTERVAL '5' SECOND,
+        |    INTERVAL '15' SECOND,
+        |    INTERVAL '0' SECOND,
+        |    false))
+        |GROUP BY window_start, window_end
+      """.stripMargin
+
+    val sink = new TestingAppendSink
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
+    env.execute()
+
+    // With emit_only_on_update = false, outputs are emitted for every step interval.
+    // This is the same as the default CUMULATE behavior.
+    // Data in the first window period [00:00:00, 00:00:15):
+    // - [00:00:00, 00:00:05): 1+2+2+5 = 10 (late event hasn't arrived yet)
+    // - [00:00:00, 00:00:10): 10 + 5(late)+6+3+3 = 27
+    // - [00:00:00, 00:00:15): 27 (no new data, but still emitted)
+    //
+    // Second window period [00:00:15, 00:00:30):
+    // - [00:00:15, 00:00:20): 4
+    // - [00:00:15, 00:00:25): 4 (no new data, but still emitted)
+    // - [00:00:15, 00:00:30): 4 (no new data, but still emitted)
+    //
+    // Third window period [00:00:30, 00:00:45):
+    // - [00:00:30, 00:00:35): 7+1 = 8
+    // - [00:00:30, 00:00:40): 8 (no new data, but still emitted)
+    // - [00:00:30, 00:00:45): 8 (no new data, but still emitted)
+    val expected = Seq(
+      "10,2020-10-10T00:00,2020-10-10T00:00:05",
+      "27,2020-10-10T00:00,2020-10-10T00:00:10",
+      "27,2020-10-10T00:00,2020-10-10T00:00:15",
+      "4,2020-10-10T00:00:15,2020-10-10T00:00:20",
+      "4,2020-10-10T00:00:15,2020-10-10T00:00:25",
+      "4,2020-10-10T00:00:15,2020-10-10T00:00:30",
+      "8,2020-10-10T00:00:30,2020-10-10T00:00:35",
+      "8,2020-10-10T00:00:30,2020-10-10T00:00:40",
+      "8,2020-10-10T00:00:30,2020-10-10T00:00:45"
+    )
+    assertThat(sink.getAppendResults.sorted.mkString("\n"))
+      .isEqualTo(expected.sorted.mkString("\n"))
+  }
+
+  /**
+   * Tests CUMULATE window with emit-only-on-update mode and multi-key grouping.
+   *
+   * <p>This test verifies that emit-only-on-update works correctly when data is grouped by multiple
+   * keys (name + window).
+   */
+  @TestTemplate
+  def testCumulateWindowWithEmitOnlyOnUpdateAndMultiKey(): Unit = {
+    val sql =
+      """
+        |SELECT
+        |  `name`,
+        |  sum(`int`),
+        |  window_start,
+        |  window_end
+        |FROM TABLE(
+        |  CUMULATE(
+        |    TABLE T1,
+        |    DESCRIPTOR(rowtime),
+        |    INTERVAL '5' SECOND,
+        |    INTERVAL '15' SECOND,
+        |    INTERVAL '0' SECOND,
+        |    true))
+        |GROUP BY `name`, window_start, window_end
+      """.stripMargin
+
+    val sink = new TestingAppendSink
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
+    env.execute()
+
+    // With emit_only_on_update = true and grouping by name:
+    // For key 'a':
+    // - [00:00:00, 00:00:05): 1+2+2+5 = 10 (late event hasn't arrived yet)
+    // - [00:00:00, 00:00:10): 10 + 5(late) + 3 = 18
+    // - [00:00:00, 00:00:15): no new data for 'a', skipped
+    //
+    // For key 'b':
+    // - [00:00:00, 00:00:05): no data for 'b' in this step
+    // - [00:00:00, 00:00:10): 6+3 = 9
+    // - [00:00:00, 00:00:15): no new data for 'b', skipped
+    // - [00:00:15, 00:00:20): 4
+    // - [00:00:30, 00:00:35): 1
+    //
+    // For key null:
+    // - [00:00:30, 00:00:35): 7
+    val expected = Seq(
+      "a,10,2020-10-10T00:00,2020-10-10T00:00:05",
+      "a,18,2020-10-10T00:00,2020-10-10T00:00:10",
+      "b,9,2020-10-10T00:00,2020-10-10T00:00:10",
+      "b,4,2020-10-10T00:00:15,2020-10-10T00:00:20",
+      "b,1,2020-10-10T00:00:30,2020-10-10T00:00:35",
+      "null,7,2020-10-10T00:00:30,2020-10-10T00:00:35"
+    )
+    assertThat(sink.getAppendResults.sorted.mkString("\n"))
+      .isEqualTo(expected.sorted.mkString("\n"))
+  }
 }


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds support for `emit-only-on-update` mode in the CUMULATE window Table-Valued Function (TVF). When enabled, the CUMULATE window will skip emitting results for step intervals where no new data has arrived, reducing unnecessary duplicate outputs in sparse data streams. This optimization is particularly useful for scenarios where data arrives intermittently, as it avoids repeatedly outputting the same aggregation results.

## Brief change log

- Added a new optional boolean parameter `emitOnlyOnUpdate` (6th parameter) to the `CUMULATE` window TVF SQL function
- Extended `CumulativeWindowSpec` to support the new `emitOnlyOnUpdate` field with JSON serialization/deserialization
- Modified `CumulativeSliceAssigner` in `SliceAssigners` to track and expose the `emitOnlyOnUpdate` configuration
- Updated `SliceSharedSyncStateWindowAggProcessor` and `AsyncStateSliceSharedWindowAggProcessor` to implement the emit-only-on-update logic by tracking whether new data arrived in the current step interval
- Improved `SqlWindowTableFunction.checkIntervalOperands()` to skip boolean parameters dynamically instead of hardcoded parameter count check
- Added integration tests for the new feature with various scenarios (enabled/disabled comparison, multi-key grouping)
- Updated documentation (both English and Chinese) with parameter description and usage examples

## Verifying this change

This change added tests and can be verified as follows:

- Added `testCumulateWindowWithEmitOnlyOnUpdate()` integration test that verifies windows are skipped when no new data arrives in a step interval
- Added `testCumulateWindowWithEmitOnlyOnUpdateDisabled()` integration test that verifies default behavior (emitOnlyOnUpdate=false) outputs all cumulating windows
- Added `testCumulateWindowWithEmitOnlyOnUpdateAndMultiKey()` integration test that verifies the feature works correctly with multiple grouping keys
- Manually verified the change by comparing output row counts between `emitOnlyOnUpdate=true` and `emitOnlyOnUpdate=false` modes

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): **no**
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
- The serializers: **no** (only added new optional field with backward-compatible JSON deserialization)
- The runtime per-record code paths (performance sensitive): **yes** (added a boolean check in the window aggregation output path, but the overhead is minimal)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
- The S3 file system connector: **no**

## Documentation

- Does this pull request introduce a new feature? **yes**
- If yes, how is the feature documented? **docs / JavaDocs**
  - Updated `docs/content/docs/dev/table/sql/queries/window-tvf.md` (English)
  - Updated `docs/content.zh/docs/dev/table/sql/queries/window-tvf.md` (Chinese)
  - Added JavaDoc comments for the new parameter in `SqlCumulateTableFunction.java`