### PR TITLE
[FLINK-39611][model] Add sequence ID auto-increment support for Triton inference

### DIFF
--- a/docs/layouts/shortcodes/generated/model_triton_advanced_section.html
+++ b/docs/layouts/shortcodes/generated/model_triton_advanced_section.html
@@ -114,7 +114,7 @@
             <td><h5>sequence-id-auto-increment</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
-            <td>Enable auto-increment strategy for sequence ID. When enabled, a monotonically increasing counter is appended to the sequence-id to ensure sequence isolation across Flink job restarts and failovers. This is particularly useful for non-reentrant models where duplicate inference requests must be avoided after failover. Format: {sequence-id}-{subtask-index}-{counter}. Requires 'sequence-id' to be configured. Defaults to false.</td>
+            <td>Enable auto-increment strategy for sequence ID. When enabled, a monotonically increasing counter is appended to the sequence-id to ensure sequence isolation across Flink job restarts and failovers. This is particularly useful for non-reentrant models where duplicate inference requests must be avoided after failover. Format: {sequence-id}-{subtask-index}-{counter}. Requires 'sequence-id' to be configured, and both 'sequence-start' and 'sequence-end' to be set to true (each generated ID represents a one-shot stateful request, so the Triton sequence batcher must open and close the slot on the same call). Defaults to false.</td>
         </tr>
         <tr>
             <td><h5>sequence-start</h5></td>

--- a/docs/layouts/shortcodes/generated/model_triton_advanced_section.html
+++ b/docs/layouts/shortcodes/generated/model_triton_advanced_section.html
@@ -111,6 +111,12 @@
             <td>Sequence ID for stateful models. A sequence represents a series of inference requests that must be routed to the same model instance to maintain state across requests (e.g., for RNN/LSTM models). See <a href="https://docs.nvidia.com/deeplearning/triton-inference-server/user-guide/docs/user_guide/architecture.html#stateful-models">Triton Stateful Models</a> for more details.</td>
         </tr>
         <tr>
+            <td><h5>sequence-id-auto-increment</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Enable auto-increment strategy for sequence ID. When enabled, a monotonically increasing counter is appended to the sequence-id to ensure sequence isolation across Flink job restarts and failovers. This is particularly useful for non-reentrant models where duplicate inference requests must be avoided after failover. Format: {sequence-id}-{subtask-index}-{counter}. Requires 'sequence-id' to be configured. Defaults to false.</td>
+        </tr>
+        <tr>
             <td><h5>sequence-start</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/docs/layouts/shortcodes/generated/model_triton_advanced_section.html
+++ b/docs/layouts/shortcodes/generated/model_triton_advanced_section.html
@@ -114,7 +114,13 @@
             <td><h5>sequence-id-auto-increment</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
