### PR TITLE
[FLINK-39096][table-planner] Enhance EXPLAIN output to display detailed estimated rowcount and cost information

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/optimize/StreamNonDeterministicUpdatePlanVisitor.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/optimize/StreamNonDeterministicUpdatePlanVisitor.java
@@ -525,6 +525,7 @@ public class StreamNonDeterministicUpdatePlanVisitor {
                                                 false,
                                                 true,
                                                 false,
+                                                false,
                                                 false);
                         throw new TableException(errorMsg);
                     }
@@ -1046,6 +1047,7 @@ public class StreamNonDeterministicUpdatePlanVisitor {
                                 false,
                                 true,
                                 false,
+                                false,
                                 false);
 
         throw new TableException(errorMsg);
@@ -1088,6 +1090,7 @@ public class StreamNonDeterministicUpdatePlanVisitor {
                                 true,
                                 false,
                                 true,
+                                false,
                                 false,
                                 false));
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/optimize/StreamPhysicalDeltaJoinForceValidator.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/optimize/StreamPhysicalDeltaJoinForceValidator.java
@@ -79,7 +79,8 @@ public class StreamPhysicalDeltaJoinForceValidator {
                 false, // withRowType
                 false, // withUpsertKey
                 false, // withQueryBlockAlias
-                true // withDuplicateChangesTrait
+                true, // withDuplicateChangesTrait
+                false // withRowCountAndCost
                 );
     }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/BatchPlanner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/BatchPlanner.scala
@@ -166,9 +166,15 @@ class BatchPlanner(
     } else {
       SqlExplainLevel.EXPPLAN_ATTRIBUTES
     }
+    // Show rowcount and cumulative cost at the default explain level to help users
+    // understand the optimizer's cost estimation. This is redundant when the level is
+    // already ALL_ATTRIBUTES (which shows cost natively), so we only enable it for the
+    // default EXPPLAN_ATTRIBUTES case.
+    val withRowCountAndCost = explainLevel != SqlExplainLevel.ALL_ATTRIBUTES
     optimizedRelNodes.foreach {
       rel =>
-        sb.append(FlinkRelOptUtil.toString(rel, explainLevel))
+        sb.append(
+          FlinkRelOptUtil.toString(rel, explainLevel, withRowCountAndCost = withRowCountAndCost))
         sb.append(System.lineSeparator)
     }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/StreamPlanner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/StreamPlanner.scala
@@ -123,6 +123,11 @@ class StreamPlanner(
       SqlExplainLevel.DIGEST_ATTRIBUTES
     }
     val withChangelogTraits = extraDetails.contains(ExplainDetail.CHANGELOG_MODE)
+    // Show rowcount and cumulative cost at the default explain level to help users
+    // understand the optimizer's cost estimation. This is redundant when the level is
+    // already ALL_ATTRIBUTES (which shows cost natively), so we only enable it
+    // for the default DIGEST_ATTRIBUTES case.
+    val withRowCountAndCost = explainLevel != SqlExplainLevel.ALL_ATTRIBUTES
     if (withAdvice) {
       sb.append(
         FlinkRelOptUtil
@@ -130,12 +135,17 @@ class StreamPlanner(
             optimizedRelNodes,
             explainLevel,
             withChangelogTraits = withChangelogTraits,
-            withAdvice = true))
+            withAdvice = true,
+            withRowCountAndCost = withRowCountAndCost))
     } else {
       optimizedRelNodes.foreach {
         rel =>
           sb.append(
-            FlinkRelOptUtil.toString(rel, explainLevel, withChangelogTraits = withChangelogTraits))
+            FlinkRelOptUtil.toString(
+              rel,
+              explainLevel,
+              withChangelogTraits = withChangelogTraits,
+              withRowCountAndCost = withRowCountAndCost))
           sb.append(System.lineSeparator)
       }
     }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/FlinkRelOptUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/FlinkRelOptUtil.scala
@@ -78,7 +78,8 @@ object FlinkRelOptUtil {
       withRowType: Boolean = false,
       withUpsertKey: Boolean = false,
       withQueryBlockAlias: Boolean = false,
-      withDuplicateChangesTrait: Boolean = false): String = {
+      withDuplicateChangesTrait: Boolean = false,
+      withRowCountAndCost: Boolean = false): String = {
     if (rel == null) {
       return null
     }
@@ -93,7 +94,8 @@ object FlinkRelOptUtil {
       withUpsertKey,
       withQueryHint = true,
       withQueryBlockAlias,
-      withDuplicateChangesTrait = withDuplicateChangesTrait)
+      withDuplicateChangesTrait = withDuplicateChangesTrait,
+      withRowCountAndCost = withRowCountAndCost)
     rel.explain(planWriter)
     sw.toString
   }
@@ -120,7 +122,8 @@ object FlinkRelOptUtil {
       relNodes: Seq[RelNode],
       detailLevel: SqlExplainLevel,
       withChangelogTraits: Boolean,
-      withAdvice: Boolean): String = {
+      withAdvice: Boolean,
+      withRowCountAndCost: Boolean): String = {
     if (relNodes == null) {
       return null
     }
@@ -136,7 +139,8 @@ object FlinkRelOptUtil {
       withQueryHint = true,
       withQueryBlockAlias = false,
       relNodes.length,
-      withAdvice = withAdvice)
+      withAdvice = withAdvice,
+      withRowCountAndCost = withRowCountAndCost)
     relNodes.foreach {
       rel =>
         rel.explain(planWriter)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/RelTreeWriterImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/RelTreeWriterImpl.scala
@@ -211,7 +211,7 @@ class RelTreeWriterImpl(
       s.append(", rowType=[").append(rel.getRowType.toString).append("]")
     }
 
-    if (explainLevel == SqlExplainLevel.ALL_ATTRIBUTES || withRowCountAndCost) {
+    if (withRowCountAndCost) {
       val rowCount = mq.getRowCount(rel)
       val cost = mq.getCumulativeCost(rel)
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/RelTreeWriterImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/RelTreeWriterImpl.scala
@@ -49,7 +49,8 @@ class RelTreeWriterImpl(
     withQueryBlockAlias: Boolean = false,
     statementNum: Integer = 1,
     withAdvice: Boolean = false,
-    withDuplicateChangesTrait: Boolean = false)
+    withDuplicateChangesTrait: Boolean = false,
+    withRowCountAndCost: Boolean = false)
   extends RelWriterImpl(pw, explainLevel, withIdPrefix) {
 
   val NODE_LEVEL_ADVICE = new util.HashMap[Integer, util.List[PlanAdvice]]()
@@ -210,11 +211,14 @@ class RelTreeWriterImpl(
       s.append(", rowType=[").append(rel.getRowType.toString).append("]")
     }
 
-    if (explainLevel == SqlExplainLevel.ALL_ATTRIBUTES) {
+    if (explainLevel == SqlExplainLevel.ALL_ATTRIBUTES || withRowCountAndCost) {
+      val rowCount = mq.getRowCount(rel)
+      val cost = mq.getCumulativeCost(rel)
+
       s.append(": rowcount = ")
-        .append(mq.getRowCount(rel))
+        .append(if (rowCount != null) rowCount else "unknown")
         .append(", cumulative cost = ")
-        .append(mq.getCumulativeCost(rel))
+        .append(if (cost != null) cost else "unknown")
     }
     pw.println(s)
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/hint/ClearQueryHintsWithInvalidPropagationShuttleTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/hint/ClearQueryHintsWithInvalidPropagationShuttleTestBase.java
@@ -137,6 +137,7 @@ abstract class ClearQueryHintsWithInvalidPropagationShuttleTestBase extends Tabl
                         true,
                         false,
                         true,
+                        false,
                         false);
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/hints/batch/JoinHintTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/hints/batch/JoinHintTestBase.java
@@ -898,6 +898,7 @@ public abstract class JoinHintTestBase extends TableTestBase {
                                                 true,
                                                 false,
                                                 true,
+                                                false,
                                                 false)));
         return astBuilder.toString();
     }

