### PR TITLE
[hotfix] warning for conditional

### DIFF
--- a/.github/workflows/template.flink-ci.yml
+++ b/.github/workflows/template.flink-ci.yml
@@ -276,7 +276,7 @@ jobs:
 
       - name: "Upload build artifacts"
         uses: actions/upload-artifact@v4
-        if: ${{ failure() && steps.test-run.outputs.debug-files-output-dir }} != ''
+        if: ${{ failure() && steps.test-run.outputs.debug-files-output-dir != '' }}
         with:
           name: logs-test-${{ needs.compile.outputs.stringified-workflow-name }}-${{ github.run_number }}-${{ matrix.stringified-module-name }}-${{ steps.test-run.outputs.debug-files-name }}
           path: ${{ steps.test-run.outputs.debug-files-output-dir }}


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes a GitHub Actions conditional expression in `.github/workflows/template.flink-ci.yml` so the comparison against an empty string is evaluated inside the `${{ }}` expression.

```
In .github/workflows/ci.yml (Line: 33, Col: 11): Error from called workflow apache/flink/.github/workflows/template.flink-ci.yml@74a3243984d23a19d1e6ac77c86d1a6c477da584 (Line: 279, Col: 13): Conditional expression contains literal text outside replacement tokens. This will cause the expression to always evaluate to truthy. Did you mean to put the entire expression inside ${{ }}?
```

https://github.com/apache/flink/actions/runs/22965038052/workflow#L33

## Brief change log

- Move the `!= ''` comparison inside the `${{ }}` expression in `.github/workflows/template.flink-ci.yml`

## Verifying this change

All pull request checks passed when I ran these changes on my fork.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable