### PR TITLE
[FLINK-39069][SQL Client] Support saving and exporting SQL execution history

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -318,7 +318,7 @@ public class CliClient implements AutoCloseable {
 
     private LineReader createLineReader(Terminal terminal, ExecutionMode mode) {
         SqlMultiLineParser parser =
-                new SqlMultiLineParser(new SqlCommandParserImpl(), executor, mode);
+                new SqlMultiLineParser(new SqlCommandParserImpl(), executor, mode, historyFilePath);
 
         // initialize line lineReader
         LineReaderBuilder builder =

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
@@ -97,6 +97,7 @@ public final class CliStrings {
                     .commandDescription("HELP", "Prints the available commands.")
                     .commandDescription("QUIT/EXIT", "Quits the SQL CLI client.")
                     .commandDescription("CLEAR", "Clears the current terminal.")
+                    .commandDescription("HISTORY", "Shows the SQL execution history.")
                     .commandDescription(
                             "SET",
                             "Sets a session configuration property. Syntax: \"SET '<key>'='<value>';\". Use \"SET;\" for listing all properties.")

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/parser/Command.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/parser/Command.java
@@ -26,6 +26,8 @@ public enum Command {
     CLEAR,
     /** Command to print help message. */
     HELP,
+    /** Command to show SQL execution history. */
+    SHOW_HISTORY,
     /** Unknown command. */
     OTHER
 }

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/parser/SqlCommandParserImpl.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/parser/SqlCommandParserImpl.java
@@ -138,6 +138,8 @@ public class SqlCommandParserImpl implements SqlCommandParser {
                 return Command.CLEAR;
             case "HELP":
                 return Command.HELP;
+            case "HISTORY":
+                return Command.SHOW_HISTORY;
             default:
                 return Command.OTHER;
         }

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/parser/SqlMultiLineParser.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/parser/SqlMultiLineParser.java
@@ -60,6 +60,9 @@ public class SqlMultiLineParser extends DefaultParser {
     /** Sql command executor. */
     private final Executor executor;
 
+    /** Path to the history file. */
+    private final java.nio.file.Path historyFilePath;
+
     /** Exception caught in parsing. */
     private SqlExecutionException parseException = null;
 
@@ -68,9 +71,18 @@ public class SqlMultiLineParser extends DefaultParser {
 
     public SqlMultiLineParser(
             SqlCommandParser parser, Executor executor, CliClient.ExecutionMode mode) {
+        this(parser, executor, mode, null);
+    }
+
+    public SqlMultiLineParser(
+            SqlCommandParser parser,
+            Executor executor,
+            CliClient.ExecutionMode mode,
+            java.nio.file.Path historyFilePath) {
         this.parser = parser;
         this.mode = mode;
         this.executor = executor;
+        this.historyFilePath = historyFilePath;
         setEscapeChars(null);
         setQuoteChars(null);
     }
@@ -107,6 +119,9 @@ public class SqlMultiLineParser extends DefaultParser {
                     break;
                 case HELP:
                     printer = Printer.createHelpCommandPrinter();
+                    break;
+                case SHOW_HISTORY:
+                    printer = Printer.createHistoryCommandPrinter(historyFilePath);
                     break;
                 default:
                     {

--- a/flink-table/flink-sql-client/src/test/resources/sql/misc.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/misc.q
@@ -22,6 +22,7 @@ The following commands are available:
 HELP               		Prints the available commands.
 QUIT/EXIT          		Quits the SQL CLI client.
 CLEAR              		Clears the current terminal.
+HISTORY            		Shows the SQL execution history.
 SET                		Sets a session configuration property. Syntax: "SET '<key>'='<value>';". Use "SET;" for listing all properties.
 RESET              		Resets a session configuration property. Syntax: "RESET '<key>';". Use "RESET;" for reset all session properties.
 INSERT INTO        		Inserts the results of a SQL SELECT query into a declared table sink.


### PR DESCRIPTION
## What is the purpose of the change

This PR implements support for viewing SQL execution history in the Flink SQL Client by adding a new `HISTORY` command.

**Related JIRA**: https://issues.apache.org/jira/browse/FLINK-39069

## Brief change log

- Add `SHOW_HISTORY` command enum type in `Command.java`
- Implement `HistoryCommandPrinter` class to read and display history file content
- Add "HISTORY" keyword parsing in `SqlCommandParserImpl`
- Pass history file path through `SqlMultiLineParser` to enable history reading
- Update help message in `CliStrings` to include the new HISTORY command
- Handle edge cases (empty file, file not exists, IO errors)

## Verifying this change

This change can be verified manually as follows:

1. Start SQL Client: `./bin/sql-client.sh embedded`
2. Execute some SQL statements, e.g., `CREATE TABLE t1 (id INT);`
3. Run `HISTORY;` command
4. Verify that previously executed statements are displayed with line numbers
5. Test edge cases: Run HISTORY when no history file exists

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): **no**
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
- The serializers: **no**
- The runtime per-record code paths: **no**
- Anything that affects deployment or recovery: **no**
- The S3 file system connector: **no**

## Documentation

- Does this pull request introduce a new feature? **yes**
- If yes, how is the feature documented? **code comments and JavaDoc**
- The `HISTORY` command is included in the SQL Client help message