### PR TITLE
[FLINK-21309][metrics] Add UUID as grouping key for prom pushgateway

### DIFF
--- a/docs/layouts/shortcodes/generated/prometheus_push_gateway_reporter_configuration.html
+++ b/docs/layouts/shortcodes/generated/prometheus_push_gateway_reporter_configuration.html
@@ -48,7 +48,7 @@
             <td><h5>metrics.reporter.prometheus.randomJobNameSuffix</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
-            <td>Specifies whether a random suffix should be appended to the job name.</td>
+            <td>Specifies whether to suffix `job` label with random unique ids to avoid metric collision among reporters from taskmanagers / jobmanager. When enabled (default / old way to avoid collision), each taskmanager / jobmanager will append a UUID to the `job` label when reporting to pushgateway. When disabled, all taskmanagers / jobmanager share the same `job` label as configured, but they group metrics under a random reporter id key so as to avoid collision. This option will be deprecated in the future as its default behavior does not comply with the best practice of prometheus `job` label. It is recommended to disable it in order to rely on the reporter id grouping key.</td>
         </tr>
         <tr>
             <td><h5>metrics.reporter.prometheus.username</h5></td>

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporter.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporter.java
@@ -23,6 +23,7 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.metrics.Metric;
 import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.metrics.reporter.Scheduled;
+import org.apache.flink.util.AbstractID;
 import org.apache.flink.util.Preconditions;
 
 import io.prometheus.client.exporter.BasicAuthHttpConnectionFactory;
@@ -32,13 +33,20 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.AbstractMap;
+import java.util.AbstractSet;
+import java.util.Iterator;
 import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
 
 /**
  * {@link MetricReporter} that exports {@link Metric Metrics} via Prometheus {@link PushGateway}.
  */
 @PublicEvolving
 public class PrometheusPushGatewayReporter extends AbstractPrometheusReporter implements Scheduled {
+    public static final String REPORTER_ID_GROUPPING_KEY =
+            "flink_prometheus_push_gateway_reporter_id";
 
     private final PushGateway pushGateway;
     private final String jobName;
@@ -64,7 +72,7 @@ public class PrometheusPushGatewayReporter extends AbstractPrometheusReporter im
             this.basicAuthEnabled = false;
         }
         this.jobName = Preconditions.checkNotNull(jobName);
-        this.groupingKey = Preconditions.checkNotNull(groupingKey);
+        this.groupingKey = new GroupingKeyMap(Preconditions.checkNotNull(groupingKey));
         this.deleteOnShutdown = deleteOnShutdown;
     }
 
@@ -95,5 +103,69 @@ public class PrometheusPushGatewayReporter extends AbstractPrometheusReporter im
             }
         }
         super.close();
