### PR TITLE
[FLINK-39076][Web UI] Display slot sharing group in operator nodes

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
@@ -1255,13 +1255,14 @@ class RestClusterClientTest {
                         new JobDetailsInfo.JobVertexDetailsInfo(
                                 new JobVertexID(),
                                 slotSharingGroupId,
+                                null,
                                 "jobVertex1",
                                 2,
                                 1,
                                 ExecutionState.RUNNING,
-                                1,
-                                2,
-                                1,
+                                1L,
+                                2L,
+                                1L,
                                 Collections.singletonMap(ExecutionState.RUNNING, 0),
                                 jobVertexMetrics));
         final JobDetailsInfo jobDetailsInfo =

--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -170,38 +170,6 @@
       "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EmptyResponseBody"
     }
   }, {
-    "url" : "/applications/:applicationid/jobmanager/config",
-    "method" : "GET",
-    "status-code" : "200 OK",
-    "file-upload" : false,
-    "path-parameters" : {
-      "pathParameters" : [ {
-        "key" : "applicationid"
-      } ]
-    },
-    "query-parameters" : {
-      "queryParameters" : [ ]
-    },
-    "request" : {
-      "type" : "object",
-      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EmptyRequestBody"
-    },
-    "response" : {
-      "type" : "array",
-      "items" : {
-        "type" : "object",
-        "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:ConfigurationInfoEntry",
-        "properties" : {
-          "key" : {
-            "type" : "string"
-          },
-          "value" : {
-            "type" : "string"
-          }
-        }
-      }
-    }
-  }, {
     "url" : "/applications/:applicationid/exceptions",
     "method" : "GET",
     "status-code" : "200 OK",
@@ -247,6 +215,38 @@
                 }
               }
             }
+          }
+        }
+      }
+    }
+  }, {
+    "url" : "/applications/:applicationid/jobmanager/config",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "applicationid"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EmptyRequestBody"
+    },
+    "response" : {
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:ConfigurationInfoEntry",
+        "properties" : {
+          "key" : {
+            "type" : "string"
+          },
+          "value" : {
+            "type" : "string"
           }
         }
       }
@@ -1369,6 +1369,9 @@
               },
               "slotSharingGroupId" : {
                 "type" : "any"
+              },
+              "slotSharingGroupName" : {
+                "type" : "string"
               },
               "name" : {
                 "type" : "string"
@@ -2831,6 +2834,57 @@
               }
             }
           }
+        }
+      }
+    }
+  }, {
+    "url" : "/jobs/:jobid/rescales/config",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "jobid"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EmptyRequestBody"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:rescales:JobRescaleConfigInfo",
+      "properties" : {
+        "rescaleHistoryMax" : {
+          "type" : "integer"
+        },
+        "schedulerExecutionMode" : {
+          "type" : "string",
+          "enum" : [ "REACTIVE" ]
+        },
+        "submissionResourceWaitTimeoutInMillis" : {
+          "type" : "integer"
+        },
+        "submissionResourceStabilizationTimeoutInMillis" : {
+          "type" : "integer"
+        },
+        "slotIdleTimeoutInMillis" : {
+          "type" : "integer"
+        },
+        "executingCooldownTimeoutInMillis" : {
+          "type" : "integer"
+        },
+        "executingResourceStabilizationTimeoutInMillis" : {
+          "type" : "integer"
+        },
+        "maximumDelayForTriggeringRescaleInMillis" : {
+          "type" : "integer"
+        },
+        "rescaleOnFailedCheckpointCount" : {
+          "type" : "integer"
         }
       }
     }
@@ -4778,57 +4832,6 @@
               }
             }
           }