-            <td>Enable auto-increment strategy for sequence ID. When enabled, a monotonically increasing counter is appended to the sequence-id to ensure sequence isolation across Flink job restarts and failovers. This is particularly useful for non-reentrant models where duplicate inference requests must be avoided after failover. Format: {sequence-id}-{subtask-index}-{counter}. Requires 'sequence-id' to be configured, and both 'sequence-start' and 'sequence-end' to be set to true (each generated ID represents a one-shot stateful request, so the Triton sequence batcher must open and close the slot on the same call). Defaults to false.</td>
+            <td>Enable auto-increment strategy for sequence ID. When enabled, a monotonically increasing counter is appended to the sequence-id to ensure sequence isolation across Flink job restarts and failovers. This is particularly useful for non-reentrant models where duplicate inference requests must be avoided after failover. Format: {sequence-id}-{subtask-index}-{counter}. Requires 'sequence-id' to be configured, and both 'sequence-start' and 'sequence-end' to be set to true (each generated ID represents a one-shot stateful request, so the Triton sequence batcher must open and close the slot on the same call). See 'sequence-id-counter-init-strategy' to control how the counter is seeded across restarts. Defaults to false.</td>
+        </tr>
+        <tr>
+            <td><h5>sequence-id-counter-init-strategy</h5></td>
+            <td style="word-wrap: break-word;">ZERO</td>
+            <td><p>Enum</p></td>
+            <td>Controls how the auto-increment counter is seeded at operator start. Only effective when 'sequence-id-auto-increment' is true. <code class="highlighter-rouge">ZERO</code> starts the counter at 0 (compact IDs, but a job restart will reuse the same numeric range as before — fine when downstream is also reset, but causes ID collisions when the previous run's records are still in flight). <code class="highlighter-rouge">NANO_TIME</code> seeds from System.nanoTime() so each restart picks a strictly larger range and old/new sequence IDs cannot overlap. <code class="highlighter-rouge">EPOCH_MILLIS</code> seeds from System.currentTimeMillis() — same isolation property as nano-time but with wall-clock readability. Defaults to <code class="highlighter-rouge">ZERO</code>.<br /><br />Possible values:<ul><li>"ZERO"</li><li>"NANO_TIME"</li><li>"EPOCH_MILLIS"</li></ul></td>
         </tr>
         <tr>
             <td><h5>sequence-start</h5></td>

--- a/docs/layouts/shortcodes/generated/triton_configuration.html
+++ b/docs/layouts/shortcodes/generated/triton_configuration.html
@@ -132,7 +132,7 @@
             <td><h5>sequence-id-auto-increment</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
-            <td>Enable auto-increment strategy for sequence ID. When enabled, a monotonically increasing counter is appended to the sequence-id to ensure sequence isolation across Flink job restarts and failovers. This is particularly useful for non-reentrant models where duplicate inference requests must be avoided after failover. Format: {sequence-id}-{subtask-index}-{counter}. Requires 'sequence-id' to be configured. Defaults to false.</td>
+            <td>Enable auto-increment strategy for sequence ID. When enabled, a monotonically increasing counter is appended to the sequence-id to ensure sequence isolation across Flink job restarts and failovers. This is particularly useful for non-reentrant models where duplicate inference requests must be avoided after failover. Format: {sequence-id}-{subtask-index}-{counter}. Requires 'sequence-id' to be configured, and both 'sequence-start' and 'sequence-end' to be set to true (each generated ID represents a one-shot stateful request, so the Triton sequence batcher must open and close the slot on the same call). Defaults to false.</td>
         </tr>
         <tr>
             <td><h5>sequence-start</h5></td>

--- a/docs/layouts/shortcodes/generated/triton_configuration.html
+++ b/docs/layouts/shortcodes/generated/triton_configuration.html
@@ -132,7 +132,13 @@
             <td><h5>sequence-id-auto-increment</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
-            <td>Enable auto-increment strategy for sequence ID. When enabled, a monotonically increasing counter is appended to the sequence-id to ensure sequence isolation across Flink job restarts and failovers. This is particularly useful for non-reentrant models where duplicate inference requests must be avoided after failover. Format: {sequence-id}-{subtask-index}-{counter}. Requires 'sequence-id' to be configured, and both 'sequence-start' and 'sequence-end' to be set to true (each generated ID represents a one-shot stateful request, so the Triton sequence batcher must open and close the slot on the same call). Defaults to false.</td>
+            <td>Enable auto-increment strategy for sequence ID. When enabled, a monotonically increasing counter is appended to the sequence-id to ensure sequence isolation across Flink job restarts and failovers. This is particularly useful for non-reentrant models where duplicate inference requests must be avoided after failover. Format: {sequence-id}-{subtask-index}-{counter}. Requires 'sequence-id' to be configured, and both 'sequence-start' and 'sequence-end' to be set to true (each generated ID represents a one-shot stateful request, so the Triton sequence batcher must open and close the slot on the same call). See 'sequence-id-counter-init-strategy' to control how the counter is seeded across restarts. Defaults to false.</td>
+        </tr>
+        <tr>
+            <td><h5>sequence-id-counter-init-strategy</h5></td>
+            <td style="word-wrap: break-word;">ZERO</td>
+            <td><p>Enum</p></td>
+            <td>Controls how the auto-increment counter is seeded at operator start. Only effective when 'sequence-id-auto-increment' is true. <code class="highlighter-rouge">ZERO</code> starts the counter at 0 (compact IDs, but a job restart will reuse the same numeric range as before — fine when downstream is also reset, but causes ID collisions when the previous run's records are still in flight). <code class="highlighter-rouge">NANO_TIME</code> seeds from System.nanoTime() so each restart picks a strictly larger range and old/new sequence IDs cannot overlap. <code class="highlighter-rouge">EPOCH_MILLIS</code> seeds from System.currentTimeMillis() — same isolation property as nano-time but with wall-clock readability. Defaults to <code class="highlighter-rouge">ZERO</code>.<br /><br />Possible values:<ul><li>"ZERO"</li><li>"NANO_TIME"</li><li>"EPOCH_MILLIS"</li></ul></td>
         </tr>
         <tr>
             <td><h5>sequence-start</h5></td>

--- a/docs/layouts/shortcodes/generated/triton_configuration.html
+++ b/docs/layouts/shortcodes/generated/triton_configuration.html
@@ -129,6 +129,12 @@
             <td>Sequence ID for stateful models. A sequence represents a series of inference requests that must be routed to the same model instance to maintain state across requests (e.g., for RNN/LSTM models). See <a href="https://docs.nvidia.com/deeplearning/triton-inference-server/user-guide/docs/user_guide/architecture.html#stateful-models">Triton Stateful Models</a> for more details.</td>
         </tr>
         <tr>
+            <td><h5>sequence-id-auto-increment</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Enable auto-increment strategy for sequence ID. When enabled, a monotonically increasing counter is appended to the sequence-id to ensure sequence isolation across Flink job restarts and failovers. This is particularly useful for non-reentrant models where duplicate inference requests must be avoided after failover. Format: {sequence-id}-{subtask-index}-{counter}. Requires 'sequence-id' to be configured. Defaults to false.</td>
+        </tr>
+        <tr>
             <td><h5>sequence-start</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/AbstractTritonModelFunction.java
+++ b/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/AbstractTritonModelFunction.java
@@ -88,8 +88,13 @@ public abstract class AbstractTritonModelFunction extends AsyncPredictFunction {
     protected transient AtomicLong sequenceCounter;
 
     /**
-     * Index of this parallel subtask. Used together with {@link #sequenceCounter} to build unique
-     * auto-incremented sequence IDs in the form {@code {base}-{subtask}-{counter}}.
+     * Index of this parallel subtask. Captured unconditionally in {@link #open(FunctionContext)}
+     * and consumed by two independent code paths: (1) the retry scheduler thread name — {@code
+     * triton-retry-scheduler-<model>-<subtask>} — so thread dumps from a parallelism&gt;1
+     * deployment can be attributed to a specific subtask instead of aliasing every instance under
+     * the same name; and (2) the auto-increment sequence ID generator, where it is combined with
+     * {@link #sequenceCounter} to produce unique IDs of the form {@code {base}-{subtask}-{counter}}
+     * across parallel instances.
      */
     protected transient int subtaskIndex;
 

--- a/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/AbstractTritonModelFunction.java
+++ b/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/AbstractTritonModelFunction.java
@@ -651,8 +651,13 @@ public abstract class AbstractTritonModelFunction extends AsyncPredictFunction {
      *
      * <p>Callers should capture the returned value in a local variable at the entry point of the
      * predict call and thread it through all retry attempts unchanged.
+     *
+     * <p>Marked {@code final} so subclasses cannot accidentally weaken the call-once contract by
+     * overriding with a memoizing or call-counting variant; the side-effect semantics are part of
+     * the API and any future per-subclass customization should happen via the existing protected
+     * fields ({@link #sequenceId}, {@link #sequenceCounter}, {@link #subtaskIndex}) instead.
      */
-    protected String nextEffectiveSequenceId() {
+    protected final String nextEffectiveSequenceId() {
         if (sequenceId == null) {
             return null;
         }

--- a/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/AbstractTritonModelFunction.java
+++ b/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/AbstractTritonModelFunction.java
@@ -121,6 +121,7 @@ public abstract class AbstractTritonModelFunction extends AsyncPredictFunction {
     private final String sequenceId;
 
     private final boolean sequenceIdAutoIncrement;
+    private final TritonOptions.SequenceIdCounterInitStrategy sequenceIdCounterInitStrategy;
     private final boolean sequenceStart;
     private final boolean sequenceEnd;
     private final String compression;
@@ -150,6 +151,8 @@ public abstract class AbstractTritonModelFunction extends AsyncPredictFunction {
         this.priority = config.get(TritonOptions.PRIORITY);
         this.sequenceId = config.get(TritonOptions.SEQUENCE_ID);
         this.sequenceIdAutoIncrement = config.get(TritonOptions.SEQUENCE_ID_AUTO_INCREMENT);
+        this.sequenceIdCounterInitStrategy =
+                config.get(TritonOptions.SEQUENCE_ID_COUNTER_INIT_STRATEGY);
         this.sequenceStart = config.get(TritonOptions.SEQUENCE_START);
         this.sequenceEnd = config.get(TritonOptions.SEQUENCE_END);
         this.compression = config.get(TritonOptions.COMPRESSION);
@@ -324,11 +327,31 @@ public abstract class AbstractTritonModelFunction extends AsyncPredictFunction {
         // Done after healthChecker.start() so that a failure in the (already-completed) subtask
         // info lookup cannot leave a half-initialized health checker behind.
         if (sequenceIdAutoIncrement) {
-            this.sequenceCounter = new AtomicLong(0);
+            // Seed the counter according to the configured init strategy. ZERO is the legacy
+            // behaviour (compact IDs, but the numeric range repeats after every restart);
+            // NANO_TIME / EPOCH_MILLIS use the wall clock at open() time so a restart is
+            // guaranteed to pick a fresh, non-overlapping range — important when downstream
+            // systems may still be processing records from the previous run.
+            final long counterSeed;
+            switch (sequenceIdCounterInitStrategy) {
+                case NANO_TIME:
+                    counterSeed = System.nanoTime();
+                    break;
+                case EPOCH_MILLIS:
+                    counterSeed = System.currentTimeMillis();
+                    break;
+                case ZERO:
+                default:
+                    counterSeed = 0L;
+                    break;
+            }
+            this.sequenceCounter = new AtomicLong(counterSeed);
             LOG.info(
-                    "Initialized sequence ID auto-increment for subtask {}: base={}",
+                    "Initialized sequence ID auto-increment for subtask {}: base={}, strategy={}, seed={}",
                     subtaskIndex,
-                    sequenceId);
+                    sequenceId,
+                    sequenceIdCounterInitStrategy,
+                    counterSeed);
         }
     }
 

--- a/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/AbstractTritonModelFunction.java
+++ b/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/AbstractTritonModelFunction.java
@@ -209,6 +209,24 @@ public abstract class AbstractTritonModelFunction extends AsyncPredictFunction {
                             + "Please provide a base sequence-id value.");
         }
 
+        // When auto-increment is enabled every record becomes its own one-shot sequence, so
+        // sequence_start AND sequence_end must both be true on every request — otherwise the
+        // Triton sequence batcher will keep the per-sequence state slot allocated indefinitely
+        // (since no `end` ever arrives) and eventually exhaust available sequence slots, while
+        // omitting `start` makes Triton route the request to a model state that was never
+        // initialized. Surfacing this as a configuration error avoids a silent server-side
+        // resource leak that would only manifest under load.
+        if (this.sequenceIdAutoIncrement && !(this.sequenceStart && this.sequenceEnd)) {
+            throw new IllegalArgumentException(
+                    "sequence-id-auto-increment requires both sequence-start=true and "
+                            + "sequence-end=true, because each generated sequence ID represents a "
+                            + "single one-shot stateful request. Got sequence-start="
+                            + this.sequenceStart
+                            + ", sequence-end="
+                            + this.sequenceEnd
+                            + ".");
+        }
+
         // Validate input schema - support multiple types
         validateInputSchema(factoryContext.getCatalogModel().getResolvedInputSchema());
     }
@@ -218,6 +236,12 @@ public abstract class AbstractTritonModelFunction extends AsyncPredictFunction {
         super.open(context);
         LOG.debug("Creating Triton HTTP client.");
         this.httpClient = TritonUtils.createHttpClient(timeout.toMillis());
+
+        // Cache the subtask index once. It is consumed by both the retry scheduler thread name
+        // and the auto-increment sequence ID generator, and was previously fetched independently
+        // in each branch (with the auto-increment branch shadowing this very field via a local
+        // variable in the retry branch).
+        this.subtaskIndex = context.getTaskInfo().getIndexOfThisSubtask();
 
         // Provision a private single-thread scheduler for delayed retries so that retry tasks are
         // bound to this operator's lifecycle. Previously CompletableFuture.delayedExecutor was
@@ -230,7 +254,6 @@ public abstract class AbstractTritonModelFunction extends AsyncPredictFunction {
             // included so that thread dumps from a parallelism>1 deployment can be attributed
             // to a specific subtask rather than aliasing every parallel instance under the same
             // "triton-retry-scheduler-<model>" name.
-            final int subtaskIndex = context.getTaskInfo().getIndexOfThisSubtask();
             final String threadName = "triton-retry-scheduler-" + modelName + "-" + subtaskIndex;
             this.retryScheduler =
                     Executors.newSingleThreadScheduledExecutor(
@@ -296,12 +319,12 @@ public abstract class AbstractTritonModelFunction extends AsyncPredictFunction {
             healthChecker.start();
         }
 
-        // Initialize sequence counter and subtask index for auto-increment strategy.
-        // Done after healthChecker.start() so that failures in the subtask-info lookup cannot
-        // leave a half-initialized health checker behind.
+        // Initialize sequence counter for auto-increment strategy. The subtask index was already
+        // captured at the top of open(); we only need to allocate the counter here.
+        // Done after healthChecker.start() so that a failure in the (already-completed) subtask
+        // info lookup cannot leave a half-initialized health checker behind.
         if (sequenceIdAutoIncrement) {
             this.sequenceCounter = new AtomicLong(0);
-            this.subtaskIndex = context.getTaskInfo().getIndexOfThisSubtask();
             LOG.info(
                     "Initialized sequence ID auto-increment for subtask {}: base={}",
                     subtaskIndex,

--- a/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/AbstractTritonModelFunction.java
+++ b/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/AbstractTritonModelFunction.java
@@ -631,6 +631,33 @@ public abstract class AbstractTritonModelFunction extends AsyncPredictFunction {
         return sequenceIdAutoIncrement;
     }
 
+    /**
+     * Returns the sequence ID to include in a single inference request. When auto-increment is
+     * enabled, this returns {@code {base}-{subtask}-{counter}} with a freshly incremented counter;
+     * otherwise it returns the configured base sequence ID verbatim (possibly {@code null}).
+     *
+     * <p><b>Important:</b> this method has a side effect (counter increment) and must be called
+     * <b>exactly once per logical record</b>. In particular it MUST NOT be called again on a retry
+     * attempt — every call consumes a new ID, and with {@code sequence-start=true &
+     * sequence-end=true} each ID corresponds to a distinct server-side sequence slot on Triton.
+     * Calling it per retry would open N slots per record but only ever close the last one,
+     * producing a slow slot leak that exhausts the Triton sequence batcher under sustained failures
+     * — the exact failure mode the constructor validations were introduced to prevent.
+     *
+     * <p>Callers should capture the returned value in a local variable at the entry point of the
+     * predict call and thread it through all retry attempts unchanged.
+     */
+    protected String nextEffectiveSequenceId() {
+        if (sequenceId == null) {
+            return null;
+        }
+        if (!sequenceIdAutoIncrement) {
+            return sequenceId;
+        }
+        final long counter = sequenceCounter.getAndIncrement();
+        return sequenceId + "-" + subtaskIndex + "-" + counter;
+    }
+
     protected boolean isSequenceStart() {
         return sequenceStart;
     }

--- a/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/AbstractTritonModelFunction.java
+++ b/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/AbstractTritonModelFunction.java
@@ -210,20 +210,15 @@ public abstract class AbstractTritonModelFunction extends AsyncPredictFunction {
         this.circuitBreakerHalfOpenRequests =
                 config.get(TritonOptions.CIRCUIT_BREAKER_HALF_OPEN_REQUESTS);
 
-        // Validate sequence-id-auto-increment requires sequence-id
         if (this.sequenceIdAutoIncrement && this.sequenceId == null) {
             throw new IllegalArgumentException(
                     "sequence-id-auto-increment requires sequence-id to be configured. "
                             + "Please provide a base sequence-id value.");
         }
 
-        // When auto-increment is enabled every record becomes its own one-shot sequence, so
-        // sequence_start AND sequence_end must both be true on every request — otherwise the
-        // Triton sequence batcher will keep the per-sequence state slot allocated indefinitely
-        // (since no `end` ever arrives) and eventually exhaust available sequence slots, while
-        // omitting `start` makes Triton route the request to a model state that was never
-        // initialized. Surfacing this as a configuration error avoids a silent server-side
-        // resource leak that would only manifest under load.
+        // Auto-increment turns every record into a one-shot sequence, so both flags must be true:
+        // a missing `end` leaks the per-sequence slot on Triton's batcher (no close ever arrives),
+        // and a missing `start` routes the request to uninitialized model state.
         if (this.sequenceIdAutoIncrement && !(this.sequenceStart && this.sequenceEnd)) {
             throw new IllegalArgumentException(
                     "sequence-id-auto-increment requires both sequence-start=true and "
@@ -245,10 +240,8 @@ public abstract class AbstractTritonModelFunction extends AsyncPredictFunction {
         LOG.debug("Creating Triton HTTP client.");
         this.httpClient = TritonUtils.createHttpClient(timeout.toMillis());
 
-        // Cache the subtask index once. It is consumed by both the retry scheduler thread name
-        // and the auto-increment sequence ID generator, and was previously fetched independently
-        // in each branch (with the auto-increment branch shadowing this very field via a local
-        // variable in the retry branch).
+        // Cache subtask index — used by both the retry scheduler thread name and the
+        // auto-increment ID generator. See field javadoc.
         this.subtaskIndex = context.getTaskInfo().getIndexOfThisSubtask();
 
         // Provision a private single-thread scheduler for delayed retries so that retry tasks are
@@ -327,16 +320,10 @@ public abstract class AbstractTritonModelFunction extends AsyncPredictFunction {
             healthChecker.start();
         }
 
-        // Initialize sequence counter for auto-increment strategy. The subtask index was already
-        // captured at the top of open(); we only need to allocate the counter here.
-        // Done after healthChecker.start() so that a failure in the (already-completed) subtask
-        // info lookup cannot leave a half-initialized health checker behind.
+        // Allocate the auto-increment counter last so a failure in the (already-completed) health
+        // checker startup cannot leave it half-initialized. See SequenceIdCounterInitStrategy for
+        // the seeding trade-offs.
         if (sequenceIdAutoIncrement) {
-            // Seed the counter according to the configured init strategy. ZERO is the legacy
-            // behaviour (compact IDs, but the numeric range repeats after every restart);
-            // NANO_TIME / EPOCH_MILLIS use the wall clock at open() time so a restart is
-            // guaranteed to pick a fresh, non-overlapping range — important when downstream
-            // systems may still be processing records from the previous run.
             final long counterSeed;
             switch (sequenceIdCounterInitStrategy) {
                 case NANO_TIME:
@@ -637,25 +624,20 @@ public abstract class AbstractTritonModelFunction extends AsyncPredictFunction {
     }
 
     /**
-     * Returns the sequence ID to include in a single inference request. When auto-increment is
-     * enabled, this returns {@code {base}-{subtask}-{counter}} with a freshly incremented counter;
-     * otherwise it returns the configured base sequence ID verbatim (possibly {@code null}).
+     * Returns the sequence ID to embed in a single inference request: under auto-increment, {@code
+     * {base}-{subtask}-{counter}} with a freshly incremented counter; otherwise the configured base
+     * sequence ID verbatim (possibly {@code null}).
      *
-     * <p><b>Important:</b> this method has a side effect (counter increment) and must be called
-     * <b>exactly once per logical record</b>. In particular it MUST NOT be called again on a retry
-     * attempt — every call consumes a new ID, and with {@code sequence-start=true &
-     * sequence-end=true} each ID corresponds to a distinct server-side sequence slot on Triton.
-     * Calling it per retry would open N slots per record but only ever close the last one,
-     * producing a slow slot leak that exhausts the Triton sequence batcher under sustained failures
-     * — the exact failure mode the constructor validations were introduced to prevent.
+     * <p><b>Call exactly once per logical record</b>, at the entry point of the predict call —
+     * never again on a retry. Each call consumes a new ID, and with {@code sequence-start=true &
+     * sequence-end=true} every ID owns a distinct server-side slot on Triton's sequence batcher.
+     * Regenerating per retry would open N slots while only ever closing the last one, leaking the
+     * other N&minus;1.
      *
-     * <p>Callers should capture the returned value in a local variable at the entry point of the
-     * predict call and thread it through all retry attempts unchanged.
-     *
-     * <p>Marked {@code final} so subclasses cannot accidentally weaken the call-once contract by
-     * overriding with a memoizing or call-counting variant; the side-effect semantics are part of
-     * the API and any future per-subclass customization should happen via the existing protected
-     * fields ({@link #sequenceId}, {@link #sequenceCounter}, {@link #subtaskIndex}) instead.
+     * <p>{@code final} to keep this contract enforceable: a memoizing or call-counting override
+     * would silently weaken it. Subclasses needing different ID composition should read the
+     * underlying fields ({@link #sequenceId}, {@link #sequenceCounter}, {@link #subtaskIndex})
+     * directly.
      */
     protected final String nextEffectiveSequenceId() {
         if (sequenceId == null) {

--- a/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/AbstractTritonModelFunction.java
+++ b/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/AbstractTritonModelFunction.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 /**
@@ -78,6 +79,20 @@ public abstract class AbstractTritonModelFunction extends AsyncPredictFunction {
      */
     protected transient ScheduledExecutorService retryScheduler;
 
+    /**
+     * Monotonically increasing counter for sequence ID auto-increment strategy. Combined with
+     * {@link #subtaskIndex} it guarantees sequence isolation across Flink job restarts, failovers
+     * and parallel instances. Only initialized when {@link
+     * TritonOptions#SEQUENCE_ID_AUTO_INCREMENT} is enabled.
+     */
+    protected transient AtomicLong sequenceCounter;
+
+    /**
+     * Index of this parallel subtask. Used together with {@link #sequenceCounter} to build unique
+     * auto-incremented sequence IDs in the form {@code {base}-{subtask}-{counter}}.
+     */
+    protected transient int subtaskIndex;
+
     private final String endpoint;
 
     /**
@@ -105,6 +120,7 @@ public abstract class AbstractTritonModelFunction extends AsyncPredictFunction {
      */
     private final String sequenceId;
 
+    private final boolean sequenceIdAutoIncrement;
     private final boolean sequenceStart;
     private final boolean sequenceEnd;
     private final String compression;
@@ -133,6 +149,7 @@ public abstract class AbstractTritonModelFunction extends AsyncPredictFunction {
         this.flattenBatchDim = config.get(TritonOptions.FLATTEN_BATCH_DIM);
         this.priority = config.get(TritonOptions.PRIORITY);
         this.sequenceId = config.get(TritonOptions.SEQUENCE_ID);
+        this.sequenceIdAutoIncrement = config.get(TritonOptions.SEQUENCE_ID_AUTO_INCREMENT);
         this.sequenceStart = config.get(TritonOptions.SEQUENCE_START);
         this.sequenceEnd = config.get(TritonOptions.SEQUENCE_END);
         this.compression = config.get(TritonOptions.COMPRESSION);
@@ -184,6 +201,13 @@ public abstract class AbstractTritonModelFunction extends AsyncPredictFunction {
         this.circuitBreakerTimeout = config.get(TritonOptions.CIRCUIT_BREAKER_TIMEOUT);
         this.circuitBreakerHalfOpenRequests =
                 config.get(TritonOptions.CIRCUIT_BREAKER_HALF_OPEN_REQUESTS);
+
+        // Validate sequence-id-auto-increment requires sequence-id
+        if (this.sequenceIdAutoIncrement && this.sequenceId == null) {
+            throw new IllegalArgumentException(
+                    "sequence-id-auto-increment requires sequence-id to be configured. "
+                            + "Please provide a base sequence-id value.");
+        }
 
         // Validate input schema - support multiple types
         validateInputSchema(factoryContext.getCatalogModel().getResolvedInputSchema());
@@ -270,6 +294,18 @@ public abstract class AbstractTritonModelFunction extends AsyncPredictFunction {
             // Start periodic health checking. The scheduler uses an initial delay equal to
             // checkInterval so it does not duplicate the eager checkNow() above.
             healthChecker.start();
+        }
+
+        // Initialize sequence counter and subtask index for auto-increment strategy.
+        // Done after healthChecker.start() so that failures in the subtask-info lookup cannot
+        // leave a half-initialized health checker behind.
+        if (sequenceIdAutoIncrement) {
+            this.sequenceCounter = new AtomicLong(0);
+            this.subtaskIndex = context.getTaskInfo().getIndexOfThisSubtask();
+            LOG.info(
+                    "Initialized sequence ID auto-increment for subtask {}: base={}",
+                    subtaskIndex,
+                    sequenceId);
         }
     }
 
@@ -543,6 +579,10 @@ public abstract class AbstractTritonModelFunction extends AsyncPredictFunction {
 
     protected String getSequenceId() {
         return sequenceId;
+    }
+
+    protected boolean isSequenceIdAutoIncrement() {
+        return sequenceIdAutoIncrement;
     }
 
     protected boolean isSequenceStart() {

--- a/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/TritonInferenceModelFunction.java
+++ b/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/TritonInferenceModelFunction.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.model.triton;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.model.triton.exception.TritonCircuitBreakerOpenException;
 import org.apache.flink.model.triton.exception.TritonClientException;
@@ -195,7 +196,14 @@ public class TritonInferenceModelFunction extends AbstractTritonModelFunction {
     @Override
     public CompletableFuture<Collection<RowData>> asyncPredict(RowData rowData) {
         CompletableFuture<Collection<RowData>> future = new CompletableFuture<>();
-        asyncPredictWithRetry(rowData, future, 0);
+        // Generate the effective sequence ID exactly once per record, BEFORE retries can fire.
+        // Under auto-increment the counter advance has a visible side effect on Triton (each ID
+        // allocates its own server-side sequence slot with sequence-start=true, which will later
+        // be closed with sequence-end=true). If we regenerated on every retry we would open N
+        // slots per record and only close the last one, leaking the rest — see the javadoc on
+        // nextEffectiveSequenceId() for the full argument.
+        String effectiveSequenceId = nextEffectiveSequenceId();
+        asyncPredictWithRetry(rowData, effectiveSequenceId, future, 0);
         return future;
     }
 
@@ -203,11 +211,17 @@ public class TritonInferenceModelFunction extends AbstractTritonModelFunction {
      * Executes inference request with retry logic and default value fallback.
      *
      * @param rowData Input data for inference
+     * @param effectiveSequenceId The sequence ID to embed in every attempt for this record. Held
+     *     constant across retries so that a single logical record corresponds to a single
+     *     server-side Triton sequence slot.
      * @param future The future to complete with result or exception
      * @param attemptNumber Current attempt number (0-indexed)
      */
     private void asyncPredictWithRetry(
-            RowData rowData, CompletableFuture<Collection<RowData>> future, int attemptNumber) {
+            RowData rowData,
+            String effectiveSequenceId,
+            CompletableFuture<Collection<RowData>> future,
+            int attemptNumber) {
 
         // If the operator is tearing down, do not schedule/execute further retry attempts.
         // `attemptNumber > 0` means we are on a retry path (a scheduled continuation); dropping
@@ -227,7 +241,7 @@ public class TritonInferenceModelFunction extends AbstractTritonModelFunction {
             // Check circuit breaker before making request
             checkCircuitBreaker();
 
-            String requestBody = buildInferenceRequest(rowData);
+            String requestBody = buildInferenceRequest(rowData, effectiveSequenceId);
             String url =
                     TritonUtils.buildInferenceUrl(getEndpoint(), getModelName(), getModelVersion());
             // Sanitized URL used exclusively for log lines and exception messages so that an
@@ -305,6 +319,7 @@ public class TritonInferenceModelFunction extends AbstractTritonModelFunction {
 
                                     handleFailureWithRetry(
                                             rowData,
+                                            effectiveSequenceId,
                                             future,
                                             attemptNumber,
                                             networkException,
@@ -333,7 +348,11 @@ public class TritonInferenceModelFunction extends AbstractTritonModelFunction {
                                             // persistent config error to force-open it and deny
                                             // traffic to an otherwise healthy server.
                                             handleErrorResponseWithRetry(
-                                                    response, rowData, future, attemptNumber);
+                                                    response,
+                                                    rowData,
+                                                    effectiveSequenceId,
+                                                    future,
+                                                    attemptNumber);
                                             return;
                                         }
 
@@ -354,6 +373,7 @@ public class TritonInferenceModelFunction extends AbstractTritonModelFunction {
                                             // exhaustion.
                                             handleFailureWithRetry(
                                                     rowData,
+                                                    effectiveSequenceId,
                                                     future,
                                                     attemptNumber,
                                                     new TritonClientException(
@@ -390,6 +410,7 @@ public class TritonInferenceModelFunction extends AbstractTritonModelFunction {
                                                             bodyReadFailure);
                                             handleFailureWithRetry(
                                                     rowData,
+                                                    effectiveSequenceId,
                                                     future,
                                                     attemptNumber,
                                                     wrapped,
@@ -418,6 +439,7 @@ public class TritonInferenceModelFunction extends AbstractTritonModelFunction {
                                                         400);
                                         handleFailureWithRetry(
                                                 rowData,
+                                                effectiveSequenceId,
                                                 future,
                                                 attemptNumber,
                                                 parseException,
@@ -430,6 +452,7 @@ public class TritonInferenceModelFunction extends AbstractTritonModelFunction {
                                         // signal. Also not retryable (deterministic).
                                         handleFailureWithRetry(
                                                 rowData,
+                                                effectiveSequenceId,
                                                 future,
                                                 attemptNumber,
                                                 e,
@@ -483,6 +506,7 @@ public class TritonInferenceModelFunction extends AbstractTritonModelFunction {
             LOG.error("Unexpected error dispatching Triton request", e);
             handleFailureWithRetry(
                     rowData,
+                    effectiveSequenceId,
                     future,
                     attemptNumber,
                     e,
@@ -512,6 +536,7 @@ public class TritonInferenceModelFunction extends AbstractTritonModelFunction {
      */
     private void handleFailureWithRetry(
             RowData rowData,
+            String effectiveSequenceId,
             CompletableFuture<Collection<RowData>> future,
             int attemptNumber,
             Throwable error,
@@ -549,7 +574,9 @@ public class TritonInferenceModelFunction extends AbstractTritonModelFunction {
             }
             try {
                 retryScheduler.schedule(
-                        () -> asyncPredictWithRetry(rowData, future, attemptNumber + 1),
+                        () ->
+                                asyncPredictWithRetry(
+                                        rowData, effectiveSequenceId, future, attemptNumber + 1),
                         delayMs,
                         TimeUnit.MILLISECONDS);
             } catch (RejectedExecutionException rejected) {
@@ -727,6 +754,7 @@ public class TritonInferenceModelFunction extends AbstractTritonModelFunction {
     private void handleErrorResponseWithRetry(
             Response response,
             RowData rowData,
+            String effectiveSequenceId,
             CompletableFuture<Collection<RowData>> future,
             int attemptNumber) {
 
@@ -872,6 +900,7 @@ public class TritonInferenceModelFunction extends AbstractTritonModelFunction {
             // 5xx is a genuine backend-health signal: count against the breaker and retry.
             handleFailureWithRetry(
                     rowData,
+                    effectiveSequenceId,
                     future,
                     attemptNumber,
                     exception,
@@ -889,6 +918,7 @@ public class TritonInferenceModelFunction extends AbstractTritonModelFunction {
             // not conflate with backend health (the real Triton server never produced it).
             handleFailureWithRetry(
                     rowData,
+                    effectiveSequenceId,
                     future,
                     attemptNumber,
                     exception,
@@ -937,33 +967,18 @@ public class TritonInferenceModelFunction extends AbstractTritonModelFunction {
         return TritonTypeMapper.deserializeFromJson(jsonNode, outputType);
     }
 
-    private String buildInferenceRequest(RowData rowData) throws JsonProcessingException {
+    @VisibleForTesting
+    String buildInferenceRequest(RowData rowData, String effectiveSequenceId)
+            throws JsonProcessingException {
         ObjectNode requestNode = objectMapper.createObjectNode();
 
-        // Generate and add request ID with optional auto-increment strategy
-        if (getSequenceId() != null) {
-            String effectiveSequenceId = getSequenceId();
-
-            // Apply auto-increment strategy if enabled
-            if (isSequenceIdAutoIncrement()) {
-                // Format: {base-sequence-id}-{subtask-index}-{counter}
-                // This ensures unique sequences across parallel instances and failovers.
-                // Concatenation is preferred over String.format on this hot path: it avoids the
-                // formatter parsing overhead per record and produces identical output for the
-                // simple "%s-%d-%d" pattern.
-                long counter = sequenceCounter.getAndIncrement();
-                effectiveSequenceId = getSequenceId() + "-" + subtaskIndex + "-" + counter;
-
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug(
-                            "Generated auto-increment sequence ID: {} (base: {}, subtask: {}, counter: {})",
-                            effectiveSequenceId,
-                            getSequenceId(),
-                            subtaskIndex,
-                            counter);
-                }
-            }
-
+        // The effective sequence ID is computed once per logical record by the caller (see
+        // AbstractTritonModelFunction#nextEffectiveSequenceId and the asyncPredict entry point)
+        // and passed in here unchanged. This method must NOT allocate a new sequence ID on its
+        // own — it is invoked on every retry attempt, and generating a fresh ID per attempt
+        // would open N Triton sequence slots per logical record while only closing the last
+        // one (leaking the first N-1 slots on a long-running job). See R3-1 in PR #27562.
+        if (effectiveSequenceId != null) {
             requestNode.put("id", effectiveSequenceId);
         }
 

--- a/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/TritonInferenceModelFunction.java
+++ b/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/TritonInferenceModelFunction.java
@@ -947,10 +947,12 @@ public class TritonInferenceModelFunction extends AbstractTritonModelFunction {
             // Apply auto-increment strategy if enabled
             if (isSequenceIdAutoIncrement()) {
                 // Format: {base-sequence-id}-{subtask-index}-{counter}
-                // This ensures unique sequences across parallel instances and failovers
+                // This ensures unique sequences across parallel instances and failovers.
+                // Concatenation is preferred over String.format on this hot path: it avoids the
+                // formatter parsing overhead per record and produces identical output for the
+                // simple "%s-%d-%d" pattern.
                 long counter = sequenceCounter.getAndIncrement();
-                effectiveSequenceId =
-                        String.format("%s-%d-%d", getSequenceId(), subtaskIndex, counter);
+                effectiveSequenceId = getSequenceId() + "-" + subtaskIndex + "-" + counter;
 
                 if (LOG.isDebugEnabled()) {
                     LOG.debug(

--- a/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/TritonInferenceModelFunction.java
+++ b/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/TritonInferenceModelFunction.java
@@ -196,12 +196,7 @@ public class TritonInferenceModelFunction extends AbstractTritonModelFunction {
     @Override
     public CompletableFuture<Collection<RowData>> asyncPredict(RowData rowData) {
         CompletableFuture<Collection<RowData>> future = new CompletableFuture<>();
-        // Generate the effective sequence ID exactly once per record, BEFORE retries can fire.
-        // Under auto-increment the counter advance has a visible side effect on Triton (each ID
-        // allocates its own server-side sequence slot with sequence-start=true, which will later
-        // be closed with sequence-end=true). If we regenerated on every retry we would open N
-        // slots per record and only close the last one, leaking the rest — see the javadoc on
-        // nextEffectiveSequenceId() for the full argument.
+        // Generate once and thread through retries — see nextEffectiveSequenceId() for why.
         String effectiveSequenceId = nextEffectiveSequenceId();
         asyncPredictWithRetry(rowData, effectiveSequenceId, future, 0);
         return future;
@@ -972,12 +967,8 @@ public class TritonInferenceModelFunction extends AbstractTritonModelFunction {
             throws JsonProcessingException {
         ObjectNode requestNode = objectMapper.createObjectNode();
 
-        // The effective sequence ID is computed once per logical record by the caller (see
-        // AbstractTritonModelFunction#nextEffectiveSequenceId and the asyncPredict entry point)
-        // and passed in here unchanged. This method must NOT allocate a new sequence ID on its
-        // own — it is invoked on every retry attempt, and generating a fresh ID per attempt
-        // would open N Triton sequence slots per logical record while only closing the last
-        // one (leaking the first N-1 slots on a long-running job). See R3-1 in PR #27562.
+        // Caller passes a sequence ID generated once per record; do NOT allocate one here, since
+        // this method runs on every retry. See nextEffectiveSequenceId() for the slot-leak why.
         if (effectiveSequenceId != null) {
             requestNode.put("id", effectiveSequenceId);
         }

--- a/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/TritonInferenceModelFunction.java
+++ b/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/TritonInferenceModelFunction.java
@@ -940,9 +940,29 @@ public class TritonInferenceModelFunction extends AbstractTritonModelFunction {
     private String buildInferenceRequest(RowData rowData) throws JsonProcessingException {
         ObjectNode requestNode = objectMapper.createObjectNode();
 
-        // Add request ID if sequence ID is provided
+        // Generate and add request ID with optional auto-increment strategy
         if (getSequenceId() != null) {
-            requestNode.put("id", getSequenceId());
+            String effectiveSequenceId = getSequenceId();
+
+            // Apply auto-increment strategy if enabled
+            if (isSequenceIdAutoIncrement()) {
+                // Format: {base-sequence-id}-{subtask-index}-{counter}
+                // This ensures unique sequences across parallel instances and failovers
+                long counter = sequenceCounter.getAndIncrement();
+                effectiveSequenceId =
+                        String.format("%s-%d-%d", getSequenceId(), subtaskIndex, counter);
+
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug(
+                            "Generated auto-increment sequence ID: {} (base: {}, subtask: {}, counter: {})",
+                            effectiveSequenceId,
+                            getSequenceId(),
+                            subtaskIndex,
+                            counter);
+                }
+            }
+
+            requestNode.put("id", effectiveSequenceId);
         }
 
         // Add parameters

--- a/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/TritonModelProviderFactory.java
+++ b/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/TritonModelProviderFactory.java
@@ -67,6 +67,8 @@ public class TritonModelProviderFactory implements ModelProviderFactory {
         set.add(TritonOptions.SEQUENCE_ID);
         set.add(TritonOptions.SEQUENCE_START);
         set.add(TritonOptions.SEQUENCE_END);
+        set.add(TritonOptions.SEQUENCE_ID_AUTO_INCREMENT);
+        set.add(TritonOptions.SEQUENCE_ID_COUNTER_INIT_STRATEGY);
         set.add(TritonOptions.COMPRESSION);
         set.add(TritonOptions.AUTH_TOKEN);
         set.add(TritonOptions.CUSTOM_HEADERS);

--- a/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/TritonOptions.java
+++ b/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/TritonOptions.java
@@ -133,8 +133,68 @@ public class TritonOptions {
                                                     + "Requires 'sequence-id' to be configured, and both 'sequence-start' and 'sequence-end' "
                                                     + "to be set to true (each generated ID represents a one-shot stateful request, so the "
                                                     + "Triton sequence batcher must open and close the slot on the same call). "
-                                                    + "Defaults to false.")
+                                                    + "See 'sequence-id-counter-init-strategy' to control how the counter is seeded "
+                                                    + "across restarts. Defaults to false.")
                                     .build());
+
+    /**
+     * Strategy for seeding the per-subtask counter that backs {@link #SEQUENCE_ID_AUTO_INCREMENT}.
+     *
+     * <p>The choice trades off ID readability against cross-restart uniqueness:
+     *
+     * <ul>
+     *   <li>{@link #ZERO} keeps IDs short and predictable but reuses the same numeric range after
+     *       every restart, so a downstream system that has not yet finished processing the old
+     *       sequence may see ID collisions.
+     *   <li>{@link #NANO_TIME} and {@link #EPOCH_MILLIS} seed the counter from the local clock at
+     *       {@code open()} time. Each restart picks a fresh, strictly larger seed (assuming a
+     *       monotonic clock), so the new ID range cannot overlap with what the previous incarnation
+     *       emitted.
+     * </ul>
+     */
+    public enum SequenceIdCounterInitStrategy {
+        /** Counter starts at 0 on every {@code open()}. Compact IDs, no cross-restart isolation. */
+        ZERO,
+
+        /**
+         * Counter starts at {@link System#nanoTime()} captured during {@code open()}. Highest
+         * resolution; the seed difference between two restarts is essentially never zero so the ID
+         * ranges cannot overlap in practice.
+         */
+        NANO_TIME,
+
+        /**
+         * Counter starts at {@link System#currentTimeMillis()} captured during {@code open()}.
+         * Lower resolution than {@link #NANO_TIME} but the seed is human-readable as a wall-clock
+         * timestamp, which is useful for log forensics.
+         */
+        EPOCH_MILLIS
+    }
+
+    @Documentation.Section({Documentation.Sections.MODEL_TRITON_ADVANCED})
+    public static final ConfigOption<SequenceIdCounterInitStrategy>
+            SEQUENCE_ID_COUNTER_INIT_STRATEGY =
+                    ConfigOptions.key("sequence-id-counter-init-strategy")
+                            .enumType(SequenceIdCounterInitStrategy.class)
+                            .defaultValue(SequenceIdCounterInitStrategy.ZERO)
+                            .withDescription(
+                                    Description.builder()
+                                            .text(
+                                                    "Controls how the auto-increment counter is seeded at operator start. "
+                                                            + "Only effective when 'sequence-id-auto-increment' is true. "
+                                                            + "%s starts the counter at 0 (compact IDs, but a job restart will reuse the same "
+                                                            + "numeric range as before — fine when downstream is also reset, but causes ID "
+                                                            + "collisions when the previous run's records are still in flight). "
+                                                            + "%s seeds from System.nanoTime() so each restart picks a strictly larger range "
+                                                            + "and old/new sequence IDs cannot overlap. "
+                                                            + "%s seeds from System.currentTimeMillis() — same isolation property as nano-time "
+                                                            + "but with wall-clock readability. "
+                                                            + "Defaults to %s.",
+                                                    code("ZERO"),
+                                                    code("NANO_TIME"),
+                                                    code("EPOCH_MILLIS"),
+                                                    code("ZERO"))
+                                            .build());
 
     @Documentation.Section({Documentation.Sections.MODEL_TRITON_ADVANCED})
     public static final ConfigOption<Boolean> SEQUENCE_START =

--- a/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/TritonOptions.java
+++ b/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/TritonOptions.java
@@ -118,6 +118,22 @@ public class TritonOptions {
                                     .build());
 
     @Documentation.Section({Documentation.Sections.MODEL_TRITON_ADVANCED})
+    public static final ConfigOption<Boolean> SEQUENCE_ID_AUTO_INCREMENT =
+            ConfigOptions.key("sequence-id-auto-increment")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Enable auto-increment strategy for sequence ID. When enabled, a monotonically "
+                                                    + "increasing counter is appended to the sequence-id to ensure sequence isolation "
+                                                    + "across Flink job restarts and failovers. This is particularly useful for non-reentrant "
+                                                    + "models where duplicate inference requests must be avoided after failover. "
+                                                    + "Format: {sequence-id}-{subtask-index}-{counter}. "
+                                                    + "Requires 'sequence-id' to be configured. Defaults to false.")
+                                    .build());
+
+    @Documentation.Section({Documentation.Sections.MODEL_TRITON_ADVANCED})
     public static final ConfigOption<Boolean> SEQUENCE_START =
             ConfigOptions.key("sequence-start")
                     .booleanType()

--- a/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/TritonOptions.java
+++ b/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/TritonOptions.java
@@ -130,7 +130,10 @@ public class TritonOptions {
                                                     + "across Flink job restarts and failovers. This is particularly useful for non-reentrant "
                                                     + "models where duplicate inference requests must be avoided after failover. "
                                                     + "Format: {sequence-id}-{subtask-index}-{counter}. "
-                                                    + "Requires 'sequence-id' to be configured. Defaults to false.")
+                                                    + "Requires 'sequence-id' to be configured, and both 'sequence-start' and 'sequence-end' "
+                                                    + "to be set to true (each generated ID represents a one-shot stateful request, so the "
+                                                    + "Triton sequence batcher must open and close the slot on the same call). "
+                                                    + "Defaults to false.")
                                     .build());
 
     @Documentation.Section({Documentation.Sections.MODEL_TRITON_ADVANCED})

--- a/flink-models/flink-model-triton/src/test/java/org/apache/flink/model/triton/TritonModelProviderFactoryTest.java
+++ b/flink-models/flink-model-triton/src/test/java/org/apache/flink/model/triton/TritonModelProviderFactoryTest.java
@@ -80,25 +80,10 @@ class TritonModelProviderFactoryTest {
     }
 
     /**
-     * End-to-end regression guard for the sequence-id auto-increment options being exposed through
-     * the factory's {@code optionalOptions()} set.
-     *
-     * <p>Background: {@link TritonModelProviderFactory#createModelProvider} calls {@code
-     * helper.validate()}, which rejects any option key not listed in {@link
-     * TritonModelProviderFactory#requiredOptions()} or {@link
-     * TritonModelProviderFactory#optionalOptions()} as "Unsupported options". Earlier rounds of
-     * this feature added {@code sequence-id-auto-increment} and {@code
-     * sequence-id-counter-init-strategy} to {@link TritonOptions} and consumed them inside {@link
-     * TritonInferenceModelFunction}, but forgot to register them with the factory — making the
-     * feature unreachable via SQL {@code CREATE MODEL ... WITH (...)} even though the unit tests
-     * that construct the function directly (bypassing factory validation) passed green. This test
-     * goes through {@link FactoryMocks#createModelProvider} which invokes the full factory chain,
-     * so any future un-registration of these options will fail here.
-     *
-     * <p>Beyond validation, we also extract the underlying {@link TritonInferenceModelFunction} and
-     * assert that the auto-increment flag was actually plumbed through to the function's internal
-     * state — guarding against a regression where the factory validates the keys but the function
-     * silently ignores them.
+     * End-to-end guard that the auto-increment options pass {@code helper.validate()} and reach the
+     * function. Going through {@link FactoryMocks#createModelProvider} exercises the full SPI +
+     * factory chain — the unit tests that construct the function directly would not catch a missing
+     * entry in {@link TritonModelProviderFactory#optionalOptions()}.
      */
     @Test
     void testSequenceIdAutoIncrementOptionsPassFactoryValidation() {
@@ -106,7 +91,6 @@ class TritonModelProviderFactoryTest {
         options.put("provider", TritonModelProviderFactory.IDENTIFIER);
         options.put(TritonOptions.ENDPOINT.key(), "http://localhost:8000");
         options.put(TritonOptions.MODEL_NAME.key(), "test-model");
-        // The two options that were previously missing from optionalOptions().
         options.put(TritonOptions.SEQUENCE_ID.key(), "job-123");
         options.put(TritonOptions.SEQUENCE_START.key(), "true");
         options.put(TritonOptions.SEQUENCE_END.key(), "true");
@@ -117,15 +101,12 @@ class TritonModelProviderFactoryTest {
                 FactoryMocks.createModelProvider(INPUT_SCHEMA, OUTPUT_SCHEMA, options);
         assertThat(provider).isNotNull().isInstanceOf(AsyncPredictRuntimeProvider.class);
 
-        // Pass null because TritonModelProviderFactory.Provider#createAsyncPredictFunction ignores
-        // its Context argument and returns the pre-built function captured at factory time.
+        // Provider#createAsyncPredictFunction ignores its Context argument.
         AsyncPredictFunction function =
                 ((AsyncPredictRuntimeProvider) provider).createAsyncPredictFunction(null);
         assertThat(function).isInstanceOf(TritonInferenceModelFunction.class);
 
-        // Guard R5-2: if a future refactor removes the options from the constructor but still
-        // keeps them in optionalOptions(), this assertion catches the silent drop. We use the
-        // protected getSequenceId() / isSequenceIdAutoIncrement() accessors (same package).
+        // Catches a silent drop where keys validate but the constructor never reads them.
         TritonInferenceModelFunction tritonFn = (TritonInferenceModelFunction) function;
         assertThat(tritonFn.isSequenceIdAutoIncrement()).isTrue();
         assertThat(tritonFn.getSequenceId()).isEqualTo("job-123");

--- a/flink-models/flink-model-triton/src/test/java/org/apache/flink/model/triton/TritonModelProviderFactoryTest.java
+++ b/flink-models/flink-model-triton/src/test/java/org/apache/flink/model/triton/TritonModelProviderFactoryTest.java
@@ -21,6 +21,8 @@ import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.factories.utils.FactoryMocks;
+import org.apache.flink.table.functions.AsyncPredictFunction;
+import org.apache.flink.table.ml.AsyncPredictRuntimeProvider;
 import org.apache.flink.table.ml.ModelProvider;
 
 import org.junit.jupiter.api.Test;
@@ -92,6 +94,11 @@ class TritonModelProviderFactoryTest {
      * that construct the function directly (bypassing factory validation) passed green. This test
      * goes through {@link FactoryMocks#createModelProvider} which invokes the full factory chain,
      * so any future un-registration of these options will fail here.
+     *
+     * <p>Beyond validation, we also extract the underlying {@link TritonInferenceModelFunction} and
+     * assert that the auto-increment flag was actually plumbed through to the function's internal
+     * state — guarding against a regression where the factory validates the keys but the function
+     * silently ignores them.
      */
     @Test
     void testSequenceIdAutoIncrementOptionsPassFactoryValidation() {
@@ -108,6 +115,19 @@ class TritonModelProviderFactoryTest {
 
         ModelProvider provider =
                 FactoryMocks.createModelProvider(INPUT_SCHEMA, OUTPUT_SCHEMA, options);
-        assertThat(provider).isNotNull();
+        assertThat(provider).isNotNull().isInstanceOf(AsyncPredictRuntimeProvider.class);
+
+        // Pass null because TritonModelProviderFactory.Provider#createAsyncPredictFunction ignores
+        // its Context argument and returns the pre-built function captured at factory time.
+        AsyncPredictFunction function =
+                ((AsyncPredictRuntimeProvider) provider).createAsyncPredictFunction(null);
+        assertThat(function).isInstanceOf(TritonInferenceModelFunction.class);
+
+        // Guard R5-2: if a future refactor removes the options from the constructor but still
+        // keeps them in optionalOptions(), this assertion catches the silent drop. We use the
+        // protected getSequenceId() / isSequenceIdAutoIncrement() accessors (same package).
+        TritonInferenceModelFunction tritonFn = (TritonInferenceModelFunction) function;
+        assertThat(tritonFn.isSequenceIdAutoIncrement()).isTrue();
+        assertThat(tritonFn.getSequenceId()).isEqualTo("job-123");
     }
 }

--- a/flink-models/flink-model-triton/src/test/java/org/apache/flink/model/triton/TritonModelProviderFactoryTest.java
+++ b/flink-models/flink-model-triton/src/test/java/org/apache/flink/model/triton/TritonModelProviderFactoryTest.java
@@ -17,12 +17,27 @@
 
 package org.apache.flink.model.triton;
 
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.factories.utils.FactoryMocks;
+import org.apache.flink.table.ml.ModelProvider;
+
 import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link TritonModelProviderFactory}. */
 class TritonModelProviderFactoryTest {
+
+    private static final ResolvedSchema INPUT_SCHEMA =
+            ResolvedSchema.of(Column.physical("input", DataTypes.STRING()));
+
+    private static final ResolvedSchema OUTPUT_SCHEMA =
+            ResolvedSchema.of(Column.physical("output", DataTypes.STRING()));
 
     @Test
     void testFactoryIdentifier() {
@@ -42,7 +57,7 @@ class TritonModelProviderFactoryTest {
     void testOptionalOptions() {
         TritonModelProviderFactory factory = new TritonModelProviderFactory();
         assertThat(factory.optionalOptions())
-                .hasSize(14)
+                .hasSize(16)
                 .containsExactlyInAnyOrder(
                         TritonOptions.MODEL_VERSION,
                         TritonOptions.TIMEOUT,
@@ -51,6 +66,8 @@ class TritonModelProviderFactoryTest {
                         TritonOptions.SEQUENCE_ID,
                         TritonOptions.SEQUENCE_START,
                         TritonOptions.SEQUENCE_END,
+                        TritonOptions.SEQUENCE_ID_AUTO_INCREMENT,
+                        TritonOptions.SEQUENCE_ID_COUNTER_INIT_STRATEGY,
                         TritonOptions.COMPRESSION,
                         TritonOptions.AUTH_TOKEN,
                         TritonOptions.CUSTOM_HEADERS,
@@ -58,5 +75,39 @@ class TritonModelProviderFactoryTest {
                         TritonOptions.RETRY_INITIAL_BACKOFF,
                         TritonOptions.RETRY_MAX_BACKOFF,
                         TritonOptions.DEFAULT_VALUE);
+    }
+
+    /**
+     * End-to-end regression guard for the sequence-id auto-increment options being exposed through
+     * the factory's {@code optionalOptions()} set.
+     *
+     * <p>Background: {@link TritonModelProviderFactory#createModelProvider} calls {@code
+     * helper.validate()}, which rejects any option key not listed in {@link
+     * TritonModelProviderFactory#requiredOptions()} or {@link
+     * TritonModelProviderFactory#optionalOptions()} as "Unsupported options". Earlier rounds of
+     * this feature added {@code sequence-id-auto-increment} and {@code
+     * sequence-id-counter-init-strategy} to {@link TritonOptions} and consumed them inside {@link
+     * TritonInferenceModelFunction}, but forgot to register them with the factory — making the
+     * feature unreachable via SQL {@code CREATE MODEL ... WITH (...)} even though the unit tests
+     * that construct the function directly (bypassing factory validation) passed green. This test
+     * goes through {@link FactoryMocks#createModelProvider} which invokes the full factory chain,
+     * so any future un-registration of these options will fail here.
+     */
+    @Test
+    void testSequenceIdAutoIncrementOptionsPassFactoryValidation() {
+        Map<String, String> options = new HashMap<>();
+        options.put("provider", TritonModelProviderFactory.IDENTIFIER);
+        options.put(TritonOptions.ENDPOINT.key(), "http://localhost:8000");
+        options.put(TritonOptions.MODEL_NAME.key(), "test-model");
+        // The two options that were previously missing from optionalOptions().
+        options.put(TritonOptions.SEQUENCE_ID.key(), "job-123");
+        options.put(TritonOptions.SEQUENCE_START.key(), "true");
+        options.put(TritonOptions.SEQUENCE_END.key(), "true");
+        options.put(TritonOptions.SEQUENCE_ID_AUTO_INCREMENT.key(), "true");
+        options.put(TritonOptions.SEQUENCE_ID_COUNTER_INIT_STRATEGY.key(), "NANO_TIME");
+
+        ModelProvider provider =
+                FactoryMocks.createModelProvider(INPUT_SCHEMA, OUTPUT_SCHEMA, options);
+        assertThat(provider).isNotNull();
     }
 }

--- a/flink-models/flink-model-triton/src/test/java/org/apache/flink/model/triton/TritonSequenceIdAutoIncrementTest.java
+++ b/flink-models/flink-model-triton/src/test/java/org/apache/flink/model/triton/TritonSequenceIdAutoIncrementTest.java
@@ -22,13 +22,20 @@ import org.apache.flink.model.triton.TritonOptions.SequenceIdCounterInitStrategy
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.binary.BinaryStringData;
 import org.apache.flink.table.factories.ModelProviderFactory;
 import org.apache.flink.table.factories.utils.FactoryMocks;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -188,6 +195,111 @@ class TritonSequenceIdAutoIncrementTest {
                     .as("strategy %s must construct successfully", strategy)
                     .isNotNull();
         }
+    }
+
+    @Test
+    void testNextEffectiveSequenceIdAdvancesOnEachCall() throws Exception {
+        // Contract: each call to nextEffectiveSequenceId() consumes one counter slot, so the
+        // IDs returned by successive calls must be distinct and strictly monotonic in the
+        // counter suffix. This is the guarantee that lets the caller pre-generate an ID at the
+        // top of asyncPredict and thread it unchanged through retries.
+        TritonInferenceModelFunction function = newAutoIncrementFunction();
+        seedAutoIncrementState(function, /* startCounter */ 0L, /* subtask */ 0);
+
+        String id0 = function.nextEffectiveSequenceId();
+        String id1 = function.nextEffectiveSequenceId();
+        String id2 = function.nextEffectiveSequenceId();
+
+        assertThat(id0).isEqualTo("job-123-0-0");
+        assertThat(id1).isEqualTo("job-123-0-1");
+        assertThat(id2).isEqualTo("job-123-0-2");
+    }
+
+    @Test
+    void testNextEffectiveSequenceIdWithoutAutoIncrementIsStable() {
+        // When auto-increment is disabled, the method must return the base sequence ID verbatim
+        // on every call (no counter, no side effects). This is the fast path for users who
+        // configure sequence-id but don't opt into auto-increment.
+        Map<String, String> options = baseOptions();
+        options.put(TritonOptions.SEQUENCE_ID.key(), "job-123");
+        ModelProviderFactory.Context context =
+                FactoryMocks.createModelContext(INPUT_SCHEMA, OUTPUT_SCHEMA, options);
+        TritonInferenceModelFunction function =
+                new TritonInferenceModelFunction(context, contextConfig(context));
+
+        assertThat(function.nextEffectiveSequenceId()).isEqualTo("job-123");
+        assertThat(function.nextEffectiveSequenceId()).isEqualTo("job-123");
+    }
+
+    @Test
+    void testBuildInferenceRequestDoesNotAdvanceCounter() throws Exception {
+        // Regression guard for R3-1: buildInferenceRequest is invoked on every retry attempt.
+        // It must NOT call the counter itself — the effective sequence ID is computed ONCE at
+        // the asyncPredict entry point and threaded through retries as a parameter. If
+        // buildInferenceRequest started generating a fresh ID per call, every retry would open
+        // a new Triton sequence slot (because sequence-start/end=true are enforced) while only
+        // the last one would ever be closed, leaking the rest — the exact failure mode the
+        // constructor validations were introduced to prevent. Here we simulate the caller
+        // handing the same ID into two successive buildInferenceRequest invocations (as the
+        // retry path does) and assert both serialized requests carry the identical "id"
+        // field, AND that the counter state has not moved.
+        TritonInferenceModelFunction function = newAutoIncrementFunction();
+        AtomicLong counter = seedAutoIncrementState(function, 7L, 0);
+
+        String fixedId = "job-123-0-7";
+        RowData row = GenericRowData.of(BinaryStringData.fromString("hello"));
+
+        String firstBody = function.buildInferenceRequest(row, fixedId);
+        String secondBody = function.buildInferenceRequest(row, fixedId);
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode first = mapper.readTree(firstBody);
+        JsonNode second = mapper.readTree(secondBody);
+
+        assertThat(first.get("id").asText())
+                .as("first attempt uses the caller-supplied effective sequence ID")
+                .isEqualTo(fixedId);
+        assertThat(second.get("id").asText())
+                .as("retry attempt must reuse the same ID — otherwise Triton slots leak")
+                .isEqualTo(fixedId);
+        assertThat(counter.get())
+                .as("buildInferenceRequest must not advance the counter")
+                .isEqualTo(7L);
+    }
+
+    private static TritonInferenceModelFunction newAutoIncrementFunction() {
+        Map<String, String> options = baseOptions();
+        options.put(TritonOptions.SEQUENCE_ID.key(), "job-123");
+        options.put(TritonOptions.SEQUENCE_ID_AUTO_INCREMENT.key(), "true");
+        options.put(TritonOptions.SEQUENCE_START.key(), "true");
+        options.put(TritonOptions.SEQUENCE_END.key(), "true");
+        ModelProviderFactory.Context context =
+                FactoryMocks.createModelContext(INPUT_SCHEMA, OUTPUT_SCHEMA, options);
+        return new TritonInferenceModelFunction(context, contextConfig(context));
+    }
+
+    /**
+     * Installs the transient state that {@link AbstractTritonModelFunction#open} would otherwise
+     * populate. We avoid calling {@code open()} directly to keep this test module free of the
+     * flink-streaming-java test-jar dependency (the only place {@code MockStreamingRuntimeContext}
+     * lives). The two fields we touch — {@code sequenceCounter} and {@code subtaskIndex} — are the
+     * only inputs the counter path reads at runtime, and they are declared on the abstract base
+     * class specifically so the auto-increment code can reach them; reflecting into them here
+     * mirrors the real {@code open()} contract exactly.
+     */
+    private static AtomicLong seedAutoIncrementState(
+            TritonInferenceModelFunction function, long startCounter, int subtask)
+            throws Exception {
+        AtomicLong counter = new AtomicLong(startCounter);
+        Field counterField = AbstractTritonModelFunction.class.getDeclaredField("sequenceCounter");
+        counterField.setAccessible(true);
+        counterField.set(function, counter);
+
+        Field subtaskField = AbstractTritonModelFunction.class.getDeclaredField("subtaskIndex");
+        subtaskField.setAccessible(true);
+        subtaskField.setInt(function, subtask);
+
+        return counter;
     }
 
     private static Map<String, String> baseOptions() {

--- a/flink-models/flink-model-triton/src/test/java/org/apache/flink/model/triton/TritonSequenceIdAutoIncrementTest.java
+++ b/flink-models/flink-model-triton/src/test/java/org/apache/flink/model/triton/TritonSequenceIdAutoIncrementTest.java
@@ -41,24 +41,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * Validates the constructor-time validation that {@link AbstractTritonModelFunction} performs for
- * the {@link TritonOptions#SEQUENCE_ID_AUTO_INCREMENT} feature.
- *
- * <p>Two invariants are guarded:
- *
- * <ol>
- *   <li>{@code sequence-id-auto-increment=true} is only meaningful with a base {@code sequence-id}
- *       — without it there is nothing to suffix.
- *   <li>Every generated ID is a one-shot stateful sequence, so both {@code sequence-start} and
- *       {@code sequence-end} must be true. Otherwise the Triton server-side sequence batcher would
- *       either receive uninitialized state (no start) or leak per-sequence slots (no end), neither
- *       of which is recoverable from the Flink side.
- * </ol>
- *
- * <p>Failing fast in the constructor — instead of at the first inference call — surfaces the
- * misconfiguration during job submission, where the user can still react. The validations are
- * narrow and worth testing because both error paths produce server-side resource exhaustion
- * symptoms that are extremely hard to diagnose from Flink logs.
+ * Tests {@link AbstractTritonModelFunction}'s constructor-time validation and runtime behaviour for
+ * {@link TritonOptions#SEQUENCE_ID_AUTO_INCREMENT}. Failing fast at job submission is preferred
+ * over failing at the first inference call because the underlying error modes (unknown sequence
+ * state, leaked Triton slots) surface as opaque server-side resource exhaustion in production.
  */
 class TritonSequenceIdAutoIncrementTest {
 
@@ -70,12 +56,11 @@ class TritonSequenceIdAutoIncrementTest {
 
     @Test
     void testAutoIncrementWithoutSequenceIdIsRejected() {
-        // sequence-id is the prefix that auto-increment appends to. Without it, the generated
-        // ID would be "-{subtask}-{counter}" — a leading dash that confuses log parsers and is
-        // almost certainly user error rather than intent.
+        // No base sequence-id → generated ID would start with a leading dash; almost certainly a
+        // user error rather than intent.
         Map<String, String> options = baseOptions();
         options.put(TritonOptions.SEQUENCE_ID_AUTO_INCREMENT.key(), "true");
-        // Both start/end true so we isolate the missing-sequence-id failure mode.
+        // start/end true so we isolate the missing-sequence-id failure mode.
         options.put(TritonOptions.SEQUENCE_START.key(), "true");
         options.put(TritonOptions.SEQUENCE_END.key(), "true");
 
@@ -89,9 +74,7 @@ class TritonSequenceIdAutoIncrementTest {
 
     @Test
     void testAutoIncrementRequiresSequenceStart() {
-        // sequence-start=false would make Triton route the request to model state that was
-        // never initialized for this fresh sequence ID; the inference result would either be
-        // garbage or an explicit error from the sequence batcher.
+        // sequence-start=false routes to uninitialized server-side state for a fresh ID.
         Map<String, String> options = baseOptions();
         options.put(TritonOptions.SEQUENCE_ID.key(), "job-123");
         options.put(TritonOptions.SEQUENCE_ID_AUTO_INCREMENT.key(), "true");
@@ -108,10 +91,7 @@ class TritonSequenceIdAutoIncrementTest {
 
     @Test
     void testAutoIncrementRequiresSequenceEnd() {
-        // The flip side of the test above. Without sequence-end the per-sequence state slot on
-        // the Triton server is never released, so a long-running job will eventually exhaust
-        // the configured max sequence count and start failing requests — a slow leak that
-        // would only show up in production load.
+        // sequence-end=false leaks per-sequence slots — slow leak only visible under prod load.
         Map<String, String> options = baseOptions();
         options.put(TritonOptions.SEQUENCE_ID.key(), "job-123");
         options.put(TritonOptions.SEQUENCE_ID_AUTO_INCREMENT.key(), "true");
@@ -128,8 +108,7 @@ class TritonSequenceIdAutoIncrementTest {
 
     @Test
     void testAutoIncrementHappyPath() {
-        // The combination the documentation actually recommends. Construction must succeed so
-        // that the validations above cannot regress into rejecting a legitimate configuration.
+        // Guards against the validations above regressing into rejecting a legitimate config.
         Map<String, String> options = baseOptions();
         options.put(TritonOptions.SEQUENCE_ID.key(), "job-123");
         options.put(TritonOptions.SEQUENCE_ID_AUTO_INCREMENT.key(), "true");
@@ -146,10 +125,8 @@ class TritonSequenceIdAutoIncrementTest {
 
     @Test
     void testAutoIncrementDisabledDoesNotEnforceStartEnd() {
-        // Regression guard: the start/end requirement must apply ONLY when auto-increment is
-        // enabled. When auto-increment is off, the user retains full control over sequence
-        // semantics and may legitimately use sequence-start/end=false (e.g. all records share
-        // a single long-lived sequence whose start/end is signalled out-of-band).
+        // start/end requirement applies ONLY when auto-increment is on; otherwise the user
+        // retains full control (e.g. one long-lived sequence signalled out-of-band).
         Map<String, String> options = baseOptions();
         options.put(TritonOptions.SEQUENCE_ID.key(), "job-123");
         // SEQUENCE_ID_AUTO_INCREMENT defaults to false.
@@ -166,9 +143,7 @@ class TritonSequenceIdAutoIncrementTest {
 
     @Test
     void testCounterInitStrategyDefaultsToZero() {
-        // Default-value contract: if the user does not configure
-        // sequence-id-counter-init-strategy, ZERO must be selected to preserve the original
-        // (pre-strategy) behaviour for existing configurations.
+        // Default ZERO preserves pre-strategy behaviour for existing configurations.
         SequenceIdCounterInitStrategy defaultStrategy =
                 TritonOptions.SEQUENCE_ID_COUNTER_INIT_STRATEGY.defaultValue();
         assertThat(defaultStrategy).isEqualTo(SequenceIdCounterInitStrategy.ZERO);
@@ -176,9 +151,7 @@ class TritonSequenceIdAutoIncrementTest {
 
     @Test
     void testCounterInitStrategyAcceptsAllEnumValues() {
-        // The strategy is only validated by the enum codec itself, but we still verify that
-        // none of the enum constants accidentally trip the constructor (e.g. by interacting
-        // with another validation rule).
+        // Verify no enum constant accidentally trips another constructor validation.
         for (SequenceIdCounterInitStrategy strategy : SequenceIdCounterInitStrategy.values()) {
             Map<String, String> options = baseOptions();
             options.put(TritonOptions.SEQUENCE_ID.key(), "job-123");
@@ -199,10 +172,8 @@ class TritonSequenceIdAutoIncrementTest {
 
     @Test
     void testNextEffectiveSequenceIdAdvancesOnEachCall() throws Exception {
-        // Contract: each call to nextEffectiveSequenceId() consumes one counter slot, so the
-        // IDs returned by successive calls must be distinct and strictly monotonic in the
-        // counter suffix. This is the guarantee that lets the caller pre-generate an ID at the
-        // top of asyncPredict and thread it unchanged through retries.
+        // Each call consumes one counter slot, yielding strictly monotonic IDs. This is what
+        // lets the caller pre-generate once at the top of asyncPredict and thread through retries.
         TritonInferenceModelFunction function = newAutoIncrementFunction();
         seedAutoIncrementState(function, /* startCounter */ 0L, /* subtask */ 0);
 
@@ -217,9 +188,7 @@ class TritonSequenceIdAutoIncrementTest {
 
     @Test
     void testNextEffectiveSequenceIdWithoutAutoIncrementIsStable() {
-        // When auto-increment is disabled, the method must return the base sequence ID verbatim
-        // on every call (no counter, no side effects). This is the fast path for users who
-        // configure sequence-id but don't opt into auto-increment.
+        // Auto-increment off → return base ID verbatim, no counter, no side effects.
         Map<String, String> options = baseOptions();
         options.put(TritonOptions.SEQUENCE_ID.key(), "job-123");
         ModelProviderFactory.Context context =
@@ -233,16 +202,9 @@ class TritonSequenceIdAutoIncrementTest {
 
     @Test
     void testBuildInferenceRequestDoesNotAdvanceCounter() throws Exception {
-        // Regression guard for R3-1: buildInferenceRequest is invoked on every retry attempt.
-        // It must NOT call the counter itself — the effective sequence ID is computed ONCE at
-        // the asyncPredict entry point and threaded through retries as a parameter. If
-        // buildInferenceRequest started generating a fresh ID per call, every retry would open
-        // a new Triton sequence slot (because sequence-start/end=true are enforced) while only
-        // the last one would ever be closed, leaking the rest — the exact failure mode the
-        // constructor validations were introduced to prevent. Here we simulate the caller
-        // handing the same ID into two successive buildInferenceRequest invocations (as the
-        // retry path does) and assert both serialized requests carry the identical "id"
-        // field, AND that the counter state has not moved.
+        // Regression guard: buildInferenceRequest runs on every retry attempt and must reuse the
+        // caller-supplied ID — generating fresh IDs here would leak Triton sequence slots. See
+        // nextEffectiveSequenceId() javadoc for the full slot-leak rationale.
         TritonInferenceModelFunction function = newAutoIncrementFunction();
         AtomicLong counter = seedAutoIncrementState(function, 7L, 0);
 
@@ -279,13 +241,9 @@ class TritonSequenceIdAutoIncrementTest {
     }
 
     /**
-     * Installs the transient state that {@link AbstractTritonModelFunction#open} would otherwise
-     * populate. We avoid calling {@code open()} directly to keep this test module free of the
-     * flink-streaming-java test-jar dependency (the only place {@code MockStreamingRuntimeContext}
-     * lives). The two fields we touch — {@code sequenceCounter} and {@code subtaskIndex} — are the
-     * only inputs the counter path reads at runtime, and they are declared on the abstract base
-     * class specifically so the auto-increment code can reach them; reflecting into them here
-     * mirrors the real {@code open()} contract exactly.
+     * Seeds the transient state {@link AbstractTritonModelFunction#open} would populate. Reflection
+     * (rather than calling {@code open()}) avoids depending on {@code MockStreamingRuntimeContext}
+     * from the flink-streaming-java test-jar.
      */
     private static AtomicLong seedAutoIncrementState(
             TritonInferenceModelFunction function, long startCounter, int subtask)

--- a/flink-models/flink-model-triton/src/test/java/org/apache/flink/model/triton/TritonSequenceIdAutoIncrementTest.java
+++ b/flink-models/flink-model-triton/src/test/java/org/apache/flink/model/triton/TritonSequenceIdAutoIncrementTest.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.model.triton;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.model.triton.TritonOptions.SequenceIdCounterInitStrategy;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.factories.ModelProviderFactory;
+import org.apache.flink.table.factories.utils.FactoryMocks;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Validates the constructor-time validation that {@link AbstractTritonModelFunction} performs for
+ * the {@link TritonOptions#SEQUENCE_ID_AUTO_INCREMENT} feature.
+ *
+ * <p>Two invariants are guarded:
+ *
+ * <ol>
+ *   <li>{@code sequence-id-auto-increment=true} is only meaningful with a base {@code sequence-id}
+ *       — without it there is nothing to suffix.
+ *   <li>Every generated ID is a one-shot stateful sequence, so both {@code sequence-start} and
+ *       {@code sequence-end} must be true. Otherwise the Triton server-side sequence batcher would
+ *       either receive uninitialized state (no start) or leak per-sequence slots (no end), neither
+ *       of which is recoverable from the Flink side.
+ * </ol>
+ *
+ * <p>Failing fast in the constructor — instead of at the first inference call — surfaces the
+ * misconfiguration during job submission, where the user can still react. The validations are
+ * narrow and worth testing because both error paths produce server-side resource exhaustion
+ * symptoms that are extremely hard to diagnose from Flink logs.
+ */
+class TritonSequenceIdAutoIncrementTest {
+
+    private static final ResolvedSchema INPUT_SCHEMA =
+            ResolvedSchema.of(Column.physical("input", DataTypes.STRING()));
+
+    private static final ResolvedSchema OUTPUT_SCHEMA =
+            ResolvedSchema.of(Column.physical("output", DataTypes.STRING()));
+
+    @Test
+    void testAutoIncrementWithoutSequenceIdIsRejected() {
+        // sequence-id is the prefix that auto-increment appends to. Without it, the generated
+        // ID would be "-{subtask}-{counter}" — a leading dash that confuses log parsers and is
+        // almost certainly user error rather than intent.
+        Map<String, String> options = baseOptions();
+        options.put(TritonOptions.SEQUENCE_ID_AUTO_INCREMENT.key(), "true");
+        // Both start/end true so we isolate the missing-sequence-id failure mode.
+        options.put(TritonOptions.SEQUENCE_START.key(), "true");
+        options.put(TritonOptions.SEQUENCE_END.key(), "true");
+
+        ModelProviderFactory.Context context =
+                FactoryMocks.createModelContext(INPUT_SCHEMA, OUTPUT_SCHEMA, options);
+
+        assertThatThrownBy(() -> new TritonInferenceModelFunction(context, contextConfig(context)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(TritonOptions.SEQUENCE_ID.key());
+    }
+
+    @Test
+    void testAutoIncrementRequiresSequenceStart() {
+        // sequence-start=false would make Triton route the request to model state that was
+        // never initialized for this fresh sequence ID; the inference result would either be
+        // garbage or an explicit error from the sequence batcher.
+        Map<String, String> options = baseOptions();
+        options.put(TritonOptions.SEQUENCE_ID.key(), "job-123");
+        options.put(TritonOptions.SEQUENCE_ID_AUTO_INCREMENT.key(), "true");
+        options.put(TritonOptions.SEQUENCE_START.key(), "false");
+        options.put(TritonOptions.SEQUENCE_END.key(), "true");
+
+        ModelProviderFactory.Context context =
+                FactoryMocks.createModelContext(INPUT_SCHEMA, OUTPUT_SCHEMA, options);
+
+        assertThatThrownBy(() -> new TritonInferenceModelFunction(context, contextConfig(context)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("sequence-start");
+    }
+
+    @Test
+    void testAutoIncrementRequiresSequenceEnd() {
+        // The flip side of the test above. Without sequence-end the per-sequence state slot on
+        // the Triton server is never released, so a long-running job will eventually exhaust
+        // the configured max sequence count and start failing requests — a slow leak that
+        // would only show up in production load.
+        Map<String, String> options = baseOptions();
+        options.put(TritonOptions.SEQUENCE_ID.key(), "job-123");
+        options.put(TritonOptions.SEQUENCE_ID_AUTO_INCREMENT.key(), "true");
+        options.put(TritonOptions.SEQUENCE_START.key(), "true");
+        options.put(TritonOptions.SEQUENCE_END.key(), "false");
+
+        ModelProviderFactory.Context context =
+                FactoryMocks.createModelContext(INPUT_SCHEMA, OUTPUT_SCHEMA, options);
+
+        assertThatThrownBy(() -> new TritonInferenceModelFunction(context, contextConfig(context)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("sequence-end");
+    }
+
+    @Test
+    void testAutoIncrementHappyPath() {
+        // The combination the documentation actually recommends. Construction must succeed so
+        // that the validations above cannot regress into rejecting a legitimate configuration.
+        Map<String, String> options = baseOptions();
+        options.put(TritonOptions.SEQUENCE_ID.key(), "job-123");
+        options.put(TritonOptions.SEQUENCE_ID_AUTO_INCREMENT.key(), "true");
+        options.put(TritonOptions.SEQUENCE_START.key(), "true");
+        options.put(TritonOptions.SEQUENCE_END.key(), "true");
+
+        ModelProviderFactory.Context context =
+                FactoryMocks.createModelContext(INPUT_SCHEMA, OUTPUT_SCHEMA, options);
+
+        TritonInferenceModelFunction function =
+                new TritonInferenceModelFunction(context, contextConfig(context));
+        assertThat(function).isNotNull();
+    }
+
+    @Test
+    void testAutoIncrementDisabledDoesNotEnforceStartEnd() {
+        // Regression guard: the start/end requirement must apply ONLY when auto-increment is
+        // enabled. When auto-increment is off, the user retains full control over sequence
+        // semantics and may legitimately use sequence-start/end=false (e.g. all records share
+        // a single long-lived sequence whose start/end is signalled out-of-band).
+        Map<String, String> options = baseOptions();
+        options.put(TritonOptions.SEQUENCE_ID.key(), "job-123");
+        // SEQUENCE_ID_AUTO_INCREMENT defaults to false.
+        options.put(TritonOptions.SEQUENCE_START.key(), "false");
+        options.put(TritonOptions.SEQUENCE_END.key(), "false");
+
+        ModelProviderFactory.Context context =
+                FactoryMocks.createModelContext(INPUT_SCHEMA, OUTPUT_SCHEMA, options);
+
+        TritonInferenceModelFunction function =
+                new TritonInferenceModelFunction(context, contextConfig(context));
+        assertThat(function).isNotNull();
+    }
+
+    @Test
+    void testCounterInitStrategyDefaultsToZero() {
+        // Default-value contract: if the user does not configure
+        // sequence-id-counter-init-strategy, ZERO must be selected to preserve the original
+        // (pre-strategy) behaviour for existing configurations.
+        SequenceIdCounterInitStrategy defaultStrategy =
+                TritonOptions.SEQUENCE_ID_COUNTER_INIT_STRATEGY.defaultValue();
+        assertThat(defaultStrategy).isEqualTo(SequenceIdCounterInitStrategy.ZERO);
+    }
+
+    @Test
+    void testCounterInitStrategyAcceptsAllEnumValues() {
+        // The strategy is only validated by the enum codec itself, but we still verify that
+        // none of the enum constants accidentally trip the constructor (e.g. by interacting
+        // with another validation rule).
+        for (SequenceIdCounterInitStrategy strategy : SequenceIdCounterInitStrategy.values()) {
+            Map<String, String> options = baseOptions();
+            options.put(TritonOptions.SEQUENCE_ID.key(), "job-123");
+            options.put(TritonOptions.SEQUENCE_ID_AUTO_INCREMENT.key(), "true");
+            options.put(TritonOptions.SEQUENCE_START.key(), "true");
+            options.put(TritonOptions.SEQUENCE_END.key(), "true");
+            options.put(TritonOptions.SEQUENCE_ID_COUNTER_INIT_STRATEGY.key(), strategy.name());
+
+            ModelProviderFactory.Context context =
+                    FactoryMocks.createModelContext(INPUT_SCHEMA, OUTPUT_SCHEMA, options);
+            TritonInferenceModelFunction function =
+                    new TritonInferenceModelFunction(context, contextConfig(context));
+            assertThat(function)
+                    .as("strategy %s must construct successfully", strategy)
+                    .isNotNull();
+        }
+    }
+
+    private static Map<String, String> baseOptions() {
+        Map<String, String> options = new HashMap<>();
+        options.put("provider", TritonModelProviderFactory.IDENTIFIER);
+        options.put(TritonOptions.ENDPOINT.key(), "http://localhost:8000");
+        options.put(TritonOptions.MODEL_NAME.key(), "test-model");
+        return options;
+    }
+
+    private static Configuration contextConfig(ModelProviderFactory.Context context) {
+        Configuration config = new Configuration();
+        context.getCatalogModel().getOptions().forEach(config::setString);
+        return config;
+    }
+}


### PR DESCRIPTION
Closes FLINK-39611

## What is the purpose of the change

This PR [FLINK-39611](https://issues.apache.org/jira/browse/FLINK-39611) (sub-task of [FLINK-38857](https://issues.apache.org/jira/browse/FLINK-38857)) adds sequence ID auto-increment strategy support for Triton Inference Server integration in Flink, addressing the need for sequence isolation across job failovers and restarts.

## Brief change log

- Add `sequence-id-auto-increment` configuration option in `TritonOptions`
- Implement auto-increment logic in `TritonInferenceModelFunction`
  * Generate unique sequence IDs: `{sequence-id}-{subtask-index}-{counter}`
  * Initialize `AtomicLong` counter in `open()` method
  * Increment counter for each inference request
- Add validation to ensure `sequence-id` is configured when auto-increment is enabled
- Add detailed logging for debugging sequence ID generation

## Use Case

This feature is particularly useful for **non-reentrant models** where:
- Duplicate inference requests must be avoided after failover
- Sequence batching requires strict isolation between parallel instances
- Models maintain stateful context that cannot handle repeated sequence IDs

### Example Configuration

```sql
CREATE MODEL my_triton_model WITH (
  'provider' = 'triton',
  'endpoint' = 'https://triton-server:8000/v2/models',
  'model-name' = 'my_stateful_model',
  'sequence-id' = 'flink-job-123',
  'sequence-id-auto-increment' = 'true',  -- Enable auto-increment
  'sequence-start' = 'true',
  'sequence-end' = 'true'
);
```

### Sequence ID Format

When auto-increment is enabled, sequence IDs follow this pattern:
```
{base-sequence-id}-{subtask-index}-{counter}
Example: flink-job-123-0-0, flink-job-123-0-1, flink-job-123-1-0
```

This ensures:
- Unique sequences across parallel subtasks (via subtask-index)
- Monotonically increasing sequences per subtask (via counter)
- Sequence isolation across job restarts (new counter starts from 0)

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

- Manual testing with Triton Inference Server
- Code formatting verified with Spotless

## Does this pull request potentially affect one of the following parts

- Dependencies: no
- The public API: yes (adds new configuration option)
- The serializers: no
- The runtime per-record code paths: no
- Anything that affects deployment or recovery: JobManager, Checkpoint Coordinator, State backends, etc.: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? yes
- If yes, how is the feature documented? JavaDocs

## Related Issues

- Sub-task: [FLINK-39611](https://issues.apache.org/jira/browse/FLINK-39611) — Add sequence ID auto-increment support for Triton inference
- Parent: [FLINK-38857](https://issues.apache.org/jira/browse/FLINK-38857) — Introduce a Triton inference module under `flink-models`

---

## PR Series Overview for FLINK-38857

This PR is part of the FLINK-38857 epic for introducing a Triton-based inference module under `flink-models`. The following table summarizes all related PRs in this series:

| No. | PR ID | PR Title | Main Module(s) | Main Content |
|:---:|:---:|---------|---------------|--------------|
| 1 | [#27385](https://github.com/apache/flink/pull/27385) | [FLINK-38857][Model] Introduce a Triton inference module under flink-models | `flink-model-triton` | Introduce the core Triton inference module with async/batched inference support via Triton HTTP/REST API |
| 2 | [#27490](https://github.com/apache/flink/pull/27490) | [FLINK-38857][Model] Add docs for Triton inference model | `docs/connectors/models` | Add comprehensive documentation for Triton model integration, including SQL examples and configuration guides |
| 3 | [#27560](https://github.com/apache/flink/pull/27560) | [FLINK-39059][model] Add unified metrics support to AsyncPredictFunction and PredictFunction | `flink-model-triton` | Add built-in metrics (requests, latency, success/failure counts) for model inference monitoring |
| 4 | [#27561](https://github.com/apache/flink/pull/27561) | [FLINK-39225][model] Add retry with default value fallback for triton inference failures | `flink-model-triton` | Implement exponential backoff retry strategy and default value fallback for robust error handling |
| **5** | [#27562](https://github.com/apache/flink/pull/27562) | [FLINK-39611][model] Add sequence ID auto-increment support for Triton inference | `flink-model-triton` | Add sequence ID auto-increment strategy for stateful models to ensure sequence isolation across failovers |
| 6 | [#27567](https://github.com/apache/flink/pull/27567) | [FLINK-38857][models] Add health check and circuit breaker for Triton inference | `flink-model-triton` | Implement health check and circuit breaker protection for fault tolerance in production deployments |
| 7 | [#27568](https://github.com/apache/flink/pull/27568) | [FLINK-39612][models] Add HTTP connection pool management for Triton inference | `flink-model-triton` | Add HTTP connection pool management to reduce latency and improve throughput by reusing connections |

### Dependency Order

```
PR #27385 (Core Module)
    ↓
PR #27490 (Documentation)
    ↓
PR #27560 (Metrics) ─┬─→ PR #27561 (Retry)
                     ├─→ PR #27562 (Sequence ID)
                     ├─→ PR #27567 (Circuit Breaker)
                     └─→ PR #27568 (Connection Pool)
```

### Notes

- **PR #27385** is the foundational PR that introduces the core Triton inference module
- All subsequent PRs build upon the core module and add specific enhancements
- Each PR can be reviewed and merged independently after the core module is merged
- All changes are **fully optional** and isolated under `flink-models` with no impact on existing Flink functionality