+    }
+
+    /**
+     * (FLINK-21309) Put "flink_prometheus_push_gateway_reporter_id" as the last entry of the
+     * grouping keys, so that each taskmanger instance and jobmanager will not collide their metrics
+     * in the PushGateway.
+     */
+    static class GroupingKeyMap extends AbstractMap<String, String> {
+        private final Map<String, String> customGroupingKeys;
+        private final String reporterId = new AbstractID().toString();
+        private final Set<Entry<String, String>> entrySet = new GroupingKeySet();
+
+        GroupingKeyMap(Map<String, String> customGroupingKeys) {
+            if (customGroupingKeys.containsKey(REPORTER_ID_GROUPPING_KEY)) {
+                throw new IllegalArgumentException(
+                        "Grouping keys must not contain the reserved key: "
+                                + REPORTER_ID_GROUPPING_KEY);
+            }
+            this.customGroupingKeys = customGroupingKeys;
+        }
+
+        @Override
+        public Set<Entry<String, String>> entrySet() {
+            return entrySet;
+        }
+
+        private class GroupingKeySet extends AbstractSet<Map.Entry<String, String>> {
+            @Override
+            public Iterator<Entry<String, String>> iterator() {
+
+                return new Iterator<>() {
+                    private Iterator<Entry<String, String>> customEntryIterator =
+                            customGroupingKeys.entrySet().iterator();
+                    private boolean consumedLast = false;
+
+                    @Override
+                    public boolean hasNext() {
+                        return customEntryIterator.hasNext() || !consumedLast;
+                    }
+
+                    @Override
+                    public Entry<String, String> next() {
+                        if (customEntryIterator.hasNext()) {
+                            return customEntryIterator.next();
+                        }
+                        if (!consumedLast) {
+                            consumedLast = true;
+                            return new AbstractMap.SimpleEntry<>(
+                                    REPORTER_ID_GROUPPING_KEY, reporterId);
+                        }
+                        throw new NoSuchElementException();
+                    }
+                };
+            }
+
+            @Override
+            public int size() {
+                return customGroupingKeys.size() + 1;
+            }
+        }
+
+        String reporterId() {
+            return reporterId;
+        }
     }
 }

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporter.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporter.java
@@ -33,12 +33,8 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.net.URL;
-import java.util.AbstractMap;
-import java.util.AbstractSet;
-import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.Set;
 
 /**
  * {@link MetricReporter} that exports {@link Metric Metrics} via Prometheus {@link PushGateway}.
@@ -75,8 +71,8 @@ public class PrometheusPushGatewayReporter extends AbstractPrometheusReporter im
         this.jobName = Preconditions.checkNotNull(jobName);
         this.groupingKey =
                 metricsGroupingByReporter
-                        ? new GroupingKeyMap(Preconditions.checkNotNull(groupingKey))
-                        : Preconditions.checkNotNull(groupingKey);
+                        ? groupWithReporterId(groupingKey)
+                        : new LinkedHashMap<>(groupingKey);
         this.deleteOnShutdown = deleteOnShutdown;
     }
 
@@ -114,62 +110,14 @@ public class PrometheusPushGatewayReporter extends AbstractPrometheusReporter im
      * grouping keys, so that each taskmanger instance and jobmanager will not collide their metrics
      * in the PushGateway.
      */
