### PR TITLE
[FLINK-39064][Table SQL / API] Add built-in REGEXP_SPLIT function to split string by regular expression pattern

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -421,7 +421,43 @@ string:
       
       `str <CHAR | VARCHAR>, regex <CHAR | VARCHAR>`
       
+      Returns an `STRING` representation of the first matched substring. `NULL` if any of the arguments are `NULL` or regex if invalid or pattern is not found.
+  - sql: REGEXP_SPLIT(str, regex)
+    table: str.regexpSplit(regex)
+    description: |
+      Splits str by the regular expression regex and returns an array of strings.
+      
+      E.g., REGEXP_SPLIT('Hello123World456', '[0-9]+') returns ['Hello', 'World', ''].
+      
+      `str <CHAR | VARCHAR>, regex <CHAR | VARCHAR>`
+      
+      Returns an `ARRAY<STRING>` of split substrings. `NULL` if any of the arguments are `NULL` or regex is invalid.
+>>>>>>> 8d75684590d (hotfix)
+=======
       Returns an `STRING` representation of the first matched substring. `NULL` if any of the arguments are `NULL` or regex is invalid or pattern is not found.
+  - sql: REGEXP_SPLIT(str, regex)
+    table: str.regexpSplit(regex)
+    description: |
+      Splits str by the regular expression regex and returns an array of strings.
+      
+      E.g., REGEXP_SPLIT('Hello123World456', '[0-9]+') returns ['Hello', 'World', ''].
+      
+      `str <CHAR | VARCHAR>, regex <CHAR | VARCHAR>`
+      
+      Returns an `ARRAY<STRING>` of split substrings. `NULL` if any of the arguments are `NULL` or regex is invalid.
+=======
+      Returns an `STRING` representation of the first matched substring. `NULL` if any of the arguments are `NULL` or regex if invalid or pattern is not found.
+  - sql: REGEXP_SPLIT(str, regex)
+    table: str.regexpSplit(regex)
+    description: |
+      Splits str by the regular expression regex and returns an array of strings.
+      
+      E.g., REGEXP_SPLIT('Hello123World456', '[0-9]+') returns ['Hello', 'World', ''].
+      
+      `str <CHAR | VARCHAR>, regex <CHAR | VARCHAR>`
+      
+      Returns an `ARRAY<STRING>` of split substrings. `NULL` if any of the arguments are `NULL` or regex is invalid.
+>>>>>>> 8d75684590d (hotfix)
   - sql: TRANSLATE(expr, fromStr, toStr)
     table: expr.translate(fromStr, toStr)
     description: |

--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -421,19 +421,6 @@ string:
       
       `str <CHAR | VARCHAR>, regex <CHAR | VARCHAR>`
       
-      Returns an `STRING` representation of the first matched substring. `NULL` if any of the arguments are `NULL` or regex if invalid or pattern is not found.
-  - sql: REGEXP_SPLIT(str, regex)
-    table: str.regexpSplit(regex)
-    description: |
-      Splits str by the regular expression regex and returns an array of strings.
-      
-      E.g., REGEXP_SPLIT('Hello123World456', '[0-9]+') returns ['Hello', 'World', ''].
-      
-      `str <CHAR | VARCHAR>, regex <CHAR | VARCHAR>`
-      
-      Returns an `ARRAY<STRING>` of split substrings. `NULL` if any of the arguments are `NULL` or regex is invalid.
->>>>>>> 8d75684590d (hotfix)
-=======
       Returns an `STRING` representation of the first matched substring. `NULL` if any of the arguments are `NULL` or regex is invalid or pattern is not found.
   - sql: REGEXP_SPLIT(str, regex)
     table: str.regexpSplit(regex)
@@ -445,19 +432,6 @@ string:
       `str <CHAR | VARCHAR>, regex <CHAR | VARCHAR>`
       
       Returns an `ARRAY<STRING>` of split substrings. `NULL` if any of the arguments are `NULL` or regex is invalid.
-=======
-      Returns an `STRING` representation of the first matched substring. `NULL` if any of the arguments are `NULL` or regex if invalid or pattern is not found.
-  - sql: REGEXP_SPLIT(str, regex)
-    table: str.regexpSplit(regex)
-    description: |
-      Splits str by the regular expression regex and returns an array of strings.
-      
-      E.g., REGEXP_SPLIT('Hello123World456', '[0-9]+') returns ['Hello', 'World', ''].
-      
-      `str <CHAR | VARCHAR>, regex <CHAR | VARCHAR>`
-      
-      Returns an `ARRAY<STRING>` of split substrings. `NULL` if any of the arguments are `NULL` or regex is invalid.
->>>>>>> 8d75684590d (hotfix)
   - sql: TRANSLATE(expr, fromStr, toStr)
     table: expr.translate(fromStr, toStr)
     description: |

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -492,6 +492,16 @@ string:
       `str <CHAR | VARCHAR>, regex <CHAR | VARCHAR>`
       
       返回一个 `STRING` 表示 str 中第一个匹配 regex 的子字符串。如果任何参数为 `NULL` 或 regex 非法或匹配失败，则返回 `NULL`。
+  - sql: REGEXP_SPLIT(str, regex)
+    table: str.regexpSplit(regex)
+    description: |
+      按正则表达式 regex 拆分字符串 str，并返回一个字符串数组。
+      
+      例如 `REGEXP_SPLIT('Hello123World456', '[0-9]+')` 返回 `['Hello', 'World', '']`。
+      
+      `str <CHAR | VARCHAR>, regex <CHAR | VARCHAR>`
+      
+      返回一个 `ARRAY<STRING>` 表示拆分后的子字符串数组。如果任何参数为 `NULL` 或 regex 非法，则返回 `NULL`。
   - sql: TRANSLATE(expr, fromStr, toStr)
     table: expr.translate(fromStr, toStr)
     description: |

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -189,6 +189,7 @@ string functions
     Expression.regexp_extract_all
     Expression.regexp_instr
     Expression.regexp_substr
