### PR TITLE
Add release automation scripts (Phase A)

### DIFF
--- a/tools/releasing/dist_ops.sh
+++ b/tools/releasing/dist_ops.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+##
+## SVN distribution operations for Flink releases.
+## Manages artifacts on dist.apache.org (dev and release repositories).
+##
+## Usage:
+##   tools $ RELEASE_VERSION=1.20.0 RC_NUM=1 releasing/dist_ops.sh stage
+##   tools $ RELEASE_VERSION=1.20.0 RC_NUM=1 releasing/dist_ops.sh promote
+##   tools $ RELEASE_VERSION=1.20.0 releasing/dist_ops.sh cleanup-rcs
+##   tools $ RELEASE_VERSION=1.20.0 releasing/dist_ops.sh cleanup-old
+##
+## Environment:
+##   RELEASE_VERSION — release version (required for stage/promote/cleanup)
+##   RC_NUM          — release candidate number (required for stage/promote)
+##   DRY_RUN=true    — print commands without executing
+##
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+CURR_DIR=`pwd`
+if [[ `basename $CURR_DIR` != "tools" ]] ; then
+  echo "You have to call the script from the tools/ dir"
+  exit 1
+fi
+
+DRY_RUN=${DRY_RUN:-false}
+DIST_DEV_URL="https://dist.apache.org/repos/dist/dev/flink"
+DIST_RELEASE_URL="https://dist.apache.org/repos/dist/release/flink"
+
+COMMAND=${1:-help}
+
+FLINK_DIR=`cd .. && pwd`
+RELEASE_DIR=${FLINK_DIR}/tools/releasing/release
+
+run_cmd() {
+  if [ "$DRY_RUN" = "true" ]; then
+    echo "[dry-run] $*"
+    return 0
+  fi
+  "$@"
+}
+
+cmd_stage() {
+  if [ -z "${RELEASE_VERSION:-}" ]; then echo "RELEASE_VERSION not set."; exit 1; fi
+  if [ -z "${RC_NUM:-}" ]; then echo "RC_NUM not set."; exit 1; fi
+
+  local rc_dir="flink-${RELEASE_VERSION}-rc${RC_NUM}"
+
+  echo "=== Staging release artifacts to dist.apache.org/dev ==="
+  echo ""
+
+  if [ ! -d "$RELEASE_DIR" ]; then
+    echo "ERROR: Release directory not found: $RELEASE_DIR"
+    echo "Run create_source_release.sh and create_binary_release.sh first."
+    exit 1
+  fi
+
+  local work_dir=`mktemp -d`
+
+  echo "Checking out dist dev repo (shallow)..."
+  run_cmd svn checkout "${DIST_DEV_URL}" --depth=immediates "$work_dir/flink"
+
+  echo "Creating RC directory: ${rc_dir}"
+  run_cmd mkdir -p "$work_dir/flink/${rc_dir}"
+
+  # Copy release artifacts — handle glob directly, not through run_cmd
+  echo "Copying release artifacts..."
+  if [ "$DRY_RUN" = "true" ]; then
+    echo "[dry-run] cp -r ${RELEASE_DIR}/* $work_dir/flink/${rc_dir}/"
+  else
+    cp -r "${RELEASE_DIR}/"* "$work_dir/flink/${rc_dir}/"
+  fi
+
+  echo "Adding to SVN..."
+  run_cmd svn add "$work_dir/flink/${rc_dir}"
+
+  echo "Committing..."
+  run_cmd svn commit "$work_dir/flink" -m "Add flink-${RELEASE_VERSION}-rc${RC_NUM}"
+
+  echo ""
+  echo "Staged at: ${DIST_DEV_URL}/flink-${RELEASE_VERSION}-rc${RC_NUM}"
+  echo "Verify at: https://dist.apache.org/repos/dist/dev/flink/"
+
+  rm -rf "$work_dir"
+}
+
+cmd_promote() {
+  if [ -z "${RELEASE_VERSION:-}" ]; then echo "RELEASE_VERSION not set."; exit 1; fi
+  if [ -z "${RC_NUM:-}" ]; then echo "RC_NUM not set."; exit 1; fi
+
+  local rc_dir="flink-${RELEASE_VERSION}-rc${RC_NUM}"
+
+  echo "=== Promoting RC to release ==="
+  echo ""
+  echo "Source: ${DIST_DEV_URL}/${rc_dir}"
+  echo "Target: ${DIST_RELEASE_URL}/flink-${RELEASE_VERSION}"
+  echo ""
+  echo "WARNING: This makes the release publicly available."
+  read -r -p "Are you sure? [y/N] " confirm
+  if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
+    echo "Aborted."
+    exit 0
+  fi
+
+  run_cmd svn move -m "Release Flink ${RELEASE_VERSION}" \
+    "${DIST_DEV_URL}/${rc_dir}" \
+    "${DIST_RELEASE_URL}/flink-${RELEASE_VERSION}"
+
+  echo "Promoted. Verify at: https://dist.apache.org/repos/dist/release/flink/"
+}
+
+cmd_cleanup_rcs() {
+  if [ -z "${RELEASE_VERSION:-}" ]; then echo "RELEASE_VERSION not set."; exit 1; fi
+
+  echo "=== Cleaning up old RCs for ${RELEASE_VERSION} ==="
+  echo ""
+
+  local work_dir=`mktemp -d`
+
+  run_cmd svn checkout "${DIST_DEV_URL}" --depth=immediates "$work_dir/flink"
+
+  local found=0
+  for rc_dir in "$work_dir"/flink/flink-"${RELEASE_VERSION}"-rc*; do
+    if [ -d "$rc_dir" ]; then
+      echo "Removing: `basename $rc_dir`"
+      run_cmd svn remove "$rc_dir"
+      found=$((found + 1))
+    fi
+  done
+
+  if [ "$found" -eq 0 ]; then
+    echo "No old RCs found."
+  else
+    run_cmd svn commit "$work_dir/flink" -m "Remove old release candidates for Apache Flink ${RELEASE_VERSION}"
+    echo "Removed $found RC(s)."
+  fi
+
+  rm -rf "$work_dir"
+}
+
+cmd_cleanup_old() {
+  if [ -z "${RELEASE_VERSION:-}" ]; then echo "RELEASE_VERSION not set."; exit 1; fi
+
+  echo "=== Checking for outdated versions to remove ==="
+  echo ""
+  echo "Current release: ${RELEASE_VERSION}"
+  echo ""
+
+  local versions=`svn list "${DIST_RELEASE_URL}" 2>/dev/null | grep "^flink-" | sed 's/flink-//;s/\///'`
+
+  echo "Versions in release repo:"
+  echo "$versions" | while read -r v; do
+    echo "  $v"
+  done
+  echo ""
+
+  echo "You should remove versions per ASF policy:"
+  echo "  - New major: remove releases older than 2 major versions"
+  echo "  - New bugfix: remove previous bugfix in same series"
+  echo ""
+  echo "To remove a version:"
+  echo "  svn remove ${DIST_RELEASE_URL}/flink-<version>"
+  echo "  (requires PMC access)"
+}
+
+cmd_help() {
+  echo "Usage: RELEASE_VERSION=x.y.z [RC_NUM=n] releasing/dist_ops.sh <command>"
+  echo ""
+  echo "Commands:"
+  echo "  stage        Stage RC artifacts to dist.apache.org/dev"
+  echo "  promote      Move RC from dev to release (irreversible)"
+  echo "  cleanup-rcs  Remove old RCs for this version from dev"
+  echo "  cleanup-old  Show outdated versions that should be removed"
+  echo ""
+  echo "Environment variables:"
+  echo "  RELEASE_VERSION  Release version (required)"
+  echo "  RC_NUM           Release candidate number (for stage/promote)"
+  echo "  DRY_RUN          Set to 'true' to print commands without executing"
+}
+
+case "$COMMAND" in
+  stage)       cmd_stage ;;
+  promote)     cmd_promote ;;
+  cleanup-rcs) cmd_cleanup_rcs ;;
+  cleanup-old) cmd_cleanup_old ;;
+  help|--help|-h) cmd_help ;;
+  *)
+    echo "Unknown command: $COMMAND"
+    cmd_help
+    exit 1
+    ;;
+esac

