### PR TITLE
[FLINK-39225][model] Add retry with default value fallback for Triton inference failures

### DIFF
--- a/docs/layouts/shortcodes/generated/model_triton_advanced_section.html
+++ b/docs/layouts/shortcodes/generated/model_triton_advanced_section.html
@@ -27,16 +27,34 @@
             <td>Custom HTTP headers as key-value pairs. Example: <code class="highlighter-rouge">'X-Custom-Header:value,X-Another:value2'</code></td>
         </tr>
         <tr>
+            <td><h5>default-value</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Fallback value returned when all retry attempts are exhausted. The value is always configured as a STRING but is parsed to match the output column type at runtime. For example, use <code class="highlighter-rouge">'FAILED'</code> for a STRING output column, <code class="highlighter-rouge">'-1'</code> for an INT output column, or <code class="highlighter-rouge">'0.0'</code> for a DOUBLE output column. If not configured, an exception is thrown after all retries fail. Enables downstream routing of failed records, e.g., <code class="highlighter-rouge">WHERE result != 'FAILED'</code> to filter out failures.</td>
+        </tr>
+        <tr>
             <td><h5>flatten-batch-dim</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
             <td>Whether to flatten the batch dimension for array inputs. When true, shape [1,N] becomes [N]. Defaults to false.</td>
         </tr>
         <tr>
+            <td><h5>max-retries</h5></td>
+            <td style="word-wrap: break-word;">0</td>
+            <td>Integer</td>
+            <td>Maximum number of retry attempts for failed inference requests. Retries are triggered by network errors and retryable server errors (HTTP 408 Request Timeout, HTTP 429 Too Many Requests, HTTP 503 Service Unavailable, HTTP 504 Gateway Timeout). Other client errors (HTTP 4xx) are not retried. Defaults to 0 (no retries).</td>
+        </tr>
+        <tr>
             <td><h5>priority</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>
             <td>Request priority level (0-255). Higher values indicate higher priority.</td>
+        </tr>
+        <tr>
+            <td><h5>retry-backoff</h5></td>
+            <td style="word-wrap: break-word;">100 ms</td>
+            <td>Duration</td>
+            <td>Initial backoff duration for the exponential retry strategy. Each subsequent retry doubles the wait time: 100ms, 200ms, 400ms, etc. Only used when max-retries &gt; 0. Defaults to 100ms.</td>
         </tr>
         <tr>
             <td><h5>sequence-end</h5></td>

--- a/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/AbstractTritonModelFunction.java
+++ b/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/AbstractTritonModelFunction.java
@@ -85,6 +85,9 @@ public abstract class AbstractTritonModelFunction extends AsyncPredictFunction {
     private final String compression;
     private final String authToken;
     private final Map<String, String> customHeaders;
+    private final int maxRetries;
+    private final Duration retryBackoff;
+    private final String defaultValue;
 
     public AbstractTritonModelFunction(
             ModelProviderFactory.Context factoryContext, ReadableConfig config) {
@@ -100,6 +103,9 @@ public abstract class AbstractTritonModelFunction extends AsyncPredictFunction {
         this.compression = config.get(TritonOptions.COMPRESSION);
         this.authToken = config.get(TritonOptions.AUTH_TOKEN);
         this.customHeaders = config.get(TritonOptions.CUSTOM_HEADERS);
+        this.maxRetries = config.get(TritonOptions.MAX_RETRIES);
+        this.retryBackoff = config.get(TritonOptions.RETRY_BACKOFF);
+        this.defaultValue = config.get(TritonOptions.DEFAULT_VALUE);
 
         // Validate input schema - support multiple types
         validateInputSchema(factoryContext.getCatalogModel().getResolvedInputSchema());
@@ -168,7 +174,7 @@ public abstract class AbstractTritonModelFunction extends AsyncPredictFunction {
                 column.getClass());
 
         Preconditions.checkArgument(
-                expectedType != null && !expectedType.equals(column.getDataType().getLogicalType()),
+                expectedType == null || expectedType.equals(column.getDataType().getLogicalType()),
                 "%s column %s should be %s, but is a %s.",
                 inputOrOutput,
                 column.getName(),
@@ -318,5 +324,17 @@ public abstract class AbstractTritonModelFunction extends AsyncPredictFunction {
 
     protected Map<String, String> getCustomHeaders() {
         return customHeaders;
+    }
+
+    protected int getMaxRetries() {
+        return maxRetries;
+    }
+
+    protected Duration getRetryBackoff() {
+        return retryBackoff;
+    }
+
+    protected String getDefaultValue() {
+        return defaultValue;
     }
 }

--- a/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/TritonInferenceModelFunction.java
+++ b/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/TritonInferenceModelFunction.java
@@ -29,6 +29,10 @@ import org.apache.flink.table.data.binary.BinaryStringData;
 import org.apache.flink.table.factories.ModelProviderFactory;
 import org.apache.flink.table.functions.AsyncPredictFunction;
 import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.util.Preconditions;
@@ -52,8 +56,10 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPOutputStream;
 
 /**
@@ -90,7 +96,7 @@ public class TritonInferenceModelFunction extends AbstractTritonModelFunction {
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
     /** Reusable buffer for gzip compression to avoid repeated allocations. */
-    private final ByteArrayOutputStream compressionBuffer = new ByteArrayOutputStream(1024);
+    private transient ByteArrayOutputStream compressionBuffer;
 
     private final LogicalType inputType;
     private final LogicalType outputType;
@@ -137,6 +143,9 @@ public class TritonInferenceModelFunction extends AbstractTritonModelFunction {
                         "Unsupported compression algorithm: '%s'. Currently only 'gzip' is supported.",
                         getCompression());
                 // Only support GZIP: Compress request body with gzip using reusable buffer.
+                if (compressionBuffer == null) {
+                    compressionBuffer = new ByteArrayOutputStream(1024);
+                }
                 compressionBuffer.reset();
                 try (GZIPOutputStream gzos = new GZIPOutputStream(compressionBuffer)) {
                     gzos.write(requestBody.getBytes(StandardCharsets.UTF_8));
@@ -161,57 +170,7 @@ public class TritonInferenceModelFunction extends AbstractTritonModelFunction {
 
             Request request = requestBuilder.build();
 
-            httpClient
-                    .newCall(request)
-                    .enqueue(
-                            new Callback() {
-                                @Override
-                                public void onFailure(Call call, IOException e) {
-                                    LOG.error(
-                                            "Triton inference request failed due to network error",
-                                            e);
-
-                                    // Wrap IOException in TritonNetworkException
-                                    TritonNetworkException networkException =
-                                            new TritonNetworkException(
-                                                    String.format(
-                                                            "Failed to connect to Triton server at %s: %s. "
-                                                                    + "This may indicate network connectivity issues, DNS resolution failure, or server unavailability.",
-                                                            url, e.getMessage()),
-                                                    e);
-
-                                    future.completeExceptionally(networkException);
-                                }
-
-                                @Override
-                                public void onResponse(Call call, Response response)
-                                        throws IOException {
-                                    try {
-                                        if (!response.isSuccessful()) {
-                                            handleErrorResponse(response, future);
-                                            return;
-                                        }
-
-                                        String responseBody = response.body().string();
-                                        Collection<RowData> result =
-                                                parseInferenceResponse(responseBody);
-                                        future.complete(result);
-                                    } catch (JsonProcessingException e) {
-                                        LOG.error("Failed to parse Triton inference response", e);
-                                        future.completeExceptionally(
-                                                new TritonClientException(
-                                                        "Failed to parse Triton response JSON: "
-                                                                + e.getMessage()
-                                                                + ". This may indicate an incompatible response format.",
-                                                        400));
-                                    } catch (Exception e) {
-                                        LOG.error("Failed to process Triton inference response", e);
-                                        future.completeExceptionally(e);
-                                    } finally {
-                                        response.close();
-                                    }
-                                }
-                            });
+            executeWithRetry(request, url, 0, future);
 
         } catch (Exception e) {
             LOG.error("Failed to build Triton inference request", e);
@@ -219,6 +178,167 @@ public class TritonInferenceModelFunction extends AbstractTritonModelFunction {
         }
 
         return future;
+    }
+
+    private void executeWithRetry(
+            Request request,
+            String url,
+            int attempt,
+            CompletableFuture<Collection<RowData>> future) {
+        httpClient
+                .newCall(request)
+                .enqueue(
+                        new Callback() {
+                            @Override
+                            public void onFailure(Call call, IOException e) {
+                                if (attempt < getMaxRetries()) {
+                                    long backoffMs = getRetryBackoff().toMillis() << attempt;
+                                    LOG.warn(
+                                            "Triton inference network error on attempt {}/{}, "
+                                                    + "retrying in {}ms: {}",
+                                            attempt + 1,
+                                            getMaxRetries() + 1,
+                                            backoffMs,
+                                            e.getMessage());
+                                    CompletableFuture.delayedExecutor(
+                                                    backoffMs, TimeUnit.MILLISECONDS)
+                                            .execute(
+                                                    () ->
+                                                            executeWithRetry(
+                                                                    request,
+                                                                    url,
+                                                                    attempt + 1,
+                                                                    future));
+                                } else {
+                                    LOG.error(
+                                            "Triton inference request failed after {} attempt(s) "
+                                                    + "due to network error",
+                                            attempt + 1,
+                                            e);
+                                    completeWithDefaultOrException(
+                                            new TritonNetworkException(
+                                                    String.format(
+                                                            "Failed to connect to Triton server at %s "
+                                                                    + "after %d attempt(s): %s. "
+                                                                    + "This may indicate network connectivity issues, "
+                                                                    + "DNS resolution failure, or server unavailability.",
+                                                            url, attempt + 1, e.getMessage()),
+                                                    e),
+                                            future);
+                                }
+                            }
+
+                            @Override
+                            public void onResponse(Call call, Response response)
+                                    throws IOException {
+                                try {
+                                    if (!response.isSuccessful()) {
+                                        int statusCode = response.code();
+                                        if (isRetryable(statusCode) && attempt < getMaxRetries()) {
+                                            long backoffMs =
+                                                    getRetryBackoff().toMillis() << attempt;
+                                            LOG.warn(
+                                                    "Triton inference failed with HTTP {} on attempt "
+                                                            + "{}/{}, retrying in {}ms",
+                                                    statusCode,
+                                                    attempt + 1,
+                                                    getMaxRetries() + 1,
+                                                    backoffMs);
+                                            CompletableFuture.delayedExecutor(
+                                                            backoffMs, TimeUnit.MILLISECONDS)
+                                                    .execute(
+                                                            () ->
+                                                                    executeWithRetry(
+                                                                            request,
+                                                                            url,
+                                                                            attempt + 1,
+                                                                            future));
+                                        } else if (isRetryable(statusCode)) {
+                                            String errorBody =
+                                                    response.body() != null
+                                                            ? response.body().string()
+                                                            : "No error details provided";
+                                            LOG.error(
+                                                    "Triton inference failed with HTTP {} after {} "
+                                                            + "attempt(s)",
+                                                    statusCode,
+                                                    attempt + 1);
+                                            completeWithDefaultOrException(
+                                                    new TritonServerException(
+                                                            String.format(
+                                                                    "Triton inference failed with HTTP %d "
+                                                                            + "after %d attempt(s): %s",
+                                                                    statusCode,
+                                                                    attempt + 1,
+                                                                    errorBody),
+                                                            statusCode),
+                                                    future);
+                                        } else {
+                                            handleErrorResponse(response, future);
+                                        }
+                                        return;
+                                    }
+
+                                    String responseBody = response.body().string();
+                                    Collection<RowData> result =
+                                            parseInferenceResponse(responseBody);
+                                    future.complete(result);
+                                } catch (JsonProcessingException e) {
+                                    LOG.error("Failed to parse Triton inference response", e);
+                                    future.completeExceptionally(
+                                            new TritonClientException(
+                                                    "Failed to parse Triton response JSON: "
+                                                            + e.getMessage()
+                                                            + ". This may indicate an incompatible response format.",
+                                                    400));
+                                } catch (Exception e) {
+                                    LOG.error("Failed to process Triton inference response", e);
+                                    future.completeExceptionally(e);
+                                } finally {
+                                    response.close();
+                                }
+                            }
+                        });
+    }
+
+    private boolean isRetryable(int statusCode) {
+        return statusCode == 503 || statusCode == 504;
+    }
+
+    private void completeWithDefaultOrException(
+            Exception e, CompletableFuture<Collection<RowData>> future) {
+        if (getDefaultValue() != null) {
+            LOG.warn(
+                    "Triton inference failed after all retries, "
+                            + "returning configured default value: {}",
+                    getDefaultValue());
+            try {
+                future.complete(Collections.singletonList(buildDefaultRowData()));
+            } catch (Exception parseEx) {
+                future.completeExceptionally(parseEx);
+            }
+        } else {
+            future.completeExceptionally(e);
+        }
+    }
+
+    private RowData buildDefaultRowData() {
+        String dv = getDefaultValue();
+        Object value;
+        if (outputType instanceof VarCharType) {
+            value = BinaryStringData.fromString(dv);
+        } else if (outputType instanceof IntType) {
+            value = Integer.parseInt(dv);
+        } else if (outputType instanceof BigIntType) {
+            value = Long.parseLong(dv);
+        } else if (outputType instanceof FloatType) {
+            value = Float.parseFloat(dv);
+        } else if (outputType instanceof DoubleType) {
+            value = Double.parseDouble(dv);
+        } else {
+            value = BinaryStringData.fromString(dv);
+        }
+        return GenericRowData.of(value);
     }
 
     /**

--- a/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/TritonInferenceModelFunction.java
+++ b/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/TritonInferenceModelFunction.java
@@ -302,7 +302,7 @@ public class TritonInferenceModelFunction extends AbstractTritonModelFunction {
     }
 
     private boolean isRetryable(int statusCode) {
-        return statusCode == 503 || statusCode == 504;
+        return statusCode == 408 || statusCode == 429 || statusCode == 503 || statusCode == 504;
     }
 
     private void completeWithDefaultOrException(

--- a/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/TritonModelProviderFactory.java
+++ b/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/TritonModelProviderFactory.java
@@ -70,6 +70,9 @@ public class TritonModelProviderFactory implements ModelProviderFactory {
         set.add(TritonOptions.COMPRESSION);
         set.add(TritonOptions.AUTH_TOKEN);
         set.add(TritonOptions.CUSTOM_HEADERS);
+        set.add(TritonOptions.MAX_RETRIES);
+        set.add(TritonOptions.RETRY_BACKOFF);
+        set.add(TritonOptions.DEFAULT_VALUE);
         return set;
     }
 

--- a/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/TritonOptions.java
+++ b/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/TritonOptions.java
@@ -181,4 +181,36 @@ public class TritonOptions {
                                                     + "Example: %s",
                                             code("'X-Custom-Header:value,X-Another:value2'"))
                                     .build());
+
+    @Documentation.Section({Documentation.Sections.MODEL_TRITON_ADVANCED})
+    public static final ConfigOption<Integer> MAX_RETRIES =
+            ConfigOptions.key("max-retries")
+                    .intType()
+                    .defaultValue(0)
+                    .withDescription(
+                            "Maximum number of retry attempts for failed inference requests. "
+                                    + "Retries are triggered by network errors and retryable server "
+                                    + "errors (HTTP 503, 504). Client errors (HTTP 4xx) are not retried. "
+                                    + "Defaults to 0 (no retries).");
+
+    @Documentation.Section({Documentation.Sections.MODEL_TRITON_ADVANCED})
+    public static final ConfigOption<Duration> RETRY_BACKOFF =
+            ConfigOptions.key("retry-backoff")
+                    .durationType()
+                    .defaultValue(Duration.ofMillis(100))
+                    .withDescription(
+                            "Initial backoff duration for the exponential retry strategy. "
+                                    + "Each subsequent retry doubles the wait time: 100ms, 200ms, 400ms, etc. "
+                                    + "Only used when max-retries > 0. Defaults to 100ms.");
+
+    @Documentation.Section({Documentation.Sections.MODEL_TRITON_ADVANCED})
+    public static final ConfigOption<String> DEFAULT_VALUE =
+            ConfigOptions.key("default-value")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Fallback value returned when all retry attempts are exhausted. "
+                                    + "Supports STRING and numeric output types. "
+                                    + "If not configured, an exception is thrown after all retries fail. "
+                                    + "Enables downstream routing of failed records.");
 }

--- a/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/TritonOptions.java
+++ b/flink-models/flink-model-triton/src/main/java/org/apache/flink/model/triton/TritonOptions.java
@@ -190,7 +190,9 @@ public class TritonOptions {
                     .withDescription(
                             "Maximum number of retry attempts for failed inference requests. "
                                     + "Retries are triggered by network errors and retryable server "
-                                    + "errors (HTTP 503, 504). Client errors (HTTP 4xx) are not retried. "
+                                    + "errors (HTTP 408 Request Timeout, HTTP 429 Too Many Requests, "
+                                    + "HTTP 503 Service Unavailable, HTTP 504 Gateway Timeout). "
+                                    + "Other client errors (HTTP 4xx) are not retried. "
                                     + "Defaults to 0 (no retries).");
 
     @Documentation.Section({Documentation.Sections.MODEL_TRITON_ADVANCED})
@@ -209,8 +211,19 @@ public class TritonOptions {
                     .stringType()
                     .noDefaultValue()
                     .withDescription(
-                            "Fallback value returned when all retry attempts are exhausted. "
-                                    + "Supports STRING and numeric output types. "
-                                    + "If not configured, an exception is thrown after all retries fail. "
-                                    + "Enables downstream routing of failed records.");
+                            Description.builder()
+                                    .text(
+                                            "Fallback value returned when all retry attempts are exhausted. "
+                                                    + "The value is always configured as a STRING but is parsed "
+                                                    + "to match the output column type at runtime. "
+                                                    + "For example, use %s for a STRING output column, "
+                                                    + "%s for an INT output column, or %s for a DOUBLE output column. "
+                                                    + "If not configured, an exception is thrown after all retries fail. "
+                                                    + "Enables downstream routing of failed records, e.g., "
+                                                    + "%s to filter out failures.",
+                                            code("'FAILED'"),
+                                            code("'-1'"),
+                                            code("'0.0'"),
+                                            code("WHERE result != 'FAILED'"))
+                                    .build());
 }

--- a/flink-models/flink-model-triton/src/test/java/org/apache/flink/model/triton/TritonInferenceRetryTest.java
+++ b/flink-models/flink-model-triton/src/test/java/org/apache/flink/model/triton/TritonInferenceRetryTest.java
@@ -157,6 +157,45 @@ class TritonInferenceRetryTest {
         assertThat(rows.get(0).<String>getFieldAs(0)).isEqualTo("FAILED");
     }
 
+    /**
+     * All attempts fail with 503 and numeric default-value is configured — returns numeric default.
+     */
+    @Test
+    void testNumericDefaultValueReturnedAfterAllRetriesFail() throws Exception {
+        String intModelName = "triton_retry_model_int";
+        Schema intOutputSchema = Schema.newBuilder().column("prediction", DataTypes.INT()).build();
+
+        Map<String, String> intModelOptions = new HashMap<>(modelOptions);
+        intModelOptions.put("max-retries", "1");
+        intModelOptions.put("default-value", "-1");
+
+        CatalogManager catalogManager = ((TableEnvironmentImpl) tEnv).getCatalogManager();
+        ObjectIdentifier modelIdentifier =
+                ObjectIdentifier.of(
+                        Objects.requireNonNull(catalogManager.getCurrentCatalog()),
+                        Objects.requireNonNull(catalogManager.getCurrentDatabase()),
+                        intModelName);
+        catalogManager.createModel(
+                CatalogModel.of(INPUT_SCHEMA, intOutputSchema, intModelOptions, ""),
+                modelIdentifier,
+                false);
+
+        server.enqueue(new MockResponse().setResponseCode(503));
+        server.enqueue(new MockResponse().setResponseCode(503));
+
+        TableResult tableResult =
+                tEnv.executeSql(
+                        "SELECT prediction FROM ML_PREDICT("
+                                + "TABLE input_table, MODEL "
+                                + intModelName
+                                + ", DESCRIPTOR(`input`))");
+
+        List<Row> rows = collectRows(tableResult);
+
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).<Integer>getFieldAs(0)).isEqualTo(-1);
+    }
+
     /** All attempts fail with 503 and no default-value — exception is thrown. */
     @Test
     void testExceptionThrownWhenNoDefaultValueAfterAllRetriesFail() {

--- a/flink-models/flink-model-triton/src/test/java/org/apache/flink/model/triton/TritonInferenceRetryTest.java
+++ b/flink-models/flink-model-triton/src/test/java/org/apache/flink/model/triton/TritonInferenceRetryTest.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.model.triton;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.TableResult;
+import org.apache.flink.table.api.internal.TableEnvironmentImpl;
+import org.apache.flink.table.catalog.CatalogManager;
+import org.apache.flink.table.catalog.CatalogModel;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CloseableIterator;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for retry and default value fallback in {@link TritonInferenceModelFunction}. */
+class TritonInferenceRetryTest {
+
+    private static final String MODEL_NAME = "triton_retry_model";
+
+    private static final Schema INPUT_SCHEMA =
+            Schema.newBuilder().column("input", DataTypes.STRING()).build();
+
+    private static final Schema OUTPUT_SCHEMA =
+            Schema.newBuilder().column("prediction", DataTypes.STRING()).build();
+
+    private static final String SUCCESS_RESPONSE =
+            "{\"outputs\":[{\"name\":\"RESULT\",\"datatype\":\"BYTES\","
+                    + "\"shape\":[1,1],\"data\":[\"ok\"]}]}";
+
+    private static MockWebServer server;
+
+    private TableEnvironment tEnv;
+    private Map<String, String> modelOptions;
+    private int requestCountBefore;
+
+    @BeforeAll
+    static void beforeAll() throws IOException {
+        server = new MockWebServer();
+        server.start();
+    }
+
+    @AfterAll
+    static void afterAll() throws IOException {
+        if (server != null) {
+            server.close();
+        }
+    }
+
+    @BeforeEach
+    void setup() {
+        tEnv = TableEnvironment.create(new Configuration());
+        tEnv.executeSql(
+                "CREATE TABLE input_table(input STRING) WITH ("
+                        + "'connector' = 'datagen',"
+                        + "'number-of-rows' = '1')");
+
+        modelOptions = new HashMap<>();
+        modelOptions.put("provider", "triton");
+        modelOptions.put("endpoint", server.url("/v2/models").toString());
+        modelOptions.put("model-name", "test-model");
+        modelOptions.put("retry-backoff", "1ms");
+
+        requestCountBefore = server.getRequestCount();
+    }
+
+    @AfterEach
+    void drainServer() throws InterruptedException {
+        // Drain any leftover responses to avoid polluting subsequent tests.
+        // MockWebServer does not expose a drain API; we clear by re-creating
+        // the queue indirectly via a no-op — leftover MockResponses are harmless
+        // as long as each test enqueues exactly what it needs.
+    }
+
+    /** First attempt fails with 503, second attempt succeeds — retry is effective. */
+    @Test
+    void testRetrySucceedsBeforeMaxAttempts() throws Exception {
+        modelOptions.put("max-retries", "2");
+        createModel();
+
+        server.enqueue(new MockResponse().setResponseCode(503));
+        server.enqueue(
+                new MockResponse()
+                        .setResponseCode(200)
+                        .addHeader("Content-Type", "application/json")
+                        .setBody(SUCCESS_RESPONSE));
+
+        TableResult tableResult =
+                tEnv.executeSql(
+                        "SELECT prediction FROM ML_PREDICT("
+                                + "TABLE input_table, MODEL "
+                                + MODEL_NAME
+                                + ", DESCRIPTOR(`input`))");
+
+        List<Row> rows = collectRows(tableResult);
+
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).<String>getFieldAs(0)).isEqualTo("ok");
+        assertThat(server.getRequestCount() - requestCountBefore).isEqualTo(2);
+    }
+
+    /** All attempts fail with 503 and default-value is configured — returns default value. */
+    @Test
+    void testDefaultValueReturnedAfterAllRetriesFail() throws Exception {
+        modelOptions.put("max-retries", "2");
+        modelOptions.put("default-value", "FAILED");
+        createModel();
+
+        server.enqueue(new MockResponse().setResponseCode(503));
+        server.enqueue(new MockResponse().setResponseCode(503));
+        server.enqueue(new MockResponse().setResponseCode(503));
+
+        TableResult tableResult =
+                tEnv.executeSql(
+                        "SELECT prediction FROM ML_PREDICT("
+                                + "TABLE input_table, MODEL "
+                                + MODEL_NAME
+                                + ", DESCRIPTOR(`input`))");
+
+        List<Row> rows = collectRows(tableResult);
+
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).<String>getFieldAs(0)).isEqualTo("FAILED");
+    }
+
+    /** All attempts fail with 503 and no default-value — exception is thrown. */
+    @Test
+    void testExceptionThrownWhenNoDefaultValueAfterAllRetriesFail() {
+        modelOptions.put("max-retries", "1");
+        createModel();
+
+        server.enqueue(new MockResponse().setResponseCode(503));
+        server.enqueue(new MockResponse().setResponseCode(503));
+
+        TableResult tableResult =
+                tEnv.executeSql(
+                        "SELECT prediction FROM ML_PREDICT("
+                                + "TABLE input_table, MODEL "
+                                + MODEL_NAME
+                                + ", DESCRIPTOR(`input`))");
+
+        assertThatThrownBy(() -> collectRows(tableResult)).isInstanceOf(Exception.class);
+    }
+
+    /** A 4xx client error is not retried — fails immediately after one request. */
+    @Test
+    void test4xxErrorNotRetried() {
+        modelOptions.put("max-retries", "3");
+        createModel();
+
+        server.enqueue(
+                new MockResponse().setResponseCode(400).setBody("{\"error\":\"bad request\"}"));
+
+        TableResult tableResult =
+                tEnv.executeSql(
+                        "SELECT prediction FROM ML_PREDICT("
+                                + "TABLE input_table, MODEL "
+                                + MODEL_NAME
+                                + ", DESCRIPTOR(`input`))");
+
+        assertThatThrownBy(() -> collectRows(tableResult)).isInstanceOf(Exception.class);
+
+        assertThat(server.getRequestCount() - requestCountBefore).isEqualTo(1);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private void createModel() {
+        CatalogManager catalogManager = ((TableEnvironmentImpl) tEnv).getCatalogManager();
+        ObjectIdentifier modelIdentifier =
+                ObjectIdentifier.of(
+                        Objects.requireNonNull(catalogManager.getCurrentCatalog()),
+                        Objects.requireNonNull(catalogManager.getCurrentDatabase()),
+                        MODEL_NAME);
+        catalogManager.createModel(
+                CatalogModel.of(INPUT_SCHEMA, OUTPUT_SCHEMA, modelOptions, ""),
+                modelIdentifier,
+                false);
+    }
+
+    private static List<Row> collectRows(TableResult tableResult) throws Exception {
+        List<Row> rows = new ArrayList<>();
+        try (CloseableIterator<Row> it = tableResult.collect()) {
+            it.forEachRemaining(rows::add);
+        }
+        return rows;
+    }
+}

--- a/flink-models/flink-model-triton/src/test/java/org/apache/flink/model/triton/TritonModelProviderFactoryTest.java
+++ b/flink-models/flink-model-triton/src/test/java/org/apache/flink/model/triton/TritonModelProviderFactoryTest.java
@@ -42,7 +42,7 @@ class TritonModelProviderFactoryTest {
     void testOptionalOptions() {
         TritonModelProviderFactory factory = new TritonModelProviderFactory();
         assertThat(factory.optionalOptions())
-                .hasSize(10)
+                .hasSize(13)
                 .containsExactlyInAnyOrder(
                         TritonOptions.MODEL_VERSION,
                         TritonOptions.TIMEOUT,
@@ -53,6 +53,9 @@ class TritonModelProviderFactoryTest {
                         TritonOptions.SEQUENCE_END,
                         TritonOptions.COMPRESSION,
                         TritonOptions.AUTH_TOKEN,
-                        TritonOptions.CUSTOM_HEADERS);
+                        TritonOptions.CUSTOM_HEADERS,
+                        TritonOptions.MAX_RETRIES,
+                        TritonOptions.RETRY_BACKOFF,
+                        TritonOptions.DEFAULT_VALUE);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

  This pull request implements retry mechanism with exponential backoff and default value fallback for Triton model inference failures, enabling robust error handling and
  downstream routing of failed records.

  ## Brief change log

    - `TritonOptions`: Added `max-retries` (default: 0), `retry-backoff` (default: 100ms), and `default-value` configuration options
    - `AbstractTritonModelFunction`: Added fields and getters for the three new retry configuration options
    - `TritonInferenceModelFunction`: Implemented exponential backoff retry logic; retries on network errors and 5xx errors (503, 504); fails immediately on 4xx client errors;     
  returns configured default value after exhausting all retries
    - `TritonModelProviderFactory`: Registered the three new options in `optionalOptions()`

  ## Verifying this change

  This change added tests and can be verified as follows:

    - Added `TritonInferenceRetryTest` with 4 test cases using MockWebServer:
      - Retry succeeds before exhausting max attempts (1 fail + 1 success)
      - Default value returned after all retries fail
      - Exception thrown when no default value is configured and all retries fail
      - 4xx client errors are not retried and fail immediately
    - Updated `TritonModelProviderFactoryTest` to include the 3 new configuration options

  ## Does this pull request potentially affect one of the following parts:

    - Dependencies (does it add or upgrade a dependency): no
    - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
    - The serializers: no
    - The runtime per-record code paths (performance sensitive): yes (retry logic adds latency on failure paths only)
    - Anything that affects deployment or recovery: no
    - The S3 file system connector: no

  ## Documentation

    - Does this pull request introduce a new feature? yes
    - If yes, how is the feature documented? not documented (configuration options added to `TritonOptions` with JavaDoc)