### PR TITLE
[FLINK-30068][runtime] Add configurable commit failure strategy for S…

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/CommitFailureStrategy.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CommitFailureStrategy.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.configuration;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * Strategy for handling unknown commit failures in sink operators.
+ *
+ * <p>This strategy applies to {@link
+ * org.apache.flink.api.connector.sink2.Committer.CommitRequest#signalFailedWithUnknownReason}. It
+ * does not affect known failures (which are always discarded) or committables that exhaust all
+ * retries.
+ *
+ * @see SinkOptions#COMMITTER_FAILURE_STRATEGY
+ */
+@PublicEvolving
+public enum CommitFailureStrategy {
+
+    /** Fail the job on unknown commit errors (default, current behavior). */
+    FAIL,
+
+    /** Log a warning and skip the committable on unknown commit errors. */
+    WARN
+}

--- a/flink-core/src/main/java/org/apache/flink/configuration/SinkOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/SinkOptions.java
@@ -38,5 +38,18 @@ public class SinkOptions {
                     .withDescription(
                             "The number of retries a Flink application attempts for committable operations (such as transactions) on retriable errors, as specified by the sink connector, before Flink fails and potentially restarts.");
 
+    /** Strategy for handling commit failures on unknown errors. */
+    @Documentation.Section(Documentation.Sections.COMMON_MISCELLANEOUS)
+    public static final ConfigOption<CommitFailureStrategy> COMMITTER_FAILURE_STRATEGY =
+            key("sink.committer.failure-strategy")
+                    .enumType(CommitFailureStrategy.class)
+                    .defaultValue(CommitFailureStrategy.FAIL)
+                    .withDescription(
+                            "Strategy for handling commit failures on unknown errors. "
+                                    + "FAIL (default) fails the job. "
+                                    + "WARN logs the error and skips the committable, allowing recovery to proceed. "
+                                    + "Note: this only applies to unknown failures signaled by the connector; "
+                                    + "committables that exhaust all retries will still fail the job regardless of this setting.");
+
     private SinkOptions() {}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CheckpointCommittableManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CheckpointCommittableManager.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.runtime.operators.sink.committables;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.connector.sink2.Committer;
+import org.apache.flink.configuration.CommitFailureStrategy;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -58,12 +59,26 @@ public interface CheckpointCommittableManager<CommT> {
 
     /**
      * Commits all due committables if all respective committables of the specific subtask and
-     * checkpoint have been received.
+     * checkpoint have been received. Uses {@link CommitFailureStrategy#FAIL} as the default
+     * strategy.
      *
      * @param committer used to commit to the external system
      * @param maxRetries
      */
-    void commit(Committer<CommT> committer, int maxRetries)
+    default void commit(Committer<CommT> committer, int maxRetries)
+            throws IOException, InterruptedException {
+        commit(committer, maxRetries, CommitFailureStrategy.FAIL);
+    }
+
+    /**
+     * Commits all due committables if all respective committables of the specific subtask and
+     * checkpoint have been received.
+     *
+     * @param committer used to commit to the external system
+     * @param maxRetries
+     * @param failureStrategy strategy for handling unknown commit failures
+     */
+    void commit(Committer<CommT> committer, int maxRetries, CommitFailureStrategy failureStrategy)
             throws IOException, InterruptedException;
 
     /**

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommitRequestImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommitRequestImplTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.sink.committables;
+
+import org.apache.flink.configuration.CommitFailureStrategy;
+import org.apache.flink.metrics.groups.SinkCommitterMetricGroup;
+import org.apache.flink.runtime.metrics.groups.MetricsGroupTestUtils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CommitRequestImplTest {
+
+    private static final SinkCommitterMetricGroup METRIC_GROUP =
+            MetricsGroupTestUtils.mockCommitterMetricGroup();
+
+    @Test
+    void testSignalFailedWithUnknownReasonDefaultStrategy() {
+        CommitRequestImpl<String> request = new CommitRequestImpl<>("test", METRIC_GROUP);
+        assertThatThrownBy(
+                        () ->
+                                request.signalFailedWithUnknownReason(
+                                        new RuntimeException("test error")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Failed to commit test");
+        assertThat(request.getState()).isEqualTo(CommitRequestState.FAILED);
+    }
+
+    @Test
+    void testSignalFailedWithUnknownReasonFailStrategy() {
+        CommitRequestImpl<String> request = new CommitRequestImpl<>("test", METRIC_GROUP);
+        request.setFailureStrategy(CommitFailureStrategy.FAIL);
+        assertThatThrownBy(
+                        () ->
+                                request.signalFailedWithUnknownReason(
+                                        new RuntimeException("test error")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Failed to commit test");
+        assertThat(request.getState()).isEqualTo(CommitRequestState.FAILED);
+    }
+
+    @Test
+    void testSignalFailedWithUnknownReasonWarnStrategy() {
+        CommitRequestImpl<String> request = new CommitRequestImpl<>("test", METRIC_GROUP);
+        request.setFailureStrategy(CommitFailureStrategy.WARN);
+        request.signalFailedWithUnknownReason(new RuntimeException("test error"));
+        assertThat(request.getState()).isEqualTo(CommitRequestState.FAILED);
+    }
+
+    @Test
+    void testSignalFailedWithKnownReasonAlwaysDiscardsRegardlessOfStrategy() {
+        for (CommitFailureStrategy strategy : CommitFailureStrategy.values()) {
+            CommitRequestImpl<String> request = new CommitRequestImpl<>("test", METRIC_GROUP);
+            request.setFailureStrategy(strategy);
+            assertThatCode(
+                            () ->
+                                    request.signalFailedWithKnownReason(
+                                            new RuntimeException("known error")))
+                    .doesNotThrowAnyException();
+            assertThat(request.getState()).isEqualTo(CommitRequestState.FAILED);
+        }
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSinkV2.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSinkV2.java
@@ -531,6 +531,18 @@ public class TestSinkV2<InputT> implements Sink<InputT> {
         }
     }
 
+    /** A {@link Committer} that always signals failure with unknown reason. */
+    static class FailWithUnknownReasonCommitter<CommT> extends DefaultCommitter<CommT> {
+
+        @Override
+        public void commit(Collection<CommitRequest<CommT>> committables) {
+            committables.forEach(
+                    c ->
+                            c.signalFailedWithUnknownReason(
+                                    new RuntimeException("Simulated unknown failure")));
+        }
+    }
+
     /** A {@link Committer} that always re-commits the committables data it received. */
     static class RetryOnceCommitter<CommT> extends DefaultCommitter<CommT> {
 


### PR DESCRIPTION
## What is the purpose of the change

When a Flink job recovers from a checkpoint/savepoint, the `CommitterOperator` replays uncommitted transactions. If a Kafka transaction has expired or the producer ID mapping is lost (e.g., `InvalidPidMappingException`), the commit fails via `signalFailedWithUnknownReason()` which throws unconditionally, causing an infinite restart loop with no way to recover -- even from earlier savepoints.

The `CommitRequestImpl` code already had TODO comments noting: *"let the user configure a strategy for failing and apply it here"*. This PR implements that configurability by adding a `CommitFailureStrategy` enum (`FAIL`/`WARN`) and a config option `sink.committer.failure-strategy` that controls whether unknown commit failures throw (default, preserving current behavior) or log a warning and skip the committable, allowing recovery to proceed.

## Brief change log

  - Added `CommitFailureStrategy` enum (`FAIL`/`WARN`) in `flink-core` with `@PublicEvolving` annotation
  - Added `sink.committer.failure-strategy` config option to `SinkOptions` (default: `FAIL`)
  - Modified `CommitRequestImpl.signalFailedWithUnknownReason()` to respect the configured strategy
  - Added logging to `CommitRequestImpl.signalFailedWithKnownReason()` to match interface contract
  - Added overloaded `commit()` method to `CheckpointCommittableManager` interface with strategy parameter (backward-compatible default method)
  - Updated `CheckpointCommittableManagerImpl` to set failure strategy on requests before committing
  - Updated `CommitterOperator` and `GlobalCommitterOperator` to read and pass the strategy config

## Verifying this change

This change added tests and can be verified as follows:

  - Added `CommitRequestImplTest` with 4 unit tests: default strategy throws, explicit `FAIL` throws, `WARN` logs and skips, `signalFailedWithKnownReason` always discards regardless of strategy
  - Added 2 tests to `CheckpointCommittableManagerImplTest`: `WARN` strategy completes without throwing on unknown failures, `FAIL` strategy throws on unknown failures
  - Added 3 tests to `SinkV2CommitterOperatorTest`: operator-level `WARN` strategy skips failures, `FAIL` strategy throws, and `WARN` strategy succeeds on state restore/recovery with a failing committer

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes (`CommitFailureStrategy` enum and `SinkOptions.COMMITTER_FAILURE_STRATEGY` are `@PublicEvolving`)
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no (only affects commit path, not per-record processing)
  - Anything that affects deployment or recovery: yes (enables recovery from previously-fatal commit failures when configured with `WARN` strategy)
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs (on `CommitFailureStrategy` enum, `SinkOptions.COMMITTER_FAILURE_STRATEGY` config option description)