### PR TITLE
[FLINK-39160][Rpc] Add RPC response frame size metrics

### DIFF
--- a/docs/content/docs/ops/metrics.md
+++ b/docs/content/docs/ops/metrics.md
@@ -1054,6 +1054,33 @@ Metrics related to data exchange between task executors using netty network comm
   </tbody>
 </table>
 
+### RPC
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th class="text-left" style="width: 18%">Scope</th>
+      <th class="text-left" style="width: 22%">Infix</th>
+      <th class="text-left" style="width: 22%">Metrics</th>
+      <th class="text-left" style="width: 30%">Description</th>
+      <th class="text-left" style="width: 8%">Type</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th rowspan="2"><strong>Job-/TaskManager</strong></th>
+      <td rowspan="2">Status.RPC</td>
+      <td>latestResponseFrameSizeBytes</td>
+      <td>Latest observed serialized RPC response size in bytes (remote or forced-serialization paths).</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>oversizedResponseRejections</td>
+      <td>Total number of serialized RPC responses rejected because they exceeded <tt>pekko.framesize</tt>.</td>
+      <td>Counter</td>
+    </tr>
+  </tbody>
+</table>
+
 ### Availability
 
 The metrics in this table are available for each of the following job states: INITIALIZING, CREATED, RUNNING, RESTARTING, CANCELLING, FAILING.

--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/pekko/FencedPekkoRpcActor.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/pekko/FencedPekkoRpcActor.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.rpc.pekko;
 
 import org.apache.flink.runtime.rpc.FencedRpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcGateway;
+import org.apache.flink.runtime.rpc.RpcResponseFrameSizeObserver;
 import org.apache.flink.runtime.rpc.exceptions.FencingTokenException;
 import org.apache.flink.runtime.rpc.messages.FencedMessage;
 import org.apache.flink.runtime.rpc.messages.LocalFencedMessage;
@@ -48,6 +49,7 @@ public class FencedPekkoRpcActor<
             int version,
             final long maximumFramesize,
             final boolean forceSerialization,
+            final RpcResponseFrameSizeObserver rpcResponseFrameSizeObserver,
             ClassLoader flinkClassLoader,
             final Map<String, String> loggingContext) {
         super(
@@ -56,6 +58,7 @@ public class FencedPekkoRpcActor<
                 version,
                 maximumFramesize,
                 forceSerialization,
+                rpcResponseFrameSizeObserver,
                 flinkClassLoader,
                 loggingContext);
     }

--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/pekko/PekkoRpcActor.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/pekko/PekkoRpcActor.java
@@ -22,6 +22,7 @@ import org.apache.flink.runtime.rpc.Local;
 import org.apache.flink.runtime.rpc.MainThreadValidatorUtil;
 import org.apache.flink.runtime.rpc.RpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcGateway;
+import org.apache.flink.runtime.rpc.RpcResponseFrameSizeObserver;
 import org.apache.flink.runtime.rpc.exceptions.EndpointNotStartedException;
 import org.apache.flink.runtime.rpc.exceptions.HandshakeException;
 import org.apache.flink.runtime.rpc.exceptions.RpcConnectionException;