--- a/tools/releasing/generate_email.sh
+++ b/tools/releasing/generate_email.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+##
+## Email template generator for Flink releases.
+## Generates pre-filled email templates for vote, result, and announcement.
+##
+## Usage:
+##   tools $ releasing/generate_email.sh vote <version> <rc_num> [gpg_fingerprint]
+##   tools $ releasing/generate_email.sh vote-result <version> <rc_num>
+##   tools $ releasing/generate_email.sh announce <version>
+##
+## Output goes to stdout. Redirect to a file if desired:
+##   tools $ releasing/generate_email.sh vote 1.20.0 1 > /tmp/vote-email.txt
+##
+
+# Note: xtrace intentionally omitted — output is the email template itself,
+# interleaving command traces would corrupt it.
+set -o errexit
+set -o nounset
+set -o pipefail
+
+CURR_DIR=`pwd`
+if [[ `basename $CURR_DIR` != "tools" ]] ; then
+  echo "You have to call the script from the tools/ dir"
+  exit 1
+fi
+
+COMMAND=${1:-help}
+
+cmd_vote() {
+  local version=${2:-}
+  local rc_num=${3:-}
+  local gpg_fingerprint=${4:-FFFFFFFF}
+
+  if [ -z "$version" ] || [ -z "$rc_num" ]; then
+    echo "Usage: generate_email.sh vote <version> <rc_num> [gpg_fingerprint]" >&2
+    exit 1
+  fi
+
+  local tag="release-${version}-rc${rc_num}"
+
+  cat <<EOF
+To: dev@flink.apache.org
+Subject: [VOTE] Release ${version}, release candidate #${rc_num}
+
+Hi everyone,
+Please review and vote on the release candidate #${rc_num} for version ${version}, as follows:
+
+[ ] +1, Approve the release
+[ ] -1, Do not approve the release (please provide specific comments)
+
+The complete staging area is available for your review, which includes:
+* JIRA release notes [1],
+* the official Apache source and binary convenience releases to be deployed to dist.apache.org [2], which are signed with the key with fingerprint ${gpg_fingerprint} [3],
+* all artifacts to be deployed to the Maven Central Repository [4],
+* source code tag "${tag}" [5],
+* website pull request listing the new release [6].
+
+The vote will be open for at least 72 hours. It is adopted by majority approval, with at least 3 PMC affirmative votes.
+
+Thanks,
+<Release Manager Name>
+
+[1] https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315522&version=<JIRA_VERSION_ID>
+[2] https://dist.apache.org/repos/dist/dev/flink/flink-${version}-rc${rc_num}
+[3] https://dist.apache.org/repos/dist/release/flink/KEYS
+[4] https://repository.apache.org/content/repositories/<STAGING_REPO_ID>
+[5] https://github.com/apache/flink/releases/tag/${tag}
+[6] <WEBSITE_PR_URL>
+EOF
+}
+
+cmd_vote_result() {
+  local version=${2:-}
+  local rc_num=${3:-}
+
+  if [ -z "$version" ] || [ -z "$rc_num" ]; then
+    echo "Usage: generate_email.sh vote-result <version> <rc_num>" >&2
+    exit 1
+  fi
+
+  cat <<EOF
+To: dev@flink.apache.org
+Subject: [RESULT] [VOTE] Release ${version}, release candidate #${rc_num}
+
+Hi everyone,
+
+I'm happy to announce that we have unanimously approved this release.
+
+There are XXX approving votes, XXX of which are binding:
+* <approver 1>
+* <approver 2>
+* <approver 3>
+
+There are no disapproving votes.
+
+Thanks everyone who has tested the release candidate and given their feedback.
+
+<Release Manager Name>
+EOF
+}
+
+cmd_announce() {
+  local version=${2:-}
+
+  if [ -z "$version" ]; then
+    echo "Usage: generate_email.sh announce <version>" >&2
+    exit 1
+  fi
+
+  local short_version=`echo "$version" | sed 's/\.[^.]*$//'`
+  local patch=`echo "$version" | awk -F. '{print $3}'`
+
+  local release_desc
+  if [ "$patch" = "0" ]; then
+    release_desc="the first release of the ${short_version} series"
+  else
+    release_desc="a bugfix release of the ${short_version} series"
+  fi
+
+  cat <<EOF
+To: dev@flink.apache.org, user@flink.apache.org, user-zh@flink.apache.org, announce@apache.org
+Subject: [ANNOUNCE] Apache Flink ${version} released
+
+The Apache Flink community is very happy to announce the release of Apache Flink ${version}, which is ${release_desc}.
+
+Apache Flink® is an open-source stream processing framework for distributed, high-performing, always-available, and accurate data streaming applications.
+
+The release is available for download at:
+https://flink.apache.org/downloads.html
+
+The full release notes are available in Jira:
+https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315522&version=<JIRA_VERSION_ID>
+
+We would like to thank all contributors of the Apache Flink community who made this release possible!
+
+Feel free to reach out to the release manager or the dev@flink.apache.org mailing list if you have any questions.
+
+Regards,
+<Release Manager Name>
+EOF
+}
+
+cmd_help() {
+  echo "Usage: releasing/generate_email.sh <command> <version> [args]"
+  echo ""
+  echo "Commands:"
+  echo "  vote <version> <rc_num> [gpg_fingerprint]   Generate vote email"
+  echo "  vote-result <version> <rc_num>               Generate vote result email"
+  echo "  announce <version>                            Generate announcement email"
+  echo ""
+  echo "Output goes to stdout. Redirect to a file:"
+  echo "  releasing/generate_email.sh vote 1.20.0 1 > /tmp/vote.txt"
+  echo ""
+  echo "Replace placeholders (<...>) with actual values before sending."
+}
+
+case "$COMMAND" in
+  vote)        cmd_vote "$@" ;;
+  vote-result) cmd_vote_result "$@" ;;
+  announce)    cmd_announce "$@" ;;
+  help|--help|-h) cmd_help ;;
+  *)
+    echo "Unknown command: $COMMAND"
+    cmd_help
+    exit 1
+    ;;
+esac