-        }
-      }
-    }
-  }, {
-    "url" : "/jobs/:jobid/rescales/config",
-    "method" : "GET",
-    "status-code" : "200 OK",
-    "file-upload" : false,
-    "path-parameters" : {
-      "pathParameters" : [ {
-        "key" : "jobid"
-      } ]
-    },
-    "query-parameters" : {
-      "queryParameters" : [ ]
-    },
-    "request" : {
-      "type" : "object",
-      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EmptyRequestBody"
-    },
-    "response" : {
-      "type" : "object",
-      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:rescales:JobRescaleConfigInfo",
-      "properties" : {
-        "executingCooldownTimeoutInMillis" : {
-          "type" : "integer"
-        },
-        "executingResourceStabilizationTimeoutInMillis" : {
-          "type" : "integer"
-        },
-        "maximumDelayForTriggeringRescaleInMillis" : {
-          "type" : "integer"
-        },
-        "rescaleHistoryMax" : {
-          "type" : "integer"
-        },
-        "rescaleOnFailedCheckpointCount" : {
-          "type" : "integer"
-        },
-        "schedulerExecutionMode" : {
-          "type" : "string",
-          "enum" : [ "REACTIVE" ]
-        },
-        "slotIdleTimeoutInMillis" : {
-          "type" : "integer"
-        },
-        "submissionResourceStabilizationTimeoutInMillis" : {
-          "type" : "integer"
-        },
-        "submissionResourceWaitTimeoutInMillis" : {
-          "type" : "integer"
         }
       }
     }

--- a/flink-runtime-web/web-dashboard/src/app/components/dagre/components/node/node.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/components/dagre/components/node/node.component.html
@@ -33,6 +33,9 @@
         <xhtml:div class="detail">{{ operator }}</xhtml:div>
         <xhtml:div class="detail description" *ngIf="!pending">{{ description }}</xhtml:div>
         <xhtml:div class="node-label">Parallelism: {{ parallelism }}</xhtml:div>
+        <xhtml:div class="node-label" *ngIf="slotSharingGroupName && !pending">
+          Slot Sharing Group: {{ slotSharingGroupName }}
+        </xhtml:div>
         <xhtml:div
           class="node-label metric"
           title="Maximum back pressured percentage across all subtasks"

--- a/flink-runtime-web/web-dashboard/src/app/components/dagre/components/node/node.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/components/dagre/components/node/node.component.html
@@ -36,6 +36,9 @@
         <xhtml:div class="node-label" *ngIf="slotSharingGroupName && !pending">
           Slot Sharing Group: {{ slotSharingGroupName }}
         </xhtml:div>
+        <xhtml:div class="node-label" *ngIf="slotSharingGroupId && !pending">
+          Slot Sharing Group ID: {{ slotSharingGroupId }}
+        </xhtml:div>
         <xhtml:div
           class="node-label metric"
           title="Maximum back pressured percentage across all subtasks"

--- a/flink-runtime-web/web-dashboard/src/app/components/dagre/components/node/node.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/components/dagre/components/node/node.component.ts
@@ -37,6 +37,8 @@ export class NodeComponent {
   backPressuredPercentage: number | undefined = NaN;
   busyPercentage: number | undefined = NaN;
   dataSkewPercentage: number | undefined = NaN;
+  slotSharingGroupId: string | null | undefined;
+  slotSharingGroupName: string | null | undefined;
   pending: boolean = true;
   backgroundColor: string;
   borderColor: string;
@@ -67,6 +69,8 @@ export class NodeComponent {
     this.operatorStrategy = this.decodeHTML(value.operator_strategy);
     this.parallelism = value.parallelism;
     this.lowWatermark = value.lowWatermark;
+    this.slotSharingGroupId = value.detail?.slotSharingGroupId;
+    this.slotSharingGroupName = value.detail?.slotSharingGroupName;
     if (value?.job_vertex_id) {
       this.pending = false;
     }

--- a/flink-runtime-web/web-dashboard/src/app/interfaces/job-detail.ts
+++ b/flink-runtime-web/web-dashboard/src/app/interfaces/job-detail.ts
@@ -98,6 +98,8 @@ export interface VerticesItem {
   duration: number;
   tasks: TasksStatus;
   metrics: MetricsStatus;
+  slotSharingGroupId?: string | null;
+  slotSharingGroupName?: string | null;
 }
 
 export interface VerticesItemRange extends VerticesItem {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobDetailsHandler.java
@@ -248,9 +248,16 @@ public class JobDetailsHandler
                         counts.getAccumulateIdleTime(),
                         counts.getAccumulateBusyTime());
 
+        // Get slot sharing group name, use slot sharing group ID as fallback if name is not set
+        String slotSharingGroupName = ejv.getSlotSharingGroup().getSlotSharingGroupName();
+        if (slotSharingGroupName == null || slotSharingGroupName.isEmpty()) {
+            slotSharingGroupName = ejv.getSlotSharingGroup().getSlotSharingGroupId().toString();
+        }
+
         return new JobDetailsInfo.JobVertexDetailsInfo(
                 ejv.getJobVertexId(),
                 ejv.getSlotSharingGroup().getSlotSharingGroupId(),
+                slotSharingGroupName,
                 ejv.getName(),
                 ejv.getMaxParallelism(),
                 ejv.getParallelism(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobDetailsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobDetailsInfo.java
@@ -364,6 +364,8 @@ public class JobDetailsInfo implements ResponseBody {
 
         public static final String FIELD_NAME_SLOT_SHARING_GROUP_ID = "slotSharingGroupId";
 
+        public static final String FIELD_NAME_SLOT_SHARING_GROUP_NAME = "slotSharingGroupName";
+
         public static final String FIELD_NAME_JOB_VERTEX_NAME = "name";
 
         public static final String FIELD_NAME_MAX_PARALLELISM = "maxParallelism";
@@ -389,6 +391,9 @@ public class JobDetailsInfo implements ResponseBody {
         @JsonProperty(FIELD_NAME_SLOT_SHARING_GROUP_ID)
         @JsonSerialize(using = SlotSharingGroupIDSerializer.class)
         private final SlotSharingGroupId slotSharingGroupId;
+
+        @JsonProperty(FIELD_NAME_SLOT_SHARING_GROUP_NAME)
+        private final String slotSharingGroupName;
 
         @JsonProperty(FIELD_NAME_JOB_VERTEX_NAME)
         private final String name;
@@ -425,6 +430,7 @@ public class JobDetailsInfo implements ResponseBody {
                 @JsonDeserialize(using = SlotSharingGroupIDDeserializer.class)
                         @JsonProperty(FIELD_NAME_SLOT_SHARING_GROUP_ID)
                         SlotSharingGroupId slotSharingGroupId,
+                @JsonProperty(FIELD_NAME_SLOT_SHARING_GROUP_NAME) String slotSharingGroupName,
                 @JsonProperty(FIELD_NAME_JOB_VERTEX_NAME) String name,
                 @JsonProperty(FIELD_NAME_MAX_PARALLELISM) int maxParallelism,
                 @JsonProperty(FIELD_NAME_PARALLELISM) int parallelism,
@@ -437,6 +443,7 @@ public class JobDetailsInfo implements ResponseBody {
                 @JsonProperty(FIELD_NAME_JOB_VERTEX_METRICS) IOMetricsInfo jobVertexMetrics) {
             this.jobVertexID = Preconditions.checkNotNull(jobVertexID);
             this.slotSharingGroupId = Preconditions.checkNotNull(slotSharingGroupId);
+            this.slotSharingGroupName = slotSharingGroupName;
             this.name = Preconditions.checkNotNull(name);
             this.maxParallelism = maxParallelism;
             this.parallelism = parallelism;
@@ -456,6 +463,11 @@ public class JobDetailsInfo implements ResponseBody {
         @JsonIgnore
         public SlotSharingGroupId getSlotSharingGroupId() {
             return slotSharingGroupId;
+        }
+
+        @JsonIgnore
+        public String getSlotSharingGroupName() {
+            return slotSharingGroupName;
         }
 
         @JsonIgnore
@@ -519,6 +531,7 @@ public class JobDetailsInfo implements ResponseBody {
                     && duration == that.duration
                     && Objects.equals(jobVertexID, that.jobVertexID)
                     && Objects.equals(slotSharingGroupId, that.slotSharingGroupId)
+                    && Objects.equals(slotSharingGroupName, that.slotSharingGroupName)
                     && Objects.equals(name, that.name)
                     && executionState == that.executionState
                     && Objects.equals(tasksPerState, that.tasksPerState)
@@ -530,6 +543,7 @@ public class JobDetailsInfo implements ResponseBody {
             return Objects.hash(
                     jobVertexID,
                     slotSharingGroupId,
+                    slotSharingGroupName,
                     name,
                     maxParallelism,
                     parallelism,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/JobDetailsInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/JobDetailsInfoTest.java
@@ -117,6 +117,7 @@ class JobDetailsInfoTest extends RestResponseMarshallingTestBase<JobDetailsInfo>
         return new JobDetailsInfo.JobVertexDetailsInfo(
                 new JobVertexID(),
                 new SlotSharingGroupId(),
+                "slotSharingGroup" + random.nextLong(),
                 "jobVertex" + random.nextLong(),
                 2 * parallelism,
                 parallelism,


### PR DESCRIPTION
## What is the purpose of the change

FLINK-39076

This change adds the ability to display the slot sharing group in operator nodes within the Flink Web UI. The slot sharing group is important for users to understand how operators are sharing slots in the TaskManager.

## Brief change log

- Added `slotSharingGroupId` field to `VerticesItem` interface in `job-detail.ts`
- Added `slotSharingGroupId` property to `NodeComponent` in `node.component.ts`
- Display slot sharing group ID in operator node labels in `node.component.html`
- The display is conditional - only shown when `slotSharingGroupId` is available and the node is not pending

## Verifying this change

This change can be verified by:
1. Starting a Flink job with slot sharing groups configured
2. Opening the Flink Web UI and navigating to the job's DAG view
3. Confirming that slot sharing group IDs are displayed in the operator nodes

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): **no**
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
- The serializers: **no**
- The runtime per-record code paths (performance): **no**
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
- The S3 file system connector: **no**

## Documentation

No documentation changes required as this is a UI enhancement.

## Checklist

- [x] The change is a proper bug fix (no).
- [x] Docs change is needed (no, UI enhancement).
- [x] Should this commit be backported to the release branches (no, new feature).
- [x] Links to ASF JIRA: N/A (FLINK-XXXXX placeholder)
- [x] How to verify this change manually (included in Verifying this change).
- [x] How to test this change (can be verified by UI interaction).
- [x] Documentation is needed (no).