-    static class GroupingKeyMap extends AbstractMap<String, String> {
-        private final Map<String, String> customGroupingKeys;
-        private final String reporterId = new AbstractID().toString();
-        private final Set<Entry<String, String>> entrySet = new GroupingKeySet();
-
-        GroupingKeyMap(Map<String, String> customGroupingKeys) {
-            if (customGroupingKeys.containsKey(REPORTER_ID_GROUPPING_KEY)) {
-                throw new IllegalArgumentException(
-                        "Grouping keys must not contain the reserved key: "
-                                + REPORTER_ID_GROUPPING_KEY);
-            }
-            this.customGroupingKeys = customGroupingKeys;
+    static Map<String, String> groupWithReporterId(Map<String, String> origin) {
+        Preconditions.checkNotNull(origin);
+        Map<String, String> groupingKey = new LinkedHashMap<>(origin);
+        if (origin.containsKey(REPORTER_ID_GROUPING_KEY)) {
+            throw new IllegalArgumentException(
+                    "Grouping keys must not contain the reserved key: " + REPORTER_ID_GROUPING_KEY);
         }
-
-        @Override
-        public Set<Entry<String, String>> entrySet() {
-            return entrySet;
-        }
-
-        private class GroupingKeySet extends AbstractSet<Map.Entry<String, String>> {
-            @Override
-            public Iterator<Entry<String, String>> iterator() {
-
-                return new Iterator<>() {
-                    private Iterator<Entry<String, String>> customEntryIterator =
-                            customGroupingKeys.entrySet().iterator();
-                    private boolean consumedLast = false;
-
-                    @Override
-                    public boolean hasNext() {
-                        return customEntryIterator.hasNext() || !consumedLast;
-                    }
-
-                    @Override
-                    public Entry<String, String> next() {
-                        if (customEntryIterator.hasNext()) {
-                            return customEntryIterator.next();
-                        }
-                        if (!consumedLast) {
-                            consumedLast = true;
-                            return new AbstractMap.SimpleEntry<>(
-                                    REPORTER_ID_GROUPPING_KEY, reporterId);
-                        }
-                        throw new NoSuchElementException();
-                    }
-                };
-            }
-
-            @Override
-            public int size() {
-                return customGroupingKeys.size() + 1;
-            }
-        }
-
-        String reporterId() {
-            return reporterId;
-        }
+        groupingKey.put(REPORTER_ID_GROUPING_KEY, new AbstractID().toString());
+        return groupingKey;
     }
 }

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporter.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporter.java
@@ -45,7 +45,7 @@ import java.util.Set;
  */
 @PublicEvolving
 public class PrometheusPushGatewayReporter extends AbstractPrometheusReporter implements Scheduled {
-    public static final String REPORTER_ID_GROUPPING_KEY =
+    public static final String REPORTER_ID_GROUPING_KEY =
             "flink_prometheus_push_gateway_reporter_id";
 
     private final PushGateway pushGateway;
@@ -58,6 +58,7 @@ public class PrometheusPushGatewayReporter extends AbstractPrometheusReporter im
     PrometheusPushGatewayReporter(
             URL hostUrl,
             String jobName,
+            boolean metricsGroupingByReporter,
             Map<String, String> groupingKey,
             final boolean deleteOnShutdown,
             @Nullable String username,
@@ -72,7 +73,10 @@ public class PrometheusPushGatewayReporter extends AbstractPrometheusReporter im
             this.basicAuthEnabled = false;
         }
         this.jobName = Preconditions.checkNotNull(jobName);
-        this.groupingKey = new GroupingKeyMap(Preconditions.checkNotNull(groupingKey));
+        this.groupingKey =
+                metricsGroupingByReporter
+                        ? new GroupingKeyMap(Preconditions.checkNotNull(groupingKey))
+                        : Preconditions.checkNotNull(groupingKey);
         this.deleteOnShutdown = deleteOnShutdown;
     }
 

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterFactory.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterFactory.java
@@ -20,7 +20,6 @@ package org.apache.flink.metrics.prometheus;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.reporter.MetricReporterFactory;
-import org.apache.flink.util.AbstractID;
 import org.apache.flink.util.StringUtils;
 
 import org.slf4j.Logger;
@@ -38,7 +37,6 @@ import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterO
 import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.HOST_URL;
 import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.JOB_NAME;
 import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.PASSWORD;
-import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.RANDOM_JOB_NAME_SUFFIX;
 import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.USERNAME;
 
 /** {@link MetricReporterFactory} for {@link PrometheusPushGatewayReporter}. */
@@ -51,9 +49,6 @@ public class PrometheusPushGatewayReporterFactory implements MetricReporterFacto
     public PrometheusPushGatewayReporter createMetricReporter(Properties properties) {
         MetricConfig metricConfig = (MetricConfig) properties;
         String configuredJobName = metricConfig.getString(JOB_NAME.key(), JOB_NAME.defaultValue());
-        boolean randomSuffix =
-                metricConfig.getBoolean(
-                        RANDOM_JOB_NAME_SUFFIX.key(), RANDOM_JOB_NAME_SUFFIX.defaultValue());
         boolean deleteOnShutdown =
                 metricConfig.getBoolean(
                         DELETE_ON_SHUTDOWN.key(), DELETE_ON_SHUTDOWN.defaultValue());
@@ -68,10 +63,6 @@ public class PrometheusPushGatewayReporterFactory implements MetricReporterFacto
         }
 
         String jobName = configuredJobName;
-        if (randomSuffix) {
-            jobName = configuredJobName + new AbstractID();
-        }
-
         String username = metricConfig.getString(USERNAME.key(), USERNAME.defaultValue());
         String password = metricConfig.getString(PASSWORD.key(), PASSWORD.defaultValue());
 
@@ -93,10 +84,9 @@ public class PrometheusPushGatewayReporterFactory implements MetricReporterFacto
                             password);
 
             LOG.info(
-                    "Configured PrometheusPushGatewayReporter with {hostUrl:{}, jobName:{}, randomJobNameSuffix:{}, deleteOnShutdown:{}, groupingKey:{}, basicAuth:{}}",
+                    "Configured PrometheusPushGatewayReporter with {hostUrl:{}, jobName:{}, deleteOnShutdown:{}, groupingKey:{}, basicAuth:{}}",
                     hostUrl,
                     jobName,
-                    randomSuffix,
                     deleteOnShutdown,
                     groupingKey,
                     reporter.basicAuthEnabled);

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterFactory.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterFactory.java
@@ -20,6 +20,7 @@ package org.apache.flink.metrics.prometheus;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.reporter.MetricReporterFactory;
+import org.apache.flink.util.AbstractID;
 import org.apache.flink.util.StringUtils;
 
 import org.slf4j.Logger;
@@ -37,6 +38,7 @@ import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterO
 import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.HOST_URL;
 import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.JOB_NAME;
 import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.PASSWORD;