--- a/tools/releasing/jira_ops.sh
+++ b/tools/releasing/jira_ops.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+##
+## JIRA operations for Flink releases.
+## Wraps Apache JIRA REST API for common release management tasks.
+##
+## Usage:
+##   tools $ releasing/jira_ops.sh blockers <version>
+##   tools $ releasing/jira_ops.sh release-notes <version>
+##   tools $ releasing/jira_ops.sh create-version <version>
+##   tools $ releasing/jira_ops.sh release-version <version>
+##
+## Environment:
+##   JIRA_USER     — JIRA username (required — even read ops are rate-limited without auth)
+##   JIRA_TOKEN    — JIRA API token (required)
+##   DRY_RUN=true  — print API calls without executing write operations
+##
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+CURR_DIR=`pwd`
+if [[ `basename $CURR_DIR` != "tools" ]] ; then
+  echo "You have to call the script from the tools/ dir"
+  exit 1
+fi
+
+DRY_RUN=${DRY_RUN:-false}
+JIRA_BASE_URL="https://issues.apache.org/jira/rest/api/2"
+PROJECT="FLINK"
+
+COMMAND=${1:-help}
+
+if [ "$COMMAND" != "help" ] && [ "$COMMAND" != "--help" ] && [ "$COMMAND" != "-h" ]; then
+  if [ -z "${JIRA_USER:-}" ] || [ -z "${JIRA_TOKEN:-}" ]; then
+    echo "JIRA_USER and JIRA_TOKEN must be set."
+    echo "Get a token at: https://id.atlassian.com/manage/api-tokens"
+    exit 1
+  fi
+fi
+
+jira_get() {
+  local path=$1
+  curl -s -f -u "${JIRA_USER}:${JIRA_TOKEN}" "${JIRA_BASE_URL}${path}"
+}
+
+jira_post() {
+  local path=$1
+  local data=$2
+  if [ "$DRY_RUN" = "true" ]; then
+    echo "[dry-run] POST ${JIRA_BASE_URL}${path}"
+    echo "[dry-run] Data: $data"
+    return 0
+  fi
+  curl -s -f -X POST \
+    -H "Content-Type: application/json" \
+    -u "${JIRA_USER}:${JIRA_TOKEN}" \
+    -d "$data" \
+    "${JIRA_BASE_URL}${path}"
+}
+
+jira_put() {
+  local path=$1
+  local data=$2
+  if [ "$DRY_RUN" = "true" ]; then
+    echo "[dry-run] PUT ${JIRA_BASE_URL}${path}"
+    echo "[dry-run] Data: $data"
+    return 0
+  fi
+  curl -s -f -X PUT \
+    -H "Content-Type: application/json" \
+    -u "${JIRA_USER}:${JIRA_TOKEN}" \
+    -d "$data" \
+    "${JIRA_BASE_URL}${path}"
+}
+
+url_encode() {
+  python3 -c "import sys, urllib.parse; print(urllib.parse.quote(sys.stdin.read().strip()))"
+}
+
+cmd_blockers() {
+  local version=${2:-}
+  if [ -z "$version" ]; then
+    echo "Usage: jira_ops.sh blockers <version>"
+    exit 1
+  fi
+
+  echo "=== Unresolved blockers for ${PROJECT} ${version} ==="
+  echo ""
+
+  local jql="project = ${PROJECT} AND fixVersion = ${version} AND resolution = Unresolved ORDER BY priority DESC"
+  local encoded_jql=`echo "$jql" | url_encode`
+
+  local result=`jira_get "/search?jql=${encoded_jql}&maxResults=200&fields=key,summary,priority,status,assignee,issuetype"`
+
+  local total=`echo "$result" | jq '.total'`
+  echo "Found $total unresolved issue(s):"
+  echo ""
+
+  echo "$result" | jq -r '.issues[] | "\(.key)\t\(.fields.priority.name)\t\(.fields.issuetype.name)\t\(.fields.assignee.displayName // "Unassigned")\t\(.fields.summary)"' | \
+    column -t -s $'\t'
+}
+
+cmd_release_notes() {
+  local version=${2:-}
+  if [ -z "$version" ]; then
+    echo "Usage: jira_ops.sh release-notes <version>"
+    exit 1
+  fi
+
+  echo "=== Release Notes for ${PROJECT} ${version} ==="
+  echo ""
+
+  local jql="project = ${PROJECT} AND Release Note is not EMPTY AND fixVersion = ${version}"
+  local encoded_jql=`echo "$jql" | url_encode`
+
+  local result=`jira_get "/search?jql=${encoded_jql}&maxResults=200&fields=key,summary,issuetype,customfield_12310192"`
+
+  local total=`echo "$result" | jq '.total'`
+  echo "Found $total issue(s) with release notes:"
+  echo ""
+
+  for type in "New Feature" "Improvement" "Bug" "Task" "Sub-task"; do
+    local items=`echo "$result" | jq -r ".issues[] | select(.fields.issuetype.name == \"$type\") | \"  * [\(.key)] - \(.fields.summary)\""`
+    if [ -n "$items" ]; then
+      echo "### $type"
+      echo "$items"
+      echo ""
+    fi
+  done
+}
+
+cmd_create_version() {
+  local version=${2:-}
+  if [ -z "$version" ]; then
+    echo "Usage: jira_ops.sh create-version <version>"
+    exit 1
+  fi
+
+  echo "Creating JIRA version: ${version}"
+
+  local today=`date +%Y-%m-%d`
+  local data=`jq -n \
+    --arg name "$version" \
+    --arg project "$PROJECT" \
+    --arg startDate "$today" \
+    '{name: $name, project: $project, startDate: $startDate}'`
+
+  jira_post "/version" "$data"
+  echo "Version ${version} created with start date ${today}."
+}
+
+cmd_release_version() {
+  local version=${2:-}
+  if [ -z "$version" ]; then
+    echo "Usage: jira_ops.sh release-version <version>"
+    exit 1
+  fi
+
+  echo "Marking JIRA version as released: ${version}"
+
+  local version_id=`jira_get "/project/${PROJECT}/versions" | \
+    jq -r ".[] | select(.name == \"$version\") | .id"`
+  if [ -z "$version_id" ]; then
+    echo "ERROR: Version ${version} not found in JIRA."
+    exit 1
+  fi
+
+  local today=`date +%Y-%m-%d`
+  local data=`jq -n \
+    --arg releaseDate "$today" \
+    '{released: true, releaseDate: $releaseDate}'`
+
+  jira_put "/version/${version_id}" "$data"
+  echo "Version ${version} marked as released (${today})."
+}
+
+cmd_help() {
+  echo "Usage: releasing/jira_ops.sh <command> <version>"
+  echo ""
+  echo "Commands:"
+  echo "  blockers <version>        List unresolved issues for a version"
+  echo "  release-notes <version>   Extract release notes from JIRA"
+  echo "  create-version <version>  Create a new JIRA version"
+  echo "  release-version <version> Mark a version as released"
+  echo ""
+  echo "Environment variables:"
+  echo "  JIRA_USER    JIRA username (required for all operations)"
+  echo "  JIRA_TOKEN   JIRA API token (required for all operations)"
+  echo "  DRY_RUN      Set to 'true' to print write calls without executing"
+}
+
+case "$COMMAND" in
+  blockers)        cmd_blockers "$@" ;;
+  release-notes)   cmd_release_notes "$@" ;;
+  create-version)  cmd_create_version "$@" ;;
+  release-version) cmd_release_version "$@" ;;
+  help|--help|-h)  cmd_help ;;
+  *)
+    echo "Unknown command: $COMMAND"
+    cmd_help
+    exit 1
+    ;;
+esac

