### PR TITLE
[hotfix] [docs] Fix broken flink-training links in hands-on section

### DIFF
--- a/docs/layouts/shortcodes/training_link.html
+++ b/docs/layouts/shortcodes/training_link.html
@@ -23,6 +23,6 @@ under the License.
         - file: The absolute path to the image file (required)
         - name: The rendered link name (required)
 */}}
-<a href="{{ .Site.Params.TrainingExercises }}/blob/{{ .Site.Params.Branch }}/{{ .Get "file" }}">
+<a href="{{ .Site.Params.TrainingExercises }}/tree/{{ .Site.Params.TrainingBranch | default "master" }}/{{ .Get "file" }}">
     {{ .Get "name" }}
 </a>

--- a/docs/layouts/shortcodes/training_repo.html
+++ b/docs/layouts/shortcodes/training_repo.html
@@ -23,7 +23,7 @@ under the License.
         - file: The absolute path to the image file (required)
         - name: The rendered link name (required)
 */}}
-<a href="{{ .Site.Params.TrainingExercises }}/tree/{{ .Site.Params.Branch }}/">
+<a href="{{ .Site.Params.TrainingExercises }}/tree/{{ .Site.Params.TrainingBranch | default "master" }}/">
     flink-training-repo
 </a>
 


### PR DESCRIPTION
## What is the purpose of the change

Fix broken flink-training links in the Learn Flink docs. Several pages have a "Hands-on" section that use the `training_repo` and `training_link` shortcodes (e.g. Intro to the DataStream API, Data Pipelines & ETL, Streaming Analytics, Event-driven Applications). Two issues affected all of these: (1) the repo link pointed to a branch (e.g. release-2.2) that does not exist in apache/flink-training; (2) the exercise links used `blob` for paths that are directories in the repo, so the URLs were wrong. Both shortcodes are now updated to fallback to `master` branch if `TrainingBranch` is not specified in `docs/config.toml`, and the exercise shortcode uses `tree` instead of `blob`, so the links work on every page that uses them.

## Brief change log

  - `training_repo.html`: fallback to `master` branch for the repo if `.Site.Params.TrainingBranch` is not able to be resolved
  - `training_link.html`: use `tree` instead of `blob` for exercise paths, fallback to `master` branch

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

I built the docs locally using the project's pinned Hugo version (0.124.1 via `setup_hugo.sh` and `build_docs.sh`) and verified the flink-training and exercise links on all affected Learn Flink pages (DataStream API, Data Pipelines & ETL, Streaming Analytics, Event-driven Applications); the links resolve correctly on each page. Note: building with a newer Hugo (e.g. 0.157 from Homebrew) produced several unrelated template errors, so I used the pinned version for verification.

## Does this pull request potentially affect one of the following parts:

  - Dependencies: no
  - The public API: no
  - The serializers: no
  - The runtime per-record code paths: no
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable