### PR TITLE
[FLINK-39139] Update lz4-java to 1.10.3

### DIFF
--- a/flink-dist/src/main/resources/META-INF/NOTICE
+++ b/flink-dist/src/main/resources/META-INF/NOTICE
@@ -17,7 +17,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.commons:commons-math3:3.6.1
 - org.apache.commons:commons-text:1.10.0
 - org.javassist:javassist:3.24.0-GA
-- org.lz4:lz4-java:1.8.0
+- at.yawk.lz4:lz4-java:1.10.3
 - org.objenesis:objenesis:3.4
 - org.xerial.snappy:snappy-java:1.1.10.7
 - tools.profiler:async-profiler:2.9

--- a/flink-formats/flink-avro-confluent-registry/pom.xml
+++ b/flink-formats/flink-avro-confluent-registry/pom.xml
@@ -61,6 +61,10 @@ under the License.
 					<artifactId>lz4-java</artifactId>
 				</exclusion>
 				<exclusion>
+					<groupId>at.yawk.lz4</groupId>
+					<artifactId>lz4-java</artifactId>
+				</exclusion>
+				<exclusion>
 					<groupId>io.swagger</groupId>
 					<artifactId>swagger-core</artifactId>
 				</exclusion>

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -231,7 +231,7 @@ under the License.
 
 		<!-- Lz4 compression library -->
 		<dependency>
-			<groupId>org.lz4</groupId>
+			<groupId>at.yawk.lz4</groupId>
 			<artifactId>lz4-java</artifactId>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@ under the License.
 		<protoc.version>3.21.7</protoc.version>
 		<okhttp.version>3.14.9</okhttp.version>
 		<testcontainers.version>1.21.4</testcontainers.version>
-		<lz4.version>1.8.0</lz4.version>
+		<lz4.version>1.10.3</lz4.version>
 		<commons.io.version>2.15.1</commons.io.version>
 		<japicmp.skip>false</japicmp.skip>
 		<flink.convergence.phase>validate</flink.convergence.phase>
@@ -577,7 +577,7 @@ under the License.
 			</dependency>
 
 			<dependency>
-				<groupId>org.lz4</groupId>
+				<groupId>at.yawk.lz4</groupId>
 				<artifactId>lz4-java</artifactId>
 				<version>${lz4.version}</version>
 			</dependency>


### PR DESCRIPTION
## What is the purpose of the change

lz4-java 1.8.0 has the following CVEs:
- [CVE-2025-66566](https://www.cve.org/CVERecord?id=CVE-2025-66566)
- [CVE-2025-12183](https://www.cve.org/CVERecord?id=CVE-2025-12183)

It has also been relocated to at.yawk.lz4

This is a backport of https://github.com/apache/flink/pull/27535

## Brief change log

- Update lz4-java to 1.10.3


## Verifying this change

Passes local tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