--- a/tools/releasing/nexus_ops.sh
+++ b/tools/releasing/nexus_ops.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+##
+## Nexus staging repository operations for Flink releases.
+## Wraps Apache Nexus 2 REST API for managing staging repositories.
+##
+## Usage:
+##   tools $ releasing/nexus_ops.sh list
+##   tools $ releasing/nexus_ops.sh close <repo-id> "<description>"
+##   tools $ releasing/nexus_ops.sh release <repo-id>
+##   tools $ releasing/nexus_ops.sh drop <repo-id>
+##
+## Environment:
+##   NEXUS_USER    — Nexus username (reads from ~/.m2/settings.xml if not set)
+##   NEXUS_TOKEN   — Nexus token (reads from ~/.m2/settings.xml if not set)
+##   DRY_RUN=true  — print API calls without executing
+##
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+CURR_DIR=`pwd`
+if [[ `basename $CURR_DIR` != "tools" ]] ; then
+  echo "You have to call the script from the tools/ dir"
+  exit 1
+fi
+
+DRY_RUN=${DRY_RUN:-false}
+NEXUS_BASE_URL="https://repository.apache.org/service/local"
+
+COMMAND=${1:-help}
+
+# Try to read credentials from ~/.m2/settings.xml if not provided
+if [ -z "${NEXUS_USER:-}" ] || [ -z "${NEXUS_TOKEN:-}" ]; then
+  settings_xml="${HOME}/.m2/settings.xml"
+  if [ -f "$settings_xml" ]; then
+    NEXUS_USER=${NEXUS_USER:-`python3 -c "
+import xml.etree.ElementTree as ET
+tree = ET.parse('$settings_xml')
+for server in tree.findall('.//server'):
+    sid = server.find('id')
+    if sid is not None and sid.text == 'apache.releases.https':
+        u = server.find('username')
+        if u is not None: print(u.text)
+        break
+" 2>/dev/null || echo ""`}
+    NEXUS_TOKEN=${NEXUS_TOKEN:-`python3 -c "
+import xml.etree.ElementTree as ET
+tree = ET.parse('$settings_xml')
+for server in tree.findall('.//server'):
+    sid = server.find('id')
+    if sid is not None and sid.text == 'apache.releases.https':
+        p = server.find('password')
+        if p is not None: print(p.text)
+        break
+" 2>/dev/null || echo ""`}
+  fi
+fi
+
+nexus_get() {
+  local path=$1
+  curl -s -f -H "Accept: application/json" \
+    -u "${NEXUS_USER}:${NEXUS_TOKEN}" \
+    "${NEXUS_BASE_URL}${path}"
+}
+
+nexus_post_xml() {
+  local path=$1
+  local data=$2
+  if [ "$DRY_RUN" = "true" ]; then
+    echo "[dry-run] POST ${NEXUS_BASE_URL}${path}"
+    echo "[dry-run] Data: $data"
+    return 0
+  fi
+  curl -s -f -X POST \
+    -H "Content-Type: application/xml" \
+    -u "${NEXUS_USER}:${NEXUS_TOKEN}" \
+    -d "$data" \
+    "${NEXUS_BASE_URL}${path}"
+}
+
+# Discover the staging profile ID for org.apache.flink
+get_staging_profile_id() {
+  local profiles=`nexus_get "/staging/profiles"`
+  local profile_id=`echo "$profiles" | jq -r '.data[] | select(.name == "org.apache.flink") | .id'`
+  if [ -z "$profile_id" ]; then
+    echo "ERROR: Could not find staging profile for org.apache.flink"
+    echo "Verify your Nexus credentials and that org.apache.flink is in your staging profiles."
+    exit 1
+  fi
+  echo "$profile_id"
+}
+
+make_promote_request_xml() {
+  local repo_id=$1
+  local description=$2
+  # Use printf to avoid XML injection from special chars in description
+  local safe_desc=`echo "$description" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g'`
+  cat <<XMLEOF
+<promoteRequest>
+  <data>
+    <stagedRepositoryId>${repo_id}</stagedRepositoryId>
+    <description>${safe_desc}</description>
+  </data>
+</promoteRequest>
+XMLEOF
+}
+
+cmd_list() {
+  echo "=== Open Staging Repositories for org.apache.flink ==="
+  echo ""
+
+  local profile_id=`get_staging_profile_id`
+  local result=`nexus_get "/staging/profile_repositories/${profile_id}"`
+
+  echo "$result" | jq -r '
+    .data[]
+    | "\(.repositoryId)\t\(.type)\t\(.description // "no description")"
+  ' | column -t -s $'\t'
+}
+
+cmd_close() {
+  local repo_id=${2:-}
+  local description=${3:-"Apache Flink release candidate"}
+
+  if [ -z "$repo_id" ]; then
+    echo "Usage: nexus_ops.sh close <repo-id> [description]"
+    exit 1
+  fi
+
+  echo "Closing staging repository: $repo_id"
+  echo "Description: $description"
+
+  local profile_id=`get_staging_profile_id`
+  local data=`make_promote_request_xml "$repo_id" "$description"`
+
+  nexus_post_xml "/staging/profiles/${profile_id}/finish" "$data"
+  echo "Close request submitted. Check status at https://repository.apache.org/#stagingRepositories"
+}
+
+cmd_release() {
+  local repo_id=${2:-}
+
+  if [ -z "$repo_id" ]; then
+    echo "Usage: nexus_ops.sh release <repo-id>"
+    exit 1
+  fi
+
+  echo "Releasing staging repository to Maven Central: $repo_id"
+  echo ""
+  echo "WARNING: This action is irreversible. Artifacts will be published to Maven Central."
+  read -r -p "Are you sure? [y/N] " confirm
+  if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
+    echo "Aborted."
+    exit 0
+  fi
+
+  local profile_id=`get_staging_profile_id`
+  local data=`make_promote_request_xml "$repo_id" "Release"`
+
+  nexus_post_xml "/staging/profiles/${profile_id}/promote" "$data"
+  echo "Release request submitted. Artifacts should appear in Maven Central within ~24 hours."
+}
+
+cmd_drop() {
+  local repo_id=${2:-}
+
+  if [ -z "$repo_id" ]; then
+    echo "Usage: nexus_ops.sh drop <repo-id>"
+    exit 1
+  fi
+
+  echo "Dropping staging repository: $repo_id"
+
+  local profile_id=`get_staging_profile_id`
+  local data=`make_promote_request_xml "$repo_id" "Dropping failed release candidate"`
+
+  nexus_post_xml "/staging/profiles/${profile_id}/drop" "$data"
+  echo "Repository $repo_id dropped."
+}
+
+cmd_help() {
+  echo "Usage: releasing/nexus_ops.sh <command> [args]"
+  echo ""
+  echo "Commands:"
+  echo "  list                           List open staging repositories"
+  echo "  close <repo-id> [description]  Close a staging repository"
+  echo "  release <repo-id>              Release to Maven Central (irreversible!)"
+  echo "  drop <repo-id>                 Drop a staging repository"
+  echo ""
+  echo "Environment variables:"
+  echo "  NEXUS_USER   Nexus username (auto-reads from ~/.m2/settings.xml)"
+  echo "  NEXUS_TOKEN  Nexus token (auto-reads from ~/.m2/settings.xml)"
+  echo "  DRY_RUN      Set to 'true' to print API calls without executing"
+}
+
+case "$COMMAND" in
+  list)    cmd_list ;;
+  close)   cmd_close "$@" ;;
+  release) cmd_release "$@" ;;
+  drop)    cmd_drop "$@" ;;
+  help|--help|-h) cmd_help ;;
+  *)
+    echo "Unknown command: $COMMAND"
+    cmd_help
+    exit 1
+    ;;
+esac