+import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.RANDOM_JOB_NAME_SUFFIX;
 import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.USERNAME;
 
 /** {@link MetricReporterFactory} for {@link PrometheusPushGatewayReporter}. */
@@ -49,6 +51,9 @@ public class PrometheusPushGatewayReporterFactory implements MetricReporterFacto
     public PrometheusPushGatewayReporter createMetricReporter(Properties properties) {
         MetricConfig metricConfig = (MetricConfig) properties;
         String configuredJobName = metricConfig.getString(JOB_NAME.key(), JOB_NAME.defaultValue());
+        boolean randomSuffix =
+                metricConfig.getBoolean(
+                        RANDOM_JOB_NAME_SUFFIX.key(), RANDOM_JOB_NAME_SUFFIX.defaultValue());
         boolean deleteOnShutdown =
                 metricConfig.getBoolean(
                         DELETE_ON_SHUTDOWN.key(), DELETE_ON_SHUTDOWN.defaultValue());
@@ -63,6 +68,10 @@ public class PrometheusPushGatewayReporterFactory implements MetricReporterFacto
         }
 
         String jobName = configuredJobName;
+        if (randomSuffix) {
+            jobName = configuredJobName + new AbstractID();
+        }
+
         String username = metricConfig.getString(USERNAME.key(), USERNAME.defaultValue());
         String password = metricConfig.getString(PASSWORD.key(), PASSWORD.defaultValue());
 