+    Expression.regexp_split
     Expression.from_base64
     Expression.to_base64
     Expression.ascii

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1362,6 +1362,18 @@ class Expression(Generic[T]):
         """
         return _binary_op("regexpSubstr")(self, regex)
 
+    def regexp_split(self, regex) -> 'Expression':
+        """
+        Splits the string by the regular expression regex and returns an array of strings.
+        null if any of the arguments are null or regex is invalid.
+
+        E.g., regexp_split('Hello123World456', '[0-9]+') returns ['Hello', 'World', ''].
+
+        :param regex: A STRING expression with a matching pattern.
+        :return: An ARRAY<STRING> of split substrings.
+        """
+        return _binary_op("regexpSplit")(self, regex)
+
     @property
     def from_base64(self) -> 'Expression[str]':
         """

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1364,10 +1364,20 @@ class Expression(Generic[T]):
 
     def regexp_split(self, regex) -> 'Expression':
         """
-        Splits the string by the regular expression regex and returns an array of strings.
-        null if any of the arguments are null or regex is invalid.
+        Returns an array of substrings by splitting the input string based on a regular expression
+        pattern.
 
-        E.g., regexp_split('Hello123World456', '[0-9]+') returns ['Hello', 'World', ''].
+        If the pattern is not found in the string, the original string is returned as the only
+        element in the array. If the pattern is empty, every character in the string is split. If
+        the string or pattern is null, a null value is returned. If the pattern is found at the
+        beginning or end of the string, or there are contiguous matches, then an empty string is
+        added to the array.
+
+        E.g.:
+
+        - lit("Hello123World456").regexp_split("[0-9]+") returns ["Hello", "World", ""]
+        - lit("a,b;c").regexp_split("[,;]") returns ["a", "b", "c"]
+        - lit("one  two   three").regexp_split("\\s+") returns ["one", "two", "three"]
 
         :param regex: A STRING expression with a matching pattern.
         :return: An ARRAY<STRING> of split substrings.

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -191,6 +191,7 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.REGEXP
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.REGEXP_EXTRACT_ALL;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.REGEXP_INSTR;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.REGEXP_REPLACE;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.REGEXP_SPLIT;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.REGEXP_SUBSTR;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.REPEAT;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.REPLACE;
@@ -1949,6 +1950,32 @@ public abstract class BaseExpressions<InType, OutType> {
     public OutType split(InType delimiter) {
         return toApiSpecificExpression(
                 unresolvedCall(SPLIT, toExpr(), objectToExpression(delimiter)));
+    }
+
+    /**
+     * Returns an array of substrings by splitting the input string based on a regular expression
+     * pattern.
+     *
+     * <p>If the pattern is not found in the string, the original string is returned as the only
+     * element in the array. If the pattern is empty, every character in the string is split. If the
+     * string or pattern is null, a null value is returned. If the pattern is found at the beginning
+     * or end of the string, or there are contiguous matches, then an empty string is added to the
+     * array.
+     *
+     * <p>Examples:
+     *
+     * <pre>{@code
+     * lit("Hello123World456").regexpSplit("[0-9]+") // ["Hello", "World", ""]
+     * lit("a,b;c").regexpSplit("[,;]") // ["a", "b", "c"]
+     * lit("one  two   three").regexpSplit("\\s+") // ["one", "two", "three"]
+     * }</pre>
+     *
+     * @param regex The regular expression pattern to split by.
+     * @return An array of substrings.
+     */
+    public OutType regexpSplit(InType regex) {
+        return toApiSpecificExpression(
+                unresolvedCall(REGEXP_SPLIT, toExpr(), objectToExpression(regex)));
     }
 
     /** Returns the keys of the map as an array. */

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -449,6 +449,20 @@ public final class BuiltInFunctionDefinitions {
                     .runtimeClass("org.apache.flink.table.runtime.functions.scalar.SplitFunction")
                     .build();
 
+    public static final BuiltInFunctionDefinition REGEXP_SPLIT =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("REGEXP_SPLIT")
+                    .sqlName("REGEXP_SPLIT")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            sequence(
+                                    logical(LogicalTypeFamily.CHARACTER_STRING),
+                                    logical(LogicalTypeFamily.CHARACTER_STRING)))
+                    .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.ARRAY(STRING()))))
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.scalar.RegexpSplitFunction")
+                    .build();
+
     public static final BuiltInFunctionDefinition URL_DECODE =
             BuiltInFunctionDefinition.newBuilder()
                     .name("URL_DECODE")

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -454,10 +454,7 @@ public final class BuiltInFunctionDefinitions {
                     .name("REGEXP_SPLIT")
                     .sqlName("REGEXP_SPLIT")
                     .kind(SCALAR)
-                    .inputTypeStrategy(
-                            sequence(
-                                    logical(LogicalTypeFamily.CHARACTER_STRING),
-                                    logical(LogicalTypeFamily.CHARACTER_STRING)))
+                    .inputTypeStrategy(SpecificInputTypeStrategies.REGEXP)
                     .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.ARRAY(STRING()))))
                     .runtimeClass(
                             "org.apache.flink.table.runtime.functions.scalar.RegexpSplitFunction")
@@ -1435,12 +1432,7 @@ public final class BuiltInFunctionDefinitions {
             BuiltInFunctionDefinition.newBuilder()
                     .name("REGEXP_COUNT")
                     .kind(SCALAR)
-                    .inputTypeStrategy(
-                            sequence(
-                                    Arrays.asList("str", "regex"),
-                                    Arrays.asList(
-                                            logical(LogicalTypeFamily.CHARACTER_STRING),
-                                            logical(LogicalTypeFamily.CHARACTER_STRING))))
+                    .inputTypeStrategy(SpecificInputTypeStrategies.REGEXP)
                     .outputTypeStrategy(explicit(DataTypes.INT()))
                     .runtimeClass(
                             "org.apache.flink.table.runtime.functions.scalar.RegexpCountFunction")
@@ -1459,19 +1451,7 @@ public final class BuiltInFunctionDefinitions {
             BuiltInFunctionDefinition.newBuilder()
                     .name("REGEXP_EXTRACT_ALL")
                     .kind(SCALAR)
-                    .inputTypeStrategy(
-                            or(
-                                    sequence(
-                                            Arrays.asList("str", "regex"),
-                                            Arrays.asList(
-                                                    logical(LogicalTypeFamily.CHARACTER_STRING),
-                                                    logical(LogicalTypeFamily.CHARACTER_STRING))),
-                                    sequence(
-                                            Arrays.asList("str", "regex", "extractIndex"),
-                                            Arrays.asList(
-                                                    logical(LogicalTypeFamily.CHARACTER_STRING),
-                                                    logical(LogicalTypeFamily.CHARACTER_STRING),
-                                                    logical(LogicalTypeFamily.INTEGER_NUMERIC)))))
+                    .inputTypeStrategy(SpecificInputTypeStrategies.REGEXP_EXTRACT_ALL)
                     .outputTypeStrategy(explicit(DataTypes.ARRAY(DataTypes.STRING())))
                     .runtimeClass(
                             "org.apache.flink.table.runtime.functions.scalar.RegexpExtractAllFunction")
@@ -1481,12 +1461,7 @@ public final class BuiltInFunctionDefinitions {
             BuiltInFunctionDefinition.newBuilder()
                     .name("REGEXP_INSTR")
                     .kind(SCALAR)
-                    .inputTypeStrategy(
-                            sequence(
-                                    Arrays.asList("str", "regex"),
-                                    Arrays.asList(
-                                            logical(LogicalTypeFamily.CHARACTER_STRING),
-                                            logical(LogicalTypeFamily.CHARACTER_STRING))))
+                    .inputTypeStrategy(SpecificInputTypeStrategies.REGEXP)
                     .outputTypeStrategy(explicit(DataTypes.INT()))
                     .runtimeClass(
                             "org.apache.flink.table.runtime.functions.scalar.RegexpInstrFunction")
@@ -1496,12 +1471,7 @@ public final class BuiltInFunctionDefinitions {
             BuiltInFunctionDefinition.newBuilder()
                     .name("REGEXP_SUBSTR")
                     .kind(SCALAR)
-                    .inputTypeStrategy(
-                            sequence(
-                                    Arrays.asList("str", "regex"),
-                                    Arrays.asList(
-                                            logical(LogicalTypeFamily.CHARACTER_STRING),
-                                            logical(LogicalTypeFamily.CHARACTER_STRING))))
+                    .inputTypeStrategy(SpecificInputTypeStrategies.REGEXP)
                     .outputTypeStrategy(explicit(DataTypes.STRING()))
                     .runtimeClass(
                             "org.apache.flink.table.runtime.functions.scalar.RegexpSubstrFunction")

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/RegexpExtractAllInputTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/RegexpExtractAllInputTypeStrategy.java
@@ -30,7 +30,6 @@ import org.apache.flink.table.types.inference.InputTypeStrategy;
 import org.apache.flink.table.types.inference.Signature;
 import org.apache.flink.table.types.inference.Signature.Argument;
 import org.apache.flink.table.types.logical.LogicalTypeFamily;
-import org.apache.flink.table.types.logical.LogicalTypeRoot;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,11 +38,11 @@ import java.util.Optional;
 import static org.apache.flink.table.types.inference.InputTypeStrategies.logical;
 
 /**
- * Input type strategy for {@link BuiltInFunctionDefinitions#REGEXP_EXTRACT}. Validates literal
+ * Input type strategy for {@link BuiltInFunctionDefinitions#REGEXP_EXTRACT_ALL}. Validates literal
  * regex patterns at planning time.
  */
 @Internal
-public class RegexpExtractInputTypeStrategy implements InputTypeStrategy {
+public class RegexpExtractAllInputTypeStrategy implements InputTypeStrategy {
 
     private static final int ARG_STR = 0;
     private static final int ARG_REGEX = 1;
@@ -51,7 +50,8 @@ public class RegexpExtractInputTypeStrategy implements InputTypeStrategy {
 
     private static final ArgumentTypeStrategy STRING_ARG =
             logical(LogicalTypeFamily.CHARACTER_STRING);
-    private static final ArgumentTypeStrategy INT_ARG = logical(LogicalTypeRoot.INTEGER);
+    private static final ArgumentTypeStrategy INTEGER_NUMERIC_ARG =
+            logical(LogicalTypeFamily.INTEGER_NUMERIC);
 
     @Override
     public ArgumentCount getArgumentCount() {
@@ -77,7 +77,8 @@ public class RegexpExtractInputTypeStrategy implements InputTypeStrategy {
         inferredDataTypes.add(inferredRegexType.get());
         if (callContext.getArgumentDataTypes().size() > ARG_EXTRACT_INDEX) {
             final Optional<DataType> inferredExtractIndexType =
-                    INT_ARG.inferArgumentType(callContext, ARG_EXTRACT_INDEX, throwOnFailure);
+                    INTEGER_NUMERIC_ARG.inferArgumentType(
+                            callContext, ARG_EXTRACT_INDEX, throwOnFailure);
             if (inferredExtractIndexType.isEmpty()) {
                 return Optional.empty();
             }
@@ -102,6 +103,6 @@ public class RegexpExtractInputTypeStrategy implements InputTypeStrategy {
                 Signature.of(
                         Argument.ofGroup("str", LogicalTypeFamily.CHARACTER_STRING),
                         Argument.ofGroup("regex", LogicalTypeFamily.CHARACTER_STRING),
-                        Argument.ofGroup("extractIndex", LogicalTypeRoot.INTEGER)));
+                        Argument.ofGroup("extractIndex", LogicalTypeFamily.INTEGER_NUMERIC)));
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/RegexpInputTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/RegexpInputTypeStrategy.java
@@ -31,14 +31,15 @@ import org.apache.flink.table.types.inference.Signature;
 import org.apache.flink.table.types.inference.Signature.Argument;
 import org.apache.flink.table.types.logical.LogicalTypeFamily;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 import static org.apache.flink.table.types.inference.InputTypeStrategies.logical;
 
 /**
- * Input type strategy for {@link BuiltInFunctionDefinitions#REGEXP}. Validates literal regex
- * patterns at planning time.
+ * Input type strategy for two-argument regex functions such as {@link
+ * BuiltInFunctionDefinitions#REGEXP}. Validates literal regex patterns at planning time.
  */
 @Internal
 public class RegexpInputTypeStrategy implements InputTypeStrategy {
@@ -57,10 +58,14 @@ public class RegexpInputTypeStrategy implements InputTypeStrategy {
     @Override
     public Optional<List<DataType>> inferInputTypes(
             final CallContext callContext, final boolean throwOnFailure) {
-        if (STRING_ARG.inferArgumentType(callContext, ARG_STR, throwOnFailure).isEmpty()) {
+        final Optional<DataType> inferredStrType =
+                STRING_ARG.inferArgumentType(callContext, ARG_STR, throwOnFailure);
+        if (inferredStrType.isEmpty()) {
             return Optional.empty();
         }
-        if (STRING_ARG.inferArgumentType(callContext, ARG_REGEX, throwOnFailure).isEmpty()) {
+        final Optional<DataType> inferredRegexType =
+                STRING_ARG.inferArgumentType(callContext, ARG_REGEX, throwOnFailure);
+        if (inferredRegexType.isEmpty()) {
             return Optional.empty();
         }
 
@@ -70,7 +75,10 @@ public class RegexpInputTypeStrategy implements InputTypeStrategy {
             return patternError;
         }
 
-        return Optional.of(callContext.getArgumentDataTypes());
+        final List<DataType> inferredDataTypes = new ArrayList<>(2);
+        inferredDataTypes.add(inferredStrType.get());
+        inferredDataTypes.add(inferredRegexType.get());
+        return Optional.of(inferredDataTypes);
     }
 
     @Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/RegexpReplaceInputTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/RegexpReplaceInputTypeStrategy.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.types.inference.Signature;
 import org.apache.flink.table.types.inference.Signature.Argument;
 import org.apache.flink.table.types.logical.LogicalTypeFamily;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -58,13 +59,19 @@ public class RegexpReplaceInputTypeStrategy implements InputTypeStrategy {
     @Override
     public Optional<List<DataType>> inferInputTypes(
             final CallContext callContext, final boolean throwOnFailure) {
-        if (STRING_ARG.inferArgumentType(callContext, ARG_STR, throwOnFailure).isEmpty()) {
+        final Optional<DataType> inferredStrType =
+                STRING_ARG.inferArgumentType(callContext, ARG_STR, throwOnFailure);
+        if (inferredStrType.isEmpty()) {
             return Optional.empty();
         }
-        if (STRING_ARG.inferArgumentType(callContext, ARG_REGEX, throwOnFailure).isEmpty()) {
+        final Optional<DataType> inferredRegexType =
+                STRING_ARG.inferArgumentType(callContext, ARG_REGEX, throwOnFailure);
+        if (inferredRegexType.isEmpty()) {
             return Optional.empty();
         }
-        if (STRING_ARG.inferArgumentType(callContext, ARG_REPLACEMENT, throwOnFailure).isEmpty()) {
+        final Optional<DataType> inferredReplacementType =
+                STRING_ARG.inferArgumentType(callContext, ARG_REPLACEMENT, throwOnFailure);
+        if (inferredReplacementType.isEmpty()) {
             return Optional.empty();
         }
 
@@ -74,7 +81,11 @@ public class RegexpReplaceInputTypeStrategy implements InputTypeStrategy {
             return patternError;
         }
 
-        return Optional.of(callContext.getArgumentDataTypes());
+        final List<DataType> inferredDataTypes = new ArrayList<>(3);
+        inferredDataTypes.add(inferredStrType.get());
+        inferredDataTypes.add(inferredRegexType.get());
+        inferredDataTypes.add(inferredReplacementType.get());
+        return Optional.of(inferredDataTypes);
     }
 
     @Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificInputTypeStrategies.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificInputTypeStrategies.java
@@ -194,11 +194,15 @@ public final class SpecificInputTypeStrategies {
     /** Type strategy for {@link BuiltInFunctionDefinitions#TO_TIMESTAMP_LTZ}. */
     public static final InputTypeStrategy TO_TIMESTAMP_LTZ = new ToTimestampLtzInputTypeStrategy();
 
-    /** Type strategy for {@link BuiltInFunctionDefinitions#REGEXP}. */
+    /** Type strategy for two-argument regex functions such as REGEXP and REGEXP_SPLIT. */
     public static final InputTypeStrategy REGEXP = new RegexpInputTypeStrategy();
 
     /** Type strategy for {@link BuiltInFunctionDefinitions#REGEXP_EXTRACT}. */
     public static final InputTypeStrategy REGEXP_EXTRACT = new RegexpExtractInputTypeStrategy();
+
+    /** Type strategy for {@link BuiltInFunctionDefinitions#REGEXP_EXTRACT_ALL}. */
+    public static final InputTypeStrategy REGEXP_EXTRACT_ALL =
+            new RegexpExtractAllInputTypeStrategy();
 
     /** Type strategy for {@link BuiltInFunctionDefinitions#REGEXP_REPLACE}. */
     public static final InputTypeStrategy REGEXP_REPLACE = new RegexpReplaceInputTypeStrategy();

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/strategies/RegexpExtractAllInputTypeStrategyTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/strategies/RegexpExtractAllInputTypeStrategyTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference.strategies;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.types.inference.InputTypeStrategiesTestBase;
+
+import java.util.stream.Stream;
+
+import static org.apache.flink.table.types.inference.strategies.SpecificInputTypeStrategies.REGEXP_EXTRACT_ALL;
+
+/** Tests for {@link RegexpExtractAllInputTypeStrategy}. */
+class RegexpExtractAllInputTypeStrategyTest extends InputTypeStrategiesTestBase {
+
+    @Override
+    protected Stream<TestSpec> testData() {
+        return Stream.of(
+                TestSpec.forStrategy("Valid literal regex compiles", REGEXP_EXTRACT_ALL)
+                        .calledWithArgumentTypes(DataTypes.STRING(), DataTypes.STRING())
+                        .calledWithLiteralAt(1, "foo(.*?)bar")
+                        .expectArgumentTypes(DataTypes.STRING(), DataTypes.STRING()),
+                TestSpec.forStrategy("Valid literal regex with extract index", REGEXP_EXTRACT_ALL)
+                        .calledWithArgumentTypes(
+                                DataTypes.STRING(), DataTypes.STRING(), DataTypes.TINYINT())
+                        .calledWithLiteralAt(1, "foo(.*?)bar")
+                        .expectArgumentTypes(
+                                DataTypes.STRING(), DataTypes.STRING(), DataTypes.TINYINT()),
+                TestSpec.forStrategy(
+                                "Non-literal regex defers compile to runtime", REGEXP_EXTRACT_ALL)
+                        .calledWithArgumentTypes(DataTypes.STRING(), DataTypes.STRING())
+                        .expectArgumentTypes(DataTypes.STRING(), DataTypes.STRING()),
+                TestSpec.forStrategy("Invalid literal regex fails at plan time", REGEXP_EXTRACT_ALL)
+                        .calledWithArgumentTypes(DataTypes.STRING(), DataTypes.STRING())
+                        .calledWithLiteralAt(1, "(")
+                        .expectErrorMessage("Invalid regular expression for"));
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/RegexpFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/RegexpFunctionsITCase.java
@@ -39,7 +39,8 @@ class RegexpFunctionsITCase extends BuiltInFunctionTestBase {
                         regexpExtractAllTestCases(),
                         regexpInstrTestCases(),
                         regexpReplaceTestCases(),
-                        regexpSubstrTestCases())
+                        regexpSubstrTestCases(),
+                        regexpSplitTestCases())
                 .flatMap(s -> s);
     }
 
@@ -518,5 +519,95 @@ class RegexpFunctionsITCase extends BuiltInFunctionTestBase {
                                 "REGEXP_SUBSTR(f0, '1024')",
                                 "Invalid input arguments. Expected signatures are:\n"
                                         + "REGEXP_SUBSTR(str <CHARACTER_STRING>, regex <CHARACTER_STRING>)"));
+    }
+
+    private Stream<TestSetSpec> regexpSplitTestCases() {
+        return Stream.of(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.REGEXP_SPLIT)
+                        .onFieldsWithData(
+                                "Hello123World456",
+                                null,
+                                "a,b;c|d",
+                                "one  two   three",
+                                123,
+                                "12345",
+                                ",123,,,123,")
+                        .andDataTypes(
+                                DataTypes.STRING().notNull(),
+                                DataTypes.STRING(),
+                                DataTypes.STRING().notNull(),
+                                DataTypes.STRING().notNull(),
+                                DataTypes.INT().notNull(),
+                                DataTypes.STRING().notNull(),
+                                DataTypes.STRING().notNull())
+                        // Basic regex split
+                        .testResult(
+                                $("f0").regexpSplit("[0-9]+"),
+                                "REGEXP_SPLIT(f0, '[0-9]+')",
+                                new String[] {"Hello", "World", ""},
+                                DataTypes.ARRAY(DataTypes.STRING()).notNull())
+                        // null input test
+                        .testResult(
+                                $("f0").regexpSplit(null),
+                                "REGEXP_SPLIT(f0, NULL)",
+                                null,
+                                DataTypes.ARRAY(DataTypes.STRING()))
+                        // Empty regex - split by character
+                        .testResult(
+                                $("f5").regexpSplit(""),
+                                "REGEXP_SPLIT(f5, '')",
+                                new String[] {"1", "2", "3", "4", "5"},
+                                DataTypes.ARRAY(DataTypes.STRING()).notNull())
+                        // null string input
+                        .testResult(
+                                $("f1").regexpSplit("[0-9]+"),
+                                "REGEXP_SPLIT(f1, '[0-9]+')",
+                                null,
+                                DataTypes.ARRAY(DataTypes.STRING()))
+                        // null string and null pattern
+                        .testResult(
+                                $("f1").regexpSplit(null),
+                                "REGEXP_SPLIT(f1, null)",
+                                null,
+                                DataTypes.ARRAY(DataTypes.STRING()))
+                        // Multi-character delimiter regex
+                        .testResult(
+                                $("f2").regexpSplit("[,;|]"),
+                                "REGEXP_SPLIT(f2, '[,;|]')",
+                                new String[] {"a", "b", "c", "d"},
+                                DataTypes.ARRAY(DataTypes.STRING()).notNull())
+                        // Whitespace regex
+                        .testResult(
+                                $("f3").regexpSplit("\\s+"),
+                                "REGEXP_SPLIT(f3, '\\\\s+')",
+                                new String[] {"one", "two", "three"},
+                                DataTypes.ARRAY(DataTypes.STRING()).notNull())
+                        // No match - return original string
+                        .testResult(
+                                $("f5").regexpSplit("[a-z]+"),
+                                "REGEXP_SPLIT(f5, '[a-z]+')",
+                                new String[] {"12345"},
+                                DataTypes.ARRAY(DataTypes.STRING()).notNull())
+                        // Invalid regex - return null
+                        .testResult(
+                                $("f0").regexpSplit("("),
+                                "REGEXP_SPLIT(f0, '(')",
+                                null,
+                                DataTypes.ARRAY(DataTypes.STRING()).notNull())
+                        // Validation error for non-string type input
+                        .testTableApiValidationError(
+                                $("f4").regexpSplit("[0-9]+"),
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "REGEXP_SPLIT(<CHARACTER_STRING>, <CHARACTER_STRING>)")
+                        .testSqlValidationError(
+                                "REGEXP_SPLIT(f4, '[0-9]+')",
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "REGEXP_SPLIT(<CHARACTER_STRING>, <CHARACTER_STRING>)")
+                        .testSqlValidationError(
+                                "REGEXP_SPLIT()",
+                                "No match found for function signature REGEXP_SPLIT()")
+                        .testSqlValidationError(
+                                "REGEXP_SPLIT(f1, '1', '2')",
+                                "No match found for function signature REGEXP_SPLIT(<CHARACTER>, <CHARACTER>, <CHARACTER>)"));
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/RegexpFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/RegexpFunctionsITCase.java
@@ -106,12 +106,6 @@ class RegexpFunctionsITCase extends BuiltInFunctionTestBase {
                                 "REGEXP_COUNT(f1, f0)",
                                 null,
                                 DataTypes.INT())
-                        // invalid regexp
-                        .testResult(
-                                $("f1").regexpCount("("),
-                                "REGEXP_COUNT(f1, '(')",
-                                null,
-                                DataTypes.INT())
                         // normal cases
                         .testResult(
                                 lit("hello world! Hello everyone!").regexpCount("Hello"),
@@ -163,7 +157,18 @@ class RegexpFunctionsITCase extends BuiltInFunctionTestBase {
                         .testSqlValidationError(
                                 "REGEXP_COUNT(f0, '1024')",
                                 "Invalid input arguments. Expected signatures are:\n"
-                                        + "REGEXP_COUNT(str <CHARACTER_STRING>, regex <CHARACTER_STRING>)"));
+                                        + "REGEXP_COUNT(str <CHARACTER_STRING>, regex <CHARACTER_STRING>)"),
+                TestSetSpec.forFunction(
+                                BuiltInFunctionDefinitions.REGEXP_COUNT,
+                                "Invalid literal regex fails at plan time")
+                        .onFieldsWithData("abcdeabde")
+                        .andDataTypes(DataTypes.STRING())
+                        .testTableApiValidationError(
+                                $("f0").regexpCount("("),
+                                "Invalid regular expression for REGEXP_COUNT:")
+                        .testSqlValidationError(
+                                "REGEXP_COUNT(f0, '(')",
+                                "Invalid regular expression for REGEXP_COUNT:"));
     }
 
     private Stream<TestSetSpec> regexpExtractTestCases() {
@@ -228,12 +233,6 @@ class RegexpFunctionsITCase extends BuiltInFunctionTestBase {
                         .testResult(
                                 $("f1").regexpExtractAll($("f1"), null),
                                 "REGEXP_EXTRACT_ALL(f1, f1, NULL)",
-                                null,
-                                DataTypes.ARRAY(DataTypes.STRING()))
-                        // invalid regexp
-                        .testResult(
-                                $("f1").regexpExtractAll("("),
-                                "REGEXP_EXTRACT_ALL(f1, '(')",
                                 null,
                                 DataTypes.ARRAY(DataTypes.STRING()))
                         // invalid extractIndex
@@ -313,7 +312,18 @@ class RegexpFunctionsITCase extends BuiltInFunctionTestBase {
                                 "REGEXP_EXTRACT_ALL(f0, '1024')",
                                 "Invalid input arguments. Expected signatures are:\n"
                                         + "REGEXP_EXTRACT_ALL(str <CHARACTER_STRING>, regex <CHARACTER_STRING>)\n"
-                                        + "REGEXP_EXTRACT_ALL(str <CHARACTER_STRING>, regex <CHARACTER_STRING>, extractIndex <INTEGER_NUMERIC>)"));
+                                        + "REGEXP_EXTRACT_ALL(str <CHARACTER_STRING>, regex <CHARACTER_STRING>, extractIndex <INTEGER_NUMERIC>)"),
+                TestSetSpec.forFunction(
+                                BuiltInFunctionDefinitions.REGEXP_EXTRACT_ALL,
+                                "Invalid literal regex fails at plan time")
+                        .onFieldsWithData("abcdeabde")
+                        .andDataTypes(DataTypes.STRING())
+                        .testTableApiValidationError(
+                                $("f0").regexpExtractAll("("),
+                                "Invalid regular expression for REGEXP_EXTRACT_ALL:")
+                        .testSqlValidationError(
+                                "REGEXP_EXTRACT_ALL(f0, '(')",
+                                "Invalid regular expression for REGEXP_EXTRACT_ALL:"));
     }
 
     private Stream<TestSetSpec> regexpInstrTestCases() {
@@ -330,12 +340,6 @@ class RegexpFunctionsITCase extends BuiltInFunctionTestBase {
                         .testResult(
                                 $("f1").regexpInstr($("f0")),
                                 "REGEXP_INSTR(f1, f0)",
-                                null,
-                                DataTypes.INT())
-                        // invalid regexp
-                        .testResult(
-                                $("f1").regexpInstr("("),
-                                "REGEXP_INSTR(f1, '(')",
                                 null,
                                 DataTypes.INT())
                         // not found
@@ -386,7 +390,18 @@ class RegexpFunctionsITCase extends BuiltInFunctionTestBase {
                         .testSqlValidationError(
                                 "REGEXP_INSTR(f0, '1024')",
                                 "Invalid input arguments. Expected signatures are:\n"
-                                        + "REGEXP_INSTR(str <CHARACTER_STRING>, regex <CHARACTER_STRING>)"));
+                                        + "REGEXP_INSTR(str <CHARACTER_STRING>, regex <CHARACTER_STRING>)"),
+                TestSetSpec.forFunction(
+                                BuiltInFunctionDefinitions.REGEXP_INSTR,
+                                "Invalid literal regex fails at plan time")
+                        .onFieldsWithData("abcdeabde")
+                        .andDataTypes(DataTypes.STRING())
+                        .testTableApiValidationError(
+                                $("f0").regexpInstr("("),
+                                "Invalid regular expression for REGEXP_INSTR:")
+                        .testSqlValidationError(
+                                "REGEXP_INSTR(f0, '(')",
+                                "Invalid regular expression for REGEXP_INSTR:"));
     }
 
     private Stream<TestSetSpec> regexpReplaceTestCases() {
@@ -463,12 +478,6 @@ class RegexpFunctionsITCase extends BuiltInFunctionTestBase {
                                 "REGEXP_SUBSTR(f1, f0)",
                                 null,
                                 DataTypes.STRING())
-                        // invalid regexp
-                        .testResult(
-                                $("f1").regexpSubstr("("),
-                                "REGEXP_SUBSTR(f1, '(')",
-                                null,
-                                DataTypes.STRING())
                         // not found
                         .testResult(
                                 $("f2").regexpSubstr("[a-z]"),
@@ -518,7 +527,18 @@ class RegexpFunctionsITCase extends BuiltInFunctionTestBase {
                         .testSqlValidationError(
                                 "REGEXP_SUBSTR(f0, '1024')",
                                 "Invalid input arguments. Expected signatures are:\n"
-                                        + "REGEXP_SUBSTR(str <CHARACTER_STRING>, regex <CHARACTER_STRING>)"));
+                                        + "REGEXP_SUBSTR(str <CHARACTER_STRING>, regex <CHARACTER_STRING>)"),
+                TestSetSpec.forFunction(
+                                BuiltInFunctionDefinitions.REGEXP_SUBSTR,
+                                "Invalid literal regex fails at plan time")
+                        .onFieldsWithData("abcdeabde")
+                        .andDataTypes(DataTypes.STRING())
+                        .testTableApiValidationError(
+                                $("f0").regexpSubstr("("),
+                                "Invalid regular expression for REGEXP_SUBSTR:")
+                        .testSqlValidationError(
+                                "REGEXP_SUBSTR(f0, '(')",
+                                "Invalid regular expression for REGEXP_SUBSTR:"));
     }
 
     private Stream<TestSetSpec> regexpSplitTestCases() {
@@ -531,7 +551,9 @@ class RegexpFunctionsITCase extends BuiltInFunctionTestBase {
                                 "one  two   three",
                                 123,
                                 "12345",
-                                ",123,,,123,")
+                                ",123,,,123,",
+                                "(",
+                                "\uD801\uDC37a")
                         .andDataTypes(
                                 DataTypes.STRING().notNull(),
                                 DataTypes.STRING(),
@@ -539,7 +561,9 @@ class RegexpFunctionsITCase extends BuiltInFunctionTestBase {
                                 DataTypes.STRING().notNull(),
                                 DataTypes.INT().notNull(),
                                 DataTypes.STRING().notNull(),
-                                DataTypes.STRING())
+                                DataTypes.STRING(),
+                                DataTypes.STRING(),
+                                DataTypes.STRING().notNull())
                         // Basic regex split
                         .testResult(
                                 $("f0").regexpSplit("[0-9]+"),
@@ -557,6 +581,12 @@ class RegexpFunctionsITCase extends BuiltInFunctionTestBase {
                                 $("f5").regexpSplit(""),
                                 "REGEXP_SPLIT(f5, '')",
                                 new String[] {"1", "2", "3", "4", "5"},
+                                DataTypes.ARRAY(DataTypes.STRING()).notNull())
+                        // Empty regex splits by Unicode code point
+                        .testResult(
+                                $("f8").regexpSplit(""),
+                                "REGEXP_SPLIT(f8, '')",
+                                new String[] {"\uD801\uDC37", "a"},
                                 DataTypes.ARRAY(DataTypes.STRING()).notNull())
                         // null string input
                         .testResult(
@@ -588,21 +618,26 @@ class RegexpFunctionsITCase extends BuiltInFunctionTestBase {
                                 "REGEXP_SPLIT(f5, '[a-z]+')",
                                 new String[] {"12345"},
                                 DataTypes.ARRAY(DataTypes.STRING()).notNull())
-                        // Invalid regex - return null
+                        // Invalid non-literal regex - return null at runtime
                         .testResult(
-                                $("f6").regexpSplit("("),
-                                "REGEXP_SPLIT(f6, '(')",
+                                $("f5").regexpSplit($("f7")),
+                                "REGEXP_SPLIT(f5, f7)",
                                 null,
                                 DataTypes.ARRAY(DataTypes.STRING()))
+                        // Invalid literal regex - fail during planning
+                        .testTableApiValidationError(
+                                $("f6").regexpSplit("("), "Invalid regular expression for")
+                        .testSqlValidationError(
+                                "REGEXP_SPLIT(f6, '(')", "Invalid regular expression for")
                         // Validation error for non-string type input
                         .testTableApiValidationError(
                                 $("f4").regexpSplit("[0-9]+"),
                                 "Invalid input arguments. Expected signatures are:\n"
-                                        + "REGEXP_SPLIT(<CHARACTER_STRING>, <CHARACTER_STRING>)")
+                                        + "REGEXP_SPLIT(str <CHARACTER_STRING>, regex <CHARACTER_STRING>)")
                         .testSqlValidationError(
                                 "REGEXP_SPLIT(f4, '[0-9]+')",
                                 "Invalid input arguments. Expected signatures are:\n"
-                                        + "REGEXP_SPLIT(<CHARACTER_STRING>, <CHARACTER_STRING>)")
+                                        + "REGEXP_SPLIT(str <CHARACTER_STRING>, regex <CHARACTER_STRING>)")
                         .testSqlValidationError(
                                 "REGEXP_SPLIT()",
                                 "No match found for function signature REGEXP_SPLIT()")

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/RegexpFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/RegexpFunctionsITCase.java
@@ -539,7 +539,7 @@ class RegexpFunctionsITCase extends BuiltInFunctionTestBase {
                                 DataTypes.STRING().notNull(),
                                 DataTypes.INT().notNull(),
                                 DataTypes.STRING().notNull(),
-                                DataTypes.STRING().notNull())
+                                DataTypes.STRING())
                         // Basic regex split
                         .testResult(
                                 $("f0").regexpSplit("[0-9]+"),
@@ -579,7 +579,7 @@ class RegexpFunctionsITCase extends BuiltInFunctionTestBase {
                         // Whitespace regex
                         .testResult(
                                 $("f3").regexpSplit("\\s+"),
-                                "REGEXP_SPLIT(f3, '\\\\s+')",
+                                "REGEXP_SPLIT(f3, '\\s+')",
                                 new String[] {"one", "two", "three"},
                                 DataTypes.ARRAY(DataTypes.STRING()).notNull())
                         // No match - return original string
@@ -590,10 +590,10 @@ class RegexpFunctionsITCase extends BuiltInFunctionTestBase {
                                 DataTypes.ARRAY(DataTypes.STRING()).notNull())
                         // Invalid regex - return null
                         .testResult(
-                                $("f0").regexpSplit("("),
-                                "REGEXP_SPLIT(f0, '(')",
+                                $("f6").regexpSplit("("),
+                                "REGEXP_SPLIT(f6, '(')",
                                 null,
-                                DataTypes.ARRAY(DataTypes.STRING()).notNull())
+                                DataTypes.ARRAY(DataTypes.STRING()))
                         // Validation error for non-string type input
                         .testTableApiValidationError(
                                 $("f4").regexpSplit("[0-9]+"),

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlFunctionUtils.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlFunctionUtils.java
@@ -487,6 +487,24 @@ public class SqlFunctionUtils {
     }
 
     /**
+     * Returns a compiled Pattern object for the given regular expression string, using a shared
+     * cache for performance optimization.
+     *
+     * @param regex the regular expression pattern string
+     * @return the compiled Pattern, or null if regex is null or invalid
+     */
+    public static @Nullable Pattern getRegexpPattern(@Nullable String regex) {
+        if (regex == null) {
+            return null;
+        }
+        try {
+            return REGEXP_PATTERN_CACHE.get(regex);
+        } catch (PatternSyntaxException e) {
+            return null;
+        }
+    }
+
+    /**
      * Parse string as key-value string and return the value matches key name. example:
      * keyvalue('k1=v1;k2=v2', ';', '=', 'k2') = 'v2' keyvalue('k1:v1,k2:v2', ',', ':', 'k3') = NULL
      *

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlFunctionUtils.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlFunctionUtils.java
@@ -491,17 +491,23 @@ public class SqlFunctionUtils {
      * cache for performance optimization.
      *
      * @param regex the regular expression pattern string
-     * @return the compiled Pattern, or null if regex is null or invalid
+     * @return the compiled Pattern, or null if regex is invalid
      */
-    public static @Nullable Pattern getRegexpPattern(@Nullable String regex) {
-        if (regex == null) {
-            return null;
-        }
+    public static @Nullable Pattern getRegexpPattern(String regex) {
         try {
             return REGEXP_PATTERN_CACHE.get(regex);
         } catch (PatternSyntaxException e) {
             return null;
         }
+    }
+
+    /** Splits the string into Unicode code points, preserving supplementary characters. */
+    public static StringData[] splitByCodePoints(String str) {
+        return str.codePoints()
+                .mapToObj(
+                        codePoint ->
+                                StringData.fromString(new String(Character.toChars(codePoint))))
+                .toArray(StringData[]::new);
     }
 
     /**

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/RegexpSplitFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/RegexpSplitFunction.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction;
+
+import javax.annotation.Nullable;
+
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+/**
+ * Implementation of {@link BuiltInFunctionDefinitions#REGEXP_SPLIT}.
+ *
+ * <p>Splits a string by a regular expression pattern and returns an array of substrings.
+ *
+ * <p>Examples:
+ *
+ * <pre>{@code
+ * REGEXP_SPLIT('Hello123World456', '[0-9]+') = ['Hello', 'World', '']
+ * REGEXP_SPLIT('a,b;c', '[,;]') = ['a', 'b', 'c']
+ * REGEXP_SPLIT('one  two   three', '\\s+') = ['one', 'two', 'three']
+ * }</pre>
+ */
+@Internal
+public class RegexpSplitFunction extends BuiltInScalarFunction {
+
+    private transient Pattern cachedPattern;
+    private transient String cachedRegex;
+
+    public RegexpSplitFunction(SpecializedFunction.SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.REGEXP_SPLIT, context);
+    }
+
+    public @Nullable ArrayData eval(@Nullable StringData str, @Nullable StringData regex) {
+        if (str == null || regex == null) {
+            return null;
+        }
+
+        String regexStr = regex.toString();
+        if (regexStr.isEmpty()) {
+            // If regex is empty, split by each character
+            String strValue = str.toString();
+            StringData[] result = new StringData[strValue.length()];
+            for (int i = 0; i < strValue.length(); i++) {
+                result[i] = StringData.fromString(String.valueOf(strValue.charAt(i)));
+            }
+            return new GenericArrayData(result);
+        }
+
+        try {
+            // Cache the compiled pattern to improve performance
+            if (cachedPattern == null || !regexStr.equals(cachedRegex)) {
+                cachedPattern = Pattern.compile(regexStr);
+                cachedRegex = regexStr;
+            }
+
+            // Use -1 as limit to keep all trailing empty strings
+            String[] splitResult = cachedPattern.split(str.toString(), -1);
+            StringData[] result = new StringData[splitResult.length];
+            for (int i = 0; i < splitResult.length; i++) {
+                result[i] = StringData.fromString(splitResult[i]);
+            }
+            return new GenericArrayData(result);
+        } catch (PatternSyntaxException e) {
+            // Return null for invalid regex pattern (consistent with other REGEXP_* functions)
+            return null;
+        }
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/RegexpSplitFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/RegexpSplitFunction.java
@@ -30,6 +30,7 @@ import javax.annotation.Nullable;
 import java.util.regex.Pattern;
 
 import static org.apache.flink.table.runtime.functions.SqlFunctionUtils.getRegexpPattern;
+import static org.apache.flink.table.runtime.functions.SqlFunctionUtils.splitByCodePoints;
 
 /**
  * Implementation of {@link BuiltInFunctionDefinitions#REGEXP_SPLIT}.
@@ -58,13 +59,7 @@ public class RegexpSplitFunction extends BuiltInScalarFunction {
 
         String regexStr = regex.toString();
         if (regexStr.isEmpty()) {
-            // If regex is empty, split by each character
-            String strValue = str.toString();
-            StringData[] result = new StringData[strValue.length()];
-            for (int i = 0; i < strValue.length(); i++) {
-                result[i] = StringData.fromString(String.valueOf(strValue.charAt(i)));
-            }
-            return new GenericArrayData(result);
+            return new GenericArrayData(splitByCodePoints(str.toString()));
         }
 
         Pattern pattern = getRegexpPattern(regexStr);


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds a new built-in function `REGEXP_SPLIT` to Flink SQL and Table API, which splits a string by a regular expression pattern and returns an array of substrings. This function is commonly available in other SQL engines (e.g., Spark, Presto, Hive) and provides users with more powerful string manipulation capabilities using regex patterns.

## Brief change log

- Added `REGEXP_SPLIT` function definition in `BuiltInFunctionDefinitions` with proper input/output type strategies
- Implemented `RegexpSplitFunction` as a scalar function with regex pattern caching for performance optimization
- Added `regexpSplit()` method to `BaseExpressions` for Table API support
- Added comprehensive test cases in `RegexpFunctionsITCase` covering various scenarios including null handling, empty regex, invalid regex patterns, and edge cases

## Verifying this change

This change added tests and can be verified as follows:

- Added integration tests in `RegexpFunctionsITCase` that cover:
  - Basic regex split functionality (e.g., splitting by digit patterns `[0-9]+`)
  - Null input handling (both null string and null pattern)
  - Empty regex pattern (split by each character)
  - Multi-character delimiter regex patterns (e.g., `[,;|]`)
  - Whitespace regex patterns (e.g., `\\s+`)
  - No match scenarios (returns original string as single-element array)
  - Invalid regex pattern handling (returns null)
  - Input validation errors for non-string type inputs
  - SQL signature validation errors

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): **no**
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **yes** (`BaseExpressions` is `@PublicEvolving`, added `regexpSplit()` method)
- The serializers: **no**
- The runtime per-record code paths (performance sensitive): **no** (new function only, with pattern caching for optimization)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
- The S3 file system connector: **no**

## Documentation

- Does this pull request introduce a new feature? **yes**
- If yes, how is the feature documented? **JavaDocs** (function usage examples are documented in `RegexpSplitFunction` class JavaDoc)