@@ -105,6 +106,7 @@ class PekkoRpcActor<T extends RpcEndpoint & RpcGateway> extends AbstractActor {
 
     private final boolean forceSerialization;
     private final Map<String, String> loggingContext;
+    private final RpcResponseFrameSizeObserver rpcResponseFrameSizeObserver;
 
     private volatile RpcEndpointTerminationResult rpcEndpointTerminationResult;
 
@@ -116,6 +118,7 @@ class PekkoRpcActor<T extends RpcEndpoint & RpcGateway> extends AbstractActor {
             final int version,
             final long maximumFramesize,
             final boolean forceSerialization,
+            final RpcResponseFrameSizeObserver rpcResponseFrameSizeObserver,
             final ClassLoader flinkClassLoader,
             final Map<String, String> loggingContext) {
         this.loggingContext = loggingContext;
@@ -124,6 +127,7 @@ class PekkoRpcActor<T extends RpcEndpoint & RpcGateway> extends AbstractActor {
         this.rpcEndpoint = checkNotNull(rpcEndpoint, "rpc endpoint");
         this.flinkClassLoader = checkNotNull(flinkClassLoader);
         this.forceSerialization = forceSerialization;
+        this.rpcResponseFrameSizeObserver = checkNotNull(rpcResponseFrameSizeObserver);
         this.mainThreadValidator = new MainThreadValidatorUtil(rpcEndpoint);
         this.terminationFuture = checkNotNull(terminationFuture);
         this.version = version;
@@ -405,7 +409,9 @@ class PekkoRpcActor<T extends RpcEndpoint & RpcGateway> extends AbstractActor {
             RpcSerializedValue serializedResult = RpcSerializedValue.valueOf(result);
 
             long resultSize = serializedResult.getSerializedDataLength();
+            rpcResponseFrameSizeObserver.onSerializedResponseFrameSize(resultSize);
             if (resultSize > maximumFramesize) {
+                rpcResponseFrameSizeObserver.onOversizedResponse();
                 return Either.Right(
                         new RpcException(
                                 "The method "

--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/pekko/PekkoRpcService.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/pekko/PekkoRpcService.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.rpc.FencedRpcEndpoint;
 import org.apache.flink.runtime.rpc.FencedRpcGateway;
 import org.apache.flink.runtime.rpc.RpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcGateway;
+import org.apache.flink.runtime.rpc.RpcResponseFrameSizeObserver;
 import org.apache.flink.runtime.rpc.RpcServer;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.RpcUtils;
@@ -112,6 +113,10 @@ public class PekkoRpcService implements RpcService {
 
     private volatile boolean stopped;
 
+    @GuardedBy("lock")
+    private RpcResponseFrameSizeObserver rpcResponseFrameSizeObserver =
+            RpcResponseFrameSizeObserver.NO_OP;
+
     @VisibleForTesting
     public PekkoRpcService(
             final ActorSystem actorSystem, final PekkoRpcServiceConfiguration configuration) {
@@ -194,6 +199,14 @@ public class PekkoRpcService implements RpcService {
     @Override
     public int getPort() {
         return port;
+    }
+
+    @Override
+    public void setRpcResponseFrameSizeObserver(
+            RpcResponseFrameSizeObserver rpcResponseFrameSizeObserver) {
+        synchronized (lock) {
+            this.rpcResponseFrameSizeObserver = checkNotNull(rpcResponseFrameSizeObserver);
+        }
     }
 
     public <C extends RpcGateway> C getSelfGateway(Class<C> selfGatewayType, RpcServer rpcServer) {
@@ -360,6 +373,7 @@ public class PekkoRpcService implements RpcService {
                                             getVersion(),
                                             configuration.getMaximumFramesize(),
                                             configuration.isForceRpcInvocationSerialization(),
+                                            rpcResponseFrameSizeObserver,
                                             flinkClassLoader,
                                             loggingContext),
                             rpcEndpoint.getEndpointId());

--- a/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/pekko/PekkoRpcActorOversizedResponseMessageTest.java
+++ b/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/pekko/PekkoRpcActorOversizedResponseMessageTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.RpcOptions;
 import org.apache.flink.core.testutils.FlinkAssertions;
 import org.apache.flink.runtime.rpc.RpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcGateway;
+import org.apache.flink.runtime.rpc.RpcResponseFrameSizeObserver;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.exceptions.RpcException;
@@ -31,11 +32,19 @@ import org.apache.flink.util.function.FunctionWithException;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -44,6 +53,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class PekkoRpcActorOversizedResponseMessageTest {
 
     private static final int FRAMESIZE = 32000;
+    private static final int CONCURRENT_OVERSIZED_REQUEST_PARALLELISM = 16;
+    private static final int CONCURRENT_OVERSIZED_REQUEST_STRESS_ROUNDS = 20;
 
     private static final String OVERSIZED_PAYLOAD = new String(new byte[FRAMESIZE]);
 
@@ -52,6 +63,7 @@ class PekkoRpcActorOversizedResponseMessageTest {
     private static RpcService rpcService1;
 
     private static RpcService rpcService2;
+    private TestingRpcResponseFrameSizeObserver testingRpcResponseFrameSizeObserver;
 
     @BeforeAll
     static void setupClass() throws Exception {
@@ -73,6 +85,12 @@ class PekkoRpcActorOversizedResponseMessageTest {
         RpcUtils.terminateRpcService(rpcService1, rpcService2);
     }
 
+    @BeforeEach
+    void setUp() {
+        testingRpcResponseFrameSizeObserver = new TestingRpcResponseFrameSizeObserver();
+        rpcService1.setRpcResponseFrameSizeObserver(testingRpcResponseFrameSizeObserver);
+    }
+
     @Test
     void testOverSizedResponseMsgAsync() throws Exception {
         assertThatThrownBy(
@@ -84,12 +102,18 @@ class PekkoRpcActorOversizedResponseMessageTest {
                 .isInstanceOf(RpcException.class)
                 .extracting(Throwable::getMessage)
                 .satisfies(message -> assertThat(message).contains(String.valueOf(FRAMESIZE)));
+        assertThat(testingRpcResponseFrameSizeObserver.getLatestSerializedResponseFrameSize())
+                .isGreaterThan(FRAMESIZE);
+        assertThat(testingRpcResponseFrameSizeObserver.getNumOversizedResponses()).isEqualTo(1L);
     }
 
     @Test
     void testNormalSizedResponseMsgAsync() throws Exception {
         final String message = runRemoteMessageResponseTest(PAYLOAD, this::requestMessageAsync);
         assertThat(message).isEqualTo(PAYLOAD);
+        assertThat(testingRpcResponseFrameSizeObserver.getLatestSerializedResponseFrameSize())
+                .isGreaterThan(0L);
+        assertThat(testingRpcResponseFrameSizeObserver.getNumOversizedResponses()).isZero();
     }
 
     @Test
@@ -97,6 +121,9 @@ class PekkoRpcActorOversizedResponseMessageTest {
         final String message =
                 runRemoteMessageResponseTest(PAYLOAD, MessageRpcGateway::messageSync);
         assertThat(message).isEqualTo(PAYLOAD);
+        assertThat(testingRpcResponseFrameSizeObserver.getLatestSerializedResponseFrameSize())
+                .isGreaterThan(0L);
+        assertThat(testingRpcResponseFrameSizeObserver.getNumOversizedResponses()).isZero();
     }
 
     @Test
@@ -108,6 +135,21 @@ class PekkoRpcActorOversizedResponseMessageTest {
                 .satisfies(
                         FlinkAssertions.anyCauseMatches(
                                 RpcException.class, String.valueOf(FRAMESIZE)));
+        assertThat(testingRpcResponseFrameSizeObserver.getLatestSerializedResponseFrameSize())
+                .isGreaterThan(FRAMESIZE);
+        assertThat(testingRpcResponseFrameSizeObserver.getNumOversizedResponses()).isEqualTo(1L);
+    }
+
+    @Test
+    void testConcurrentOverSizedResponseMsgAsync() throws Exception {
+        runConcurrentRemoteOverSizedResponseMsgTest(CONCURRENT_OVERSIZED_REQUEST_PARALLELISM, 1);
+    }
+
+    @Test
+    void testConcurrentOverSizedResponseMsgAsyncStress() throws Exception {
+        runConcurrentRemoteOverSizedResponseMsgTest(
+                CONCURRENT_OVERSIZED_REQUEST_PARALLELISM,
+                CONCURRENT_OVERSIZED_REQUEST_STRESS_ROUNDS);
     }
 
     /**
@@ -171,6 +213,94 @@ class PekkoRpcActorOversizedResponseMessageTest {
         }
     }
 
+    private void runConcurrentRemoteOverSizedResponseMsgTest(int parallelism, int rounds)
+            throws Exception {
+        final List<MessageRpcEndpoint> endpoints = new ArrayList<>(parallelism);
+        final List<MessageRpcGateway> rpcGateways = new ArrayList<>(parallelism);
+        final ExecutorService executor = Executors.newFixedThreadPool(parallelism);
+
+        try {
+            for (int i = 0; i < parallelism; i++) {
+                final MessageRpcEndpoint rpcEndpoint =
+                        new MessageRpcEndpoint(rpcService1, OVERSIZED_PAYLOAD);
+                rpcEndpoint.start();
+                endpoints.add(rpcEndpoint);
+
+                rpcGateways.add(
+                        rpcService2
+                                .connect(rpcEndpoint.getAddress(), MessageRpcGateway.class)
+                                .get());
+            }
+
+            for (int round = 0; round < rounds; round++) {
+                assertConcurrentOversizedResponses(rpcGateways, executor);
+            }
+
+            assertThat(testingRpcResponseFrameSizeObserver.getLatestSerializedResponseFrameSize())
+                    .isGreaterThan(FRAMESIZE);
+            assertThat(testingRpcResponseFrameSizeObserver.getNumOversizedResponses())
+                    .isEqualTo((long) parallelism * rounds);
+        } finally {
+            executor.shutdownNow();
+            executor.awaitTermination(30L, TimeUnit.SECONDS);
+            terminateRpcEndpoints(endpoints);
+        }
+    }
+
+    private void assertConcurrentOversizedResponses(
+            List<MessageRpcGateway> rpcGateways, ExecutorService executor) throws Exception {
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        final List<CompletableFuture<Throwable>> responseFailures =
+                new ArrayList<>(rpcGateways.size());
+
+        for (MessageRpcGateway rpcGateway : rpcGateways) {
+            responseFailures.add(
+                    CompletableFuture.supplyAsync(
+                            () -> {
+                                try {
+                                    startLatch.await();
+                                    requestMessageAsync(rpcGateway);
+                                    return null;
+                                } catch (Throwable throwable) {
+                                    return throwable;
+                                }
+                            },
+                            executor));
+        }
+
+        startLatch.countDown();
+        CompletableFuture.allOf(responseFailures.toArray(new CompletableFuture[0]))
+                .get(30L, TimeUnit.SECONDS);
+
+        for (CompletableFuture<Throwable> responseFailure : responseFailures) {
+            assertThat(responseFailure.get())
+                    .as("Every oversized response request should fail")
+                    .isNotNull()
+                    .satisfies(
+                            FlinkAssertions.anyCauseMatches(
+                                    RpcException.class, String.valueOf(FRAMESIZE)));
+        }
+    }
+
+    private void terminateRpcEndpoints(List<MessageRpcEndpoint> rpcEndpoints) throws Exception {
+        Exception firstException = null;
+        for (MessageRpcEndpoint rpcEndpoint : rpcEndpoints) {
+            try {
+                RpcUtils.terminateRpcEndpoint(rpcEndpoint);
+            } catch (Exception exception) {
+                if (firstException == null) {
+                    firstException = exception;
+                } else {
+                    firstException.addSuppressed(exception);
+                }
+            }
+        }
+
+        if (firstException != null) {
+            throw firstException;
+        }
+    }
+
     // -------------------------------------------------------------------------
 
     interface MessageRpcGateway extends RpcGateway {
@@ -196,6 +326,30 @@ class PekkoRpcActorOversizedResponseMessageTest {
         @Override
         public String messageSync() throws RpcException {
             return message;
+        }
+    }
+
+    private static class TestingRpcResponseFrameSizeObserver
+            implements RpcResponseFrameSizeObserver {
+        private final AtomicLong latestSerializedResponseFrameSize = new AtomicLong(0L);
+        private final AtomicLong numOversizedResponses = new AtomicLong(0L);
+
+        @Override
+        public void onSerializedResponseFrameSize(long serializedResponseSize) {
+            latestSerializedResponseFrameSize.set(serializedResponseSize);
+        }
+
+        @Override
+        public void onOversizedResponse() {
+            numOversizedResponses.incrementAndGet();
+        }
+
+        long getLatestSerializedResponseFrameSize() {
+            return latestSerializedResponseFrameSize.get();
+        }
+
+        long getNumOversizedResponses() {
+            return numOversizedResponses.get();
         }
     }
 }

--- a/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/RpcResponseFrameSizeObserver.java
+++ b/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/RpcResponseFrameSizeObserver.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc;
+
+/** Observer for serialized RPC response frame sizes. */
+@FunctionalInterface
+public interface RpcResponseFrameSizeObserver {
+
+    RpcResponseFrameSizeObserver NO_OP = serializedResponseSize -> {};
+
+    /** Reports the serialized RPC response size in bytes. */
+    void onSerializedResponseFrameSize(long serializedResponseSize);
+
+    /** Reports that a serialized response exceeded the configured maximum frame size. */
+    default void onOversizedResponse() {}
+}

--- a/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/RpcService.java
+++ b/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/RpcService.java
@@ -34,6 +34,18 @@ import java.util.concurrent.CompletableFuture;
 public interface RpcService extends AutoCloseableAsync {
 
     /**
+     * Installs an observer for RPC response frame-size metrics.
+     *
+     * <p>The observer is used for endpoints/actors created after this method is called. Existing
+     * endpoints/actors may continue using the previously configured observer.
+     *
+     * <p>The default implementation is a no-op so existing {@link RpcService} implementations
+     * remain backwards compatible.
+     */
+    default void setRpcResponseFrameSizeObserver(
+            RpcResponseFrameSizeObserver rpcResponseFrameSizeObserver) {}
+
+    /**
      * Return the hostname or host address under which the rpc service can be reached. If the rpc
      * service cannot be contacted remotely, then it will return an empty string.
      *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -418,6 +418,9 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
                             hostname,
                             ConfigurationUtils.getSystemResourceMetricsProbingInterval(
                                     configuration));
+            commonRpcService.setRpcResponseFrameSizeObserver(
+                    MetricUtils.instantiateRpcResponseFrameSizeMetrics(
+                            processMetricGroup.addGroup("Status")));
 
             archivedApplicationStore =
                     createArchivedApplicationStore(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
@@ -50,6 +50,8 @@ public class MetricNames {
     public static final String TASK_SLOTS_TOTAL = "taskSlotsTotal";
     public static final String NUM_REGISTERED_TASK_MANAGERS = "numRegisteredTaskManagers";
     public static final String NUM_PENDING_TASK_MANAGERS = "numPendingTaskManagers";
+    public static final String RPC_LATEST_RESPONSE_FRAME_SIZE = "latestResponseFrameSizeBytes";
+    public static final String RPC_OVERSIZED_RESPONSE_REJECTIONS = "oversizedResponseRejections";
 
     public static final String NUM_RESTARTS = "numRestarts";
     public static final String NUM_RESCALES = "numRescales";

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/MetricUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/MetricUtils.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MetricOptions;
+import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.MeterView;
 import org.apache.flink.metrics.MetricGroup;
@@ -34,6 +35,7 @@ import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.groups.AbstractMetricGroup;
 import org.apache.flink.runtime.metrics.groups.ProcessMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
+import org.apache.flink.runtime.rpc.RpcResponseFrameSizeObserver;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.RpcSystem;
 import org.apache.flink.runtime.taskexecutor.slot.SlotNotFoundException;
@@ -63,6 +65,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -74,6 +77,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class MetricUtils {
     private static final Logger LOG = LoggerFactory.getLogger(MetricUtils.class);
     private static final String METRIC_GROUP_STATUS_NAME = "Status";
+    private static final String METRIC_GROUP_RPC_NAME = "RPC";
     private static final String METRICS_ACTOR_SYSTEM_NAME = "flink-metrics";
 
     static final String METRIC_GROUP_HEAP_NAME = "Heap";
@@ -140,6 +144,29 @@ public class MetricUtils {
         instantiateThreadMetrics(jvm.addGroup("Threads"));
         instantiateCPUMetrics(jvm.addGroup("CPU"));
         instantiateFileDescriptorMetrics(jvm.addGroup("FileDescriptor"));
+    }
+
+    public static RpcResponseFrameSizeObserver instantiateRpcResponseFrameSizeMetrics(
+            MetricGroup statusMetricGroup) {
+        final MetricGroup rpcMetricGroup = statusMetricGroup.addGroup(METRIC_GROUP_RPC_NAME);
+        final AtomicLong latestSerializedResponseFrameSize = new AtomicLong(0L);
+
+        rpcMetricGroup.gauge(
+                MetricNames.RPC_LATEST_RESPONSE_FRAME_SIZE, latestSerializedResponseFrameSize::get);
+        final Counter oversizedResponseRejectionsCounter =
+                rpcMetricGroup.counter(MetricNames.RPC_OVERSIZED_RESPONSE_REJECTIONS);
+
+        return new RpcResponseFrameSizeObserver() {
+            @Override
+            public void onSerializedResponseFrameSize(long serializedResponseSize) {
+                latestSerializedResponseFrameSize.set(serializedResponseSize);
+            }
+
+            @Override
+            public void onOversizedResponse() {
+                oversizedResponseRejectionsCounter.inc();
+            }
+        };
     }
 
     public static void instantiateFlinkMemoryMetricGroup(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -639,6 +639,8 @@ public class TaskManagerRunner implements FatalErrorHandler {
                         externalAddress,
                         resourceID,
                         taskManagerServicesConfiguration.getSystemResourceMetricsProbingInterval());
+        rpcService.setRpcResponseFrameSizeObserver(
+                MetricUtils.instantiateRpcResponseFrameSizeMetrics(taskManagerMetricGroup.f1));
 
         final ExecutorService ioExecutor =
                 Executors.newFixedThreadPool(


### PR DESCRIPTION
Introduce RpcResponseFrameSizeObserver and wire it through PekkoRpcService and PekkoRpcActor to record serialized RPC response sizes and count oversized-response rejections when exceeding pekko.framesize.

Register and expose the new Status.RPC metrics for JobManager and TaskManager, document them, and extend oversized-response tests to validate observer reporting.

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->
## What is the purpose of the change

This pull request adds observability for RPC response frame sizes and oversized-response rejections. It helps operators detect when serialized RPC responses approach or exceed `pekko.framesize`, improving diagnosis of RPC payload issues.

## Brief change log

- Introduced `RpcResponseFrameSizeObserver` in `flink-rpc-core` and added a hook in `RpcService` to install an observer.
- Wired observer propagation through `PekkoRpcService`, `PekkoRpcActor`, and `FencedPekkoRpcActor`.
- Recorded two runtime metrics under `Status.RPC`: `latestResponseFrameSizeBytes` (gauge) and `oversizedResponseRejections` (counter).
- Registered the metrics in both `ClusterEntrypoint` (Jobmanager) and `TaskManagerRunner` (Taskmanager).
- Documented the new metrics in `docs/content/docs/ops/metrics.md`.
- Extended `PekkoRpcActorOversizedResponseMessageTest` with observer-based assertions, including concurrent/stress oversized-response scenarios.

## Verifying this change

This change added tests and can be verified as follows:

- Extended `PekkoRpcActorOversizedResponseMessageTest` to validate frame-size observation and oversized-response rejection counting for normal-sized async/sync responses, oversized async/sync responses, local oversized responses, and concurrent/stress concurrent oversized responses.
- Ran targeted test: `./mvnw -pl flink-rpc/flink-rpc-akka -Dtest=PekkoRpcActorOversizedResponseMessageTest test`


## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? docs