--- a/flink-table/flink-table-planner/src/test/resources/explain/testExecuteSqlWithExplainInsert.out
+++ b/flink-table/flink-table-planner/src/test/resources/explain/testExecuteSqlWithExplainInsert.out
@@ -5,9 +5,9 @@ LogicalLegacySink(name=[`default_catalog`.`default_database`.`MySink`], fields=[
       +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [CollectionTableSource(a, b, c)]]])
 
 == Optimized Physical Plan ==
-LegacySink(name=[`default_catalog`.`default_database`.`MySink`], fields=[d, e])
-+- Calc(select=[a, b], where=[>(a, 10)])
-   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CollectionTableSource(a, b, c)]]], fields=[a, b, c])
+LegacySink(name=[`default_catalog`.`default_database`.`MySink`], fields=[d, e]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
++- Calc(select=[a, b], where=[>(a, 10)]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CollectionTableSource(a, b, c)]]], fields=[a, b, c]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
 
 == Optimized Execution Plan ==
 LegacySink(name=[`default_catalog`.`default_database`.`MySink`], fields=[d, e])

--- a/flink-table/flink-table-planner/src/test/resources/explain/testExecuteSqlWithExplainInsertIntoStaticPartition.out
+++ b/flink-table/flink-table-planner/src/test/resources/explain/testExecuteSqlWithExplainInsertIntoStaticPartition.out
@@ -4,9 +4,9 @@ LogicalSink(table=[default_catalog.default_database.MySink], fields=[f0, f1, EXP
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [CollectionTableSource(f0, f1, f2)]]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.MySink], fields=[f0, f1, EXPR$2])
-+- Calc(select=[f0, f1, '123' AS EXPR$2])
-   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CollectionTableSource(f0, f1, f2)]]], fields=[f0, f1, f2])
+Sink(table=[default_catalog.default_database.MySink], fields=[f0, f1, EXPR$2]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
++- Calc(select=[f0, f1, '123' AS EXPR$2]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CollectionTableSource(f0, f1, f2)]]], fields=[f0, f1, f2]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
 
 == Optimized Execution Plan ==
 Sink(table=[default_catalog.default_database.MySink], fields=[f0, f1, EXPR$2])

--- a/flink-table/flink-table-planner/src/test/resources/explain/testExecuteSqlWithExplainInsertOverwriteStaticPartition.out
+++ b/flink-table/flink-table-planner/src/test/resources/explain/testExecuteSqlWithExplainInsertOverwriteStaticPartition.out
@@ -4,9 +4,9 @@ LogicalSink(table=[default_catalog.default_database.MySink], fields=[f0, f1, EXP
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [CollectionTableSource(f0, f1, f2)]]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.MySink], fields=[f0, f1, EXPR$2])
-+- Calc(select=[f0, f1, '123' AS EXPR$2])
-   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CollectionTableSource(f0, f1, f2)]]], fields=[f0, f1, f2])
+Sink(table=[default_catalog.default_database.MySink], fields=[f0, f1, EXPR$2]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
++- Calc(select=[f0, f1, '123' AS EXPR$2]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CollectionTableSource(f0, f1, f2)]]], fields=[f0, f1, f2]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
 
 == Optimized Execution Plan ==
 Sink(table=[default_catalog.default_database.MySink], fields=[f0, f1, EXPR$2])

--- a/flink-table/flink-table-planner/src/test/resources/explain/testExecuteSqlWithExplainInsertPartialColumn.out
+++ b/flink-table/flink-table-planner/src/test/resources/explain/testExecuteSqlWithExplainInsertPartialColumn.out
@@ -5,9 +5,9 @@ LogicalLegacySink(name=[`default_catalog`.`default_database`.`MySink`], fields=[
       +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [CollectionTableSource(a, b, c)]]])
 
 == Optimized Physical Plan ==
-LegacySink(name=[`default_catalog`.`default_database`.`MySink`], fields=[d, e])
-+- Calc(select=[a, null:INTEGER AS EXPR$1], where=[>(a, 10)])
-   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CollectionTableSource(a, b, c)]]], fields=[a, b, c])
+LegacySink(name=[`default_catalog`.`default_database`.`MySink`], fields=[d, e]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
++- Calc(select=[a, null:INTEGER AS EXPR$1], where=[>(a, 10)]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CollectionTableSource(a, b, c)]]], fields=[a, b, c]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
 
 == Optimized Execution Plan ==
 LegacySink(name=[`default_catalog`.`default_database`.`MySink`], fields=[d, e])

--- a/flink-table/flink-table-planner/src/test/resources/explain/testExecuteSqlWithExplainSelect.out
+++ b/flink-table/flink-table-planner/src/test/resources/explain/testExecuteSqlWithExplainSelect.out
@@ -4,8 +4,8 @@ LogicalProject(a=[$0], b=[$1], c=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [CollectionTableSource(a, b, c)]]])
 
 == Optimized Physical Plan ==
-Calc(select=[a, b, c], where=[>(a, 10)])
-+- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CollectionTableSource(a, b, c)]]], fields=[a, b, c])
+Calc(select=[a, b, c], where=[>(a, 10)]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
++- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CollectionTableSource(a, b, c)]]], fields=[a, b, c]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
 
 == Optimized Execution Plan ==
 Calc(select=[a, b, c], where=[(a > 10)])

--- a/flink-table/flink-table-planner/src/test/resources/explain/testExplainSqlWithInsert.out
+++ b/flink-table/flink-table-planner/src/test/resources/explain/testExplainSqlWithInsert.out
@@ -5,9 +5,9 @@ LogicalLegacySink(name=[`default_catalog`.`default_database`.`MySink`], fields=[
       +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [CollectionTableSource(a, b, c)]]])
 
 == Optimized Physical Plan ==
-LegacySink(name=[`default_catalog`.`default_database`.`MySink`], fields=[d, e])
-+- Calc(select=[a, b], where=[>(a, 10)])
-   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CollectionTableSource(a, b, c)]]], fields=[a, b, c])
+LegacySink(name=[`default_catalog`.`default_database`.`MySink`], fields=[d, e]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
++- Calc(select=[a, b], where=[>(a, 10)]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CollectionTableSource(a, b, c)]]], fields=[a, b, c]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
 
 == Optimized Execution Plan ==
 LegacySink(name=[`default_catalog`.`default_database`.`MySink`], fields=[d, e])

--- a/flink-table/flink-table-planner/src/test/resources/explain/testExplainSqlWithSelect.out
+++ b/flink-table/flink-table-planner/src/test/resources/explain/testExplainSqlWithSelect.out
@@ -4,8 +4,8 @@ LogicalProject(a=[$0], b=[$1], c=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [CollectionTableSource(a, b, c)]]])
 
 == Optimized Physical Plan ==
-Calc(select=[a, b, c], where=[>(a, 10)], changelogMode=[I])
-+- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CollectionTableSource(a, b, c)]]], fields=[a, b, c], changelogMode=[I])
+Calc(select=[a, b, c], where=[>(a, 10)], changelogMode=[I]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
++- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CollectionTableSource(a, b, c)]]], fields=[a, b, c], changelogMode=[I]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
 
 == Optimized Execution Plan ==
 Calc(select=[a, b, c], where=[(a > 10)])

--- a/flink-table/flink-table-planner/src/test/resources/explain/testStatementSetExecutionExplain.out
+++ b/flink-table/flink-table-planner/src/test/resources/explain/testStatementSetExecutionExplain.out
@@ -8,10 +8,10 @@ LogicalSink(table=[default_catalog.default_database.MySink], fields=[first])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [CsvTableSource(read fields: first, id, score, last)]]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.MySink], fields=[last])
-+- Union(all=[true], union=[last])
-   :- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CsvTableSource(read fields: last)]]], fields=[last])
-   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CsvTableSource(read fields: first)]]], fields=[first])
+Sink(table=[default_catalog.default_database.MySink], fields=[last]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
++- Union(all=[true], union=[last]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+   :- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CsvTableSource(read fields: last)]]], fields=[last]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CsvTableSource(read fields: first)]]], fields=[first]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
 
 == Optimized Execution Plan ==
 Sink(table=[default_catalog.default_database.MySink], fields=[last])

--- a/flink-table/flink-table-planner/src/test/resources/explain/testStreamTableEnvironmentExecutionExplain.out
+++ b/flink-table/flink-table-planner/src/test/resources/explain/testStreamTableEnvironmentExecutionExplain.out
@@ -4,8 +4,8 @@ LogicalSink(table=[default_catalog.default_database.MySink], fields=[first])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [CsvTableSource(read fields: first, id, score, last)]]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.MySink], fields=[first])
-+- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CsvTableSource(read fields: first)]]], fields=[first])
+Sink(table=[default_catalog.default_database.MySink], fields=[first]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
++- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CsvTableSource(read fields: first)]]], fields=[first]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
 
 == Optimized Execution Plan ==
 Sink(table=[default_catalog.default_database.MySink], fields=[first])

--- a/flink-table/flink-table-planner/src/test/resources/explain/testStreamTableEnvironmentExplain.out
+++ b/flink-table/flink-table-planner/src/test/resources/explain/testStreamTableEnvironmentExplain.out
@@ -4,8 +4,8 @@ LogicalSink(table=[default_catalog.default_database.MySink], fields=[first])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [CsvTableSource(read fields: first, id, score, last)]]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.MySink], fields=[first])
-+- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CsvTableSource(read fields: first)]]], fields=[first])
+Sink(table=[default_catalog.default_database.MySink], fields=[first]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
++- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CsvTableSource(read fields: first)]]], fields=[first]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
 
 == Optimized Execution Plan ==
 Sink(table=[default_catalog.default_database.MySink], fields=[first])

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/api/batch/ExplainTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/api/batch/ExplainTest.xml
@@ -30,17 +30,17 @@ LogicalProject(a=[$0], EXPR$1=[$1], d=[$2], EXPR$10=[$3])
             +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2]])
 
 == Optimized Physical Plan ==
