### PR TITLE
[FLINK-39035][format][avro] Support Avro fast-read and column pruning…

### DIFF
--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroDeserializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroDeserializationSchema.java
@@ -18,6 +18,15 @@
 
 package org.apache.flink.formats.avro;
 
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.formats.avro.AvroFormatOptions.AvroEncoding;
+import org.apache.flink.formats.avro.typeutils.AvroFactory;
+import org.apache.flink.formats.avro.typeutils.AvroTypeInfo;
+import org.apache.flink.formats.avro.typeutils.GenericRecordAvroTypeInfo;
+import org.apache.flink.formats.avro.utils.MutableByteArrayInputStream;
+import org.apache.flink.util.Preconditions;
+
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumReader;
@@ -28,19 +37,11 @@ import org.apache.avro.io.JsonDecoder;
 import org.apache.avro.specific.SpecificData;
 import org.apache.avro.specific.SpecificDatumReader;
 import org.apache.avro.specific.SpecificRecord;
-import org.apache.flink.api.common.serialization.DeserializationSchema;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.formats.avro.AvroFormatOptions.AvroEncoding;
-import org.apache.flink.formats.avro.typeutils.AvroFactory;
-import org.apache.flink.formats.avro.typeutils.AvroTypeInfo;
-import org.apache.flink.formats.avro.typeutils.GenericRecordAvroTypeInfo;
-import org.apache.flink.formats.avro.utils.MutableByteArrayInputStream;
-import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.Objects;
-
-import javax.annotation.Nullable;
 
 /**
  * Deserialization schema that deserializes from Avro binary format.

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroDeserializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroDeserializationSchema.java
@@ -71,7 +71,26 @@ public class AvroDeserializationSchema<T> implements DeserializationSchema<T> {
      */
     public static AvroDeserializationSchema<GenericRecord> forGeneric(
             Schema schema, AvroEncoding encoding) {
-        return new AvroDeserializationSchema<>(GenericRecord.class, schema, encoding);
+        return forGeneric(null, schema, encoding, null, false);
+    }
+
+    /**
+     * Creates {@link AvroDeserializationSchema} that produces {@link GenericRecord} using provided
+     * schema.
+     *
+     * @param actualSchema schema of upstream actual write
+     * @param schema schema of produced records
+     * @param encoding Avro serialization approach to use for decoding
+     * @return deserialized record in form of {@link GenericRecord}
+     */
+    public static AvroDeserializationSchema<GenericRecord> forGeneric(
+            Schema actualSchema,
+            Schema schema,
+            AvroEncoding encoding,
+            String actualSchemaString,
+            boolean fastRead) {
+        return new AvroDeserializationSchema<>(
+                GenericRecord.class, schema, actualSchema, encoding, actualSchemaString, fastRead);
     }
 
     /**
@@ -104,8 +123,11 @@ public class AvroDeserializationSchema<T> implements DeserializationSchema<T> {
     /** Class to deserialize to. */
     private final Class<T> recordClazz;
 
-    /** Schema in case of GenericRecord for serialization purpose. */
+    /** Schema in case of GenericRecord for downstream serialization purpose. */
     private final String schemaString;
+
+    /** Schema in case of GenericRecord for upstream serialization purpose. */
+    private final String writeSchemaString;
 
     /** Reader that deserializes byte array into a record. */
     private transient GenericDatumReader<T> datumReader;
