### PR TITLE
[FLINK-39050][Table SQL/Planner] Support configurable handling strategy for null rowtime field in watermark generation

### DIFF
--- a/docs/layouts/shortcodes/generated/execution_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/execution_config_configuration.html
@@ -339,6 +339,12 @@ By default no operator is disabled.</td>
             <td>When a source do not receive any elements for the timeout time, it will be marked as temporarily idle. This allows downstream tasks to advance their watermarks without the need to wait for watermarks from this source while it is idle. Default value is 0, which means detecting source idleness is not enabled.</td>
         </tr>
         <tr>
+            <td><h5>table.exec.source.rowtime-null-handling</h5><br> <span class="label label-primary">Streaming</span></td>
+            <td style="word-wrap: break-word;">FAIL</td>
+            <td><p>Enum</p></td>
+            <td>Specifies the behavior when the rowtime field is null during watermark generation.<br /><br />Possible values:<ul><li>"FAIL": Throw a runtime exception when encountering null rowtime. A null rowtime typically indicates that the source is receiving unexpected null values in a column that should not be null, which suggests the data flow needs to be cleaned up. This is the default and recommended option.</li><li>"DROP": Drop the record silently and increment the 'numNullRowtimeRecordsDropped' metric. Note that this may result in data loss.</li><li>"SKIP_WATERMARK": Forward the record without advancing the watermark and increment the 'numNullRowtimeRecordsSkipped' metric. Note that this may cause issues in downstream operators if they expect valid rowtime values.</li></ul></td>
+        </tr>
+        <tr>
             <td><h5>table.exec.spill-compression.block-size</h5><br> <span class="label label-primary">Batch</span></td>
             <td style="word-wrap: break-word;">64 kb</td>
             <td>MemorySize</td>

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
@@ -106,6 +106,14 @@ public class ExecutionConfigOptions {
                                                     + "an additional stateful operator.")
                                     .build());
 
+    @Documentation.TableOption(execMode = Documentation.ExecMode.STREAMING)
+    public static final ConfigOption<RowtimeNullHandling> TABLE_EXEC_SOURCE_ROWTIME_NULL_HANDLING =
+            key("table.exec.source.rowtime-null-handling")
+                    .enumType(RowtimeNullHandling.class)
+                    .defaultValue(RowtimeNullHandling.FAIL)
+                    .withDescription(
+                            "Specifies the behavior when the rowtime field is null during watermark generation.");
+
     // ------------------------------------------------------------------------
     //  Sink Options
     // ------------------------------------------------------------------------
@@ -1001,6 +1009,43 @@ public class ExecutionConfigOptions {
         private final InlineElement description;
 
         RowtimeInserter(InlineElement description) {
+            this.description = description;
+        }
+
+        @Internal
+        @Override
+        public InlineElement getDescription() {
+            return description;
+        }
+    }
+
+    /**
+     * Specifies the behavior when the rowtime field is null during watermark generation in
+     * streaming mode.
+     */
+    @PublicEvolving
+    public enum RowtimeNullHandling implements DescribedEnum {
+        FAIL(
+                text(
+                        "Throw a runtime exception when encountering null rowtime. "
+                                + "A null rowtime typically indicates that the source is receiving "
+                                + "unexpected null values in a column that should not be null, "
+                                + "which suggests the data flow needs to be cleaned up. "
+                                + "This is the default and recommended option.")),
+        DROP(
+                text(
+                        "Drop the record silently and increment the 'numNullRowtimeRecordsDropped' metric. "
+                                + "Note that this may result in data loss.")),
+        SKIP_WATERMARK(
+                text(
+                        "Forward the record without advancing the watermark "
+                                + "and increment the 'numNullRowtimeRecordsSkipped' metric. "
+                                + "Note that this may cause issues in downstream operators "
+                                + "if they expect valid rowtime values."));
+
+        private final InlineElement description;
+
+        RowtimeNullHandling(InlineElement description) {
             this.description = description;
         }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWatermarkAssigner.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWatermarkAssigner.java
@@ -129,9 +129,12 @@ public class StreamExecWatermarkAssigner extends ExecNodeBase<RowData>
         final long idleTimeout =
                 config.get(ExecutionConfigOptions.TABLE_EXEC_SOURCE_IDLE_TIMEOUT).toMillis();
 
+        final ExecutionConfigOptions.RowtimeNullHandling rowtimeNullHandling =
+                config.get(ExecutionConfigOptions.TABLE_EXEC_SOURCE_ROWTIME_NULL_HANDLING);
+
         final WatermarkAssignerOperatorFactory operatorFactory =
                 new WatermarkAssignerOperatorFactory(
-                        rowtimeFieldIndex, idleTimeout, watermarkGenerator);
+                        rowtimeFieldIndex, idleTimeout, watermarkGenerator, rowtimeNullHandling);
 
         return ExecNodeUtil.createOneInputTransformation(
                 inputTransform,

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/wmassigners/WatermarkAssignerOperatorFactory.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/wmassigners/WatermarkAssignerOperatorFactory.java
@@ -22,6 +22,7 @@ import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+import org.apache.flink.table.api.config.ExecutionConfigOptions.RowtimeNullHandling;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.generated.GeneratedWatermarkGenerator;
 import org.apache.flink.table.runtime.generated.WatermarkGenerator;
@@ -38,13 +39,17 @@ public class WatermarkAssignerOperatorFactory extends AbstractStreamOperatorFact
 
     private final GeneratedWatermarkGenerator generatedWatermarkGenerator;
 
+    private final RowtimeNullHandling rowtimeNullHandling;
+
     public WatermarkAssignerOperatorFactory(
             int rowtimeFieldIndex,
             long idleTimeout,
-            GeneratedWatermarkGenerator generatedWatermarkGenerator) {
+            GeneratedWatermarkGenerator generatedWatermarkGenerator,
+            RowtimeNullHandling rowtimeNullHandling) {
         this.rowtimeFieldIndex = rowtimeFieldIndex;
         this.idleTimeout = idleTimeout;
         this.generatedWatermarkGenerator = generatedWatermarkGenerator;
+        this.rowtimeNullHandling = rowtimeNullHandling;
     }
 
     @SuppressWarnings("unchecked")
@@ -58,7 +63,8 @@ public class WatermarkAssignerOperatorFactory extends AbstractStreamOperatorFact
                 rowtimeFieldIndex,
                 watermarkGenerator,
                 idleTimeout,
-                processingTimeService);
+                processingTimeService,
+                rowtimeNullHandling);
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

