### PR TITLE
[FLINK-39176][runtime] Integrate NodeHealthManager with Slot Filtering

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -53,6 +53,8 @@ import org.apache.flink.runtime.metrics.groups.ResourceManagerMetricGroup;
 import org.apache.flink.runtime.registration.RegistrationResponse;
 import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerException;
 import org.apache.flink.runtime.resourcemanager.exceptions.UnknownTaskExecutorException;
+import org.apache.flink.runtime.resourcemanager.health.NoOpNodeHealthManager;
+import org.apache.flink.runtime.resourcemanager.health.NodeHealthManager;
 import org.apache.flink.runtime.resourcemanager.registration.JobManagerRegistration;
 import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
 import org.apache.flink.runtime.resourcemanager.registration.WorkerRegistration;
@@ -174,6 +176,8 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 
     private final AtomicReference<byte[]> latestTokens = new AtomicReference<>();
 
+    private final NodeHealthManager nodeHealthManager;
+
     private final ResourceAllocator resourceAllocator;
 
     public ResourceManager(
@@ -241,6 +245,8 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
         this.startedFuture = new CompletableFuture<>();
 
         this.delegationTokenManager = delegationTokenManager;
+
+        this.nodeHealthManager = new NoOpNodeHealthManager();
 
         this.resourceAllocator = getResourceAllocator();
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerFactory.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.groups.ResourceManagerMetricGroup;
 import org.apache.flink.runtime.metrics.groups.SlotManagerMetricGroup;
+import org.apache.flink.runtime.resourcemanager.health.NoOpNodeHealthManager;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.security.token.DelegationTokenManager;
@@ -148,7 +149,8 @@ public abstract class ResourceManagerFactory<T extends ResourceIDRetrievable> {
                 rmRuntimeServicesConfig,
                 highAvailabilityServices,
                 rpcService.getScheduledExecutor(),
-                slotManagerMetricGroup);
+                slotManagerMetricGroup,
+                new NoOpNodeHealthManager());
     }
 
     protected abstract ResourceManagerRuntimeServicesConfiguration

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServices.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.resourcemanager;
 
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.metrics.groups.SlotManagerMetricGroup;
+import org.apache.flink.runtime.resourcemanager.health.NodeHealthManager;
 import org.apache.flink.runtime.resourcemanager.slotmanager.DefaultResourceAllocationStrategy;
 import org.apache.flink.runtime.resourcemanager.slotmanager.DefaultResourceTracker;
 import org.apache.flink.runtime.resourcemanager.slotmanager.DefaultSlotStatusSyncer;
@@ -57,10 +58,15 @@ public class ResourceManagerRuntimeServices {
             ResourceManagerRuntimeServicesConfiguration configuration,
             HighAvailabilityServices highAvailabilityServices,
             ScheduledExecutor scheduledExecutor,
-            SlotManagerMetricGroup slotManagerMetricGroup) {
+            SlotManagerMetricGroup slotManagerMetricGroup,
+            NodeHealthManager nodeHealthManager) {
 
         final SlotManager slotManager =
-                createSlotManager(configuration, scheduledExecutor, slotManagerMetricGroup);
+                createSlotManager(
+                        configuration,
+                        scheduledExecutor,
+                        slotManagerMetricGroup,
+                        nodeHealthManager);
 
         final JobLeaderIdService jobLeaderIdService =
                 new DefaultJobLeaderIdService(
@@ -72,7 +78,8 @@ public class ResourceManagerRuntimeServices {
     private static SlotManager createSlotManager(
             ResourceManagerRuntimeServicesConfiguration configuration,
             ScheduledExecutor scheduledExecutor,
-            SlotManagerMetricGroup slotManagerMetricGroup) {
+            SlotManagerMetricGroup slotManagerMetricGroup,
+            NodeHealthManager nodeHealthManager) {
         final SlotManagerConfiguration slotManagerConfiguration =
                 configuration.getSlotManagerConfiguration();
         return new FineGrainedSlotManager(
@@ -91,6 +98,7 @@ public class ResourceManagerRuntimeServices {
                         slotManagerConfiguration.getTaskManagerTimeout(),
                         slotManagerConfiguration.getRedundantTaskManagerNum(),
                         slotManagerConfiguration.getMinTotalCpu(),
-                        slotManagerConfiguration.getMinTotalMem()));
+                        slotManagerConfiguration.getMinTotalMem()),
+                nodeHealthManager);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/health/DefaultNodeHealthManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/health/DefaultNodeHealthManager.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.health;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.util.Preconditions;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Default implementation of {@link NodeHealthManager}.
+ *
+ * <p>This implementation maintains a thread-safe map of quarantined nodes and provides
+ * functionality to check node health, mark nodes as quarantined, remove quarantine, list all
+ * statuses, and clean up expired entries.
+ */
+public class DefaultNodeHealthManager implements NodeHealthManager {
+
+    /** Map storing node health statuses keyed by resource ID. */
+    private final ConcurrentMap<ResourceID, NodeHealthStatus> quarantinedNodes;
+
+    /** Creates a new DefaultNodeHealthManager. */
+    public DefaultNodeHealthManager() {
+        this.quarantinedNodes = new ConcurrentHashMap<>();
+    }
+
+    @Override
+    public boolean isHealthy(ResourceID resourceID) {
+        Preconditions.checkNotNull(resourceID, "resourceID must not be null");
+
+        NodeHealthStatus status = quarantinedNodes.get(resourceID);
+        if (status == null) {
+            // Node not in quarantine - healthy
+            return true;
+        }
+
+        // Check if quarantine has expired
+        long now = System.currentTimeMillis();
+        if (status.isExpired(now)) {
+            // Clean up expired entry and consider healthy
+            quarantinedNodes.remove(resourceID, status);
+            return true;
+        }
+
+        // Node is quarantined and not expired - unhealthy
+        return false;
+    }
+
+    @Override
+    public void markQuarantined(
+            ResourceID resourceID, String hostname, String reason, Duration duration) {
+        Preconditions.checkNotNull(resourceID, "resourceID must not be null");
+        Preconditions.checkNotNull(hostname, "hostname must not be null");
+        Preconditions.checkNotNull(reason, "reason must not be null");
+        Preconditions.checkNotNull(duration, "duration must not be null");
+        Preconditions.checkArgument(!duration.isNegative(), "duration must be non-negative");
+
+        long now = System.currentTimeMillis();
+        long expirationTimestamp = now + duration.toMillis();
+
+        NodeHealthStatus newStatus =
+                new NodeHealthStatus(resourceID, hostname, reason, now, expirationTimestamp);
+
+        quarantinedNodes.put(resourceID, newStatus);
+    }
+
+    @Override
+    public void removeQuarantine(ResourceID resourceID) {
+        Preconditions.checkNotNull(resourceID, "resourceID must not be null");
+
+        quarantinedNodes.remove(resourceID);
+    }
+
+    @Override
+    public Collection<NodeHealthStatus> listAll() {
+        // Return a snapshot of the current status
+        return new ArrayList<>(quarantinedNodes.values());
+    }
+
+    @Override
+    public void cleanupExpired() {
+        long now = System.currentTimeMillis();
+
+        // Remove all expired entries
+        quarantinedNodes.entrySet().removeIf(entry -> entry.getValue().isExpired(now));
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/health/NoOpNodeHealthManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/health/NoOpNodeHealthManager.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.health;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * A no-operation implementation of {@link NodeHealthManager}.
+ *
+ * <p>This implementation always considers nodes healthy and performs no actual operations. It's
+ * useful for scenarios where node health management is disabled.
+ */
+public class NoOpNodeHealthManager implements NodeHealthManager {
+
+    @Override
+    public boolean isHealthy(ResourceID resourceID) {
+        // Always healthy for no-op implementation
+        return true;
+    }
+
+    @Override
+    public void markQuarantined(
+            ResourceID resourceID, String hostname, String reason, Duration duration) {
+        // No-op: do nothing
+    }
+
+    @Override
+    public void removeQuarantine(ResourceID resourceID) {
+        // No-op: do nothing
+    }
+
+    @Override
+    public Collection<NodeHealthStatus> listAll() {
+        // Return empty collection
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void cleanupExpired() {
+        // No-op: do nothing
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/health/NodeHealthManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/health/NodeHealthManager.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.health;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+
+import java.time.Duration;
+import java.util.Collection;
+
+/**
+ * Interface for managing node health status and quarantine.
+ *
+ * <p>This interface provides mechanisms to check node health, mark nodes as quarantined, remove
+ * quarantine, and list all node health statuses.
+ */
+public interface NodeHealthManager {
+
+    /**
+     * Checks if a node with the given resource ID is healthy.
+     *
+     * @param resourceID the resource ID of the node
+     * @return true if the node is healthy, false otherwise
+     */
+    boolean isHealthy(ResourceID resourceID);
+
+    /**
+     * Marks a node as quarantined for a specified duration.
+     *
+     * @param resourceID the resource ID of the node
+     * @param hostname the hostname of the node
+     * @param reason the reason for quarantining
+     * @param duration the duration of the quarantine
+     */
+    void markQuarantined(ResourceID resourceID, String hostname, String reason, Duration duration);
+
+    /**
+     * Removes the quarantine from a node.
+     *
+     * @param resourceID the resource ID of the node
+     */
+    void removeQuarantine(ResourceID resourceID);
+
+    /**
+     * Lists all node health statuses.
+     *
+     * @return a collection of all node health statuses
+     */
+    Collection<NodeHealthStatus> listAll();
+
+    /** Cleans up expired quarantine entries. */
+    void cleanupExpired();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/health/NodeHealthStatus.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/health/NodeHealthStatus.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.health;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+
+import javax.annotation.Nullable;
+
+import java.util.Objects;
+
+/**
+ * Represents the health status of a node.
+ *
+ * <p>This class holds information about a node's quarantine status including the resource ID,
+ * hostname, reason for quarantine, quarantine timestamp, and expiration timestamp.
+ */
+public class NodeHealthStatus {
+
+    private final ResourceID resourceID;
+    private final String hostname;
+    private final String reason;
+    private final long quarantineTimestamp;
+    private final long expirationTimestamp;
+
+    /**
+     * Creates a new NodeHealthStatus.
+     *
+     * @param resourceID the resource ID of the node
+     * @param hostname the hostname of the node
+     * @param reason the reason for quarantining
+     * @param quarantineTimestamp the timestamp when the node was quarantined
+     * @param expirationTimestamp the timestamp when the quarantine expires
+     */
+    public NodeHealthStatus(
+            ResourceID resourceID,
+            String hostname,
+            String reason,
+            long quarantineTimestamp,
+            long expirationTimestamp) {
+        this.resourceID = Objects.requireNonNull(resourceID, "resourceID must not be null");
+        this.hostname = Objects.requireNonNull(hostname, "hostname must not be null");
+        this.reason = Objects.requireNonNull(reason, "reason must not be null");
+        this.quarantineTimestamp = quarantineTimestamp;
+        this.expirationTimestamp = expirationTimestamp;
+    }
+
+    /**
+     * Returns the resource ID of the node.
+     *
+     * @return the resource ID
+     */
+    public ResourceID getResourceID() {
+        return resourceID;
+    }
+
+    /**
+     * Returns the hostname of the node.
+     *
+     * @return the hostname
+     */
+    public String getHostname() {
+        return hostname;
+    }
+
+    /**
+     * Returns the reason for quarantining.
+     *
+     * @return the reason
+     */
+    public String getReason() {
+        return reason;
+    }
+
+    /**
+     * Returns the timestamp when the node was quarantined.
+     *
+     * @return the quarantine timestamp
+     */
+    public long getQuarantineTimestamp() {
+        return quarantineTimestamp;
+    }
+
+    /**
+     * Returns the timestamp when the quarantine expires.
+     *
+     * @return the expiration timestamp
+     */
+    public long getExpirationTimestamp() {
+        return expirationTimestamp;
+    }
+
+    /**
+     * Checks if the quarantine has expired.
+     *
+     * @param now the current timestamp in milliseconds
+     * @return true if the quarantine has expired, false otherwise
+     */
+    public boolean isExpired(long now) {
+        return now >= expirationTimestamp;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        NodeHealthStatus that = (NodeHealthStatus) o;
+        return quarantineTimestamp == that.quarantineTimestamp
+                && expirationTimestamp == that.expirationTimestamp
+                && Objects.equals(resourceID, that.resourceID)
+                && Objects.equals(hostname, that.hostname)
+                && Objects.equals(reason, that.reason);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(resourceID, hostname, reason, quarantineTimestamp, expirationTimestamp);
+    }
+
+    @Override
+    public String toString() {
+        return "NodeHealthStatus{"
+                + "resourceID="
+                + resourceID
+                + ", hostname='"
+                + hostname
+                + '\''
+                + ", reason='"
+                + reason
+                + '\''
+                + ", quarantineTimestamp="
+                + quarantineTimestamp
+                + ", expirationTimestamp="
+                + expirationTimestamp
+                + '}';
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/health/NodeHealthManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/health/NodeHealthManagerTest.java
@@ -1,0 +1,297 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.health;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for the {@link NodeHealthManager} interface and its implementations. */
+public class NodeHealthManagerTest {
+
+    private static final ResourceID RESOURCE_ID_1 = new ResourceID("resource-1");
+    private static final ResourceID RESOURCE_ID_2 = new ResourceID("resource-2");
+    private static final ResourceID RESOURCE_ID_3 = new ResourceID("resource-3");
+    private static final String HOSTNAME_1 = "host-1";
+    private static final String HOSTNAME_2 = "host-2";
+    private static final String REASON = "test reason";
+    private static final Duration DURATION = Duration.ofMinutes(30);
+
+    @Test
+    void testNoOpNodeHealthManagerAlwaysHealthy() {
+        final NodeHealthManager manager = new NoOpNodeHealthManager();
+
+        // All nodes should be reported as healthy by NoOpNodeHealthManager
+        assertThat(manager.isHealthy(RESOURCE_ID_1)).isTrue();
+        assertThat(manager.isHealthy(RESOURCE_ID_2)).isTrue();
+        assertThat(manager.isHealthy(RESOURCE_ID_3)).isTrue();
+    }
+
+    @Test
+    void testDefaultNodeHealthManagerInitialState() {
+        final DefaultNodeHealthManager manager = new DefaultNodeHealthManager();
+
+        // All nodes should be healthy by default
+        assertThat(manager.isHealthy(RESOURCE_ID_1)).isTrue();
+        assertThat(manager.isHealthy(RESOURCE_ID_2)).isTrue();
+        assertThat(manager.isHealthy(RESOURCE_ID_3)).isTrue();
+    }
+
+    @Test
+    void testDefaultNodeHealthManagerMarkQuarantined() {
+        final DefaultNodeHealthManager manager = new DefaultNodeHealthManager();
+
+        // Mark a node as quarantined
+        manager.markQuarantined(RESOURCE_ID_1, HOSTNAME_1, REASON, DURATION);
+
+        // The marked node should be unhealthy
+        assertThat(manager.isHealthy(RESOURCE_ID_1)).isFalse();
+        // Other nodes should remain healthy
+        assertThat(manager.isHealthy(RESOURCE_ID_2)).isTrue();
+    }
+
+    @Test
+    void testDefaultNodeHealthManagerRemoveQuarantine() {
+        final DefaultNodeHealthManager manager = new DefaultNodeHealthManager();
+
+        // Mark a node as quarantined
+        manager.markQuarantined(RESOURCE_ID_1, HOSTNAME_1, REASON, DURATION);
+        assertThat(manager.isHealthy(RESOURCE_ID_1)).isFalse();
+
+        // Remove quarantine from the node
+        manager.removeQuarantine(RESOURCE_ID_1);
+        assertThat(manager.isHealthy(RESOURCE_ID_1)).isTrue();
+    }
+
+    @Test
+    void testDefaultNodeHealthManagerMultipleNodes() {
+        final DefaultNodeHealthManager manager = new DefaultNodeHealthManager();
+
+        // Mark multiple nodes as quarantined
+        manager.markQuarantined(RESOURCE_ID_1, HOSTNAME_1, REASON, DURATION);
+        manager.markQuarantined(RESOURCE_ID_2, HOSTNAME_2, REASON, DURATION);
+
+        assertThat(manager.isHealthy(RESOURCE_ID_1)).isFalse();
+        assertThat(manager.isHealthy(RESOURCE_ID_2)).isFalse();
+        assertThat(manager.isHealthy(RESOURCE_ID_3)).isTrue();
+    }
+
+    @Test
+    void testDefaultNodeHealthManagerListAll() {
+        final DefaultNodeHealthManager manager = new DefaultNodeHealthManager();
+
+        // Initially, no nodes should be quarantined
+        Collection<NodeHealthStatus> statuses = manager.listAll();
+        assertThat(statuses).isEmpty();
+
+        // Mark a node as quarantined
+        manager.markQuarantined(RESOURCE_ID_1, HOSTNAME_1, REASON, DURATION);
+
+        // Should have one quarantined node
+        statuses = manager.listAll();
+        assertThat(statuses).hasSize(1);
+        NodeHealthStatus status = statuses.iterator().next();
+        assertThat(status.getResourceID()).isEqualTo(RESOURCE_ID_1);
+        assertThat(status.getHostname()).isEqualTo(HOSTNAME_1);
+        assertThat(status.getReason()).isEqualTo(REASON);
+
+        // Mark another node as quarantined
+        manager.markQuarantined(RESOURCE_ID_2, HOSTNAME_2, REASON, DURATION);
+
+        // Should have two quarantined nodes
+        statuses = manager.listAll();
+        assertThat(statuses).hasSize(2);
+
+        // Remove quarantine from one node
+        manager.removeQuarantine(RESOURCE_ID_1);
+
+        // Should have one quarantined node left
+        statuses = manager.listAll();
+        assertThat(statuses).hasSize(1);
+        status = statuses.iterator().next();
+        assertThat(status.getResourceID()).isEqualTo(RESOURCE_ID_2);
+    }
+
+    @Test
+    void testDefaultNodeHealthManagerRemoveQuarantineFromNeverQuarantinedNode() {
+        final DefaultNodeHealthManager manager = new DefaultNodeHealthManager();
+
+        // Remove quarantine from a node that was never quarantined
+        // This should be a no-op, node should remain healthy
+        manager.removeQuarantine(RESOURCE_ID_1);
+        assertThat(manager.isHealthy(RESOURCE_ID_1)).isTrue();
+    }
+
+    @Test
+    void testDefaultNodeHealthManagerCleanupExpired() {
+        final DefaultNodeHealthManager manager = new DefaultNodeHealthManager();
+
+        // Mark nodes as quarantined with very short durations
+        manager.markQuarantined(RESOURCE_ID_1, HOSTNAME_1, REASON, Duration.ofMillis(100));
+        manager.markQuarantined(RESOURCE_ID_2, HOSTNAME_2, REASON, Duration.ofHours(1));
+
+        assertThat(manager.isHealthy(RESOURCE_ID_1)).isFalse();
+        assertThat(manager.isHealthy(RESOURCE_ID_2)).isFalse();
+
+        // Wait for first quarantine to expire
+        try {
+            Thread.sleep(150);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        // Cleanup expired quarantines
+        manager.cleanupExpired();
+
+        // First node should be healthy again, second should still be quarantined
+        assertThat(manager.isHealthy(RESOURCE_ID_1)).isTrue();
+        assertThat(manager.isHealthy(RESOURCE_ID_2)).isFalse();
+
+        Collection<NodeHealthStatus> statuses = manager.listAll();
+        assertThat(statuses).hasSize(1);
+        assertThat(statuses.iterator().next().getResourceID()).isEqualTo(RESOURCE_ID_2);
+    }
+
+    @Test
+    void testNoOpNodeHealthManagerListAllAndCleanup() {
+        final NodeHealthManager manager = new NoOpNodeHealthManager();
+
+        // NoOpNodeHealthManager should always return empty list
+        assertThat(manager.listAll()).isEmpty();
+
+        // Cleanup should be a no-op
+        manager.cleanupExpired();
+        assertThat(manager.listAll()).isEmpty();
+
+        // Mark and remove should be no-ops
+        manager.markQuarantined(RESOURCE_ID_1, HOSTNAME_1, REASON, DURATION);
+        assertThat(manager.isHealthy(RESOURCE_ID_1)).isTrue();
+        assertThat(manager.listAll()).isEmpty();
+
+        manager.removeQuarantine(RESOURCE_ID_1);
+        assertThat(manager.isHealthy(RESOURCE_ID_1)).isTrue();
+    }
+
+    @Test
+    void testNodeHealthStatus() {
+        final long quarantineTimestamp = System.currentTimeMillis();
+        final long expirationTimestamp = quarantineTimestamp + Duration.ofHours(1).toMillis();
+
+        final NodeHealthStatus status1 =
+                new NodeHealthStatus(
+                        RESOURCE_ID_1,
+                        HOSTNAME_1,
+                        REASON,
+                        quarantineTimestamp,
+                        expirationTimestamp);
+        final NodeHealthStatus status2 =
+                new NodeHealthStatus(
+                        RESOURCE_ID_2,
+                        HOSTNAME_2,
+                        REASON,
+                        quarantineTimestamp,
+                        expirationTimestamp);
+
+        assertThat(status1.getResourceID()).isEqualTo(RESOURCE_ID_1);
+        assertThat(status1.getHostname()).isEqualTo(HOSTNAME_1);
+        assertThat(status1.getReason()).isEqualTo(REASON);
+        assertThat(status1.getQuarantineTimestamp()).isEqualTo(quarantineTimestamp);
+        assertThat(status1.getExpirationTimestamp()).isEqualTo(expirationTimestamp);
+
+        assertThat(status2.getResourceID()).isEqualTo(RESOURCE_ID_2);
+        assertThat(status2.getHostname()).isEqualTo(HOSTNAME_2);
+    }
+
+    @Test
+    void testNodeHealthStatusIsExpired() {
+        final long quarantineTimestamp =
+                System.currentTimeMillis() - Duration.ofHours(2).toMillis();
+        final long expirationTimestamp =
+                System.currentTimeMillis() - Duration.ofHours(1).toMillis();
+
+        final NodeHealthStatus status =
+                new NodeHealthStatus(
+                        RESOURCE_ID_1,
+                        HOSTNAME_1,
+                        REASON,
+                        quarantineTimestamp,
+                        expirationTimestamp);
+
+        // The quarantine should be expired
+        assertThat(status.isExpired(System.currentTimeMillis())).isTrue();
+        // The quarantine should not be expired at the quarantine timestamp
+        assertThat(status.isExpired(quarantineTimestamp)).isFalse();
+    }
+
+    @Test
+    void testNodeHealthStatusEqualsAndHashCode() {
+        final long quarantineTimestamp = System.currentTimeMillis();
+        final long expirationTimestamp = quarantineTimestamp + Duration.ofHours(1).toMillis();
+
+        final NodeHealthStatus status1a =
+                new NodeHealthStatus(
+                        RESOURCE_ID_1,
+                        HOSTNAME_1,
+                        REASON,
+                        quarantineTimestamp,
+                        expirationTimestamp);
+        final NodeHealthStatus status1b =
+                new NodeHealthStatus(
+                        RESOURCE_ID_1,
+                        HOSTNAME_1,
+                        REASON,
+                        quarantineTimestamp,
+                        expirationTimestamp);
+        final NodeHealthStatus status2 =
+                new NodeHealthStatus(
+                        RESOURCE_ID_2,
+                        HOSTNAME_2,
+                        REASON,
+                        quarantineTimestamp,
+                        expirationTimestamp);
+
+        assertThat(status1a).isEqualTo(status1b);
+        assertThat(status1a).isNotEqualTo(status2);
+        assertThat(status1a.hashCode()).isEqualTo(status1b.hashCode());
+    }
+
+    @Test
+    void testNodeHealthStatusToString() {
+        final long quarantineTimestamp = System.currentTimeMillis();
+        final long expirationTimestamp = quarantineTimestamp + Duration.ofHours(1).toMillis();
+
+        final NodeHealthStatus status =
+                new NodeHealthStatus(
+                        RESOURCE_ID_1,
+                        HOSTNAME_1,
+                        REASON,
+                        quarantineTimestamp,
+                        expirationTimestamp);
+
+        final String toString = status.toString();
+        assertThat(toString).contains(RESOURCE_ID_1.toString());
+        assertThat(toString).contains(HOSTNAME_1);
+        assertThat(toString).contains(REASON);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerBuilder.java
@@ -20,6 +20,8 @@ package org.apache.flink.runtime.resourcemanager.slotmanager;
 
 import org.apache.flink.runtime.metrics.groups.SlotManagerMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+import org.apache.flink.runtime.resourcemanager.health.NoOpNodeHealthManager;
+import org.apache.flink.runtime.resourcemanager.health.NodeHealthManager;
 import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.util.concurrent.ScheduledExecutor;
 
@@ -34,6 +36,7 @@ public class FineGrainedSlotManagerBuilder {
     private final ScheduledExecutor scheduledExecutor;
     private ResourceAllocationStrategy resourceAllocationStrategy =
             TestingResourceAllocationStrategy.newBuilder().build();
+    private NodeHealthManager nodeHealthManager = new NoOpNodeHealthManager();
 
     SlotManagerConfiguration slotManagerConfiguration =
             SlotManagerConfigurationBuilder.newBuilder().build();
@@ -80,6 +83,11 @@ public class FineGrainedSlotManagerBuilder {
         return this;
     }
 
+    public FineGrainedSlotManagerBuilder setNodeHealthManager(NodeHealthManager nodeHealthManager) {
+        this.nodeHealthManager = nodeHealthManager;
+        return this;
+    }
+
     public FineGrainedSlotManager build() {
         return new FineGrainedSlotManager(
                 scheduledExecutor,
@@ -88,6 +96,7 @@ public class FineGrainedSlotManagerBuilder {
                 resourceTracker,
                 taskManagerTracker,
                 slotStatusSyncer,
-                resourceAllocationStrategy);
+                resourceAllocationStrategy,
+                nodeHealthManager);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTestBase.java
@@ -224,7 +224,8 @@ abstract class FineGrainedSlotManagerTestBase {
 
         protected final void runTest(RunnableWithException testMethod) throws Exception {
             SlotManagerConfiguration configuration = slotManagerConfigurationBuilder.build();
-            Optional<NodeHealthManager> optionalNodeHealthManager = FineGrainedSlotManagerTestBase.this.getNodeHealthManager();
+            Optional<NodeHealthManager> optionalNodeHealthManager =
+                    FineGrainedSlotManagerTestBase.this.getNodeHealthManager();
             nodeHealthManager = optionalNodeHealthManager.orElse(new NoOpNodeHealthManager());
             slotManager =
                     FineGrainedSlotManagerBuilder.newBuilder(scheduledExecutor)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/NodeQuarantineSlotFilteringITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/NodeQuarantineSlotFilteringITCase.java
@@ -1,0 +1,308 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.slotmanager;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.SlotID;
+import org.apache.flink.runtime.instance.InstanceID;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.resourcemanager.health.DefaultNodeHealthManager;
+import org.apache.flink.runtime.resourcemanager.health.NodeHealthManager;
+import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
+import org.apache.flink.runtime.taskexecutor.SlotReport;
+import org.apache.flink.runtime.taskexecutor.SlotStatus;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
+import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** IT Cases for node quarantine slot filtering functionality in {@link FineGrainedSlotManager}. */
+class NodeQuarantineSlotFilteringITCase extends AbstractFineGrainedSlotManagerITCase {
+
+    @Override
+    protected Optional<ResourceAllocationStrategy> getResourceAllocationStrategy(
+            SlotManagerConfiguration slotManagerConfiguration) {
+        return Optional.of(
+                new DefaultResourceAllocationStrategy(
+                        DEFAULT_TOTAL_RESOURCE_PROFILE,
+                        DEFAULT_NUM_SLOTS_PER_WORKER,
+                        slotManagerConfiguration.getTaskManagerLoadBalanceMode(),
+                        slotManagerConfiguration.getTaskManagerTimeout(),
+                        slotManagerConfiguration.getRedundantTaskManagerNum(),
+                        slotManagerConfiguration.getMinTotalCpu(),
+                        slotManagerConfiguration.getMinTotalMem()));
+    }
+
+    @Override
+    protected Optional<NodeHealthManager> getNodeHealthManager() {
+        return Optional.of(new DefaultNodeHealthManager());
+    }
+
+    /** Tests that slots on quarantined nodes are not allocated. */
+    @Test
+    void testSlotAllocationSkipsQuarantinedNodes() throws Exception {
+        final JobID jobId = new JobID();
+        final AtomicInteger slotRequestCount = new AtomicInteger(0);
+
+        final TaskExecutorGateway taskExecutorGateway1 =
+                new TestingTaskExecutorGatewayBuilder()
+                        .setRequestSlotFunction(
+                                tuple6 -> {
+                                    slotRequestCount.incrementAndGet();
+                                    return CompletableFuture.completedFuture(Acknowledge.get());
+                                })
+                        .createTestingTaskExecutorGateway();
+
+        final TaskExecutorGateway taskExecutorGateway2 =
+                new TestingTaskExecutorGatewayBuilder()
+                        .setRequestSlotFunction(
+                                tuple6 -> {
+                                    slotRequestCount.incrementAndGet();
+                                    return CompletableFuture.completedFuture(Acknowledge.get());
+                                })
+                        .createTestingTaskExecutorGateway();
+
+        new Context() {
+            {
+                runTest(
+                        () -> {
+                            // Register two task managers
+                            final ResourceID resourceId1 = ResourceID.generate();
+                            final ResourceID resourceId2 = ResourceID.generate();
+                            final InstanceID instanceId1 = new InstanceID();
+                            final InstanceID instanceId2 = new InstanceID();
+
+                            final TaskExecutorConnection taskExecutorConnection1 =
+                                    new TaskExecutorConnection(resourceId1, taskExecutorGateway1);
+                            final TaskExecutorConnection taskExecutorConnection2 =
+                                    new TaskExecutorConnection(resourceId2, taskExecutorGateway2);
+
+                            final SlotID slotId1 = new SlotID(resourceId1, 0);
+                            final SlotID slotId2 = new SlotID(resourceId2, 0);
+                            final SlotReport slotReport1 =
+                                    new SlotReport(
+                                            new SlotStatus(slotId1, DEFAULT_SLOT_RESOURCE_PROFILE));
+                            final SlotReport slotReport2 =
+                                    new SlotReport(
+                                            new SlotStatus(slotId2, DEFAULT_SLOT_RESOURCE_PROFILE));
+
+                            runInMainThread(
+                                    () -> {
+                                        // Register both task managers
+                                        getSlotManager()
+                                                .registerTaskManager(
+                                                        taskExecutorConnection1,
+                                                        slotReport1,
+                                                        DEFAULT_TOTAL_RESOURCE_PROFILE,
+                                                        DEFAULT_SLOT_RESOURCE_PROFILE);
+                                        getSlotManager()
+                                                .registerTaskManager(
+                                                        taskExecutorConnection2,
+                                                        slotReport2,
+                                                        DEFAULT_TOTAL_RESOURCE_PROFILE,
+                                                        DEFAULT_SLOT_RESOURCE_PROFILE);
+
+                                        // Quarantine the first task manager
+                                        getNodeHealthManager()
+                                                .markQuarantined(
+                                                        resourceId1,
+                                                        "localhost",
+                                                        "test quarantine",
+                                                        Duration.ofMinutes(10));
+
+                                        // Request a slot
+                                        getSlotManager()
+                                                .processResourceRequirements(
+                                                        createResourceRequirements(jobId, 1));
+                                    });
+
+                            // Wait for slot allocation
+                            Thread.sleep(100);
+
+                            // Verify that only one slot request was made (to the healthy node)
+                            assertThat(slotRequestCount.get()).isEqualTo(1);
+
+                            // Verify that the quarantined node is indeed unhealthy
+                            assertThat(getNodeHealthManager().isHealthy(resourceId1)).isFalse();
+                            assertThat(getNodeHealthManager().isHealthy(resourceId2)).isTrue();
+                        });
+            }
+        };
+    }
+
+    /** Tests that slots become available again after quarantine expires. */
+    @Test
+    void testSlotAllocationAfterQuarantineExpires() throws Exception {
+        final JobID jobId = new JobID();
+        final AtomicInteger slotRequestCount = new AtomicInteger(0);
+
+        final TaskExecutorGateway taskExecutorGateway =
+                new TestingTaskExecutorGatewayBuilder()
+                        .setRequestSlotFunction(
+                                tuple6 -> {
+                                    slotRequestCount.incrementAndGet();
+                                    return CompletableFuture.completedFuture(Acknowledge.get());
+                                })
+                        .createTestingTaskExecutorGateway();
+
+        new Context() {
+            {
+                runTest(
+                        () -> {
+                            // Register a task manager
+                            final ResourceID resourceId = ResourceID.generate();
+                            final InstanceID instanceId = new InstanceID();
+
+                            final TaskExecutorConnection taskExecutorConnection =
+                                    new TaskExecutorConnection(resourceId, taskExecutorGateway);
+
+                            final SlotID slotId = new SlotID(resourceId, 0);
+                            final SlotReport slotReport =
+                                    new SlotReport(
+                                            new SlotStatus(slotId, DEFAULT_SLOT_RESOURCE_PROFILE));
+
+                            runInMainThread(
+                                    () -> {
+                                        // Register the task manager
+                                        getSlotManager()
+                                                .registerTaskManager(
+                                                        taskExecutorConnection,
+                                                        slotReport,
+                                                        DEFAULT_TOTAL_RESOURCE_PROFILE,
+                                                        DEFAULT_SLOT_RESOURCE_PROFILE);
+
+                                        // Quarantine the task manager for a short duration
+                                        getNodeHealthManager()
+                                                .markQuarantined(
+                                                        resourceId,
+                                                        "localhost",
+                                                        "test quarantine",
+                                                        Duration.ofMillis(50));
+
+                                        // Request a slot while quarantined
+                                        getSlotManager()
+                                                .processResourceRequirements(
+                                                        createResourceRequirements(jobId, 1));
+                                    });
+
+                            // Wait for quarantine to expire
+                            Thread.sleep(100);
+
+                            runInMainThread(
+                                    () -> {
+                                        // Request a slot after quarantine expires
+                                        getSlotManager()
+                                                .processResourceRequirements(
+                                                        createResourceRequirements(jobId, 1));
+                                    });
+
+                            // Wait for slot allocation
+                            Thread.sleep(100);
+
+                            // Verify that the node is healthy again and slot was allocated
+                            assertThat(getNodeHealthManager().isHealthy(resourceId)).isTrue();
+                            assertThat(slotRequestCount.get()).isEqualTo(1);
+                        });
+            }
+        };
+    }
+
+    /** Tests that quarantine can be manually removed. */
+    @Test
+    void testManualQuarantineRemoval() throws Exception {
+        final JobID jobId = new JobID();
+        final AtomicInteger slotRequestCount = new AtomicInteger(0);
+
+        final TaskExecutorGateway taskExecutorGateway =
+                new TestingTaskExecutorGatewayBuilder()
+                        .setRequestSlotFunction(
+                                tuple6 -> {
+                                    slotRequestCount.incrementAndGet();
+                                    return CompletableFuture.completedFuture(Acknowledge.get());
+                                })
+                        .createTestingTaskExecutorGateway();
+
+        new Context() {
+            {
+                runTest(
+                        () -> {
+                            // Register a task manager
+                            final ResourceID resourceId = ResourceID.generate();
+                            final InstanceID instanceId = new InstanceID();
+
+                            final TaskExecutorConnection taskExecutorConnection =
+                                    new TaskExecutorConnection(resourceId, taskExecutorGateway);
+
+                            final SlotID slotId = new SlotID(resourceId, 0);
+                            final SlotReport slotReport =
+                                    new SlotReport(
+                                            new SlotStatus(slotId, DEFAULT_SLOT_RESOURCE_PROFILE));
+
+                            runInMainThread(
+                                    () -> {
+                                        // Register the task manager
+                                        getSlotManager()
+                                                .registerTaskManager(
+                                                        taskExecutorConnection,
+                                                        slotReport,
+                                                        DEFAULT_TOTAL_RESOURCE_PROFILE,
+                                                        DEFAULT_SLOT_RESOURCE_PROFILE);
+
+                                        // Quarantine the task manager
+                                        getNodeHealthManager()
+                                                .markQuarantined(
+                                                        resourceId,
+                                                        "localhost",
+                                                        "test quarantine",
+                                                        Duration.ofMinutes(10));
+
+                                        // Verify node is quarantined
+                                        assertThat(getNodeHealthManager().isHealthy(resourceId))
+                                                .isFalse();
+
+                                        // Manually remove quarantine
+                                        getNodeHealthManager().removeQuarantine(resourceId);
+
+                                        // Verify node is healthy again
+                                        assertThat(getNodeHealthManager().isHealthy(resourceId))
+                                                .isTrue();
+
+                                        // Request a slot
+                                        getSlotManager()
+                                                .processResourceRequirements(
+                                                        createResourceRequirements(jobId, 1));
+                                    });
+
+                            // Wait for slot allocation
+                            Thread.sleep(100);
+
+                            // Verify that slot was allocated
+                            assertThat(slotRequestCount.get()).isEqualTo(1);
+                        });
+            }
+        };
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This is PR-2 in the [FLINK-39176](https://issues.apache.org/jira/browse/FLINK-39176) series: **Node Health Management & Quarantine Framework**.

This PR implements the integration of NodeHealthManager with the slot allocation process in FineGrainedSlotManager. It enables filtering out quarantined nodes during slot allocation to prevent jobs from being scheduled on unhealthy nodes.

This PR builds on PR #27701 (NodeHealthManager abstraction) and implements Phase 2 of the node health management mechanism.

<img width="1536" height="1024" alt="image" src="https://github.com/user-attachments/assets/ba5a141e-fbd0-4b79-bb1f-f65963864fbe" />


### PR Series Overview

This feature is implemented across 6 PRs, each independently reviewable and mergeable:

| PR | Title | Link |
|----|-------|------|
| PR-1 | Introduce NodeHealthManager Abstraction | [#27701](https://github.com/apache/flink/pull/27701) |
| **PR-2** | **Integrate NodeHealthManager with Slot Filtering** | **This PR** |
| PR-3 | Add REST API for Node Quarantine | [#27712](https://github.com/apache/flink/pull/27712) |
| PR-4 | Configuration Support for Node Quarantine | [#27714](https://github.com/apache/flink/pull/27714) |
| PR-5 | Expiration Cleanup Scheduler | [#27715](https://github.com/apache/flink/pull/27715) |
| PR-6 | Web UI Node Health Page | [#27716](https://github.com/apache/flink/pull/27716) |

## Brief change log

- Modified FineGrainedSlotManager to filter out quarantined nodes during slot allocation in allocateSlotsAccordingTo() method
- Updated ResourceManagerRuntimeServices to accept NodeHealthManager parameter in createSlotManager() method
- Enhanced ResourceManagerFactory to pass NoOpNodeHealthManager as default implementation
- Extended FineGrainedSlotManagerBuilder and FineGrainedSlotManagerTestBase to support NodeHealthManager in test infrastructure
- Added comprehensive integration test NodeQuarantineSlotFilteringITCase covering slot allocation filtering, quarantine expiry, and manual removal scenarios
- Fixed compilation issues in test infrastructure related to method name conflicts

## Verifying this change

This change is verified by:
- Existing unit tests continue to pass
- New integration test NodeQuarantineSlotFilteringITCase validates the slot filtering functionality
- Manual testing with quarantined nodes shows slots are correctly filtered
- Compilation succeeds with mvnw clean spotless:apply install -DskipTests -Pfast

## Does this pull request potentially affect

- Public API: No
- Serializers: No  
- The runtime per-record code paths: No
- Anything that affects deployment or recovery: JobManager failover: No
- The S3 file system connector: No

## Documentation

- Does this pull request introduce a new feature: Yes, node health-based slot filtering
- If yes, how is the feature documented: Code comments and integration tests. Full documentation will be added in subsequent PRs for REST API and configuration options.