@@ -78,15 +87,17 @@ public class PrometheusPushGatewayReporterFactory implements MetricReporterFacto
                     new PrometheusPushGatewayReporter(
                             new URL(hostUrl),
                             jobName,
+                            !randomSuffix,
                             groupingKey,
                             deleteOnShutdown,
                             username,
                             password);
 
             LOG.info(
-                    "Configured PrometheusPushGatewayReporter with {hostUrl:{}, jobName:{}, deleteOnShutdown:{}, groupingKey:{}, basicAuth:{}}",
+                    "Configured PrometheusPushGatewayReporter with {hostUrl:{}, jobName:{}, randomJobNameSuffix:{}, deleteOnShutdown:{}, groupingKey:{}, basicAuth:{}}",
                     hostUrl,
                     jobName,
+                    randomSuffix,
                     deleteOnShutdown,
                     groupingKey,
                     reporter.basicAuthEnabled);

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterOptions.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterOptions.java
@@ -45,13 +45,6 @@ public class PrometheusPushGatewayReporterOptions {
                     .defaultValue("")
                     .withDescription("The job name under which metrics will be pushed");
 
-    public static final ConfigOption<Boolean> RANDOM_JOB_NAME_SUFFIX =
-            ConfigOptions.key("randomJobNameSuffix")
-                    .booleanType()
-                    .defaultValue(true)
-                    .withDescription(
-                            "Specifies whether a random suffix should be appended to the job name.");
-
     public static final ConfigOption<Boolean> DELETE_ON_SHUTDOWN =
             ConfigOptions.key("deleteOnShutdown")
                     .booleanType()

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterOptions.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterOptions.java
@@ -45,7 +45,6 @@ public class PrometheusPushGatewayReporterOptions {
                     .defaultValue("")
                     .withDescription("The job name under which metrics will be pushed");
 
-    @Deprecated
     public static final ConfigOption<Boolean> RANDOM_JOB_NAME_SUFFIX =
             ConfigOptions.key("randomJobNameSuffix")
                     .booleanType()
@@ -54,7 +53,8 @@ public class PrometheusPushGatewayReporterOptions {
                             "Specifies whether to suffix `job` label with random unique ids to avoid metric collision among reporters from taskmanagers / jobmanager."
                                     + " When enabled (default / old way to avoid collision), each taskmanager / jobmanager will append a UUID to the `job` label when reporting to pushgateway."
                                     + " When disabled, all taskmanagers / jobmanager share the same `job` label as configured, but they group metrics under a random reporter id key so as to avoid collision."
-                                    + " This option is deprecated and it is recommended to disable it in order to rely on the reporter id grouping key.");
+                                    + " This option will be deprecated in the future as its default behavior does not comply with the best practice of prometheus `job` label."
+                                    + " It is recommended to disable it in order to rely on the reporter id grouping key.");
 
     public static final ConfigOption<Boolean> DELETE_ON_SHUTDOWN =
             ConfigOptions.key("deleteOnShutdown")

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterOptions.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterOptions.java
@@ -49,11 +49,12 @@ public class PrometheusPushGatewayReporterOptions {
     public static final ConfigOption<Boolean> RANDOM_JOB_NAME_SUFFIX =
             ConfigOptions.key("randomJobNameSuffix")
                     .booleanType()
-                    .defaultValue(false)
+                    .defaultValue(true)
                     .withDescription(
-                            "Specifies whether random suffixing `job` label (the old way) to avoid metric collision among reporters from taskamangers."
-                                    + " When disabled (now default) , metrics will be grouped under a random reporter id while job name is faithful to configuration."
-                                    + " This option is deprecated and it is recommended to rely on the reporter id grouping key.");
+                            "Specifies whether to suffix `job` label with random unique ids to avoid metric collision among reporters from taskmanagers / jobmanager."
+                                    + " When enabled (default / old way to avoid collision), each taskmanager / jobmanager will append a UUID to the `job` label when reporting to pushgateway."
+                                    + " When disabled, all taskmanagers / jobmanager share the same `job` label as configured, but they group metrics under a random reporter id key so as to avoid collision."
+                                    + " This option is deprecated and it is recommended to disable it in order to rely on the reporter id grouping key.");
 
     public static final ConfigOption<Boolean> DELETE_ON_SHUTDOWN =
             ConfigOptions.key("deleteOnShutdown")

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterOptions.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterOptions.java
@@ -45,6 +45,16 @@ public class PrometheusPushGatewayReporterOptions {
                     .defaultValue("")
                     .withDescription("The job name under which metrics will be pushed");
 
+    @Deprecated
+    public static final ConfigOption<Boolean> RANDOM_JOB_NAME_SUFFIX =
+            ConfigOptions.key("randomJobNameSuffix")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Specifies whether random suffixing `job` label (the old way) to avoid metric collision among reporters from taskamangers."
+                                    + " When disabled (now default) , metrics will be grouped under a random reporter id while job name is faithful to configuration."
+                                    + " This option is deprecated and it is recommended to rely on the reporter id grouping key.");
+
     public static final ConfigOption<Boolean> DELETE_ON_SHUTDOWN =
             ConfigOptions.key("deleteOnShutdown")
                     .booleanType()

--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterTest.java
@@ -25,8 +25,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.event.Level;
 
+import java.util.AbstractMap;
+import java.util.Iterator;
 import java.util.Map;
 
+import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporter.REPORTER_ID_GROUPPING_KEY;
 import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.HOST_URL;
 import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.PASSWORD;
 import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.USERNAME;
@@ -59,6 +62,22 @@ class PrometheusPushGatewayReporterTest {
 
         groupingKey = PrometheusPushGatewayReporterFactory.parseGroupingKey("k1");
         assertThat(groupingKey).isEmpty();
+    }
+
+    @Test
+    void testGroupingKeysIteratorEndsWithReporterId() {
+        PrometheusPushGatewayReporter.GroupingKeyMap groupingKey =
+                new PrometheusPushGatewayReporter.GroupingKeyMap(
+                        PrometheusPushGatewayReporterFactory.parseGroupingKey("k1=v1;k2=v2"));
+        assertThat(groupingKey.size()).isEqualTo(3);
+        Iterator<Map.Entry<String, String>> it = groupingKey.entrySet().iterator();
+        for (int i = 0; i < 2; i++) {
+            it.next();
+        }
+        assertThat(it.next())
+                .isEqualTo(
+                        new AbstractMap.SimpleEntry(
+                                REPORTER_ID_GROUPPING_KEY, groupingKey.reporterId()));
     }
 
     @Test

--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterTest.java
@@ -30,6 +30,7 @@ import java.util.Iterator;
 import java.util.Map;
 
 import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporter.REPORTER_ID_GROUPPING_KEY;
+import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.GROUPING_KEY;
 import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.HOST_URL;
 import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.PASSWORD;
 import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.USERNAME;
@@ -78,6 +79,21 @@ class PrometheusPushGatewayReporterTest {
                 .isEqualTo(
                         new AbstractMap.SimpleEntry(
                                 REPORTER_ID_GROUPPING_KEY, groupingKey.reporterId()));
+    }
+
+    @Test
+    void testRejectReporterIdInUserGroupingKey() {
+        MetricConfig metricConfig = new MetricConfig();
+        metricConfig.setProperty(HOST_URL.key(), "http://localhost:8080");
+        metricConfig.setProperty(GROUPING_KEY.key(), "k1=v1;" + REPORTER_ID_GROUPPING_KEY + "=123");
+        assertThatThrownBy(
+                        () ->
+                                new PrometheusPushGatewayReporterFactory()
+                                        .createMetricReporter(metricConfig))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Grouping keys must not contain the reserved key: "
+                                + REPORTER_ID_GROUPPING_KEY);
     }
 
     @Test

