### PR TITLE
[FLINK-39145][checkpointing] Account for already closed classloader during async operation failure

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnable.java
@@ -153,16 +153,18 @@ final class AsyncCheckpointRunnable implements Runnable, Closeable {
                         taskName,
                         checkpointMetaData.getCheckpointId(),
                         e);
+                handleExecutionException(e);
             } catch (IllegalStateException ignored) {
                 // in case the classloader is already closed
+                // and we can not log the exception properly
                 LOG.info(
                         "{} - asynchronous part of checkpoint {} could not be completed. {}",
                         taskName,
                         checkpointMetaData.getCheckpointId(),
                         ExceptionUtils.stringifyException(e));
+            } finally {
+                finishedFuture.completeExceptionally(e);
             }
-            handleExecutionException(e);
-            finishedFuture.completeExceptionally(e);
         } finally {
             unregisterConsumer.accept(this);
             FileSystemSafetyNet.closeSafetyNetAndGuardedResourcesForThread();

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnable.java
@@ -147,11 +147,20 @@ final class AsyncCheckpointRunnable implements Runnable, Closeable {
 
             finishedFuture.complete(null);
         } catch (Exception e) {
-            LOG.info(
-                    "{} - asynchronous part of checkpoint {} could not be completed.",
-                    taskName,
-                    checkpointMetaData.getCheckpointId(),
-                    e);
+            try {
+                LOG.info(
+                        "{} - asynchronous part of checkpoint {} could not be completed.",
+                        taskName,
+                        checkpointMetaData.getCheckpointId(),
+                        e);
+            } catch (IllegalStateException ignored) {
+                // in case the classloader is already closed
+                LOG.info(
+                        "{} - asynchronous part of checkpoint {} could not be completed. {}",
+                        taskName,
+                        checkpointMetaData.getCheckpointId(),
+                        ExceptionUtils.stringifyException(e));
+            }
             handleExecutionException(e);
             finishedFuture.completeExceptionally(e);
         } finally {


### PR DESCRIPTION
## What is the purpose of the change

Fix a CI test flakiness due to `IllegalStateException: Trying to access closed classloader` taskmanager failure, leading later to `Caused by: org.apache.flink.runtime.jobmanager.scheduler.NoResourceAvailableException: Could not acquire the minimum required resources.`

```
2026-02-22T11:43:05.1838408Z Feb 22 11:43:05 2026-02-22T11:43:05.159497771Z AsyncOperations-thread-1 ERROR An exception occurred processing Appender FileAppender java.lang.IllegalStateException: Trying to access closed classloader. Please check if you store classloaders directly or indirectly in static fields. If the stacktrace suggests that the leak occurs in a third party library and cannot be fixed immediately, you can disable this check with the configuration 'classloader.check-leaked-classloader'.
2026-02-22T11:43:05.1840429Z Feb 22 11:43:05 	at org.apache.flink.util.FlinkUserCodeClassLoaders$SafetyNetWrapperClassLoader.ensureInner(FlinkUserCodeClassLoaders.java:189)
2026-02-22T11:43:05.1841608Z Feb 22 11:43:05 	at org.apache.flink.util.FlinkUserCodeClassLoaders$SafetyNetWrapperClassLoader.loadClass(FlinkUserCodeClassLoaders.java:197)
2026-02-22T11:43:05.1842392Z Feb 22 11:43:05 	at java.base/java.lang.Class.forName0(Native Method)
2026-02-22T11:43:05.1842972Z Feb 22 11:43:05 	at java.base/java.lang.Class.forName(Class.java:467)
2026-02-22T11:43:05.1843863Z Feb 22 11:43:05 	at org.apache.logging.log4j.util.LoaderUtil.loadClass(LoaderUtil.java:207)
2026-02-22T11:43:05.1844638Z Feb 22 11:43:05 	at org.apache.logging.log4j.core.impl.ThrowableProxyHelper.loadClass(ThrowableProxyHelper.java:213)
2026-02-22T11:43:05.1845619Z Feb 22 11:43:05 	at org.apache.logging.log4j.core.impl.ThrowableProxyHelper.toExtendedStackTrace(ThrowableProxyHelper.java:112)
2026-02-22T11:43:05.1846485Z Feb 22 11:43:05 	at org.apache.logging.log4j.core.impl.ThrowableProxy.<init>(ThrowableProxy.java:113)
2026-02-22T11:43:05.1847427Z Feb 22 11:43:05 	at org.apache.logging.log4j.core.impl.ThrowableProxy.<init>(ThrowableProxy.java:96)
2026-02-22T11:43:05.1848712Z Feb 22 11:43:05 	at org.apache.logging.log4j.core.impl.Log4jLogEvent.getThrownProxy(Log4jLogEvent.java:818)
2026-02-22T11:43:05.1850103Z Feb 22 11:43:05 	at org.apache.logging.log4j.core.pattern.ExtendedThrowablePatternConverter.format(ExtendedThrowablePatternConverter.java:63)
2026-02-22T11:43:05.1851359Z Feb 22 11:43:05 	at org.apache.logging.log4j.core.pattern.PatternFormatter.format(PatternFormatter.java:44)
2026-02-22T11:43:05.1852225Z Feb 22 11:43:05 	at org.apache.logging.log4j.core.layout.PatternLayout$PatternFormatterPatternSerializer.toSerializable(PatternLayout.java:397)
2026-02-22T11:43:05.1853092Z Feb 22 11:43:05 	at org.apache.logging.log4j.core.layout.PatternLayout.toText(PatternLayout.java:252)
2026-02-22T11:43:05.1854021Z Feb 22 11:43:05 	at org.apache.logging.log4j.core.layout.PatternLayout.encode(PatternLayout.java:238)
2026-02-22T11:43:05.1854767Z Feb 22 11:43:05 	at org.apache.logging.log4j.core.layout.PatternLayout.encode(PatternLayout.java:58)
2026-02-22T11:43:05.1855606Z Feb 22 11:43:05 	at org.apache.logging.log4j.core.appender.AbstractOutputStreamAppender.directEncodeEvent(AbstractOutputStreamAppender.java:227)
2026-02-22T11:43:05.1860155Z Feb 22 11:43:05 	at org.apache.logging.log4j.core.appender.AbstractOutputStreamAppender.tryAppend(AbstractOutputStreamAppender.java:220)
2026-02-22T11:43:05.1862060Z Feb 22 11:43:05 	at org.apache.logging.log4j.core.appender.AbstractOutputStreamAppender.append(AbstractOutputStreamAppender.java:211)
2026-02-22T11:43:05.1863545Z Feb 22 11:43:05 	at org.apache.logging.log4j.core.config.AppenderControl.tryCallAppender(AppenderControl.java:160)
2026-02-22T11:43:05.1864920Z Feb 22 11:43:05 	at org.apache.logging.log4j.core.config.AppenderControl.callAppender0(AppenderControl.java:133)
2026-02-22T11:43:05.1866340Z Feb 22 11:43:05 	at org.apache.logging.log4j.core.config.AppenderControl.callAppenderPreventRecursion(AppenderControl.java:124)
2026-02-22T11:43:05.1867838Z Feb 22 11:43:05 	at org.apache.logging.log4j.core.config.AppenderControl.callAppender(AppenderControl.java:88)
2026-02-22T11:43:05.1869152Z Feb 22 11:43:05 	at org.apache.logging.log4j.core.config.LoggerConfig.callAppenders(LoggerConfig.java:714)
2026-02-22T11:43:05.1870475Z Feb 22 11:43:05 	at org.apache.logging.log4j.core.config.LoggerConfig.processLogEvent(LoggerConfig.java:672)
2026-02-22T11:43:05.1872201Z Feb 22 11:43:05 	at org.apache.logging.log4j.core.config.LoggerConfig.log(LoggerConfig.java:648)
2026-02-22T11:43:05.1873432Z Feb 22 11:43:05 	at org.apache.logging.log4j.core.config.LoggerConfig.log(LoggerConfig.java:584)
2026-02-22T11:43:05.1874858Z Feb 22 11:43:05 	at org.apache.logging.log4j.core.config.AwaitCompletionReliabilityStrategy.log(AwaitCompletionReliabilityStrategy.java:92)
2026-02-22T11:43:05.1876199Z Feb 22 11:43:05 	at org.apache.logging.log4j.core.Logger.log(Logger.java:187)
2026-02-22T11:43:05.1877499Z Feb 22 11:43:05 	at org.apache.logging.log4j.spi.AbstractLogger.tryLogMessage(AbstractLogger.java:2904)
2026-02-22T11:43:05.1878881Z Feb 22 11:43:05 	at org.apache.logging.log4j.spi.AbstractLogger.logMessageTrackRecursion(AbstractLogger.java:2857)
2026-02-22T11:43:05.1880226Z Feb 22 11:43:05 	at org.apache.logging.log4j.spi.AbstractLogger.logMessageSafely(AbstractLogger.java:2839)
2026-02-22T11:43:05.1881650Z Feb 22 11:43:05 	at org.apache.logging.log4j.spi.AbstractLogger.logMessage(AbstractLogger.java:2629)
2026-02-22T11:43:05.1883154Z Feb 22 11:43:05 	at org.apache.logging.log4j.spi.AbstractLogger.logIfEnabled(AbstractLogger.java:2392)
2026-02-22T11:43:05.1884361Z Feb 22 11:43:05 	at org.apache.logging.slf4j.Log4jLogger.info(Log4jLogger.java:188)
2026-02-22T11:43:05.1885637Z Feb 22 11:43:05 	at org.apache.flink.streaming.runtime.tasks.AsyncCheckpointRunnable.run(AsyncCheckpointRunnable.java:150)
2026-02-22T11:43:05.1887062Z Feb 22 11:43:05 	at org.apache.flink.util.MdcUtils.lambda$wrapRunnable$1(MdcUtils.java:70)
2026-02-22T11:43:05.1888421Z Feb 22 11:43:05 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
2026-02-22T11:43:05.1889769Z Feb 22 11:43:05 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
2026-02-22T11:43:05.1891027Z Feb 22 11:43:05 	at java.base/java.lang.Thread.run(Thread.java:833)
```

[Example](https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=72565&view=logs&j=5c8e7682-d68f-54d1-16a2-a09310218a49&t=9d734c8c-6253-55e6-3bce-47e7cdf68ac4)

## Brief change log

- Try-catch block to log the error on best-effort basis if classloader is no longer available for extended stacktrace logging.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable