### PR TITLE
[FLINK-39251][Formats] Support Nanosecond Logical Types in Flink Avro 

### DIFF
--- a/flink-formats/flink-avro/pom.xml
+++ b/flink-formats/flink-avro/pom.xml
@@ -257,6 +257,7 @@ under the License.
 						<configuration>
 							<testSourceDirectory>${project.basedir}/src/test/resources/avro</testSourceDirectory>
 							<testOutputDirectory>${project.basedir}/target/generated-test-sources/</testOutputDirectory>
+							<enableDecimalLogicalType>true</enableDecimalLogicalType>
 						</configuration>
 					</execution>
 				</executions>

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroToRowDataConverters.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroToRowDataConverters.java
@@ -29,8 +29,10 @@ import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.utils.LogicalTypeUtils;
 
 import org.apache.avro.generic.GenericFixed;
@@ -128,12 +130,13 @@ public class AvroToRowDataConverters {
             case TIME_WITHOUT_TIME_ZONE:
                 return AvroToRowDataConverters::convertToTime;
             case TIMESTAMP_WITHOUT_TIME_ZONE:
-                return AvroToRowDataConverters::convertToTimestamp;
+                return createTimestampConverter(((TimestampType) type).getPrecision());
             case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
                 if (legacyTimestampMapping) {
                     throw new UnsupportedOperationException("Unsupported type: " + type);
                 } else {
-                    return AvroToRowDataConverters::convertToTimestamp;
+                    return createTimestampConverter(
+                            ((LocalZonedTimestampType) type).getPrecision());
                 }
             case CHAR:
             case VARCHAR:
@@ -211,24 +214,37 @@ public class AvroToRowDataConverters {
         };
     }
 