--- a/tools/releasing/preflight_check.sh
+++ b/tools/releasing/preflight_check.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+##
+## Pre-flight checks for Flink release prerequisites.
+## Verifies that all tools, credentials, and configurations are in place
+## before starting the release process.
+##
+## Usage: tools $ releasing/preflight_check.sh [--java-version 11|8]
+##
+
+# Note: xtrace intentionally omitted for this script — output is a
+# formatted report, not a command trace.
+set -o errexit
+set -o nounset
+set -o pipefail
+
+CURR_DIR=`pwd`
+if [[ `basename $CURR_DIR` != "tools" ]] ; then
+  echo "You have to call the script from the tools/ dir"
+  exit 1
+fi
+
+EXPECTED_JAVA_MAJOR=${1:-11}
+PASS_COUNT=0
+FAIL_COUNT=0
+WARN_COUNT=0
+
+pass() { echo "  [PASS] $1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail() { echo "  [FAIL] $1"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+warn() { echo "  [WARN] $1"; WARN_COUNT=$((WARN_COUNT + 1)); }
+
+echo ""
+echo "=== Flink Release Pre-flight Checks ==="
+echo ""
+
+# 1. GPG key
+echo "GPG Configuration:"
+if gpg_keys=`gpg --list-secret-keys --keyid-format SHORT 2>/dev/null` && [ -n "$gpg_keys" ]; then
+  key_id=`echo "$gpg_keys" | grep -m1 'sec' | sed 's/.*\/\([A-F0-9]*\).*/\1/'`
+  pass "GPG secret key found: $key_id"
+
+  # Check if key is in dist.apache.org KEYS file
+  keys_content=`curl -s https://dist.apache.org/repos/dist/release/flink/KEYS 2>/dev/null || echo ""`
+  if [ -n "$keys_content" ] && echo "$keys_content" | grep -qi "$key_id"; then
+    pass "GPG key $key_id found in dist.apache.org KEYS file"
+  else
+    fail "GPG key $key_id NOT found in dist.apache.org KEYS file — publish it before releasing"
+  fi
+else
+  fail "No GPG secret key found — run 'gpg --gen-key' to create one"
+fi
+
+# 2. Git signing key
+if git_signing_key=`git config --global user.signingkey 2>/dev/null` && [ -n "$git_signing_key" ]; then
+  pass "Git signing key configured: $git_signing_key"
+else
+  fail "Git signing key not configured — run 'git config --global user.signingkey <KEY_ID>'"
+fi
+
+echo ""
+echo "Maven & Nexus Configuration:"
+
+# 3. Nexus tokens in settings.xml
+settings_xml="${HOME}/.m2/settings.xml"
+if [ -f "$settings_xml" ]; then
+  if grep -q "apache.releases.https" "$settings_xml"; then
+    pass "Nexus release token found in $settings_xml"
+  else
+    fail "apache.releases.https not found in $settings_xml — configure Nexus user token"
+  fi
+  if grep -q "apache.snapshots.https" "$settings_xml"; then
+    pass "Nexus snapshot token found in $settings_xml"
+  else
+    fail "apache.snapshots.https not found in $settings_xml — configure Nexus user token"
+  fi
+else
+  fail "$settings_xml not found — create it with Nexus user tokens"
+fi
+
+echo ""
+echo "Build Tools:"
+
+# 4. Java version
+if java_version=`java -version 2>&1 | head -1 | sed 's/.*"\(.*\)".*/\1/'`; then
+  java_major=`echo "$java_version" | cut -d. -f1`
+  if [ "$java_major" -ge "$EXPECTED_JAVA_MAJOR" ]; then
+    pass "Java version: $java_version (required: ${EXPECTED_JAVA_MAJOR}+)"
+  else
+    fail "Java version: $java_version (required: ${EXPECTED_JAVA_MAJOR}+)"
+  fi
+else
+  fail "Java not found"
+fi
+
+# 5. Maven version
+if mvn_version=`mvn --version 2>/dev/null | head -1 | sed 's/.*Maven \([0-9.]*\).*/\1/'`; then
+  pass "Maven version: $mvn_version"
+else
+  fail "Maven not found"
+fi
+
+# 6. GNU tar (macOS check)
+if [ "`uname`" == "Darwin" ]; then
+  if tar_version=`tar --version 2>/dev/null | head -1` && echo "$tar_version" | grep -q "GNU"; then
+    pass "GNU tar available: $tar_version"
+  else
+    fail "GNU tar not found — run 'brew install gnu-tar && ln -s /opt/homebrew/bin/gtar /usr/local/bin/tar'"
+  fi
+else
+  pass "tar: `tar --version 2>/dev/null | head -1`"
+fi
+
+echo ""
+echo "CLI Tools:"
+
+# 7. Required CLIs
+for tool in svn jq curl; do
+  if command -v "$tool" &> /dev/null; then
+    pass "$tool available"
+  else
+    fail "$tool not found"
+  fi
+done
+
+if command -v gh &> /dev/null; then
+  if gh auth status &>/dev/null; then
+    pass "gh CLI authenticated"
+  else
+    warn "gh CLI installed but not authenticated — run 'gh auth login'"
+  fi
+else
+  fail "gh CLI not found — install with: brew install gh"
+fi
+
+echo ""
+echo "PyPI (optional — needed for Phase 6):"
+
+# 8. PyPI credentials
+if [ -n "${TWINE_USERNAME:-}" ] && [ -n "${TWINE_PASSWORD:-}" ]; then
+  pass "PyPI credentials found (TWINE_USERNAME / TWINE_PASSWORD)"
+else
+  warn "PyPI credentials not in environment — set TWINE_USERNAME and TWINE_PASSWORD before Phase 6"
+fi
+
+if command -v twine &> /dev/null; then
+  pass "twine available"
+else
+  warn "twine not found — needed for Phase 6 (pip install twine)"
+fi
+
+echo ""
+echo "=== Results ==="
+echo "  ${PASS_COUNT} passed, ${FAIL_COUNT} failed, ${WARN_COUNT} warnings"
+echo ""
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  echo "Fix the failures above before starting the release."
+  exit 1
+else
+  echo "All critical checks passed. Ready to release."
+  exit 0
+fi

--- a/tools/releasing/pyflink_ops.sh
+++ b/tools/releasing/pyflink_ops.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+##
+## PyFlink wheel build and download operations.
+## Automates GitHub Actions trigger, wait, download, and organization
+## of wheel packages for a release.
+##
+## Usage:
+##   tools $ releasing/pyflink_ops.sh trigger <owner/repo> <branch>
+##   tools $ releasing/pyflink_ops.sh wait <owner/repo> <run_id>
+##   tools $ releasing/pyflink_ops.sh download <owner/repo> <run_id>
+##
+## Prerequisites: gh CLI must be installed and authenticated.
+##
+## Note: PyPI storage quota must be checked manually at:
+##   https://pypi.org/manage/project/apache-flink/settings/
+##
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+CURR_DIR=`pwd`
+if [[ `basename $CURR_DIR` != "tools" ]] ; then
+  echo "You have to call the script from the tools/ dir"
+  exit 1
+fi
+
+DRY_RUN=${DRY_RUN:-false}
+
+COMMAND=${1:-help}
+
+FLINK_DIR=`cd .. && pwd`
+PYFLINK_DIST="${FLINK_DIR}/flink-python/dist"
+
+cmd_trigger() {
+  local repo=${2:-}
+  local branch=${3:-}
+
+  if [ -z "$repo" ] || [ -z "$branch" ]; then
+    echo "Usage: pyflink_ops.sh trigger <owner/repo> <branch>"
+    echo "Example: pyflink_ops.sh trigger myuser/flink release-1.20.0-rc1"
+    exit 1
+  fi
+
+  echo "Triggering Nightly (beta) workflow on ${repo}@${branch}..."
+
+  if [ "$DRY_RUN" = "true" ]; then
+    echo "[dry-run] gh workflow run \"Nightly (beta)\" --repo $repo --ref $branch"
+    return 0
+  fi
+
+  gh workflow run "Nightly (beta)" --repo "$repo" --ref "$branch"
+
+  echo "Workflow triggered. Waiting 10 seconds for it to appear..."
+  sleep 10
+
+  local run_id=`gh run list --repo "$repo" --workflow="Nightly (beta)" --branch "$branch" --limit 1 --json databaseId --jq '.[0].databaseId'`
+
+  echo "Run ID: ${run_id}"
+  echo ""
+  echo "To wait for completion: releasing/pyflink_ops.sh wait ${repo} ${run_id}"
+  echo "To download artifacts:  releasing/pyflink_ops.sh download ${repo} ${run_id}"
+}
+
+cmd_wait() {
+  local repo=${2:-}
+  local run_id=${3:-}
+
+  if [ -z "$repo" ] || [ -z "$run_id" ]; then
+    echo "Usage: pyflink_ops.sh wait <owner/repo> <run_id>"
+    exit 1
+  fi
+
+  echo "Waiting for workflow run ${run_id} to complete..."
+  echo "(This may take a while — wheel builds typically take 1-2 hours)"
+  echo ""
+
+  gh run watch "$run_id" --repo "$repo" --exit-status
+
+  echo ""
+  echo "Workflow complete. Download artifacts with:"
+  echo "  releasing/pyflink_ops.sh download ${repo} ${run_id}"
+}
+
+cmd_download() {
+  local repo=${2:-}
+  local run_id=${3:-}
+
+  if [ -z "$repo" ] || [ -z "$run_id" ]; then
+    echo "Usage: pyflink_ops.sh download <owner/repo> <run_id>"
+    exit 1
+  fi
+
+  echo "Downloading wheel artifacts from run ${run_id}..."
+
+  local download_dir=`mktemp -d`
+
+  gh run download "$run_id" --repo "$repo" --dir "$download_dir"
+
+  echo "Artifacts downloaded to: $download_dir"
+  echo ""
+
+  mkdir -p "$PYFLINK_DIST"
+
+  # Move wheel files to flink-python/dist/
+  echo "Organizing wheel files into ${PYFLINK_DIST}..."
+  find "$download_dir" -name "*.whl" -exec mv {} "$PYFLINK_DIST/" \;
+  local count=`find "$PYFLINK_DIST" -name "*.whl" | wc -l | tr -d ' '`
+
+  echo ""
+  echo "Done. ${count} wheel file(s) in ${PYFLINK_DIST}:"
+  ls -la "$PYFLINK_DIST/"*.whl 2>/dev/null || echo "  (none found)"
+
+  rm -rf "$download_dir"
+}
+
+cmd_help() {
+  echo "Usage: releasing/pyflink_ops.sh <command> [args]"
+  echo ""
+  echo "Commands:"
+  echo "  trigger <owner/repo> <branch>    Trigger wheel build workflow"
+  echo "  wait <owner/repo> <run_id>       Wait for workflow to complete"
+  echo "  download <owner/repo> <run_id>   Download wheel artifacts"
+  echo ""
+  echo "Example workflow:"
+  echo "  releasing/pyflink_ops.sh trigger myuser/flink release-1.20.0-rc1"
+  echo "  releasing/pyflink_ops.sh wait myuser/flink 12345678"
+  echo "  releasing/pyflink_ops.sh download myuser/flink 12345678"
+  echo ""
+  echo "Note: PyPI storage quota must be checked manually at:"
+  echo "  https://pypi.org/manage/project/apache-flink/settings/"
+}
+
+case "$COMMAND" in
+  trigger)        cmd_trigger "$@" ;;
+  wait)           cmd_wait "$@" ;;
+  download)       cmd_download "$@" ;;
+  help|--help|-h) cmd_help ;;
+  *)
+    echo "Unknown command: $COMMAND"
+    cmd_help
+    exit 1
+    ;;
+esac