--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterTest.java
@@ -25,14 +25,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.event.Level;
 
-import java.util.AbstractMap;
 import java.util.Iterator;
 import java.util.Map;
 
-import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporter.REPORTER_ID_GROUPPING_KEY;
+import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporter.REPORTER_ID_GROUPING_KEY;
 import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.GROUPING_KEY;
 import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.HOST_URL;
 import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.PASSWORD;
+import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.RANDOM_JOB_NAME_SUFFIX;
 import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.USERNAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -67,25 +67,23 @@ class PrometheusPushGatewayReporterTest {
 
     @Test
     void testGroupingKeysIteratorEndsWithReporterId() {
-        PrometheusPushGatewayReporter.GroupingKeyMap groupingKey =
-                new PrometheusPushGatewayReporter.GroupingKeyMap(
+        Map<String, String> groupingKeyWithReporterId =
+                PrometheusPushGatewayReporter.groupWithReporterId(
                         PrometheusPushGatewayReporterFactory.parseGroupingKey("k1=v1;k2=v2"));
-        assertThat(groupingKey.size()).isEqualTo(3);
-        Iterator<Map.Entry<String, String>> it = groupingKey.entrySet().iterator();
+        assertThat(groupingKeyWithReporterId.size()).isEqualTo(3);
+        Iterator<String> it = groupingKeyWithReporterId.keySet().iterator();
         for (int i = 0; i < 2; i++) {
             it.next();
         }
-        assertThat(it.next())
-                .isEqualTo(
-                        new AbstractMap.SimpleEntry(
-                                REPORTER_ID_GROUPPING_KEY, groupingKey.reporterId()));
+        assertThat(it.next()).isEqualTo(REPORTER_ID_GROUPING_KEY);
     }
 
     @Test
     void testRejectReporterIdInUserGroupingKey() {
         MetricConfig metricConfig = new MetricConfig();
         metricConfig.setProperty(HOST_URL.key(), "http://localhost:8080");
-        metricConfig.setProperty(GROUPING_KEY.key(), "k1=v1;" + REPORTER_ID_GROUPPING_KEY + "=123");
+        metricConfig.setProperty(GROUPING_KEY.key(), "k1=v1;" + REPORTER_ID_GROUPING_KEY + "=123");
+        metricConfig.setProperty(RANDOM_JOB_NAME_SUFFIX.key(), "false");
         assertThatThrownBy(
                         () ->
                                 new PrometheusPushGatewayReporterFactory()
@@ -93,7 +91,7 @@ class PrometheusPushGatewayReporterTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining(
                         "Grouping keys must not contain the reserved key: "
-                                + REPORTER_ID_GROUPPING_KEY);
+                                + REPORTER_ID_GROUPING_KEY);
     }
 
     @Test


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Previously we are relying on random uuid suffix of `job` label to avoid metric collisions among taskmangers. This makes it difficult to aggregate over `job` label.
Now we use the uuid as grouping key (`flink_prometheus_push_gateway_reporter_id`) instead, while respecting prometheus guide line on `job` label usage.


## Brief change log

  - Deprecate the `randomJobNameSuffix` flag from the config options, and suggest to disable it in the doc (enabled by default).
  - When `randomJobNameSuffix` is disabled, `job` label will not be suffixed, but an additional reporter id grouping key will be added to avoid metric group collision among taskmanagers.
  - Systematically add flink_prometheus_push_gateway_reporter_id = UUID as last grouping key in all case.


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

This change added tests and can be verified as follows:
- Added unit test to make sure that flink_prometheus_push_gateway_reporter_id = UUID is appended to user provided grouping keys.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
