### PR TITLE
[FLINK-39190] Relocate Jackson in filesystem plugin POMs to prevent classpath conflicts

### DIFF
--- a/flink-filesystems/flink-azure-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-azure-fs-hadoop/pom.xml
@@ -150,6 +150,12 @@ under the License.
 									<pattern>org.apache.flink.runtime.util</pattern>
 									<shadedPattern>org.apache.flink.fs.azure.common</shadedPattern>
 								</relocation>
+								<!-- Relocate Jackson to prevent conflicts with user jobs that depend on newer
+								     Jackson versions. -->
+								<relocation>
+									<pattern>com.fasterxml.jackson</pattern>
+									<shadedPattern>org.apache.flink.fs.azure.shaded.jackson</shadedPattern>
+								</relocation>
 							</relocations>
 							<filters>
 								<filter>

--- a/flink-filesystems/flink-azure-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-azure-fs-hadoop/pom.xml
@@ -150,8 +150,11 @@ under the License.
 									<pattern>org.apache.flink.runtime.util</pattern>
 									<shadedPattern>org.apache.flink.fs.azure.common</shadedPattern>
 								</relocation>
-								<!-- Relocate Jackson to prevent conflicts with user jobs that depend on newer
-								     Jackson versions. -->
+								<!-- Relocate Jackson to a plugin-specific namespace rather than reusing a
+								     Flink-wide shaded Jackson, because each filesystem plugin is loaded in
+								     isolation and may bundle a different transitive Jackson version.
+								     Per-plugin relocation keeps each JAR self-contained and prevents its
+								     bundled Jackson from shadowing the version on the user's job classpath. -->
 								<relocation>
 									<pattern>com.fasterxml.jackson</pattern>
 									<shadedPattern>org.apache.flink.fs.azure.shaded.jackson</shadedPattern>

--- a/flink-filesystems/flink-gs-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-gs-fs-hadoop/pom.xml
@@ -224,6 +224,12 @@ under the License.
 									<pattern>org.apache.flink.runtime.util</pattern>
 									<shadedPattern>org.apache.flink.fs.gs.org.apache.flink.runtime.util</shadedPattern>
 								</relocation>
+								<!-- Relocate Jackson to prevent conflicts with user jobs that depend on newer
+								     Jackson versions. -->
+								<relocation>
+									<pattern>com.fasterxml.jackson</pattern>
+									<shadedPattern>org.apache.flink.fs.gs.shaded.jackson</shadedPattern>
+								</relocation>
 							</relocations>
 							<filters>
 								<filter>

--- a/flink-filesystems/flink-gs-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-gs-fs-hadoop/pom.xml
@@ -224,8 +224,11 @@ under the License.
 									<pattern>org.apache.flink.runtime.util</pattern>
 									<shadedPattern>org.apache.flink.fs.gs.org.apache.flink.runtime.util</shadedPattern>
 								</relocation>
-								<!-- Relocate Jackson to prevent conflicts with user jobs that depend on newer
-								     Jackson versions. -->
+								<!-- Relocate Jackson to a plugin-specific namespace rather than reusing a
+								     Flink-wide shaded Jackson, because each filesystem plugin is loaded in
+								     isolation and may bundle a different transitive Jackson version.
+								     Per-plugin relocation keeps each JAR self-contained and prevents its
+								     bundled Jackson from shadowing the version on the user's job classpath. -->
 								<relocation>
 									<pattern>com.fasterxml.jackson</pattern>
 									<shadedPattern>org.apache.flink.fs.gs.shaded.jackson</shadedPattern>

--- a/flink-filesystems/flink-oss-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-oss-fs-hadoop/pom.xml
@@ -167,6 +167,12 @@ under the License.
 									<pattern>org.apache.flink.runtime.util</pattern>
 									<shadedPattern>org.apache.flink.fs.osshadoop.common</shadedPattern>
 								</relocation>
+								<!-- Relocate Jackson to prevent conflicts with user jobs that depend on newer
+								     Jackson versions. -->
+								<relocation>
+									<pattern>com.fasterxml.jackson</pattern>
+									<shadedPattern>org.apache.flink.fs.osshadoop.shaded.jackson</shadedPattern>
+								</relocation>
 							</relocations>
 							<filters>
 								<filter>

--- a/flink-filesystems/flink-oss-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-oss-fs-hadoop/pom.xml
@@ -167,8 +167,11 @@ under the License.
 									<pattern>org.apache.flink.runtime.util</pattern>
 									<shadedPattern>org.apache.flink.fs.osshadoop.common</shadedPattern>
 								</relocation>
-								<!-- Relocate Jackson to prevent conflicts with user jobs that depend on newer
-								     Jackson versions. -->
+								<!-- Relocate Jackson to a plugin-specific namespace rather than reusing a
+								     Flink-wide shaded Jackson, because each filesystem plugin is loaded in
+								     isolation and may bundle a different transitive Jackson version.
+								     Per-plugin relocation keeps each JAR self-contained and prevents its
+								     bundled Jackson from shadowing the version on the user's job classpath. -->
 								<relocation>
 									<pattern>com.fasterxml.jackson</pattern>
 									<shadedPattern>org.apache.flink.fs.osshadoop.shaded.jackson</shadedPattern>

--- a/flink-filesystems/flink-s3-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-s3-fs-hadoop/pom.xml
@@ -262,6 +262,12 @@ under the License.
 									<pattern>org.apache.flink.runtime.util</pattern>
 									<shadedPattern>org.apache.flink.fs.s3hadoop.common</shadedPattern>
 								</relocation>
+								<!-- Relocate Jackson to prevent conflicts with user jobs that depend on newer
+								     Jackson versions. -->
+								<relocation>
+									<pattern>com.fasterxml.jackson</pattern>
+									<shadedPattern>org.apache.flink.fs.s3hadoop.shaded.jackson</shadedPattern>
+								</relocation>
 							</relocations>
 							<filters>
 								<filter>

--- a/flink-filesystems/flink-s3-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-s3-fs-hadoop/pom.xml
@@ -262,8 +262,11 @@ under the License.
 									<pattern>org.apache.flink.runtime.util</pattern>
 									<shadedPattern>org.apache.flink.fs.s3hadoop.common</shadedPattern>
 								</relocation>
-								<!-- Relocate Jackson to prevent conflicts with user jobs that depend on newer
-								     Jackson versions. -->
+								<!-- Relocate Jackson to a plugin-specific namespace rather than reusing a
+								     Flink-wide shaded Jackson, because each filesystem plugin is loaded in
+								     isolation and may bundle a different transitive Jackson version.
+								     Per-plugin relocation keeps each JAR self-contained and prevents its
+								     bundled Jackson from shadowing the version on the user's job classpath. -->
 								<relocation>
 									<pattern>com.fasterxml.jackson</pattern>
 									<shadedPattern>org.apache.flink.fs.s3hadoop.shaded.jackson</shadedPattern>

--- a/flink-filesystems/flink-s3-fs-presto/pom.xml
+++ b/flink-filesystems/flink-s3-fs-presto/pom.xml
@@ -553,6 +553,12 @@ under the License.
 									<pattern>org.apache.flink.runtime.util</pattern>
 									<shadedPattern>org.apache.flink.fs.s3presto.common</shadedPattern>
 								</relocation>
+								<!-- Relocate Jackson to prevent conflicts with user jobs that depend on newer
+								     Jackson versions. -->
+								<relocation>
+									<pattern>com.fasterxml.jackson</pattern>
+									<shadedPattern>org.apache.flink.fs.s3presto.shaded.jackson</shadedPattern>
+								</relocation>
 							</relocations>
 							<filters>
 								<filter>

--- a/flink-filesystems/flink-s3-fs-presto/pom.xml
+++ b/flink-filesystems/flink-s3-fs-presto/pom.xml
@@ -553,8 +553,11 @@ under the License.
 									<pattern>org.apache.flink.runtime.util</pattern>
 									<shadedPattern>org.apache.flink.fs.s3presto.common</shadedPattern>
 								</relocation>
-								<!-- Relocate Jackson to prevent conflicts with user jobs that depend on newer
-								     Jackson versions. -->
+								<!-- Relocate Jackson to a plugin-specific namespace rather than reusing a
+								     Flink-wide shaded Jackson, because each filesystem plugin is loaded in
+								     isolation and may bundle a different transitive Jackson version.
+								     Per-plugin relocation keeps each JAR self-contained and prevents its
+								     bundled Jackson from shadowing the version on the user's job classpath. -->
 								<relocation>
 									<pattern>com.fasterxml.jackson</pattern>
 									<shadedPattern>org.apache.flink.fs.s3presto.shaded.jackson</shadedPattern>


### PR DESCRIPTION
## What is the purpose of the change

This PR relocates Jackson in filesystem plugin shade configurations

All Hadoop-based filesystem plugins (s3-hadoop, s3-presto, azure, gs, oss) pull in jackson-databind 2.17.x transitively via AWS SDK v1 or Hadoop, but do not relocate it. If the plugin JAR ends up on the job classpath, its older unshaded Jackson shadows any newer version used by the job, causing for example:                                                                                                                                                                                       
`NoSuchFieldError: CLEAR_CURRENT_TOKEN_ON_CLOSE ` 

`StreamReadFeature.CLEAR_CURRENT_TOKEN_ON_CLOSE` was added in Jackson 2.18.0, so any job using jackson-dataformat-csv 2.18+ fails at runtime with this error.

## Brief change log

Added a com.fasterxml.jackson relocation to the maven-shade-plugin configuration of each affected module, using a module-specific shaded package (e.g. org.apache.flink.fs.s3hadoop.shaded.jackson), consistent with how flink-shaded-jackson handles the core runtime.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes (no new dependencies, but changes how the are handled)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: don't know

## Documentation

  - Does this pull request introduce a new feature? no

