### PR TITLE
[FLINK-39051][Table SQL/Planner] Support APPROX_COUNT_DISTINCT aggregate function in streaming mode with Window TVF

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -1355,6 +1355,14 @@ aggregate:
     description: By default or with keyword ALL, returns a multiset of expression across all input rows. NULL values will be ignored. Use DISTINCT for one unique instance of each value.
   - sql: VARIANCE([ ALL | DISTINCT ] expression)
     description: Synonyms for VAR_SAMP().
+  - sql: APPROX_COUNT_DISTINCT(expression)
+    description: |
+      Returns the approximate number of distinct values of expression using the HyperLogLog++ algorithm.
+      This function provides a memory-efficient way to estimate cardinality with a relative standard error
+      of approximately 1%. Unlike COUNT(DISTINCT), which requires O(n) memory, APPROX_COUNT_DISTINCT uses
+      O(1) memory (approximately 16KB). Supported in both batch and streaming modes (including Window TVF
+      such as TUMBLE, HOP, CUMULATE). Note that this function does not support retraction operations in
+      non-windowed streaming aggregations. NULL values are ignored.
   - sql: RANK()
     description: Returns the rank of a value in a group of values. The result is one plus the number of rows preceding or equal to the current row in the ordering of the partition. The values will produce gaps in the sequence.
   - sql: DENSE_RANK()

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -1440,6 +1440,12 @@ aggregate:
       默认情况下或使用关键字 `ALL`，返回跨所有输入行的多组表达式。`NULL` 值将被忽略。使用 `DISTINCT` 则对所有值去重后计算。
   - sql: VARIANCE([ ALL | DISTINCT ] expression)
     description: VAR_SAMP() 的同义方法。
+  - sql: APPROX_COUNT_DISTINCT(expression)
+    description: |
+      使用 HyperLogLog++ 算法返回 expression 的近似去重计数。该函数提供了一种内存高效的基数估算方式，
+      相对标准误差约为 1%。与需要 O(n) 内存的 COUNT(DISTINCT) 不同，APPROX_COUNT_DISTINCT 仅使用 O(1) 内存
+      （约 16KB）。支持批处理和流处理模式（包括窗口 TVF，如 TUMBLE、HOP、CUMULATE）。注意：该函数不支持
+      非窗口流聚合中的撤回操作。NULL 值会被忽略。
   - sql: RANK()
     description: 返回值在一组值中的排名。结果是 1 加上分区顺序中当前行之前或等于当前行的行数。排名在序列中不一定连续。
   - sql: DENSE_RANK()

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/AggFunctionFactory.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/AggFunctionFactory.scala
@@ -26,7 +26,7 @@ import org.apache.flink.table.planner.functions.bridging.BridgingSqlAggFunction
 import org.apache.flink.table.planner.functions.sql.{SqlFirstLastValueAggFunction, SqlListAggFunction}
 import org.apache.flink.table.planner.functions.utils.AggSqlFunction
 import org.apache.flink.table.runtime.functions.aggregate._
-import org.apache.flink.table.runtime.functions.aggregate.BatchApproxCountDistinctAggFunctions._
+import org.apache.flink.table.runtime.functions.aggregate.ApproxCountDistinctAggFunctions._
 import org.apache.flink.table.runtime.functions.aggregate.PercentileAggFunction.{MultiPercentileAggFunction, SinglePercentileAggFunction}
 import org.apache.flink.table.types.logical._
 import org.apache.flink.table.types.logical.LogicalTypeRoot._
@@ -451,9 +451,14 @@ class AggFunctionFactory(
   private def createApproxCountDistinctAggFunction(
       argTypes: Array[LogicalType],
       index: Int): UserDefinedFunction = {
-    if (!isBounded) {
+    // APPROX_COUNT_DISTINCT now supports both batch and streaming modes.
+    // In streaming mode, it supports Window TVF (TUMBLE, HOP, CUMULATE) through merge().
+    // Note: Non-windowed streaming aggregation with retraction is NOT supported
+    // because HyperLogLog cannot remove elements once added.
+    if (!isBounded && aggCallNeedRetractions(index)) {
       throw new TableException(
-        s"APPROX_COUNT_DISTINCT aggregate function does not support yet for streaming.")
+        "APPROX_COUNT_DISTINCT aggregate function does not support retraction in streaming mode. " +
+          "Please use it with Window TVF (TUMBLE, HOP, CUMULATE) or in append-only streams.")
     }
     argTypes(0).getTypeRoot match {
       case TINYINT =>

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/ApproxCountDistinctAggFunctionTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/ApproxCountDistinctAggFunctionTest.java
@@ -1,0 +1,504 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions.aggfunctions;
+
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.DecimalDataUtils;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.data.binary.BinaryStringData;
+import org.apache.flink.table.functions.AggregateFunction;
+import org.apache.flink.table.runtime.functions.aggregate.ApproxCountDistinctAggFunctions.ApproxCountDistinctAggFunction;
+import org.apache.flink.table.runtime.functions.aggregate.ApproxCountDistinctAggFunctions.ByteApproxCountDistinctAggFunction;
+import org.apache.flink.table.runtime.functions.aggregate.ApproxCountDistinctAggFunctions.DateApproxCountDistinctAggFunction;
+import org.apache.flink.table.runtime.functions.aggregate.ApproxCountDistinctAggFunctions.DecimalApproxCountDistinctAggFunction;
+import org.apache.flink.table.runtime.functions.aggregate.ApproxCountDistinctAggFunctions.DoubleApproxCountDistinctAggFunction;
+import org.apache.flink.table.runtime.functions.aggregate.ApproxCountDistinctAggFunctions.FloatApproxCountDistinctAggFunction;
+import org.apache.flink.table.runtime.functions.aggregate.ApproxCountDistinctAggFunctions.IntApproxCountDistinctAggFunction;
+import org.apache.flink.table.runtime.functions.aggregate.ApproxCountDistinctAggFunctions.LongApproxCountDistinctAggFunction;
+import org.apache.flink.table.runtime.functions.aggregate.ApproxCountDistinctAggFunctions.ShortApproxCountDistinctAggFunction;
+import org.apache.flink.table.runtime.functions.aggregate.ApproxCountDistinctAggFunctions.StringApproxCountDistinctAggFunction;
+import org.apache.flink.table.runtime.functions.aggregate.ApproxCountDistinctAggFunctions.TimeApproxCountDistinctAggFunction;
+import org.apache.flink.table.runtime.functions.aggregate.ApproxCountDistinctAggFunctions.TimestampApproxCountDistinctAggFunction;
+import org.apache.flink.table.runtime.functions.aggregate.ApproxCountDistinctAggFunctions.TimestampLtzApproxCountDistinctAggFunction;
+import org.apache.flink.table.runtime.functions.aggregate.hyperloglog.HllBuffer;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
+import org.apache.flink.table.types.logical.TimestampType;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test case for built-in APPROX_COUNT_DISTINCT aggregate function supporting both batch and
+ * streaming modes.
+ */
+final class ApproxCountDistinctAggFunctionTest {
+
+    /** Base class for the test. */
+    abstract static class ApproxCountDistinctAggFunctionTestBase<IN>
+            extends AggFunctionTestBase<IN, Long, HllBuffer> {
+
+        @Override
+        protected Class<?> getAccClass() {
+            return HllBuffer.class;
+        }
+    }
+
+    /** Test for merge functionality which is essential for Window TVF support. */
+    abstract static class MergeTestBase<IN> extends ApproxCountDistinctAggFunctionTestBase<IN> {
+
+        protected abstract ApproxCountDistinctAggFunction<IN> getTypedAggregator();
+
+        @Override
+        protected AggregateFunction<Long, HllBuffer> getAggregator() {
+            return getTypedAggregator();
+        }
+
+        @Test
+        void testMerge() {
+            ApproxCountDistinctAggFunction<IN> agg = getTypedAggregator();
+
+            // Create two accumulators
+            HllBuffer buffer1 = agg.createAccumulator();
+            HllBuffer buffer2 = agg.createAccumulator();
+
+            // Add data to each accumulator separately
+            List<List<IN>> inputs = getInputValueSets();
+            if (inputs.size() >= 2) {
+                for (IN value : inputs.get(0)) {
+                    agg.accumulate(buffer1, value);
+                }
+                for (IN value : inputs.get(1)) {
+                    agg.accumulate(buffer2, value);
+                }
+
+                // Merge two accumulators
+                HllBuffer mergedBuffer = agg.createAccumulator();
+                agg.merge(mergedBuffer, Arrays.asList(buffer1, buffer2));
+
+                // Verify merged result is not null
+                Long mergedResult = agg.getValue(mergedBuffer);
+                assertThat(mergedResult).isNotNull();
+                assertThat(mergedResult).isGreaterThanOrEqualTo(0L);
+
+                // 合并结果应该小于等于两个独立结果之和
+                Long result1 = agg.getValue(buffer1);
+                Long result2 = agg.getValue(buffer2);
+                assertThat(mergedResult).isLessThanOrEqualTo(result1 + result2);
+            }
+        }
+
+        @Test
+        void testMergeWithNullBuffer() {
+            ApproxCountDistinctAggFunction<IN> agg = getTypedAggregator();
+
+            HllBuffer buffer1 = agg.createAccumulator();
+            List<List<IN>> inputs = getInputValueSets();
+            if (!inputs.isEmpty()) {
+                for (IN value : inputs.get(0)) {
+                    agg.accumulate(buffer1, value);
+                }
+            }
+
+            Long beforeMerge = agg.getValue(buffer1);
+
+            // Merge with null buffer should not affect the result
+            agg.merge(buffer1, Collections.singletonList(null));
+
+            Long afterMerge = agg.getValue(buffer1);
+            assertThat(afterMerge).isEqualTo(beforeMerge);
+        }
+
+        @Test
+        void testResetAccumulator() {
+            ApproxCountDistinctAggFunction<IN> agg = getTypedAggregator();
+
+            HllBuffer buffer = agg.createAccumulator();
+            List<List<IN>> inputs = getInputValueSets();
+            if (!inputs.isEmpty()) {
+                for (IN value : inputs.get(0)) {
+                    agg.accumulate(buffer, value);
+                }
+            }
+
+            // Reset and verify
+            agg.resetAccumulator(buffer);
+            assertThat(agg.getValue(buffer)).isEqualTo(0L);
+        }
+    }
+
+    /** Test for {@link ByteApproxCountDistinctAggFunction}. */
+    @Nested
+    final class ByteApproxCountDistinctAggFunctionTest extends MergeTestBase<Byte> {
+
+        @Override
+        protected ApproxCountDistinctAggFunction<Byte> getTypedAggregator() {
+            return new ByteApproxCountDistinctAggFunction();
+        }
+
+        @Override
+        protected List<List<Byte>> getInputValueSets() {
+            return Arrays.asList(
+                    Arrays.asList(Byte.valueOf("1"), Byte.valueOf("1"), Byte.valueOf("1")),
+                    Arrays.asList(Byte.valueOf("1"), Byte.valueOf("2"), Byte.valueOf("3")),
+                    Arrays.asList(null, null, null, null, null, null),
+                    Arrays.asList(null, Byte.valueOf("10")));
+        }
+
+        @Override
+        protected List<Long> getExpectedResults() {
+            return Arrays.asList(1L, 3L, 0L, 1L);
+        }
+    }
+
+    /** Test for {@link ShortApproxCountDistinctAggFunction}. */
+    @Nested
+    final class ShortApproxCountDistinctAggFunctionTest extends MergeTestBase<Short> {
+
+        @Override
+        protected ApproxCountDistinctAggFunction<Short> getTypedAggregator() {
+            return new ShortApproxCountDistinctAggFunction();
+        }
+
+        @Override
+        protected List<List<Short>> getInputValueSets() {
+            return Arrays.asList(
+                    Arrays.asList(Short.valueOf("1"), Short.valueOf("1"), Short.valueOf("1")),
+                    Arrays.asList(Short.valueOf("1"), Short.valueOf("2"), Short.valueOf("3")),
+                    Arrays.asList(null, null, null, null, null, null),
+                    Arrays.asList(null, Short.valueOf("10")));
+        }
+
+        @Override
+        protected List<Long> getExpectedResults() {
+            return Arrays.asList(1L, 3L, 0L, 1L);
+        }
+    }
+
+    /** Test for {@link IntApproxCountDistinctAggFunction}. */
+    @Nested
+    final class IntegerApproxCountDistinctAggFunctionTest extends MergeTestBase<Integer> {
+
+        @Override
+        protected ApproxCountDistinctAggFunction<Integer> getTypedAggregator() {
+            return new IntApproxCountDistinctAggFunction();
+        }
+
+        @Override
+        protected List<List<Integer>> getInputValueSets() {
+            return Arrays.asList(
+                    Arrays.asList(Integer.valueOf("1"), Integer.valueOf("1"), Integer.valueOf("1")),
+                    Arrays.asList(Integer.valueOf("1"), Integer.valueOf("2"), Integer.valueOf("3")),
+                    Arrays.asList(null, null, null, null, null, null),
+                    Arrays.asList(null, Integer.valueOf("10")));
+        }
+
+        @Override
+        protected List<Long> getExpectedResults() {
+            return Arrays.asList(1L, 3L, 0L, 1L);
+        }
+    }
+
+    /** Test for {@link LongApproxCountDistinctAggFunction}. */
+    @Nested
+    final class LongApproxCountDistinctAggFunctionTest extends MergeTestBase<Long> {
+
+        @Override
+        protected ApproxCountDistinctAggFunction<Long> getTypedAggregator() {
+            return new LongApproxCountDistinctAggFunction();
+        }
+
+        @Override
+        protected List<List<Long>> getInputValueSets() {
+            return Arrays.asList(
+                    Arrays.asList(Long.valueOf("1"), Long.valueOf("1"), Long.valueOf("1")),
+                    Arrays.asList(Long.valueOf("1"), Long.valueOf("2"), Long.valueOf("3")),
+                    Arrays.asList(null, null, null, null, null, null),
+                    Arrays.asList(null, Long.valueOf("10")));
+        }
+
+        @Override
+        protected List<Long> getExpectedResults() {
+            return Arrays.asList(1L, 3L, 0L, 1L);
+        }
+    }
+
+    /** Test for {@link FloatApproxCountDistinctAggFunction}. */
+    @Nested
+    final class FloatApproxCountDistinctAggFunctionTest extends MergeTestBase<Float> {
+
+        @Override
+        protected ApproxCountDistinctAggFunction<Float> getTypedAggregator() {
+            return new FloatApproxCountDistinctAggFunction();
+        }
+
+        @Override
+        protected List<List<Float>> getInputValueSets() {
+            return Arrays.asList(
+                    Arrays.asList(1.0f, 1.0f, 1.0f),
+                    Arrays.asList(1.0f, 2.0f, 3.0f),
+                    Arrays.asList(0.0f, -0.0f),
+                    Arrays.asList(Float.NaN, 1.1f, 2.2f),
+                    Arrays.asList(null, null, null, null, null, null),
+                    Arrays.asList(null, 10f));
+        }
+
+        @Override
+        protected List<Long> getExpectedResults() {
+            return Arrays.asList(1L, 3L, 1L, 3L, 0L, 1L);
+        }
+    }
+
+    /** Test for {@link DoubleApproxCountDistinctAggFunction}. */
+    @Nested
+    final class DoubleApproxCountDistinctAggFunctionTest extends MergeTestBase<Double> {
+
+        @Override
+        protected ApproxCountDistinctAggFunction<Double> getTypedAggregator() {
+            return new DoubleApproxCountDistinctAggFunction();
+        }
+
+        @Override
+        protected List<List<Double>> getInputValueSets() {
+            return Arrays.asList(
+                    Arrays.asList(1.0d, 1.0d, 1.0d),
+                    Arrays.asList(1.0d, 2.0d, 3.0d),
+                    Arrays.asList(0.0d, -0.0d),
+                    Arrays.asList(Double.NaN, 1.1d, 2.2d),
+                    Arrays.asList(null, null, null, null, null, null),
+                    Arrays.asList(null, 10d));
+        }
+
+        @Override
+        protected List<Long> getExpectedResults() {
+            return Arrays.asList(1L, 3L, 1L, 3L, 0L, 1L);
+        }
+    }
+
+    /** Test for {@link DecimalApproxCountDistinctAggFunction}. */
+    abstract static class DecimalApproxCountDistinctAggFunctionTestBase
+            extends MergeTestBase<DecimalData> {
+
+        private final int precision;
+        private final int scale;
+
+        DecimalApproxCountDistinctAggFunctionTestBase(int precision, int scale) {
+            this.precision = precision;
+            this.scale = scale;
+        }
+
+        @Override
+        protected ApproxCountDistinctAggFunction<DecimalData> getTypedAggregator() {
+            return new DecimalApproxCountDistinctAggFunction(new DecimalType(precision, scale));
+        }
+
+        @Override
+        protected List<List<DecimalData>> getInputValueSets() {
+            return Arrays.asList(
+                    Arrays.asList(
+                            DecimalDataUtils.castFrom("1", precision, scale),
+                            DecimalDataUtils.castFrom("1000.000001", precision, scale),
+                            DecimalDataUtils.castFrom("-1", precision, scale),
+                            DecimalDataUtils.castFrom("-999.998999", precision, scale),
+                            null,
+                            DecimalDataUtils.castFrom("0", precision, scale),
+                            DecimalDataUtils.castFrom("-999.999", precision, scale),
+                            null,
+                            DecimalDataUtils.castFrom("999.999", precision, scale)),
+                    Arrays.asList(null, null, null, null, null),
+                    Arrays.asList(null, DecimalDataUtils.castFrom("0", precision, scale)));
+        }
+
+        @Override
+        protected List<Long> getExpectedResults() {
+            return Arrays.asList(7L, 0L, 1L);
+        }
+    }
+
+    /** Test for {@link DecimalApproxCountDistinctAggFunction} for 20 precision and 6 scale. */
+    @Nested
+    final class Decimal20ApproxCountDistinctAggFunctionTest
+            extends DecimalApproxCountDistinctAggFunctionTestBase {
+
+        Decimal20ApproxCountDistinctAggFunctionTest() {
+            super(20, 6);
+        }
+    }
+
+    /** Test for {@link DecimalApproxCountDistinctAggFunction} for 12 precision and 6 scale. */
+    @Nested
+    final class Decimal12ApproxCountDistinctAggFunctionTest
+            extends DecimalApproxCountDistinctAggFunctionTestBase {
+
+        Decimal12ApproxCountDistinctAggFunctionTest() {
+            super(12, 6);
+        }
+    }
+
+    /** Test for {@link DateApproxCountDistinctAggFunction}. */
+    @Nested
+    final class DateApproxCountDistinctAggFunctionTest extends MergeTestBase<Integer> {
+
+        @Override
+        protected ApproxCountDistinctAggFunction<Integer> getTypedAggregator() {
+            return new DateApproxCountDistinctAggFunction();
+        }
+
+        @Override
+        protected List<List<Integer>> getInputValueSets() {
+            return Arrays.asList(
+                    Arrays.asList(Integer.valueOf("1"), Integer.valueOf("1"), Integer.valueOf("1")),
+                    Arrays.asList(Integer.valueOf("1"), Integer.valueOf("2"), Integer.valueOf("3")),
+                    Arrays.asList(null, null, null, null, null, null),
+                    Arrays.asList(null, Integer.valueOf("10")));
+        }
+
+        @Override
+        protected List<Long> getExpectedResults() {
+            return Arrays.asList(1L, 3L, 0L, 1L);
+        }
+    }
+
+    /** Test for {@link TimeApproxCountDistinctAggFunction}. */
+    @Nested
+    final class TimeApproxCountDistinctAggFunctionTest extends MergeTestBase<Integer> {
+
+        @Override
+        protected ApproxCountDistinctAggFunction<Integer> getTypedAggregator() {
+            return new TimeApproxCountDistinctAggFunction();
+        }
+
+        @Override
+        protected List<List<Integer>> getInputValueSets() {
+            return Arrays.asList(
+                    Arrays.asList(Integer.valueOf("1"), Integer.valueOf("1"), Integer.valueOf("1")),
+                    Arrays.asList(Integer.valueOf("1"), Integer.valueOf("2"), Integer.valueOf("3")),
+                    Arrays.asList(null, null, null, null, null, null),
+                    Arrays.asList(null, Integer.valueOf("10")));
+        }
+
+        @Override
+        protected List<Long> getExpectedResults() {
+            return Arrays.asList(1L, 3L, 0L, 1L);
+        }
+    }
+
+    /** Test for {@link TimestampApproxCountDistinctAggFunction}. */
+    @Nested
+    final class TimestampApproxCountDistinctAggFunctionTest extends MergeTestBase<TimestampData> {
+
+        @Override
+        protected ApproxCountDistinctAggFunction<TimestampData> getTypedAggregator() {
+            return new TimestampApproxCountDistinctAggFunction(new TimestampType(3));
+        }
+
+        @Override
+        protected List<List<TimestampData>> getInputValueSets() {
+            return Arrays.asList(
+                    Arrays.asList(
+                            TimestampData.fromEpochMillis(0),
+                            TimestampData.fromEpochMillis(1000),
+                            TimestampData.fromEpochMillis(100),
+                            null,
+                            TimestampData.fromEpochMillis(10)),
+                    Arrays.asList(null, null, null, null, null),
+                    Arrays.asList(
+                            null,
+                            TimestampData.fromEpochMillis(1),
+                            TimestampData.fromEpochMillis(1)));
+        }
+
+        @Override
+        protected List<Long> getExpectedResults() {
+            return Arrays.asList(4L, 0L, 1L);
+        }
+    }
+
+    /** Test for {@link TimestampLtzApproxCountDistinctAggFunction}. */
+    @Nested
+    final class TimestampLtzApproxCountDistinctAggFunctionTest
+            extends MergeTestBase<TimestampData> {
+
+        @Override
+        protected ApproxCountDistinctAggFunction<TimestampData> getTypedAggregator() {
+            return new TimestampLtzApproxCountDistinctAggFunction(new LocalZonedTimestampType(6));
+        }
+
+        @Override
+        protected List<List<TimestampData>> getInputValueSets() {
+            return Arrays.asList(
+                    Arrays.asList(
+                            TimestampData.fromEpochMillis(0),
+                            TimestampData.fromEpochMillis(1000),
+                            TimestampData.fromEpochMillis(100),
+                            null,
+                            TimestampData.fromEpochMillis(10)),
+                    Arrays.asList(null, null, null, null, null),
+                    Arrays.asList(
+                            null,
+                            TimestampData.fromEpochMillis(1),
+                            TimestampData.fromEpochMillis(1)));
+        }
+
+        @Override
+        protected List<Long> getExpectedResults() {
+            return Arrays.asList(4L, 0L, 1L);
+        }
+    }
+
+    /** Test for {@link StringApproxCountDistinctAggFunction}. */
+    @Nested
+    final class StringApproxCountDistinctAggFunctionTest extends MergeTestBase<BinaryStringData> {
+
+        @Override
+        protected ApproxCountDistinctAggFunction<BinaryStringData> getTypedAggregator() {
+            return new StringApproxCountDistinctAggFunction();
+        }
+
+        @Override
+        protected List<List<BinaryStringData>> getInputValueSets() {
+            return Arrays.asList(
+                    Arrays.asList(
+                            BinaryStringData.fromString("abc"),
+                            BinaryStringData.fromString("def"),
+                            BinaryStringData.fromString("ghi"),
+                            null,
+                            BinaryStringData.fromString("jkl"),
+                            null,
+                            BinaryStringData.fromString("zzz")),
+                    Arrays.asList(null, null),
+                    Arrays.asList(null, BinaryStringData.fromString("a")),
+                    Arrays.asList(
+                            BinaryStringData.fromString("x"),
+                            null,
+                            BinaryStringData.fromString("x")));
+        }
+
+        @Override
+        protected List<Long> getExpectedResults() {
+            return Arrays.asList(5L, 0L, 1L, 1L);
+        }
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/BatchApproxCountDistinctITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/BatchApproxCountDistinctITCase.java
@@ -1,0 +1,471 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime.batch.sql;
+
+import org.apache.flink.table.api.TableResult;
+import org.apache.flink.table.planner.factories.TestValuesTableFactory;
+import org.apache.flink.table.planner.runtime.utils.BatchTestBase;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CollectionUtil;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for APPROX_COUNT_DISTINCT aggregate function in batch mode.
+ *
+ * <p>This test verifies backward compatibility after unifying the batch and streaming
+ * implementations of APPROX_COUNT_DISTINCT.
+ */
+class BatchApproxCountDistinctITCase extends BatchTestBase {
+
+    @BeforeEach
+    @Override
+    public void before() throws Exception {
+        super.before();
+    }
+
+    @Test
+    void testApproxCountDistinctWithString() throws Exception {
+        List<Row> testData =
+                Arrays.asList(
+                        Row.of(1, "user_a"),
+                        Row.of(2, "user_a"), // duplicate
+                        Row.of(3, "user_b"),
+                        Row.of(4, "user_c"),
+                        Row.of(5, "user_c"), // duplicate
+                        Row.of(6, "user_d"));
+
+        String dataId = TestValuesTableFactory.registerData(testData);
+
+        tEnv().executeSql(
+                        String.format(
+                                "CREATE TABLE test_source (\n"
+                                        + "  id INT,\n"
+                                        + "  user_id STRING\n"
+                                        + ") WITH (\n"
+                                        + "  'connector' = 'values',\n"
+                                        + "  'data-id' = '%s',\n"
+                                        + "  'bounded' = 'true'\n"
+                                        + ")",
+                                dataId));
+
+        String sql = "SELECT APPROX_COUNT_DISTINCT(user_id) AS approx_uv FROM test_source";
+
+        TableResult result = tEnv().executeSql(sql);
+        List<Row> results = CollectionUtil.iteratorToList(result.collect());
+
+        assertThat(results).hasSize(1);
+        // user_a, user_b, user_c, user_d -> 4 distinct values
+        Long approxUv = (Long) results.get(0).getField("approx_uv");
+        assertThat(approxUv).isEqualTo(4L);
+    }
+
+    @Test
+    void testApproxCountDistinctWithInteger() throws Exception {
+        List<Row> testData =
+                Arrays.asList(
+                        Row.of(1, 100),
+                        Row.of(2, 100), // duplicate
+                        Row.of(3, 200),
+                        Row.of(4, 300),
+                        Row.of(5, 200), // duplicate
+                        Row.of(6, 400));
+
+        String dataId = TestValuesTableFactory.registerData(testData);
+
+        tEnv().executeSql(
+                        String.format(
+                                "CREATE TABLE int_source (\n"
+                                        + "  id INT,\n"
+                                        + "  value_int INT\n"
+                                        + ") WITH (\n"
+                                        + "  'connector' = 'values',\n"
+                                        + "  'data-id' = '%s',\n"
+                                        + "  'bounded' = 'true'\n"
+                                        + ")",
+                                dataId));
+
+        String sql = "SELECT APPROX_COUNT_DISTINCT(value_int) AS approx_distinct FROM int_source";
+
+        TableResult result = tEnv().executeSql(sql);
+        List<Row> results = CollectionUtil.iteratorToList(result.collect());
+
+        assertThat(results).hasSize(1);
+        // 100, 200, 300, 400 -> 4 distinct values
+        Long approxDistinct = (Long) results.get(0).getField("approx_distinct");
+        assertThat(approxDistinct).isEqualTo(4L);
+    }
+
+    @Test
+    void testApproxCountDistinctWithLong() throws Exception {
+        List<Row> testData =
+                Arrays.asList(
+                        Row.of(1, 1000000000L),
+                        Row.of(2, 2000000000L),
+                        Row.of(3, 1000000000L), // duplicate
+                        Row.of(4, 3000000000L));
+
+        String dataId = TestValuesTableFactory.registerData(testData);
+
+        tEnv().executeSql(
+                        String.format(
+                                "CREATE TABLE long_source (\n"
+                                        + "  id INT,\n"
+                                        + "  value_long BIGINT\n"
+                                        + ") WITH (\n"
+                                        + "  'connector' = 'values',\n"
+                                        + "  'data-id' = '%s',\n"
+                                        + "  'bounded' = 'true'\n"
+                                        + ")",
+                                dataId));
+
+        String sql = "SELECT APPROX_COUNT_DISTINCT(value_long) AS approx_distinct FROM long_source";
+
+        TableResult result = tEnv().executeSql(sql);
+        List<Row> results = CollectionUtil.iteratorToList(result.collect());
+
+        assertThat(results).hasSize(1);
+        Long approxDistinct = (Long) results.get(0).getField("approx_distinct");
+        assertThat(approxDistinct).isEqualTo(3L);
+    }
+
+    @Test
+    void testApproxCountDistinctWithDouble() throws Exception {
+        List<Row> testData =
+                Arrays.asList(
+                        Row.of(1, 1.1d),
+                        Row.of(2, 2.2d),
+                        Row.of(3, 1.1d), // duplicate
+                        Row.of(4, 3.3d),
+                        Row.of(5, 0.0d),
+                        Row.of(6, -0.0d)); // 0.0 and -0.0 should be treated as the same
+
+        String dataId = TestValuesTableFactory.registerData(testData);
+
+        tEnv().executeSql(
+                        String.format(
+                                "CREATE TABLE double_source (\n"
+                                        + "  id INT,\n"
+                                        + "  value_double DOUBLE\n"
+                                        + ") WITH (\n"
+                                        + "  'connector' = 'values',\n"
+                                        + "  'data-id' = '%s',\n"
+                                        + "  'bounded' = 'true'\n"
+                                        + ")",
+                                dataId));
+
+        String sql =
+                "SELECT APPROX_COUNT_DISTINCT(value_double) AS approx_distinct FROM double_source";
+
+        TableResult result = tEnv().executeSql(sql);
+        List<Row> results = CollectionUtil.iteratorToList(result.collect());
+
+        assertThat(results).hasSize(1);
+        // 1.1, 2.2, 3.3, 0.0 -> 4 distinct values (0.0 and -0.0 are same)
+        Long approxDistinct = (Long) results.get(0).getField("approx_distinct");
+        assertThat(approxDistinct).isEqualTo(4L);
+    }
+
+    @Test
+    void testApproxCountDistinctWithDecimal() throws Exception {
+        List<Row> testData =
+                Arrays.asList(
+                        Row.of(1, new BigDecimal("123.45")),
+                        Row.of(2, new BigDecimal("234.56")),
+                        Row.of(3, new BigDecimal("123.45")), // duplicate
+                        Row.of(4, new BigDecimal("345.67")));
+
+        String dataId = TestValuesTableFactory.registerData(testData);
+
+        tEnv().executeSql(
+                        String.format(
+                                "CREATE TABLE decimal_source (\n"
+                                        + "  id INT,\n"
+                                        + "  value_decimal DECIMAL(10, 2)\n"
+                                        + ") WITH (\n"
+                                        + "  'connector' = 'values',\n"
+                                        + "  'data-id' = '%s',\n"
+                                        + "  'bounded' = 'true'\n"
+                                        + ")",
+                                dataId));
+
+        String sql =
+                "SELECT APPROX_COUNT_DISTINCT(value_decimal) AS approx_distinct FROM decimal_source";
+
+        TableResult result = tEnv().executeSql(sql);
+        List<Row> results = CollectionUtil.iteratorToList(result.collect());
+
+        assertThat(results).hasSize(1);
+        Long approxDistinct = (Long) results.get(0).getField("approx_distinct");
+        assertThat(approxDistinct).isEqualTo(3L);
+    }
+
+    @Test
+    void testApproxCountDistinctWithDate() throws Exception {
+        List<Row> testData =
+                Arrays.asList(
+                        Row.of(1, LocalDate.of(2024, 1, 1)),
+                        Row.of(2, LocalDate.of(2024, 1, 2)),
+                        Row.of(3, LocalDate.of(2024, 1, 1)), // duplicate
+                        Row.of(4, LocalDate.of(2024, 1, 3)));
+
+        String dataId = TestValuesTableFactory.registerData(testData);
+
+        tEnv().executeSql(
+                        String.format(
+                                "CREATE TABLE date_source (\n"
+                                        + "  id INT,\n"
+                                        + "  value_date DATE\n"
+                                        + ") WITH (\n"
+                                        + "  'connector' = 'values',\n"
+                                        + "  'data-id' = '%s',\n"
+                                        + "  'bounded' = 'true'\n"
+                                        + ")",
+                                dataId));
+
+        String sql = "SELECT APPROX_COUNT_DISTINCT(value_date) AS approx_distinct FROM date_source";
+
+        TableResult result = tEnv().executeSql(sql);
+        List<Row> results = CollectionUtil.iteratorToList(result.collect());
+
+        assertThat(results).hasSize(1);
+        Long approxDistinct = (Long) results.get(0).getField("approx_distinct");
+        assertThat(approxDistinct).isEqualTo(3L);
+    }
+
+    @Test
+    void testApproxCountDistinctWithTime() throws Exception {
+        List<Row> testData =
+                Arrays.asList(
+                        Row.of(1, LocalTime.of(10, 0, 0)),
+                        Row.of(2, LocalTime.of(11, 0, 0)),
+                        Row.of(3, LocalTime.of(10, 0, 0)), // duplicate
+                        Row.of(4, LocalTime.of(12, 0, 0)));
+
+        String dataId = TestValuesTableFactory.registerData(testData);
+
+        tEnv().executeSql(
+                        String.format(
+                                "CREATE TABLE time_source (\n"
+                                        + "  id INT,\n"
+                                        + "  value_time TIME\n"
+                                        + ") WITH (\n"
+                                        + "  'connector' = 'values',\n"
+                                        + "  'data-id' = '%s',\n"
+                                        + "  'bounded' = 'true'\n"
+                                        + ")",
+                                dataId));
+
+        String sql = "SELECT APPROX_COUNT_DISTINCT(value_time) AS approx_distinct FROM time_source";
+
+        TableResult result = tEnv().executeSql(sql);
+        List<Row> results = CollectionUtil.iteratorToList(result.collect());
+
+        assertThat(results).hasSize(1);
+        Long approxDistinct = (Long) results.get(0).getField("approx_distinct");
+        assertThat(approxDistinct).isEqualTo(3L);
+    }
+
+    @Test
+    void testApproxCountDistinctWithTimestamp() throws Exception {
+        List<Row> testData =
+                Arrays.asList(
+                        Row.of(1, LocalDateTime.of(2024, 1, 1, 10, 0, 0)),
+                        Row.of(2, LocalDateTime.of(2024, 1, 1, 11, 0, 0)),
+                        Row.of(3, LocalDateTime.of(2024, 1, 1, 10, 0, 0)), // duplicate
+                        Row.of(4, LocalDateTime.of(2024, 1, 1, 12, 0, 0)));
+
+        String dataId = TestValuesTableFactory.registerData(testData);
+
+        tEnv().executeSql(
+                        String.format(
+                                "CREATE TABLE timestamp_source (\n"
+                                        + "  id INT,\n"
+                                        + "  value_ts TIMESTAMP(3)\n"
+                                        + ") WITH (\n"
+                                        + "  'connector' = 'values',\n"
+                                        + "  'data-id' = '%s',\n"
+                                        + "  'bounded' = 'true'\n"
+                                        + ")",
+                                dataId));
+
+        String sql =
+                "SELECT APPROX_COUNT_DISTINCT(value_ts) AS approx_distinct FROM timestamp_source";
+
+        TableResult result = tEnv().executeSql(sql);
+        List<Row> results = CollectionUtil.iteratorToList(result.collect());
+
+        assertThat(results).hasSize(1);
+        Long approxDistinct = (Long) results.get(0).getField("approx_distinct");
+        assertThat(approxDistinct).isEqualTo(3L);
+    }
+
+    @Test
+    void testApproxCountDistinctWithNullValues() throws Exception {
+        List<Row> testData =
+                Arrays.asList(
+                        Row.of(1, "user_a"),
+                        Row.of(2, null), // NULL should be ignored
+                        Row.of(3, "user_b"),
+                        Row.of(4, null), // NULL should be ignored
+                        Row.of(5, "user_a")); // duplicate
+
+        String dataId = TestValuesTableFactory.registerData(testData);
+
+        tEnv().executeSql(
+                        String.format(
+                                "CREATE TABLE null_source (\n"
+                                        + "  id INT,\n"
+                                        + "  user_id STRING\n"
+                                        + ") WITH (\n"
+                                        + "  'connector' = 'values',\n"
+                                        + "  'data-id' = '%s',\n"
+                                        + "  'bounded' = 'true'\n"
+                                        + ")",
+                                dataId));
+
+        String sql = "SELECT APPROX_COUNT_DISTINCT(user_id) AS approx_uv FROM null_source";
+
+        TableResult result = tEnv().executeSql(sql);
+        List<Row> results = CollectionUtil.iteratorToList(result.collect());
+
+        assertThat(results).hasSize(1);
+        // user_a, user_b (NULLs are ignored) -> 2 distinct values
+        Long approxUv = (Long) results.get(0).getField("approx_uv");
+        assertThat(approxUv).isEqualTo(2L);
+    }
+
+    @Test
+    void testApproxCountDistinctWithGroupBy() throws Exception {
+        List<Row> testData =
+                Arrays.asList(
+                        Row.of(1, "category_a", "user_1"),
+                        Row.of(2, "category_a", "user_2"),
+                        Row.of(3, "category_a", "user_1"), // duplicate in category_a
+                        Row.of(4, "category_b", "user_3"),
+                        Row.of(5, "category_b", "user_4"),
+                        Row.of(6, "category_b", "user_5"));
+
+        String dataId = TestValuesTableFactory.registerData(testData);
+
+        tEnv().executeSql(
+                        String.format(
+                                "CREATE TABLE group_source (\n"
+                                        + "  id INT,\n"
+                                        + "  category STRING,\n"
+                                        + "  user_id STRING\n"
+                                        + ") WITH (\n"
+                                        + "  'connector' = 'values',\n"
+                                        + "  'data-id' = '%s',\n"
+                                        + "  'bounded' = 'true'\n"
+                                        + ")",
+                                dataId));
+
+        String sql =
+                "SELECT category, APPROX_COUNT_DISTINCT(user_id) AS approx_uv "
+                        + "FROM group_source GROUP BY category ORDER BY category";
+
+        TableResult result = tEnv().executeSql(sql);
+        List<Row> results = CollectionUtil.iteratorToList(result.collect());
+
+        assertThat(results).hasSize(2);
+        // category_a: user_1, user_2 -> 2 distinct
+        assertThat(results.get(0).getField("category")).isEqualTo("category_a");
+        assertThat(results.get(0).getField("approx_uv")).isEqualTo(2L);
+        // category_b: user_3, user_4, user_5 -> 3 distinct
+        assertThat(results.get(1).getField("category")).isEqualTo("category_b");
+        assertThat(results.get(1).getField("approx_uv")).isEqualTo(3L);
+    }
+
+    @Test
+    void testApproxCountDistinctPrecision() throws Exception {
+        // Test precision with larger dataset
+        List<Row> largeData = new ArrayList<>();
+        int distinctCount = 10000;
+
+        for (int i = 0; i < distinctCount; i++) {
+            largeData.add(Row.of(i, "user_" + i));
+        }
+
+        String dataId = TestValuesTableFactory.registerData(largeData);
+
+        tEnv().executeSql(
+                        String.format(
+                                "CREATE TABLE large_source (\n"
+                                        + "  id INT,\n"
+                                        + "  user_id STRING\n"
+                                        + ") WITH (\n"
+                                        + "  'connector' = 'values',\n"
+                                        + "  'data-id' = '%s',\n"
+                                        + "  'bounded' = 'true'\n"
+                                        + ")",
+                                dataId));
+
+        String sql = "SELECT APPROX_COUNT_DISTINCT(user_id) AS approx_uv FROM large_source";
+
+        TableResult result = tEnv().executeSql(sql);
+        List<Row> results = CollectionUtil.iteratorToList(result.collect());
+
+        assertThat(results).hasSize(1);
+        Long approxUv = (Long) results.get(0).getField("approx_uv");
+
+        // HLL++ relative standard error is approximately 1%, allow 2% tolerance
+        double error = Math.abs(approxUv - distinctCount) / (double) distinctCount;
+        assertThat(error).isLessThan(0.02);
+    }
+
+    @Test
+    void testApproxCountDistinctWithEmptyTable() throws Exception {
+        List<Row> emptyData = new ArrayList<>();
+
+        String dataId = TestValuesTableFactory.registerData(emptyData);
+
+        tEnv().executeSql(
+                        String.format(
+                                "CREATE TABLE empty_source (\n"
+                                        + "  id INT,\n"
+                                        + "  user_id STRING\n"
+                                        + ") WITH (\n"
+                                        + "  'connector' = 'values',\n"
+                                        + "  'data-id' = '%s',\n"
+                                        + "  'bounded' = 'true'\n"
+                                        + ")",
+                                dataId));
+
+        String sql = "SELECT APPROX_COUNT_DISTINCT(user_id) AS approx_uv FROM empty_source";
+
+        TableResult result = tEnv().executeSql(sql);
+        List<Row> results = CollectionUtil.iteratorToList(result.collect());
+
+        assertThat(results).hasSize(1);
+        Long approxUv = (Long) results.get(0).getField("approx_uv");
+        assertThat(approxUv).isEqualTo(0L);
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/StreamApproxCountDistinctITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/StreamApproxCountDistinctITCase.java
@@ -1,0 +1,360 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime.stream.sql;
+
+import org.apache.flink.table.api.TableResult;
+import org.apache.flink.table.planner.factories.TestValuesTableFactory;
+import org.apache.flink.table.planner.runtime.utils.StreamingTestBase;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CollectionUtil;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for APPROX_COUNT_DISTINCT aggregate function in streaming mode.
+ *
+ * <p>This test verifies that APPROX_COUNT_DISTINCT works correctly with Window TVF (TUMBLE, HOP,
+ * CUMULATE) in streaming mode.
+ */
+class StreamApproxCountDistinctITCase extends StreamingTestBase {
+
+    @BeforeEach
+    void setupTestData() {
+        // Prepare test data
+        List<Row> testData =
+                Arrays.asList(
+                        // Window 1: [00:00:00, 00:00:05)
+                        Row.of(
+                                1,
+                                "user_a",
+                                LocalDateTime.of(2024, 1, 1, 0, 0, 1)), // user_a @ 00:00:01
+                        Row.of(
+                                2,
+                                "user_a",
+                                LocalDateTime.of(
+                                        2024, 1, 1, 0, 0, 2)), // user_a @ 00:00:02 (duplicate)
+                        Row.of(
+                                3,
+                                "user_b",
+                                LocalDateTime.of(2024, 1, 1, 0, 0, 3)), // user_b @ 00:00:03
+                        Row.of(
+                                4,
+                                "user_c",
+                                LocalDateTime.of(2024, 1, 1, 0, 0, 4)), // user_c @ 00:00:04
+
+                        // Window 2: [00:00:05, 00:00:10)
+                        Row.of(
+                                5,
+                                "user_a",
+                                LocalDateTime.of(2024, 1, 1, 0, 0, 6)), // user_a @ 00:00:06
+                        Row.of(
+                                6,
+                                "user_d",
+                                LocalDateTime.of(2024, 1, 1, 0, 0, 7)), // user_d @ 00:00:07
+                        Row.of(
+                                7,
+                                "user_d",
+                                LocalDateTime.of(
+                                        2024, 1, 1, 0, 0, 8)), // user_d @ 00:00:08 (duplicate)
+
+                        // Window 3: [00:00:10, 00:00:15)
+                        Row.of(
+                                8,
+                                "user_e",
+                                LocalDateTime.of(2024, 1, 1, 0, 0, 11)), // user_e @ 00:00:11
+                        Row.of(
+                                9,
+                                "user_f",
+                                LocalDateTime.of(2024, 1, 1, 0, 0, 12)), // user_f @ 00:00:12
+                        Row.of(
+                                10,
+                                "user_g",
+                                LocalDateTime.of(2024, 1, 1, 0, 0, 13)), // user_g @ 00:00:13
+                        Row.of(
+                                11,
+                                "user_h",
+                                LocalDateTime.of(2024, 1, 1, 0, 0, 14)) // user_h @ 00:00:14
+                        );
+
+        String dataId = TestValuesTableFactory.registerData(testData);
+
+        tEnv().executeSql(
+                        String.format(
+                                "CREATE TABLE test_source (\n"
+                                        + "  id INT,\n"
+                                        + "  user_id STRING,\n"
+                                        + "  event_time TIMESTAMP(3),\n"
+                                        + "  WATERMARK FOR event_time AS event_time - INTERVAL '1' SECOND\n"
+                                        + ") WITH (\n"
+                                        + "  'connector' = 'values',\n"
+                                        + "  'data-id' = '%s',\n"
+                                        + "  'bounded' = 'true'\n"
+                                        + ")",
+                                dataId));
+    }
+
+    @Test
+    void testApproxCountDistinctWithTumbleWindow() throws Exception {
+        // TUMBLE window test: 5-second window
+        // Note: ORDER BY on non-time-attribute fields is not supported in streaming mode,
+        // so we sort results in Java code instead.
+        String sql =
+                "SELECT\n"
+                        + "  window_start,\n"
+                        + "  window_end,\n"
+                        + "  APPROX_COUNT_DISTINCT(user_id) AS approx_uv\n"
+                        + "FROM TABLE(\n"
+                        + "  TUMBLE(TABLE test_source, DESCRIPTOR(event_time), INTERVAL '5' SECOND)\n"
+                        + ")\n"
+                        + "GROUP BY window_start, window_end";
+
+        TableResult result = tEnv().executeSql(sql);
+        List<Row> results = CollectionUtil.iteratorToList(result.collect());
+        // Sort by window_start in Java since streaming mode does not support ORDER BY
+        results.sort(
+                (r1, r2) -> {
+                    LocalDateTime t1 = (LocalDateTime) r1.getField("window_start");
+                    LocalDateTime t2 = (LocalDateTime) r2.getField("window_start");
+                    return t1.compareTo(t2);
+                });
+
+        assertThat(results).hasSize(3);
+
+        // Verify approximate UV for each window
+        // Window1 [00:00:00, 00:00:05): user_a, user_b, user_c -> 3
+        // Window2 [00:00:05, 00:00:10): user_a, user_d -> 2
+        // Window3 [00:00:10, 00:00:15): user_e, user_f, user_g, user_h -> 4
+        Long window1Uv = (Long) results.get(0).getField("approx_uv");
+        Long window2Uv = (Long) results.get(1).getField("approx_uv");
+        Long window3Uv = (Long) results.get(2).getField("approx_uv");
+
+        // HLL++ precision is approximately 1%, should be exact for small data sets
+        assertThat(window1Uv).isEqualTo(3L);
+        assertThat(window2Uv).isEqualTo(2L);
+        assertThat(window3Uv).isEqualTo(4L);
+    }
+
+    @Test
+    void testApproxCountDistinctWithHopWindow() throws Exception {
+        // HOP window test: 10-second window, 5-second slide
+        String sql =
+                "SELECT\n"
+                        + "  window_start,\n"
+                        + "  window_end,\n"
+                        + "  APPROX_COUNT_DISTINCT(user_id) AS approx_uv\n"
+                        + "FROM TABLE(\n"
+                        + "  HOP(TABLE test_source, DESCRIPTOR(event_time), INTERVAL '5' SECOND, INTERVAL '10' SECOND)\n"
+                        + ")\n"
+                        + "GROUP BY window_start, window_end";
+
+        TableResult result = tEnv().executeSql(sql);
+        List<Row> results = CollectionUtil.iteratorToList(result.collect());
+
+        // HOP windows overlap, each record may appear in multiple windows
+        assertThat(results).isNotEmpty();
+
+        // Verify result validity
+        for (Row row : results) {
+            Long approxUv = (Long) row.getField("approx_uv");
+            assertThat(approxUv).isGreaterThanOrEqualTo(0L);
+        }
+    }
+
+    @Test
+    void testApproxCountDistinctWithCumulateWindow() throws Exception {
+        // CUMULATE window test: 15-second max window, 5-second step
+        String sql =
+                "SELECT\n"
+                        + "  window_start,\n"
+                        + "  window_end,\n"
+                        + "  APPROX_COUNT_DISTINCT(user_id) AS approx_uv\n"
+                        + "FROM TABLE(\n"
+                        + "  CUMULATE(TABLE test_source, DESCRIPTOR(event_time), INTERVAL '5' SECOND, INTERVAL '15' SECOND)\n"
+                        + ")\n"
+                        + "GROUP BY window_start, window_end";
+
+        TableResult result = tEnv().executeSql(sql);
+        List<Row> results = CollectionUtil.iteratorToList(result.collect());
+
+        // CUMULATE windows produce cumulative effect
+        // [00:00, 00:05) -> 3 UV
+        // [00:00, 00:10) -> 4 UV (cumulative)
+        // [00:00, 00:15) -> 8 UV (cumulative)
+        assertThat(results).isNotEmpty();
+
+        // Verify cumulative effect: later windows UV should be >= earlier windows UV
+        for (Row row : results) {
+            Long approxUv = (Long) row.getField("approx_uv");
+            assertThat(approxUv).isGreaterThanOrEqualTo(0L);
+        }
+    }
+
+    @Test
+    void testApproxCountDistinctWithDifferentDataTypes() throws Exception {
+        // Test different data types
+        List<Row> intData =
+                Arrays.asList(
+                        Row.of(1, 100, LocalDateTime.of(2024, 1, 1, 0, 0, 1)),
+                        Row.of(2, 100, LocalDateTime.of(2024, 1, 1, 0, 0, 2)),
+                        Row.of(3, 200, LocalDateTime.of(2024, 1, 1, 0, 0, 3)),
+                        Row.of(4, 300, LocalDateTime.of(2024, 1, 1, 0, 0, 4)));
+
+        String intDataId = TestValuesTableFactory.registerData(intData);
+
+        tEnv().executeSql(
+                        String.format(
+                                "CREATE TABLE int_source (\n"
+                                        + "  id INT,\n"
+                                        + "  value_int INT,\n"
+                                        + "  event_time TIMESTAMP(3),\n"
+                                        + "  WATERMARK FOR event_time AS event_time - INTERVAL '1' SECOND\n"
+                                        + ") WITH (\n"
+                                        + "  'connector' = 'values',\n"
+                                        + "  'data-id' = '%s',\n"
+                                        + "  'bounded' = 'true'\n"
+                                        + ")",
+                                intDataId));
+
+        String sql =
+                "SELECT\n"
+                        + "  window_start,\n"
+                        + "  window_end,\n"
+                        + "  APPROX_COUNT_DISTINCT(value_int) AS approx_distinct_int\n"
+                        + "FROM TABLE(\n"
+                        + "  TUMBLE(TABLE int_source, DESCRIPTOR(event_time), INTERVAL '10' SECOND)\n"
+                        + ")\n"
+                        + "GROUP BY window_start, window_end";
+
+        TableResult result = tEnv().executeSql(sql);
+        List<Row> results = CollectionUtil.iteratorToList(result.collect());
+
+        assertThat(results).hasSize(1);
+        // 100, 200, 300 -> 3 distinct values
+        Long approxDistinct = (Long) results.get(0).getField("approx_distinct_int");
+        assertThat(approxDistinct).isEqualTo(3L);
+    }
+
+    @Test
+    void testApproxCountDistinctWithNullValues() throws Exception {
+        // Test with NULL values
+        List<Row> nullData =
+                Arrays.asList(
+                        Row.of(1, "user_a", LocalDateTime.of(2024, 1, 1, 0, 0, 1)),
+                        Row.of(2, null, LocalDateTime.of(2024, 1, 1, 0, 0, 2)), // NULL
+                        Row.of(3, "user_b", LocalDateTime.of(2024, 1, 1, 0, 0, 3)),
+                        Row.of(4, null, LocalDateTime.of(2024, 1, 1, 0, 0, 4)), // NULL
+                        Row.of(5, "user_a", LocalDateTime.of(2024, 1, 1, 0, 0, 5)) // duplicate
+                        );
+
+        String nullDataId = TestValuesTableFactory.registerData(nullData);
+
+        tEnv().executeSql(
+                        String.format(
+                                "CREATE TABLE null_source (\n"
+                                        + "  id INT,\n"
+                                        + "  user_id STRING,\n"
+                                        + "  event_time TIMESTAMP(3),\n"
+                                        + "  WATERMARK FOR event_time AS event_time - INTERVAL '1' SECOND\n"
+                                        + ") WITH (\n"
+                                        + "  'connector' = 'values',\n"
+                                        + "  'data-id' = '%s',\n"
+                                        + "  'bounded' = 'true'\n"
+                                        + ")",
+                                nullDataId));
+
+        String sql =
+                "SELECT\n"
+                        + "  window_start,\n"
+                        + "  window_end,\n"
+                        + "  APPROX_COUNT_DISTINCT(user_id) AS approx_uv\n"
+                        + "FROM TABLE(\n"
+                        + "  TUMBLE(TABLE null_source, DESCRIPTOR(event_time), INTERVAL '10' SECOND)\n"
+                        + ")\n"
+                        + "GROUP BY window_start, window_end";
+
+        TableResult result = tEnv().executeSql(sql);
+        List<Row> results = CollectionUtil.iteratorToList(result.collect());
+
+        assertThat(results).hasSize(1);
+        // user_a, user_b (NULLs are ignored) -> 2 distinct values
+        Long approxUv = (Long) results.get(0).getField("approx_uv");
+        assertThat(approxUv).isEqualTo(2L);
+    }
+
+    @Test
+    void testApproxCountDistinctPrecision() throws Exception {
+        // Test precision: verify HLL++ relative standard error is approximately 1% using large
+        // dataset
+        List<Row> largeData = new ArrayList<>();
+        int distinctCount = 10000;
+        LocalDateTime baseTime = LocalDateTime.of(2024, 1, 1, 0, 0, 0);
+
+        for (int i = 0; i < distinctCount; i++) {
+            largeData.add(
+                    Row.of(
+                            i,
+                            "user_" + i,
+                            baseTime.plusSeconds(i % 60))); // distributed within 60 seconds
+        }
+
+        String largeDataId = TestValuesTableFactory.registerData(largeData);
+
+        tEnv().executeSql(
+                        String.format(
+                                "CREATE TABLE large_source (\n"
+                                        + "  id INT,\n"
+                                        + "  user_id STRING,\n"
+                                        + "  event_time TIMESTAMP(3),\n"
+                                        + "  WATERMARK FOR event_time AS event_time - INTERVAL '1' SECOND\n"
+                                        + ") WITH (\n"
+                                        + "  'connector' = 'values',\n"
+                                        + "  'data-id' = '%s',\n"
+                                        + "  'bounded' = 'true'\n"
+                                        + ")",
+                                largeDataId));
+
+        String sql =
+                "SELECT\n"
+                        + "  window_start,\n"
+                        + "  window_end,\n"
+                        + "  APPROX_COUNT_DISTINCT(user_id) AS approx_uv\n"
+                        + "FROM TABLE(\n"
+                        + "  TUMBLE(TABLE large_source, DESCRIPTOR(event_time), INTERVAL '2' MINUTE)\n"
+                        + ")\n"
+                        + "GROUP BY window_start, window_end";
+
+        TableResult result = tEnv().executeSql(sql);
+        List<Row> results = CollectionUtil.iteratorToList(result.collect());
+
+        assertThat(results).hasSize(1);
+        Long approxUv = (Long) results.get(0).getField("approx_uv");
+
+        // HLL++ 相对标准误差约为 1%，允许 2% 的偏差
+        double error = Math.abs(approxUv - distinctCount) / (double) distinctCount;
+        assertThat(error).isLessThan(0.02);
+    }
+}

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/AggregateTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/AggregateTest.xml
@@ -169,6 +169,30 @@ GlobalGroupAggregate(groupBy=[b], select=[b, COUNT(distinct$0 count$0) AS EXPR$1
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testApproximateCountDistinct">
+    <Resource name="sql">
+      <![CDATA[SELECT APPROX_COUNT_DISTINCT(b) FROM MyTable]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[COUNT(APPROXIMATE DISTINCT $0)])
++- LogicalProject(b=[$1])
+   +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[$4])
+      +- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[PROCTIME()], rowtime=[$3])
+         +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+GroupAggregate(select=[COUNT(b) AS EXPR$0])
++- Exchange(distribution=[single])
+   +- Calc(select=[b])
+      +- WatermarkAssigner(rowtime=[rowtime], watermark=[rowtime])
+         +- Calc(select=[b, rowtime])
+            +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, rowtime])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testAvgOnDifferentTypes">
     <Resource name="sql">
       <![CDATA[

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/agg/AggregateTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/agg/AggregateTest.scala
@@ -423,8 +423,9 @@ class AggregateTest extends TableTestBase {
 
   @Test
   def testApproximateCountDistinct(): Unit = {
-    assertThatExceptionOfType(classOf[TableException])
-      .isThrownBy(() => util.verifyExecPlan("SELECT APPROX_COUNT_DISTINCT(b) FROM MyTable"))
+    // APPROX_COUNT_DISTINCT is now supported in streaming mode on append-only streams.
+    // Retraction mode is still not supported (HyperLogLog cannot remove elements).
+    util.verifyExecPlan("SELECT APPROX_COUNT_DISTINCT(b) FROM MyTable")
   }
 
   @Test

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/aggregate/ApproxCountDistinctAggFunctions.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/aggregate/ApproxCountDistinctAggFunctions.java
@@ -1,0 +1,437 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.aggregate;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.DecimalDataUtils;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.data.binary.BinaryStringData;
+import org.apache.flink.table.runtime.functions.aggregate.hyperloglog.HllBuffer;
+import org.apache.flink.table.runtime.functions.aggregate.hyperloglog.HyperLogLogPlusPlus;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.DateType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.SmallIntType;
+import org.apache.flink.table.types.logical.TimeType;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.VarCharType;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.flink.table.runtime.functions.aggregate.hyperloglog.XXH64.DEFAULT_SEED;
+import static org.apache.flink.table.runtime.functions.aggregate.hyperloglog.XXH64.hashInt;
+import static org.apache.flink.table.runtime.functions.aggregate.hyperloglog.XXH64.hashLong;
+import static org.apache.flink.table.runtime.functions.aggregate.hyperloglog.XXH64.hashUnsafeBytes;
+import static org.apache.flink.table.types.utils.DataTypeUtils.toInternalDataType;
+
+/**
+ * Built-in APPROX_COUNT_DISTINCT aggregate functions supporting both Batch and Streaming modes.
+ *
+ * <p>This implementation uses the HyperLogLog++ algorithm for approximate distinct counting, which
+ * provides a relative standard error of approximately 1%.
+ *
+ * <p>Key features:
+ *
+ * <ul>
+ *   <li>Supports both batch and streaming SQL
+ *   <li>Supports Window TVF (TUMBLE, HOP, CUMULATE) through the merge() method
+ *   <li>Uses Flink's internal HyperLogLog++ implementation
+ *   <li>Space complexity: O(m) where m is related to precision (approximately 16KB for 1% error)
+ * </ul>
+ *
+ * <p>Comparison with COUNT(DISTINCT x):
+ *
+ * <ul>
+ *   <li>COUNT(DISTINCT x) provides exact results but requires O(n) memory
+ *   <li>APPROX_COUNT_DISTINCT provides approximate results with bounded error (~1%) using O(1)
+ *       memory
+ *   <li>Use APPROX_COUNT_DISTINCT when exact counts are not required and memory is a concern
+ * </ul>
+ *
+ * <p>Note: This function does NOT support retraction operations in non-windowed streaming
+ * aggregations because HyperLogLog is a probabilistic data structure that cannot remove elements
+ * once added.
+ */
+@Internal
+public class ApproxCountDistinctAggFunctions {
+
+    /** Base function for APPROX_COUNT_DISTINCT aggregate. */
+    public abstract static class ApproxCountDistinctAggFunction<T>
+            extends BuiltInAggregateFunction<Long, HllBuffer> {
+
+        private static final long serialVersionUID = 1L;
+
+        /**
+         * The maximum relative standard deviation allowed. The precision for '0.01' is 14, which is
+         * enough. See
+         * https://docs.google.com/document/d/1gyjfMHy43U9OWBXxfaeG-3MjGzejW1dlpyMwEYAAWEI/view?fullscreen#
+         */
+        private static final Double RELATIVE_SD = 0.01;
+
+        private transient HyperLogLogPlusPlus hll;
+
+        private final transient DataType valueDataType;
+
+        public ApproxCountDistinctAggFunction(LogicalType valueType) {
+            this.valueDataType = toInternalDataType(valueType);
+        }
+
+        private HyperLogLogPlusPlus getOrCreateHll() {
+            if (hll == null) {
+                hll = new HyperLogLogPlusPlus(RELATIVE_SD);
+            }
+            return hll;
+        }
+
+        @Override
+        public HllBuffer createAccumulator() {
+            HyperLogLogPlusPlus hllInstance = getOrCreateHll();
+            HllBuffer buffer = new HllBuffer();
+            buffer.array = new long[hllInstance.getNumWords()];
+            resetAccumulator(buffer);
+            return buffer;
+        }
+
+        /**
+         * Accumulates a value into the HyperLogLog buffer.
+         *
+         * @param buffer the accumulator buffer
+         * @param input the input value to accumulate
+         */
+        public void accumulate(HllBuffer buffer, Object input) {
+            if (input != null) {
+                @SuppressWarnings("unchecked")
+                T typedInput = (T) input;
+                getOrCreateHll().updateByHashcode(buffer, getHashcode(typedInput));
+            }
+        }
+
+        /**
+         * Computes the hash code for the given value.
+         *
+         * @param value the input value
+         * @return the hash code
+         */
+        abstract long getHashcode(T value);
+
+        /**
+         * Merges multiple HyperLogLog buffers into one. This method is essential for supporting
+         * Window TVF aggregations (TUMBLE, HOP, CUMULATE).
+         *
+         * @param buffer the target accumulator buffer
+         * @param it iterable of source buffers to merge
+         */
+        public void merge(HllBuffer buffer, Iterable<HllBuffer> it) {
+            HyperLogLogPlusPlus hllInstance = getOrCreateHll();
+            for (HllBuffer tmpBuffer : it) {
+                if (tmpBuffer != null && tmpBuffer.array != null) {
+                    hllInstance.merge(buffer, tmpBuffer);
+                }
+            }
+        }
+
+        /**
+         * Resets the accumulator to its initial state.
+         *
+         * @param buffer the accumulator buffer to reset
+         */
+        public void resetAccumulator(HllBuffer buffer) {
+            HyperLogLogPlusPlus hllInstance = getOrCreateHll();
+            int numWords = hllInstance.getNumWords();
+            for (int word = 0; word < numWords; word++) {
+                buffer.array[word] = 0;
+            }
+        }
+
+        @Override
+        public Long getValue(HllBuffer buffer) {
+            return getOrCreateHll().query(buffer);
+        }
+
+        @Override
+        public List<DataType> getArgumentDataTypes() {
+            return Collections.singletonList(valueDataType);
+        }
+
+        @Override
+        public DataType getAccumulatorDataType() {
+            return DataTypes.STRUCTURED(
+                    HllBuffer.class,
+                    DataTypes.FIELD(
+                            "array",
+                            DataTypes.ARRAY(DataTypes.BIGINT().notNull())
+                                    .notNull()
+                                    .bridgedTo(long[].class)));
+        }
+
+        @Override
+        public DataType getOutputDataType() {
+            return DataTypes.BIGINT();
+        }
+    }
+
+    /** Built-in TINYINT (byte) APPROX_COUNT_DISTINCT aggregate function. */
+    public static class ByteApproxCountDistinctAggFunction
+            extends ApproxCountDistinctAggFunction<Byte> {
+
+        private static final long serialVersionUID = 1L;
+
+        public ByteApproxCountDistinctAggFunction() {
+            super(new TinyIntType());
+        }
+
+        @Override
+        long getHashcode(Byte value) {
+            return hashInt(value, DEFAULT_SEED);
+        }
+    }
+
+    /** Built-in SMALLINT (short) APPROX_COUNT_DISTINCT aggregate function. */
+    public static class ShortApproxCountDistinctAggFunction
+            extends ApproxCountDistinctAggFunction<Short> {
+
+        private static final long serialVersionUID = 1L;
+
+        public ShortApproxCountDistinctAggFunction() {
+            super(new SmallIntType());
+        }
+
+        @Override
+        long getHashcode(Short value) {
+            return hashInt(value, DEFAULT_SEED);
+        }
+    }
+
+    /** Built-in INT (integer) APPROX_COUNT_DISTINCT aggregate function. */
+    public static class IntApproxCountDistinctAggFunction
+            extends ApproxCountDistinctAggFunction<Integer> {
+
+        private static final long serialVersionUID = 1L;
+
+        public IntApproxCountDistinctAggFunction() {
+            super(new IntType());
+        }
+
+        @Override
+        long getHashcode(Integer value) {
+            return hashInt(value, DEFAULT_SEED);
+        }
+    }
+
+    /** Built-in BIGINT (long) APPROX_COUNT_DISTINCT aggregate function. */
+    public static class LongApproxCountDistinctAggFunction
+            extends ApproxCountDistinctAggFunction<Long> {
+
+        private static final long serialVersionUID = 1L;
+
+        public LongApproxCountDistinctAggFunction() {
+            super(new BigIntType());
+        }
+
+        @Override
+        long getHashcode(Long value) {
+            return hashLong(value, DEFAULT_SEED);
+        }
+    }
+
+    /** Built-in FLOAT APPROX_COUNT_DISTINCT aggregate function. */
+    public static class FloatApproxCountDistinctAggFunction
+            extends ApproxCountDistinctAggFunction<Float> {
+
+        private static final long serialVersionUID = 1L;
+
+        public FloatApproxCountDistinctAggFunction() {
+            super(new FloatType());
+        }
+
+        @Override
+        long getHashcode(Float value) {
+            return hashInt(Float.floatToIntBits(normalizeFloat(value)), DEFAULT_SEED);
+        }
+
+        private Float normalizeFloat(Float value) {
+            if (value.isNaN()) {
+                return Float.NaN;
+            } else if (value == -0.0f) {
+                return 0.0f;
+            } else {
+                return value;
+            }
+        }
+    }
+
+    /** Built-in DOUBLE APPROX_COUNT_DISTINCT aggregate function. */
+    public static class DoubleApproxCountDistinctAggFunction
+            extends ApproxCountDistinctAggFunction<Double> {
+
+        private static final long serialVersionUID = 1L;
+
+        public DoubleApproxCountDistinctAggFunction() {
+            super(new DoubleType());
+        }
+
+        @Override
+        long getHashcode(Double value) {
+            return hashLong(Double.doubleToLongBits(normalizeDouble(value)), DEFAULT_SEED);
+        }
+
+        private Double normalizeDouble(Double value) {
+            if (value.isNaN()) {
+                return Double.NaN;
+            } else if (value == -0.0d) {
+                return 0.0d;
+            } else {
+                return value;
+            }
+        }
+    }
+
+    /** Built-in DECIMAL APPROX_COUNT_DISTINCT aggregate function. */
+    public static class DecimalApproxCountDistinctAggFunction
+            extends ApproxCountDistinctAggFunction<DecimalData> {
+
+        private static final long serialVersionUID = 1L;
+
+        private final int precision;
+
+        public DecimalApproxCountDistinctAggFunction(DecimalType decimalType) {
+            super(decimalType);
+            this.precision = decimalType.getPrecision();
+        }
+
+        @Override
+        long getHashcode(DecimalData d) {
+            if (DecimalDataUtils.isByteArrayDecimal(precision)) {
+                byte[] bytes = d.toBigDecimal().unscaledValue().toByteArray();
+                MemorySegment segment = MemorySegmentFactory.wrap(bytes);
+                return hashUnsafeBytes(segment, 0, segment.size(), DEFAULT_SEED);
+            } else {
+                return hashLong(d.toUnscaledLong(), DEFAULT_SEED);
+            }
+        }
+    }
+
+    /** Built-in DATE APPROX_COUNT_DISTINCT aggregate function. */
+    public static class DateApproxCountDistinctAggFunction
+            extends ApproxCountDistinctAggFunction<Integer> {
+
+        private static final long serialVersionUID = 1L;
+
+        public DateApproxCountDistinctAggFunction() {
+            super(new DateType());
+        }
+
+        @Override
+        long getHashcode(Integer value) {
+            return hashLong(value, DEFAULT_SEED);
+        }
+    }
+
+    /** Built-in TIME APPROX_COUNT_DISTINCT aggregate function. */
+    public static class TimeApproxCountDistinctAggFunction
+            extends ApproxCountDistinctAggFunction<Integer> {
+
+        private static final long serialVersionUID = 1L;
+
+        public TimeApproxCountDistinctAggFunction() {
+            super(new TimeType());
+        }
+
+        @Override
+        long getHashcode(Integer value) {
+            return hashLong(value, DEFAULT_SEED);
+        }
+    }
+
+    /** Built-in TIMESTAMP APPROX_COUNT_DISTINCT aggregate function. */
+    public static class TimestampApproxCountDistinctAggFunction
+            extends ApproxCountDistinctAggFunction<TimestampData> {
+
+        private static final long serialVersionUID = 1L;
+
+        public TimestampApproxCountDistinctAggFunction(TimestampType type) {
+            super(type);
+        }
+
+        @Override
+        long getHashcode(TimestampData value) {
+            // Combine milliseconds and nanoseconds for high-precision timestamps
+            // This ensures TIMESTAMP(6) and higher precision values are distinguished correctly
+            long combinedValue = value.getMillisecond() * 1_000_000L + value.getNanoOfMillisecond();
+            return hashLong(combinedValue, DEFAULT_SEED);
+        }
+    }
+
+    /** Built-in TIMESTAMP WITH LOCAL TIME ZONE APPROX_COUNT_DISTINCT aggregate function. */
+    public static class TimestampLtzApproxCountDistinctAggFunction
+            extends ApproxCountDistinctAggFunction<TimestampData> {
+
+        private static final long serialVersionUID = 1L;
+
+        public TimestampLtzApproxCountDistinctAggFunction(LocalZonedTimestampType type) {
+            super(type);
+        }
+
+        @Override
+        long getHashcode(TimestampData value) {
+            // Combine milliseconds and nanoseconds for high-precision timestamps
+            // This ensures TIMESTAMP_LTZ(6) and higher precision values are distinguished correctly
+            long combinedValue = value.getMillisecond() * 1_000_000L + value.getNanoOfMillisecond();
+            return hashLong(combinedValue, DEFAULT_SEED);
+        }
+    }
+
+    /** Built-in VARCHAR (string) APPROX_COUNT_DISTINCT aggregate function. */
+    public static class StringApproxCountDistinctAggFunction
+            extends ApproxCountDistinctAggFunction<BinaryStringData> {
+
+        private static final long serialVersionUID = 1L;
+
+        public StringApproxCountDistinctAggFunction() {
+            super(new VarCharType());
+        }
+
+        @Override
+        long getHashcode(BinaryStringData s) {
+            MemorySegment[] segments = s.getSegments();
+            if (segments.length == 1) {
+                return hashUnsafeBytes(
+                        segments[0], s.getOffset(), s.getSizeInBytes(), DEFAULT_SEED);
+            } else {
+                return hashUnsafeBytes(
+                        MemorySegmentFactory.wrap(s.toBytes()),
+                        0,
+                        s.getSizeInBytes(),
+                        DEFAULT_SEED);
+            }
+        }
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/aggregate/BatchApproxCountDistinctAggFunctions.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/aggregate/BatchApproxCountDistinctAggFunctions.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.runtime.functions.aggregate;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.table.api.DataTypes;
@@ -51,7 +52,15 @@ import static org.apache.flink.table.runtime.functions.aggregate.hyperloglog.XXH
 import static org.apache.flink.table.runtime.functions.aggregate.hyperloglog.XXH64.hashUnsafeBytes;
 import static org.apache.flink.table.types.utils.DataTypeUtils.toInternalDataType;
 
-/** Built-in APPROX_COUNT_DISTINCT aggregate function for Batch sql. */
+/**
+ * Built-in APPROX_COUNT_DISTINCT aggregate function for Batch SQL.
+ *
+ * @deprecated Use {@link ApproxCountDistinctAggFunctions} instead, which supports both batch and
+ *     streaming modes. This class is kept for backward compatibility and will be removed in a
+ *     future release.
+ */
+@Deprecated
+@Internal
 public class BatchApproxCountDistinctAggFunctions {
 
     /** Base function for APPROX_COUNT_DISTINCT aggregate. */


### PR DESCRIPTION
## What is the purpose of the change

This pull request extends the `APPROX_COUNT_DISTINCT` aggregate function to support streaming mode, including Window TVF (TUMBLE, HOP, CUMULATE). Previously, this function was only available in batch mode. The implementation uses the HyperLogLog++ algorithm to provide approximate distinct counting with approximately 1% relative standard error while using constant memory (approximately 16KB). This enables efficient cardinality estimation in streaming scenarios where exact counts are not required.

## Brief change log

- Added a new unified `ApproxCountDistinctAggFunctions` class that supports both batch and streaming modes
- Deprecated the existing `BatchApproxCountDistinctAggFunctions` class for backward compatibility
- Updated `AggFunctionFactory` to use the new implementation and added validation to reject retraction scenarios in non-windowed streaming aggregations
- Implemented `merge()` method required for Window TVF aggregation
- Optimized timestamp hashing to support high-precision TIMESTAMP values (nanosecond precision)
- Added SQL function documentation in both English and Chinese
- Added release notes for Flink 2.2

## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

This change added tests and can be verified as follows:

- Added `ApproxCountDistinctAggFunctionTest` with unit tests covering all supported data types (TINYINT, SMALLINT, INT, BIGINT, FLOAT, DOUBLE, DECIMAL, DATE, TIME, TIMESTAMP, TIMESTAMP_LTZ, VARCHAR/CHAR) and merge functionality
- Added `StreamApproxCountDistinctITCase` with integration tests for:
  - TUMBLE window aggregation
  - HOP window aggregation
  - CUMULATE window aggregation
  - Different data types in streaming mode
  - NULL value handling
  - Precision validation with 10,000 records (error rate < 2%)
- Added `BatchApproxCountDistinctITCase` with integration tests for:
  - All supported data types in batch mode
  - GROUP BY aggregation
  - NULL value handling
  - Empty table handling
  - Precision validation with 10,000 records

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): **no**
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
- The serializers: **no**
- The runtime per-record code paths (performance sensitive): **no**
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
- The S3 file system connector: **no**

## Documentation

- Does this pull request introduce a new feature? **yes**
- If yes, how is the feature documented? **docs / JavaDocs**
  - Added function documentation in `docs/data/sql_functions.yml` and `docs/data/sql_functions_zh.yml`
  - Added comprehensive JavaDocs in `ApproxCountDistinctAggFunctions` class