-HashJoin(joinType=[InnerJoin], where=[=(a, d)], select=[a, EXPR$1, d, EXPR$10], build=[left])
-:- HashAggregate(isMerge=[true], groupBy=[a], select=[a, Final_SUM(sum$0) AS EXPR$1])
-:  +- Exchange(distribution=[hash[a]])
-:     +- LocalHashAggregate(groupBy=[a], select=[a, Partial_SUM(b) AS sum$0])
-:        +- Calc(select=[a, b])
-:           +- BoundedStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c])
-+- HashAggregate(isMerge=[true], groupBy=[d], select=[d, Final_SUM(sum$0) AS EXPR$1])
-   +- Exchange(distribution=[hash[d]])
-      +- LocalHashAggregate(groupBy=[d], select=[d, Partial_SUM(e) AS sum$0])
-         +- Calc(select=[d, e])
-            +- BoundedStreamScan(table=[[default_catalog, default_database, MyTable2]], fields=[d, e, f])
+HashJoin(joinType=[InnerJoin], where=[=(a, d)], select=[a, EXPR$1, d, EXPR$10], build=[left]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+:- HashAggregate(isMerge=[true], groupBy=[a], select=[a, Final_SUM(sum$0) AS EXPR$1]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+:  +- Exchange(distribution=[hash[a]]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+:     +- LocalHashAggregate(groupBy=[a], select=[a, Partial_SUM(b) AS sum$0]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+:        +- Calc(select=[a, b]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+:           +- BoundedStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
++- HashAggregate(isMerge=[true], groupBy=[d], select=[d, Final_SUM(sum$0) AS EXPR$1]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+   +- Exchange(distribution=[hash[d]]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+      +- LocalHashAggregate(groupBy=[d], select=[d, Partial_SUM(e) AS sum$0]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+         +- Calc(select=[d, e]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+            +- BoundedStreamScan(table=[[default_catalog, default_database, MyTable2]], fields=[d, e, f]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
 
 == Optimized Execution Plan ==
 MultipleInput(readOrder=[0,1], members=[\nHashJoin(joinType=[InnerJoin], where=[(a = d)], select=[a, EXPR$1, d, EXPR$10], build=[left])\n:- HashAggregate(isMerge=[true], groupBy=[a], select=[a, Final_SUM(sum$0) AS EXPR$1])\n:  +- [#1] Exchange(distribution=[hash[a]])\n+- HashAggregate(isMerge=[true], groupBy=[d], select=[d, Final_SUM(sum$0) AS EXPR$1])\n   +- [#2] Exchange(distribution=[hash[d]])\n])
@@ -103,12 +103,12 @@ LogicalProject(EXPR$0=[$1])
       +- LogicalTableScan(table=[[default_catalog, default_database, MyTable1]])
 
 == Optimized Physical Plan ==
-Calc(select=[EXPR$0])
-+- HashAggregate(isMerge=[true], groupBy=[a], select=[a, Final_COUNT(count1$0) AS EXPR$0])
-   +- Exchange(distribution=[hash[a]])
-      +- LocalHashAggregate(groupBy=[a], select=[a, Partial_COUNT(*) AS count1$0])
-         +- Calc(select=[a])
-            +- BoundedStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c])
+Calc(select=[EXPR$0]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
++- HashAggregate(isMerge=[true], groupBy=[a], select=[a, Final_COUNT(count1$0) AS EXPR$0]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+   +- Exchange(distribution=[hash[a]]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+      +- LocalHashAggregate(groupBy=[a], select=[a, Partial_COUNT(*) AS count1$0]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+         +- Calc(select=[a]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+            +- BoundedStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
 
 == Optimized Execution Plan ==
 Calc(select=[EXPR$0])
@@ -153,7 +153,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2])
 +- LogicalTableScan(table=[[default_catalog, default_database, MyTable1]])
 
 == Optimized Physical Plan ==
-BoundedStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c])
+BoundedStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
 
 == Optimized Execution Plan ==
 BoundedStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c])
@@ -182,8 +182,8 @@ LogicalProject(a=[$0], b=[$1], c=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable1]])
 
 == Optimized Physical Plan ==
-Calc(select=[a, b, c], where=[=(MOD(a, 2), 0)])
-+- BoundedStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c])
+Calc(select=[a, b, c], where=[=(MOD(a, 2), 0)]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
++- BoundedStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
 
 == Optimized Execution Plan ==
 Calc(select=[a, b, c], where=[(MOD(a, 2) = 0)])
@@ -218,12 +218,12 @@ LogicalProject(a=[$0], b=[$1], c=[$2], e=[$4], f=[$5])
       +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2]])
 
 == Optimized Physical Plan ==
-Calc(select=[a, b, c, e, f])
-+- SortMergeJoin(joinType=[InnerJoin], where=[=(a, d)], select=[a, b, c, d, e, f])
-   :- Exchange(distribution=[hash[a]])
-   :  +- BoundedStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c])
-   +- Exchange(distribution=[hash[d]])
-      +- BoundedStreamScan(table=[[default_catalog, default_database, MyTable2]], fields=[d, e, f])
+Calc(select=[a, b, c, e, f]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
++- SortMergeJoin(joinType=[InnerJoin], where=[=(a, d)], select=[a, b, c, d, e, f]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+   :- Exchange(distribution=[hash[a]]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+   :  +- BoundedStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+   +- Exchange(distribution=[hash[d]]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+      +- BoundedStreamScan(table=[[default_catalog, default_database, MyTable2]], fields=[d, e, f]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
 
 == Optimized Execution Plan ==
 Calc(select=[a, b, c, e, f])
@@ -280,21 +280,21 @@ LogicalSink(table=[default_catalog.default_database.sink2], fields=[a, cnt])
             +- LogicalTableScan(table=[[default_catalog, default_database, MyTable1]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.sink1], fields=[a, cnt])
-+- Calc(select=[a, cnt], where=[>(cnt, 10)])
-   +- HashAggregate(isMerge=[true], groupBy=[a], select=[a, Final_COUNT(count1$0) AS cnt])
-      +- Exchange(distribution=[hash[a]])
-         +- LocalHashAggregate(groupBy=[a], select=[a, Partial_COUNT(*) AS count1$0])
-            +- Calc(select=[a])
-               +- BoundedStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c])
+Sink(table=[default_catalog.default_database.sink1], fields=[a, cnt]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
++- Calc(select=[a, cnt], where=[>(cnt, 10)]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+   +- HashAggregate(isMerge=[true], groupBy=[a], select=[a, Final_COUNT(count1$0) AS cnt]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+      +- Exchange(distribution=[hash[a]]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+         +- LocalHashAggregate(groupBy=[a], select=[a, Partial_COUNT(*) AS count1$0]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+            +- Calc(select=[a]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+               +- BoundedStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
 
-Sink(table=[default_catalog.default_database.sink2], fields=[a, cnt])
-+- Calc(select=[a, cnt], where=[<(cnt, 10)])
-   +- HashAggregate(isMerge=[true], groupBy=[a], select=[a, Final_COUNT(count1$0) AS cnt])
-      +- Exchange(distribution=[hash[a]])
-         +- LocalHashAggregate(groupBy=[a], select=[a, Partial_COUNT(*) AS count1$0])
-            +- Calc(select=[a])
-               +- BoundedStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c])
+Sink(table=[default_catalog.default_database.sink2], fields=[a, cnt]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
++- Calc(select=[a, cnt], where=[<(cnt, 10)]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+   +- HashAggregate(isMerge=[true], groupBy=[a], select=[a, Final_COUNT(count1$0) AS cnt]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+      +- Exchange(distribution=[hash[a]]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+         +- LocalHashAggregate(groupBy=[a], select=[a, Partial_COUNT(*) AS count1$0]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+            +- Calc(select=[a]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+               +- BoundedStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
 
 == Optimized Execution Plan ==
 HashAggregate(isMerge=[true], groupBy=[a], select=[a, Final_COUNT(count1$0) AS cnt])(reuse_id=[1])
@@ -373,9 +373,9 @@ LogicalSink(table=[default_catalog.default_database.sink], fields=[a, b, c])
       +- LogicalTableScan(table=[[default_catalog, default_database, MyTable1]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.sink], fields=[a, b, c])
-+- Calc(select=[a, b, c], where=[>(a, 10)])
-   +- BoundedStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c])
+Sink(table=[default_catalog.default_database.sink], fields=[a, b, c]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
++- Calc(select=[a, b, c], where=[>(a, 10)]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+   +- BoundedStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
 
 == Optimized Execution Plan ==
 Sink(table=[default_catalog.default_database.sink], fields=[a, b, c])
@@ -412,10 +412,10 @@ LogicalSort(sort0=[$0], dir0=[ASC-nulls-first], fetch=[5])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable1]])
 
 == Optimized Physical Plan ==
-SortLimit(orderBy=[a ASC], offset=[0], fetch=[5], global=[true])
-+- Exchange(distribution=[single])
-   +- SortLimit(orderBy=[a ASC], offset=[0], fetch=[5], global=[false])
-      +- BoundedStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c])
+SortLimit(orderBy=[a ASC], offset=[0], fetch=[5], global=[true]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
++- Exchange(distribution=[single]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+   +- SortLimit(orderBy=[a ASC], offset=[0], fetch=[5], global=[false]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+      +- BoundedStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
 
 == Optimized Execution Plan ==
 SortLimit(orderBy=[a ASC], offset=[0], fetch=[5], global=[true])
@@ -453,7 +453,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2])
 +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
 
 == Optimized Physical Plan ==
-TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])
+TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
 
 == Optimized Execution Plan ==
 TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])
@@ -484,9 +484,9 @@ LogicalUnion(all=[true])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2]])
 
 == Optimized Physical Plan ==
-Union(all=[true], union=[a, b, c])
-:- BoundedStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c])
-+- BoundedStreamScan(table=[[default_catalog, default_database, MyTable2]], fields=[d, e, f])
+Union(all=[true], union=[a, b, c]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+:- BoundedStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
++- BoundedStreamScan(table=[[default_catalog, default_database, MyTable2]], fields=[d, e, f]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
 
 == Optimized Execution Plan ==
 Union(all=[true], union=[a, b, c])

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/api/stream/ExplainTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/api/stream/ExplainTest.xml
@@ -23,7 +23,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2])
 +- LogicalTableScan(table=[[default_catalog, default_database, MyTable1]])
 
 == Optimized Physical Plan ==
-DataStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c])
+DataStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
 
 == Optimized Execution Plan ==
 DataStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c])
