### PR TITLE
[FLINK-39176][runtime] Introduce NodeHealthManager abstraction

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -53,6 +53,8 @@ import org.apache.flink.runtime.metrics.groups.ResourceManagerMetricGroup;
 import org.apache.flink.runtime.registration.RegistrationResponse;
 import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerException;
 import org.apache.flink.runtime.resourcemanager.exceptions.UnknownTaskExecutorException;
+import org.apache.flink.runtime.resourcemanager.health.NoOpNodeHealthManager;
+import org.apache.flink.runtime.resourcemanager.health.NodeHealthManager;
 import org.apache.flink.runtime.resourcemanager.registration.JobManagerRegistration;
 import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
 import org.apache.flink.runtime.resourcemanager.registration.WorkerRegistration;
@@ -174,6 +176,8 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 
     private final AtomicReference<byte[]> latestTokens = new AtomicReference<>();
 
+    private final NodeHealthManager nodeHealthManager;
+
     private final ResourceAllocator resourceAllocator;
 
     public ResourceManager(
@@ -241,6 +245,8 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
         this.startedFuture = new CompletableFuture<>();
 
         this.delegationTokenManager = delegationTokenManager;
+
+        this.nodeHealthManager = new NoOpNodeHealthManager();
 
         this.resourceAllocator = getResourceAllocator();
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/health/DefaultNodeHealthManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/health/DefaultNodeHealthManager.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.health;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.util.Preconditions;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Default implementation of {@link NodeHealthManager}.
+ *
+ * <p>This implementation maintains a thread-safe map of quarantined nodes and provides
+ * functionality to check node health, mark nodes as quarantined, remove quarantine, list all
+ * statuses, and clean up expired entries.
+ */
+public class DefaultNodeHealthManager implements NodeHealthManager {
+
+    /** Map storing node health statuses keyed by resource ID. */
+    private final ConcurrentMap<ResourceID, NodeHealthStatus> quarantinedNodes;
+
+    /** Creates a new DefaultNodeHealthManager. */
+    public DefaultNodeHealthManager() {
+        this.quarantinedNodes = new ConcurrentHashMap<>();
+    }
+
+    @Override
+    public boolean isHealthy(ResourceID resourceID) {
+        Preconditions.checkNotNull(resourceID, "resourceID must not be null");
+
+        NodeHealthStatus status = quarantinedNodes.get(resourceID);
+        if (status == null) {
+            // Node not in quarantine - healthy
+            return true;
+        }
+
+        // Check if quarantine has expired
+        long now = System.currentTimeMillis();
+        if (status.isExpired(now)) {
+            // Clean up expired entry and consider healthy
+            quarantinedNodes.remove(resourceID, status);
+            return true;
+        }
+
+        // Node is quarantined and not expired - unhealthy
+        return false;
+    }
+
+    @Override
+    public void markQuarantined(
+            ResourceID resourceID, String hostname, String reason, Duration duration) {
+        Preconditions.checkNotNull(resourceID, "resourceID must not be null");
+        Preconditions.checkNotNull(hostname, "hostname must not be null");
+        Preconditions.checkNotNull(reason, "reason must not be null");
+        Preconditions.checkNotNull(duration, "duration must not be null");
+        Preconditions.checkArgument(!duration.isNegative(), "duration must be non-negative");
+
+        long now = System.currentTimeMillis();
+        long expirationTimestamp = now + duration.toMillis();
+
+        NodeHealthStatus newStatus =
+                new NodeHealthStatus(resourceID, hostname, reason, now, expirationTimestamp);
+
+        quarantinedNodes.put(resourceID, newStatus);
+    }
+
+    @Override
+    public void removeQuarantine(ResourceID resourceID) {
+        Preconditions.checkNotNull(resourceID, "resourceID must not be null");
+
+        quarantinedNodes.remove(resourceID);
+    }
+
+    @Override
+    public Collection<NodeHealthStatus> listAll() {
+        // Return a snapshot of the current status
+        return new ArrayList<>(quarantinedNodes.values());
+    }
+
+    @Override
+    public void cleanupExpired() {
+        long now = System.currentTimeMillis();
+
+        // Remove all expired entries
+        quarantinedNodes.entrySet().removeIf(entry -> entry.getValue().isExpired(now));
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/health/NoOpNodeHealthManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/health/NoOpNodeHealthManager.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.health;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * A no-operation implementation of {@link NodeHealthManager}.
+ *
+ * <p>This implementation always considers nodes healthy and performs no actual operations. It's
+ * useful for scenarios where node health management is disabled.
+ */
+public class NoOpNodeHealthManager implements NodeHealthManager {
+
+    @Override
+    public boolean isHealthy(ResourceID resourceID) {
+        // Always healthy for no-op implementation
+        return true;
+    }
+
+    @Override
+    public void markQuarantined(
+            ResourceID resourceID, String hostname, String reason, Duration duration) {
+        // No-op: do nothing
+    }
+
+    @Override
+    public void removeQuarantine(ResourceID resourceID) {
+        // No-op: do nothing
+    }
+
+    @Override
+    public Collection<NodeHealthStatus> listAll() {
+        // Return empty collection
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void cleanupExpired() {
+        // No-op: do nothing
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/health/NodeHealthManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/health/NodeHealthManager.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.health;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+
+import java.time.Duration;
+import java.util.Collection;
+
+/**
+ * Interface for managing node health status and quarantine.
+ *
+ * <p>This interface provides mechanisms to check node health, mark nodes as quarantined, remove
+ * quarantine, and list all node health statuses.
+ */
+public interface NodeHealthManager {
+
+    /**
+     * Checks if a node with the given resource ID is healthy.
+     *
+     * @param resourceID the resource ID of the node
+     * @return true if the node is healthy, false otherwise
+     */
+    boolean isHealthy(ResourceID resourceID);
+
+    /**
+     * Marks a node as quarantined for a specified duration.
+     *
+     * @param resourceID the resource ID of the node
+     * @param hostname the hostname of the node
+     * @param reason the reason for quarantining
+     * @param duration the duration of the quarantine
+     */
+    void markQuarantined(ResourceID resourceID, String hostname, String reason, Duration duration);
+
+    /**
+     * Removes the quarantine from a node.
+     *
+     * @param resourceID the resource ID of the node
+     */
+    void removeQuarantine(ResourceID resourceID);
+
+    /**
+     * Lists all node health statuses.
+     *
+     * @return a collection of all node health statuses
+     */
+    Collection<NodeHealthStatus> listAll();
+
+    /** Cleans up expired quarantine entries. */
+    void cleanupExpired();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/health/NodeHealthStatus.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/health/NodeHealthStatus.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.health;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+
+import javax.annotation.Nullable;
+
+import java.util.Objects;
+
+/**
+ * Represents the health status of a node.
+ *
+ * <p>This class holds information about a node's quarantine status including the resource ID,
+ * hostname, reason for quarantine, quarantine timestamp, and expiration timestamp.
+ */
+public class NodeHealthStatus {
+
+    private final ResourceID resourceID;
+    private final String hostname;
+    private final String reason;
+    private final long quarantineTimestamp;
+    private final long expirationTimestamp;
+
+    /**
+     * Creates a new NodeHealthStatus.
+     *
+     * @param resourceID the resource ID of the node
+     * @param hostname the hostname of the node
+     * @param reason the reason for quarantining
+     * @param quarantineTimestamp the timestamp when the node was quarantined
+     * @param expirationTimestamp the timestamp when the quarantine expires
+     */
+    public NodeHealthStatus(
+            ResourceID resourceID,
+            String hostname,
+            String reason,
+            long quarantineTimestamp,
+            long expirationTimestamp) {
+        this.resourceID = Objects.requireNonNull(resourceID, "resourceID must not be null");
+        this.hostname = Objects.requireNonNull(hostname, "hostname must not be null");
+        this.reason = Objects.requireNonNull(reason, "reason must not be null");
+        this.quarantineTimestamp = quarantineTimestamp;
+        this.expirationTimestamp = expirationTimestamp;
+    }
+
+    /**
+     * Returns the resource ID of the node.
+     *
+     * @return the resource ID
+     */
+    public ResourceID getResourceID() {
+        return resourceID;
+    }
+
+    /**
+     * Returns the hostname of the node.
+     *
+     * @return the hostname
+     */
+    public String getHostname() {
+        return hostname;
+    }
+
+    /**
+     * Returns the reason for quarantining.
+     *
+     * @return the reason
+     */
+    public String getReason() {
+        return reason;
+    }
+
+    /**
+     * Returns the timestamp when the node was quarantined.
+     *
+     * @return the quarantine timestamp
+     */
+    public long getQuarantineTimestamp() {
+        return quarantineTimestamp;
+    }
+
+    /**
+     * Returns the timestamp when the quarantine expires.
+     *
+     * @return the expiration timestamp
+     */
+    public long getExpirationTimestamp() {
+        return expirationTimestamp;
+    }
+
+    /**
+     * Checks if the quarantine has expired.
+     *
+     * @param now the current timestamp in milliseconds
+     * @return true if the quarantine has expired, false otherwise
+     */
+    public boolean isExpired(long now) {
+        return now >= expirationTimestamp;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        NodeHealthStatus that = (NodeHealthStatus) o;
+        return quarantineTimestamp == that.quarantineTimestamp
+                && expirationTimestamp == that.expirationTimestamp
+                && Objects.equals(resourceID, that.resourceID)
+                && Objects.equals(hostname, that.hostname)
+                && Objects.equals(reason, that.reason);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(resourceID, hostname, reason, quarantineTimestamp, expirationTimestamp);
+    }
+
+    @Override
+    public String toString() {
+        return "NodeHealthStatus{"
+                + "resourceID="
+                + resourceID
+                + ", hostname='"
+                + hostname
+                + '\''
+                + ", reason='"
+                + reason
+                + '\''
+                + ", quarantineTimestamp="
+                + quarantineTimestamp
+                + ", expirationTimestamp="
+                + expirationTimestamp
+                + '}';
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/health/NodeHealthManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/health/NodeHealthManagerTest.java
@@ -1,0 +1,297 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.health;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for the {@link NodeHealthManager} interface and its implementations. */
+public class NodeHealthManagerTest {
+
+    private static final ResourceID RESOURCE_ID_1 = new ResourceID("resource-1");
+    private static final ResourceID RESOURCE_ID_2 = new ResourceID("resource-2");
+    private static final ResourceID RESOURCE_ID_3 = new ResourceID("resource-3");
+    private static final String HOSTNAME_1 = "host-1";
+    private static final String HOSTNAME_2 = "host-2";
+    private static final String REASON = "test reason";
+    private static final Duration DURATION = Duration.ofMinutes(30);
+
+    @Test
+    void testNoOpNodeHealthManagerAlwaysHealthy() {
+        final NodeHealthManager manager = new NoOpNodeHealthManager();
+
+        // All nodes should be reported as healthy by NoOpNodeHealthManager
+        assertThat(manager.isHealthy(RESOURCE_ID_1)).isTrue();
+        assertThat(manager.isHealthy(RESOURCE_ID_2)).isTrue();
+        assertThat(manager.isHealthy(RESOURCE_ID_3)).isTrue();
+    }
+
+    @Test
+    void testDefaultNodeHealthManagerInitialState() {
+        final DefaultNodeHealthManager manager = new DefaultNodeHealthManager();
+
+        // All nodes should be healthy by default
+        assertThat(manager.isHealthy(RESOURCE_ID_1)).isTrue();
+        assertThat(manager.isHealthy(RESOURCE_ID_2)).isTrue();
+        assertThat(manager.isHealthy(RESOURCE_ID_3)).isTrue();
+    }
+
+    @Test
+    void testDefaultNodeHealthManagerMarkQuarantined() {
+        final DefaultNodeHealthManager manager = new DefaultNodeHealthManager();
+
+        // Mark a node as quarantined
+        manager.markQuarantined(RESOURCE_ID_1, HOSTNAME_1, REASON, DURATION);
+
+        // The marked node should be unhealthy
+        assertThat(manager.isHealthy(RESOURCE_ID_1)).isFalse();
+        // Other nodes should remain healthy
+        assertThat(manager.isHealthy(RESOURCE_ID_2)).isTrue();
+    }
+
+    @Test
+    void testDefaultNodeHealthManagerRemoveQuarantine() {
+        final DefaultNodeHealthManager manager = new DefaultNodeHealthManager();
+
+        // Mark a node as quarantined
+        manager.markQuarantined(RESOURCE_ID_1, HOSTNAME_1, REASON, DURATION);
+        assertThat(manager.isHealthy(RESOURCE_ID_1)).isFalse();
+
+        // Remove quarantine from the node
+        manager.removeQuarantine(RESOURCE_ID_1);
+        assertThat(manager.isHealthy(RESOURCE_ID_1)).isTrue();
+    }
+
+    @Test
+    void testDefaultNodeHealthManagerMultipleNodes() {
+        final DefaultNodeHealthManager manager = new DefaultNodeHealthManager();
+
+        // Mark multiple nodes as quarantined
+        manager.markQuarantined(RESOURCE_ID_1, HOSTNAME_1, REASON, DURATION);
+        manager.markQuarantined(RESOURCE_ID_2, HOSTNAME_2, REASON, DURATION);
+
+        assertThat(manager.isHealthy(RESOURCE_ID_1)).isFalse();
+        assertThat(manager.isHealthy(RESOURCE_ID_2)).isFalse();
+        assertThat(manager.isHealthy(RESOURCE_ID_3)).isTrue();
+    }
+
+    @Test
+    void testDefaultNodeHealthManagerListAll() {
+        final DefaultNodeHealthManager manager = new DefaultNodeHealthManager();
+
+        // Initially, no nodes should be quarantined
+        Collection<NodeHealthStatus> statuses = manager.listAll();
+        assertThat(statuses).isEmpty();
+
+        // Mark a node as quarantined
+        manager.markQuarantined(RESOURCE_ID_1, HOSTNAME_1, REASON, DURATION);
+
+        // Should have one quarantined node
+        statuses = manager.listAll();
+        assertThat(statuses).hasSize(1);
+        NodeHealthStatus status = statuses.iterator().next();
+        assertThat(status.getResourceID()).isEqualTo(RESOURCE_ID_1);
+        assertThat(status.getHostname()).isEqualTo(HOSTNAME_1);
+        assertThat(status.getReason()).isEqualTo(REASON);
+
+        // Mark another node as quarantined
+        manager.markQuarantined(RESOURCE_ID_2, HOSTNAME_2, REASON, DURATION);
+
+        // Should have two quarantined nodes
+        statuses = manager.listAll();
+        assertThat(statuses).hasSize(2);
+
+        // Remove quarantine from one node
+        manager.removeQuarantine(RESOURCE_ID_1);
+
+        // Should have one quarantined node left
+        statuses = manager.listAll();
+        assertThat(statuses).hasSize(1);
+        status = statuses.iterator().next();
+        assertThat(status.getResourceID()).isEqualTo(RESOURCE_ID_2);
+    }
+
+    @Test
+    void testDefaultNodeHealthManagerRemoveQuarantineFromNeverQuarantinedNode() {
+        final DefaultNodeHealthManager manager = new DefaultNodeHealthManager();
+
+        // Remove quarantine from a node that was never quarantined
+        // This should be a no-op, node should remain healthy
+        manager.removeQuarantine(RESOURCE_ID_1);
+        assertThat(manager.isHealthy(RESOURCE_ID_1)).isTrue();
+    }
+
+    @Test
+    void testDefaultNodeHealthManagerCleanupExpired() {
+        final DefaultNodeHealthManager manager = new DefaultNodeHealthManager();
+
+        // Mark nodes as quarantined with very short durations
+        manager.markQuarantined(RESOURCE_ID_1, HOSTNAME_1, REASON, Duration.ofMillis(100));
+        manager.markQuarantined(RESOURCE_ID_2, HOSTNAME_2, REASON, Duration.ofHours(1));
+
+        assertThat(manager.isHealthy(RESOURCE_ID_1)).isFalse();
+        assertThat(manager.isHealthy(RESOURCE_ID_2)).isFalse();
+
+        // Wait for first quarantine to expire
+        try {
+            Thread.sleep(150);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        // Cleanup expired quarantines
+        manager.cleanupExpired();
+
+        // First node should be healthy again, second should still be quarantined
+        assertThat(manager.isHealthy(RESOURCE_ID_1)).isTrue();
+        assertThat(manager.isHealthy(RESOURCE_ID_2)).isFalse();
+
+        Collection<NodeHealthStatus> statuses = manager.listAll();
+        assertThat(statuses).hasSize(1);
+        assertThat(statuses.iterator().next().getResourceID()).isEqualTo(RESOURCE_ID_2);
+    }
+
+    @Test
+    void testNoOpNodeHealthManagerListAllAndCleanup() {
+        final NodeHealthManager manager = new NoOpNodeHealthManager();
+
+        // NoOpNodeHealthManager should always return empty list
+        assertThat(manager.listAll()).isEmpty();
+
+        // Cleanup should be a no-op
+        manager.cleanupExpired();
+        assertThat(manager.listAll()).isEmpty();
+
+        // Mark and remove should be no-ops
+        manager.markQuarantined(RESOURCE_ID_1, HOSTNAME_1, REASON, DURATION);
+        assertThat(manager.isHealthy(RESOURCE_ID_1)).isTrue();
+        assertThat(manager.listAll()).isEmpty();
+
+        manager.removeQuarantine(RESOURCE_ID_1);
+        assertThat(manager.isHealthy(RESOURCE_ID_1)).isTrue();
+    }
+
+    @Test
+    void testNodeHealthStatus() {
+        final long quarantineTimestamp = System.currentTimeMillis();
+        final long expirationTimestamp = quarantineTimestamp + Duration.ofHours(1).toMillis();
+
+        final NodeHealthStatus status1 =
+                new NodeHealthStatus(
+                        RESOURCE_ID_1,
+                        HOSTNAME_1,
+                        REASON,
+                        quarantineTimestamp,
+                        expirationTimestamp);
+        final NodeHealthStatus status2 =
+                new NodeHealthStatus(
+                        RESOURCE_ID_2,
+                        HOSTNAME_2,
+                        REASON,
+                        quarantineTimestamp,
+                        expirationTimestamp);
+
+        assertThat(status1.getResourceID()).isEqualTo(RESOURCE_ID_1);
+        assertThat(status1.getHostname()).isEqualTo(HOSTNAME_1);
+        assertThat(status1.getReason()).isEqualTo(REASON);
+        assertThat(status1.getQuarantineTimestamp()).isEqualTo(quarantineTimestamp);
+        assertThat(status1.getExpirationTimestamp()).isEqualTo(expirationTimestamp);
+
+        assertThat(status2.getResourceID()).isEqualTo(RESOURCE_ID_2);
+        assertThat(status2.getHostname()).isEqualTo(HOSTNAME_2);
+    }
+
+    @Test
+    void testNodeHealthStatusIsExpired() {
+        final long quarantineTimestamp =
+                System.currentTimeMillis() - Duration.ofHours(2).toMillis();
+        final long expirationTimestamp =
+                System.currentTimeMillis() - Duration.ofHours(1).toMillis();
+
+        final NodeHealthStatus status =
+                new NodeHealthStatus(
+                        RESOURCE_ID_1,
+                        HOSTNAME_1,
+                        REASON,
+                        quarantineTimestamp,
+                        expirationTimestamp);
+
+        // The quarantine should be expired
+        assertThat(status.isExpired(System.currentTimeMillis())).isTrue();
+        // The quarantine should not be expired at the quarantine timestamp
+        assertThat(status.isExpired(quarantineTimestamp)).isFalse();
+    }
+
+    @Test
+    void testNodeHealthStatusEqualsAndHashCode() {
+        final long quarantineTimestamp = System.currentTimeMillis();
+        final long expirationTimestamp = quarantineTimestamp + Duration.ofHours(1).toMillis();
+
+        final NodeHealthStatus status1a =
+                new NodeHealthStatus(
+                        RESOURCE_ID_1,
+                        HOSTNAME_1,
+                        REASON,
+                        quarantineTimestamp,
+                        expirationTimestamp);
+        final NodeHealthStatus status1b =
+                new NodeHealthStatus(
+                        RESOURCE_ID_1,
+                        HOSTNAME_1,
+                        REASON,
+                        quarantineTimestamp,
+                        expirationTimestamp);
+        final NodeHealthStatus status2 =
+                new NodeHealthStatus(
+                        RESOURCE_ID_2,
+                        HOSTNAME_2,
+                        REASON,
+                        quarantineTimestamp,
+                        expirationTimestamp);
+
+        assertThat(status1a).isEqualTo(status1b);
+        assertThat(status1a).isNotEqualTo(status2);
+        assertThat(status1a.hashCode()).isEqualTo(status1b.hashCode());
+    }
+
+    @Test
+    void testNodeHealthStatusToString() {
+        final long quarantineTimestamp = System.currentTimeMillis();
+        final long expirationTimestamp = quarantineTimestamp + Duration.ofHours(1).toMillis();
+
+        final NodeHealthStatus status =
+                new NodeHealthStatus(
+                        RESOURCE_ID_1,
+                        HOSTNAME_1,
+                        REASON,
+                        quarantineTimestamp,
+                        expirationTimestamp);
+
+        final String toString = status.toString();
+        assertThat(toString).contains(RESOURCE_ID_1.toString());
+        assertThat(toString).contains(HOSTNAME_1);
+        assertThat(toString).contains(REASON);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This is PR-1 in the [FLINK-39176](https://issues.apache.org/jira/browse/FLINK-39176) series: **Node Health Management & Quarantine Framework**.

This PR introduces the NodeHealthManager abstraction layer as the first phase of implementing a generic blacklist mechanism for compute nodes in Flink. The abstraction allows pluggable node health management strategies while maintaining backward compatibility by defaulting to a No-Op implementation.

<img width="1536" height="1024" alt="image" src="https://github.com/user-attachments/assets/8575046e-94ff-4e4d-9845-e3dad51fbe47" />


### PR Series Overview

This feature is implemented across 6 PRs, each independently reviewable and mergeable:

| PR | Title | Link |
|----|-------|------|
| **PR-1** | **Introduce NodeHealthManager Abstraction** | **This PR** |
| PR-2 | Integrate NodeHealthManager with Slot Filtering | [#27711](https://github.com/apache/flink/pull/27711) |
| PR-3 | Add REST API for Node Quarantine | [#27712](https://github.com/apache/flink/pull/27712) |
| PR-4 | Configuration Support for Node Quarantine | [#27714](https://github.com/apache/flink/pull/27714) |
| PR-5 | Expiration Cleanup Scheduler | [#27715](https://github.com/apache/flink/pull/27715) |
| PR-6 | Web UI Node Health Page | [#27716](https://github.com/apache/flink/pull/27716) |

## Brief change log

* Introduced `NodeHealthManager` interface to define the contract for node health management
* Added `NodeHealthStatus` data class to represent node health information
* Implemented `NoOpNodeHealthManager` that treats all nodes as healthy (default behavior)
* Implemented `DefaultNodeHealthManager` that manages node health states using `ConcurrentHashMap`
* Integrated `NodeHealthManager` into `ResourceManager` as a member variable
* Added comprehensive unit tests in `NodeHealthManagerTest`

## Verifying this change

* Added `NodeHealthManagerTest` with 9 test cases covering all core functionalities
* Tests verify:
  - No-Op implementation always returns healthy status
  - Default implementation correctly manages node health states
  - Concurrent access scenarios
  - Health status retrieval and updates

* All unit tests pass successfully (13 tests)

## Does this pull request potentially affect one of the following parts

* Dependencies: No
* The public API: No (internal API)
* The runtime per-record code paths: No
* The state snapshotting: No
* The state backends: No
* The message passing between components: No
* The allocation of resources: No
* The logging behavior: No
* The connector ecosystem: No

## Documentation

This is an internal refactoring change. No documentation updates are required as the feature is not exposed to users yet. Documentation will be added in subsequent PRs when the blacklist mechanism is fully implemented and exposed to users.
