### PR TITLE
[FLINK-39219] [table] Support lineage extraction for DataStreamscan/sink providers

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSink.java
@@ -182,6 +182,8 @@ public abstract class CommonExecSink extends ExecNodeBase<Object>
             outputObject = ((SinkFunctionProvider) runtimeProvider).createSinkFunction();
         } else if (runtimeProvider instanceof SinkV2Provider) {
             outputObject = ((SinkV2Provider) runtimeProvider).createSink();
+        } else if (runtimeProvider instanceof DataStreamSinkProvider) {
+            outputObject = runtimeProvider;
         }
 
         Optional<LineageVertex> lineageVertexOpt =

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecTableSourceScan.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecTableSourceScan.java
@@ -183,6 +183,7 @@ public abstract class CommonExecTableSourceScan extends ExecNodeBase<RowData>
                             .getTransformation();
             metadata.fill(sourceTransform);
         } else if (provider instanceof DataStreamScanProvider) {
+            lineageVertex = TableLineageUtils.extractLineageDataset(provider);
             sourceTransform =
                     ((DataStreamScanProvider) provider)
                             .produceDataStream(createProviderContext(metadata, config), env)
@@ -218,6 +219,18 @@ public abstract class CommonExecTableSourceScan extends ExecNodeBase<RowData>
         if (sourceTransform instanceof TransformationWithLineage) {
             ((TransformationWithLineage<RowData>) sourceTransform)
                     .setLineageVertex(sourceLineageVertex);
+        } else {
+            // When DataStreamScanProvider returns a multi-operator pipeline, the outermost
+            // transformation may not implement TransformationWithLineage. Search the transitive
+            // predecessors to find a SourceTransformation or LegacySourceTransformation that does.
+            for (Transformation<?> predecessor : sourceTransform.getTransitivePredecessors()) {
+                if (predecessor != sourceTransform
+                        && predecessor instanceof TransformationWithLineage) {
+                    ((TransformationWithLineage<?>) predecessor)
+                            .setLineageVertex(sourceLineageVertex);
+                    break;
+                }
+            }
         }
 
         if (sourceParallelismConfigured) {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/lineage/TableLineageUtilsTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/lineage/TableLineageUtilsTest.java
@@ -18,7 +18,13 @@
 
 package org.apache.flink.table.planner.lineage;
 
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.lineage.DefaultLineageDataset;
 import org.apache.flink.streaming.api.lineage.LineageDataset;
+import org.apache.flink.streaming.api.lineage.LineageVertex;
+import org.apache.flink.streaming.api.lineage.LineageVertexProvider;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.catalog.Catalog;
@@ -29,12 +35,17 @@ import org.apache.flink.table.catalog.GenericInMemoryCatalog;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.connector.ProviderContext;
+import org.apache.flink.table.connector.sink.DataStreamSinkProvider;
+import org.apache.flink.table.connector.source.DataStreamScanProvider;
+import org.apache.flink.table.data.RowData;
 
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -113,5 +124,125 @@ class TableLineageUtilsTest {
         TableLineageDatasetImpl tableLineageDataset = (TableLineageDatasetImpl) lineageDataset;
         assertThat(tableLineageDataset.catalogContext().getCatalogName()).isEmpty();
         assertThat(tableLineageDataset.name()).isEqualTo(objectIdentifier.asSummaryString());
+    }
+
+    @Test
+    void testExtractLineageDatasetFromDataStreamScanProvider() {
+        DataStreamScanProvider provider =
+                new DataStreamScanProvider() {
+                    @Override
+                    public DataStream<RowData> produceDataStream(
+                            ProviderContext providerContext, StreamExecutionEnvironment execEnv) {
+                        return null;
+                    }
+
+                    @Override
+                    public boolean isBounded() {
+                        return false;
+                    }
+                };
+
+        // A plain DataStreamScanProvider without LineageVertexProvider should return empty
+        Optional<LineageVertex> result = TableLineageUtils.extractLineageDataset(provider);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void testExtractLineageDatasetFromDataStreamScanProviderWithLineage() {
+        DataStreamScanProvider provider =
+                new TestDataStreamScanProviderWithLineage("test-source", "test://namespace");
+
+        Optional<LineageVertex> result = TableLineageUtils.extractLineageDataset(provider);
+        assertThat(result).isPresent();
+        assertThat(result.get().datasets()).hasSize(1);
+        assertThat(result.get().datasets().get(0).name()).isEqualTo("test-source");
+        assertThat(result.get().datasets().get(0).namespace()).isEqualTo("test://namespace");
+    }
+
+    @Test
+    void testExtractLineageDatasetFromDataStreamSinkProvider() {
+        DataStreamSinkProvider provider =
+                new DataStreamSinkProvider() {
+                    @Override
+                    public DataStreamSink<?> consumeDataStream(
+                            ProviderContext providerContext, DataStream<RowData> dataStream) {
+                        return null;
+                    }
+                };
+
+        // A plain DataStreamSinkProvider without LineageVertexProvider should return empty
+        Optional<LineageVertex> result = TableLineageUtils.extractLineageDataset(provider);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void testExtractLineageDatasetFromDataStreamSinkProviderWithLineage() {
+        DataStreamSinkProvider provider =
+                new TestDataStreamSinkProviderWithLineage("test-sink", "test://namespace");
+
+        Optional<LineageVertex> result = TableLineageUtils.extractLineageDataset(provider);
+        assertThat(result).isPresent();
+        assertThat(result.get().datasets()).hasSize(1);
+        assertThat(result.get().datasets().get(0).name()).isEqualTo("test-sink");
+        assertThat(result.get().datasets().get(0).namespace()).isEqualTo("test://namespace");
+    }
+
+    /**
+     * A {@link DataStreamScanProvider} that also implements {@link LineageVertexProvider}, similar
+     * to how Apache Paimon's PaimonDataStreamScanProvider works.
+     */
+    private static class TestDataStreamScanProviderWithLineage
+            implements DataStreamScanProvider, LineageVertexProvider {
+        private final String name;
+        private final String namespace;
+
+        TestDataStreamScanProviderWithLineage(String name, String namespace) {
+            this.name = name;
+            this.namespace = namespace;
+        }
+
+        @Override
+        public DataStream<RowData> produceDataStream(
+                ProviderContext providerContext, StreamExecutionEnvironment execEnv) {
+            return null;
+        }
+
+        @Override
+        public boolean isBounded() {
+            return false;
+        }
+
+        @Override
+        public LineageVertex getLineageVertex() {
+            return () ->
+                    List.of(new DefaultLineageDataset(name, namespace, Collections.emptyMap()));
+        }
+    }
+
+    /**
+     * A {@link DataStreamSinkProvider} that also implements {@link LineageVertexProvider}, similar
+     * to how Apache Paimon's PaimonDataStreamSinkProvider works.
+     */
+    private static class TestDataStreamSinkProviderWithLineage
+            implements DataStreamSinkProvider, LineageVertexProvider {
+        private final String name;
+        private final String namespace;
+
+        TestDataStreamSinkProviderWithLineage(String name, String namespace) {
+            this.name = name;
+            this.namespace = namespace;
+        }
+
+        @Override
+        public DataStreamSink<?> consumeDataStream(
+                ProviderContext providerContext, DataStream<RowData> dataStream) {
+            return null;
+        }
+
+        @Override
+        public LineageVertex getLineageVertex() {
+            return () ->
+                    List.of(new DefaultLineageDataset(name, namespace, Collections.emptyMap()));
+        }
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/TransformationsTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/TransformationsTest.java
@@ -21,11 +21,16 @@ package org.apache.flink.table.planner.plan.nodes.exec;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.ProcessFunction;
+import org.apache.flink.streaming.api.lineage.DefaultLineageDataset;
 import org.apache.flink.streaming.api.lineage.LineageDataset;
+import org.apache.flink.streaming.api.lineage.LineageVertex;
+import org.apache.flink.streaming.api.lineage.LineageVertexProvider;
 import org.apache.flink.streaming.api.transformations.LegacySourceTransformation;
+import org.apache.flink.streaming.api.transformations.TransformationWithLineage;
 import org.apache.flink.streaming.api.transformations.WithBoundedness;
 import org.apache.flink.table.api.CompiledPlan;
 import org.apache.flink.table.api.DataTypes;
@@ -39,10 +44,13 @@ import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.api.internal.CompiledPlanUtils;
 import org.apache.flink.table.connector.ProviderContext;
+import org.apache.flink.table.connector.sink.DataStreamSinkProvider;
 import org.apache.flink.table.connector.source.DataStreamScanProvider;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.planner.factories.TableFactoryHarness;
 import org.apache.flink.table.planner.factories.TableFactoryHarness.ScanSourceBase;
+import org.apache.flink.table.planner.factories.TableFactoryHarness.SinkBase;
+import org.apache.flink.table.planner.lineage.TableSinkLineageVertex;
 import org.apache.flink.table.planner.lineage.TableSourceLineageVertex;
 import org.apache.flink.table.planner.utils.JsonTestUtils;
 import org.apache.flink.util.Collector;
@@ -55,6 +63,7 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -252,6 +261,299 @@ class TransformationsTest {
                         "\\d+_my-source",
                         "T\\[\\d+\\]",
                         "\\[\\d+\\]\\:TableSourceScan\\(table=\\[\\[default_catalog, default_database, T\\]\\], fields=\\[i\\]\\)"));
+    }
+
+    @Test
+    void testDataStreamScanProviderLineage() {
+        final StreamTableEnvironment env =
+                StreamTableEnvironment.create(
+                        StreamExecutionEnvironment.getExecutionEnvironment(),
+                        EnvironmentSettings.newInstance().inStreamingMode().build());
+
+        final DataStreamScanProvider scanProvider =
+                new DataStreamScanProvider() {
+                    @Override
+                    public boolean isBounded() {
+                        return false;
+                    }
+
+                    @Override
+                    public DataStream<RowData> produceDataStream(
+                            ProviderContext providerContext, StreamExecutionEnvironment execEnv) {
+                        // Single-operator pipeline: returns the SourceTransformation directly
+                        return execEnv.fromData(1, 2, 3).map(i -> (RowData) null);
+                    }
+                };
+
+        final LineageVertexProvider lineageProvider =
+                () ->
+                        () ->
+                                List.of(
+                                        new DefaultLineageDataset(
+                                                "test-source",
+                                                "test://namespace",
+                                                Collections.emptyMap()));
+
+        final TableDescriptor sourceDescriptor =
+                TableFactoryHarness.newBuilder()
+                        .schema(dummySchema())
+                        .source(
+                                new ScanSourceBase() {
+                                    @Override
+                                    public ScanRuntimeProvider getScanRuntimeProvider(
+                                            ScanContext runtimeProviderContext) {
+                                        return new DataStreamScanProviderWithLineage(
+                                                scanProvider, lineageProvider);
+                                    }
+                                })
+                        .build();
+
+        env.createTemporaryTable("T", sourceDescriptor);
+        final Table table = env.from("T");
+
+        Transformation<?> transform = env.toChangelogStream(table).getTransformation();
+
+        TransformationWithLineage<?> lineageTransform = null;
+        for (Transformation<?> t : transform.getTransitivePredecessors()) {
+            if (t instanceof TransformationWithLineage
+                    && ((TransformationWithLineage<?>) t).getLineageVertex() != null) {
+                lineageTransform = (TransformationWithLineage<?>) t;
+                break;
+            }
+        }
+
+        assertThat(lineageTransform).isNotNull();
+        assertThat(lineageTransform.getLineageVertex())
+                .isInstanceOf(TableSourceLineageVertex.class);
+
+        TableSourceLineageVertex sourceLineageVertex =
+                (TableSourceLineageVertex) lineageTransform.getLineageVertex();
+        assertThat(sourceLineageVertex.boundedness()).isEqualTo(Boundedness.CONTINUOUS_UNBOUNDED);
+
+        List<LineageDataset> datasets = sourceLineageVertex.datasets();
+        assertThat(datasets).hasSize(1);
+        assertThat(datasets.get(0).name()).contains("T");
+        assertThat(datasets.get(0).namespace()).isEqualTo("test://namespace");
+    }
+
+    @Test
+    void testDataStreamSinkProviderLineage() {
+        final StreamTableEnvironment env =
+                StreamTableEnvironment.create(
+                        StreamExecutionEnvironment.getExecutionEnvironment(),
+                        EnvironmentSettings.newInstance().inStreamingMode().build());
+
+        final LineageVertexProvider lineageProvider =
+                () ->
+                        () ->
+                                List.of(
+                                        new DefaultLineageDataset(
+                                                "test-sink",
+                                                "test://sink-namespace",
+                                                Collections.emptyMap()));
+
+        // Create source table using values connector
+        env.createTemporaryTable(
+                "source_table",
+                TableDescriptor.forConnector("values")
+                        .option("bounded", "false")
+                        .schema(dummySchema())
+                        .build());
+
+        // Create sink table with DataStreamSinkProvider that implements LineageVertexProvider
+        final TableDescriptor sinkDescriptor =
+                TableFactoryHarness.newBuilder()
+                        .schema(dummySchema())
+                        .sink(
+                                new SinkBase() {
+                                    @Override
+                                    public SinkRuntimeProvider getSinkRuntimeProvider(
+                                            Context context) {
+                                        return new DataStreamSinkProviderWithLineage(
+                                                lineageProvider);
+                                    }
+                                })
+                        .build();
+
+        env.createTemporaryTable("sink_table", sinkDescriptor);
+
+        // Go through the full planner path via insertInto + compilePlan
+        final Table table = env.from("source_table");
+        final CompiledPlan plan = table.insertInto("sink_table").compilePlan();
+        final List<Transformation<?>> transformations =
+                CompiledPlanUtils.toTransformations(env, plan);
+
+        // Find the sink transformation with lineage
+        TransformationWithLineage<?> sinkLineageTransform = null;
+        for (Transformation<?> t : transformations.get(0).getTransitivePredecessors()) {
+            if (t instanceof TransformationWithLineage
+                    && ((TransformationWithLineage<?>) t).getLineageVertex()
+                            instanceof TableSinkLineageVertex) {
+                sinkLineageTransform = (TransformationWithLineage<?>) t;
+                break;
+            }
+        }
+
+        assertThat(sinkLineageTransform).isNotNull();
+
+        TableSinkLineageVertex sinkLineageVertex =
+                (TableSinkLineageVertex) sinkLineageTransform.getLineageVertex();
+
+        List<LineageDataset> datasets = sinkLineageVertex.datasets();
+        assertThat(datasets).hasSize(1);
+        assertThat(datasets.get(0).name()).contains("sink_table");
+        assertThat(datasets.get(0).namespace()).isEqualTo("test://sink-namespace");
+    }
+
+    @Test
+    void testDataStreamScanProviderLineageWithMultiOperatorPipeline() {
+        final StreamTableEnvironment env =
+                StreamTableEnvironment.create(
+                        StreamExecutionEnvironment.getExecutionEnvironment(),
+                        EnvironmentSettings.newInstance().inStreamingMode().build());
+
+        final DataStreamScanProvider scanProvider =
+                new DataStreamScanProvider() {
+                    @Override
+                    public boolean isBounded() {
+                        return false;
+                    }
+
+                    @Override
+                    public DataStream<RowData> produceDataStream(
+                            ProviderContext providerContext, StreamExecutionEnvironment execEnv) {
+                        final SingleOutputStreamOperator<Integer> ints = execEnv.fromData(1, 2, 3);
+                        // Multi-operator pipeline: the outermost transformation is a process
+                        // operator, not the SourceTransformation itself.
+                        return ints.process(
+                                new ProcessFunction<>() {
+                                    @Override
+                                    public void processElement(
+                                            Integer value, Context ctx, Collector<RowData> out) {
+                                        throw new IllegalStateException("Should not be called.");
+                                    }
+                                });
+                    }
+                };
+
+        // Also implement LineageVertexProvider on the source, similar to how connectors
+        // like Apache Paimon provide lineage information.
+        final LineageVertexProvider lineageProvider =
+                () ->
+                        () ->
+                                List.of(
+                                        new DefaultLineageDataset(
+                                                "test-source",
+                                                "test://namespace",
+                                                Collections.emptyMap()));
+
+        final TableDescriptor sourceDescriptor =
+                TableFactoryHarness.newBuilder()
+                        .schema(dummySchema())
+                        .source(
+                                new ScanSourceBase() {
+                                    @Override
+                                    public ScanRuntimeProvider getScanRuntimeProvider(
+                                            ScanContext runtimeProviderContext) {
+                                        // Return a provider that implements both interfaces
+                                        return new DataStreamScanProviderWithLineage(
+                                                scanProvider, lineageProvider);
+                                    }
+                                })
+                        .build();
+
+        env.createTemporaryTable("T", sourceDescriptor);
+        final Table table = env.from("T");
+
+        // Go through the full StreamTableEnvironment planner path
+        Transformation<?> transform = env.toChangelogStream(table).getTransformation();
+
+        // Find the TransformationWithLineage in the pipeline (should be the
+        // SourceTransformation found via transitive predecessors)
+        TransformationWithLineage<?> lineageTransform = null;
+        for (Transformation<?> t : transform.getTransitivePredecessors()) {
+            if (t instanceof TransformationWithLineage) {
+                lineageTransform = (TransformationWithLineage<?>) t;
+                break;
+            }
+        }
+
+        assertThat(lineageTransform).isNotNull();
+        assertThat(lineageTransform.getLineageVertex()).isNotNull();
+        assertThat(lineageTransform.getLineageVertex())
+                .isInstanceOf(TableSourceLineageVertex.class);
+
+        TableSourceLineageVertex sourceLineageVertex =
+                (TableSourceLineageVertex) lineageTransform.getLineageVertex();
+        assertThat(sourceLineageVertex.boundedness()).isEqualTo(Boundedness.CONTINUOUS_UNBOUNDED);
+
+        List<LineageDataset> datasets = sourceLineageVertex.datasets();
+        assertThat(datasets).hasSize(1);
+        // The table-level dataset should be present (name is the table identifier)
+        assertThat(datasets.get(0).name()).contains("T");
+        // Namespace should come from the connector's LineageVertex
+        assertThat(datasets.get(0).namespace()).isEqualTo("test://namespace");
+    }
+
+    /**
+     * A {@link DataStreamScanProvider} that also implements {@link LineageVertexProvider}, similar
+     * to how connectors like Apache Paimon provide lineage information alongside DataStream
+     * providers.
+     */
+    private static class DataStreamScanProviderWithLineage
+            implements DataStreamScanProvider, LineageVertexProvider {
+
+        private final DataStreamScanProvider delegate;
+        private final LineageVertexProvider lineageDelegate;
+
+        DataStreamScanProviderWithLineage(
+                DataStreamScanProvider delegate, LineageVertexProvider lineageDelegate) {
+            this.delegate = delegate;
+            this.lineageDelegate = lineageDelegate;
+        }
+
+        @Override
+        public DataStream<RowData> produceDataStream(
+                ProviderContext providerContext, StreamExecutionEnvironment execEnv) {
+            return delegate.produceDataStream(providerContext, execEnv);
+        }
+
+        @Override
+        public boolean isBounded() {
+            return delegate.isBounded();
+        }
+
+        @Override
+        public LineageVertex getLineageVertex() {
+            return lineageDelegate.getLineageVertex();
+        }
+    }
+
+    /**
+     * A {@link DataStreamSinkProvider} that also implements {@link LineageVertexProvider}, similar
+     * to how connectors like Apache Paimon provide lineage information alongside DataStream
+     * providers.
+     */
+    private static class DataStreamSinkProviderWithLineage
+            implements DataStreamSinkProvider, LineageVertexProvider {
+
+        private final LineageVertexProvider lineageDelegate;
+
+        DataStreamSinkProviderWithLineage(LineageVertexProvider lineageDelegate) {
+            this.lineageDelegate = lineageDelegate;
+        }
+
+        @Override
+        public DataStreamSink<?> consumeDataStream(
+                ProviderContext providerContext, DataStream<RowData> dataStream) {
+            return dataStream.sinkTo(
+                    new org.apache.flink.streaming.api.functions.sink.v2.DiscardingSink<>());
+        }
+
+        @Override
+        public LineageVertex getLineageVertex() {
+            return lineageDelegate.getLineageVertex();
+        }
     }
 
     // --------------------------------------------------------------------------------------------


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist
  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
This pull request adds lineage vertex extraction support for DataStreamScanProvider and DataStreamSinkProvider.

## Brief change log
- This pull request adds lineage vertex extraction support for DataStreamScanProvider and DataStreamSinkProvider in the table planner. 
- Previously, only Source, SinkFunction, and SinkV2 providers had their LineageVertex extracted for FLIP-314 lineage events.
- Connectors that use DataStream providers (e.g. Apache Paimon) were silently missing lineage dataset facets. This ensures all scan/sink provider types are treated consistently for lineage reporting.
- Specifically was trying to solve this issue for reference: https://github.com/apache/paimon/issues/7306


## Verifying this change

This change added tests and can be verified as follows:
- Added unit tests for the changes done in flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/lineage/TableLineageUtilsTest.java.
- Verified manually by running a flink cluster that the changes made are running as expected.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (no)