-    private static TimestampData convertToTimestamp(Object object) {
-        final long millis;
-        if (object instanceof Long) {
-            millis = (Long) object;
-        } else if (object instanceof Instant) {
-            millis = ((Instant) object).toEpochMilli();
-        } else if (object instanceof LocalDateTime) {
-            return TimestampData.fromLocalDateTime((LocalDateTime) object);
-        } else {
-            JodaConverter jodaConverter = JodaConverter.getConverter();
-            if (jodaConverter != null) {
-                millis = jodaConverter.convertTimestamp(object);
+    private static AvroToRowDataConverter createTimestampConverter(int precision) {
+        return object -> {
+            if (object instanceof Long) {
+                long val = (Long) object;
+                if (precision <= 3) {
+                    return TimestampData.fromEpochMillis(val);
+                } else if (precision <= 6) {
+                    long millis = Math.floorDiv(val, 1000L);
+                    int nanosOfMilli = (int) (Math.floorMod(val, 1000L) * 1000);
+                    return TimestampData.fromEpochMillis(millis, nanosOfMilli);
+                } else {
+                    long millis = Math.floorDiv(val, 1000_000L);
+                    int nanosOfMilli = (int) Math.floorMod(val, 1000_000L);
+                    return TimestampData.fromEpochMillis(millis, nanosOfMilli);
+                }
+            } else if (object instanceof Instant) {
+                return TimestampData.fromInstant((Instant) object);
+            } else if (object instanceof LocalDateTime) {
+                return TimestampData.fromLocalDateTime((LocalDateTime) object);
             } else {
-                throw new IllegalArgumentException(
-                        "Unexpected object type for TIMESTAMP logical type. Received: " + object);
+                JodaConverter jodaConverter = JodaConverter.getConverter();
+                if (jodaConverter != null) {
+                    long millis = jodaConverter.convertTimestamp(object);
+                    return TimestampData.fromEpochMillis(millis);
+                } else {
+                    throw new IllegalArgumentException(
+                            "Unexpected object type for TIMESTAMP logical type. Received: "
+                                    + object);
+                }
             }
-        }
-        return TimestampData.fromEpochMillis(millis);
+        };
     }
 
     private static int convertToDate(Object object) {

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/RowDataToAvroConverters.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/RowDataToAvroConverters.java
@@ -25,8 +25,10 @@ import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.util.CollectionUtil;
 
 import org.apache.avro.Schema;
@@ -156,6 +158,7 @@ public class RowDataToAvroConverters {
                         };
                 break;
             case TIMESTAMP_WITHOUT_TIME_ZONE:
+                final int timestampPrecision = ((TimestampType) type).getPrecision();
                 if (legacyTimestampMapping) {
                     converter =
                             new RowDataToAvroConverter() {
@@ -173,15 +176,26 @@ public class RowDataToAvroConverters {
 
                                 @Override
                                 public Object convert(Schema schema, Object object) {
-                                    return ((TimestampData) object)
-                                            .toLocalDateTime()
-                                            .toInstant(ZoneOffset.UTC)
-                                            .toEpochMilli();
+                                    java.time.Instant instant =
+                                            ((TimestampData) object)
+                                                    .toLocalDateTime()
+                                                    .toInstant(ZoneOffset.UTC);
+                                    if (timestampPrecision <= 3) {
+                                        return instant.toEpochMilli();
+                                    } else if (timestampPrecision <= 6) {
+                                        return instant.getEpochSecond() * 1_000_000L
+                                                + instant.getNano() / 1000L;
+                                    } else {
+                                        return instant.getEpochSecond() * 1_000_000_000L
+                                                + instant.getNano();
+                                    }
                                 }
                             };
                 }
                 break;
             case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                final int localZonedTimestampPrecision =
+                        ((LocalZonedTimestampType) type).getPrecision();
                 if (legacyTimestampMapping) {
                     throw new UnsupportedOperationException("Unsupported type: " + type);
                 } else {
@@ -191,7 +205,17 @@ public class RowDataToAvroConverters {
 
                                 @Override
                                 public Object convert(Schema schema, Object object) {
-                                    return ((TimestampData) object).toInstant().toEpochMilli();
+                                    java.time.Instant instant =
+                                            ((TimestampData) object).toInstant();
+                                    if (localZonedTimestampPrecision <= 3) {
+                                        return instant.toEpochMilli();
+                                    } else if (localZonedTimestampPrecision <= 6) {
+                                        return instant.getEpochSecond() * 1_000_000L
+                                                + instant.getNano() / 1000L;
+                                    } else {
+                                        return instant.getEpochSecond() * 1_000_000_000L
+                                                + instant.getNano();
+                                    }
                                 }
                             };
                 }

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/AvroSchemaConverter.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/AvroSchemaConverter.java
@@ -194,7 +194,8 @@ public class AvroSchemaConverter {
             case LONG:
                 if (legacyTimestampMapping) {
                     if (schema.getLogicalType() == LogicalTypes.timestampMillis()
-                            || schema.getLogicalType() == LogicalTypes.timestampMicros()) {
+                            || schema.getLogicalType() == LogicalTypes.timestampMicros()
+                            || schema.getLogicalType() == LogicalTypes.timestampNanos()) {
                         return Types.SQL_TIMESTAMP;
                     } else if (schema.getLogicalType() == LogicalTypes.timeMicros()
                             || schema.getLogicalType() == LogicalTypes.timeMillis()) {
@@ -203,10 +204,12 @@ public class AvroSchemaConverter {
                 } else {
                     // Avro logical timestamp types to Flink DataStream timestamp types
                     if (schema.getLogicalType() == LogicalTypes.timestampMillis()
-                            || schema.getLogicalType() == LogicalTypes.timestampMicros()) {
+                            || schema.getLogicalType() == LogicalTypes.timestampMicros()
+                            || schema.getLogicalType() == LogicalTypes.timestampNanos()) {
                         return Types.INSTANT;
                     } else if (schema.getLogicalType() == LogicalTypes.localTimestampMillis()
-                            || schema.getLogicalType() == LogicalTypes.localTimestampMicros()) {
+                            || schema.getLogicalType() == LogicalTypes.localTimestampMicros()
+                            || schema.getLogicalType() == LogicalTypes.localTimestampNanos()) {
                         return Types.LOCAL_DATE_TIME;
                     } else if (schema.getLogicalType() == LogicalTypes.timeMicros()
                             || schema.getLogicalType() == LogicalTypes.timeMillis()) {
@@ -350,6 +353,8 @@ public class AvroSchemaConverter {
                         return DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).notNull();
                     } else if (schema.getLogicalType() == LogicalTypes.timestampMicros()) {
                         return DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(6).notNull();
+                    } else if (schema.getLogicalType() == LogicalTypes.timestampNanos()) {
+                        return DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(9).notNull();
                     } else if (schema.getLogicalType() == LogicalTypes.timeMillis()) {
                         return DataTypes.TIME(3).notNull();
                     } else if (schema.getLogicalType() == LogicalTypes.timeMicros()) {
@@ -358,6 +363,8 @@ public class AvroSchemaConverter {
                         return DataTypes.TIMESTAMP(3).notNull();
                     } else if (schema.getLogicalType() == LogicalTypes.localTimestampMicros()) {
                         return DataTypes.TIMESTAMP(6).notNull();
+                    } else if (schema.getLogicalType() == LogicalTypes.localTimestampNanos()) {
+                        return DataTypes.TIMESTAMP(9).notNull();
                     }
                 }
 
@@ -479,12 +486,14 @@ public class AvroSchemaConverter {
                         avroLogicalType = LogicalTypes.localTimestampMillis();
                     } else if (precision <= 6) {
                         avroLogicalType = LogicalTypes.localTimestampMicros();
+                    } else if (precision <= 9) {
+                        avroLogicalType = LogicalTypes.localTimestampNanos();
                     } else {
                         throw new IllegalArgumentException(
                                 "Avro does not support LOCAL TIMESTAMP type "
                                         + "with precision: "
                                         + precision
-                                        + ", it only supports precision less than 6.");
+                                        + ", it only supports precision less than 9.");
                     }
                 }
                 Schema timestamp = avroLogicalType.addToSchema(SchemaBuilder.builder().longType());
@@ -501,12 +510,14 @@ public class AvroSchemaConverter {
                         avroLogicalType = LogicalTypes.timestampMillis();
                     } else if (precision <= 6) {
                         avroLogicalType = LogicalTypes.timestampMicros();
+                    } else if (precision <= 9) {
+                        avroLogicalType = LogicalTypes.timestampNanos();
                     } else {
                         throw new IllegalArgumentException(
                                 "Avro does not support TIMESTAMP type "
                                         + "with precision: "
                                         + precision
-                                        + ", it only supports precision less than 6.");
+                                        + ", it only supports precision less than 9.");
                     }
                     timestamp = avroLogicalType.addToSchema(SchemaBuilder.builder().longType());
                     return nullable ? nullableSchema(timestamp) : timestamp;

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroOutputFormatITCase.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroOutputFormatITCase.java
@@ -25,7 +25,6 @@ import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.formats.avro.AvroOutputFormat.Codec;
 import org.apache.flink.formats.avro.generated.Colors;
-import org.apache.flink.formats.avro.generated.Fixed2;
 import org.apache.flink.formats.avro.generated.User;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -185,12 +184,11 @@ public class AvroOutputFormatITCase extends JavaProgramTestBaseJUnit4 {
             user.setTypeTimeMicros(LocalTime.ofSecondOfDay(0).plus(123456L, ChronoUnit.MICROS));
             user.setTypeTimestampMillis(Instant.parse("2014-03-01T12:12:12.321Z"));
             user.setTypeTimestampMicros(Instant.ofEpochSecond(0).plus(123456L, ChronoUnit.MICROS));
+            user.setTypeTimestampNanos(Instant.ofEpochSecond(0).plus(123456789L, ChronoUnit.NANOS));
             // 20.00
-            user.setTypeDecimalBytes(
-                    ByteBuffer.wrap(BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()));
+            user.setTypeDecimalBytes(BigDecimal.valueOf(2000, 2));
             // 20.00
-            user.setTypeDecimalFixed(
-                    new Fixed2(BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()));
+            user.setTypeDecimalFixed(BigDecimal.valueOf(2000, 2));
             return user;
         }
     }

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroOutputFormatTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroOutputFormatTest.java
@@ -23,7 +23,6 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.formats.avro.generated.Colors;
-import org.apache.flink.formats.avro.generated.Fixed2;
 import org.apache.flink.formats.avro.generated.User;
 import org.apache.flink.mock.Whitebox;
 
@@ -198,13 +197,12 @@ class AvroOutputFormatTest {
             user.setTypeTimeMicros(LocalTime.ofSecondOfDay(0).plus(123456L, ChronoUnit.MICROS));
             user.setTypeTimestampMillis(Instant.parse("2014-03-01T12:12:12.321Z"));
             user.setTypeTimestampMicros(Instant.ofEpochSecond(0).plus(123456L, ChronoUnit.MICROS));
+            user.setTypeTimestampNanos(Instant.ofEpochSecond(0).plus(123456789L, ChronoUnit.NANOS));
 
             // 20.00
-            user.setTypeDecimalBytes(
-                    ByteBuffer.wrap(BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()));
+            user.setTypeDecimalBytes(BigDecimal.valueOf(2000, 2));
             // 20.00
-            user.setTypeDecimalFixed(
-                    new Fixed2(BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()));
+            user.setTypeDecimalFixed(BigDecimal.valueOf(2000, 2));
 
             outputFormat.writeRecord(user);
         }

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroRecordInputFormatTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroRecordInputFormatTest.java
@@ -31,7 +31,6 @@ import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.formats.avro.generated.Address;
 import org.apache.flink.formats.avro.generated.Colors;
-import org.apache.flink.formats.avro.generated.Fixed2;
 import org.apache.flink.formats.avro.generated.User;
 import org.apache.flink.formats.avro.typeutils.AvroTypeInfo;
 import org.apache.flink.formats.avro.utils.AvroKryoSerializerUtils;
@@ -139,12 +138,11 @@ public class AvroRecordInputFormatTest {
         user1.setTypeTimeMicros(LocalTime.ofSecondOfDay(0).plus(123456L, ChronoUnit.MICROS));
         user1.setTypeTimestampMillis(Instant.parse("2014-03-01T12:12:12.321Z"));
         user1.setTypeTimestampMicros(Instant.ofEpochSecond(0).plus(123456L, ChronoUnit.MICROS));
+        user1.setTypeTimestampNanos(Instant.ofEpochSecond(0).plus(123456789L, ChronoUnit.NANOS));
         // 20.00
-        user1.setTypeDecimalBytes(
-                ByteBuffer.wrap(BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()));
+        user1.setTypeDecimalBytes(BigDecimal.valueOf(2000, 2));
         // 20.00
-        user1.setTypeDecimalFixed(
-                new Fixed2(BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()));
+        user1.setTypeDecimalFixed(BigDecimal.valueOf(2000, 2));
 
         // Construct via builder
         User user2 =
@@ -179,14 +177,12 @@ public class AvroRecordInputFormatTest {
                         .setTypeTimestampMillis(Instant.parse("2014-03-01T12:12:12.321Z"))
                         .setTypeTimestampMicros(
                                 Instant.ofEpochSecond(0).plus(123456L, ChronoUnit.MICROS))
+                        .setTypeTimestampNanos(
+                                Instant.ofEpochSecond(0).plus(123456789L, ChronoUnit.NANOS))
                         // 20.00
-                        .setTypeDecimalBytes(
-                                ByteBuffer.wrap(
-                                        BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()))
+                        .setTypeDecimalBytes(BigDecimal.valueOf(2000, 2))
                         // 20.00
-                        .setTypeDecimalFixed(
-                                new Fixed2(
-                                        BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()))
+                        .setTypeDecimalFixed(BigDecimal.valueOf(2000, 2))
                         .build();
         DatumWriter<User> userDatumWriter = new SpecificDatumWriter<>(User.class);
         DataFileWriter<User> dataFileWriter = new DataFileWriter<>(userDatumWriter);

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroRowDataDeSerializationSchemaTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroRowDataDeSerializationSchemaTest.java
@@ -117,6 +117,7 @@ class AvroRowDataDeSerializationSchemaTest {
                                 FIELD("date", DATE()),
                                 FIELD("timestamp3", TIMESTAMP(3)),
                                 FIELD("timestamp3_2", TIMESTAMP(3)),
+                                FIELD("timestamp9", TIMESTAMP(9)),
                                 FIELD("map", MAP(STRING(), BIGINT())),
                                 FIELD("map2map", MAP(STRING(), MAP(STRING(), INT()))),
                                 FIELD("map2array", MAP(STRING(), ARRAY(INT()))),
@@ -124,7 +125,7 @@ class AvroRowDataDeSerializationSchemaTest {
                         .notNull();
         final RowType rowType = (RowType) dataType.getLogicalType();
 
-        final Schema schema = AvroSchemaConverter.convertToSchema(rowType);
+        final Schema schema = AvroSchemaConverter.convertToSchema(rowType, false);
         final GenericRecord record = new GenericData.Record(schema);
         record.put(0, true);
         record.put(1, (int) Byte.MAX_VALUE);
@@ -149,34 +150,35 @@ class AvroRowDataDeSerializationSchemaTest {
         record.put(12, 10087);
         record.put(13, 1589530213123L);
         record.put(14, 1589530213122L);
+        record.put(15, 1589530213123456789L);
 
         Map<String, Long> map = new HashMap<>();
         map.put("flink", 12L);
         map.put("avro", 23L);
-        record.put(15, map);
+        record.put(16, map);
 
         Map<String, Map<String, Integer>> map2map = new HashMap<>();
         Map<String, Integer> innerMap = new HashMap<>();
         innerMap.put("inner_key1", 123);
         innerMap.put("inner_key2", 234);
         map2map.put("outer_key", innerMap);
-        record.put(16, map2map);
+        record.put(17, map2map);
 
         List<Integer> list1 = Arrays.asList(1, 2, 3, 4, 5, 6);
         List<Integer> list2 = Arrays.asList(11, 22, 33, 44, 55);
         Map<String, List<Integer>> map2list = new HashMap<>();
         map2list.put("list1", list1);
         map2list.put("list2", list2);
-        record.put(17, map2list);
+        record.put(18, map2list);
 
         Map<String, String> map2 = new HashMap<>();
         map2.put("key1", null);
-        record.put(18, map2);
+        record.put(19, map2);
 
         AvroRowDataSerializationSchema serializationSchema =
-                createSerializationSchema(dataType, encoding, true);
+                createSerializationSchema(dataType, encoding, false);
         AvroRowDataDeserializationSchema deserializationSchema =
-                createDeserializationSchema(dataType, encoding, true);
+                createDeserializationSchema(dataType, encoding, false);
 
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
         GenericDatumWriter<IndexedRecord> datumWriter = new GenericDatumWriter<>(schema);
@@ -358,6 +360,10 @@ class AvroRowDataDeSerializationSchemaTest {
                 .isEqualTo(new AtomicDataType(new BigIntType(false)));
         assertThat(dataType.getChildren().get(3))
                 .isEqualTo(new AtomicDataType(new BigIntType(false)));
+        assertThat(dataType.getChildren().get(4))
+                .isEqualTo(new AtomicDataType(new BigIntType(false)));
+        assertThat(dataType.getChildren().get(5))
+                .isEqualTo(new AtomicDataType(new BigIntType(false)));
 
         assertThatThrownBy(() -> createSerializationSchema(dataType, AvroEncoding.BINARY, true))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -396,10 +402,14 @@ class AvroRowDataDeSerializationSchemaTest {
         RowData rowData2 = deserializationSchema.deserialize(output);
         assertThat(rowData2).isEqualTo(rowData);
 
-        assertThat(rowData.getTimestamp(2, 3).toLocalDateTime().toString())
+        assertThat(rowData.getTimestamp(2, 9).toInstant().toString())
+                .isEqualTo("1970-01-01T00:00:00.123456789Z");
+        assertThat(rowData.getTimestamp(3, 3).toLocalDateTime().toString())
                 .isEqualTo("2014-03-01T12:12:12.321");
-        assertThat(rowData.getTimestamp(3, 6).toLocalDateTime().toString())
-                .isEqualTo("1970-01-01T00:02:03.456");
+        assertThat(rowData.getTimestamp(4, 6).toLocalDateTime().toString())
+                .isEqualTo("1970-01-01T00:00:00.123456");
+        assertThat(rowData.getTimestamp(5, 9).toLocalDateTime().toString())
+                .isEqualTo("1970-01-01T00:00:00.123456789");
     }
 
     private AvroRowDataSerializationSchema createSerializationSchema(

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroSplittableInputFormatTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroSplittableInputFormatTest.java
@@ -25,7 +25,6 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.formats.avro.generated.Address;
 import org.apache.flink.formats.avro.generated.Colors;
 import org.apache.flink.formats.avro.generated.Fixed16;
-import org.apache.flink.formats.avro.generated.Fixed2;
 import org.apache.flink.formats.avro.generated.User;
 
 import org.apache.avro.file.DataFileWriter;
@@ -119,12 +118,11 @@ class AvroSplittableInputFormatTest {
         user1.setTypeTimeMicros(LocalTime.ofSecondOfDay(0).plus(123456L, ChronoUnit.MICROS));
         user1.setTypeTimestampMillis(Instant.parse("2014-03-01T12:12:12.321Z"));
         user1.setTypeTimestampMicros(Instant.ofEpochSecond(0).plus(123456L, ChronoUnit.MICROS));
+        user1.setTypeTimestampNanos(Instant.ofEpochSecond(0).plus(123456789L, ChronoUnit.NANOS));
         // 20.00
-        user1.setTypeDecimalBytes(
-                ByteBuffer.wrap(BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()));
+        user1.setTypeDecimalBytes(BigDecimal.valueOf(2000, 2));
         // 20.00
-        user1.setTypeDecimalFixed(
-                new Fixed2(BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()));
+        user1.setTypeDecimalFixed(BigDecimal.valueOf(2000, 2));
 
         // Construct via builder
         User user2 =
@@ -159,14 +157,12 @@ class AvroSplittableInputFormatTest {
                         .setTypeTimestampMillis(Instant.parse("2014-03-01T12:12:12.321Z"))
                         .setTypeTimestampMicros(
                                 Instant.ofEpochSecond(0).plus(123456L, ChronoUnit.MICROS))
+                        .setTypeTimestampNanos(
+                                Instant.ofEpochSecond(0).plus(123456789L, ChronoUnit.NANOS))
                         // 20.00
-                        .setTypeDecimalBytes(
-                                ByteBuffer.wrap(
-                                        BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()))
+                        .setTypeDecimalBytes(BigDecimal.valueOf(2000, 2))
                         // 20.00
-                        .setTypeDecimalFixed(
-                                new Fixed2(
-                                        BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()))
+                        .setTypeDecimalFixed(BigDecimal.valueOf(2000, 2))
                         .build();
         DatumWriter<User> userDatumWriter = new SpecificDatumWriter<>(User.class);
         DataFileWriter<User> dataFileWriter = new DataFileWriter<>(userDatumWriter);
@@ -198,12 +194,11 @@ class AvroSplittableInputFormatTest {
             user.setTypeTimeMicros(LocalTime.ofSecondOfDay(0).plus(123456L, ChronoUnit.MICROS));
             user.setTypeTimestampMillis(Instant.parse("2014-03-01T12:12:12.321Z"));
             user.setTypeTimestampMicros(Instant.ofEpochSecond(0).plus(123456L, ChronoUnit.MICROS));
+            user.setTypeTimestampNanos(Instant.ofEpochSecond(0).plus(123456789L, ChronoUnit.NANOS));
             // 20.00
-            user.setTypeDecimalBytes(
-                    ByteBuffer.wrap(BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()));
+            user.setTypeDecimalBytes(BigDecimal.valueOf(2000, 2));
             // 20.00
-            user.setTypeDecimalFixed(
-                    new Fixed2(BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()));
+            user.setTypeDecimalFixed(BigDecimal.valueOf(2000, 2));
 
             dataFileWriter.append(user);
         }
@@ -234,7 +229,7 @@ class AvroSplittableInputFormatTest {
             format.close();
         }
 
-        assertThat(elementsPerSplit).containsExactly(1604, 1203, 1203, 990);
+        assertThat(elementsPerSplit).containsExactly(1564, 1173, 1173, 1090);
         assertThat(elements).isEqualTo(NUM_RECORDS);
         format.close();
     }
@@ -280,7 +275,7 @@ class AvroSplittableInputFormatTest {
             format.close();
         }
 
-        assertThat(elementsPerSplit).containsExactly(1604, 1203, 1203, 990);
+        assertThat(elementsPerSplit).containsExactly(1564, 1173, 1173, 1090);
         assertThat(elements).isEqualTo(NUM_RECORDS);
         format.close();
     }
@@ -326,7 +321,7 @@ class AvroSplittableInputFormatTest {
             format.close();
         }
 
-        assertThat(elementsPerSplit).containsExactly(1604, 1203, 1203, 990);
+        assertThat(elementsPerSplit).containsExactly(1564, 1173, 1173, 1090);
         assertThat(elements).isEqualTo(NUM_RECORDS);
         format.close();
     }

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/EncoderDecoderTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/EncoderDecoderTest.java
@@ -21,7 +21,6 @@ package org.apache.flink.formats.avro;
 import org.apache.flink.formats.avro.generated.Address;
 import org.apache.flink.formats.avro.generated.Colors;
 import org.apache.flink.formats.avro.generated.Fixed16;
-import org.apache.flink.formats.avro.generated.Fixed2;
 import org.apache.flink.formats.avro.generated.User;
 import org.apache.flink.formats.avro.utils.DataInputDecoder;
 import org.apache.flink.formats.avro.utils.DataOutputEncoder;
@@ -299,12 +298,9 @@ class EncoderDecoderTest {
                         LocalTime.ofSecondOfDay(0).plus(123456L, ChronoUnit.MICROS),
                         Instant.parse("2014-03-01T12:12:12.321Z"),
                         Instant.ofEpochSecond(0).plus(123456L, ChronoUnit.MICROS),
-                        ByteBuffer.wrap(
-                                BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()), // 20.00
-                        new Fixed2(
-                                BigDecimal.valueOf(2000, 2)
-                                        .unscaledValue()
-                                        .toByteArray())); // 20.00
+                        Instant.ofEpochSecond(0).plus(123456789L, ChronoUnit.NANOS),
+                        BigDecimal.valueOf(2000, 2),
+                        BigDecimal.valueOf(2000, 2));
 
         testObjectSerialization(user);
     }

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroSchemaConverterTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroSchemaConverterTest.java
@@ -610,6 +610,7 @@ class AvroSchemaConverterTest {
                             "type_time_micros",
                             "type_timestamp_millis",
                             "type_timestamp_micros",
+                            "type_timestamp_nanos",
                             "type_decimal_bytes",
                             "type_decimal_fixed"
                         },
@@ -634,6 +635,7 @@ class AvroSchemaConverterTest {
                         Types.SQL_TIME,
                         Types.SQL_TIMESTAMP,
                         Types.SQL_TIMESTAMP,
+                        Types.SQL_TIMESTAMP,
                         Types.BIG_DEC,
                         Types.BIG_DEC);
 
@@ -649,11 +651,15 @@ class AvroSchemaConverterTest {
                         new String[] {
                             "type_timestamp_millis",
                             "type_timestamp_micros",
+                            "type_timestamp_nanos",
                             "type_local_timestamp_millis",
-                            "type_local_timestamp_micros"
+                            "type_local_timestamp_micros",
+                            "type_local_timestamp_nanos"
                         },
                         Types.INSTANT,
                         Types.INSTANT,
+                        Types.INSTANT,
+                        Types.LOCAL_DATE_TIME,
                         Types.LOCAL_DATE_TIME,
                         Types.LOCAL_DATE_TIME);
         final RowTypeInfo timestampsRowTypeInfo = (RowTypeInfo) timestamps;
@@ -666,11 +672,15 @@ class AvroSchemaConverterTest {
                         new String[] {
                             "type_timestamp_millis",
                             "type_timestamp_micros",
+                            "type_timestamp_nanos",
                             "type_local_timestamp_millis",
-                            "type_local_timestamp_micros"
+                            "type_local_timestamp_micros",
+                            "type_local_timestamp_nanos"
                         },
                         Types.SQL_TIMESTAMP,
                         Types.SQL_TIMESTAMP,
+                        Types.SQL_TIMESTAMP,
+                        Types.LONG,
                         Types.LONG,
                         Types.LONG);
         final RowTypeInfo timestampsRowTypeInfo = (RowTypeInfo) timestamps;
@@ -685,11 +695,15 @@ class AvroSchemaConverterTest {
                                 DataTypes.FIELD(
                                         "type_timestamp_micros", DataTypes.TIMESTAMP(6).notNull()),
                                 DataTypes.FIELD(
+                                        "type_timestamp_nanos", DataTypes.TIMESTAMP(9).notNull()),
+                                DataTypes.FIELD(
                                         "type_local_timestamp_millis",
                                         DataTypes.BIGINT().notNull()),
                                 DataTypes.FIELD(
                                         "type_local_timestamp_micros",
-                                        DataTypes.BIGINT().notNull()))
+                                        DataTypes.BIGINT().notNull()),
+                                DataTypes.FIELD(
+                                        "type_local_timestamp_nanos", DataTypes.BIGINT().notNull()))
                         .notNull();
 
         assertThat(actual).isEqualTo(timestamps);
@@ -705,11 +719,17 @@ class AvroSchemaConverterTest {
                                         "type_timestamp_micros",
                                         DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(6).notNull()),
                                 DataTypes.FIELD(
+                                        "type_timestamp_nanos",
+                                        DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(9).notNull()),
+                                DataTypes.FIELD(
                                         "type_local_timestamp_millis",
                                         DataTypes.TIMESTAMP(3).notNull()),
                                 DataTypes.FIELD(
                                         "type_local_timestamp_micros",
-                                        DataTypes.TIMESTAMP(6).notNull()))
+                                        DataTypes.TIMESTAMP(6).notNull()),
+                                DataTypes.FIELD(
+                                        "type_local_timestamp_nanos",
+                                        DataTypes.TIMESTAMP(9).notNull()))
                         .notNull();
 
         assertThat(actual).isEqualTo(timestamps);
@@ -765,6 +785,8 @@ class AvroSchemaConverterTest {
                                         "type_timestamp_millis", DataTypes.TIMESTAMP(3).notNull()),
                                 DataTypes.FIELD(
                                         "type_timestamp_micros", DataTypes.TIMESTAMP(6).notNull()),
+                                DataTypes.FIELD(
+                                        "type_timestamp_nanos", DataTypes.BIGINT().notNull()),
                                 DataTypes.FIELD(
                                         "type_decimal_bytes", DataTypes.DECIMAL(4, 2).notNull()),
                                 DataTypes.FIELD(

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroTypeExtractionTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroTypeExtractionTest.java
@@ -102,14 +102,15 @@ class AvroTypeExtractionTest {
                         + "\"type_long_test\": null, \"type_double_test\": 123.45, \"type_null_test\": null, "
                         + "\"type_bool_test\": true, \"type_array_string\": [\"ELEMENT 1\", \"ELEMENT 2\"], "
                         + "\"type_array_boolean\": [true, false], \"type_nullable_array\": null, \"type_enum\": \"GREEN\", "
-                        + "\"type_map\": {\"KEY 2\": 17554, \"KEY 1\": 8546456}, \"type_fixed\": null, \"type_union\": null, "
+                        + "\"type_map\": {\"KEY 1\": 8546456, \"KEY 2\": 17554}, \"type_fixed\": null, \"type_union\": null, "
                         + "\"type_nested\": {\"num\": 239, \"street\": \"Baker Street\", \"city\": \"London\", "
                         + "\"state\": \"London\", \"zip\": \"NW1 6XE\"}, "
                         + "\"type_bytes\": \"\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\", "
                         + "\"type_date\": \"2014-03-01\", \"type_time_millis\": \"12:12:12\", \"type_time_micros\": \"00:00:00.123456\", "
                         + "\"type_timestamp_millis\": \"2014-03-01T12:12:12.321Z\", "
                         + "\"type_timestamp_micros\": \"1970-01-01T00:00:00.123456Z\", "
-                        + "\"type_decimal_bytes\": \"\\u0007Ð\", \"type_decimal_fixed\": [7, -48]}\n"
+                        + "\"type_timestamp_nanos\": \"1970-01-01T00:00:00.123456789Z\", "
+                        + "\"type_decimal_bytes\": 20.00, \"type_decimal_fixed\": 20.00}\n"
                         + "{\"name\": \"Charlie\", \"favorite_number\": null, "
                         + "\"favorite_color\": \"blue\", \"type_long_test\": 1337, \"type_double_test\": 1.337, "
                         + "\"type_null_test\": null, \"type_bool_test\": false, \"type_array_string\": [], "
@@ -121,8 +122,9 @@ class AvroTypeExtractionTest {
                         + "\"type_date\": \"2014-03-01\", \"type_time_millis\": \"12:12:12\", \"type_time_micros\": \"00:00:00.123456\", "
                         + "\"type_timestamp_millis\": \"2014-03-01T12:12:12.321Z\", "
                         + "\"type_timestamp_micros\": \"1970-01-01T00:00:00.123456Z\", "
-                        + "\"type_decimal_bytes\": \"\\u0007Ð\", "
-                        + "\"type_decimal_fixed\": [7, -48]}\n";
+                        + "\"type_timestamp_nanos\": \"1970-01-01T00:00:00.123456789Z\", "
+                        + "\"type_decimal_bytes\": 20.00, "
+                        + "\"type_decimal_fixed\": 20.00}\n";
     }
 
     @ParameterizedTest
@@ -163,7 +165,8 @@ class AvroTypeExtractionTest {
                         + "\"type_date\": \"2014-03-01\", \"type_time_millis\": \"12:12:12\", \"type_time_micros\": \"00:00:00.123456\", "
                         + "\"type_timestamp_millis\": \"2014-03-01T12:12:12.321Z\", "
                         + "\"type_timestamp_micros\": \"1970-01-01T00:00:00.123456Z\", "
-                        + "\"type_decimal_bytes\": \"\\u0007Ð\", \"type_decimal_fixed\": [7, -48]}\n"
+                        + "\"type_timestamp_nanos\": \"1970-01-01T00:00:00.123456789Z\", "
+                        + "\"type_decimal_bytes\": 20.00, \"type_decimal_fixed\": 20.00}\n"
                         + "{\"name\": \"Charlie\", \"favorite_number\": null, "
                         + "\"favorite_color\": \"blue\", \"type_long_test\": 1337, \"type_double_test\": 1.337, "
                         + "\"type_null_test\": null, \"type_bool_test\": false, \"type_array_string\": [], "
@@ -175,7 +178,8 @@ class AvroTypeExtractionTest {
                         + "\"type_date\": \"2014-03-01\", \"type_time_millis\": \"12:12:12\", \"type_time_micros\": \"00:00:00.123456\", "
                         + "\"type_timestamp_millis\": \"2014-03-01T12:12:12.321Z\", "
                         + "\"type_timestamp_micros\": \"1970-01-01T00:00:00.123456Z\", "
-                        + "\"type_decimal_bytes\": \"\\u0007Ð\", \"type_decimal_fixed\": [7, -48]}\n";
+                        + "\"type_timestamp_nanos\": \"1970-01-01T00:00:00.123456789Z\", "
+                        + "\"type_decimal_bytes\": 20.00, \"type_decimal_fixed\": 20.00}\n";
     }
 
     @ParameterizedTest

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/utils/AvroTestUtils.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/utils/AvroTestUtils.java
@@ -24,7 +24,6 @@ import org.apache.flink.formats.avro.AvroFormatOptions.AvroEncoding;
 import org.apache.flink.formats.avro.generated.Address;
 import org.apache.flink.formats.avro.generated.Colors;
 import org.apache.flink.formats.avro.generated.Fixed16;
-import org.apache.flink.formats.avro.generated.Fixed2;
 import org.apache.flink.formats.avro.generated.Timestamps;
 import org.apache.flink.formats.avro.generated.User;
 import org.apache.flink.formats.avro.typeutils.AvroSerializerLargeGenericRecordTest;
@@ -107,20 +106,15 @@ public final class AvroTestUtils {
                         .setTypeTimestampMillis(Instant.parse("2014-03-01T12:12:12.321Z"))
                         .setTypeTimestampMicros(
                                 Instant.ofEpochSecond(0).plus(123456L, ChronoUnit.MICROS))
+                        .setTypeTimestampNanos(
+                                Instant.ofEpochSecond(0).plus(123456789L, ChronoUnit.NANOS))
                         // byte array must contain the two's-complement representation of the
                         // unscaled integer value in big-endian byte order
-                        .setTypeDecimalBytes(
-                                ByteBuffer.wrap(
-                                        BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()))
-                        // array of length n can store at most
-                        // Math.floor(Math.log10(Math.pow(2, 8 * n - 1) - 1))
-                        // base-10 digits of precision
-                        .setTypeDecimalFixed(
-                                new Fixed2(
-                                        BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()))
+                        .setTypeDecimalBytes(BigDecimal.valueOf(2000, 2))
+                        .setTypeDecimalFixed(BigDecimal.valueOf(2000, 2))
                         .build();
 
-        final Row rowUser = new Row(23);
+        final Row rowUser = new Row(24);
         rowUser.setField(0, "Charlie");
         rowUser.setField(1, null);
         rowUser.setField(2, "blue");
@@ -144,8 +138,10 @@ public final class AvroTestUtils {
         rowUser.setField(19, Timestamp.valueOf("2014-03-01 12:12:12.321"));
         rowUser.setField(
                 20, Timestamp.from(Instant.ofEpochSecond(0).plus(123456L, ChronoUnit.MICROS)));
-        rowUser.setField(21, BigDecimal.valueOf(2000, 2));
+        rowUser.setField(
+                21, Timestamp.from(Instant.ofEpochSecond(0).plus(123456789L, ChronoUnit.NANOS)));
         rowUser.setField(22, BigDecimal.valueOf(2000, 2));
+        rowUser.setField(23, BigDecimal.valueOf(2000, 2));
 
         final Tuple3<Class<? extends SpecificRecord>, SpecificRecord, Row> t = new Tuple3<>();
         t.f0 = User.class;
@@ -176,7 +172,8 @@ public final class AvroTestUtils {
                         + "{\"name\":\"type_time_millis\",\"type\":{\"type\":\"int\",\"logicalType\":\"time-millis\"}},{\"name\":\"type_time_micros\","
                         + "\"type\":{\"type\":\"long\",\"logicalType\":\"time-micros\"}},{\"name\":\"type_timestamp_millis\",\"type\":{\"type\":\"long\","
                         + "\"logicalType\":\"timestamp-millis\"}},{\"name\":\"type_timestamp_micros\",\"type\":{\"type\":\"long\","
-                        + "\"logicalType\":\"timestamp-micros\"}},{\"name\":\"type_decimal_bytes\",\"type\":{\"type\":\"bytes\","
+                        + "\"logicalType\":\"timestamp-micros\"}},{\"name\":\"type_timestamp_nanos\",\"type\":{\"type\":\"long\","
+                        + "\"logicalType\":\"timestamp-nanos\"}},{\"name\":\"type_decimal_bytes\",\"type\":{\"type\":\"bytes\","
                         + "\"logicalType\":\"decimal\",\"precision\":4,\"scale\":2}},{\"name\":\"type_decimal_fixed\",\"type\":{\"type\":\"fixed\","
                         + "\"name\":\"Fixed2\",\"size\":2,\"logicalType\":\"decimal\",\"precision\":4,\"scale\":2}}]}";
         final Schema schema = new Schema.Parser().parse(schemaString);
@@ -223,6 +220,9 @@ public final class AvroTestUtils {
         user.put(
                 "type_timestamp_micros", Instant.ofEpochSecond(0).plus(123456L, ChronoUnit.MICROS));
         user.put(
+                "type_timestamp_nanos",
+                Instant.ofEpochSecond(0).plus(123456789L, ChronoUnit.NANOS));
+        user.put(
                 "type_decimal_bytes",
                 ByteBuffer.wrap(BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()));
         user.put(
@@ -231,7 +231,7 @@ public final class AvroTestUtils {
                         schema.getField("type_decimal_fixed").schema(),
                         BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()));
 
-        final Row rowUser = new Row(23);
+        final Row rowUser = new Row(24);
         rowUser.setField(0, "Charlie");
         rowUser.setField(1, null);
         rowUser.setField(2, "blue");
@@ -255,8 +255,10 @@ public final class AvroTestUtils {
         rowUser.setField(19, Timestamp.valueOf("2014-03-01 12:12:12.321"));
         rowUser.setField(
                 20, Timestamp.from(Instant.ofEpochSecond(0).plus(123456L, ChronoUnit.MICROS)));
-        rowUser.setField(21, BigDecimal.valueOf(2000, 2));
+        rowUser.setField(
+                21, Timestamp.from(Instant.ofEpochSecond(0).plus(123456789L, ChronoUnit.NANOS)));
         rowUser.setField(22, BigDecimal.valueOf(2000, 2));
+        rowUser.setField(23, BigDecimal.valueOf(2000, 2));
 
         final Tuple3<GenericRecord, Row, Schema> t = new Tuple3<>();
         t.f0 = user;
@@ -274,34 +276,49 @@ public final class AvroTestUtils {
                         + "\"fields\": [{\"name\":\"type_timestamp_millis\",\"type\":{\"type\":\"long\","
                         + "\"logicalType\":\"timestamp-millis\"}},{\"name\":\"type_timestamp_micros\",\"type\":{\"type\":\"long\","
                         + "\"logicalType\":\"timestamp-micros\"}},{\"name\": \"type_local_timestamp_millis\", \"type\": {\"type\": \"long\", \"logicalType\": \"local-timestamp-millis\"}},"
-                        + "{\"name\": \"type_local_timestamp_micros\", \"type\": {\"type\": \"long\", \"logicalType\": \"local-timestamp-micros\"}}]}";
+                        + "{\"name\": \"type_local_timestamp_micros\", \"type\": {\"type\": \"long\", \"logicalType\": \"local-timestamp-micros\"}},"
+                        + "{\"name\": \"type_timestamp_nanos\", \"type\": {\"type\": \"long\", \"logicalType\": \"timestamp-nanos\"}},"
+                        + "{\"name\": \"type_local_timestamp_nanos\", \"type\": {\"type\": \"long\", \"logicalType\": \"local-timestamp-nanos\"}}]}";
         final Schema schema = new Schema.Parser().parse(schemaString);
         final GenericRecord timestampRecord = new GenericData.Record(schema);
         timestampRecord.put("type_timestamp_millis", Instant.parse("2014-03-01T12:12:12.321Z"));
         timestampRecord.put(
                 "type_timestamp_micros", Instant.ofEpochSecond(0).plus(123456L, ChronoUnit.MICROS));
         timestampRecord.put(
+                "type_timestamp_nanos",
+                Instant.ofEpochSecond(0).plus(123456789L, ChronoUnit.NANOS));
+        timestampRecord.put(
                 "type_local_timestamp_millis", LocalDateTime.parse("2014-03-01T12:12:12.321"));
         timestampRecord.put(
                 "type_local_timestamp_micros", LocalDateTime.parse("1970-01-01T00:00:00.123456"));
+        timestampRecord.put(
+                "type_local_timestamp_nanos", LocalDateTime.parse("1970-01-01T00:00:00.123456789"));
 
         final Timestamps timestamps =
                 Timestamps.newBuilder()
                         .setTypeTimestampMillis(Instant.parse("2014-03-01T12:12:12.321Z"))
                         .setTypeTimestampMicros(
                                 Instant.ofEpochSecond(0).plus(123456L, ChronoUnit.MICROS))
+                        .setTypeTimestampNanos(
+                                Instant.ofEpochSecond(0).plus(123456789L, ChronoUnit.NANOS))
                         .setTypeLocalTimestampMillis(LocalDateTime.parse("2014-03-01T12:12:12.321"))
                         .setTypeLocalTimestampMicros(
                                 LocalDateTime.parse("1970-01-01T00:00:00.123456"))
+                        .setTypeLocalTimestampNanos(
+                                LocalDateTime.parse("1970-01-01T00:00:00.123456789"))
                         .build();
 
-        final Row timestampRow = new Row(4);
+        final Row timestampRow = new Row(6);
         timestampRow.setField(0, Timestamp.valueOf("2014-03-01 12:12:12.321"));
         timestampRow.setField(
                 1, Timestamp.from(Instant.ofEpochSecond(0).plus(123456L, ChronoUnit.MICROS)));
         timestampRow.setField(2, Timestamp.valueOf(LocalDateTime.parse("2014-03-01T12:12:12.321")));
         timestampRow.setField(
                 3, Timestamp.valueOf(LocalDateTime.parse("1970-01-01T00:00:00.123456")));
+        timestampRow.setField(
+                4, Timestamp.from(Instant.ofEpochSecond(0).plus(123456789L, ChronoUnit.NANOS)));
+        timestampRow.setField(
+                5, Timestamp.valueOf(LocalDateTime.parse("1970-01-01T00:00:00.123456789")));
 
         final Tuple4<Class<? extends SpecificRecord>, SpecificRecord, GenericRecord, Row> t =
                 new Tuple4<>();

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/utils/TestDataGenerator.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/utils/TestDataGenerator.java
@@ -21,7 +21,6 @@ package org.apache.flink.formats.avro.utils;
 import org.apache.flink.formats.avro.generated.Address;
 import org.apache.flink.formats.avro.generated.Colors;
 import org.apache.flink.formats.avro.generated.Fixed16;
-import org.apache.flink.formats.avro.generated.Fixed2;
 import org.apache.flink.formats.avro.generated.SimpleUser;
 import org.apache.flink.formats.avro.generated.User;
 
@@ -62,8 +61,9 @@ public class TestDataGenerator {
                 LocalTime.ofSecondOfDay(0).plus(123456L, ChronoUnit.MICROS),
                 Instant.parse("2014-03-01T12:12:12.321Z"),
                 Instant.ofEpochSecond(0).plus(123456L, ChronoUnit.MICROS),
-                ByteBuffer.wrap(BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()),
-                new Fixed2(BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()));
+                Instant.ofEpochSecond(0).plus(123456789L, ChronoUnit.NANOS),
+                BigDecimal.valueOf(2000, 2),
+                BigDecimal.valueOf(2000, 2));
     }
 
     public static SimpleUser generateRandomSimpleUser(Random rnd) {

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/table/runtime/batch/AvroTypesITCase.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/table/runtime/batch/AvroTypesITCase.java
@@ -21,7 +21,6 @@ package org.apache.flink.table.runtime.batch;
 import org.apache.flink.formats.avro.generated.Address;
 import org.apache.flink.formats.avro.generated.Colors;
 import org.apache.flink.formats.avro.generated.Fixed16;
-import org.apache.flink.formats.avro.generated.Fixed2;
 import org.apache.flink.formats.avro.generated.User;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -84,11 +83,10 @@ class AvroTypesITCase extends AbstractTestBase {
                     .setTypeTimestampMillis(Instant.parse("2014-03-01T12:12:12.321Z"))
                     .setTypeTimestampMicros(
                             Instant.ofEpochSecond(0).plus(123456L, ChronoUnit.MICROS))
-                    .setTypeDecimalBytes(
-                            ByteBuffer.wrap(
-                                    BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()))
-                    .setTypeDecimalFixed(
-                            new Fixed2(BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()))
+                    .setTypeTimestampNanos(
+                            Instant.ofEpochSecond(0).plus(123456789L, ChronoUnit.NANOS))
+                    .setTypeDecimalBytes(BigDecimal.valueOf(2000, 2))
+                    .setTypeDecimalFixed(BigDecimal.valueOf(2000, 2))
                     .build();
 
     private static final User USER_2 =
@@ -114,11 +112,10 @@ class AvroTypesITCase extends AbstractTestBase {
                     .setTypeTimestampMillis(Instant.parse("2014-03-01T12:12:12.321Z"))
                     .setTypeTimestampMicros(
                             Instant.ofEpochSecond(0).plus(123456L, ChronoUnit.MICROS))
-                    .setTypeDecimalBytes(
-                            ByteBuffer.wrap(
-                                    BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()))
-                    .setTypeDecimalFixed(
-                            new Fixed2(BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()))
+                    .setTypeTimestampNanos(
+                            Instant.ofEpochSecond(0).plus(123456789L, ChronoUnit.NANOS))
+                    .setTypeDecimalBytes(BigDecimal.valueOf(2000, 2))
+                    .setTypeDecimalFixed(BigDecimal.valueOf(2000, 2))
                     .build();
 
     private static final User USER_3 =
@@ -144,11 +141,10 @@ class AvroTypesITCase extends AbstractTestBase {
                     .setTypeTimestampMillis(Instant.parse("2014-03-01T12:12:12.321Z"))
                     .setTypeTimestampMicros(
                             Instant.ofEpochSecond(0).plus(123456L, ChronoUnit.MICROS))
-                    .setTypeDecimalBytes(
-                            ByteBuffer.wrap(
-                                    BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()))
-                    .setTypeDecimalFixed(
-                            new Fixed2(BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()))
+                    .setTypeTimestampNanos(
+                            Instant.ofEpochSecond(0).plus(123456789L, ChronoUnit.NANOS))
+                    .setTypeDecimalBytes(BigDecimal.valueOf(2000, 2))
+                    .setTypeDecimalFixed(BigDecimal.valueOf(2000, 2))
                     .build();
 
     @Test
@@ -168,15 +164,15 @@ class AvroTypesITCase extends AbstractTestBase {
                 "+I[Charlie, null, blue, 1337, 1.337, null, false, [], [], null, RED, {}, null, null, "
                         + "{\"num\": 42, \"street\": \"Bakerstreet\", \"city\": \"Berlin\", \"state\": \"Berlin\", \"zip\": \"12049\"}, "
                         + "java.nio.HeapByteBuffer[pos=0 lim=10 cap=10], 2014-03-01, 12:12:12.345, 00:00:00.123456, 2014-03-01T12:12:12.321Z, "
-                        + "1970-01-01T00:00:00.123456Z, java.nio.HeapByteBuffer[pos=0 lim=2 cap=2], [7, -48]]\n"
+                        + "1970-01-01T00:00:00.123456Z, 1970-01-01T00:00:00.123456789Z, java.nio.HeapByteBuffer[pos=0 lim=2 cap=2], [7, -48]]\n"
                         + "+I[Whatever, null, black, 42, 0.0, null, true, [hello], [true], null, GREEN, {}, "
                         + "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], null, null, "
                         + "java.nio.HeapByteBuffer[pos=0 lim=10 cap=10], 2014-03-01, 12:12:12, 00:00:00.123456, 2014-03-01T12:12:12.321Z, "
-                        + "1970-01-01T00:00:00.123456Z, java.nio.HeapByteBuffer[pos=0 lim=2 cap=2], [7, -48]]\n"
+                        + "1970-01-01T00:00:00.123456Z, 1970-01-01T00:00:00.123456789Z, java.nio.HeapByteBuffer[pos=0 lim=2 cap=2], [7, -48]]\n"
                         + "+I[Terminator, null, yellow, 1, 0.0, null, false, [world], [false], null, GREEN, {}, "
                         + "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], null, null, "
                         + "java.nio.HeapByteBuffer[pos=0 lim=10 cap=10], 2014-03-01, 12:12:12, 00:00:00.123456, 2014-03-01T12:12:12.321Z, "
-                        + "1970-01-01T00:00:00.123456Z, java.nio.HeapByteBuffer[pos=0 lim=2 cap=2], [7, -48]]";
+                        + "1970-01-01T00:00:00.123456Z, 1970-01-01T00:00:00.123456789Z, java.nio.HeapByteBuffer[pos=0 lim=2 cap=2], [7, -48]]";
         TestBaseUtils.compareResultAsText(results, expected);
     }
 

--- a/flink-formats/flink-avro/src/test/resources/avro/user.avsc
+++ b/flink-formats/flink-avro/src/test/resources/avro/user.avsc
@@ -44,6 +44,7 @@
      {"name": "type_time_micros", "type": {"type": "long", "logicalType": "time-micros"}},
      {"name": "type_timestamp_millis", "type": {"type": "long", "logicalType": "timestamp-millis"}},
      {"name": "type_timestamp_micros", "type": {"type": "long", "logicalType": "timestamp-micros"}},
+     {"name": "type_timestamp_nanos", "type": {"type": "long", "logicalType": "timestamp-nanos"}},
      {"name": "type_decimal_bytes", "type": {"type": "bytes", "logicalType": "decimal", "precision": 4, "scale": 2}},
      {"name": "type_decimal_fixed", "type": {"name": "Fixed2", "size": 2, "type": "fixed", "logicalType": "decimal", "precision": 4, "scale": 2}}
  ]
@@ -122,8 +123,10 @@
  "fields": [
      {"name": "type_timestamp_millis", "type": {"type": "long", "logicalType": "timestamp-millis"}},
      {"name": "type_timestamp_micros", "type": {"type": "long", "logicalType": "timestamp-micros"}},
+     {"name": "type_timestamp_nanos", "type": {"type": "long", "logicalType": "timestamp-nanos"}},
      {"name": "type_local_timestamp_millis", "type": {"type": "long", "logicalType": "local-timestamp-millis"}},
-     {"name": "type_local_timestamp_micros", "type": {"type": "long", "logicalType": "local-timestamp-micros"}}
+     {"name": "type_local_timestamp_micros", "type": {"type": "long", "logicalType": "local-timestamp-micros"}},
+     {"name": "type_local_timestamp_nanos", "type": {"type": "long", "logicalType": "local-timestamp-nanos"}}
  ]
 }
 ]

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@ under the License.
 		<!-- Project `flink-benchmarks` uses zk testing server in `curator-test` for performance
 		benchmark, please confirm it will not affect the benchmarks when the version is bumped. -->
 		<curator.version>5.4.0</curator.version>
-		<avro.version>1.11.4</avro.version>
+		<avro.version>1.12.1</avro.version>
 		<!-- Version for transitive Jackson dependencies that are not used within Flink itself.-->
 		<jackson.mapper.asl.version>1.9.14.jdk17-redhat-00001</jackson.mapper.asl.version>
 		<jackson-bom.version>2.20.1</jackson-bom.version>


### PR DESCRIPTION
## What is the purpose of the change

Currently, the Flink Avro format support for `TIMESTAMP` and `TIMESTAMP_WITH_LOCAL_TIME_ZONE` is capped at microsecond precision (6). 
Standard Apache Avro (up to 1.11) only defines logical types for `timestamp-millis` and `timestamp-micros`.

When Flink tables utilize **nanosecond precision (`TIMESTAMP(9)`)**, there is no native Avro logical type mapping, leading to either fallback behaviour (treating as raw `BIGINT`) or unsupported type exceptions during automatic schema conversion.

This pull request adds support for **nanosecond-precision logical types** (`timestamp-nanos` and `local-timestamp-nanos`) in the Flink Avro format. It also upgrades **Avro to version 1.12.1** and enables **decimal logical types** handling for improved compatibility and numeric fidelity.

Specifically:
- Supports mapping Flink's `TIMESTAMP(9)` and `TIMESTAMP_WITH_LOCAL_TIME_ZONE(9)` back-and-forth with Avro's `timestamp-nanos` and `local-timestamp-nanos` logical types.
- Enables high-precision temporal calculations without losing precision at microsecond or millisecond boundaries.

## Brief change log

- **`AvroToRowDataConverters.java`**:
  - Replaced the static timestamp converter with a precision-aware `createTimestampConverter(int precision)` that handles millisecond, microsecond, and nanosecond cases into `TimestampData`.
- **`RowDataToAvroConverters.java`**:
  - Updated conversion for `TIMESTAMP_WITHOUT_TIME_ZONE` and `TIMESTAMP_WITH_LOCAL_TIME_ZONE` to respect higher precision values up to 9 (nanoseconds) when packing epoch values.
- **`AvroSchemaConverter.java`**:
  - Mapped `LogicalTypes.timestampNanos()` and `LogicalTypes.localTimestampNanos()` schemas into equivalent Flink SQL styles (`TIMESTAMP(9)` / `TIMESTAMP_WITH_LOCAL_TIME_ZONE(9)`).
  - Updated conversion from Flink data types to Avro schema to support precision up to 9 for timestamp types.
- **`pom.xml`**:
  - Upgraded Avro dependency to **1.12.1**.

## Verifying this change

This change added tests and can be verified as follows:
- Updated unit tests within `AvroSchemaConverterTest.java` (e.g., asserting fields like `type_timestamp_nanos`, `type_local_timestamp_nanos` map correctly).
- Ran pre-existing Avro suite (`AvroOutputFormatTest`, `AvroTypeExtractionTest`) to ensure backwards compatibility with upgraded baseline versions.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **yes** (Upgraded Avro to 1.12.1)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **yes** (Adjusts converter inner-loops, standard for type feature additions)
  - Anything that affects deployment or recovery: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **yes**
  - If yes, how is the feature documented? **not applicable** (Automatic type mapping addition, validated by updated test cases)