### PR TITLE
[FLINK-39123][table] Updated ValueLiteralExpression Support for Larger Precision TIMESTAMP_LTZ Instances

### DIFF
--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/expressions/ExpressionTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/expressions/ExpressionTest.java
@@ -18,11 +18,18 @@
 
 package org.apache.flink.table.expressions;
 
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.AND;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.EQUALS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.table.functions.ScalarFunctionDefinition;
-
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
@@ -42,13 +49,6 @@ import java.time.ZonedDateTime;
 import java.time.temporal.ChronoField;
 import java.util.LinkedHashMap;
 import java.util.Map;
-
-import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.AND;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.EQUALS;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link org.apache.flink.table.expressions.Expression} and its sub-classes. */
 class ExpressionTest {
@@ -276,6 +276,33 @@ class ExpressionTest {
                                 .getValueAs(Period.class)
                                 .orElseThrow(AssertionError::new))
                 .isEqualTo(expected);
+    }
+
+    @Test
+    void testTimestampLtzPrecision0AsSerializableString() {
+        final Instant instant = Instant.ofEpochSecond(1234);
+        assertThat(
+                        new ValueLiteralExpression(instant, DataTypes.TIMESTAMP_LTZ(0).notNull())
+                                .asSerializableString(DefaultSqlFactory.INSTANCE))
+                .isEqualTo("TIMESTAMP WITH LOCAL TIME ZONE '1970-01-01 00:20:34'");
+    }
+
+    @Test
+    void testTimestampLtzPrecision3AsSerializableString() {
+        final Instant instant = Instant.ofEpochMilli(1234567);
+        assertThat(
+                        new ValueLiteralExpression(instant, DataTypes.TIMESTAMP_LTZ(3).notNull())
+                                .asSerializableString(DefaultSqlFactory.INSTANCE))
+                .isEqualTo("TIMESTAMP WITH LOCAL TIME ZONE '1970-01-01 00:20:34.567'");
+    }
+
+    @Test
+    void testTimestampLtzPrecision9AsSerializableString() {
+        final Instant instant = Instant.ofEpochSecond(1, 123456789);
+        assertThat(
+                        new ValueLiteralExpression(instant, DataTypes.TIMESTAMP_LTZ(9).notNull())
+                                .asSerializableString(DefaultSqlFactory.INSTANCE))
+                .isEqualTo("TIMESTAMP WITH LOCAL TIME ZONE '1970-01-01 00:00:01.123456789'");
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/expressions/LiteralExpressionsSerializationITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/expressions/LiteralExpressionsSerializationITCase.java
@@ -63,6 +63,7 @@ public class LiteralExpressionsSerializationITCase {
         final LocalDateTime localDateTimeWithoutSeconds =
                 LocalDateTime.of(localDate, localTimeWithoutSeconds);
         final Instant instant = Instant.ofEpochMilli(1234567);
+        final Instant nanoInstant = Instant.ofEpochSecond(1, 123456789);
         final Duration duration = Duration.ofDays(99).plusSeconds(34).plusMillis(999);
         final Period period = Period.ofMonths(470);
         final Table t =
@@ -86,6 +87,7 @@ public class LiteralExpressionsSerializationITCase {
                                 lit(localDateTime, DataTypes.TIMESTAMP(3).notNull()),
                                 lit(localDateTimeWithoutSeconds, DataTypes.TIMESTAMP(3).notNull()),
                                 lit(instant, DataTypes.TIMESTAMP_LTZ(3).notNull()),
+                                lit(nanoInstant, DataTypes.TIMESTAMP_LTZ(9).notNull()),
                                 lit(
                                         duration,
                                         DataTypes.INTERVAL(DataTypes.DAY(), DataTypes.SECOND(9))
@@ -122,7 +124,8 @@ public class LiteralExpressionsSerializationITCase {
                                 + "TIME '12:12:00',\n"
                                 + "TIMESTAMP '2024-02-03 12:12:12.333',\n"
                                 + "TIMESTAMP '2024-02-03 12:12:00',\n"
-                                + "TO_TIMESTAMP_LTZ(1234567, 3),\n"
+                                + "TIMESTAMP WITH LOCAL TIME ZONE '1970-01-01 00:20:34.567',\n"
+                                + "TIMESTAMP WITH LOCAL TIME ZONE '1970-01-01 00:00:01.123456789',\n"
                                 + "INTERVAL '99 00:00:34.999' DAY TO SECOND(3),\n"
                                 + "INTERVAL '39-2' YEAR TO MONTH");
 
@@ -149,6 +152,7 @@ public class LiteralExpressionsSerializationITCase {
                                 localDateTime,
                                 localDateTimeWithoutSeconds,
                                 instant,
+                                nanoInstant,
                                 duration,
                                 period));
     }


### PR DESCRIPTION
## What is the purpose of the change

This pull request addresses [FLINK-39123](https://issues.apache.org/jira/browse/FLINK-39123) by extending `ValueLiteralExpression` support for higher precision levels in `TIMESTAMP_LTZ()` types. Previously, precision was explicitly capped at 3; this change aligns Flink with the expanded precision support introduced in more recent Calcite releases (1.33+).

## Brief change log

- Updated the `ValueLiteralExpression.asSerializableString()` function for `TIMESTAMP_WITH_LOCAL_TIME_ZONE` cases to remove the previous precision constraint (capped at 3) in favor of generating outputting a properly formatted `TIMESTAMP WITH LOCAL TIME ZONE` string.
  - Added a series of tests within the existing `ExpressionTest` to verify behavior for various precision levels (e.g., 0, 3, 9), which were originally written as negative tests cases to confirm current behavior such as throwing an `TableException` for larger precision values.
  - Added and updated tests cases within the `LiteralExpressionsSerializationITCase` to explicitly check higher precision values to ensure they were applied as expected.

## Verifying this change

This change added a series of tests in `ExpressionTest` and `LiteralExpressionsSerializationITCase` (both via a red-green cycle) to confirm expected outputs, namely:
- `ExpressionTest.testTimestampLtzPrecision{precision}AsSerializableString` to verify varying precision levels and their respective outputs (three tests total)
- `LiteralExpressionsSerializationITCase.testSqlSerialization` to update the previous case (using precision of 3) with the updated output and an additional case (using precision of 9).

### Example Tests
<img width="709" height="464" alt="Screenshot 2026-02-23 at 11 47 21 AM" src="https://github.com/user-attachments/assets/27d42667-ddae-4aa5-8c08-d1e79fd27abd" />

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: **no/don't know**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **no**