### PR TITLE
[FLINK-39237][Doc] Decouple flink-training links from the Flink branch

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -50,6 +50,7 @@ pygmentsUseClasses = true
 
   # Flink training exercises
   TrainingExercises = "//github.com/apache/flink-training"
+  TrainingExercisesBranch = "master"
 
   # This suffix is appended to the Scala-dependent Maven artifact names
   ScalaVersion = "_2.12"

--- a/docs/layouts/shortcodes/training_link.html
+++ b/docs/layouts/shortcodes/training_link.html
@@ -23,6 +23,6 @@ under the License.
         - file: The absolute path to the image file (required)
         - name: The rendered link name (required)
 */}}
-<a href="{{ .Site.Params.TrainingExercises }}/blob/{{ .Site.Params.Branch }}/{{ .Get "file" }}">
+<a href="{{ .Site.Params.TrainingExercises }}/blob/{{ .Site.Params.TrainingExercisesBranch }}/{{ .Get "file" }}">
     {{ .Get "name" }}
 </a>

--- a/docs/layouts/shortcodes/training_repo.html
+++ b/docs/layouts/shortcodes/training_repo.html
@@ -23,7 +23,6 @@ under the License.
         - file: The absolute path to the image file (required)
         - name: The rendered link name (required)
 */}}
-<a href="{{ .Site.Params.TrainingExercises }}/tree/{{ .Site.Params.Branch }}/">
+<a href="{{ .Site.Params.TrainingExercises }}/tree/{{ .Site.Params.TrainingExercisesBranch }}/">
     flink-training-repo
 </a>
-


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This fixes broken `flink-training` links in the docs on release branches.

Today the `training_link` shortcode uses `Site.Params.Branch`, which is updated to values such as `release-2.2` when a new Flink docs branch is created. The `apache/flink-training` repository does not create matching release branches, so those links resolve to non-existent GitHub paths and return 404s.

## Brief change log

This change introduces a dedicated `TrainingExercisesBranch` config entry and updates the training shortcodes to use it instead of the Flink docs `Branch`.
- add `TrainingExercisesBranch = "master"` to `docs/config.toml`
- update `training_link.html` to use `TrainingExercisesBranch`
- update `training_repo.html` to use `TrainingExercisesBranch`


## Verifying this change

Build and verify the docs in local.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
