### PR TITLE
[FLINK-39059][table] Add unified metrics support to AsyncPredictFunction and PredictFunction

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/AsyncPredictFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/AsyncPredictFunction.java
@@ -19,6 +19,9 @@
 package org.apache.flink.table.functions;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Histogram;
+import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
@@ -30,22 +33,170 @@ import java.util.concurrent.CompletableFuture;
  * A wrapper class of {@link AsyncTableFunction} for asynchronous model inference.
  *
  * <p>The output type of this table function is fixed as {@link RowData}.
+ *
+ * <p>This class provides built-in metrics for monitoring model inference performance, including:
+ *
+ * <ul>
+ *   <li>inference_requests: Total number of inference requests
+ *   <li>inference_requests_success: Number of successful inference requests
+ *   <li>inference_requests_failure: Number of failed inference requests
+ *   <li>inference_latency: Histogram of inference latency in milliseconds
+ *   <li>inference_rows_output: Total number of output rows from inference
+ * </ul>
  */
 @PublicEvolving
 public abstract class AsyncPredictFunction extends AsyncTableFunction<RowData> {
 
+    // ------------------------------------------------------------------------
+    // Metrics
+    // ------------------------------------------------------------------------
+
+    /** Counter for total inference requests. */
+    private transient Counter inferenceRequests;
+
+    /** Counter for successful inference requests. */
+    private transient Counter inferenceRequestsSuccess;
+
+    /** Counter for failed inference requests. */
+    private transient Counter inferenceRequestsFailure;
+
+    /** Histogram for inference latency in milliseconds. */
+    private transient Histogram inferenceLatency;
+
+    /** Counter for total output rows from inference. */
+    private transient Counter inferenceRowsOutput;
+
+    // ------------------------------------------------------------------------
+    // Lifecycle Methods
+    // ------------------------------------------------------------------------
+
+    @Override
+    public void open(FunctionContext context) throws Exception {
+        super.open(context);
+        initializeMetrics(context);
+    }
+
+    /**
+     * Initialize metrics for monitoring model inference performance.
+     *
+     * <p>This method creates a metric group named "model_inference" and registers the following
+     * metrics:
+     *
+     * <ul>
+     *   <li>requests: Counter for total inference requests
+     *   <li>requests_success: Counter for successful inference requests
+     *   <li>requests_failure: Counter for failed inference requests
+     *   <li>latency: Histogram for inference latency (milliseconds)
+     *   <li>rows_output: Counter for total output rows
+     * </ul>
+     *
+     * <p>Subclasses can override {@link #createLatencyHistogram(MetricGroup)} to provide a custom
+     * histogram implementation.
+     *
+     * @param context The function context
+     */
+    protected void initializeMetrics(FunctionContext context) {
+        MetricGroup metricGroup = context.getMetricGroup().addGroup("model_inference");
+
+        inferenceRequests = metricGroup.counter("requests");
+        inferenceRequestsSuccess = metricGroup.counter("requests_success");
+        inferenceRequestsFailure = metricGroup.counter("requests_failure");
+        inferenceLatency = createLatencyHistogram(metricGroup);
+        inferenceRowsOutput = metricGroup.counter("rows_output");
+    }
+
+    /**
+     * Create a histogram for tracking inference latency. Subclasses can override this method to
+     * provide a custom histogram implementation.
+     *
+     * @param metricGroup The metric group to register the histogram
+     * @return A Histogram instance, or null to disable latency tracking
+     */
+    protected Histogram createLatencyHistogram(MetricGroup metricGroup) {
+        // Default: no histogram (return null)
+        // Subclasses can override to provide implementation
+        return null;
+    }
+
+    // ------------------------------------------------------------------------
+    // Prediction Methods
+    // ------------------------------------------------------------------------
+
     /**
      * Asynchronously predict result based on input row.
+     *
+     * <p>Subclasses must implement this method to perform the actual inference logic.
      *
      * @param inputRow - A {@link RowData} that wraps input for predict function.
      * @return A collection of all predicted results.
      */
     public abstract CompletableFuture<Collection<RowData>> asyncPredict(RowData inputRow);
 
-    /** Invokes {@link #asyncPredict} and chains futures. */
+    /**
+     * Wrapper method that tracks metrics around asyncPredict calls.
+     *
+     * <p>This method automatically tracks inference metrics including request count,
+     * success/failure count, latency, and output row count.
+     *
+     * @param inputRow The input row data
+     * @return A CompletableFuture containing the prediction results
+     */
+    protected final CompletableFuture<Collection<RowData>> asyncPredictWithMetrics(
+            RowData inputRow) {
+
+        // Increment request counter
+        if (inferenceRequests != null) {
+            inferenceRequests.inc();
+        }
+
+        // Record start time
+        final long startTime = System.currentTimeMillis();
+
+        // Call the actual prediction method
+        return asyncPredict(inputRow)
+                .whenComplete(
+                        (result, exception) -> {
+                            // Record latency
+                            recordLatency(startTime);
+
+                            // Record success/failure
+                            if (exception != null) {
+                                if (inferenceRequestsFailure != null) {
+                                    inferenceRequestsFailure.inc();
+                                }
+                            } else {
+                                if (inferenceRequestsSuccess != null) {
+                                    inferenceRequestsSuccess.inc();
+                                }
+
+                                // Record output rows count
+                                if (result != null && inferenceRowsOutput != null) {
+                                    inferenceRowsOutput.inc(result.size());
+                                }
+                            }
+                        });
+    }
+
+    /**
+     * Records the inference latency metric.
+     *
+     * @param startTime The start time of the inference request in milliseconds
+     */
+    protected final void recordLatency(long startTime) {
+        if (inferenceLatency != null) {
+            long latency = System.currentTimeMillis() - startTime;
+            inferenceLatency.update(latency);
+        }
+    }
+
+    // ------------------------------------------------------------------------
+    // Table Function Evaluation
+    // ------------------------------------------------------------------------
+
+    /** Invokes {@link #asyncPredict} with metrics tracking and chains futures. */
     public void eval(CompletableFuture<Collection<RowData>> future, Object... args) {
         GenericRowData argsData = GenericRowData.of(args);
-        asyncPredict(argsData)
+        asyncPredictWithMetrics(argsData)
                 .whenComplete(
                         (result, exception) -> {
                             if (exception != null) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/AsyncPredictFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/AsyncPredictFunction.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.functions;
 
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Histogram;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.table.api.TableException;
@@ -37,72 +36,23 @@ import java.util.concurrent.CompletableFuture;
  * <p>This class provides built-in metrics for monitoring model inference performance, including:
  *
  * <ul>
- *   <li>inference_requests: Total number of inference requests
- *   <li>inference_requests_success: Number of successful inference requests
- *   <li>inference_requests_failure: Number of failed inference requests
- *   <li>inference_latency: Histogram of inference latency in milliseconds
- *   <li>inference_rows_output: Total number of output rows from inference
+ *   <li>requests: Total number of inference requests
+ *   <li>requests_success: Number of successful inference requests
+ *   <li>requests_failure: Number of failed inference requests
+ *   <li>latency: Histogram of inference latency in milliseconds
+ *   <li>rows_output: Total number of output rows from inference
  * </ul>
  */
 @PublicEvolving
 public abstract class AsyncPredictFunction extends AsyncTableFunction<RowData> {
 
-    // ------------------------------------------------------------------------
-    // Metrics
-    // ------------------------------------------------------------------------
-
-    /** Counter for total inference requests. */
-    private transient Counter inferenceRequests;
-
-    /** Counter for successful inference requests. */
-    private transient Counter inferenceRequestsSuccess;
-
-    /** Counter for failed inference requests. */
-    private transient Counter inferenceRequestsFailure;
-
-    /** Histogram for inference latency in milliseconds. */
-    private transient Histogram inferenceLatency;
-
-    /** Counter for total output rows from inference. */
-    private transient Counter inferenceRowsOutput;
-
-    // ------------------------------------------------------------------------
-    // Lifecycle Methods
-    // ------------------------------------------------------------------------
+    private transient PredictFunctionMetrics metrics;
 
     @Override
     public void open(FunctionContext context) throws Exception {
         super.open(context);
-        initializeMetrics(context);
-    }
-
-    /**
-     * Initialize metrics for monitoring model inference performance.
-     *
-     * <p>This method creates a metric group named "model_inference" and registers the following
-     * metrics:
-     *
-     * <ul>
-     *   <li>requests: Counter for total inference requests
-     *   <li>requests_success: Counter for successful inference requests
-     *   <li>requests_failure: Counter for failed inference requests
-     *   <li>latency: Histogram for inference latency (milliseconds)
-     *   <li>rows_output: Counter for total output rows
-     * </ul>
-     *
-     * <p>Subclasses can override {@link #createLatencyHistogram(MetricGroup)} to provide a custom
-     * histogram implementation.
-     *
-     * @param context The function context
-     */
-    protected void initializeMetrics(FunctionContext context) {
         MetricGroup metricGroup = context.getMetricGroup().addGroup("model_inference");
-
-        inferenceRequests = metricGroup.counter("requests");
-        inferenceRequestsSuccess = metricGroup.counter("requests_success");
-        inferenceRequestsFailure = metricGroup.counter("requests_failure");
-        inferenceLatency = createLatencyHistogram(metricGroup);
-        inferenceRowsOutput = metricGroup.counter("rows_output");
+        metrics = new PredictFunctionMetrics(metricGroup, createLatencyHistogram(metricGroup));
     }
 
     /**
@@ -113,14 +63,8 @@ public abstract class AsyncPredictFunction extends AsyncTableFunction<RowData> {
      * @return A Histogram instance, or null to disable latency tracking
      */
     protected Histogram createLatencyHistogram(MetricGroup metricGroup) {
-        // Default: no histogram (return null)
-        // Subclasses can override to provide implementation
         return null;
     }
-
-    // ------------------------------------------------------------------------
-    // Prediction Methods
-    // ------------------------------------------------------------------------
 
     /**
      * Asynchronously predict result based on input row.
@@ -143,55 +87,23 @@ public abstract class AsyncPredictFunction extends AsyncTableFunction<RowData> {
      */
     protected final CompletableFuture<Collection<RowData>> asyncPredictWithMetrics(
             RowData inputRow) {
-
-        // Increment request counter
-        if (inferenceRequests != null) {
-            inferenceRequests.inc();
-        }
-
-        // Record start time
+        metrics.incRequests();
         final long startTime = System.currentTimeMillis();
 
-        // Call the actual prediction method
         return asyncPredict(inputRow)
                 .whenComplete(
                         (result, exception) -> {
-                            // Record latency
-                            recordLatency(startTime);
-
-                            // Record success/failure
+                            metrics.recordLatency(startTime);
                             if (exception != null) {
-                                if (inferenceRequestsFailure != null) {
-                                    inferenceRequestsFailure.inc();
-                                }
+                                metrics.incRequestsFailure();
                             } else {
-                                if (inferenceRequestsSuccess != null) {
-                                    inferenceRequestsSuccess.inc();
-                                }
-
-                                // Record output rows count
-                                if (result != null && inferenceRowsOutput != null) {
-                                    inferenceRowsOutput.inc(result.size());
+                                metrics.incRequestsSuccess();
+                                if (result != null) {
+                                    metrics.incRowsOutput(result.size());
                                 }
                             }
                         });
     }
-
-    /**
-     * Records the inference latency metric.
-     *
-     * @param startTime The start time of the inference request in milliseconds
-     */
-    protected final void recordLatency(long startTime) {
-        if (inferenceLatency != null) {
-            long latency = System.currentTimeMillis() - startTime;
-            inferenceLatency.update(latency);
-        }
-    }
-
-    // ------------------------------------------------------------------------
-    // Table Function Evaluation
-    // ------------------------------------------------------------------------
 
     /** Invokes {@link #asyncPredict} with metrics tracking and chains futures. */
     public void eval(CompletableFuture<Collection<RowData>> future, Object... args) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/AsyncPredictFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/AsyncPredictFunction.java
@@ -19,11 +19,13 @@
 package org.apache.flink.table.functions;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.metrics.Histogram;
 import org.apache.flink.metrics.MetricGroup;
-import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.Preconditions;
 
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
@@ -33,15 +35,25 @@ import java.util.concurrent.CompletableFuture;
  *
  * <p>The output type of this table function is fixed as {@link RowData}.
  *
- * <p>This class provides built-in metrics for monitoring model inference performance, including:
+ * <p>This class provides built-in metrics for monitoring model inference performance under the
+ * {@code model_inference} metric group, including:
  *
  * <ul>
- *   <li>requests: Total number of inference requests
- *   <li>requests_success: Number of successful inference requests
- *   <li>requests_failure: Number of failed inference requests
- *   <li>latency: Histogram of inference latency in milliseconds
- *   <li>rows_output: Total number of output rows from inference
+ *   <li>{@code requests}: Total number of inference requests.
+ *   <li>{@code requests_success}: Number of successful inference requests.
+ *   <li>{@code requests_failure}: Number of failed inference requests.
+ *   <li>{@code latency}: Histogram of inference latency in milliseconds. <b>Only registered when a
+ *       subclass overrides {@link #createLatencyHistogram(MetricGroup)} to return a non-null {@link
+ *       Histogram};</b> the default implementation disables latency tracking. The histogram records
+ *       both successful and failed requests.
+ *   <li>{@code rows_output}: Total number of output rows. A {@code null} result is treated as a
+ *       successful request with zero rows.
  * </ul>
+ *
+ * <p>The request-counting invariant {@code requests == requests_success + requests_failure} is
+ * preserved regardless of whether the user {@link #asyncPredict} implementation signals failure by
+ * throwing synchronously, returning a {@code null} future, or returning a future that completes
+ * exceptionally.
  */
 @PublicEvolving
 public abstract class AsyncPredictFunction extends AsyncTableFunction<RowData> {
@@ -59,8 +71,12 @@ public abstract class AsyncPredictFunction extends AsyncTableFunction<RowData> {
      * Create a histogram for tracking inference latency. Subclasses can override this method to
      * provide a custom histogram implementation.
      *
-     * @param metricGroup The metric group to register the histogram
-     * @return A Histogram instance, or null to disable latency tracking
+     * <p>The default implementation returns {@code null}, which disables the {@code latency}
+     * metric. Subclasses that want latency tracking should register a histogram on the given {@code
+     * metricGroup} (for example, a {@code DropwizardHistogramWrapper}) and return it.
+     *
+     * @param metricGroup The metric group to register the histogram on.
+     * @return A Histogram instance, or {@code null} to disable latency tracking.
      */
     protected Histogram createLatencyHistogram(MetricGroup metricGroup) {
         return null;
@@ -72,55 +88,85 @@ public abstract class AsyncPredictFunction extends AsyncTableFunction<RowData> {
      * <p>Subclasses must implement this method to perform the actual inference logic.
      *
      * @param inputRow - A {@link RowData} that wraps input for predict function.
-     * @return A collection of all predicted results.
+     * @return A collection of all predicted results. Returning a future that completes with {@code
+     *     null} is permitted and is treated as a successful request with no output rows.
      */
     public abstract CompletableFuture<Collection<RowData>> asyncPredict(RowData inputRow);
 
     /**
-     * Wrapper method that tracks metrics around asyncPredict calls.
-     *
-     * <p>This method automatically tracks inference metrics including request count,
-     * success/failure count, latency, and output row count.
-     *
-     * @param inputRow The input row data
-     * @return A CompletableFuture containing the prediction results
+     * Invokes {@link #asyncPredict} with metrics tracking, tolerating both synchronous failures
+     * (thrown exceptions) and asynchronous failures (exceptionally completed futures). The returned
+     * future is guaranteed to drive exactly one of the {@code requests_success} / {@code
+     * requests_failure} counters.
      */
-    protected final CompletableFuture<Collection<RowData>> asyncPredictWithMetrics(
-            RowData inputRow) {
+    private CompletableFuture<Collection<RowData>> asyncPredictWithMetrics(RowData inputRow) {
         metrics.incRequests();
         final long startTime = System.currentTimeMillis();
 
-        return asyncPredict(inputRow)
-                .whenComplete(
-                        (result, exception) -> {
-                            metrics.recordLatency(startTime);
-                            if (exception != null) {
-                                metrics.incRequestsFailure();
-                            } else {
-                                metrics.incRequestsSuccess();
-                                if (result != null) {
-                                    metrics.incRowsOutput(result.size());
-                                }
-                            }
-                        });
+        CompletableFuture<Collection<RowData>> predictFuture;
+        try {
+            predictFuture = asyncPredict(inputRow);
+            if (predictFuture == null) {
+                throw new NullPointerException(
+                        "asyncPredict(...) returned a null CompletableFuture; "
+                                + "implementations must always return a non-null future.");
+            }
+        } catch (Throwable t) {
+            metrics.recordLatency(startTime);
+            metrics.incRequestsFailure();
+            CompletableFuture<Collection<RowData>> failed = new CompletableFuture<>();
+            failed.completeExceptionally(t);
+            return failed;
+        }
+
+        return predictFuture.whenComplete(
+                (result, exception) -> {
+                    metrics.recordLatency(startTime);
+                    if (exception != null) {
+                        metrics.incRequestsFailure();
+                    } else {
+                        metrics.incRequestsSuccess();
+                        if (result != null) {
+                            metrics.incRowsOutput(result.size());
+                        }
+                    }
+                });
     }
 
     /** Invokes {@link #asyncPredict} with metrics tracking and chains futures. */
     public void eval(CompletableFuture<Collection<RowData>> future, Object... args) {
+        Preconditions.checkState(
+                metrics != null,
+                "open(FunctionContext) must be invoked before eval(...). "
+                        + "If you override open(), make sure to call super.open(context).");
+
         GenericRowData argsData = GenericRowData.of(args);
         asyncPredictWithMetrics(argsData)
                 .whenComplete(
                         (result, exception) -> {
                             if (exception != null) {
+                                // Do not embed the raw input row in the exception message to avoid
+                                // leaking potentially sensitive payloads into logs. Emit only the
+                                // arity; the original cause is chained for debugging.
                                 future.completeExceptionally(
-                                        new TableException(
+                                        new FlinkRuntimeException(
                                                 String.format(
-                                                        "Failed to execute asynchronously prediction with input row %s.",
-                                                        argsData),
+                                                        "Failed to execute asynchronous prediction (input arity=%d).",
+                                                        argsData.getArity()),
                                                 exception));
                                 return;
                             }
                             future.complete(result);
                         });
+    }
+
+    @VisibleForTesting
+    PredictFunctionMetrics getMetrics() {
+        return metrics;
+    }
+
+    @VisibleForTesting
+    CompletableFuture<Collection<RowData>> asyncPredictWithMetricsForTesting(RowData inputRow) {
+        return asyncPredictWithMetrics(inputRow);
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/PredictFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/PredictFunction.java
@@ -19,6 +19,9 @@
 package org.apache.flink.table.functions;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Histogram;
+import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.util.FlinkRuntimeException;
@@ -29,28 +32,159 @@ import java.util.Collection;
  * A wrapper class of {@link TableFunction} for synchronous model inference.
  *
  * <p>The output type of this table function is fixed as {@link RowData}.
+ *
+ * <p>This class provides built-in metrics for monitoring model inference performance, including:
+ *
+ * <ul>
+ *   <li>inference_requests: Total number of inference requests
+ *   <li>inference_requests_success: Number of successful inference requests
+ *   <li>inference_requests_failure: Number of failed inference requests
+ *   <li>inference_latency: Histogram of inference latency in milliseconds
+ *   <li>inference_rows_output: Total number of output rows from inference
+ * </ul>
  */
 @PublicEvolving
 public abstract class PredictFunction extends TableFunction<RowData> {
 
+    // ------------------------------------------------------------------------
+    // Metrics
+    // ------------------------------------------------------------------------
+
+    /** Counter for total inference requests. */
+    private transient Counter inferenceRequests;
+
+    /** Counter for successful inference requests. */
+    private transient Counter inferenceRequestsSuccess;
+
+    /** Counter for failed inference requests. */
+    private transient Counter inferenceRequestsFailure;
+
+    /** Histogram for inference latency in milliseconds. */
+    private transient Histogram inferenceLatency;
+
+    /** Counter for total output rows from inference. */
+    private transient Counter inferenceRowsOutput;
+
+    // ------------------------------------------------------------------------
+    // Lifecycle Methods
+    // ------------------------------------------------------------------------
+
+    @Override
+    public void open(FunctionContext context) throws Exception {
+        super.open(context);
+        initializeMetrics(context);
+    }
+
+    /**
+     * Initialize metrics for monitoring model inference performance.
+     *
+     * <p>This method creates a metric group named "model_inference" and registers the following
+     * metrics:
+     *
+     * <ul>
+     *   <li>requests: Counter for total inference requests
+     *   <li>requests_success: Counter for successful inference requests
+     *   <li>requests_failure: Counter for failed inference requests
+     *   <li>latency: Histogram for inference latency (milliseconds)
+     *   <li>rows_output: Counter for total output rows
+     * </ul>
+     *
+     * <p>Subclasses can override {@link #createLatencyHistogram(MetricGroup)} to provide a custom
+     * histogram implementation.
+     *
+     * @param context The function context
+     */
+    protected void initializeMetrics(FunctionContext context) {
+        MetricGroup metricGroup = context.getMetricGroup().addGroup("model_inference");
+
+        inferenceRequests = metricGroup.counter("requests");
+        inferenceRequestsSuccess = metricGroup.counter("requests_success");
+        inferenceRequestsFailure = metricGroup.counter("requests_failure");
+        inferenceLatency = createLatencyHistogram(metricGroup);
+        inferenceRowsOutput = metricGroup.counter("rows_output");
+    }
+
+    /**
+     * Create a histogram for tracking inference latency. Subclasses can override this method to
+     * provide a custom histogram implementation.
+     *
+     * @param metricGroup The metric group to register the histogram
+     * @return A Histogram instance, or null to disable latency tracking
+     */
+    protected Histogram createLatencyHistogram(MetricGroup metricGroup) {
+        // Default: no histogram (return null)
+        // Subclasses can override to provide implementation
+        return null;
+    }
+
+    // ------------------------------------------------------------------------
+    // Prediction Methods
+    // ------------------------------------------------------------------------
+
     /**
      * Synchronously predict result based on input row.
+     *
+     * <p>Subclasses must implement this method to perform the actual inference logic.
      *
      * @param inputRow - A {@link RowData} that wraps input for predict function.
      * @return A collection of predicted results.
      */
     public abstract Collection<RowData> predict(RowData inputRow);
 
-    /** Invoke {@link #predict} and handle exceptions. */
+    /**
+     * Records the inference latency metric.
+     *
+     * @param startTime The start time of the inference request in milliseconds
+     */
+    protected final void recordLatency(long startTime) {
+        if (inferenceLatency != null) {
+            long latency = System.currentTimeMillis() - startTime;
+            inferenceLatency.update(latency);
+        }
+    }
+
+    // ------------------------------------------------------------------------
+    // Table Function Evaluation
+    // ------------------------------------------------------------------------
+
+    /** Invoke {@link #predict} with metrics tracking and handle exceptions. */
     public final void eval(Object... args) {
         GenericRowData argsData = GenericRowData.of(args);
+
+        // Increment request counter
+        if (inferenceRequests != null) {
+            inferenceRequests.inc();
+        }
+
+        // Record start time
+        long startTime = System.currentTimeMillis();
+
         try {
             Collection<RowData> results = predict(argsData);
+
+            // Record success metrics
+            recordLatency(startTime);
+            if (inferenceRequestsSuccess != null) {
+                inferenceRequestsSuccess.inc();
+            }
+
             if (results == null) {
                 return;
             }
+
+            // Record output rows
+            if (inferenceRowsOutput != null) {
+                inferenceRowsOutput.inc(results.size());
+            }
+
             results.forEach(this::collect);
         } catch (Exception e) {
+            // Record failure metrics
+            recordLatency(startTime);
+            if (inferenceRequestsFailure != null) {
+                inferenceRequestsFailure.inc();
+            }
+
             throw new FlinkRuntimeException(
                     String.format("Failed to execute prediction with input row %s.", argsData), e);
         }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/PredictFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/PredictFunction.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.functions;
 
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Histogram;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.table.data.GenericRowData;
@@ -36,72 +35,23 @@ import java.util.Collection;
  * <p>This class provides built-in metrics for monitoring model inference performance, including:
  *
  * <ul>
- *   <li>inference_requests: Total number of inference requests
- *   <li>inference_requests_success: Number of successful inference requests
- *   <li>inference_requests_failure: Number of failed inference requests
- *   <li>inference_latency: Histogram of inference latency in milliseconds
- *   <li>inference_rows_output: Total number of output rows from inference
+ *   <li>requests: Total number of inference requests
+ *   <li>requests_success: Number of successful inference requests
+ *   <li>requests_failure: Number of failed inference requests
+ *   <li>latency: Histogram of inference latency in milliseconds
+ *   <li>rows_output: Total number of output rows from inference
  * </ul>
  */
 @PublicEvolving
 public abstract class PredictFunction extends TableFunction<RowData> {
 
-    // ------------------------------------------------------------------------
-    // Metrics
-    // ------------------------------------------------------------------------
-
-    /** Counter for total inference requests. */
-    private transient Counter inferenceRequests;
-
-    /** Counter for successful inference requests. */
-    private transient Counter inferenceRequestsSuccess;
-
-    /** Counter for failed inference requests. */
-    private transient Counter inferenceRequestsFailure;
-
-    /** Histogram for inference latency in milliseconds. */
-    private transient Histogram inferenceLatency;
-
-    /** Counter for total output rows from inference. */
-    private transient Counter inferenceRowsOutput;
-
-    // ------------------------------------------------------------------------
-    // Lifecycle Methods
-    // ------------------------------------------------------------------------
+    private transient PredictFunctionMetrics metrics;
 
     @Override
     public void open(FunctionContext context) throws Exception {
         super.open(context);
-        initializeMetrics(context);
-    }
-
-    /**
-     * Initialize metrics for monitoring model inference performance.
-     *
-     * <p>This method creates a metric group named "model_inference" and registers the following
-     * metrics:
-     *
-     * <ul>
-     *   <li>requests: Counter for total inference requests
-     *   <li>requests_success: Counter for successful inference requests
-     *   <li>requests_failure: Counter for failed inference requests
-     *   <li>latency: Histogram for inference latency (milliseconds)
-     *   <li>rows_output: Counter for total output rows
-     * </ul>
-     *
-     * <p>Subclasses can override {@link #createLatencyHistogram(MetricGroup)} to provide a custom
-     * histogram implementation.
-     *
-     * @param context The function context
-     */
-    protected void initializeMetrics(FunctionContext context) {
         MetricGroup metricGroup = context.getMetricGroup().addGroup("model_inference");
-
-        inferenceRequests = metricGroup.counter("requests");
-        inferenceRequestsSuccess = metricGroup.counter("requests_success");
-        inferenceRequestsFailure = metricGroup.counter("requests_failure");
-        inferenceLatency = createLatencyHistogram(metricGroup);
-        inferenceRowsOutput = metricGroup.counter("rows_output");
+        metrics = new PredictFunctionMetrics(metricGroup, createLatencyHistogram(metricGroup));
     }
 
     /**
@@ -112,14 +62,8 @@ public abstract class PredictFunction extends TableFunction<RowData> {
      * @return A Histogram instance, or null to disable latency tracking
      */
     protected Histogram createLatencyHistogram(MetricGroup metricGroup) {
-        // Default: no histogram (return null)
-        // Subclasses can override to provide implementation
         return null;
     }
-
-    // ------------------------------------------------------------------------
-    // Prediction Methods
-    // ------------------------------------------------------------------------
 
     /**
      * Synchronously predict result based on input row.
@@ -131,60 +75,25 @@ public abstract class PredictFunction extends TableFunction<RowData> {
      */
     public abstract Collection<RowData> predict(RowData inputRow);
 
-    /**
-     * Records the inference latency metric.
-     *
-     * @param startTime The start time of the inference request in milliseconds
-     */
-    protected final void recordLatency(long startTime) {
-        if (inferenceLatency != null) {
-            long latency = System.currentTimeMillis() - startTime;
-            inferenceLatency.update(latency);
-        }
-    }
-
-    // ------------------------------------------------------------------------
-    // Table Function Evaluation
-    // ------------------------------------------------------------------------
-
     /** Invoke {@link #predict} with metrics tracking and handle exceptions. */
     public final void eval(Object... args) {
         GenericRowData argsData = GenericRowData.of(args);
-
-        // Increment request counter
-        if (inferenceRequests != null) {
-            inferenceRequests.inc();
-        }
-
-        // Record start time
+        metrics.incRequests();
         long startTime = System.currentTimeMillis();
 
         try {
             Collection<RowData> results = predict(argsData);
-
-            // Record success metrics
-            recordLatency(startTime);
-            if (inferenceRequestsSuccess != null) {
-                inferenceRequestsSuccess.inc();
-            }
+            metrics.recordLatency(startTime);
+            metrics.incRequestsSuccess();
 
             if (results == null) {
                 return;
             }
-
-            // Record output rows
-            if (inferenceRowsOutput != null) {
-                inferenceRowsOutput.inc(results.size());
-            }
-
+            metrics.incRowsOutput(results.size());
             results.forEach(this::collect);
         } catch (Exception e) {
-            // Record failure metrics
-            recordLatency(startTime);
-            if (inferenceRequestsFailure != null) {
-                inferenceRequestsFailure.inc();
-            }
-
+            metrics.recordLatency(startTime);
+            metrics.incRequestsFailure();
             throw new FlinkRuntimeException(
                     String.format("Failed to execute prediction with input row %s.", argsData), e);
         }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/PredictFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/PredictFunction.java
@@ -19,11 +19,13 @@
 package org.apache.flink.table.functions;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.metrics.Histogram;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.Preconditions;
 
 import java.util.Collection;
 
@@ -32,15 +34,24 @@ import java.util.Collection;
  *
  * <p>The output type of this table function is fixed as {@link RowData}.
  *
- * <p>This class provides built-in metrics for monitoring model inference performance, including:
+ * <p>This class provides built-in metrics for monitoring model inference performance under the
+ * {@code model_inference} metric group, including:
  *
  * <ul>
- *   <li>requests: Total number of inference requests
- *   <li>requests_success: Number of successful inference requests
- *   <li>requests_failure: Number of failed inference requests
- *   <li>latency: Histogram of inference latency in milliseconds
- *   <li>rows_output: Total number of output rows from inference
+ *   <li>{@code requests}: Total number of inference requests.
+ *   <li>{@code requests_success}: Number of successful inference requests.
+ *   <li>{@code requests_failure}: Number of failed inference requests.
+ *   <li>{@code latency}: Histogram of inference latency in milliseconds. <b>Only registered when a
+ *       subclass overrides {@link #createLatencyHistogram(MetricGroup)} to return a non-null {@link
+ *       Histogram};</b> the default implementation disables latency tracking. The histogram records
+ *       both successful and failed requests.
+ *   <li>{@code rows_output}: Total number of output rows. A {@code null} result is treated as a
+ *       successful request with zero rows.
  * </ul>
+ *
+ * <p>The request-counting invariant {@code requests == requests_success + requests_failure} is
+ * preserved even when the user {@link #predict} implementation throws an {@link Error} (such as
+ * {@link OutOfMemoryError}).
  */
 @PublicEvolving
 public abstract class PredictFunction extends TableFunction<RowData> {
@@ -58,8 +69,12 @@ public abstract class PredictFunction extends TableFunction<RowData> {
      * Create a histogram for tracking inference latency. Subclasses can override this method to
      * provide a custom histogram implementation.
      *
-     * @param metricGroup The metric group to register the histogram
-     * @return A Histogram instance, or null to disable latency tracking
+     * <p>The default implementation returns {@code null}, which disables the {@code latency}
+     * metric. Subclasses that want latency tracking should register a histogram on the given {@code
+     * metricGroup} (for example, a {@code DropwizardHistogramWrapper}) and return it.
+     *
+     * @param metricGroup The metric group to register the histogram on.
+     * @return A Histogram instance, or {@code null} to disable latency tracking.
      */
     protected Histogram createLatencyHistogram(MetricGroup metricGroup) {
         return null;
@@ -71,31 +86,56 @@ public abstract class PredictFunction extends TableFunction<RowData> {
      * <p>Subclasses must implement this method to perform the actual inference logic.
      *
      * @param inputRow - A {@link RowData} that wraps input for predict function.
-     * @return A collection of predicted results.
+     * @return A collection of predicted results. Returning {@code null} is permitted and is treated
+     *     as a successful request that produced no output.
      */
     public abstract Collection<RowData> predict(RowData inputRow);
 
     /** Invoke {@link #predict} with metrics tracking and handle exceptions. */
     public final void eval(Object... args) {
+        Preconditions.checkState(
+                metrics != null,
+                "open(FunctionContext) must be invoked before eval(...). "
+                        + "If you override open(), make sure to call super.open(context).");
+
         GenericRowData argsData = GenericRowData.of(args);
         metrics.incRequests();
         long startTime = System.currentTimeMillis();
 
+        Collection<RowData> results;
         try {
-            Collection<RowData> results = predict(argsData);
-            metrics.recordLatency(startTime);
-            metrics.incRequestsSuccess();
-
-            if (results == null) {
-                return;
-            }
-            metrics.incRowsOutput(results.size());
-            results.forEach(this::collect);
-        } catch (Exception e) {
+            results = predict(argsData);
+        } catch (Throwable t) {
             metrics.recordLatency(startTime);
             metrics.incRequestsFailure();
-            throw new FlinkRuntimeException(
-                    String.format("Failed to execute prediction with input row %s.", argsData), e);
+            // Do not embed the raw input row in the exception message to avoid leaking
+            // potentially sensitive payloads (PII, binary tensors, etc.) into logs. Emit the
+            // arity only; the original cause is still chained for debugging.
+            FlinkRuntimeException wrapped =
+                    new FlinkRuntimeException(
+                            String.format(
+                                    "Failed to execute prediction (input arity=%d).",
+                                    argsData.getArity()),
+                            t);
+            if (t instanceof Error) {
+                // Surface JVM-level errors without wrapping so callers can observe them as-is.
+                throw (Error) t;
+            }
+            throw wrapped;
         }
+
+        metrics.recordLatency(startTime);
+        metrics.incRequestsSuccess();
+
+        if (results == null) {
+            return;
+        }
+        metrics.incRowsOutput(results.size());
+        results.forEach(this::collect);
+    }
+
+    @VisibleForTesting
+    PredictFunctionMetrics getMetrics() {
+        return metrics;
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/PredictFunctionMetrics.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/PredictFunctionMetrics.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Histogram;
+import org.apache.flink.metrics.MetricGroup;
+
+/**
+ * Encapsulates the built-in metrics for {@link PredictFunction} and {@link AsyncPredictFunction}.
+ *
+ * <p>Registered metrics:
+ *
+ * <ul>
+ *   <li>requests: Total number of inference requests
+ *   <li>requests_success: Number of successful inference requests
+ *   <li>requests_failure: Number of failed inference requests
+ *   <li>latency: Histogram of inference latency in milliseconds (optional)
+ *   <li>rows_output: Total number of output rows from inference
+ * </ul>
+ */
+@Internal
+public class PredictFunctionMetrics {
+
+    private final Counter requests;
+    private final Counter requestsSuccess;
+    private final Counter requestsFailure;
+    private final Histogram latency;
+    private final Counter rowsOutput;
+
+    public PredictFunctionMetrics(MetricGroup metricGroup, Histogram latencyHistogram) {
+        requests = metricGroup.counter("requests");
+        requestsSuccess = metricGroup.counter("requests_success");
+        requestsFailure = metricGroup.counter("requests_failure");
+        latency = latencyHistogram;
+        rowsOutput = metricGroup.counter("rows_output");
+    }
+
+    public void incRequests() {
+        requests.inc();
+    }
+
+    public void incRequestsSuccess() {
+        requestsSuccess.inc();
+    }
+
+    public void incRequestsFailure() {
+        requestsFailure.inc();
+    }
+
+    public void incRowsOutput(long count) {
+        rowsOutput.inc(count);
+    }
+
+    public void recordLatency(long startTime) {
+        if (latency != null) {
+            latency.update(System.currentTimeMillis() - startTime);
+        }
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/PredictFunctionMetrics.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/PredictFunctionMetrics.java
@@ -22,18 +22,28 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Histogram;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
 
 /**
  * Encapsulates the built-in metrics for {@link PredictFunction} and {@link AsyncPredictFunction}.
  *
- * <p>Registered metrics:
+ * <p>Registered metrics (all counters; latency is optional):
  *
  * <ul>
- *   <li>requests: Total number of inference requests
- *   <li>requests_success: Number of successful inference requests
- *   <li>requests_failure: Number of failed inference requests
- *   <li>latency: Histogram of inference latency in milliseconds (optional)
- *   <li>rows_output: Total number of output rows from inference
+ *   <li>{@code requests}: Total number of inference requests.
+ *   <li>{@code requests_success}: Number of successful inference requests.
+ *   <li>{@code requests_failure}: Number of failed inference requests. Together with {@code
+ *       requests_success} this sums to {@code requests} regardless of whether the failure was
+ *       signalled via a thrown {@link Throwable} or an exceptionally completed future.
+ *   <li>{@code latency}: Histogram of inference latency in milliseconds. Only registered when the
+ *       owning function returns a non-null {@link Histogram} from {@code createLatencyHistogram}.
+ *       The histogram records <b>both</b> successful and failed requests; callers that need to
+ *       separate the two should register their own histograms.
+ *   <li>{@code rows_output}: Total number of output rows emitted by successful inference requests.
+ *       A {@code null} result from a user {@code predict}/{@code asyncPredict} call is treated as a
+ *       successful request with zero output rows.
  * </ul>
  */
 @Internal
@@ -42,15 +52,16 @@ public class PredictFunctionMetrics {
     private final Counter requests;
     private final Counter requestsSuccess;
     private final Counter requestsFailure;
-    private final Histogram latency;
+    @Nullable private final Histogram latency;
     private final Counter rowsOutput;
 
-    public PredictFunctionMetrics(MetricGroup metricGroup, Histogram latencyHistogram) {
-        requests = metricGroup.counter("requests");
-        requestsSuccess = metricGroup.counter("requests_success");
-        requestsFailure = metricGroup.counter("requests_failure");
-        latency = latencyHistogram;
-        rowsOutput = metricGroup.counter("rows_output");
+    public PredictFunctionMetrics(MetricGroup metricGroup, @Nullable Histogram latencyHistogram) {
+        Preconditions.checkNotNull(metricGroup, "metricGroup must not be null");
+        this.requests = metricGroup.counter("requests");
+        this.requestsSuccess = metricGroup.counter("requests_success");
+        this.requestsFailure = metricGroup.counter("requests_failure");
+        this.latency = latencyHistogram;
+        this.rowsOutput = metricGroup.counter("rows_output");
     }
 
     public void incRequests() {
@@ -69,9 +80,38 @@ public class PredictFunctionMetrics {
         rowsOutput.inc(count);
     }
 
+    /**
+     * Records the elapsed time since {@code startTime} (in milliseconds) into the latency
+     * histogram, if one was provided. No-op otherwise.
+     */
     public void recordLatency(long startTime) {
         if (latency != null) {
             latency.update(System.currentTimeMillis() - startTime);
         }
+    }
+
+    // ------------------------------------------------------------------------
+    // Package-private accessors for testing.
+    // ------------------------------------------------------------------------
+
+    Counter getRequests() {
+        return requests;
+    }
+
+    Counter getRequestsSuccess() {
+        return requestsSuccess;
+    }
+
+    Counter getRequestsFailure() {
+        return requestsFailure;
+    }
+
+    Counter getRowsOutput() {
+        return rowsOutput;
+    }
+
+    @Nullable
+    Histogram getLatency() {
+        return latency;
     }
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/functions/AsyncPredictFunctionTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/functions/AsyncPredictFunctionTest.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions;
+
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link AsyncPredictFunction}. */
+class AsyncPredictFunctionTest {
+
+    @Test
+    void testSuccessfulAsyncPrediction() throws Exception {
+        TestAsyncPredictFunction function = new TestAsyncPredictFunction(Mode.SUCCESS);
+        function.open(new FunctionContext(null));
+
+        CompletableFuture<Collection<RowData>> out = new CompletableFuture<>();
+        function.eval(out, "input", 1);
+
+        Collection<RowData> result = out.get();
+        assertThat(result).hasSize(2);
+
+        PredictFunctionMetrics metrics = function.getMetrics();
+        assertThat(metrics.getRequests().getCount()).isEqualTo(1L);
+        assertThat(metrics.getRequestsSuccess().getCount()).isEqualTo(1L);
+        assertThat(metrics.getRequestsFailure().getCount()).isZero();
+        assertThat(metrics.getRowsOutput().getCount()).isEqualTo(2L);
+    }
+
+    @Test
+    void testAsyncPredictReturnsExceptionallyCompletedFuture() throws Exception {
+        TestAsyncPredictFunction function = new TestAsyncPredictFunction(Mode.FAIL_ASYNC);
+        function.open(new FunctionContext(null));
+
+        // Use a distinctive payload so we can assert it is NOT leaked into the exception message.
+        String sensitivePayload = "SECRET_TOKEN_XYZ789";
+        CompletableFuture<Collection<RowData>> out = new CompletableFuture<>();
+        function.eval(out, sensitivePayload, 42);
+
+        assertThatThrownBy(out::get)
+                .isInstanceOf(ExecutionException.class)
+                .hasCauseInstanceOf(FlinkRuntimeException.class)
+                .hasMessageContaining("Failed to execute asynchronous prediction")
+                .hasMessageContaining("arity=2")
+                // Input payload must NOT be leaked into the exception message.
+                .hasMessageNotContaining(sensitivePayload)
+                .hasMessageNotContaining("42");
+
+        PredictFunctionMetrics metrics = function.getMetrics();
+        assertThat(metrics.getRequests().getCount()).isEqualTo(1L);
+        assertThat(metrics.getRequestsSuccess().getCount()).isZero();
+        assertThat(metrics.getRequestsFailure().getCount()).isEqualTo(1L);
+        assertThat(metrics.getRowsOutput().getCount()).isZero();
+    }
+
+    @Test
+    void testAsyncPredictThrowsSynchronously() throws Exception {
+        // A misbehaving subclass that throws before producing a future must still preserve
+        // the request-accounting invariant (requests == success + failure).
+        TestAsyncPredictFunction function = new TestAsyncPredictFunction(Mode.FAIL_SYNC);
+        function.open(new FunctionContext(null));
+
+        CompletableFuture<Collection<RowData>> out = new CompletableFuture<>();
+        function.eval(out, "input", 1);
+
+        assertThatThrownBy(out::get)
+                .isInstanceOf(ExecutionException.class)
+                .hasCauseInstanceOf(FlinkRuntimeException.class);
+
+        PredictFunctionMetrics metrics = function.getMetrics();
+        assertThat(metrics.getRequests().getCount()).isEqualTo(1L);
+        assertThat(metrics.getRequestsSuccess().getCount()).isZero();
+        assertThat(metrics.getRequestsFailure().getCount()).isEqualTo(1L);
+    }
+
+    @Test
+    void testAsyncPredictReturnsNullFuture() throws Exception {
+        // A misbehaving subclass that returns a null CompletableFuture must be treated as a
+        // failure, not as an NPE that escapes the metrics wrapper.
+        TestAsyncPredictFunction function = new TestAsyncPredictFunction(Mode.RETURN_NULL_FUTURE);
+        function.open(new FunctionContext(null));
+
+        CompletableFuture<Collection<RowData>> out = new CompletableFuture<>();
+        function.eval(out, "input", 1);
+
+        assertThatThrownBy(out::get)
+                .isInstanceOf(ExecutionException.class)
+                .hasCauseInstanceOf(FlinkRuntimeException.class);
+
+        PredictFunctionMetrics metrics = function.getMetrics();
+        assertThat(metrics.getRequests().getCount()).isEqualTo(1L);
+        assertThat(metrics.getRequestsFailure().getCount()).isEqualTo(1L);
+    }
+
+    @Test
+    void testAsyncPredictReturnsFutureCompletedWithNullCollection() throws Exception {
+        // Future completes normally with null - treat as success with zero rows.
+        TestAsyncPredictFunction function = new TestAsyncPredictFunction(Mode.SUCCESS_NULL_RESULT);
+        function.open(new FunctionContext(null));
+
+        CompletableFuture<Collection<RowData>> out = new CompletableFuture<>();
+        function.eval(out, "input", 1);
+        assertThat(out.get()).isNull();
+
+        PredictFunctionMetrics metrics = function.getMetrics();
+        assertThat(metrics.getRequests().getCount()).isEqualTo(1L);
+        assertThat(metrics.getRequestsSuccess().getCount()).isEqualTo(1L);
+        assertThat(metrics.getRequestsFailure().getCount()).isZero();
+        assertThat(metrics.getRowsOutput().getCount()).isZero();
+    }
+
+    @Test
+    void testAsyncPredictReturnsEmptyCollection() throws Exception {
+        TestAsyncPredictFunction function = new TestAsyncPredictFunction(Mode.SUCCESS_EMPTY);
+        function.open(new FunctionContext(null));
+
+        CompletableFuture<Collection<RowData>> out = new CompletableFuture<>();
+        function.eval(out, "input", 1);
+        assertThat(out.get()).isEmpty();
+
+        PredictFunctionMetrics metrics = function.getMetrics();
+        assertThat(metrics.getRequests().getCount()).isEqualTo(1L);
+        assertThat(metrics.getRequestsSuccess().getCount()).isEqualTo(1L);
+        assertThat(metrics.getRequestsFailure().getCount()).isZero();
+        assertThat(metrics.getRowsOutput().getCount()).isZero();
+    }
+
+    @Test
+    void testRequestInvariantAcrossManyCalls() throws Exception {
+        // Mixed workload: every other call fails asynchronously.
+        TestAsyncPredictFunction function = new TestAsyncPredictFunction(Mode.SUCCESS);
+        function.open(new FunctionContext(null));
+
+        int total = 10;
+        for (int i = 0; i < total; i++) {
+            function.setNextMode(i % 2 == 0 ? Mode.SUCCESS : Mode.FAIL_ASYNC);
+            CompletableFuture<Collection<RowData>> out = new CompletableFuture<>();
+            function.eval(out, "input", i);
+            // drain
+            out.whenComplete((r, t) -> {});
+            try {
+                out.get();
+            } catch (ExecutionException ignored) {
+                // expected for the failure branch
+            }
+        }
+
+        PredictFunctionMetrics metrics = function.getMetrics();
+        long requests = metrics.getRequests().getCount();
+        long success = metrics.getRequestsSuccess().getCount();
+        long failure = metrics.getRequestsFailure().getCount();
+        assertThat(requests).isEqualTo(total);
+        assertThat(success + failure).isEqualTo(requests);
+        assertThat(success).isEqualTo(5L);
+        assertThat(failure).isEqualTo(5L);
+    }
+
+    @Test
+    void testEvalBeforeOpenThrowsIllegalState() {
+        TestAsyncPredictFunction function = new TestAsyncPredictFunction(Mode.SUCCESS);
+        CompletableFuture<Collection<RowData>> out = new CompletableFuture<>();
+        assertThatThrownBy(() -> function.eval(out, "input", 1))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("open(FunctionContext) must be invoked before eval");
+    }
+
+    // ------------------------------------------------------------------------
+    // Test Implementations
+    // ------------------------------------------------------------------------
+
+    private enum Mode {
+        SUCCESS,
+        SUCCESS_EMPTY,
+        SUCCESS_NULL_RESULT,
+        FAIL_ASYNC,
+        FAIL_SYNC,
+        RETURN_NULL_FUTURE
+    }
+
+    private static class TestAsyncPredictFunction extends AsyncPredictFunction {
+        private volatile Mode mode;
+
+        TestAsyncPredictFunction(Mode mode) {
+            this.mode = mode;
+        }
+
+        void setNextMode(Mode mode) {
+            this.mode = mode;
+        }
+
+        @Override
+        public CompletableFuture<Collection<RowData>> asyncPredict(RowData inputRow) {
+            switch (mode) {
+                case SUCCESS:
+                    RowData r1 =
+                            GenericRowData.of(
+                                    StringData.fromString("prediction1"), inputRow.getInt(1));
+                    RowData r2 =
+                            GenericRowData.of(
+                                    StringData.fromString("prediction2"), inputRow.getInt(1) * 2);
+                    return CompletableFuture.completedFuture(Arrays.asList(r1, r2));
+                case SUCCESS_EMPTY:
+                    return CompletableFuture.completedFuture(Collections.emptyList());
+                case SUCCESS_NULL_RESULT:
+                    return CompletableFuture.completedFuture(null);
+                case FAIL_ASYNC:
+                    CompletableFuture<Collection<RowData>> failed = new CompletableFuture<>();
+                    failed.completeExceptionally(new RuntimeException("simulated async failure"));
+                    return failed;
+                case FAIL_SYNC:
+                    throw new RuntimeException("simulated synchronous failure");
+                case RETURN_NULL_FUTURE:
+                    return null;
+                default:
+                    throw new IllegalStateException("unknown mode: " + mode);
+            }
+        }
+    }
+}

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/functions/PredictFunctionTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/functions/PredictFunctionTest.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions;
+
+import org.apache.flink.metrics.Histogram;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link PredictFunction}. */
+class PredictFunctionTest {
+
+    private TestPredictFunction predictFunction;
+    private TestCollector testCollector;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        predictFunction = new TestPredictFunction();
+        testCollector = new TestCollector();
+        predictFunction.open(new FunctionContext(null));
+        predictFunction.setCollector(testCollector);
+    }
+
+    @Test
+    void testBasicPrediction() {
+        // Test successful prediction
+        predictFunction.eval("input1", 42);
+
+        assertThat(testCollector.getCollectedResults()).hasSize(2);
+        assertThat(testCollector.getCollectedResults().get(0).getArity()).isEqualTo(2);
+    }
+
+    @Test
+    void testMultiplePredictions() {
+        // Test multiple predictions work correctly
+        predictFunction.eval("input1", 1);
+        predictFunction.eval("input2", 2);
+
+        // Each prediction returns 2 results
+        assertThat(testCollector.getCollectedResults()).hasSize(4);
+    }
+
+    @Test
+    void testFailureHandling() throws Exception {
+        TestPredictFunction failingFunction = new TestPredictFunction(true);
+        TestCollector failCollector = new TestCollector();
+        failingFunction.open(new FunctionContext(null));
+        failingFunction.setCollector(failCollector);
+
+        assertThatThrownBy(() -> failingFunction.eval("input", 1))
+                .isInstanceOf(FlinkRuntimeException.class)
+                .hasMessageContaining("Failed to execute prediction");
+    }
+
+    @Test
+    void testNullResults() throws Exception {
+        TestPredictFunction nullResultFunction = new TestPredictFunction(false, true);
+        TestCollector nullCollector = new TestCollector();
+        nullResultFunction.open(new FunctionContext(null));
+        nullResultFunction.setCollector(nullCollector);
+
+        nullResultFunction.eval("input", 1);
+        assertThat(nullCollector.getCollectedResults()).isEmpty();
+    }
+
+    @Test
+    void testEmptyResults() throws Exception {
+        TestPredictFunction emptyResultFunction = new TestPredictFunction(false, false, true);
+        TestCollector emptyCollector = new TestCollector();
+        emptyResultFunction.open(new FunctionContext(null));
+        emptyResultFunction.setCollector(emptyCollector);
+
+        emptyResultFunction.eval("input", 1);
+        assertThat(emptyCollector.getCollectedResults()).isEmpty();
+    }
+
+    @Test
+    void testCustomHistogram() throws Exception {
+        TestPredictFunctionWithHistogram functionWithHistogram =
+                new TestPredictFunctionWithHistogram();
+        TestCollector histCollector = new TestCollector();
+        functionWithHistogram.open(new FunctionContext(null));
+        functionWithHistogram.setCollector(histCollector);
+
+        functionWithHistogram.eval("input", 1);
+        assertThat(histCollector.getCollectedResults()).hasSize(2);
+    }
+
+    // ------------------------------------------------------------------------
+    // Test Implementations
+    // ------------------------------------------------------------------------
+
+    /** Test collector for capturing output. */
+    private static class TestCollector implements Collector<RowData> {
+        private final List<RowData> collectedResults = new ArrayList<>();
+
+        @Override
+        public void collect(RowData record) {
+            collectedResults.add(record);
+        }
+
+        @Override
+        public void close() {}
+
+        List<RowData> getCollectedResults() {
+            return collectedResults;
+        }
+    }
+
+    /** Testing implementation of {@link PredictFunction}. */
+    private static class TestPredictFunction extends PredictFunction {
+        private final boolean shouldFail;
+        private final boolean returnNull;
+        private final boolean returnEmpty;
+
+        TestPredictFunction() {
+            this(false, false, false);
+        }
+
+        TestPredictFunction(boolean shouldFail) {
+            this(shouldFail, false, false);
+        }
+
+        TestPredictFunction(boolean shouldFail, boolean returnNull) {
+            this(shouldFail, returnNull, false);
+        }
+
+        TestPredictFunction(boolean shouldFail, boolean returnNull, boolean returnEmpty) {
+            this.shouldFail = shouldFail;
+            this.returnNull = returnNull;
+            this.returnEmpty = returnEmpty;
+        }
+
+        @Override
+        public Collection<RowData> predict(RowData inputRow) {
+            if (shouldFail) {
+                throw new RuntimeException("Simulated prediction failure");
+            }
+
+            if (returnNull) {
+                return null;
+            }
+
+            if (returnEmpty) {
+                return Collections.emptyList();
+            }
+
+            // Return two rows as prediction results
+            RowData result1 =
+                    GenericRowData.of(StringData.fromString("prediction1"), inputRow.getInt(1));
+            RowData result2 =
+                    GenericRowData.of(StringData.fromString("prediction2"), inputRow.getInt(1) * 2);
+
+            return Arrays.asList(result1, result2);
+        }
+    }
+
+    /** Testing implementation of {@link PredictFunction} with custom histogram. */
+    private static class TestPredictFunctionWithHistogram extends TestPredictFunction {
+        @Override
+        protected Histogram createLatencyHistogram(MetricGroup metricGroup) {
+            // Return a simple test histogram
+            return metricGroup.histogram("latency", new TestHistogram());
+        }
+    }
+
+    /** Testing implementation of {@link Histogram}. */
+    private static class TestHistogram implements Histogram {
+        private long count = 0;
+
+        @Override
+        public void update(long value) {
+            count++;
+        }
+
+        @Override
+        public long getCount() {
+            return count;
+        }
+
+        @Override
+        public org.apache.flink.metrics.HistogramStatistics getStatistics() {
+            return null;
+        }
+    }
+}

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/functions/PredictFunctionTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/functions/PredictFunctionTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.functions;
 
 import org.apache.flink.metrics.Histogram;
+import org.apache.flink.metrics.HistogramStatistics;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
@@ -54,21 +55,31 @@ class PredictFunctionTest {
 
     @Test
     void testBasicPrediction() {
-        // Test successful prediction
         predictFunction.eval("input1", 42);
 
         assertThat(testCollector.getCollectedResults()).hasSize(2);
         assertThat(testCollector.getCollectedResults().get(0).getArity()).isEqualTo(2);
+
+        PredictFunctionMetrics metrics = predictFunction.getMetrics();
+        assertThat(metrics.getRequests().getCount()).isEqualTo(1L);
+        assertThat(metrics.getRequestsSuccess().getCount()).isEqualTo(1L);
+        assertThat(metrics.getRequestsFailure().getCount()).isZero();
+        assertThat(metrics.getRowsOutput().getCount()).isEqualTo(2L);
     }
 
     @Test
     void testMultiplePredictions() {
-        // Test multiple predictions work correctly
         predictFunction.eval("input1", 1);
         predictFunction.eval("input2", 2);
 
         // Each prediction returns 2 results
         assertThat(testCollector.getCollectedResults()).hasSize(4);
+
+        PredictFunctionMetrics metrics = predictFunction.getMetrics();
+        assertThat(metrics.getRequests().getCount()).isEqualTo(2L);
+        assertThat(metrics.getRequestsSuccess().getCount()).isEqualTo(2L);
+        assertThat(metrics.getRequestsFailure().getCount()).isZero();
+        assertThat(metrics.getRowsOutput().getCount()).isEqualTo(4L);
     }
 
     @Test
@@ -78,9 +89,37 @@ class PredictFunctionTest {
         failingFunction.open(new FunctionContext(null));
         failingFunction.setCollector(failCollector);
 
-        assertThatThrownBy(() -> failingFunction.eval("input", 1))
+        // Use a distinctive payload so we can assert it is NOT leaked into the exception message.
+        String sensitivePayload = "SECRET_TOKEN_ABC123";
+        assertThatThrownBy(() -> failingFunction.eval(sensitivePayload, 42))
                 .isInstanceOf(FlinkRuntimeException.class)
-                .hasMessageContaining("Failed to execute prediction");
+                .hasMessageContaining("Failed to execute prediction")
+                .hasMessageContaining("arity=2")
+                // Input payload must NOT be leaked into the exception message.
+                .hasMessageNotContaining(sensitivePayload)
+                .hasMessageNotContaining("42");
+
+        PredictFunctionMetrics metrics = failingFunction.getMetrics();
+        assertThat(metrics.getRequests().getCount()).isEqualTo(1L);
+        assertThat(metrics.getRequestsSuccess().getCount()).isZero();
+        assertThat(metrics.getRequestsFailure().getCount()).isEqualTo(1L);
+        assertThat(metrics.getRowsOutput().getCount()).isZero();
+    }
+
+    @Test
+    void testErrorIsNotSwallowedAndStillCountsAsFailure() throws Exception {
+        ErrorThrowingPredictFunction function = new ErrorThrowingPredictFunction();
+        function.open(new FunctionContext(null));
+        function.setCollector(new TestCollector());
+
+        assertThatThrownBy(() -> function.eval("input", 1)).isInstanceOf(OutOfMemoryError.class);
+
+        // Even though the Error is re-thrown as-is, the request-accounting invariant
+        // (requests == success + failure) must hold.
+        PredictFunctionMetrics metrics = function.getMetrics();
+        assertThat(metrics.getRequests().getCount()).isEqualTo(1L);
+        assertThat(metrics.getRequestsSuccess().getCount()).isZero();
+        assertThat(metrics.getRequestsFailure().getCount()).isEqualTo(1L);
     }
 
     @Test
@@ -92,6 +131,13 @@ class PredictFunctionTest {
 
         nullResultFunction.eval("input", 1);
         assertThat(nullCollector.getCollectedResults()).isEmpty();
+
+        // null return is treated as a successful request with zero output rows.
+        PredictFunctionMetrics metrics = nullResultFunction.getMetrics();
+        assertThat(metrics.getRequests().getCount()).isEqualTo(1L);
+        assertThat(metrics.getRequestsSuccess().getCount()).isEqualTo(1L);
+        assertThat(metrics.getRequestsFailure().getCount()).isZero();
+        assertThat(metrics.getRowsOutput().getCount()).isZero();
     }
 
     @Test
@@ -103,18 +149,51 @@ class PredictFunctionTest {
 
         emptyResultFunction.eval("input", 1);
         assertThat(emptyCollector.getCollectedResults()).isEmpty();
+
+        PredictFunctionMetrics metrics = emptyResultFunction.getMetrics();
+        assertThat(metrics.getRequests().getCount()).isEqualTo(1L);
+        assertThat(metrics.getRequestsSuccess().getCount()).isEqualTo(1L);
+        assertThat(metrics.getRequestsFailure().getCount()).isZero();
+        assertThat(metrics.getRowsOutput().getCount()).isZero();
     }
 
     @Test
-    void testCustomHistogram() throws Exception {
-        TestPredictFunctionWithHistogram functionWithHistogram =
-                new TestPredictFunctionWithHistogram();
-        TestCollector histCollector = new TestCollector();
-        functionWithHistogram.open(new FunctionContext(null));
-        functionWithHistogram.setCollector(histCollector);
+    void testCustomHistogramIsInvokedOnBothSuccessAndFailure() throws Exception {
+        TestHistogram successHistogram = new TestHistogram();
+        TestPredictFunctionWithHistogram successFunction =
+                new TestPredictFunctionWithHistogram(successHistogram, false);
+        successFunction.open(new FunctionContext(null));
+        successFunction.setCollector(new TestCollector());
+        successFunction.eval("input", 1);
+        assertThat(successHistogram.getCount()).isEqualTo(1L);
 
-        functionWithHistogram.eval("input", 1);
-        assertThat(histCollector.getCollectedResults()).hasSize(2);
+        TestHistogram failureHistogram = new TestHistogram();
+        TestPredictFunctionWithHistogram failingFunction =
+                new TestPredictFunctionWithHistogram(failureHistogram, true);
+        failingFunction.open(new FunctionContext(null));
+        failingFunction.setCollector(new TestCollector());
+        assertThatThrownBy(() -> failingFunction.eval("input", 1))
+                .isInstanceOf(FlinkRuntimeException.class);
+        assertThat(failureHistogram.getCount()).isEqualTo(1L);
+    }
+
+    @Test
+    void testDefaultLatencyHistogramIsDisabled() throws Exception {
+        // Default createLatencyHistogram returns null; recordLatency() must be a no-op and not
+        // throw. The base test function exercises the success path already.
+        assertThat(predictFunction.getMetrics().getLatency()).isNull();
+        predictFunction.eval("input1", 1);
+        // Sanity check: still succeeds.
+        assertThat(predictFunction.getMetrics().getRequestsSuccess().getCount()).isEqualTo(1L);
+    }
+
+    @Test
+    void testEvalBeforeOpenThrowsIllegalState() {
+        TestPredictFunction unopened = new TestPredictFunction();
+        unopened.setCollector(new TestCollector());
+        assertThatThrownBy(() -> unopened.eval("input", 1))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("open(FunctionContext) must be invoked before eval");
     }
 
     // ------------------------------------------------------------------------
@@ -167,35 +246,44 @@ class PredictFunctionTest {
             if (shouldFail) {
                 throw new RuntimeException("Simulated prediction failure");
             }
-
             if (returnNull) {
                 return null;
             }
-
             if (returnEmpty) {
                 return Collections.emptyList();
             }
-
-            // Return two rows as prediction results
             RowData result1 =
                     GenericRowData.of(StringData.fromString("prediction1"), inputRow.getInt(1));
             RowData result2 =
                     GenericRowData.of(StringData.fromString("prediction2"), inputRow.getInt(1) * 2);
-
             return Arrays.asList(result1, result2);
         }
     }
 
-    /** Testing implementation of {@link PredictFunction} with custom histogram. */
-    private static class TestPredictFunctionWithHistogram extends TestPredictFunction {
+    /** Throws an {@link Error} (not an {@link Exception}) to verify the failure counter path. */
+    private static class ErrorThrowingPredictFunction extends PredictFunction {
         @Override
-        protected Histogram createLatencyHistogram(MetricGroup metricGroup) {
-            // Return a simple test histogram
-            return metricGroup.histogram("latency", new TestHistogram());
+        public Collection<RowData> predict(RowData inputRow) {
+            throw new OutOfMemoryError("simulated OOM");
         }
     }
 
-    /** Testing implementation of {@link Histogram}. */
+    /** Testing implementation of {@link PredictFunction} with a user-supplied histogram. */
+    private static class TestPredictFunctionWithHistogram extends TestPredictFunction {
+        private final TestHistogram histogram;
+
+        TestPredictFunctionWithHistogram(TestHistogram histogram, boolean shouldFail) {
+            super(shouldFail);
+            this.histogram = histogram;
+        }
+
+        @Override
+        protected Histogram createLatencyHistogram(MetricGroup metricGroup) {
+            return metricGroup.histogram("latency", histogram);
+        }
+    }
+
+    /** Minimal {@link Histogram} that counts update() invocations. */
     private static class TestHistogram implements Histogram {
         private long count = 0;
 
@@ -210,8 +298,45 @@ class PredictFunctionTest {
         }
 
         @Override
-        public org.apache.flink.metrics.HistogramStatistics getStatistics() {
-            return null;
+        public HistogramStatistics getStatistics() {
+            // Return an empty statistics object instead of null so downstream reporters that
+            // don't null-check don't NPE when reusing this helper.
+            return new HistogramStatistics() {
+                @Override
+                public double getQuantile(double quantile) {
+                    return 0.0;
+                }
+
+                @Override
+                public long[] getValues() {
+                    return new long[0];
+                }
+
+                @Override
+                public int size() {
+                    return 0;
+                }
+
+                @Override
+                public double getMean() {
+                    return 0.0;
+                }
+
+                @Override
+                public double getStdDev() {
+                    return 0.0;
+                }
+
+                @Override
+                public long getMax() {
+                    return 0L;
+                }
+
+                @Override
+                public long getMin() {
+                    return 0L;
+                }
+            };
         }
     }
 }


### PR DESCRIPTION
Closes FLINK-39059

This PR FLINK-39059 adds built-in metrics for monitoring model inference performance in both AsyncPredictFunction and PredictFunction.

## Changes
- Add built-in metrics for model inference monitoring
- Metrics include: requests, success/failure counts, latency, output rows  
- Subclasses can override createLatencyHistogram() to provide custom histogram
- All model implementations (OpenAI, Triton, etc.) automatically get metrics
- Zero code changes needed in subclasses

## Metrics Provided
The following metrics are automatically tracked:
- `inference_requests`: Total number of inference requests
- `inference_requests_success`: Number of successful inference requests
- `inference_requests_failure`: Number of failed inference requests
- `inference_latency`: Histogram of inference latency in milliseconds (optional, can be overridden)
- `inference_rows_output`: Total number of output rows from inference

## Benefits
1. **Zero code changes for subclasses**: All existing model implementations automatically get metrics
2. **Consistent monitoring**: All model functions use the same metrics schema
3. **Extensible**: Subclasses can override `createLatencyHistogram()` for custom implementations
4. **Performance insight**: Provides visibility into model inference performance and reliability

---

## PR Series Overview for FLINK-38857

This PR is part of the FLINK-38857 epic for introducing a Triton-based inference module under `flink-models`. The following table summarizes all related PRs in this series:

| No. | PR ID | PR Title | Main Module(s) | Main Content |
|:---:|:---:|---------|---------------|--------------|
| 1 | [#27385](https://github.com/apache/flink/pull/27385) | [FLINK-38857][Model] Introduce a Triton inference module under flink-models | `flink-model-triton` | Introduce the core Triton inference module with async/batched inference support via Triton HTTP/REST API |
| 2 | [#27490](https://github.com/apache/flink/pull/27490) | [FLINK-38857][Model] Add docs for Triton inference model | `docs/connectors/models` | Add comprehensive documentation for Triton model integration, including SQL examples and configuration guides |
| **3** | [#27560](https://github.com/apache/flink/pull/27560) | [FLINK-39059][model] Add unified metrics support to AsyncPredictFunction and PredictFunction | `flink-model-triton` | Add built-in metrics (requests, latency, success/failure counts) for model inference monitoring |
| 4 | [#27561](https://github.com/apache/flink/pull/27561) | [FLINK-39225][model] Add retry with default value fallback for triton inference failures | `flink-model-triton` | Implement exponential backoff retry strategy and default value fallback for robust error handling |
| 5 | [#27562](https://github.com/apache/flink/pull/27562) | [FLINK-39611][model] Add sequence ID auto-increment support for Triton inference | `flink-model-triton` | Add sequence ID auto-increment strategy for stateful models to ensure sequence isolation across failovers |
| 6 | [#27567](https://github.com/apache/flink/pull/27567) | [FLINK-38857][models] Add health check and circuit breaker for Triton inference | `flink-model-triton` | Implement health check and circuit breaker protection for fault tolerance in production deployments |
| 7 | [#27568](https://github.com/apache/flink/pull/27568) | [FLINK-39612][models] Add HTTP connection pool management for Triton inference | `flink-model-triton` | Add HTTP connection pool management to reduce latency and improve throughput by reusing connections |

### Dependency Order

```
PR #27385 (Core Module)
    ↓
PR #27490 (Documentation)
    ↓
PR #27560 (Metrics) ─┬─→ PR #27561 (Retry)
                     ├─→ PR #27562 (Sequence ID)
                     ├─→ PR #27567 (Circuit Breaker)
                     └─→ PR #27568 (Connection Pool)
```

### Notes

- **PR #27385** is the foundational PR that introduces the core Triton inference module
- All subsequent PRs build upon the core module and add specific enhancements
- Each PR can be reviewed and merged independently after the core module is merged
- All changes are **fully optional** and isolated under `flink-models` with no impact on existing Flink functionality