--- a/tools/releasing/pyflink_ops.sh
+++ b/tools/releasing/pyflink_ops.sh
@@ -112,7 +112,9 @@ cmd_download() {
 
   echo "Downloading wheel artifacts from run ${run_id}..."
 
-  local download_dir=`mktemp -d`
+  local download_dir
+  download_dir=`mktemp -d`
+  trap "rm -rf '$download_dir'" EXIT
 
   gh run download "$run_id" --repo "$repo" --dir "$download_dir"
 
@@ -124,12 +126,14 @@ cmd_download() {
   # Move wheel files to flink-python/dist/
   echo "Organizing wheel files into ${PYFLINK_DIST}..."
   find "$download_dir" -name "*.whl" -exec mv {} "$PYFLINK_DIST/" \;
-  local count=`find "$PYFLINK_DIST" -name "*.whl" | wc -l | tr -d ' '`
+  local count
+  count=`find "$PYFLINK_DIST" -name "*.whl" | wc -l | tr -d ' '`
 
   echo ""
   echo "Done. ${count} wheel file(s) in ${PYFLINK_DIST}:"
   ls -la "$PYFLINK_DIST/"*.whl 2>/dev/null || echo "  (none found)"
 
+  trap - EXIT
   rm -rf "$download_dir"
 }
 

--- a/tools/releasing/update_all_versions.sh
+++ b/tools/releasing/update_all_versions.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+##
+## Cross-repo version update operations for major Flink releases.
+## Handles version-related updates beyond what update_branch_version.sh covers.
+##
+## Usage:
+##   tools $ RELEASE_VERSION=1.20.0 releasing/update_all_versions.sh add-flink-version
+##   tools $ RELEASE_VERSION=1.20.0 releasing/update_all_versions.sh update-nightly-workflow
+##   tools $ RELEASE_VERSION=1.20.0 releasing/update_all_versions.sh show-cross-repo-tasks
+##
+## These operations are only needed for major releases (x.y.0).
+##
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+CURR_DIR=`pwd`
+if [[ `basename $CURR_DIR` != "tools" ]] ; then
+  echo "You have to call the script from the tools/ dir"
+  exit 1
+fi
+
+DRY_RUN=${DRY_RUN:-false}
+
+COMMAND=${1:-help}
+
+cd ..
+FLINK_DIR=`pwd`
+
+cmd_add_flink_version() {
+  if [ -z "${RELEASE_VERSION:-}" ]; then echo "RELEASE_VERSION not set."; exit 1; fi
+
+  local MAJOR=`echo "$RELEASE_VERSION" | cut -d. -f1`
+  local MINOR=`echo "$RELEASE_VERSION" | cut -d. -f2`
+
+  echo "=== Adding FlinkVersion enum entry ==="
+
+  local version_file=`find "$FLINK_DIR" -path "*/flink-annotations/src/main/java/org/apache/flink/FlinkVersion.java" -type f`
+
+  if [ -z "$version_file" ]; then
+    echo "ERROR: FlinkVersion.java not found"
+    exit 1
+  fi
+
+  echo "File: $version_file"
+
+  local version_enum="v${MAJOR}_${MINOR}"
+  if grep -q "$version_enum" "$version_file"; then
+    echo "Version ${version_enum} already exists in FlinkVersion.java"
+    return 0
+  fi
+
+  local version_string="${MAJOR}.${MINOR}"
+
+  if [ "$DRY_RUN" = "true" ]; then
+    echo "[dry-run] Would add: ${version_enum}(\"${version_string}\");"
+    echo "[dry-run] to: $version_file"
+    return 0
+  fi
+
+  # Find the last version entry line number
+  local last_version_line=`grep -n 'v[0-9]*_[0-9]*("' "$version_file" | tail -1 | cut -d: -f1`
+
+  if [ -z "$last_version_line" ]; then
+    echo "ERROR: Could not find existing version entries in FlinkVersion.java"
+    exit 1
+  fi
+
+  # Get indent from existing line
+  local last_line_content=`sed -n "${last_version_line}p" "$version_file"`
+
+  # Replace trailing semicolon with comma on last entry using perl (macOS-safe)
+  perl -pi -e "s/;$/,/ if \$. == ${last_version_line}" "$version_file"
+
+  # Insert new version after last entry using perl
+  local indent=`echo "$last_line_content" | sed 's/[^ ].*//'`
+  perl -pi -e "print \"${indent}${version_enum}(\\\"${version_string}\\\");\n\" if \$. == ${last_version_line}" "$version_file"
+
+  echo "Added ${version_enum}(\"${version_string}\") to FlinkVersion.java"
+}
+
+cmd_update_nightly_workflow() {
+  if [ -z "${RELEASE_VERSION:-}" ]; then echo "RELEASE_VERSION not set."; exit 1; fi
+
+  local MAJOR=`echo "$RELEASE_VERSION" | cut -d. -f1`
+  local MINOR=`echo "$RELEASE_VERSION" | cut -d. -f2`
+
+  echo "=== Updating GitHub Actions nightly workflow ==="
+
+  local workflow_file="$FLINK_DIR/.github/workflows/nightly-trigger.yml"
+
+  if [ ! -f "$workflow_file" ]; then
+    echo "WARNING: $workflow_file not found. Skipping."
+    return 0
+  fi
+
+  echo "File: $workflow_file"
+  echo ""
+  echo "The nightly workflow should include the two most recent release branches and master."
+  echo "Please manually verify the branch list in:"
+  echo "  $workflow_file"
+  echo ""
+  echo "Expected branches: master, release-${MAJOR}.${MINOR}, release-${MAJOR}.$((MINOR - 1))"
+}
+
+cmd_show_cross_repo_tasks() {
+  if [ -z "${RELEASE_VERSION:-}" ]; then echo "RELEASE_VERSION not set."; exit 1; fi
+
+  local MAJOR=`echo "$RELEASE_VERSION" | cut -d. -f1`
+  local MINOR=`echo "$RELEASE_VERSION" | cut -d. -f2`
+  local PATCH=`echo "$RELEASE_VERSION" | cut -d. -f3`
+
+  echo "=== Cross-Repository Tasks for Flink ${RELEASE_VERSION} ==="
+  echo ""
+  echo "The following updates must be made in OTHER repositories."
+  echo ""
+
+  echo "1. flink-docker repository:"
+  echo "   git clone https://github.com/apache/flink-docker"
+  echo "   git checkout dev-master"
+  echo "   git checkout -b dev-${MAJOR}.${MINOR}"
+  echo "   # Update .github/workflows/ci.yml to point to ${MAJOR}.${MINOR}-SNAPSHOT"
+  echo "   # On dev-master: update to next SNAPSHOT version"
+  echo ""
+
+  echo "2. flink-benchmarks repository:"
+  echo "   git clone https://github.com/apache/flink-benchmarks"
+  echo "   git checkout master"
+  echo "   git checkout -b dev-${MAJOR}.${MINOR}"
+  echo "   # On master: update pom.xml flink.version to next SNAPSHOT"
+  echo ""
+
+  echo "3. flink-web (website) repository:"
+  echo "   # Update docs/data/flink.yml"
+  echo "   # Update docs/data/release_archive.yml"
+  echo "   # Add blog post to _posts/"
+  echo "   # (Major) Update FlinkStableVersion in docs/config.toml"
+  echo ""
+
+  if [ "$PATCH" = "0" ]; then
+    echo "NOTE: This is a MAJOR release — all 3 repos need updates."
+  else
+    echo "NOTE: This is a BUGFIX release — only the website repo needs updates."
+  fi
+}
+
+cmd_help() {
+  echo "Usage: RELEASE_VERSION=x.y.z releasing/update_all_versions.sh <command>"
+  echo ""
+  echo "Commands:"
+  echo "  add-flink-version         Add entry to FlinkVersion enum (major only)"
+  echo "  update-nightly-workflow   Show nightly workflow update guidance"
+  echo "  show-cross-repo-tasks    Show tasks needed in other repositories"
+  echo ""
+  echo "For POM/docs/pyflink version updates, use the existing scripts:"
+  echo "  update_branch_version.sh  — update version on current branch"
+  echo "  create_snapshot_branch.sh — create snapshot branch for major release"
+}
+
+case "$COMMAND" in
+  add-flink-version)       cmd_add_flink_version ;;
+  update-nightly-workflow)  cmd_update_nightly_workflow ;;
+  show-cross-repo-tasks)   cmd_show_cross_repo_tasks ;;
+  help|--help|-h)          cmd_help ;;
+  *)
+    echo "Unknown command: $COMMAND"
+    cmd_help
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary

Adds 7 new shell scripts to `tools/releasing/` that automate the manual gaps in the Apache Flink release process. These are Layer 1 (gap-filling scripts) of a proposed layered release automation approach.

- **`preflight_check.sh`** — Validates GPG keys, Maven/Nexus config, Java version, CLI tools, and PyPI credentials before starting a release
- **`jira_ops.sh`** — Wraps JIRA REST API for blockers, release notes, version create/release
- **`nexus_ops.sh`** — Wraps Apache Nexus 2 REST API for staging repo list/close/release/drop (eliminates web UI dependency)
- **`dist_ops.sh`** — Wraps SVN operations on dist.apache.org for staging, promoting, and cleaning up release artifacts
- **`generate_email.sh`** — Generates pre-filled email templates for vote, vote-result, and announcement emails
- **`pyflink_ops.sh`** — Automates GitHub Actions trigger/wait/download for PyFlink wheel builds
- **`update_all_versions.sh`** — Handles FlinkVersion enum updates and shows cross-repo tasks for major releases

All scripts follow existing `tools/releasing/` conventions (ASF headers, `set -o errexit/nounset/pipefail`, `tools/` dir check, backtick substitution). Each supports `DRY_RUN=true` for write operations and has built-in `help` commands. No new dependencies beyond standard Unix tools + `curl` + `jq`.

Design doc and implementation plan included in `docs/plans/`.

## Test plan

- [ ] Run `releasing/preflight_check.sh` — verify pass/fail/warn report
- [ ] Run `releasing/jira_ops.sh help` — verify usage without credentials
- [ ] Run `releasing/nexus_ops.sh help` — verify usage without credentials
- [ ] Run `releasing/dist_ops.sh help` — verify usage without env vars
- [ ] Run `releasing/generate_email.sh vote 1.20.0 1` — verify template output
- [ ] Run `releasing/generate_email.sh announce 1.20.0` — verify "first release" wording
- [ ] Run `releasing/generate_email.sh announce 1.20.1` — verify "bugfix release" wording
- [ ] Run `releasing/pyflink_ops.sh help` — verify usage
- [ ] Run `releasing/update_all_versions.sh help` — verify usage without env vars
- [ ] Run `RELEASE_VERSION=1.20.0 releasing/update_all_versions.sh show-cross-repo-tasks` — verify checklist
- [ ] Run `DRY_RUN=true` on write commands to verify no real API calls are made
- [ ] Verify credentials are not leaked via xtrace output