### PR TITLE
[FLINK-38697][runtime] Store task information blob key in JobVertex

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
@@ -460,10 +460,22 @@ public class ExecutionJobVertex
         // serialize the task information!
         synchronized (stateMonitor) {
             if (taskInformationOrBlobKey == null) {
+                // check if JobVertex already has a cached key from a previous ExecutionGraph
+                PermanentBlobKey cachedKey = jobVertex.getTaskInformationBlobKey();
+                if (cachedKey != null) {
+                    taskInformationOrBlobKey = Either.Right(cachedKey);
+                    return taskInformationOrBlobKey;
+                }
+
                 final BlobWriter blobWriter = graph.getBlobWriter();
                 final TaskInformation taskInformation = getTaskInformation();
                 taskInformationOrBlobKey =
                         BlobWriter.serializeAndTryOffload(taskInformation, getJobId(), blobWriter);
+
+                // persist the key back to JobVertex so the next ExecutionGraph rebuild reuses it
+                if (taskInformationOrBlobKey.isRight()) {
+                    jobVertex.setTaskInformationBlobKey(taskInformationOrBlobKey.right());
+                }
             }
 
             return taskInformationOrBlobKey;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.io.InputSplitSource;
 import org.apache.flink.runtime.OperatorIDPair;
+import org.apache.flink.runtime.blob.PermanentBlobKey;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.tasks.TaskInvokable;
 import org.apache.flink.runtime.jobmanager.scheduler.CoLocationGroup;
@@ -123,6 +124,13 @@ public class JobVertex implements java.io.Serializable {
 
     /** The group inside which the vertex subtasks share slots. */
     @Nullable private CoLocationGroupImpl coLocationGroup;
+
+    /**
+     * The blob key of the offloaded TaskInformation for this vertex. Stored here to enable reuse
+     * across ExecutionGraph rebuilds (e.g., during adaptive scheduler restarts), preventing
+     * unbounded accumulation of orphaned blobs in permanent storage.
+     */
+    @Nullable private PermanentBlobKey taskInformationBlobKey = null;
 
     /**
      * Optional, the name of the operator, such as 'Flat Map' or 'Join', to be included in the JSON
@@ -411,6 +419,15 @@ public class JobVertex implements java.io.Serializable {
 
     public List<SerializedValue<OperatorCoordinator.Provider>> getOperatorCoordinators() {
         return Collections.unmodifiableList(operatorCoordinators);
+    }
+
+    public void setTaskInformationBlobKey(@Nullable PermanentBlobKey key) {
+        this.taskInformationBlobKey = key;
+    }
+
+    @Nullable
+    public PermanentBlobKey getTaskInformationBlobKey() {
+        return taskInformationBlobKey;
     }
 
     public void addOperatorCoordinator(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionGraphFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionGraphFactory.java
@@ -69,6 +69,11 @@ public class DefaultExecutionGraphFactory implements ExecutionGraphFactory {
 
     private final boolean nonFinishedHybridPartitionShouldBeUnknown;
 
+    @Override
+    public BlobWriter getBlobWriter() {
+        return blobWriter;
+    }
+
     public DefaultExecutionGraphFactory(
             Configuration configuration,
             ClassLoader userCodeClassLoader,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionGraphFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionGraphFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.scheduler;
 
+import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
 import org.apache.flink.runtime.checkpoint.CheckpointStatsTracker;
 import org.apache.flink.runtime.checkpoint.CheckpointsCleaner;
@@ -34,6 +35,9 @@ import org.slf4j.Logger;
 
 /** Factory for creating an {@link ExecutionGraph}. */
 public interface ExecutionGraphFactory {
+
+    /** Returns the {@link BlobWriter} used by execution graphs created by this factory. */
+    BlobWriter getBlobWriter();
 
     /**
      * Create and restore {@link ExecutionGraph} from the given {@link JobGraph} and services.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -35,6 +35,7 @@ import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.queryablestate.KvStateID;
 import org.apache.flink.runtime.OperatorIDPair;
 import org.apache.flink.runtime.accumulators.AccumulatorSnapshot;
+import org.apache.flink.runtime.blob.PermanentBlobKey;
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
@@ -724,11 +725,34 @@ public abstract class SchedulerBase implements SchedulerNG, CheckpointScheduling
 
         FutureUtils.assertNoException(checkpointServicesShutdownFuture);
 
+        cleanupTaskInformationBlobKeys();
         incrementVersionsOfAllVertices();
         cancelAllPendingSlotRequestsInternal();
         executionGraph.suspend(cause);
         operatorCoordinatorHandler.disposeAllOperatorCoordinators();
         return checkpointServicesShutdownFuture;
+    }
+
+    /**
+     * Deletes cached TaskInformation blob keys from the blob store and clears them from
+     * JobVertices. This prevents orphaned blobs from accumulating in the HA blob store across JM
+     * restarts, since the in-memory cache on JobVertex is lost on restart and new blobs would be
+     * created.
+     */
+    private void cleanupTaskInformationBlobKeys() {
+        for (ExecutionJobVertex ejv : executionGraph.getVerticesTopologically()) {
+            PermanentBlobKey key = ejv.getJobVertex().getTaskInformationBlobKey();
+            if (key != null) {
+                log.debug(
+                        "Deleting TaskInformation blob {} for vertex {}.",
+                        key,
+                        ejv.getJobVertexId());
+                executionGraphFactory
+                        .getBlobWriter()
+                        .deletePermanent(executionGraph.getJobID(), key);
+                ejv.getJobVertex().setTaskInformationBlobKey(null);
+            }
+        }
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
@@ -35,6 +35,7 @@ import org.apache.flink.core.failure.FailureEnricher.Context;
 import org.apache.flink.queryablestate.KvStateID;
 import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.accumulators.AccumulatorSnapshot;
+import org.apache.flink.runtime.blob.PermanentBlobKey;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
@@ -777,6 +778,7 @@ public class AdaptiveScheduler
     public CompletableFuture<Void> closeAsync() {
         LOG.debug("Closing the AdaptiveScheduler. Trying to suspend the current job execution.");
 
+        cleanupTaskInformationBlobKeys();
         state.suspend(new FlinkException("AdaptiveScheduler is being stopped."));
 
         Preconditions.checkState(
@@ -794,6 +796,23 @@ public class AdaptiveScheduler
                 // PendingCheckpoint
                 checkpointsCleaner::closeAsync,
                 getMainThreadExecutor());
+    }
+
+    /**
+     * Deletes cached TaskInformation blob keys from the blob store and clears them from
+     * JobVertices. This prevents orphaned blobs from accumulating in the HA blob store across JM
+     * restarts, since the in-memory cache on JobVertex is lost on restart and new blobs would be
+     * created.
+     */
+    private void cleanupTaskInformationBlobKeys() {
+        for (JobVertex vertex : jobGraph.getVertices()) {
+            PermanentBlobKey key = vertex.getTaskInformationBlobKey();
+            if (key != null) {
+                LOG.debug("Deleting TaskInformation blob {} for vertex {}.", key, vertex.getID());
+                executionGraphFactory.getBlobWriter().deletePermanent(jobGraph.getJobID(), key);
+                vertex.setTaskInformationBlobKey(null);
+            }
+        }
     }
 
     private void stopCheckpointServicesSafely(JobStatus terminalState) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertexTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertexTest.java
@@ -19,6 +19,8 @@
 package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.runtime.JobException;
+import org.apache.flink.runtime.blob.PermanentBlobKey;
+import org.apache.flink.runtime.blob.TestingBlobWriter;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.JobVertex;
@@ -30,6 +32,8 @@ import org.apache.flink.runtime.scheduler.VertexParallelismStore;
 import org.apache.flink.runtime.scheduler.adaptivebatch.AdaptiveBatchScheduler;
 import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.testutils.executor.TestExecutorExtension;
+import org.apache.flink.types.Either;
+import org.apache.flink.util.SerializedValue;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -58,6 +62,28 @@ class ExecutionJobVertexTest {
         assertThatThrownBy(() -> ExecutionGraphTestUtils.getExecutionJobVertex(jobVertex))
                 .isInstanceOf(JobException.class)
                 .hasMessageContaining("higher than the max parallelism");
+    }
+
+    @Test
+    void testTaskInformationBlobKeyIsReusedAcrossExecutionGraphRebuilds() throws Exception {
+        JobVertex jobVertex = new JobVertex("testVertex");
+        jobVertex.setInvokableClass(AbstractInvokable.class);
+        jobVertex.getOrCreateResultDataSet(
+                new IntermediateDataSetID(), ResultPartitionType.BLOCKING);
+
+        final ExecutionJobVertex ejv1 = createExecutionJobVertex(jobVertex, 1);
+
+        Either<SerializedValue<TaskInformation>, PermanentBlobKey> key1 =
+                ejv1.getTaskInformationOrBlobKey();
+        assertThat(key1.isRight()).isTrue();
+
+        final ExecutionJobVertex ejv2 = createExecutionJobVertex(jobVertex, 1);
+
+        Either<SerializedValue<TaskInformation>, PermanentBlobKey> key2 =
+                ejv2.getTaskInformationOrBlobKey();
+        assertThat(key2.isRight()).isTrue();
+
+        assertThat(key2.right()).isEqualTo(key1.right());
     }
 
     @Test
@@ -164,6 +190,27 @@ class ExecutionJobVertexTest {
 
     private static ExecutionJobVertex createDynamicExecutionJobVertex() throws Exception {
         return createDynamicExecutionJobVertex(-1, -1, 1);
+    }
+
+    public static ExecutionJobVertex createExecutionJobVertex(
+            JobVertex jobVertex, int defaultMaxParallelism) throws Exception {
+
+        final DefaultExecutionGraph eg =
+                TestingDefaultExecutionGraphBuilder.newBuilder()
+                        .setBlobWriter(new TestingBlobWriter())
+                        .build(EXECUTOR_RESOURCE.getExecutor());
+        final VertexParallelismStore vertexParallelismStore =
+                AdaptiveBatchScheduler.computeVertexParallelismStoreForDynamicGraph(
+                        Collections.singletonList(jobVertex), defaultMaxParallelism);
+        final VertexParallelismInformation vertexParallelismInfo =
+                vertexParallelismStore.getParallelismInfo(jobVertex.getID());
+
+        return new ExecutionJobVertex(
+                eg,
+                jobVertex,
+                vertexParallelismInfo,
+                new CoordinatorStoreImpl(),
+                UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
     }
 
     public static ExecutionJobVertex createDynamicExecutionJobVertex(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
@@ -31,6 +31,8 @@ import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.events.Event;
 import org.apache.flink.events.EventBuilder;
 import org.apache.flink.metrics.Gauge;
+import org.apache.flink.runtime.blob.PermanentBlobKey;
+import org.apache.flink.runtime.blob.TestingBlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
@@ -174,6 +176,34 @@ public class AdaptiveSchedulerTest extends AdaptiveSchedulerTestBase {
                         .build();
 
         assertThat(scheduler.getState()).isInstanceOf(Created.class);
+    }
+
+    @Test
+    void testCloseAsyncCleansUpTaskInformationBlobKeys() throws Exception {
+        final TestingBlobWriter blobWriter = new TestingBlobWriter();
+        final JobGraph jobGraph = createJobGraph();
+
+        // Simulate a previous run: upload a blob and cache its key on the JobVertex
+        final JobVertex jobVertex = jobGraph.getVertices().iterator().next();
+        final PermanentBlobKey blobKey =
+                blobWriter.putPermanent(jobGraph.getJobID(), new byte[] {1, 2, 3});
+        jobVertex.setTaskInformationBlobKey(blobKey);
+
+        assertThat(blobWriter.numberOfBlobs()).isEqualTo(1);
+
+        scheduler =
+                new AdaptiveSchedulerBuilder(
+                                jobGraph,
+                                singleThreadMainThreadExecutor,
+                                EXECUTOR_RESOURCE.getExecutor())
+                        .setBlobWriter(blobWriter)
+                        .build();
+
+        // closeAsync() triggers cleanupTaskInformationBlobKeys() before suspending
+        closeInExecutorService(scheduler, singleThreadMainThreadExecutor);
+
+        assertThat(blobWriter.numberOfBlobs()).isEqualTo(0);
+        assertThat(jobVertex.getTaskInformationBlobKey()).isNull();
     }
 
     @Test


### PR DESCRIPTION
The change ensures that `TaskInformation` blob keys are reused across `ExecutionGraph` rebuilds triggered by the adaptive scheduler, rather than creating a new permanent blob on every restart.
Previously, each time the adaptive scheduler rebuilt the `ExecutionGraph` (e.g. after a `TaskManager` failure), `ExecutionJobVertex` would upload a fresh `TaskInformation` blob to the `BlobServer` even if the content was identical. These blob keys are randomized, which  was introduced to the blob key to prevent hash-collisions (probably during work on [FLINK-6196](https://issues.apache.org/jira/plugins/servlet/mobile#issue/FLINK-6916)). 

The fix caches the `PermanentBlobKey` on `JobVertex`, which unlike `ExecutionJobVertex` is never recreated during adaptive scheduler restarts. On subsequent `ExecutionGraph` rebuilds, `ExecutionJobVertex` checks if  `JobVertex` already holds a cached key and reuses it instead of uploading a new blob. This mirrors the existing pattern used by job JAR blobs, which are correctly reused across restarts by storing their keys persistently in the `JobGraph`. Since permanent blobs are only cleaned up when a job reaches a globally terminated state, these orphaned blobs accumulate indefinitely on the JM's blob storage, eventually causing storage exhaustion and job stalling.

However, since the blob key cache lives in-memory on `JobVertex`, it is lost on a JM restart. Without additional handling, old blobs would be left behind in the HA blob store indefinitely, as new uploads would produce new keys with no reference to the previous ones. To address this, both `SchedulerBase` and `AdaptiveScheduler` now delete cached `TaskInformation` blobs during JM shutdown (in `closeAsync()`), before the `ExecutionGraph` is suspended. This ensures that blobs uploaded during the JM's lifetime are removed from the store on a clean shutdown, preventing accumulation across JM restarts.


## Brief change log

  - cache `TaskInformation`'s `PermanentBlobKey` on `JobVertex` to reuse it across `ExecutionGraph` rebuilds


## Verifying this change

This change added tests and can be verified as follows:

  - Added test that validates that `PermanentBlobKey` is cached and reused by `ExecutionJobVertex`'es related to given `JobVertex`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / no / **don't know**)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
