### PR TITLE
[FLINK-34415] Move away from Kafka-Zookeeper based tests in favor of Kafka-KRaft

### DIFF
--- a/flink-end-to-end-tests/flink-sql-client-test/src/test/java/SqlClientITCase.java
+++ b/flink-end-to-end-tests/flink-sql-client-test/src/test/java/SqlClientITCase.java
@@ -81,6 +81,7 @@ public class SqlClientITCase {
     @Container
     public static final KafkaContainer KAFKA =
             new KafkaContainer(DockerImageName.parse(DockerImageVersions.KAFKA))
+                    .withKraft()
                     .withNetwork(NETWORK)
                     .withNetworkAliases(INTER_CONTAINER_KAFKA_ALIAS)
                     .withLogConsumer(LOG_CONSUMER);


### PR DESCRIPTION
## What is the purpose of the change
Through this change, shifting the testcases from zookeeper based Kafka to kraft based Kafka.


## Brief change log
Changed in testcases to initiate Kafka test container with kraft rather than zookeeper.


## Verifying this change
Changed testcases are working and new changes are visible in console logs.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) - no 
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) - no
  - The serializers: (yes / no / don't know) - no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) - no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) - no
  - The S3 file system connector: (yes / no / don't know) - no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) - no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) - no