@@ -119,8 +141,14 @@ public class AvroDeserializationSchema<T> implements DeserializationSchema<T> {
     /** Avro decoder that decodes data. */
     private transient Decoder decoder;
 
-    /** Avro schema for the reader. */
+    /** Avro schema for the downstream reader. */
     private transient Schema reader;
+
+    /** Avro schema for the upstream writer. */
+    private transient Schema writer;
+
+    /** Avro schema for the upstream writer. */
+    private final boolean fastRead;
 
     /**
      * Creates a Avro deserialization schema.
@@ -133,6 +161,27 @@ public class AvroDeserializationSchema<T> implements DeserializationSchema<T> {
      */
     AvroDeserializationSchema(
             Class<T> recordClazz, @Nullable Schema reader, AvroEncoding encoding) {
+        this(recordClazz, reader, null, encoding, null, false);
+    }
+
+    /**
+     * Creates a Avro deserialization schema.
+     *
+     * @param recordClazz class to which deserialize. Should be one of: {@link
+     *     org.apache.avro.specific.SpecificRecord}, {@link org.apache.avro.generic.GenericRecord}.
+     * @param reader reader's Avro schema. Should be provided if recordClazz is {@link
+     *     GenericRecord}
+     * @param writer writer's Avro schema. Should be provided if user want to column pruning.
+     * @param encoding encoding approach to use. Identifies the Avro decoder class to use.
+     * @param writeSchemaString Optional for advanced users manually specify.
+     */
+    AvroDeserializationSchema(
+            Class<T> recordClazz,
+            @Nullable Schema reader,
+            @Nullable Schema writer,
+            AvroEncoding encoding,
+            @Nullable String writeSchemaString,
+            boolean fastRead) {
         Preconditions.checkNotNull(recordClazz, "Avro record class must not be null.");
         this.recordClazz = recordClazz;
         this.reader = reader;
@@ -141,7 +190,16 @@ public class AvroDeserializationSchema<T> implements DeserializationSchema<T> {
         } else {
             this.schemaString = null;
         }
+        this.writer = writer;
+        if (writeSchemaString != null) {
+            this.writeSchemaString = writeSchemaString;
+        } else if (this.writer != null) {
+            this.writeSchemaString = this.writer.toString();
+        } else {
+            this.writeSchemaString = null;
+        }
         this.encoding = encoding;
+        this.fastRead = fastRead;
     }
 
     GenericDatumReader<T> getDatumReader() {
@@ -172,15 +230,9 @@ public class AvroDeserializationSchema<T> implements DeserializationSchema<T> {
         // read record
         checkAvroInitialized();
         inputStream.setBuffer(message);
-        Schema readerSchema = getReaderSchema();
-        GenericDatumReader<T> datumReader = getDatumReader();
-
-        datumReader.setSchema(readerSchema);
-
         if (encoding == AvroEncoding.JSON) {
             ((JsonDecoder) this.decoder).configure(inputStream);
         }
-
         return datumReader.read(null, decoder);
     }
 
@@ -195,12 +247,21 @@ public class AvroDeserializationSchema<T> implements DeserializationSchema<T> {
             SpecificData specificData =
                     AvroFactory.getSpecificDataForClass(
                             (Class<? extends SpecificData>) recordClazz, cl);
+            specificData.setFastReaderEnabled(fastRead);
             this.datumReader = new SpecificDatumReader<>(specificData);
             this.reader = AvroFactory.extractAvroSpecificSchema(recordClazz, specificData);
+            datumReader.setSchema(reader);
         } else {
             this.reader = new Schema.Parser().parse(schemaString);
             GenericData genericData = new GenericData(cl);
-            this.datumReader = new GenericDatumReader<>(null, this.reader, genericData);
+            genericData.setFastReaderEnabled(fastRead);
+            this.writer =
+                    new Schema.Parser()
+                            .parse(
+                                    writeSchemaString == null || writeSchemaString.isEmpty()
+                                            ? schemaString
+                                            : writeSchemaString);
+            this.datumReader = new GenericDatumReader<>(this.writer, this.reader, genericData);
         }
 
         this.inputStream = new MutableByteArrayInputStream();

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroFormatOptions.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroFormatOptions.java
@@ -83,5 +83,23 @@ public class AvroFormatOptions {
                                     + "you can obtain the correct mapping by disable using this legacy mapping."
                                     + " Use legacy behavior by default for compatibility consideration.");
 
+    public static final ConfigOption<Boolean> AVRO_FAST_READ =
+            ConfigOptions.key("avro.fast-read.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Optional for avro fast reader. "
+                                    + "Avro Fastread improves Avro read speeds by constructing a resolution chain. "
+                                    + "get more information about this feature, please visit https://issues.apache.org/jira/browse/AVRO-3230");
+
+    public static final ConfigOption<String> AVRO_WRITER_SCHEMA_STRING =
+            ConfigOptions.key("avro.writer.schemaString")
+                    .stringType()
+                    .defaultValue(null)
+                    .withDescription(
+                            "Optional for Avro deserialization. This string serves as the reader schema "
+                                    + "for the upstream table. Configuring this allows for effective column pruning, "
+                                    + "as only the fields specified in this schema will be read.");
+
     private AvroFormatOptions() {}
 }

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroFormatOptions.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroFormatOptions.java
@@ -84,7 +84,7 @@ public class AvroFormatOptions {
                                     + " Use legacy behavior by default for compatibility consideration.");
 
     public static final ConfigOption<Boolean> AVRO_FAST_READ =
-            ConfigOptions.key("avro.fast-read.enabled")
+            ConfigOptions.key("fast-read.enabled")
                     .booleanType()
                     .defaultValue(false)
                     .withDescription(
@@ -93,7 +93,7 @@ public class AvroFormatOptions {
                                     + "get more information about this feature, please visit https://issues.apache.org/jira/browse/AVRO-3230");
 
     public static final ConfigOption<String> AVRO_WRITER_SCHEMA_STRING =
-            ConfigOptions.key("avro.writer.schemaString")
+            ConfigOptions.key("writer.schemaString")
                     .stringType()
                     .defaultValue(null)
                     .withDescription(

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDataDeserializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDataDeserializationSchema.java
@@ -109,6 +109,34 @@ public class AvroRowDataDeserializationSchema implements DeserializationSchema<R
     }
 
     /**
+     * Creates an Avro deserialization schema for the given logical type.
+     *
+     * @param rowType The logical type used to deserialize the data.
+     * @param typeInfo The TypeInformation to be used by {@link
+     *     AvroRowDataDeserializationSchema#getProducedType()}.
+     * @param encoding The serialization approach used to deserialize the data.
+     * @param legacyTimestampMapping Whether to use legacy timestamp mapping.
+     */
+    public AvroRowDataDeserializationSchema(
+            RowType actualRowType,
+            RowType rowType,
+            TypeInformation<RowData> typeInfo,
+            AvroEncoding encoding,
+            boolean legacyTimestampMapping,
+            boolean fastRead,
+            String writerSchemaString) {
+        this(
+                AvroDeserializationSchema.forGeneric(
+                        AvroSchemaConverter.convertToSchema(actualRowType, legacyTimestampMapping),
+                        AvroSchemaConverter.convertToSchema(rowType, legacyTimestampMapping),
+                        encoding,
+                        writerSchemaString,
+                        fastRead),
+                AvroToRowDataConverters.createRowConverter(rowType, legacyTimestampMapping),
+                typeInfo);
+    }
+
+    /**
      * Creates a Avro deserialization schema for the given logical type.
      *
      * @param nestedSchema Deserialization schema to deserialize as {@link GenericRecord}

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroDeserializationSchemaTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroDeserializationSchemaTest.java
@@ -24,13 +24,21 @@ import org.apache.flink.formats.avro.generated.Address;
 import org.apache.flink.formats.avro.generated.UnionLogicalType;
 import org.apache.flink.formats.avro.utils.TestDataGenerator;
 
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Encoder;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
+import java.io.ByteArrayOutputStream;
 import java.time.Instant;
 import java.util.Random;
 
+import static org.apache.flink.formats.avro.utils.AvroTestUtils.createEncoder;
 import static org.apache.flink.formats.avro.utils.AvroTestUtils.writeRecord;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -84,5 +92,171 @@ class AvroDeserializationSchemaTest {
         byte[] encodedData = writeRecord(data, encoding);
         UnionLogicalType deserializedData = deserializer.deserialize(encodedData);
         assertThat(deserializedData).isEqualTo(data);
+    }
+
+    @ParameterizedTest
+    @EnumSource(AvroEncoding.class)
+    void testFastReadWithGenericRecord(AvroEncoding encoding) throws Exception {
+        // Create a schema with multiple fields
+        Schema schema =
+                SchemaBuilder.record("TestRecord")
+                        .namespace("org.apache.flink.formats.avro.test")
+                        .fields()
+                        .requiredString("name")
+                        .requiredInt("age")
+                        .requiredDouble("score")
+                        .endRecord();
+
+        // Create a GenericRecord with test data
+        GenericRecord record = new GenericData.Record(schema);
+        record.put("name", "Alice");
+        record.put("age", 30);
+        record.put("score", 95.5);
+
+        // Serialize the record
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        GenericDatumWriter<IndexedRecord> datumWriter = new GenericDatumWriter<>(schema);
+        Encoder encoder = createEncoder(encoding, schema, outputStream);
+        datumWriter.write(record, encoder);
+        encoder.flush();
+        byte[] encodedData = outputStream.toByteArray();
+
+        // Create deserializer with fast read enabled
+        DeserializationSchema<GenericRecord> deserializer =
+                AvroDeserializationSchema.forGeneric(null, schema, encoding, null, true);
+
+        // Deserialize and verify
+        GenericRecord deserializedRecord = deserializer.deserialize(encodedData);
+        assertThat(deserializedRecord).isNotNull();
+        assertThat(deserializedRecord.get("name").toString()).isEqualTo("Alice");
+        assertThat(deserializedRecord.get("age")).isEqualTo(30);
+        assertThat(deserializedRecord.get("score")).isEqualTo(95.5);
+    }
+
+    @ParameterizedTest
+    @EnumSource(AvroEncoding.class)
+    void testFastReadWithSpecificRecord(AvroEncoding encoding) throws Exception {
+        // Use the existing Address test data
+        Address address = TestDataGenerator.generateRandomAddress(new Random(42));
+
+        // Serialize the address
+        byte[] encodedAddress = writeRecord(address, encoding);
+
+        // Create deserializer with fast read enabled
+        DeserializationSchema<Address> deserializer =
+                new AvroDeserializationSchema<>(Address.class, null, null, encoding, null, true);
+
+        // Deserialize and verify
+        Address deserializedAddress = deserializer.deserialize(encodedAddress);
+        assertThat(deserializedAddress).isEqualTo(address);
+    }
+
+    @ParameterizedTest
+    @EnumSource(AvroEncoding.class)
+    void testColumnPruningWithGenericRecord(AvroEncoding encoding) throws Exception {
+        // Create a full schema with 5 fields
+        Schema fullSchema =
+                SchemaBuilder.record("FullRecord")
+                        .namespace("org.apache.flink.formats.avro.test")
+                        .fields()
+                        .requiredLong("id")
+                        .requiredString("name")
+                        .requiredInt("age")
+                        .requiredString("email")
+                        .requiredDouble("score")
+                        .endRecord();
+
+        // Create a projected schema with only 3 fields (id, name, score)
+        Schema projectedSchema =
+                SchemaBuilder.record("ProjectedRecord")
+                        .namespace("org.apache.flink.formats.avro.test")
+                        .fields()
+                        .requiredLong("id")
+                        .requiredString("name")
+                        .requiredDouble("score")
+                        .endRecord();
+
+        // Create a GenericRecord with all 5 fields
+        GenericRecord fullRecord = new GenericData.Record(fullSchema);
+        fullRecord.put("id", 123L);
+        fullRecord.put("name", "Bob");
+        fullRecord.put("age", 25);
+        fullRecord.put("email", "bob@example.com");
+        fullRecord.put("score", 88.5);
+
+        // Serialize the full record
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        GenericDatumWriter<IndexedRecord> datumWriter = new GenericDatumWriter<>(fullSchema);
+        Encoder encoder = createEncoder(encoding, fullSchema, outputStream);
+        datumWriter.write(fullRecord, encoder);
+        encoder.flush();
+        byte[] encodedData = outputStream.toByteArray();
+
+        // Create deserializer with column pruning (writer schema = full, reader schema
+        // = projected)
+        DeserializationSchema<GenericRecord> deserializer =
+                AvroDeserializationSchema.forGeneric(
+                        fullSchema, projectedSchema, encoding, null, false);
+
+        // Deserialize and verify only projected fields are present
+        GenericRecord deserializedRecord = deserializer.deserialize(encodedData);
+        assertThat(deserializedRecord).isNotNull();
+        assertThat(deserializedRecord.get("id")).isEqualTo(123L);
+        assertThat(deserializedRecord.get("name").toString()).isEqualTo("Bob");
+        assertThat(deserializedRecord.get("score")).isEqualTo(88.5);
+
+        // Verify that the projected schema only has 3 fields
+        assertThat(deserializedRecord.getSchema().getFields()).hasSize(3);
+    }
+
+    @ParameterizedTest
+    @EnumSource(AvroEncoding.class)
+    void testFastReadAndColumnPruningCombined(AvroEncoding encoding) throws Exception {
+        // Create a full schema with 4 fields
+        Schema fullSchema =
+                SchemaBuilder.record("FullRecord")
+                        .namespace("org.apache.flink.formats.avro.test")
+                        .fields()
+                        .requiredLong("id")
+                        .requiredString("name")
+                        .requiredInt("age")
+                        .requiredDouble("score")
+                        .endRecord();
+
+        // Create a projected schema with only 2 fields (id, score)
+        Schema projectedSchema =
+                SchemaBuilder.record("ProjectedRecord")
+                        .namespace("org.apache.flink.formats.avro.test")
+                        .fields()
+                        .requiredLong("id")
+                        .requiredDouble("score")
+                        .endRecord();
+
+        // Create a GenericRecord with all 4 fields
+        GenericRecord fullRecord = new GenericData.Record(fullSchema);
+        fullRecord.put("id", 789L);
+        fullRecord.put("name", "David");
+        fullRecord.put("age", 35);
+        fullRecord.put("score", 87.3);
+
+        // Serialize the full record
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        GenericDatumWriter<IndexedRecord> datumWriter = new GenericDatumWriter<>(fullSchema);
+        Encoder encoder = createEncoder(encoding, fullSchema, outputStream);
+        datumWriter.write(fullRecord, encoder);
+        encoder.flush();
+        byte[] encodedData = outputStream.toByteArray();
+
+        // Create deserializer with both fast read and column pruning enabled
+        DeserializationSchema<GenericRecord> deserializer =
+                AvroDeserializationSchema.forGeneric(
+                        fullSchema, projectedSchema, encoding, null, true);
+
+        // Deserialize and verify
+        GenericRecord deserializedRecord = deserializer.deserialize(encodedData);
+        assertThat(deserializedRecord).isNotNull();
+        assertThat(deserializedRecord.getSchema().getFields()).hasSize(2);
+        assertThat(deserializedRecord.get("id")).isEqualTo(789L);
+        assertThat(deserializedRecord.get("score")).isEqualTo(87.3);
     }
 }

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroRowDataDeSerializationSchemaTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroRowDataDeSerializationSchemaTest.java
@@ -425,4 +425,229 @@ class AvroRowDataDeSerializationSchemaTest {
         deserializationSchema.open(null);
         return deserializationSchema;
     }
+
+    private AvroRowDataDeserializationSchema createDeserializationSchemaWithFastRead(
+            DataType dataType, AvroEncoding encoding, boolean legacyTimestampMapping)
+            throws Exception {
+        final RowType rowType = (RowType) dataType.getLogicalType();
+        final TypeInformation<RowData> typeInfo = InternalTypeInfo.of(rowType);
+
+        AvroRowDataDeserializationSchema deserializationSchema =
+                new AvroRowDataDeserializationSchema(
+                        rowType, rowType, typeInfo, encoding, legacyTimestampMapping, true, null);
+        deserializationSchema.open(null);
+        return deserializationSchema;
+    }
+
+    private AvroRowDataDeserializationSchema createDeserializationSchemaWithColumnPruning(
+            RowType actualRowType,
+            RowType projectedRowType,
+            AvroEncoding encoding,
+            boolean legacyTimestampMapping)
+            throws Exception {
+        final TypeInformation<RowData> typeInfo = InternalTypeInfo.of(projectedRowType);
+
+        AvroRowDataDeserializationSchema deserializationSchema =
+                new AvroRowDataDeserializationSchema(
+                        actualRowType,
+                        projectedRowType,
+                        typeInfo,
+                        encoding,
+                        legacyTimestampMapping,
+                        false,
+                        null);
+        deserializationSchema.open(null);
+        return deserializationSchema;
+    }
+
+    @ParameterizedTest
+    @EnumSource(AvroEncoding.class)
+    void testFastReadEnabled(AvroEncoding encoding) throws Exception {
+        final DataType dataType =
+                ROW(FIELD("name", STRING()), FIELD("age", INT()), FIELD("score", DOUBLE()))
+                        .notNull();
+        final RowType rowType = (RowType) dataType.getLogicalType();
+
+        final Schema schema = AvroSchemaConverter.convertToSchema(rowType);
+        final GenericRecord record = new GenericData.Record(schema);
+        record.put(0, "Alice");
+        record.put(1, 30);
+        record.put(2, 95.5);
+
+        AvroRowDataDeserializationSchema deserializationSchema =
+                createDeserializationSchemaWithFastRead(dataType, encoding, true);
+
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        GenericDatumWriter<IndexedRecord> datumWriter = new GenericDatumWriter<>(schema);
+        Encoder encoder = createEncoder(encoding, schema, byteArrayOutputStream);
+        datumWriter.write(record, encoder);
+        encoder.flush();
+        byte[] input = byteArrayOutputStream.toByteArray();
+
+        RowData rowData = deserializationSchema.deserialize(input);
+
+        assertThat(rowData).isNotNull();
+        assertThat(rowData.getString(0).toString()).isEqualTo("Alice");
+        assertThat(rowData.getInt(1)).isEqualTo(30);
+        assertThat(rowData.getDouble(2)).isEqualTo(95.5);
+    }
+
+    @ParameterizedTest
+    @EnumSource(AvroEncoding.class)
+    void testColumnPruning(AvroEncoding encoding) throws Exception {
+        // Create a full schema with 5 fields
+        final DataType fullDataType =
+                ROW(
+                                FIELD("id", BIGINT()),
+                                FIELD("name", STRING()),
+                                FIELD("age", INT()),
+                                FIELD("email", STRING()),
+                                FIELD("score", DOUBLE()))
+                        .notNull();
+        final RowType fullRowType = (RowType) fullDataType.getLogicalType();
+
+        // Create a projected schema with only 3 fields (id, name, score)
+        final DataType projectedDataType =
+                ROW(FIELD("id", BIGINT()), FIELD("name", STRING()), FIELD("score", DOUBLE()))
+                        .notNull();
+        final RowType projectedRowType = (RowType) projectedDataType.getLogicalType();
+
+        final Schema fullSchema = AvroSchemaConverter.convertToSchema(fullRowType);
+        final GenericRecord record = new GenericData.Record(fullSchema);
+        record.put(0, 123L);
+        record.put(1, "Bob");
+        record.put(2, 25);
+        record.put(3, "bob@example.com");
+        record.put(4, 88.5);
+
+        AvroRowDataDeserializationSchema deserializationSchema =
+                createDeserializationSchemaWithColumnPruning(
+                        fullRowType, projectedRowType, encoding, true);
+
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        GenericDatumWriter<IndexedRecord> datumWriter = new GenericDatumWriter<>(fullSchema);
+        Encoder encoder = createEncoder(encoding, fullSchema, byteArrayOutputStream);
+        datumWriter.write(record, encoder);
+        encoder.flush();
+        byte[] input = byteArrayOutputStream.toByteArray();
+
+        RowData rowData = deserializationSchema.deserialize(input);
+
+        // Verify only the projected fields are present
+        assertThat(rowData).isNotNull();
+        assertThat(rowData.getArity()).isEqualTo(3);
+        assertThat(rowData.getLong(0)).isEqualTo(123L);
+        assertThat(rowData.getString(1).toString()).isEqualTo("Bob");
+        assertThat(rowData.getDouble(2)).isEqualTo(88.5);
+    }
+
+    @ParameterizedTest
+    @EnumSource(AvroEncoding.class)
+    void testColumnPruningWithNestedTypes(AvroEncoding encoding) throws Exception {
+        // Create a full schema with nested types
+        final DataType fullDataType =
+                ROW(
+                                FIELD("id", BIGINT()),
+                                FIELD("name", STRING()),
+                                FIELD("tags", ARRAY(STRING())),
+                                FIELD("metadata", MAP(STRING(), STRING())),
+                                FIELD("score", DOUBLE()))
+                        .notNull();
+        final RowType fullRowType = (RowType) fullDataType.getLogicalType();
+
+        // Project only id, tags, and score
+        final DataType projectedDataType =
+                ROW(FIELD("id", BIGINT()), FIELD("tags", ARRAY(STRING())), FIELD("score", DOUBLE()))
+                        .notNull();
+        final RowType projectedRowType = (RowType) projectedDataType.getLogicalType();
+
+        final Schema fullSchema = AvroSchemaConverter.convertToSchema(fullRowType);
+        final GenericRecord record = new GenericData.Record(fullSchema);
+        record.put(0, 456L);
+        record.put(1, "Charlie");
+        record.put(2, Arrays.asList("tag1", "tag2", "tag3"));
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("key1", "value1");
+        record.put(3, metadata);
+        record.put(4, 92.0);
+
+        AvroRowDataDeserializationSchema deserializationSchema =
+                createDeserializationSchemaWithColumnPruning(
+                        fullRowType, projectedRowType, encoding, true);
+
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        GenericDatumWriter<IndexedRecord> datumWriter = new GenericDatumWriter<>(fullSchema);
+        Encoder encoder = createEncoder(encoding, fullSchema, byteArrayOutputStream);
+        datumWriter.write(record, encoder);
+        encoder.flush();
+        byte[] input = byteArrayOutputStream.toByteArray();
+
+        RowData rowData = deserializationSchema.deserialize(input);
+
+        assertThat(rowData).isNotNull();
+        assertThat(rowData.getArity()).isEqualTo(3);
+        assertThat(rowData.getLong(0)).isEqualTo(456L);
+        assertThat(rowData.getArray(1).size()).isEqualTo(3);
+        assertThat(rowData.getDouble(2)).isEqualTo(92.0);
+    }
+
+    @ParameterizedTest
+    @EnumSource(AvroEncoding.class)
+    void testFastReadWithColumnPruning(AvroEncoding encoding) throws Exception {
+        // Test both features together
+        final DataType fullDataType =
+                ROW(
+                                FIELD("id", BIGINT()),
+                                FIELD("name", STRING()),
+                                FIELD("age", INT()),
+                                FIELD("score", DOUBLE()))
+                        .notNull();
+        final RowType fullRowType = (RowType) fullDataType.getLogicalType();
+
+        final DataType projectedDataType =
+                ROW(FIELD("id", BIGINT()), FIELD("score", DOUBLE())).notNull();
+        final RowType projectedRowType = (RowType) projectedDataType.getLogicalType();
+
+        final Schema fullSchema = AvroSchemaConverter.convertToSchema(fullRowType);
+        final GenericRecord record = new GenericData.Record(fullSchema);
+        record.put(0, 789L);
+        record.put(1, "David");
+        record.put(2, 35);
+        record.put(3, 87.3);
+
+        final TypeInformation<RowData> typeInfo = InternalTypeInfo.of(projectedRowType);
+        AvroRowDataDeserializationSchema deserializationSchema =
+                new AvroRowDataDeserializationSchema(
+                        fullRowType, projectedRowType, typeInfo, encoding, true, true, null);
+        deserializationSchema.open(null);
+
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        GenericDatumWriter<IndexedRecord> datumWriter = new GenericDatumWriter<>(fullSchema);
+        Encoder encoder = createEncoder(encoding, fullSchema, byteArrayOutputStream);
+        datumWriter.write(record, encoder);
+        encoder.flush();
+        byte[] input = byteArrayOutputStream.toByteArray();
+
+        RowData rowData = deserializationSchema.deserialize(input);
+
+        assertThat(rowData).isNotNull();
+        assertThat(rowData.getArity()).isEqualTo(2);
+        assertThat(rowData.getLong(0)).isEqualTo(789L);
+        assertThat(rowData.getDouble(1)).isEqualTo(87.3);
+    }
+
+    @Test
+    void testSerializability() throws Exception {
+        final DataType dataType = ROW(FIELD("name", STRING()), FIELD("age", INT())).notNull();
+        final RowType rowType = (RowType) dataType.getLogicalType();
+        final TypeInformation<RowData> typeInfo = InternalTypeInfo.of(rowType);
+
+        AvroRowDataDeserializationSchema original =
+                new AvroRowDataDeserializationSchema(
+                        rowType, rowType, typeInfo, AvroEncoding.BINARY, true, true, null);
+
+        AvroRowDataDeserializationSchema deserialized = InstantiationUtil.clone(original);
+
+        assertThat(deserialized).isNotNull();
+    }
 }


### PR DESCRIPTION
# What is the purpose of the change
To optimize avro format reading performance， about https://issues.apache.org/jira/browse/FLINK-39035

# Brief change log
add option for avro
1. support fastread
2. support user config writerSchemaString
3. The concepts of Avro reader and writer were distinguished.

# Verifying this change
Unit tests have been added.

# Does this pull request potentially affect one of the following parts:
Dependencies (does it add or upgrade a dependency): (no)
The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
The serializers: (yes)
The runtime per-record code paths (performance sensitive): (no)
Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
The S3 file system connector: (no)
# Documentation
Does this pull request introduce a new feature? (no)
If yes, how is the feature documented? (not applicable)