This pull request introduces a new configuration option `table.exec.source.rowtime-null-handling` to handle null rowtime fields during watermark generation in Flink Table SQL. Previously, when the rowtime field was null, the `WatermarkAssignerOperator` would throw a `RuntimeException`, which could cause job failures in scenarios where null rowtime values are expected (e.g., CDC sources with missing timestamps). 

This change provides users with three configurable strategies:
- `FAIL` (default): Throw an exception (maintains backward compatibility)
- `DROP`: Silently drop the record and increment a metric counter
- `SKIP_WATERMARK`: Forward the record without advancing the watermark and increment a metric counter

## Brief change log

- Added new configuration option `table.exec.source.rowtime-null-handling` in `ExecutionConfigOptions` with enum `RowtimeNullHandling`
- Modified `WatermarkAssignerOperator` to handle null rowtime fields based on the configured strategy
- Added two new metrics: `numNullRowtimeRecordsDropped` and `numNullRowtimeRecordsSkipped` to track null rowtime handling
- Extended `WatermarkAssignerOperatorFactory` to pass the null handling configuration
- Updated `StreamExecWatermarkAssigner` to read and apply the configuration
- Added comprehensive unit tests for all three strategies
- Updated documentation (both English and Chinese) for the new configuration option

## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

This change added tests and can be verified as follows:

- Added unit test `testNullRowtimeWithFailStrategy` to verify the FAIL strategy throws exception with helpful error message
- Added unit test `testNullRowtimeWithDropStrategy` to verify records with null rowtime are dropped correctly
- Added unit test `testNullRowtimeDropMetricCounter` to verify DROP strategy handles multiple null records
- Added unit test `testNullRowtimeSkipMetricCounter` to verify SKIP_WATERMARK strategy forwards records without advancing watermark
- Added unit test `testNullRowtimeWithSkipWatermarkStrategy` to verify watermark is not affected by null rowtime records when using SKIP_WATERMARK

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): **no**
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **yes** (added new `@PublicEvolving` enum `RowtimeNullHandling` and configuration option)
- The serializers: **no**
- The runtime per-record code paths (performance sensitive): **yes** (added null check and switch statement in `WatermarkAssignerOperator.processElement()`, but impact is minimal as null check is a single field access)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
- The S3 file system connector: **no**

## Documentation

- Does this pull request introduce a new feature? **yes**
- If yes, how is the feature documented? **docs / JavaDocs** (Updated `time_attributes.md` in both English and Chinese, added configuration documentation in `execution_config_configuration.html`, and added JavaDoc for the new configuration option and enum)