@@ -51,7 +51,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2])
 +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
 
 == Optimized Physical Plan ==
-TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])
+TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
 
 == Optimized Execution Plan ==
 TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])
@@ -81,11 +81,11 @@ LogicalProject(EXPR$0=[$1])
       +- LogicalTableScan(table=[[default_catalog, default_database, MyTable1]])
 
 == Optimized Physical Plan ==
-Calc(select=[EXPR$0])
-+- GroupAggregate(groupBy=[a], select=[a, COUNT(*) AS EXPR$0])
-   +- Exchange(distribution=[hash[a]])
-      +- Calc(select=[a])
-         +- DataStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c])
+Calc(select=[EXPR$0]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
++- GroupAggregate(groupBy=[a], select=[a, COUNT(*) AS EXPR$0]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+   +- Exchange(distribution=[hash[a]]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+      +- Calc(select=[a]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+         +- DataStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
 
 == Optimized Execution Plan ==
 Calc(select=[EXPR$0])
@@ -128,8 +128,8 @@ LogicalProject(a=[$0], b=[$1], c=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable1]])
 
 == Optimized Physical Plan ==
-Calc(select=[a, b, c], where=[=(MOD(a, 2), 0)])
-+- DataStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c])
+Calc(select=[a, b, c], where=[=(MOD(a, 2), 0)]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
++- DataStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
 
 == Optimized Execution Plan ==
 Calc(select=[a, b, c], where=[(MOD(a, 2) = 0)])
@@ -164,12 +164,12 @@ LogicalProject(a=[$0], b=[$1], c=[$2], e=[$4], f=[$5])
       +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2]])
 
 == Optimized Physical Plan ==
-Calc(select=[a, b, c, e, f])
-+- Join(joinType=[InnerJoin], where=[=(a, d)], select=[a, b, c, d, e, f], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
-   :- Exchange(distribution=[hash[a]])
-   :  +- DataStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c])
-   +- Exchange(distribution=[hash[d]])
-      +- DataStreamScan(table=[[default_catalog, default_database, MyTable2]], fields=[d, e, f])
+Calc(select=[a, b, c, e, f]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
++- Join(joinType=[InnerJoin], where=[=(a, d)], select=[a, b, c, d, e, f], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+   :- Exchange(distribution=[hash[a]]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+   :  +- DataStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+   +- Exchange(distribution=[hash[d]]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+      +- DataStreamScan(table=[[default_catalog, default_database, MyTable2]], fields=[d, e, f]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
 
 == Optimized Execution Plan ==
 Calc(select=[a, b, c, e, f])
@@ -226,19 +226,19 @@ LogicalSink(table=[default_catalog.default_database.upsertSink2], fields=[a, cnt
             +- LogicalTableScan(table=[[default_catalog, default_database, MyTable1]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.upsertSink1], fields=[a, cnt])
-+- Calc(select=[a, cnt], where=[>(cnt, 10)])
-   +- GroupAggregate(groupBy=[a], select=[a, COUNT(*) AS cnt])
-      +- Exchange(distribution=[hash[a]])
-         +- Calc(select=[a])
-            +- DataStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c])
+Sink(table=[default_catalog.default_database.upsertSink1], fields=[a, cnt]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
++- Calc(select=[a, cnt], where=[>(cnt, 10)]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+   +- GroupAggregate(groupBy=[a], select=[a, COUNT(*) AS cnt]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+      +- Exchange(distribution=[hash[a]]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+         +- Calc(select=[a]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+            +- DataStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
 
-Sink(table=[default_catalog.default_database.upsertSink2], fields=[a, cnt])
-+- Calc(select=[a, cnt], where=[<(cnt, 10)])
-   +- GroupAggregate(groupBy=[a], select=[a, COUNT(*) AS cnt])
-      +- Exchange(distribution=[hash[a]])
-         +- Calc(select=[a])
-            +- DataStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c])
+Sink(table=[default_catalog.default_database.upsertSink2], fields=[a, cnt]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
++- Calc(select=[a, cnt], where=[<(cnt, 10)]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+   +- GroupAggregate(groupBy=[a], select=[a, COUNT(*) AS cnt]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+      +- Exchange(distribution=[hash[a]]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+         +- Calc(select=[a]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+            +- DataStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
 
 == Optimized Execution Plan ==
 GroupAggregate(groupBy=[a], select=[a, COUNT(*) AS cnt])(reuse_id=[1])
@@ -313,9 +313,9 @@ LogicalSink(table=[default_catalog.default_database.appendSink], fields=[a, b, c
       +- LogicalTableScan(table=[[default_catalog, default_database, MyTable1]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.appendSink], fields=[a, b, c])
-+- Calc(select=[a, b, c], where=[>(a, 10)])
-   +- DataStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c])
+Sink(table=[default_catalog.default_database.appendSink], fields=[a, b, c]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
++- Calc(select=[a, b, c], where=[>(a, 10)]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+   +- DataStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
 
 == Optimized Execution Plan ==
 Sink(table=[default_catalog.default_database.appendSink], fields=[a, b, c])
@@ -352,9 +352,9 @@ LogicalSort(sort0=[$0], dir0=[ASC-nulls-first], fetch=[5])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable1]])
 
 == Optimized Physical Plan ==
-SortLimit(orderBy=[a ASC], offset=[0], fetch=[5], strategy=[AppendFastStrategy])
-+- Exchange(distribution=[single])
-   +- DataStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c])
+SortLimit(orderBy=[a ASC], offset=[0], fetch=[5], strategy=[AppendFastStrategy]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
++- Exchange(distribution=[single]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+   +- DataStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
 
 == Optimized Execution Plan ==
 SortLimit(orderBy=[a ASC], offset=[0], fetch=[5], strategy=[AppendFastStrategy])
@@ -392,9 +392,9 @@ LogicalUnion(all=[true])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2]])
 
 == Optimized Physical Plan ==
-Union(all=[true], union=[a, b, c])
-:- DataStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c])
-+- DataStreamScan(table=[[default_catalog, default_database, MyTable2]], fields=[d, e, f])
+Union(all=[true], union=[a, b, c]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+:- DataStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
++- DataStreamScan(table=[[default_catalog, default_database, MyTable2]], fields=[d, e, f]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
 
 == Optimized Execution Plan ==
 Union(all=[true], union=[a, b, c])
@@ -452,33 +452,33 @@ LogicalSink(table=[default_catalog.default_database.appendSink2], fields=[id1, E
                      +- LogicalTableScan(table=[[default_catalog, default_database, T2]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.appendSink1], fields=[id1, EXPR$1])
-+- GroupWindowAggregate(groupBy=[id1], window=[TumblingGroupWindow('w$, ts, 8000)], select=[id1, LISTAGG(text, $f3) AS EXPR$1])
-   +- Exchange(distribution=[hash[id1]])
-      +- Calc(select=[id1, ts, text, _UTF-16LE'#' AS $f3])
-         +- Calc(select=[id1, rowtime AS ts, text])
-            +- IntervalJoin(joinType=[InnerJoin], windowBounds=[isRowTime=true, leftLowerBound=-299999, leftUpperBound=179999, leftTimeIndex=2, rightTimeIndex=1], where=[AND(=(id1, id2), >(rowtime, -(rowtime0, 300000:INTERVAL MINUTE)), <(rowtime, +(rowtime0, 180000:INTERVAL MINUTE)))], select=[id1, text, rowtime, id2, rowtime0])
-               :- Exchange(distribution=[hash[id1]])
-               :  +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 0:INTERVAL MILLISECOND)])
-               :     +- DataStreamScan(table=[[default_catalog, default_database, T1]], fields=[id1, text, rowtime])
-               +- Exchange(distribution=[hash[id2]])
-                  +- Calc(select=[id2, rowtime])
-                     +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 0:INTERVAL MILLISECOND)])
-                        +- DataStreamScan(table=[[default_catalog, default_database, T2]], fields=[id2, cnt, name, goods, rowtime])
+Sink(table=[default_catalog.default_database.appendSink1], fields=[id1, EXPR$1]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
++- GroupWindowAggregate(groupBy=[id1], window=[TumblingGroupWindow('w$, ts, 8000)], select=[id1, LISTAGG(text, $f3) AS EXPR$1]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+   +- Exchange(distribution=[hash[id1]]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+      +- Calc(select=[id1, ts, text, _UTF-16LE'#' AS $f3]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+         +- Calc(select=[id1, rowtime AS ts, text]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+            +- IntervalJoin(joinType=[InnerJoin], windowBounds=[isRowTime=true, leftLowerBound=-299999, leftUpperBound=179999, leftTimeIndex=2, rightTimeIndex=1], where=[AND(=(id1, id2), >(rowtime, -(rowtime0, 300000:INTERVAL MINUTE)), <(rowtime, +(rowtime0, 180000:INTERVAL MINUTE)))], select=[id1, text, rowtime, id2, rowtime0]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+               :- Exchange(distribution=[hash[id1]]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+               :  +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 0:INTERVAL MILLISECOND)]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+               :     +- DataStreamScan(table=[[default_catalog, default_database, T1]], fields=[id1, text, rowtime]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+               +- Exchange(distribution=[hash[id2]]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+                  +- Calc(select=[id2, rowtime]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+                     +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 0:INTERVAL MILLISECOND)]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+                        +- DataStreamScan(table=[[default_catalog, default_database, T2]], fields=[id2, cnt, name, goods, rowtime]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
 
-Sink(table=[default_catalog.default_database.appendSink2], fields=[id1, EXPR$1])
-+- GroupWindowAggregate(groupBy=[id1], window=[SlidingGroupWindow('w$, ts, 6000, 12000)], select=[id1, LISTAGG(text, $f3) AS EXPR$1])
-   +- Exchange(distribution=[hash[id1]])
-      +- Calc(select=[id1, ts, text, _UTF-16LE'*' AS $f3])
-         +- Calc(select=[id1, rowtime AS ts, text])
-            +- IntervalJoin(joinType=[InnerJoin], windowBounds=[isRowTime=true, leftLowerBound=-299999, leftUpperBound=179999, leftTimeIndex=2, rightTimeIndex=1], where=[AND(=(id1, id2), >(rowtime, -(rowtime0, 300000:INTERVAL MINUTE)), <(rowtime, +(rowtime0, 180000:INTERVAL MINUTE)))], select=[id1, text, rowtime, id2, rowtime0])
-               :- Exchange(distribution=[hash[id1]])
-               :  +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 0:INTERVAL MILLISECOND)])
-               :     +- DataStreamScan(table=[[default_catalog, default_database, T1]], fields=[id1, text, rowtime])
-               +- Exchange(distribution=[hash[id2]])
-                  +- Calc(select=[id2, rowtime])
-                     +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 0:INTERVAL MILLISECOND)])
-                        +- DataStreamScan(table=[[default_catalog, default_database, T2]], fields=[id2, cnt, name, goods, rowtime])
+Sink(table=[default_catalog.default_database.appendSink2], fields=[id1, EXPR$1]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
++- GroupWindowAggregate(groupBy=[id1], window=[SlidingGroupWindow('w$, ts, 6000, 12000)], select=[id1, LISTAGG(text, $f3) AS EXPR$1]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+   +- Exchange(distribution=[hash[id1]]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+      +- Calc(select=[id1, ts, text, _UTF-16LE'*' AS $f3]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+         +- Calc(select=[id1, rowtime AS ts, text]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+            +- IntervalJoin(joinType=[InnerJoin], windowBounds=[isRowTime=true, leftLowerBound=-299999, leftUpperBound=179999, leftTimeIndex=2, rightTimeIndex=1], where=[AND(=(id1, id2), >(rowtime, -(rowtime0, 300000:INTERVAL MINUTE)), <(rowtime, +(rowtime0, 180000:INTERVAL MINUTE)))], select=[id1, text, rowtime, id2, rowtime0]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+               :- Exchange(distribution=[hash[id1]]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+               :  +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 0:INTERVAL MILLISECOND)]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+               :     +- DataStreamScan(table=[[default_catalog, default_database, T1]], fields=[id1, text, rowtime]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+               +- Exchange(distribution=[hash[id2]]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+                  +- Calc(select=[id2, rowtime]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+                     +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 0:INTERVAL MILLISECOND)]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
+                        +- DataStreamScan(table=[[default_catalog, default_database, T2]], fields=[id2, cnt, name, goods, rowtime]): rowcount = , cumulative cost = {rows, cpu, io, network, memory}
 
 == Optimized Execution Plan ==
 Calc(select=[id1, rowtime AS ts, text])(reuse_id=[1])

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
@@ -35,7 +35,7 @@ import org.apache.flink.table.planner.runtime.stream.sql.FunctionITCase.TestUDF
 import org.apache.flink.table.planner.runtime.stream.table.FunctionITCase.SimpleScalarFunction
 import org.apache.flink.table.planner.runtime.utils.StreamingEnvUtil
 import org.apache.flink.table.planner.utils.{TableTestUtil, TestTableSourceSinks}
-import org.apache.flink.table.planner.utils.TableTestUtil.{replaceNodeIdInOperator, replaceStageId, replaceStreamNodeId}
+import org.apache.flink.table.planner.utils.TableTestUtil.{replaceEstimatedCost, replaceNodeIdInOperator, replaceStageId, replaceStreamNodeId}
 import org.apache.flink.table.types.DataType
 import org.apache.flink.table.utils.UserDefinedFunctions.{GENERATED_LOWER_UDF_CLASS, GENERATED_LOWER_UDF_CODE}
 import org.apache.flink.testutils.junit.utils.TempDirUtils
@@ -157,8 +157,8 @@ class TableEnvironmentTest {
 
     val expected = TableTestUtil.readFromResource("/explain/testStreamTableEnvironmentExplain.out")
     val actual = tEnv.explainSql("insert into MySink select first from MyTable")
-    assertThat(TableTestUtil.replaceStageId(actual))
-      .isEqualTo(TableTestUtil.replaceStageId(expected))
+    assertThat(TableTestUtil.replaceStageId(replaceEstimatedCost(actual)))
+      .isEqualTo(TableTestUtil.replaceStageId(replaceEstimatedCost(expected)))
   }
 
   @Test
@@ -177,8 +177,8 @@ class TableEnvironmentTest {
 
     val expected = TableTestUtil.readFromResource("/explain/testStreamTableEnvironmentExplain.out")
     val actual = tEnv.explainSql("execute insert into MySink select first from MyTable")
-    assertThat(TableTestUtil.replaceStageId(actual))
-      .isEqualTo(TableTestUtil.replaceStageId(expected))
+    assertThat(TableTestUtil.replaceStageId(replaceEstimatedCost(actual)))
+      .isEqualTo(TableTestUtil.replaceStageId(replaceEstimatedCost(expected)))
   }
 
   @Test
@@ -256,9 +256,12 @@ class TableEnvironmentTest {
       "insert into MySink select first from MyTable",
       ExplainDetail.JSON_EXECUTION_PLAN)
 
-    assertThat(TableTestUtil.replaceNodeIdInOperator(TableTestUtil.replaceStreamNodeId(actual)))
+    assertThat(
+      TableTestUtil.replaceNodeIdInOperator(
+        TableTestUtil.replaceStreamNodeId(replaceEstimatedCost(actual))))
       .isEqualTo(
-        TableTestUtil.replaceNodeIdInOperator(TableTestUtil.replaceStreamNodeId(expected))
+        TableTestUtil.replaceNodeIdInOperator(
+          TableTestUtil.replaceStreamNodeId(replaceEstimatedCost(expected)))
       )
   }
 
@@ -284,8 +287,12 @@ class TableEnvironmentTest {
     statementSet.addInsertSql("insert into MySink select first from MyTable")
     val actual = statementSet.explain(ExplainDetail.JSON_EXECUTION_PLAN)
 
-    assertThat(TableTestUtil.replaceNodeIdInOperator(TableTestUtil.replaceStreamNodeId(actual)))
-      .isEqualTo(TableTestUtil.replaceNodeIdInOperator(TableTestUtil.replaceStreamNodeId(expected)))
+    assertThat(
+      TableTestUtil.replaceNodeIdInOperator(
+        TableTestUtil.replaceStreamNodeId(replaceEstimatedCost(actual))))
+      .isEqualTo(
+        TableTestUtil.replaceNodeIdInOperator(
+          TableTestUtil.replaceStreamNodeId(replaceEstimatedCost(expected))))
   }
 
   @Test
@@ -313,9 +320,12 @@ class TableEnvironmentTest {
       ExplainDetail.JSON_EXECUTION_PLAN
     )
 
-    assertThat(TableTestUtil.replaceNodeIdInOperator(TableTestUtil.replaceStreamNodeId(actual)))
+    assertThat(
+      TableTestUtil.replaceNodeIdInOperator(
+        TableTestUtil.replaceStreamNodeId(replaceEstimatedCost(actual))))
       .isEqualTo(
-        TableTestUtil.replaceNodeIdInOperator(TableTestUtil.replaceStreamNodeId(expected))
+        TableTestUtil.replaceNodeIdInOperator(
+          TableTestUtil.replaceStreamNodeId(replaceEstimatedCost(expected)))
       )
   }
 
@@ -2129,7 +2139,8 @@ class TableEnvironmentTest {
     val actual =
       tableEnv.explainSql("select * from MyTable where a > 10", ExplainDetail.CHANGELOG_MODE)
     val expected = TableTestUtil.readFromResource("/explain/testExplainSqlWithSelect.out")
-    assertThat(replaceStageId(actual)).isEqualTo(replaceStageId(expected))
+    assertThat(replaceStageId(replaceEstimatedCost(actual)))
+      .isEqualTo(replaceStageId(replaceEstimatedCost(expected)))
   }
 
   @Test
@@ -2152,7 +2163,8 @@ class TableEnvironmentTest {
       "execute select * from MyTable where a > 10",
       ExplainDetail.CHANGELOG_MODE)
     val expected = TableTestUtil.readFromResource("/explain/testExplainSqlWithSelect.out")
-    assertThat(replaceStageId(actual)).isEqualTo(replaceStageId(expected))
+    assertThat(replaceStageId(replaceEstimatedCost(actual)))
+      .isEqualTo(replaceStageId(replaceEstimatedCost(expected)))
   }
 
   @Test
@@ -2186,7 +2198,8 @@ class TableEnvironmentTest {
 
     val actual = tableEnv.explainSql("insert into MySink select a, b from MyTable where a > 10")
     val expected = TableTestUtil.readFromResource("/explain/testExplainSqlWithInsert.out")
-    assertThat(replaceStageId(actual)).isEqualTo(replaceStageId(expected))
+    assertThat(replaceStageId(replaceEstimatedCost(actual)))
+      .isEqualTo(replaceStageId(replaceEstimatedCost(expected)))
   }
 
   @Test
@@ -3595,10 +3608,12 @@ class TableEnvironmentTest {
     assertThat(it).hasNext
     val row = it.next()
     assertThat(row.getArity).isOne
-    val actual = replaceNodeIdInOperator(replaceStreamNodeId(row.getField(0).toString.trim))
-    val expected = replaceNodeIdInOperator(
-      replaceStreamNodeId(TableTestUtil.readFromResource(resultPath).trim))
-    assertThat(replaceStageId(expected)).isEqualTo(replaceStageId(actual))
+    val actual = replaceEstimatedCost(
+      replaceNodeIdInOperator(replaceStreamNodeId(row.getField(0).toString.trim)))
+    val expected = replaceEstimatedCost(
+      replaceNodeIdInOperator(replaceStreamNodeId(TableTestUtil.readFromResource(resultPath).trim)))
+    assertThat(replaceStageId(replaceEstimatedCost(expected)))
+      .isEqualTo(replaceStageId(replaceEstimatedCost(actual)))
     assertThat(it.hasNext).isFalse
   }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
@@ -1260,14 +1260,15 @@ abstract class TableTestUtilBase(test: TableTestBase, isStreamingMode: Boolean) 
   private def doVerifyExplain(explainResult: String, extraDetails: ExplainDetail*): Unit = {
     def replace(result: String, explainDetail: ExplainDetail): String = {
       val replaced = explainDetail match {
-        case ExplainDetail.ESTIMATED_COST => replaceEstimatedCost(result)
         case ExplainDetail.JSON_EXECUTION_PLAN =>
           replaceNodeIdInOperator(replaceStreamNodeId(replaceStageId(result)))
         case _ => result
       }
       replaced
     }
-    var replacedResult = explainResult
+    // Always normalize estimated cost numbers because the Optimized Physical Plan section
+    // now shows rowcount and cumulative cost by default, and these numbers are unstable.
+    var replacedResult = replaceEstimatedCost(explainResult)
     extraDetails.foreach(detail => replacedResult = replace(replacedResult, detail))
     assertEqualsOrExpand("explain", TableTestUtil.replaceStageId(replacedResult), expand = false)
   }
@@ -1293,7 +1294,8 @@ abstract class TableTestUtilBase(test: TableTestBase, isStreamingMode: Boolean) 
             optimizedRels,
             detailLevel = explainLevel,
             withChangelogTraits = withChangelogTraits,
-            withAdvice = true)
+            withAdvice = true,
+            withRowCountAndCost = false)
         } else {
           optimizedRels
             .map {
@@ -1975,6 +1977,19 @@ object TableTestUtil {
    */
   def replaceStageId(s: String): String = {
     s.replaceAll("\\r\\n", "\n").replaceAll("Stage \\d+", "")
+  }
+
+  /** Replace the estimated cost numbers for a given plan, because they may be unstable. */
+  def replaceEstimatedCost(s: String): String = {
+    var str = s.replaceAll("\\r\\n", "\n")
+    val scientificFormRegExpr = "[+-]?[\\d]+([\\.][\\d]*)?([Ee][+-]?[0-9]{0,2})?"
+    str = str.replaceAll(s"rowcount = $scientificFormRegExpr", "rowcount = ")
+    str = str.replaceAll(s"$scientificFormRegExpr rows", "rows")
+    str = str.replaceAll(s"$scientificFormRegExpr cpu", "cpu")
+    str = str.replaceAll(s"$scientificFormRegExpr io", "io")
+    str = str.replaceAll(s"$scientificFormRegExpr network", "network")
+    str = str.replaceAll(s"$scientificFormRegExpr memory", "memory")
+    str
   }
 
   /**


### PR DESCRIPTION
Currently, when executing EXPLAIN statements in Flink SQL, detailed cost information (including rowcount and cumulative cost breakdown) is only displayed when using `ExplainDetail.ESTIMATED_COST` (which sets the explain level to `ALL_ATTRIBUTES`). In the default `EXPPLAN_ATTRIBUTES` mode, this valuable information is not shown, making it harder for users to understand query optimizer decisions and identify performance bottlenecks.

This PR enhances the EXPLAIN output to display detailed estimated rowcount and cumulative cost information at the `EXPPLAN_ATTRIBUTES` level as well, improving query plan readability and facilitating performance analysis.

## Brief change log

- Modified `RelTreeWriterImpl.scala` to display rowcount and cumulative cost at both `ALL_ATTRIBUTES` and `EXPPLAN_ATTRIBUTES` explain levels
- Added null checks for rowcount and cost values to improve error handling
- Cost details now consistently show FlinkCost breakdown in format: `{rows, cpu, io, network, memory}`

## Verifying this change

This change can be verified by:

1. **Manual Testing**: Execute any EXPLAIN statement in Flink SQL and observe that rowcount and cost information is now displayed by default:
   ```sql
   EXPLAIN SELECT * FROM table1 JOIN table2 ON table1.id = table2.id;
   ```
   
   **Before**: Only operator names and attributes shown
   **After**: Each operator line includes `: rowcount = <value>, cumulative cost = {<cost details>}`

2. **Existing Tests**: Run existing explain tests to ensure compatibility:
   ```bash
   mvn test -pl flink-table/flink-table-planner -Dtest=ExplainTest
   ```

## Does this pull request potentially affect one of the following parts

- Dependencies (does it add or upgrade a dependency): **No**
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **No**
- The serializers: **No**
- The runtime per-record code paths (performance sensitive): **No**
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **No**
- The S3 file system connector: **No**

## Documentation

- Does this pull request introduce a new feature: **No** (Enhancement)
- If yes, how is the feature documented: **Not applicable** (Existing EXPLAIN functionality)

## Additional Notes

The change is minimal and focused on improving the user experience when analyzing query plans. The FlinkCost class already provides a comprehensive `toString()` method that formats all five cost dimensions (rows, cpu, io, network, memory), which is now properly exposed to users at the default explain level.

This enhancement will help users:
- Better understand query optimizer cost estimations
- Identify expensive operations more easily
- Perform more effective performance tuning
- Debug query plan issues with more context
