### PR TITLE
[FLINK-39489][Web Dashboard] Add Top N Metrics Dashboard

### DIFF
--- a/docs/layouts/shortcodes/generated/rest_v1_dispatcher.html
+++ b/docs/layouts/shortcodes/generated/rest_v1_dispatcher.html
@@ -3461,7 +3461,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">Returns Top N metrics for a job including CPU consumers, backpressured operators, and GC-intensive tasks.</td>
+      <td colspan="2">Returns Top N metrics for a job across five dimensions: backpressured subtasks, busy subtasks, lagging sources, CPU consumers (TaskManager-scoped) and GC-intensive TaskManagers.</td>
     </tr>
     <tr>
       <td colspan="2">Path parameters</td>
@@ -3522,6 +3522,27 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
         }
       }
     },
+    "topBusyOperators" : {
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:TopNMetricsResponseBody:BusyOperatorInfo",
+        "properties" : {
+          "busyRatio" : {
+            "type" : "number"
+          },
+          "operatorId" : {
+            "type" : "string"
+          },
+          "operatorName" : {
+            "type" : "string"
+          },
+          "subtaskId" : {
+            "type" : "integer"
+          }
+        }
+      }
+    },
     "topCpuConsumers" : {
       "type" : "array",
       "items" : {
@@ -3562,6 +3583,30 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
             "type" : "string"
           },
           "taskName" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "topLaggingSources" : {
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:TopNMetricsResponseBody:SourceLagInfo",
+        "properties" : {
+          "maxEmitEventTimeLagMs" : {
+            "type" : "number"
+          },
+          "maxFetchEventTimeLagMs" : {
+            "type" : "number"
+          },
+          "pendingRecords" : {
+            "type" : "number"
+          },
+          "vertexId" : {
+            "type" : "string"
+          },
+          "vertexName" : {
             "type" : "string"
           }
         }

--- a/docs/layouts/shortcodes/generated/rest_v1_dispatcher.html
+++ b/docs/layouts/shortcodes/generated/rest_v1_dispatcher.html
@@ -3454,6 +3454,129 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
 <table class="rest-api table table-bordered">
   <tbody>
     <tr>
+      <td class="text-left" colspan="2"><h5><strong>/jobs/:jobid/metrics/top-n</strong></h5></td>
+    </tr>
+    <tr>
+      <td class="text-left" style="width: 20%">Verb: <code>GET</code></td>
+      <td class="text-left">Response code: <code>200 OK</code></td>
+    </tr>
+    <tr>
+      <td colspan="2">Returns Top N metrics for a job including CPU consumers, backpressured operators, and GC-intensive tasks.</td>
+    </tr>
+    <tr>
+      <td colspan="2">Path parameters</td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <ul>
+<li><code>jobid</code> - 32-character hexadecimal string value that identifies a job.</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">Query parameters</td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <ul>
+<li><code>topN</code> (optional): Positive integer (1..100) controlling how many entries are returned for each Top N dimension. Defaults to 5 when omitted.</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <label>
+          <details>
+          <summary>Request</summary>
+          <pre><code>{}</code></pre>
+        </label>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <label>
+          <details>
+          <summary>Response</summary>
+          <pre><code>{
+  "type" : "object",
+  "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:TopNMetricsResponseBody",
+  "properties" : {
+    "topBackpressureOperators" : {
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:TopNMetricsResponseBody:BackpressureOperatorInfo",
+        "properties" : {
+          "backpressureRatio" : {
+            "type" : "number"
+          },
+          "operatorId" : {
+            "type" : "string"
+          },
+          "operatorName" : {
+            "type" : "string"
+          },
+          "subtaskId" : {
+            "type" : "integer"
+          }
+        }
+      }
+    },
+    "topCpuConsumers" : {
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:TopNMetricsResponseBody:CpuConsumerInfo",
+        "properties" : {
+          "cpuPercentage" : {
+            "type" : "number"
+          },
+          "operatorName" : {
+            "type" : "string"
+          },
+          "subtaskId" : {
+            "type" : "integer"
+          },
+          "taskManagerId" : {
+            "type" : "string"
+          },
+          "taskName" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "topGcIntensiveTasks" : {
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:TopNMetricsResponseBody:GcTaskInfo",
+        "properties" : {
+          "gcTimePercentage" : {
+            "type" : "number"
+          },
+          "taskId" : {
+            "type" : "string"
+          },
+          "taskManagerId" : {
+            "type" : "string"
+          },
+          "taskName" : {
+            "type" : "string"
+          }
+        }
+      }
+    }
+  }
+}</code></pre>
+        </label>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<table class="rest-api table table-bordered">
+  <tbody>
+    <tr>
       <td class="text-left" colspan="2"><h5><strong>/jobs/:jobid/plan</strong></h5></td>
     </tr>
     <tr>

--- a/docs/static/generated/rest_v1_dispatcher.yml
+++ b/docs/static/generated/rest_v1_dispatcher.yml
@@ -900,8 +900,9 @@ paths:
                 $ref: "#/components/schemas/MetricCollectionResponseBody"
   /jobs/{jobid}/metrics/top-n:
     get:
-      description: "Returns Top N metrics for a job including CPU consumers, backpressured\
-        \ operators, and GC-intensive tasks."
+      description: "Returns Top N metrics for a job across five dimensions: backpressured\
+        \ subtasks, busy subtasks, lagging sources, CPU consumers (TaskManager-scoped)\
+        \ and GC-intensive TaskManagers."
       operationId: getTopNMetrics
       parameters:
       - name: jobid
@@ -2023,6 +2024,19 @@ components:
       type: object
       properties:
         backpressureRatio:
+          type: number
+          format: double
+        operatorId:
+          type: string
+        operatorName:
+          type: string
+        subtaskId:
+          type: integer
+          format: int32
+    BusyOperatorInfo:
+      type: object
+      properties:
+        busyRatio:
           type: number
           format: double
         operatorId:
@@ -3487,6 +3501,22 @@ components:
           $ref: "#/components/schemas/SlotSharingGroupId"
         slotSharingGroupName:
           type: string
+    SourceLagInfo:
+      type: object
+      properties:
+        maxEmitEventTimeLagMs:
+          type: number
+          format: double
+        maxFetchEventTimeLagMs:
+          type: number
+          format: double
+        pendingRecords:
+          type: number
+          format: double
+        vertexId:
+          type: string
+        vertexName:
+          type: string
     StatsSummaryDto:
       type: object
       properties:
@@ -3990,6 +4020,10 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/BackpressureOperatorInfo"
+        topBusyOperators:
+          type: array
+          items:
+            $ref: "#/components/schemas/BusyOperatorInfo"
         topCpuConsumers:
           type: array
           items:
@@ -3998,6 +4032,10 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/GcTaskInfo"
+        topLaggingSources:
+          type: array
+          items:
+            $ref: "#/components/schemas/SourceLagInfo"
     TriggerCause:
       type: string
       enum:

--- a/docs/static/generated/rest_v1_dispatcher.yml
+++ b/docs/static/generated/rest_v1_dispatcher.yml
@@ -898,6 +898,34 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/MetricCollectionResponseBody"
+  /jobs/{jobid}/metrics/top-n:
+    get:
+      description: "Returns Top N metrics for a job including CPU consumers, backpressured\
+        \ operators, and GC-intensive tasks."
+      operationId: getTopNMetrics
+      parameters:
+      - name: jobid
+        in: path
+        description: 32-character hexadecimal string value that identifies a job.
+        required: true
+        schema:
+          $ref: "#/components/schemas/JobID"
+      - name: topN
+        in: query
+        description: Positive integer (1..100) controlling how many entries are returned
+          for each Top N dimension. Defaults to 5 when omitted.
+        required: false
+        style: form
+        schema:
+          type: integer
+          format: int32
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TopNMetricsResponseBody"
   /jobs/{jobid}/plan:
     get:
       description: Returns the dataflow plan of a job.
@@ -1991,6 +2019,19 @@ components:
           - $ref: "#/components/schemas/SavepointInfo"
         status:
           $ref: "#/components/schemas/QueueStatus"
+    BackpressureOperatorInfo:
+      type: object
+      properties:
+        backpressureRatio:
+          type: number
+          format: double
+        operatorId:
+          type: string
+        operatorName:
+          type: string
+        subtaskId:
+          type: integer
+          format: int32
     CheckpointAlignment:
       type: object
       properties:
@@ -2302,6 +2343,21 @@ components:
         total:
           type: integer
           format: int64
+    CpuConsumerInfo:
+      type: object
+      properties:
+        cpuPercentage:
+          type: number
+          format: double
+        operatorName:
+          type: string
+        subtaskId:
+          type: integer
+          format: int32
+        taskManagerId:
+          type: string
+        taskName:
+          type: string
     DashboardConfiguration:
       type: object
       properties:
@@ -2422,6 +2478,18 @@ components:
         time:
           type: integer
           format: int64
+    GcTaskInfo:
+      type: object
+      properties:
+        gcTimePercentage:
+          type: number
+          format: double
+        taskId:
+          type: string
+        taskManagerId:
+          type: string
+        taskName:
+          type: string
     HardwareDescription:
       type: object
       properties:
@@ -3915,6 +3983,21 @@ components:
       - FULL
       - ON_CPU
       - OFF_CPU
+    TopNMetricsResponseBody:
+      type: object
+      properties:
+        topBackpressureOperators:
+          type: array
+          items:
+            $ref: "#/components/schemas/BackpressureOperatorInfo"
+        topCpuConsumers:
+          type: array
+          items:
+            $ref: "#/components/schemas/CpuConsumerInfo"
+        topGcIntensiveTasks:
+          type: array
+          items:
+            $ref: "#/components/schemas/GcTaskInfo"
     TriggerCause:
       type: string
       enum:

--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -2830,6 +2830,51 @@
               }
             }
           }
+        },
+        "topBusyOperators" : {
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:TopNMetricsResponseBody:BusyOperatorInfo",
+            "properties" : {
+              "operatorId" : {
+                "type" : "string"
+              },
+              "operatorName" : {
+                "type" : "string"
+              },
+              "busyRatio" : {
+                "type" : "number"
+              },
+              "subtaskId" : {
+                "type" : "integer"
+              }
+            }
+          }
+        },
+        "topLaggingSources" : {
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:TopNMetricsResponseBody:SourceLagInfo",
+            "properties" : {
+              "vertexId" : {
+                "type" : "string"
+              },
+              "vertexName" : {
+                "type" : "string"
+              },
+              "pendingRecords" : {
+                "type" : "number"
+              },
+              "maxFetchEventTimeLagMs" : {
+                "type" : "number"
+              },
+              "maxEmitEventTimeLagMs" : {
+                "type" : "number"
+              }
+            }
+          }
         }
       }
     }

--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -2742,6 +2742,98 @@
       "type" : "any"
     }
   }, {
+    "url" : "/jobs/:jobid/metrics/top-n",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "jobid"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ {
+        "key" : "topN",
+        "mandatory" : false
+      } ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EmptyRequestBody"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:TopNMetricsResponseBody",
+      "properties" : {
+        "topCpuConsumers" : {
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:TopNMetricsResponseBody:CpuConsumerInfo",
+            "properties" : {
+              "subtaskId" : {
+                "type" : "integer"
+              },
+              "taskName" : {
+                "type" : "string"
+              },
+              "operatorName" : {
+                "type" : "string"
+              },
+              "cpuPercentage" : {
+                "type" : "number"
+              },
+              "taskManagerId" : {
+                "type" : "string"
+              }
+            }
+          }
+        },
+        "topBackpressureOperators" : {
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:TopNMetricsResponseBody:BackpressureOperatorInfo",
+            "properties" : {
+              "operatorId" : {
+                "type" : "string"
+              },
+              "operatorName" : {
+                "type" : "string"
+              },
+              "backpressureRatio" : {
+                "type" : "number"
+              },
+              "subtaskId" : {
+                "type" : "integer"
+              }
+            }
+          }
+        },
+        "topGcIntensiveTasks" : {
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:TopNMetricsResponseBody:GcTaskInfo",
+            "properties" : {
+              "taskId" : {
+                "type" : "string"
+              },
+              "taskName" : {
+                "type" : "string"
+              },
+              "gcTimePercentage" : {
+                "type" : "number"
+              },
+              "taskManagerId" : {
+                "type" : "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  }, {
     "url" : "/jobs/:jobid/plan",
     "method" : "GET",
     "status-code" : "200 OK",

--- a/flink-runtime-web/web-dashboard/src/app/components/topn-metrics/topn-metrics.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/components/topn-metrics/topn-metrics.component.html
@@ -1,0 +1,113 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<div class="topn-metrics-container">
+  <div class="topn-metrics-section">
+    <h3>Top N CPU Consumers</h3>
+    <nz-table #cpuTable [nzData]="topCpuConsumers" [nzShowPagination]="false" [nzSize]="'small'">
+      <thead>
+        <tr>
+          <th>Rank</th>
+          <th>Subtask ID</th>
+          <th>Operator Name</th>
+          <th>Task Name</th>
+          <th>CPU Usage</th>
+          <th>TaskManager</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let item of cpuTable.data; let i = index">
+          <td>{{ i + 1 }}</td>
+          <td>{{ item.subtaskId }}</td>
+          <td>{{ item.operatorName }}</td>
+          <td>{{ item.taskName }}</td>
+          <td [class.high-cpu]="item.cpuPercentage > 80">
+            {{ formatPercentage(item.cpuPercentage) }}
+          </td>
+          <td>{{ item.taskManagerId }}</td>
+        </tr>
+      </tbody>
+    </nz-table>
+    <div *ngIf="topCpuConsumers.length === 0" class="no-data">
+      <p>No CPU metrics available</p>
+    </div>
+  </div>
+
+  <div class="topn-metrics-section">
+    <h3>Top N Backpressure Operators</h3>
+    <nz-table
+      #bpTable
+      [nzData]="topBackpressureOperators"
+      [nzShowPagination]="false"
+      [nzSize]="'small'"
+    >
+      <thead>
+        <tr>
+          <th>Rank</th>
+          <th>Operator ID</th>
+          <th>Operator Name</th>
+          <th>Subtask ID</th>
+          <th>Backpressure Ratio</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let item of bpTable.data; let i = index">
+          <td>{{ i + 1 }}</td>
+          <td>{{ item.operatorId }}</td>
+          <td>{{ item.operatorName }}</td>
+          <td>{{ item.subtaskId }}</td>
+          <td [class.high-backpressure]="item.backpressureRatio > 0.5">
+            {{ formatPercentage(item.backpressureRatio * 100) }}
+          </td>
+        </tr>
+      </tbody>
+    </nz-table>
+    <div *ngIf="topBackpressureOperators.length === 0" class="no-data">
+      <p>No backpressure metrics available</p>
+    </div>
+  </div>
+
+  <div class="topn-metrics-section">
+    <h3>Top N GC Intensive Tasks</h3>
+    <nz-table #gcTable [nzData]="topGcIntensiveTasks" [nzShowPagination]="false" [nzSize]="'small'">
+      <thead>
+        <tr>
+          <th>Rank</th>
+          <th>Task ID</th>
+          <th>Task Name</th>
+          <th>GC Time Percentage</th>
+          <th>TaskManager</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let item of gcTable.data; let i = index">
+          <td>{{ i + 1 }}</td>
+          <td>{{ item.taskId }}</td>
+          <td>{{ item.taskName }}</td>
+          <td [class.high-gc]="item.gcTimePercentage > 30">
+            {{ formatPercentage(item.gcTimePercentage) }}
+          </td>
+          <td>{{ item.taskManagerId }}</td>
+        </tr>
+      </tbody>
+    </nz-table>
+    <div *ngIf="topGcIntensiveTasks.length === 0" class="no-data">
+      <p>No GC metrics available</p>
+    </div>
+  </div>
+</div>

--- a/flink-runtime-web/web-dashboard/src/app/components/topn-metrics/topn-metrics.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/components/topn-metrics/topn-metrics.component.html
@@ -17,97 +17,273 @@
   -->
 
 <div class="topn-metrics-container">
+  <!-- ======================================================================
+       Primary triage: per-subtask / per-vertex signals that map directly to
+       actionable Flink problems (stalled operators, overloaded operators,
+       sources falling behind).
+       ====================================================================== -->
   <div class="topn-metrics-section">
-    <h3>Top N CPU Consumers</h3>
-    <nz-table #cpuTable [nzData]="topCpuConsumers" [nzShowPagination]="false" [nzSize]="'small'">
-      <thead>
-        <tr>
-          <th>Rank</th>
-          <th>Subtask ID</th>
-          <th>Operator Name</th>
-          <th>Task Name</th>
-          <th>CPU Usage</th>
-          <th>TaskManager</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr *ngFor="let item of cpuTable.data; let i = index">
-          <td>{{ i + 1 }}</td>
-          <td>{{ item.subtaskId }}</td>
-          <td>{{ item.operatorName }}</td>
-          <td>{{ item.taskName }}</td>
-          <td [class.high-cpu]="item.cpuPercentage > 80">
-            {{ formatPercentage(item.cpuPercentage) }}
-          </td>
-          <td>{{ item.taskManagerId }}</td>
-        </tr>
-      </tbody>
-    </nz-table>
-    <div *ngIf="topCpuConsumers.length === 0" class="no-data">
-      <p>No CPU metrics available</p>
-    </div>
-  </div>
-
-  <div class="topn-metrics-section">
-    <h3>Top N Backpressure Operators</h3>
-    <nz-table
-      #bpTable
-      [nzData]="topBackpressureOperators"
-      [nzShowPagination]="false"
-      [nzSize]="'small'"
+    <h3
+      class="topn-metrics-title"
+      role="button"
+      tabindex="0"
+      [attr.aria-expanded]="!collapsed.backpressure"
+      (click)="toggle('backpressure')"
+      (keydown.enter)="toggle('backpressure')"
+      (keydown.space)="toggle('backpressure'); $event.preventDefault()"
     >
-      <thead>
-        <tr>
-          <th>Rank</th>
-          <th>Operator ID</th>
-          <th>Operator Name</th>
-          <th>Subtask ID</th>
-          <th>Backpressure Ratio</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr *ngFor="let item of bpTable.data; let i = index">
-          <td>{{ i + 1 }}</td>
-          <td>{{ item.operatorId }}</td>
-          <td>{{ item.operatorName }}</td>
-          <td>{{ item.subtaskId }}</td>
-          <td [class.high-backpressure]="item.backpressureRatio > 0.5">
-            {{ formatPercentage(item.backpressureRatio * 100) }}
-          </td>
-        </tr>
-      </tbody>
-    </nz-table>
-    <div *ngIf="topBackpressureOperators.length === 0" class="no-data">
-      <p>No backpressure metrics available</p>
-    </div>
+      <span class="topn-metrics-caret" [class.collapsed]="collapsed.backpressure">▾</span>
+      Top N Backpressured Subtasks
+    </h3>
+    <ng-container *ngIf="!collapsed.backpressure">
+      <nz-table
+        #bpTable
+        [nzData]="topBackpressureOperators"
+        [nzShowPagination]="false"
+        [nzSize]="'small'"
+      >
+        <thead>
+          <tr>
+            <th>Rank</th>
+            <th>Operator ID</th>
+            <th>Operator Name</th>
+            <th>Subtask ID</th>
+            <th>Backpressure Ratio</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let item of bpTable.data; let i = index">
+            <td>{{ i + 1 }}</td>
+            <td>{{ item.operatorId }}</td>
+            <td>{{ item.operatorName }}</td>
+            <td>{{ item.subtaskId }}</td>
+            <td [class.high-backpressure]="item.backpressureRatio > 0.5">
+              {{ formatPercentage(item.backpressureRatio * 100) }}
+            </td>
+          </tr>
+        </tbody>
+      </nz-table>
+      <div *ngIf="topBackpressureOperators.length === 0" class="no-data">
+        <p>No backpressure metrics available</p>
+      </div>
+    </ng-container>
   </div>
 
   <div class="topn-metrics-section">
-    <h3>Top N GC Intensive Tasks</h3>
-    <nz-table #gcTable [nzData]="topGcIntensiveTasks" [nzShowPagination]="false" [nzSize]="'small'">
-      <thead>
-        <tr>
-          <th>Rank</th>
-          <th>Task ID</th>
-          <th>Task Name</th>
-          <th>GC Time Percentage</th>
-          <th>TaskManager</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr *ngFor="let item of gcTable.data; let i = index">
-          <td>{{ i + 1 }}</td>
-          <td>{{ item.taskId }}</td>
-          <td>{{ item.taskName }}</td>
-          <td [class.high-gc]="item.gcTimePercentage > 30">
-            {{ formatPercentage(item.gcTimePercentage) }}
-          </td>
-          <td>{{ item.taskManagerId }}</td>
-        </tr>
-      </tbody>
-    </nz-table>
-    <div *ngIf="topGcIntensiveTasks.length === 0" class="no-data">
-      <p>No GC metrics available</p>
+    <h3
+      class="topn-metrics-title"
+      role="button"
+      tabindex="0"
+      [attr.aria-expanded]="!collapsed.busy"
+      (click)="toggle('busy')"
+      (keydown.enter)="toggle('busy')"
+      (keydown.space)="toggle('busy'); $event.preventDefault()"
+    >
+      <span class="topn-metrics-caret" [class.collapsed]="collapsed.busy">▾</span>
+      Top N Busy Subtasks
+    </h3>
+    <ng-container *ngIf="!collapsed.busy">
+      <p class="topn-metrics-hint">
+        Per-subtask CPU via
+        <code>busyTimeMsPerSecond</code>
+        . Sustained high values = the operator itself is the bottleneck.
+      </p>
+      <nz-table
+        #busyTable
+        [nzData]="topBusyOperators"
+        [nzShowPagination]="false"
+        [nzSize]="'small'"
+      >
+        <thead>
+          <tr>
+            <th>Rank</th>
+            <th>Operator ID</th>
+            <th>Operator Name</th>
+            <th>Subtask ID</th>
+            <th>Busy Ratio</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let item of busyTable.data; let i = index">
+            <td>{{ i + 1 }}</td>
+            <td>{{ item.operatorId }}</td>
+            <td>{{ item.operatorName }}</td>
+            <td>{{ item.subtaskId }}</td>
+            <td [class.high-busy]="item.busyRatio > 0.8">
+              {{ formatPercentage(item.busyRatio * 100) }}
+            </td>
+          </tr>
+        </tbody>
+      </nz-table>
+      <div *ngIf="topBusyOperators.length === 0" class="no-data">
+        <p>No busy-time metrics available</p>
+      </div>
+    </ng-container>
+  </div>
+
+  <div class="topn-metrics-section">
+    <h3
+      class="topn-metrics-title"
+      role="button"
+      tabindex="0"
+      [attr.aria-expanded]="!collapsed.sourceLag"
+      (click)="toggle('sourceLag')"
+      (keydown.enter)="toggle('sourceLag')"
+      (keydown.space)="toggle('sourceLag'); $event.preventDefault()"
+    >
+      <span class="topn-metrics-caret" [class.collapsed]="collapsed.sourceLag">▾</span>
+      Top N Lagging Sources
+    </h3>
+    <ng-container *ngIf="!collapsed.sourceLag">
+      <p class="topn-metrics-hint">
+        FLIP-33 source metrics (Kafka, Pulsar, ...).
+        <em>n/a</em>
+        = not reported by this connector.
+      </p>
+      <nz-table
+        #lagTable
+        [nzData]="topLaggingSources"
+        [nzShowPagination]="false"
+        [nzSize]="'small'"
+      >
+        <thead>
+          <tr>
+            <th>Rank</th>
+            <th>Source Vertex ID</th>
+            <th>Source Vertex Name</th>
+            <th>Pending Records</th>
+            <th>Max Fetch Event-Time Lag</th>
+            <th>Max Emit Event-Time Lag</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let item of lagTable.data; let i = index">
+            <td>{{ i + 1 }}</td>
+            <td>{{ item.vertexId }}</td>
+            <td>{{ item.vertexName }}</td>
+            <td [class.high-lag]="item.pendingRecords !== null && item.pendingRecords > 0">
+              {{ formatLag(item.pendingRecords, 'records') }}
+            </td>
+            <td
+              [class.high-lag]="
+                item.maxFetchEventTimeLagMs !== null && item.maxFetchEventTimeLagMs > 0
+              "
+            >
+              {{ formatLag(item.maxFetchEventTimeLagMs, 'ms') }}
+            </td>
+            <td
+              [class.high-lag]="
+                item.maxEmitEventTimeLagMs !== null && item.maxEmitEventTimeLagMs > 0
+              "
+            >
+              {{ formatLag(item.maxEmitEventTimeLagMs, 'ms') }}
+            </td>
+          </tr>
+        </tbody>
+      </nz-table>
+      <div *ngIf="topLaggingSources.length === 0" class="no-data">
+        <p>No source lag metrics available</p>
+      </div>
+    </ng-container>
+  </div>
+
+  <!-- ======================================================================
+       JVM diagnostics: TaskManager-scoped signals that are useful as a second
+       line of investigation (e.g. confirming a GC pause correlates with a
+       checkpoint timeout). Collapsed by default.
+       ====================================================================== -->
+  <div class="topn-metrics-section topn-metrics-section-jvm">
+    <div class="topn-metrics-jvm-header">JVM diagnostics (auxiliary)</div>
+
+    <div class="topn-metrics-subsection">
+      <h3
+        class="topn-metrics-title"
+        role="button"
+        tabindex="0"
+        [attr.aria-expanded]="!collapsed.cpu"
+        (click)="toggle('cpu')"
+        (keydown.enter)="toggle('cpu')"
+        (keydown.space)="toggle('cpu'); $event.preventDefault()"
+      >
+        <span class="topn-metrics-caret" [class.collapsed]="collapsed.cpu">▾</span>
+        Top N CPU Load TaskManagers
+      </h3>
+      <ng-container *ngIf="!collapsed.cpu">
+        <p class="topn-metrics-hint">
+          Per-TaskManager, not per-operator. For single-operator attribution use Top N Busy Subtasks
+          above.
+        </p>
+        <nz-table
+          #cpuTable
+          [nzData]="topCpuConsumers"
+          [nzShowPagination]="false"
+          [nzSize]="'small'"
+        >
+          <thead>
+            <tr>
+              <th>Rank</th>
+              <th>TaskManager</th>
+              <th>CPU Usage</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let item of cpuTable.data; let i = index">
+              <td>{{ i + 1 }}</td>
+              <td>{{ item.taskManagerId }}</td>
+              <td [class.high-cpu]="item.cpuPercentage > 80">
+                {{ formatPercentage(item.cpuPercentage) }}
+              </td>
+            </tr>
+          </tbody>
+        </nz-table>
+        <div *ngIf="topCpuConsumers.length === 0" class="no-data">
+          <p>No CPU metrics available</p>
+        </div>
+      </ng-container>
+    </div>
+
+    <div class="topn-metrics-subsection">
+      <h3
+        class="topn-metrics-title"
+        role="button"
+        tabindex="0"
+        [attr.aria-expanded]="!collapsed.gc"
+        (click)="toggle('gc')"
+        (keydown.enter)="toggle('gc')"
+        (keydown.space)="toggle('gc'); $event.preventDefault()"
+      >
+        <span class="topn-metrics-caret" [class.collapsed]="collapsed.gc">▾</span>
+        Top N GC Intensive TaskManagers
+      </h3>
+      <ng-container *ngIf="!collapsed.gc">
+        <p class="topn-metrics-hint">Per-TaskManager, cumulative GC milliseconds since start.</p>
+        <nz-table
+          #gcTable
+          [nzData]="topGcIntensiveTasks"
+          [nzShowPagination]="false"
+          [nzSize]="'small'"
+        >
+          <thead>
+            <tr>
+              <th>Rank</th>
+              <th>TaskManager</th>
+              <th>GC Time (ms)</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let item of gcTable.data; let i = index">
+              <td>{{ i + 1 }}</td>
+              <td>{{ item.taskManagerId }}</td>
+              <td [class.high-gc]="item.gcTimePercentage > 30000">
+                {{ item.gcTimePercentage | number: '1.0-0' }}
+              </td>
+            </tr>
+          </tbody>
+        </nz-table>
+        <div *ngIf="topGcIntensiveTasks.length === 0" class="no-data">
+          <p>No GC metrics available</p>
+        </div>
+      </ng-container>
     </div>
   </div>
 </div>

--- a/flink-runtime-web/web-dashboard/src/app/components/topn-metrics/topn-metrics.component.less
+++ b/flink-runtime-web/web-dashboard/src/app/components/topn-metrics/topn-metrics.component.less
@@ -37,11 +37,75 @@
     font-size: 16px;
   }
 
+  .topn-metrics-title {
+    cursor: pointer;
+    user-select: none;
+
+    &:hover {
+      color: #1890ff;
+    }
+
+    &:focus-visible {
+      outline: 2px solid #1890ff;
+      outline-offset: 2px;
+    }
+  }
+
+  .topn-metrics-caret {
+    display: inline-block;
+    margin-right: 4px;
+    color: #8c8c8c;
+    font-size: 16px;
+    line-height: 1;
+    transition: transform 0.15s ease-in-out;
+
+    &.collapsed {
+      transform: rotate(-90deg);
+    }
+  }
+
+  .topn-metrics-hint {
+    margin-bottom: 8px;
+    color: #8c8c8c;
+    font-size: 12px;
+  }
+
   .no-data {
     padding: 20px;
     color: #8c8c8c;
     font-style: italic;
     text-align: center;
+  }
+}
+
+// JVM diagnostics wrapper: visually demotes CPU / GC tables into an auxiliary
+// group that is clearly separate from the primary-triage signals above.
+.topn-metrics-section-jvm {
+  margin-top: 8px;
+  padding: 12px 16px 4px;
+  border-top: 1px dashed #e8e8e8;
+  border-radius: 4px;
+  background: #fafafa;
+
+  .topn-metrics-jvm-header {
+    margin-bottom: 12px;
+    color: #8c8c8c;
+    font-weight: 500;
+    font-size: 12px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .topn-metrics-subsection {
+    margin-bottom: 16px;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+
+    h3 {
+      font-size: 14px;
+    }
   }
 }
 
@@ -52,6 +116,16 @@
 
 .high-backpressure {
   color: #d4380d;
+  font-weight: 600;
+}
+
+.high-busy {
+  color: #d4380d;
+  font-weight: 600;
+}
+
+.high-lag {
+  color: #d46b08;
   font-weight: 600;
 }
 

--- a/flink-runtime-web/web-dashboard/src/app/components/topn-metrics/topn-metrics.component.less
+++ b/flink-runtime-web/web-dashboard/src/app/components/topn-metrics/topn-metrics.component.less
@@ -16,25 +16,46 @@
  * limitations under the License.
  */
 
-export * from './configuration';
-export * from './jar';
-export * from './job-overview';
-export * from './job-detail';
-export * from './job-exception';
-export * from './job-timeline';
-export * from './job-config';
-export * from './job-vertex';
-export * from './job-checkpoint';
-export * from './job-backpressure';
-export * from './job-flamegraph';
-export * from './job-rescales';
-export * from './plan';
-export * from './overview';
-export * from './task-manager';
-export * from './job-accumulators';
-export * from './job-manager';
-export * from './job-metrics';
-export * from './application-overview';
-export * from './application-detail';
-export * from './application-exception';
-export * from './topn-metrics';
+.topn-metrics-container {
+  margin-bottom: 16px;
+  padding: 16px;
+  border-radius: 4px;
+  background: #fff;
+}
+
+.topn-metrics-section {
+  margin-bottom: 24px;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+
+  h3 {
+    margin-bottom: 12px;
+    color: #262626;
+    font-weight: 600;
+    font-size: 16px;
+  }
+
+  .no-data {
+    padding: 20px;
+    color: #8c8c8c;
+    font-style: italic;
+    text-align: center;
+  }
+}
+
+.high-cpu {
+  color: #cf1322;
+  font-weight: 600;
+}
+
+.high-backpressure {
+  color: #d4380d;
+  font-weight: 600;
+}
+
+.high-gc {
+  color: #d46b08;
+  font-weight: 600;
+}

--- a/flink-runtime-web/web-dashboard/src/app/components/topn-metrics/topn-metrics.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/components/topn-metrics/topn-metrics.component.ts
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+
+import { CpuConsumerInfo, BackpressureOperatorInfo, GcTaskInfo } from '@flink-runtime-web/interfaces';
+import { NzCardModule } from 'ng-zorro-antd/card';
+import { NzGridModule } from 'ng-zorro-antd/grid';
+import { NzProgressModule } from 'ng-zorro-antd/progress';
+import { NzTableModule } from 'ng-zorro-antd/table';
+
+@Component({
+  selector: 'flink-topn-metrics',
+  templateUrl: './topn-metrics.component.html',
+  styleUrls: ['./topn-metrics.component.less'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true,
+  imports: [CommonModule, NzCardModule, NzGridModule, NzTableModule, NzProgressModule]
+})
+export class TopNMetricsComponent {
+  @Input() topCpuConsumers: CpuConsumerInfo[] = [];
+  @Input() topBackpressureOperators: BackpressureOperatorInfo[] = [];
+  @Input() topGcIntensiveTasks: GcTaskInfo[] = [];
+
+  formatPercentage(value: number): string {
+    return `${value.toFixed(2)}%`;
+  }
+}

--- a/flink-runtime-web/web-dashboard/src/app/components/topn-metrics/topn-metrics.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/components/topn-metrics/topn-metrics.component.ts
@@ -19,11 +19,19 @@
 import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 
-import { CpuConsumerInfo, BackpressureOperatorInfo, GcTaskInfo } from '@flink-runtime-web/interfaces';
+import {
+  BackpressureOperatorInfo,
+  BusyOperatorInfo,
+  CpuConsumerInfo,
+  GcTaskInfo,
+  SourceLagInfo
+} from '@flink-runtime-web/interfaces';
 import { NzCardModule } from 'ng-zorro-antd/card';
 import { NzGridModule } from 'ng-zorro-antd/grid';
 import { NzProgressModule } from 'ng-zorro-antd/progress';
 import { NzTableModule } from 'ng-zorro-antd/table';
+
+type TopNSection = 'backpressure' | 'busy' | 'sourceLag' | 'cpu' | 'gc';
 
 @Component({
   selector: 'flink-topn-metrics',
@@ -34,11 +42,41 @@ import { NzTableModule } from 'ng-zorro-antd/table';
   imports: [CommonModule, NzCardModule, NzGridModule, NzTableModule, NzProgressModule]
 })
 export class TopNMetricsComponent {
-  @Input() topCpuConsumers: CpuConsumerInfo[] = [];
   @Input() topBackpressureOperators: BackpressureOperatorInfo[] = [];
+  @Input() topBusyOperators: BusyOperatorInfo[] = [];
+  @Input() topLaggingSources: SourceLagInfo[] = [];
+  @Input() topCpuConsumers: CpuConsumerInfo[] = [];
   @Input() topGcIntensiveTasks: GcTaskInfo[] = [];
+
+  /**
+   * Per-section collapse state. Primary-triage sections (backpressure / busy / source lag) are
+   * expanded by default because they are the first-line diagnostic signals; JVM-level sections
+   * (CPU load / GC time) are collapsed by default and shown as auxiliary diagnostics.
+   */
+  collapsed: Record<TopNSection, boolean> = {
+    backpressure: false,
+    busy: false,
+    sourceLag: false,
+    cpu: true,
+    gc: true
+  };
+
+  toggle(section: TopNSection): void {
+    this.collapsed[section] = !this.collapsed[section];
+  }
 
   formatPercentage(value: number): string {
     return `${value.toFixed(2)}%`;
+  }
+
+  /** Render a lag metric that may be unavailable (`null`). */
+  formatLag(value: number | null, unit: 'records' | 'ms'): string {
+    if (value == null) {
+      return 'n/a';
+    }
+    if (unit === 'records') {
+      return Math.round(value).toLocaleString();
+    }
+    return `${Math.round(value).toLocaleString()} ms`;
   }
 }

--- a/flink-runtime-web/web-dashboard/src/app/interfaces/topn-metrics.ts
+++ b/flink-runtime-web/web-dashboard/src/app/interfaces/topn-metrics.ts
@@ -16,25 +16,30 @@
  * limitations under the License.
  */
 
-export * from './configuration';
-export * from './jar';
-export * from './job-overview';
-export * from './job-detail';
-export * from './job-exception';
-export * from './job-timeline';
-export * from './job-config';
-export * from './job-vertex';
-export * from './job-checkpoint';
-export * from './job-backpressure';
-export * from './job-flamegraph';
-export * from './job-rescales';
-export * from './plan';
-export * from './overview';
-export * from './task-manager';
-export * from './job-accumulators';
-export * from './job-manager';
-export * from './job-metrics';
-export * from './application-overview';
-export * from './application-detail';
-export * from './application-exception';
-export * from './topn-metrics';
+export interface TopNMetrics {
+  topCpuConsumers: CpuConsumerInfo[];
+  topBackpressureOperators: BackpressureOperatorInfo[];
+  topGcIntensiveTasks: GcTaskInfo[];
+}
+
+export interface CpuConsumerInfo {
+  subtaskId: number;
+  taskName: string;
+  operatorName: string;
+  cpuPercentage: number;
+  taskManagerId: string;
+}
+
+export interface BackpressureOperatorInfo {
+  operatorId: string;
+  operatorName: string;
+  backpressureRatio: number;
+  subtaskId: number;
+}
+
+export interface GcTaskInfo {
+  taskId: string;
+  taskName: string;
+  gcTimePercentage: number;
+  taskManagerId: string;
+}

--- a/flink-runtime-web/web-dashboard/src/app/interfaces/topn-metrics.ts
+++ b/flink-runtime-web/web-dashboard/src/app/interfaces/topn-metrics.ts
@@ -20,10 +20,16 @@ export interface TopNMetrics {
   topCpuConsumers: CpuConsumerInfo[];
   topBackpressureOperators: BackpressureOperatorInfo[];
   topGcIntensiveTasks: GcTaskInfo[];
+  topBusyOperators: BusyOperatorInfo[];
+  topLaggingSources: SourceLagInfo[];
 }
 
 export interface CpuConsumerInfo {
-  subtaskId: number;
+  /**
+   * `null` when the reading is TaskManager-scoped (e.g. JVM process CPU load). Otherwise the
+   * originating subtask index.
+   */
+  subtaskId: number | null;
   taskName: string;
   operatorName: string;
   cpuPercentage: number;
@@ -42,4 +48,24 @@ export interface GcTaskInfo {
   taskName: string;
   gcTimePercentage: number;
   taskManagerId: string;
+}
+
+export interface BusyOperatorInfo {
+  operatorId: string;
+  operatorName: string;
+  busyRatio: number;
+  subtaskId: number;
+}
+
+/**
+ * Lagging source vertex aggregates. Any of the three metric fields may be `null` when the
+ * source connector does not expose that metric (e.g. `pendingRecords` or event-time lags).
+ * `null` should be rendered as "n/a" in the UI and MUST NOT be conflated with a legitimate 0.
+ */
+export interface SourceLagInfo {
+  vertexId: string;
+  vertexName: string;
+  pendingRecords: number | null;
+  maxFetchEventTimeLagMs: number | null;
+  maxEmitEventTimeLagMs: number | null;
 }

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/job.config.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/job.config.ts
@@ -30,7 +30,8 @@ export const JOB_MODULE_DEFAULT_CONFIG: Required<JobModuleConfig> = {
     { title: 'TimeLine', path: 'timeline' },
     { title: 'Checkpoints', path: 'checkpoints' },
     { title: 'Configuration', path: 'configuration' },
-    { title: 'Rescales', path: 'rescales' }
+    { title: 'Rescales', path: 'rescales' },
+    { title: 'TopN Metric', path: 'topn-metric' }
   ]
 };
 

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/job.config.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/job.config.ts
@@ -29,9 +29,9 @@ export const JOB_MODULE_DEFAULT_CONFIG: Required<JobModuleConfig> = {
     { title: 'Data Skew', path: 'dataskew' },
     { title: 'TimeLine', path: 'timeline' },
     { title: 'Checkpoints', path: 'checkpoints' },
+    { title: 'TopN Metric', path: 'topn-metric' },
     { title: 'Configuration', path: 'configuration' },
-    { title: 'Rescales', path: 'rescales' },
-    { title: 'TopN Metric', path: 'topn-metric' }
+    { title: 'Rescales', path: 'rescales' }
   ]
 };
 

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/modules/completed-job/routes.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/modules/completed-job/routes.ts
@@ -54,7 +54,8 @@ const OVERRIDE_JOB_MODULE_CONFIG_FACTORY = (statusService: StatusService): JobMo
           { title: 'Checkpoints', path: 'checkpoints' },
           { title: 'Job Configuration', path: 'configuration' },
           { title: 'Rescales', path: 'rescales' },
-          { title: 'Cluster Configuration', path: 'cluster_configuration' }
+          { title: 'Cluster Configuration', path: 'cluster_configuration' },
+          { title: 'TopN Metric', path: 'topn-metric' }
         ]
       : JOB_MODULE_DEFAULT_CONFIG.routerTabs
   };
@@ -147,6 +148,16 @@ export const COMPLETED_JOB_ROUES: Routes = [
         canActivate: [ClusterConfigGuard],
         data: {
           path: 'cluster_configuration'
+        }
+      },
+      {
+        path: 'topn-metric',
+        loadComponent: () =>
+          import('@flink-runtime-web/pages/job/topn-metric/job-topn-metric.component').then(
+            m => m.JobTopnMetricComponent
+          ),
+        data: {
+          path: 'topn-metric'
         }
       },
       { path: '**', redirectTo: 'overview', pathMatch: 'full' }

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/modules/running-job/routes.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/modules/running-job/routes.ts
@@ -88,6 +88,16 @@ export const RUNNING_JOB_ROUTES: Routes = [
           path: 'rescales'
         }
       },
+      {
+        path: 'topn-metric',
+        loadComponent: () =>
+          import('@flink-runtime-web/pages/job/topn-metric/job-topn-metric.component').then(
+            m => m.JobTopnMetricComponent
+          ),
+        data: {
+          path: 'topn-metric'
+        }
+      },
       { path: '**', redirectTo: 'overview', pathMatch: 'full' }
     ]
   }

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/topn-metric/job-topn-metric.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/topn-metric/job-topn-metric.component.html
@@ -1,0 +1,23 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<flink-topn-metrics
+  [topCpuConsumers]="topCpuConsumers"
+  [topBackpressureOperators]="topBackpressureOperators"
+  [topGcIntensiveTasks]="topGcIntensiveTasks"
+></flink-topn-metrics>

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/topn-metric/job-topn-metric.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/topn-metric/job-topn-metric.component.html
@@ -17,7 +17,9 @@
   -->
 
 <flink-topn-metrics
-  [topCpuConsumers]="topCpuConsumers"
   [topBackpressureOperators]="topBackpressureOperators"
+  [topBusyOperators]="topBusyOperators"
+  [topLaggingSources]="topLaggingSources"
+  [topCpuConsumers]="topCpuConsumers"
   [topGcIntensiveTasks]="topGcIntensiveTasks"
 ></flink-topn-metrics>

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/topn-metric/job-topn-metric.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/topn-metric/job-topn-metric.component.ts
@@ -21,7 +21,13 @@ import { Subject } from 'rxjs';
 import { switchMap, takeUntil, withLatestFrom } from 'rxjs/operators';
 
 import { TopNMetricsComponent } from '@flink-runtime-web/components/topn-metrics/topn-metrics.component';
-import { BackpressureOperatorInfo, CpuConsumerInfo, GcTaskInfo } from '@flink-runtime-web/interfaces';
+import {
+  BackpressureOperatorInfo,
+  BusyOperatorInfo,
+  CpuConsumerInfo,
+  GcTaskInfo,
+  SourceLagInfo
+} from '@flink-runtime-web/interfaces';
 import { JobLocalService } from '@flink-runtime-web/pages/job/job-local.service';
 import { StatusService, TopNMetricsService } from '@flink-runtime-web/services';
 
@@ -33,8 +39,10 @@ import { StatusService, TopNMetricsService } from '@flink-runtime-web/services';
   imports: [TopNMetricsComponent]
 })
 export class JobTopnMetricComponent implements OnInit, OnDestroy {
-  public topCpuConsumers: CpuConsumerInfo[] = [];
   public topBackpressureOperators: BackpressureOperatorInfo[] = [];
+  public topBusyOperators: BusyOperatorInfo[] = [];
+  public topLaggingSources: SourceLagInfo[] = [];
+  public topCpuConsumers: CpuConsumerInfo[] = [];
   public topGcIntensiveTasks: GcTaskInfo[] = [];
 
   private readonly destroy$ = new Subject<void>();
@@ -55,8 +63,10 @@ export class JobTopnMetricComponent implements OnInit, OnDestroy {
         switchMap(([, job]) => this.topNMetricsService.loadTopNMetrics(job.jid))
       )
       .subscribe(metrics => {
-        this.topCpuConsumers = metrics.topCpuConsumers ?? [];
         this.topBackpressureOperators = metrics.topBackpressureOperators ?? [];
+        this.topBusyOperators = metrics.topBusyOperators ?? [];
+        this.topLaggingSources = metrics.topLaggingSources ?? [];
+        this.topCpuConsumers = metrics.topCpuConsumers ?? [];
         this.topGcIntensiveTasks = metrics.topGcIntensiveTasks ?? [];
         this.cdr.markForCheck();
       });

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/topn-metric/job-topn-metric.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/topn-metric/job-topn-metric.component.ts
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
+import { Subject } from 'rxjs';
+import { switchMap, takeUntil, withLatestFrom } from 'rxjs/operators';
+
+import { TopNMetricsComponent } from '@flink-runtime-web/components/topn-metrics/topn-metrics.component';
+import { BackpressureOperatorInfo, CpuConsumerInfo, GcTaskInfo } from '@flink-runtime-web/interfaces';
+import { JobLocalService } from '@flink-runtime-web/pages/job/job-local.service';
+import { StatusService, TopNMetricsService } from '@flink-runtime-web/services';
+
+@Component({
+  selector: 'flink-job-topn-metric',
+  templateUrl: './job-topn-metric.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true,
+  imports: [TopNMetricsComponent]
+})
+export class JobTopnMetricComponent implements OnInit, OnDestroy {
+  public topCpuConsumers: CpuConsumerInfo[] = [];
+  public topBackpressureOperators: BackpressureOperatorInfo[] = [];
+  public topGcIntensiveTasks: GcTaskInfo[] = [];
+
+  private readonly destroy$ = new Subject<void>();
+
+  constructor(
+    private readonly jobLocalService: JobLocalService,
+    private readonly topNMetricsService: TopNMetricsService,
+    private readonly statusService: StatusService,
+    private readonly cdr: ChangeDetectorRef
+  ) {}
+
+  ngOnInit(): void {
+    // Re-fetch on every refresh tick, pinned to the currently focused job.
+    this.statusService.refresh$
+      .pipe(
+        takeUntil(this.destroy$),
+        withLatestFrom(this.jobLocalService.jobDetailChanges()),
+        switchMap(([, job]) => this.topNMetricsService.loadTopNMetrics(job.jid))
+      )
+      .subscribe(metrics => {
+        this.topCpuConsumers = metrics.topCpuConsumers ?? [];
+        this.topBackpressureOperators = metrics.topBackpressureOperators ?? [];
+        this.topGcIntensiveTasks = metrics.topGcIntensiveTasks ?? [];
+        this.cdr.markForCheck();
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+}

--- a/flink-runtime-web/web-dashboard/src/app/services/public-api.ts
+++ b/flink-runtime-web/web-dashboard/src/app/services/public-api.ts
@@ -25,3 +25,4 @@ export * from './task-manager.service';
 export * from './metrics.service';
 export * from './config.service';
 export * from './application.service';
+export * from './topn-metrics.service';

--- a/flink-runtime-web/web-dashboard/src/app/services/topn-metrics.service.ts
+++ b/flink-runtime-web/web-dashboard/src/app/services/topn-metrics.service.ts
@@ -16,25 +16,24 @@
  * limitations under the License.
  */
 
-export * from './configuration';
-export * from './jar';
-export * from './job-overview';
-export * from './job-detail';
-export * from './job-exception';
-export * from './job-timeline';
-export * from './job-config';
-export * from './job-vertex';
-export * from './job-checkpoint';
-export * from './job-backpressure';
-export * from './job-flamegraph';
-export * from './job-rescales';
-export * from './plan';
-export * from './overview';
-export * from './task-manager';
-export * from './job-accumulators';
-export * from './job-manager';
-export * from './job-metrics';
-export * from './application-overview';
-export * from './application-detail';
-export * from './application-exception';
-export * from './topn-metrics';
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { EMPTY, Observable } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+import { TopNMetrics } from '@flink-runtime-web/interfaces';
+
+import { ConfigService } from './config.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class TopNMetricsService {
+  constructor(private readonly httpClient: HttpClient, private readonly configService: ConfigService) {}
+
+  public loadTopNMetrics(jobId: string): Observable<TopNMetrics> {
+    return this.httpClient
+      .get<TopNMetrics>(`${this.configService.BASE_URL}/jobs/${jobId}/metrics/top-n`)
+      .pipe(catchError(() => EMPTY));
+  }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/metrics/TopNMetricsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/metrics/TopNMetricsHandler.java
@@ -19,10 +19,12 @@
 package org.apache.flink.runtime.rest.handler.job.metrics;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
 import org.apache.flink.runtime.metrics.MetricNames;
-import org.apache.flink.runtime.rest.handler.AbstractRestHandler;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;
 import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.handler.job.AbstractExecutionGraphHandler;
+import org.apache.flink.runtime.rest.handler.legacy.ExecutionGraphCache;
 import org.apache.flink.runtime.rest.handler.legacy.metrics.MetricFetcher;
 import org.apache.flink.runtime.rest.handler.legacy.metrics.MetricStore;
 import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
@@ -31,6 +33,7 @@ import org.apache.flink.runtime.rest.messages.job.metrics.TopNMetricsHeaders;
 import org.apache.flink.runtime.rest.messages.job.metrics.TopNMetricsMessageParameters;
 import org.apache.flink.runtime.rest.messages.job.metrics.TopNMetricsResponseBody;
 import org.apache.flink.runtime.rest.messages.job.metrics.TopNQueryParameter;
+import org.apache.flink.runtime.scheduler.ExecutionGraphInfo;
 import org.apache.flink.runtime.webmonitor.RestfulGateway;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
 
@@ -45,25 +48,42 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
 
 /**
- * Request handler that returns Top N metrics for a job, including:
+ * Request handler that returns Top N metrics for a job, organized into a "primary triage" tier and
+ * a "JVM diagnostics" tier:
  *
  * <ul>
- *   <li><b>CPU consumers</b> &mdash; aggregated at the TaskManager level, scored by {@code
- *       Status.JVM.CPU.Load} of the JVM process. CPU is not a per-subtask quantity in Flink, so
- *       results are TaskManager-scoped.
- *   <li><b>Backpressured operators</b> &mdash; aggregated at the subtask level, scored by {@code
- *       backPressuredTimeMsPerSecond} (0&ndash;1000 ms/s), exposed as a ratio in [0, 1].
- *   <li><b>GC-intensive TaskManagers</b> &mdash; aggregated at the TaskManager level, scored by the
- *       sum of {@code Status.JVM.GarbageCollector.*.Time} across all known garbage collectors
- *       reported by that TaskManager (cumulative milliseconds since TM start).
+ *   <li><b>Primary triage (per-subtask / per-vertex, directly actionable)</b>
+ *       <ul>
+ *         <li><b>Backpressured subtasks</b> &mdash; scored by {@code backPressuredTimeMsPerSecond}
+ *             (0&ndash;1000&nbsp;ms/s), exposed as a ratio in [0,&nbsp;1].
+ *         <li><b>Busy subtasks</b> &mdash; scored by {@code busyTimeMsPerSecond}
+ *             (0&ndash;1000&nbsp;ms/s), exposed as a ratio in [0,&nbsp;1]. This is the
+ *             operator-level "where is CPU actually being spent" indicator; it complements the
+ *             JVM-level CPU load below.
+ *         <li><b>Lagging sources</b> &mdash; vertices reporting at least one of {@code
+ *             pendingRecords}, {@code currentFetchEventTimeLag}, or {@code
+ *             currentEmitEventTimeLag}. {@code pendingRecords} is summed across subtasks; the two
+ *             lag metrics are taken as the per-vertex maximum. Vertices are ranked by pending
+ *             records first, then by fetch-lag, then by emit-lag.
+ *       </ul>
+ *   <li><b>JVM diagnostics (TaskManager-scoped, coarser)</b>
+ *       <ul>
+ *         <li><b>CPU consumers</b> &mdash; scored by {@code Status.JVM.CPU.Load} of the JVM
+ *             process. CPU is not a per-subtask quantity in Flink, so results are
+ *             TaskManager-scoped.
+ *         <li><b>GC-intensive TaskManagers</b> &mdash; scored by the sum of {@code
+ *             Status.JVM.GarbageCollector.*.Time} across all known garbage collectors reported by
+ *             that TaskManager (cumulative milliseconds since TM start).
+ *       </ul>
  * </ul>
  *
  * <p>This handler does not filter TaskManagers by job assignment: JVM metrics are inherently
@@ -72,11 +92,8 @@ import static java.util.Objects.requireNonNull;
  */
 @Internal
 public class TopNMetricsHandler
-        extends AbstractRestHandler<
-                RestfulGateway,
-                EmptyRequestBody,
-                TopNMetricsResponseBody,
-                TopNMetricsMessageParameters> {
+        extends AbstractExecutionGraphHandler<
+                TopNMetricsResponseBody, TopNMetricsMessageParameters> {
 
     private static final Logger LOG = LoggerFactory.getLogger(TopNMetricsHandler.class);
 
@@ -97,20 +114,49 @@ public class TopNMetricsHandler
     private static final String METRIC_BACKPRESSURED_TIME_MS_PER_SECOND =
             MetricNames.TASK_BACK_PRESSURED_TIME;
 
+    /**
+     * Per-subtask busy time in milliseconds per second, range [0, 1000]. See {@link
+     * MetricNames#TASK_BUSY_TIME}. Task-scoped metric (lives at the same level as back-pressure in
+     * the metric store), so it can be read via {@code SubtaskMetricStore#getMetric(name)}.
+     */
+    private static final String METRIC_BUSY_TIME_MS_PER_SECOND = MetricNames.TASK_BUSY_TIME;
+
+    /**
+     * FLIP-33 source metric names. These are operator-scoped and therefore keyed as {@code
+     * <operatorName>.<metricName>} inside the {@link MetricStore.SubtaskMetricStore}, so they must
+     * be discovered by suffix match rather than by exact-name lookup.
+     */
+    private static final String METRIC_PENDING_RECORDS = MetricNames.PENDING_RECORDS;
+
+    private static final String METRIC_FETCH_EVENT_TIME_LAG =
+            MetricNames.CURRENT_FETCH_EVENT_TIME_LAG;
+
+    private static final String METRIC_EMIT_EVENT_TIME_LAG =
+            MetricNames.CURRENT_EMIT_EVENT_TIME_LAG;
+
     private final MetricFetcher metricFetcher;
 
     public TopNMetricsHandler(
             GatewayRetriever<? extends RestfulGateway> leaderRetriever,
             Duration timeout,
             Map<String, String> headers,
-            MetricFetcher metricFetcher) {
-        super(leaderRetriever, timeout, headers, TopNMetricsHeaders.getInstance());
+            MetricFetcher metricFetcher,
+            ExecutionGraphCache executionGraphCache,
+            Executor executor) {
+        super(
+                leaderRetriever,
+                timeout,
+                headers,
+                TopNMetricsHeaders.getInstance(),
+                executionGraphCache,
+                executor);
         this.metricFetcher = requireNonNull(metricFetcher, "metricFetcher must not be null");
     }
 
     @Override
-    protected CompletableFuture<TopNMetricsResponseBody> handleRequest(
-            @Nonnull HandlerRequest<EmptyRequestBody> request, @Nonnull RestfulGateway gateway)
+    protected TopNMetricsResponseBody handleRequest(
+            @Nonnull HandlerRequest<EmptyRequestBody> request,
+            @Nonnull ExecutionGraphInfo executionGraphInfo)
             throws RestHandlerException {
         metricFetcher.update();
 
@@ -119,17 +165,27 @@ public class TopNMetricsHandler
         final List<Integer> topNValues = request.getQueryParameter(TopNQueryParameter.class);
         final int topN = topNValues.isEmpty() ? DEFAULT_TOP_N : topNValues.get(0);
 
+        // Build a mapping from vertex ID to friendly vertex name
+        final Map<String, String> vertexIdToName = buildVertexIdToNameMap(executionGraphInfo);
+
         try {
             List<TopNMetricsResponseBody.CpuConsumerInfo> topCpuConsumers =
                     getTopCpuConsumers(metricStore, topN);
             List<TopNMetricsResponseBody.BackpressureOperatorInfo> topBackpressureOperators =
-                    getTopBackpressureOperators(metricStore, jobId, topN);
+                    getTopBackpressureOperators(metricStore, jobId, topN, vertexIdToName);
             List<TopNMetricsResponseBody.GcTaskInfo> topGcIntensiveTasks =
                     getTopGcIntensiveTaskManagers(metricStore, topN);
+            List<TopNMetricsResponseBody.BusyOperatorInfo> topBusyOperators =
+                    getTopBusyOperators(metricStore, jobId, topN, vertexIdToName);
+            List<TopNMetricsResponseBody.SourceLagInfo> topLaggingSources =
+                    getTopLaggingSources(metricStore, jobId, topN, vertexIdToName);
 
-            return CompletableFuture.completedFuture(
-                    new TopNMetricsResponseBody(
-                            topCpuConsumers, topBackpressureOperators, topGcIntensiveTasks));
+            return new TopNMetricsResponseBody(
+                    topCpuConsumers,
+                    topBackpressureOperators,
+                    topGcIntensiveTasks,
+                    topBusyOperators,
+                    topLaggingSources);
 
         } catch (Exception e) {
             LOG.warn("Could not retrieve Top N metrics for job {}.", jobId, e);
@@ -138,6 +194,21 @@ public class TopNMetricsHandler
                     HttpResponseStatus.INTERNAL_SERVER_ERROR,
                     e);
         }
+    }
+
+    /**
+     * Build a mapping from vertex ID to friendly vertex name.
+     *
+     * @param executionGraphInfo the execution graph info
+     * @return a map from vertex ID to vertex name
+     */
+    private Map<String, String> buildVertexIdToNameMap(ExecutionGraphInfo executionGraphInfo) {
+        final Map<String, String> vertexIdToName = new HashMap<>();
+        for (AccessExecutionJobVertex vertex :
+                executionGraphInfo.getArchivedExecutionGraph().getVerticesTopologically()) {
+            vertexIdToName.put(vertex.getJobVertexId().toString(), vertex.getName());
+        }
+        return vertexIdToName;
     }
 
     /**
@@ -157,9 +228,12 @@ public class TopNMetricsHandler
                 continue;
             }
             // JVM CPU load is reported as a fraction in [0, 1]; expose as percentage.
+            // The TM ID already encodes host:port-<suffix>; no friendlier alias is exported by
+            // TaskManagers today, so we surface it for both the display name and the TM id
+            // fields. subtaskId is null because the reading is TaskManager-scoped.
             result.add(
                     new TopNMetricsResponseBody.CpuConsumerInfo(
-                            -1, tmId, "TaskManager", cpuLoad * 100.0, tmId));
+                            null, tmId, tmId, cpuLoad * 100.0, tmId));
         }
         return result.stream()
                 .sorted(
@@ -175,7 +249,7 @@ public class TopNMetricsHandler
      * metrics in the store yet (e.g. just submitted), an empty list is returned.
      */
     private List<TopNMetricsResponseBody.BackpressureOperatorInfo> getTopBackpressureOperators(
-            MetricStore metricStore, String jobId, int topN) {
+            MetricStore metricStore, String jobId, int topN, Map<String, String> vertexIdToName) {
         List<TopNMetricsResponseBody.BackpressureOperatorInfo> result = new ArrayList<>();
         if (metricStore.getJobMetricStore(jobId) == null) {
             return result;
@@ -189,6 +263,9 @@ public class TopNMetricsHandler
             if (taskStore == null) {
                 continue;
             }
+            // Get friendly vertex name
+            final String vertexName = vertexIdToName.getOrDefault(vertexId, vertexId);
+
             for (Map.Entry<Integer, MetricStore.SubtaskMetricStore> subtask :
                     taskStore.getAllSubtaskMetricStores().entrySet()) {
                 final int subtaskIndex = subtask.getKey();
@@ -204,7 +281,7 @@ public class TopNMetricsHandler
                 final double ratio = Math.max(0.0, Math.min(1.0, bpMsPerSec / 1000.0));
                 result.add(
                         new TopNMetricsResponseBody.BackpressureOperatorInfo(
-                                vertexId, vertexId, ratio, subtaskIndex));
+                                vertexId, vertexName, ratio, subtaskIndex));
             }
         }
         return result.stream()
@@ -215,6 +292,183 @@ public class TopNMetricsHandler
                                 .reversed())
                 .limit(topN)
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Collect Top N subtasks of the given job by busy time (ms/s). Structurally identical to {@link
+     * #getTopBackpressureOperators}: {@code busyTimeMsPerSecond} is a task-scoped metric emitted by
+     * the runtime and therefore reachable through {@code SubtaskMetricStore#getMetric}. Values are
+     * clamped and exposed as a ratio in [0,&nbsp;1].
+     */
+    private List<TopNMetricsResponseBody.BusyOperatorInfo> getTopBusyOperators(
+            MetricStore metricStore, String jobId, int topN, Map<String, String> vertexIdToName) {
+        List<TopNMetricsResponseBody.BusyOperatorInfo> result = new ArrayList<>();
+        if (metricStore.getJobMetricStore(jobId) == null) {
+            return result;
+        }
+        final Map<String, Map<Integer, Integer>> jobVertices =
+                metricStore.getRepresentativeAttempts().getOrDefault(jobId, Collections.emptyMap());
+
+        for (String vertexId : jobVertices.keySet()) {
+            final MetricStore.TaskMetricStore taskStore =
+                    metricStore.getTaskMetricStore(jobId, vertexId);
+            if (taskStore == null) {
+                continue;
+            }
+            final String vertexName = vertexIdToName.getOrDefault(vertexId, vertexId);
+
+            for (Map.Entry<Integer, MetricStore.SubtaskMetricStore> subtask :
+                    taskStore.getAllSubtaskMetricStores().entrySet()) {
+                final int subtaskIndex = subtask.getKey();
+                final Double busyMsPerSec =
+                        parseDoubleOrNull(
+                                subtask.getValue().getMetric(METRIC_BUSY_TIME_MS_PER_SECOND),
+                                vertexId + "." + subtaskIndex);
+                if (busyMsPerSec == null) {
+                    continue;
+                }
+                final double ratio = Math.max(0.0, Math.min(1.0, busyMsPerSec / 1000.0));
+                result.add(
+                        new TopNMetricsResponseBody.BusyOperatorInfo(
+                                vertexId, vertexName, ratio, subtaskIndex));
+            }
+        }
+        return result.stream()
+                .sorted(
+                        Comparator.comparingDouble(
+                                        TopNMetricsResponseBody.BusyOperatorInfo::getBusyRatio)
+                                .reversed())
+                .limit(topN)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Collect Top N lagging source vertices of the given job. A vertex is eligible if at least one
+     * of its subtasks exposes {@code pendingRecords}, {@code currentFetchEventTimeLag}, or {@code
+     * currentEmitEventTimeLag}. Because these metrics are operator-scoped, they are keyed inside
+     * {@link MetricStore.SubtaskMetricStore} as {@code <operatorName>.<metricName>}; we locate them
+     * by suffix match on the raw metrics map.
+     *
+     * <p>Aggregation across subtasks of a vertex:
+     *
+     * <ul>
+     *   <li>{@code pendingRecords} &mdash; <i>sum</i> (cluster-level backlog).
+     *   <li>fetch / emit event-time lag &mdash; <i>max</i> (worst-case freshness).
+     * </ul>
+     *
+     * <p>Missing dimensions are reported as {@code null} so the UI can render them as "n/a".
+     * Ranking prefers {@code pendingRecords} (when known), then fetch lag, then emit lag.
+     */
+    private List<TopNMetricsResponseBody.SourceLagInfo> getTopLaggingSources(
+            MetricStore metricStore, String jobId, int topN, Map<String, String> vertexIdToName) {
+        List<TopNMetricsResponseBody.SourceLagInfo> result = new ArrayList<>();
+        if (metricStore.getJobMetricStore(jobId) == null) {
+            return result;
+        }
+        final Map<String, Map<Integer, Integer>> jobVertices =
+                metricStore.getRepresentativeAttempts().getOrDefault(jobId, Collections.emptyMap());
+
+        for (String vertexId : jobVertices.keySet()) {
+            final MetricStore.TaskMetricStore taskStore =
+                    metricStore.getTaskMetricStore(jobId, vertexId);
+            if (taskStore == null) {
+                continue;
+            }
+
+            double pendingSum = 0.0;
+            boolean pendingSeen = false;
+            Double maxFetchLag = null;
+            Double maxEmitLag = null;
+
+            for (Map.Entry<Integer, MetricStore.SubtaskMetricStore> subtask :
+                    taskStore.getAllSubtaskMetricStores().entrySet()) {
+                final MetricStore.SubtaskMetricStore subtaskStore = subtask.getValue();
+
+                final Double pending =
+                        findOperatorMetric(subtaskStore, METRIC_PENDING_RECORDS, vertexId);
+                if (pending != null) {
+                    pendingSum += pending;
+                    pendingSeen = true;
+                }
+
+                final Double fetchLag =
+                        findOperatorMetric(subtaskStore, METRIC_FETCH_EVENT_TIME_LAG, vertexId);
+                if (fetchLag != null && (maxFetchLag == null || fetchLag > maxFetchLag)) {
+                    maxFetchLag = fetchLag;
+                }
+
+                final Double emitLag =
+                        findOperatorMetric(subtaskStore, METRIC_EMIT_EVENT_TIME_LAG, vertexId);
+                if (emitLag != null && (maxEmitLag == null || emitLag > maxEmitLag)) {
+                    maxEmitLag = emitLag;
+                }
+            }
+
+            if (!pendingSeen && maxFetchLag == null && maxEmitLag == null) {
+                continue;
+            }
+
+            final String vertexName = vertexIdToName.getOrDefault(vertexId, vertexId);
+            result.add(
+                    new TopNMetricsResponseBody.SourceLagInfo(
+                            vertexId,
+                            vertexName,
+                            pendingSeen ? pendingSum : null,
+                            maxFetchLag,
+                            maxEmitLag));
+        }
+
+        // Unavailable (null) metrics rank as the smallest so vertices with real data float to
+        // the top; reversed() then flips the overall order to descending.
+        final Comparator<Double> nullsSmallest = Comparator.nullsFirst(Comparator.naturalOrder());
+        return result.stream()
+                .sorted(
+                        Comparator.comparing(
+                                        (TopNMetricsResponseBody.SourceLagInfo v) ->
+                                                v.getPendingRecords(),
+                                        nullsSmallest)
+                                .thenComparing(
+                                        TopNMetricsResponseBody.SourceLagInfo
+                                                ::getMaxFetchEventTimeLagMs,
+                                        nullsSmallest)
+                                .thenComparing(
+                                        TopNMetricsResponseBody.SourceLagInfo
+                                                ::getMaxEmitEventTimeLagMs,
+                                        nullsSmallest)
+                                .reversed())
+                .limit(topN)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Resolve an operator-scoped metric stored under {@code <operatorName>.<metricName>} in the
+     * given subtask store. If multiple operators within the same subtask expose the same metric
+     * (chained sources), the numeric values are summed; this matches the "cluster-level backlog"
+     * semantics for {@code pendingRecords} and is a reasonable over-estimate for lag values (a
+     * chained source's lag is typically dominated by a single operator anyway).
+     */
+    private Double findOperatorMetric(
+            MetricStore.SubtaskMetricStore subtaskStore, String metricName, String vertexId) {
+        if (subtaskStore == null) {
+            return null;
+        }
+        // FLIP-33 source metrics are operator-scoped and therefore keyed as
+        // "<operatorName>.<metricName>" in the MetricStore subtask view. We sum across all
+        // matching operator keys within the subtask to tolerate chained operators that each
+        // expose their own source metrics.
+        final String suffix = "." + metricName;
+        Double aggregated = null;
+        for (Map.Entry<String, String> entry : subtaskStore.metrics.entrySet()) {
+            final String key = entry.getKey();
+            if (!key.endsWith(suffix)) {
+                continue;
+            }
+            final Double value = parseDoubleOrNull(entry.getValue(), vertexId + "." + key);
+            if (value != null) {
+                aggregated = aggregated == null ? value : aggregated + value;
+            }
+        }
+        return aggregated;
     }
 
     /**
@@ -245,9 +499,11 @@ public class TopNMetricsHandler
                 }
             }
             if (hasValue) {
+                // Try to get a friendlier TM name
+                // TM ID already carries host:port-<suffix>; no friendlier alias is reported.
+                final String tmName = tmId;
                 result.add(
-                        new TopNMetricsResponseBody.GcTaskInfo(
-                                tmId, "TaskManager", totalGcMillis, tmId));
+                        new TopNMetricsResponseBody.GcTaskInfo(tmId, tmName, totalGcMillis, tmId));
             }
         }
         return result.stream()

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/metrics/TopNMetricsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/metrics/TopNMetricsHandler.java
@@ -1,0 +1,274 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.job.metrics;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.metrics.MetricNames;
+import org.apache.flink.runtime.rest.handler.AbstractRestHandler;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.handler.legacy.metrics.MetricFetcher;
+import org.apache.flink.runtime.rest.handler.legacy.metrics.MetricStore;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
+import org.apache.flink.runtime.rest.messages.job.metrics.TopNMetricsHeaders;
+import org.apache.flink.runtime.rest.messages.job.metrics.TopNMetricsMessageParameters;
+import org.apache.flink.runtime.rest.messages.job.metrics.TopNMetricsResponseBody;
+import org.apache.flink.runtime.rest.messages.job.metrics.TopNQueryParameter;
+import org.apache.flink.runtime.webmonitor.RestfulGateway;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Request handler that returns Top N metrics for a job, including:
+ *
+ * <ul>
+ *   <li><b>CPU consumers</b> &mdash; aggregated at the TaskManager level, scored by {@code
+ *       Status.JVM.CPU.Load} of the JVM process. CPU is not a per-subtask quantity in Flink, so
+ *       results are TaskManager-scoped.
+ *   <li><b>Backpressured operators</b> &mdash; aggregated at the subtask level, scored by {@code
+ *       backPressuredTimeMsPerSecond} (0&ndash;1000 ms/s), exposed as a ratio in [0, 1].
+ *   <li><b>GC-intensive TaskManagers</b> &mdash; aggregated at the TaskManager level, scored by the
+ *       sum of {@code Status.JVM.GarbageCollector.*.Time} across all known garbage collectors
+ *       reported by that TaskManager (cumulative milliseconds since TM start).
+ * </ul>
+ *
+ * <p>This handler does not filter TaskManagers by job assignment: JVM metrics are inherently
+ * cluster-wide and per-job attribution would require slot-to-TM resolution that the metric store
+ * does not currently expose.
+ */
+@Internal
+public class TopNMetricsHandler
+        extends AbstractRestHandler<
+                RestfulGateway,
+                EmptyRequestBody,
+                TopNMetricsResponseBody,
+                TopNMetricsMessageParameters> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TopNMetricsHandler.class);
+
+    private static final int DEFAULT_TOP_N = 5;
+
+    /** TaskManager-scoped JVM CPU load, range [0, 1] (fraction of available cores). */
+    private static final String METRIC_CPU_LOAD = "Status.JVM.CPU.Load";
+
+    /** Per-collector GC time in milliseconds: {@code Status.JVM.GarbageCollector.<name>.Time}. */
+    private static final String METRIC_GC_TIME_PREFIX = "Status.JVM.GarbageCollector.";
+
+    private static final String METRIC_GC_TIME_SUFFIX = ".Time";
+
+    /**
+     * Per-subtask back-pressure time in milliseconds per second, range [0, 1000]. See {@link
+     * MetricNames#TASK_BACK_PRESSURED_TIME}.
+     */
+    private static final String METRIC_BACKPRESSURED_TIME_MS_PER_SECOND =
+            MetricNames.TASK_BACK_PRESSURED_TIME;
+
+    private final MetricFetcher metricFetcher;
+
+    public TopNMetricsHandler(
+            GatewayRetriever<? extends RestfulGateway> leaderRetriever,
+            Duration timeout,
+            Map<String, String> headers,
+            MetricFetcher metricFetcher) {
+        super(leaderRetriever, timeout, headers, TopNMetricsHeaders.getInstance());
+        this.metricFetcher = requireNonNull(metricFetcher, "metricFetcher must not be null");
+    }
+
+    @Override
+    protected CompletableFuture<TopNMetricsResponseBody> handleRequest(
+            @Nonnull HandlerRequest<EmptyRequestBody> request, @Nonnull RestfulGateway gateway)
+            throws RestHandlerException {
+        metricFetcher.update();
+
+        final MetricStore metricStore = metricFetcher.getMetricStore();
+        final String jobId = request.getPathParameter(JobIDPathParameter.class).toString();
+        final List<Integer> topNValues = request.getQueryParameter(TopNQueryParameter.class);
+        final int topN = topNValues.isEmpty() ? DEFAULT_TOP_N : topNValues.get(0);
+
+        try {
+            List<TopNMetricsResponseBody.CpuConsumerInfo> topCpuConsumers =
+                    getTopCpuConsumers(metricStore, topN);
+            List<TopNMetricsResponseBody.BackpressureOperatorInfo> topBackpressureOperators =
+                    getTopBackpressureOperators(metricStore, jobId, topN);
+            List<TopNMetricsResponseBody.GcTaskInfo> topGcIntensiveTasks =
+                    getTopGcIntensiveTaskManagers(metricStore, topN);
+
+            return CompletableFuture.completedFuture(
+                    new TopNMetricsResponseBody(
+                            topCpuConsumers, topBackpressureOperators, topGcIntensiveTasks));
+
+        } catch (Exception e) {
+            LOG.warn("Could not retrieve Top N metrics for job {}.", jobId, e);
+            throw new RestHandlerException(
+                    "Could not retrieve Top N metrics for job " + jobId,
+                    HttpResponseStatus.INTERNAL_SERVER_ERROR,
+                    e);
+        }
+    }
+
+    /**
+     * Collect Top N TaskManagers by JVM CPU load. CPU is TaskManager-scoped in Flink, so the {@code
+     * subtaskId} field of the response is set to {@code -1} (not applicable) and {@code
+     * operatorName} carries the literal {@code "TaskManager"}.
+     */
+    private List<TopNMetricsResponseBody.CpuConsumerInfo> getTopCpuConsumers(
+            MetricStore metricStore, int topN) {
+        List<TopNMetricsResponseBody.CpuConsumerInfo> result = new ArrayList<>();
+        for (Map.Entry<String, MetricStore.TaskManagerMetricStore> entry :
+                metricStore.getTaskManagers().entrySet()) {
+            final String tmId = entry.getKey();
+            final MetricStore.TaskManagerMetricStore tmStore = entry.getValue();
+            final Double cpuLoad = parseDoubleOrNull(tmStore.getMetric(METRIC_CPU_LOAD), tmId);
+            if (cpuLoad == null) {
+                continue;
+            }
+            // JVM CPU load is reported as a fraction in [0, 1]; expose as percentage.
+            result.add(
+                    new TopNMetricsResponseBody.CpuConsumerInfo(
+                            -1, tmId, "TaskManager", cpuLoad * 100.0, tmId));
+        }
+        return result.stream()
+                .sorted(
+                        Comparator.comparingDouble(
+                                        TopNMetricsResponseBody.CpuConsumerInfo::getCpuPercentage)
+                                .reversed())
+                .limit(topN)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Collect Top N subtasks of the given job by back-pressure time (ms/s). If the job has no
+     * metrics in the store yet (e.g. just submitted), an empty list is returned.
+     */
+    private List<TopNMetricsResponseBody.BackpressureOperatorInfo> getTopBackpressureOperators(
+            MetricStore metricStore, String jobId, int topN) {
+        List<TopNMetricsResponseBody.BackpressureOperatorInfo> result = new ArrayList<>();
+        if (metricStore.getJobMetricStore(jobId) == null) {
+            return result;
+        }
+        final Map<String, Map<Integer, Integer>> jobVertices =
+                metricStore.getRepresentativeAttempts().getOrDefault(jobId, Collections.emptyMap());
+
+        for (String vertexId : jobVertices.keySet()) {
+            final MetricStore.TaskMetricStore taskStore =
+                    metricStore.getTaskMetricStore(jobId, vertexId);
+            if (taskStore == null) {
+                continue;
+            }
+            for (Map.Entry<Integer, MetricStore.SubtaskMetricStore> subtask :
+                    taskStore.getAllSubtaskMetricStores().entrySet()) {
+                final int subtaskIndex = subtask.getKey();
+                final Double bpMsPerSec =
+                        parseDoubleOrNull(
+                                subtask.getValue()
+                                        .getMetric(METRIC_BACKPRESSURED_TIME_MS_PER_SECOND),
+                                vertexId + "." + subtaskIndex);
+                if (bpMsPerSec == null) {
+                    continue;
+                }
+                // Expose as a ratio in [0, 1] to keep the field name "backpressureRatio" honest.
+                final double ratio = Math.max(0.0, Math.min(1.0, bpMsPerSec / 1000.0));
+                result.add(
+                        new TopNMetricsResponseBody.BackpressureOperatorInfo(
+                                vertexId, vertexId, ratio, subtaskIndex));
+            }
+        }
+        return result.stream()
+                .sorted(
+                        Comparator.comparingDouble(
+                                        TopNMetricsResponseBody.BackpressureOperatorInfo
+                                                ::getBackpressureRatio)
+                                .reversed())
+                .limit(topN)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Collect Top N TaskManagers by total GC time. For each TaskManager we sum {@code
+     * Status.JVM.GarbageCollector.<name>.Time} across all known GC names. The result carries
+     * cumulative GC time in milliseconds in the {@code gcTimePercentage} slot (the wire field is
+     * kept stable for compatibility; see the response-body doc for the semantic contract).
+     */
+    private List<TopNMetricsResponseBody.GcTaskInfo> getTopGcIntensiveTaskManagers(
+            MetricStore metricStore, int topN) {
+        List<TopNMetricsResponseBody.GcTaskInfo> result = new ArrayList<>();
+        for (Map.Entry<String, MetricStore.TaskManagerMetricStore> entry :
+                metricStore.getTaskManagers().entrySet()) {
+            final String tmId = entry.getKey();
+            final MetricStore.TaskManagerMetricStore tmStore = entry.getValue();
+            if (tmStore.garbageCollectorNames.isEmpty()) {
+                continue;
+            }
+            double totalGcMillis = 0.0;
+            boolean hasValue = false;
+            for (String gcName : tmStore.garbageCollectorNames) {
+                final String metricKey = METRIC_GC_TIME_PREFIX + gcName + METRIC_GC_TIME_SUFFIX;
+                final Double gcMillis =
+                        parseDoubleOrNull(tmStore.getMetric(metricKey), tmId + "." + gcName);
+                if (gcMillis != null) {
+                    totalGcMillis += gcMillis;
+                    hasValue = true;
+                }
+            }
+            if (hasValue) {
+                result.add(
+                        new TopNMetricsResponseBody.GcTaskInfo(
+                                tmId, "TaskManager", totalGcMillis, tmId));
+            }
+        }
+        return result.stream()
+                .sorted(
+                        Comparator.comparingDouble(
+                                        TopNMetricsResponseBody.GcTaskInfo::getGcTimePercentage)
+                                .reversed())
+                .limit(topN)
+                .collect(Collectors.toList());
+    }
+
+    private static Double parseDoubleOrNull(String value, String contextForLog) {
+        if (value == null) {
+            return null;
+        }
+        try {
+            return Double.parseDouble(value);
+        } catch (NumberFormatException e) {
+            LOG.debug(
+                    "Ignoring non-numeric metric value '{}' (context: {}).", value, contextForLog);
+            return null;
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/TopNMetricsHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/TopNMetricsHeaders.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job.metrics;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
+import org.apache.flink.runtime.rest.messages.RuntimeMessageHeaders;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+/** {@link RuntimeMessageHeaders} for {@link TopNMetricsHandler}. */
+public final class TopNMetricsHeaders
+        implements RuntimeMessageHeaders<
+                EmptyRequestBody, TopNMetricsResponseBody, TopNMetricsMessageParameters> {
+
+    private static final TopNMetricsHeaders INSTANCE = new TopNMetricsHeaders();
+
+    private TopNMetricsHeaders() {}
+
+    @Override
+    public Class<EmptyRequestBody> getRequestClass() {
+        return EmptyRequestBody.class;
+    }
+
+    @Override
+    public Class<TopNMetricsResponseBody> getResponseClass() {
+        return TopNMetricsResponseBody.class;
+    }
+
+    @Override
+    public HttpResponseStatus getResponseStatusCode() {
+        return HttpResponseStatus.OK;
+    }
+
+    @Override
+    public TopNMetricsMessageParameters getUnresolvedMessageParameters() {
+        return new TopNMetricsMessageParameters();
+    }
+
+    @Override
+    public HttpMethodWrapper getHttpMethod() {
+        return HttpMethodWrapper.GET;
+    }
+
+    @Override
+    public String getTargetRestEndpointURL() {
+        return "/jobs/:" + JobIDPathParameter.KEY + "/metrics/top-n";
+    }
+
+    public static TopNMetricsHeaders getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Returns Top N metrics for a job including CPU consumers, "
+                + "backpressured operators, and GC-intensive tasks.";
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/TopNMetricsHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/TopNMetricsHeaders.java
@@ -70,7 +70,8 @@ public final class TopNMetricsHeaders
 
     @Override
     public String getDescription() {
-        return "Returns Top N metrics for a job including CPU consumers, "
-                + "backpressured operators, and GC-intensive tasks.";
+        return "Returns Top N metrics for a job across five dimensions: "
+                + "backpressured subtasks, busy subtasks, lagging sources, "
+                + "CPU consumers (TaskManager-scoped) and GC-intensive TaskManagers.";
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/TopNMetricsMessageParameters.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/TopNMetricsMessageParameters.java
@@ -16,25 +16,21 @@
  * limitations under the License.
  */
 
-export * from './configuration';
-export * from './jar';
-export * from './job-overview';
-export * from './job-detail';
-export * from './job-exception';
-export * from './job-timeline';
-export * from './job-config';
-export * from './job-vertex';
-export * from './job-checkpoint';
-export * from './job-backpressure';
-export * from './job-flamegraph';
-export * from './job-rescales';
-export * from './plan';
-export * from './overview';
-export * from './task-manager';
-export * from './job-accumulators';
-export * from './job-manager';
-export * from './job-metrics';
-export * from './application-overview';
-export * from './application-detail';
-export * from './application-exception';
-export * from './topn-metrics';
+package org.apache.flink.runtime.rest.messages.job.metrics;
+
+import org.apache.flink.runtime.rest.messages.JobMessageParameters;
+import org.apache.flink.runtime.rest.messages.MessageQueryParameter;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/** {@link org.apache.flink.runtime.rest.messages.MessageParameters} for Top N metrics. */
+public class TopNMetricsMessageParameters extends JobMessageParameters {
+
+    public final TopNQueryParameter topNQueryParameter = new TopNQueryParameter();
+
+    @Override
+    public Collection<MessageQueryParameter<?>> getQueryParameters() {
+        return Collections.singletonList(topNQueryParameter);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/TopNMetricsResponseBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/TopNMetricsResponseBody.java
@@ -1,0 +1,306 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job.metrics;
+
+import org.apache.flink.runtime.rest.messages.ResponseBody;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Objects;
+
+/** Response body for Top N metrics aggregation. */
+public class TopNMetricsResponseBody implements ResponseBody {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final String FIELD_NAME_TOP_CPU_CONSUMERS = "topCpuConsumers";
+    public static final String FIELD_NAME_TOP_BACKPRESSURE_OPERATORS = "topBackpressureOperators";
+    public static final String FIELD_NAME_TOP_GC_INTENSIVE_TASKS = "topGcIntensiveTasks";
+
+    @JsonProperty(FIELD_NAME_TOP_CPU_CONSUMERS)
+    private final List<CpuConsumerInfo> topCpuConsumers;
+
+    @JsonProperty(FIELD_NAME_TOP_BACKPRESSURE_OPERATORS)
+    private final List<BackpressureOperatorInfo> topBackpressureOperators;
+
+    @JsonProperty(FIELD_NAME_TOP_GC_INTENSIVE_TASKS)
+    private final List<GcTaskInfo> topGcIntensiveTasks;
+
+    @JsonCreator
+    public TopNMetricsResponseBody(
+            @JsonProperty(FIELD_NAME_TOP_CPU_CONSUMERS) List<CpuConsumerInfo> topCpuConsumers,
+            @JsonProperty(FIELD_NAME_TOP_BACKPRESSURE_OPERATORS)
+                    List<BackpressureOperatorInfo> topBackpressureOperators,
+            @JsonProperty(FIELD_NAME_TOP_GC_INTENSIVE_TASKS) List<GcTaskInfo> topGcIntensiveTasks) {
+        this.topCpuConsumers = topCpuConsumers;
+        this.topBackpressureOperators = topBackpressureOperators;
+        this.topGcIntensiveTasks = topGcIntensiveTasks;
+    }
+
+    public List<CpuConsumerInfo> getTopCpuConsumers() {
+        return topCpuConsumers;
+    }
+
+    public List<BackpressureOperatorInfo> getTopBackpressureOperators() {
+        return topBackpressureOperators;
+    }
+
+    public List<GcTaskInfo> getTopGcIntensiveTasks() {
+        return topGcIntensiveTasks;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TopNMetricsResponseBody that = (TopNMetricsResponseBody) o;
+        return Objects.equals(topCpuConsumers, that.topCpuConsumers)
+                && Objects.equals(topBackpressureOperators, that.topBackpressureOperators)
+                && Objects.equals(topGcIntensiveTasks, that.topGcIntensiveTasks);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(topCpuConsumers, topBackpressureOperators, topGcIntensiveTasks);
+    }
+
+    /** Information about CPU-intensive subtasks. */
+    public static class CpuConsumerInfo {
+
+        public static final String FIELD_NAME_SUBTASK_ID = "subtaskId";
+        public static final String FIELD_NAME_TASK_NAME = "taskName";
+        public static final String FIELD_NAME_OPERATOR_NAME = "operatorName";
+        public static final String FIELD_NAME_CPU_PERCENTAGE = "cpuPercentage";
+        public static final String FIELD_NAME_TASKMANAGER_ID = "taskManagerId";
+
+        @JsonProperty(FIELD_NAME_SUBTASK_ID)
+        private final int subtaskId;
+
+        @JsonProperty(FIELD_NAME_TASK_NAME)
+        private final String taskName;
+
+        @JsonProperty(FIELD_NAME_OPERATOR_NAME)
+        private final String operatorName;
+
+        @JsonProperty(FIELD_NAME_CPU_PERCENTAGE)
+        private final double cpuPercentage;
+
+        @JsonProperty(FIELD_NAME_TASKMANAGER_ID)
+        private final String taskManagerId;
+
+        @JsonCreator
+        public CpuConsumerInfo(
+                @JsonProperty(FIELD_NAME_SUBTASK_ID) int subtaskId,
+                @JsonProperty(FIELD_NAME_TASK_NAME) String taskName,
+                @JsonProperty(FIELD_NAME_OPERATOR_NAME) String operatorName,
+                @JsonProperty(FIELD_NAME_CPU_PERCENTAGE) double cpuPercentage,
+                @JsonProperty(FIELD_NAME_TASKMANAGER_ID) String taskManagerId) {
+            this.subtaskId = subtaskId;
+            this.taskName = taskName;
+            this.operatorName = operatorName;
+            this.cpuPercentage = cpuPercentage;
+            this.taskManagerId = taskManagerId;
+        }
+
+        public int getSubtaskId() {
+            return subtaskId;
+        }
+
+        public String getTaskName() {
+            return taskName;
+        }
+
+        public String getOperatorName() {
+            return operatorName;
+        }
+
+        public double getCpuPercentage() {
+            return cpuPercentage;
+        }
+
+        public String getTaskManagerId() {
+            return taskManagerId;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            CpuConsumerInfo that = (CpuConsumerInfo) o;
+            return subtaskId == that.subtaskId
+                    && Double.compare(that.cpuPercentage, cpuPercentage) == 0
+                    && Objects.equals(taskName, that.taskName)
+                    && Objects.equals(operatorName, that.operatorName)
+                    && Objects.equals(taskManagerId, that.taskManagerId);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(subtaskId, taskName, operatorName, cpuPercentage, taskManagerId);
+        }
+    }
+
+    /** Information about backpressured operators. */
+    public static class BackpressureOperatorInfo {
+
+        public static final String FIELD_NAME_OPERATOR_ID = "operatorId";
+        public static final String FIELD_NAME_OPERATOR_NAME = "operatorName";
+        public static final String FIELD_NAME_BACKPRESSURE_RATIO = "backpressureRatio";
+        public static final String FIELD_NAME_SUBTASK_ID = "subtaskId";
+
+        @JsonProperty(FIELD_NAME_OPERATOR_ID)
+        private final String operatorId;
+
+        @JsonProperty(FIELD_NAME_OPERATOR_NAME)
+        private final String operatorName;
+
+        @JsonProperty(FIELD_NAME_BACKPRESSURE_RATIO)
+        private final double backpressureRatio;
+
+        @JsonProperty(FIELD_NAME_SUBTASK_ID)
+        private final int subtaskId;
+
+        @JsonCreator
+        public BackpressureOperatorInfo(
+                @JsonProperty(FIELD_NAME_OPERATOR_ID) String operatorId,
+                @JsonProperty(FIELD_NAME_OPERATOR_NAME) String operatorName,
+                @JsonProperty(FIELD_NAME_BACKPRESSURE_RATIO) double backpressureRatio,
+                @JsonProperty(FIELD_NAME_SUBTASK_ID) int subtaskId) {
+            this.operatorId = operatorId;
+            this.operatorName = operatorName;
+            this.backpressureRatio = backpressureRatio;
+            this.subtaskId = subtaskId;
+        }
+
+        public String getOperatorId() {
+            return operatorId;
+        }
+
+        public String getOperatorName() {
+            return operatorName;
+        }
+
+        public double getBackpressureRatio() {
+            return backpressureRatio;
+        }
+
+        public int getSubtaskId() {
+            return subtaskId;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            BackpressureOperatorInfo that = (BackpressureOperatorInfo) o;
+            return Double.compare(that.backpressureRatio, backpressureRatio) == 0
+                    && subtaskId == that.subtaskId
+                    && Objects.equals(operatorId, that.operatorId)
+                    && Objects.equals(operatorName, that.operatorName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(operatorId, operatorName, backpressureRatio, subtaskId);
+        }
+    }
+
+    /** Information about GC-intensive tasks. */
+    public static class GcTaskInfo {
+
+        public static final String FIELD_NAME_TASK_ID = "taskId";
+        public static final String FIELD_NAME_TASK_NAME = "taskName";
+        public static final String FIELD_NAME_GC_TIME_PERCENTAGE = "gcTimePercentage";
+        public static final String FIELD_NAME_TASKMANAGER_ID = "taskManagerId";
+
+        @JsonProperty(FIELD_NAME_TASK_ID)
+        private final String taskId;
+
+        @JsonProperty(FIELD_NAME_TASK_NAME)
+        private final String taskName;
+
+        @JsonProperty(FIELD_NAME_GC_TIME_PERCENTAGE)
+        private final double gcTimePercentage;
+
+        @JsonProperty(FIELD_NAME_TASKMANAGER_ID)
+        private final String taskManagerId;
+
+        @JsonCreator
+        public GcTaskInfo(
+                @JsonProperty(FIELD_NAME_TASK_ID) String taskId,
+                @JsonProperty(FIELD_NAME_TASK_NAME) String taskName,
+                @JsonProperty(FIELD_NAME_GC_TIME_PERCENTAGE) double gcTimePercentage,
+                @JsonProperty(FIELD_NAME_TASKMANAGER_ID) String taskManagerId) {
+            this.taskId = taskId;
+            this.taskName = taskName;
+            this.gcTimePercentage = gcTimePercentage;
+            this.taskManagerId = taskManagerId;
+        }
+
+        public String getTaskId() {
+            return taskId;
+        }
+
+        public String getTaskName() {
+            return taskName;
+        }
+
+        public double getGcTimePercentage() {
+            return gcTimePercentage;
+        }
+
+        public String getTaskManagerId() {
+            return taskManagerId;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            GcTaskInfo that = (GcTaskInfo) o;
+            return Double.compare(that.gcTimePercentage, gcTimePercentage) == 0
+                    && Objects.equals(taskId, that.taskId)
+                    && Objects.equals(taskName, that.taskName)
+                    && Objects.equals(taskManagerId, that.taskManagerId);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(taskId, taskName, gcTimePercentage, taskManagerId);
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/TopNMetricsResponseBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/TopNMetricsResponseBody.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.rest.messages.ResponseBody;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -34,6 +35,8 @@ public class TopNMetricsResponseBody implements ResponseBody {
     public static final String FIELD_NAME_TOP_CPU_CONSUMERS = "topCpuConsumers";
     public static final String FIELD_NAME_TOP_BACKPRESSURE_OPERATORS = "topBackpressureOperators";
     public static final String FIELD_NAME_TOP_GC_INTENSIVE_TASKS = "topGcIntensiveTasks";
+    public static final String FIELD_NAME_TOP_BUSY_OPERATORS = "topBusyOperators";
+    public static final String FIELD_NAME_TOP_LAGGING_SOURCES = "topLaggingSources";
 
     @JsonProperty(FIELD_NAME_TOP_CPU_CONSUMERS)
     private final List<CpuConsumerInfo> topCpuConsumers;
@@ -44,15 +47,31 @@ public class TopNMetricsResponseBody implements ResponseBody {
     @JsonProperty(FIELD_NAME_TOP_GC_INTENSIVE_TASKS)
     private final List<GcTaskInfo> topGcIntensiveTasks;
 
+    @JsonProperty(FIELD_NAME_TOP_BUSY_OPERATORS)
+    private final List<BusyOperatorInfo> topBusyOperators;
+
+    @JsonProperty(FIELD_NAME_TOP_LAGGING_SOURCES)
+    private final List<SourceLagInfo> topLaggingSources;
+
     @JsonCreator
     public TopNMetricsResponseBody(
             @JsonProperty(FIELD_NAME_TOP_CPU_CONSUMERS) List<CpuConsumerInfo> topCpuConsumers,
             @JsonProperty(FIELD_NAME_TOP_BACKPRESSURE_OPERATORS)
                     List<BackpressureOperatorInfo> topBackpressureOperators,
-            @JsonProperty(FIELD_NAME_TOP_GC_INTENSIVE_TASKS) List<GcTaskInfo> topGcIntensiveTasks) {
-        this.topCpuConsumers = topCpuConsumers;
-        this.topBackpressureOperators = topBackpressureOperators;
-        this.topGcIntensiveTasks = topGcIntensiveTasks;
+            @JsonProperty(FIELD_NAME_TOP_GC_INTENSIVE_TASKS) List<GcTaskInfo> topGcIntensiveTasks,
+            @JsonProperty(FIELD_NAME_TOP_BUSY_OPERATORS) List<BusyOperatorInfo> topBusyOperators,
+            @JsonProperty(FIELD_NAME_TOP_LAGGING_SOURCES) List<SourceLagInfo> topLaggingSources) {
+        this.topCpuConsumers = topCpuConsumers == null ? Collections.emptyList() : topCpuConsumers;
+        this.topBackpressureOperators =
+                topBackpressureOperators == null
+                        ? Collections.emptyList()
+                        : topBackpressureOperators;
+        this.topGcIntensiveTasks =
+                topGcIntensiveTasks == null ? Collections.emptyList() : topGcIntensiveTasks;
+        this.topBusyOperators =
+                topBusyOperators == null ? Collections.emptyList() : topBusyOperators;
+        this.topLaggingSources =
+                topLaggingSources == null ? Collections.emptyList() : topLaggingSources;
     }
 
     public List<CpuConsumerInfo> getTopCpuConsumers() {
@@ -67,6 +86,14 @@ public class TopNMetricsResponseBody implements ResponseBody {
         return topGcIntensiveTasks;
     }
 
+    public List<BusyOperatorInfo> getTopBusyOperators() {
+        return topBusyOperators;
+    }
+
+    public List<SourceLagInfo> getTopLaggingSources() {
+        return topLaggingSources;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -78,12 +105,19 @@ public class TopNMetricsResponseBody implements ResponseBody {
         TopNMetricsResponseBody that = (TopNMetricsResponseBody) o;
         return Objects.equals(topCpuConsumers, that.topCpuConsumers)
                 && Objects.equals(topBackpressureOperators, that.topBackpressureOperators)
-                && Objects.equals(topGcIntensiveTasks, that.topGcIntensiveTasks);
+                && Objects.equals(topGcIntensiveTasks, that.topGcIntensiveTasks)
+                && Objects.equals(topBusyOperators, that.topBusyOperators)
+                && Objects.equals(topLaggingSources, that.topLaggingSources);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(topCpuConsumers, topBackpressureOperators, topGcIntensiveTasks);
+        return Objects.hash(
+                topCpuConsumers,
+                topBackpressureOperators,
+                topGcIntensiveTasks,
+                topBusyOperators,
+                topLaggingSources);
     }
 
     /** Information about CPU-intensive subtasks. */
@@ -95,8 +129,12 @@ public class TopNMetricsResponseBody implements ResponseBody {
         public static final String FIELD_NAME_CPU_PERCENTAGE = "cpuPercentage";
         public static final String FIELD_NAME_TASKMANAGER_ID = "taskManagerId";
 
+        /**
+         * {@code null} for TaskManager-scoped CPU readings (e.g. aggregated process CPU load of the
+         * TaskManager JVM); otherwise the originating subtask index.
+         */
         @JsonProperty(FIELD_NAME_SUBTASK_ID)
-        private final int subtaskId;
+        private final Integer subtaskId;
 
         @JsonProperty(FIELD_NAME_TASK_NAME)
         private final String taskName;
@@ -112,7 +150,7 @@ public class TopNMetricsResponseBody implements ResponseBody {
 
         @JsonCreator
         public CpuConsumerInfo(
-                @JsonProperty(FIELD_NAME_SUBTASK_ID) int subtaskId,
+                @JsonProperty(FIELD_NAME_SUBTASK_ID) Integer subtaskId,
                 @JsonProperty(FIELD_NAME_TASK_NAME) String taskName,
                 @JsonProperty(FIELD_NAME_OPERATOR_NAME) String operatorName,
                 @JsonProperty(FIELD_NAME_CPU_PERCENTAGE) double cpuPercentage,
@@ -124,7 +162,7 @@ public class TopNMetricsResponseBody implements ResponseBody {
             this.taskManagerId = taskManagerId;
         }
 
-        public int getSubtaskId() {
+        public Integer getSubtaskId() {
             return subtaskId;
         }
 
@@ -153,8 +191,8 @@ public class TopNMetricsResponseBody implements ResponseBody {
                 return false;
             }
             CpuConsumerInfo that = (CpuConsumerInfo) o;
-            return subtaskId == that.subtaskId
-                    && Double.compare(that.cpuPercentage, cpuPercentage) == 0
+            return Double.compare(that.cpuPercentage, cpuPercentage) == 0
+                    && Objects.equals(subtaskId, that.subtaskId)
                     && Objects.equals(taskName, that.taskName)
                     && Objects.equals(operatorName, that.operatorName)
                     && Objects.equals(taskManagerId, that.taskManagerId);
@@ -301,6 +339,180 @@ public class TopNMetricsResponseBody implements ResponseBody {
         @Override
         public int hashCode() {
             return Objects.hash(taskId, taskName, gcTimePercentage, taskManagerId);
+        }
+    }
+
+    /**
+     * Information about "busy" subtasks, scored by {@code busyTimeMsPerSecond} (range [0, 1000],
+     * exposed here as a ratio in [0, 1]). Structurally parallel to {@link BackpressureOperatorInfo}
+     * so the UI can render them side-by-side.
+     */
+    public static class BusyOperatorInfo {
+
+        public static final String FIELD_NAME_OPERATOR_ID = "operatorId";
+        public static final String FIELD_NAME_OPERATOR_NAME = "operatorName";
+        public static final String FIELD_NAME_BUSY_RATIO = "busyRatio";
+        public static final String FIELD_NAME_SUBTASK_ID = "subtaskId";
+
+        @JsonProperty(FIELD_NAME_OPERATOR_ID)
+        private final String operatorId;
+
+        @JsonProperty(FIELD_NAME_OPERATOR_NAME)
+        private final String operatorName;
+
+        @JsonProperty(FIELD_NAME_BUSY_RATIO)
+        private final double busyRatio;
+
+        @JsonProperty(FIELD_NAME_SUBTASK_ID)
+        private final int subtaskId;
+
+        @JsonCreator
+        public BusyOperatorInfo(
+                @JsonProperty(FIELD_NAME_OPERATOR_ID) String operatorId,
+                @JsonProperty(FIELD_NAME_OPERATOR_NAME) String operatorName,
+                @JsonProperty(FIELD_NAME_BUSY_RATIO) double busyRatio,
+                @JsonProperty(FIELD_NAME_SUBTASK_ID) int subtaskId) {
+            this.operatorId = operatorId;
+            this.operatorName = operatorName;
+            this.busyRatio = busyRatio;
+            this.subtaskId = subtaskId;
+        }
+
+        public String getOperatorId() {
+            return operatorId;
+        }
+
+        public String getOperatorName() {
+            return operatorName;
+        }
+
+        public double getBusyRatio() {
+            return busyRatio;
+        }
+
+        public int getSubtaskId() {
+            return subtaskId;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            BusyOperatorInfo that = (BusyOperatorInfo) o;
+            return Double.compare(that.busyRatio, busyRatio) == 0
+                    && subtaskId == that.subtaskId
+                    && Objects.equals(operatorId, that.operatorId)
+                    && Objects.equals(operatorName, that.operatorName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(operatorId, operatorName, busyRatio, subtaskId);
+        }
+    }
+
+    /**
+     * Information about lagging source vertices. A "source vertex" here means any vertex that
+     * exposes at least one of {@code pendingRecords}, {@code currentFetchEventTimeLag}, or {@code
+     * currentEmitEventTimeLag} on any of its subtasks; true input-topology detection is not
+     * available in the metric store.
+     *
+     * <p>{@link #pendingRecords} is the cluster-level sum across subtasks (unit: records; {@code
+     * null} if unavailable). {@link #maxFetchEventTimeLagMs} and {@link #maxEmitEventTimeLagMs} are
+     * the maxima across subtasks of the vertex (unit: milliseconds; {@code null} if unavailable).
+     */
+    public static class SourceLagInfo {
+
+        public static final String FIELD_NAME_VERTEX_ID = "vertexId";
+        public static final String FIELD_NAME_VERTEX_NAME = "vertexName";
+        public static final String FIELD_NAME_PENDING_RECORDS = "pendingRecords";
+        public static final String FIELD_NAME_MAX_FETCH_EVENT_TIME_LAG_MS =
+                "maxFetchEventTimeLagMs";
+        public static final String FIELD_NAME_MAX_EMIT_EVENT_TIME_LAG_MS = "maxEmitEventTimeLagMs";
+
+        @JsonProperty(FIELD_NAME_VERTEX_ID)
+        private final String vertexId;
+
+        @JsonProperty(FIELD_NAME_VERTEX_NAME)
+        private final String vertexName;
+
+        /** {@code null} when the underlying source does not report this metric. */
+        @JsonProperty(FIELD_NAME_PENDING_RECORDS)
+        private final Double pendingRecords;
+
+        /** {@code null} when the underlying source does not report this metric. */
+        @JsonProperty(FIELD_NAME_MAX_FETCH_EVENT_TIME_LAG_MS)
+        private final Double maxFetchEventTimeLagMs;
+
+        /** {@code null} when the underlying source does not report this metric. */
+        @JsonProperty(FIELD_NAME_MAX_EMIT_EVENT_TIME_LAG_MS)
+        private final Double maxEmitEventTimeLagMs;
+
+        @JsonCreator
+        public SourceLagInfo(
+                @JsonProperty(FIELD_NAME_VERTEX_ID) String vertexId,
+                @JsonProperty(FIELD_NAME_VERTEX_NAME) String vertexName,
+                @JsonProperty(FIELD_NAME_PENDING_RECORDS) Double pendingRecords,
+                @JsonProperty(FIELD_NAME_MAX_FETCH_EVENT_TIME_LAG_MS) Double maxFetchEventTimeLagMs,
+                @JsonProperty(FIELD_NAME_MAX_EMIT_EVENT_TIME_LAG_MS) Double maxEmitEventTimeLagMs) {
+            this.vertexId = vertexId;
+            this.vertexName = vertexName;
+            this.pendingRecords = pendingRecords;
+            this.maxFetchEventTimeLagMs = maxFetchEventTimeLagMs;
+            this.maxEmitEventTimeLagMs = maxEmitEventTimeLagMs;
+        }
+
+        public String getVertexId() {
+            return vertexId;
+        }
+
+        public String getVertexName() {
+            return vertexName;
+        }
+
+        /** May be {@code null} when {@code pendingRecords} is not reported by the source. */
+        public Double getPendingRecords() {
+            return pendingRecords;
+        }
+
+        /** May be {@code null} when {@code fetchEventTimeLag} is not reported by the source. */
+        public Double getMaxFetchEventTimeLagMs() {
+            return maxFetchEventTimeLagMs;
+        }
+
+        /** May be {@code null} when {@code emitEventTimeLag} is not reported by the source. */
+        public Double getMaxEmitEventTimeLagMs() {
+            return maxEmitEventTimeLagMs;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            SourceLagInfo that = (SourceLagInfo) o;
+            return Objects.equals(pendingRecords, that.pendingRecords)
+                    && Objects.equals(maxFetchEventTimeLagMs, that.maxFetchEventTimeLagMs)
+                    && Objects.equals(maxEmitEventTimeLagMs, that.maxEmitEventTimeLagMs)
+                    && Objects.equals(vertexId, that.vertexId)
+                    && Objects.equals(vertexName, that.vertexName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(
+                    vertexId,
+                    vertexName,
+                    pendingRecords,
+                    maxFetchEventTimeLagMs,
+                    maxEmitEventTimeLagMs);
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/TopNQueryParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/TopNQueryParameter.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job.metrics;
+
+import org.apache.flink.runtime.rest.messages.ConversionException;
+import org.apache.flink.runtime.rest.messages.MessageQueryParameter;
+
+/**
+ * Query parameter specifying how many entries to return per dimension on the Top N metrics
+ * endpoint. Defaults are applied by the handler when the parameter is absent.
+ */
+public class TopNQueryParameter extends MessageQueryParameter<Integer> {
+
+    public static final String KEY = "topN";
+
+    /** Hard upper bound to prevent pathological requests from scanning the entire metric store. */
+    public static final int MAX_TOP_N = 100;
+
+    public TopNQueryParameter() {
+        super(KEY, MessageParameterRequisiteness.OPTIONAL);
+    }
+
+    @Override
+    public Integer convertStringToValue(String value) throws ConversionException {
+        final int topN;
+        try {
+            topN = Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            throw new ConversionException("topN must be an integer, was: " + value);
+        }
+        if (topN < 1) {
+            throw new ConversionException("topN must be >= 1, was: " + topN);
+        }
+        if (topN > MAX_TOP_N) {
+            throw new ConversionException("topN must be <= " + MAX_TOP_N + ", was: " + topN);
+        }
+        return topN;
+    }
+
+    @Override
+    public String convertValueToString(Integer value) {
+        return value.toString();
+    }
+
+    @Override
+    public String getDescription() {
+        return "Positive integer (1.."
+                + MAX_TOP_N
+                + ") controlling how many entries are returned for each Top N dimension. "
+                + "Defaults to 5 when omitted.";
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
@@ -96,6 +96,7 @@ import org.apache.flink.runtime.rest.handler.job.metrics.JobVertexMetricsHandler
 import org.apache.flink.runtime.rest.handler.job.metrics.JobVertexWatermarksHandler;
 import org.apache.flink.runtime.rest.handler.job.metrics.SubtaskMetricsHandler;
 import org.apache.flink.runtime.rest.handler.job.metrics.TaskManagerMetricsHandler;
+import org.apache.flink.runtime.rest.handler.job.metrics.TopNMetricsHandler;
 import org.apache.flink.runtime.rest.handler.job.rescales.JobRescaleConfigHandler;
 import org.apache.flink.runtime.rest.handler.job.rescales.JobRescaleDetailsHandler;
 import org.apache.flink.runtime.rest.handler.job.rescales.JobRescalesHistoryHandler;
@@ -569,6 +570,9 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
         final JobMetricsHandler jobMetricsHandler =
                 new JobMetricsHandler(leaderRetriever, timeout, responseHeaders, metricFetcher);
 
+        final TopNMetricsHandler topNMetricsHandler =
+                new TopNMetricsHandler(leaderRetriever, timeout, responseHeaders, metricFetcher);
+
         final SubtaskMetricsHandler subtaskMetricsHandler =
                 new SubtaskMetricsHandler(leaderRetriever, timeout, responseHeaders, metricFetcher);
 
@@ -868,6 +872,7 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
                         jobVertexWatermarksHandler.getMessageHeaders(),
                         jobVertexWatermarksHandler));
         handlers.add(Tuple2.of(jobMetricsHandler.getMessageHeaders(), jobMetricsHandler));
+        handlers.add(Tuple2.of(topNMetricsHandler.getMessageHeaders(), topNMetricsHandler));
         handlers.add(Tuple2.of(subtaskMetricsHandler.getMessageHeaders(), subtaskMetricsHandler));
         handlers.add(
                 Tuple2.of(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
@@ -571,7 +571,13 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
                 new JobMetricsHandler(leaderRetriever, timeout, responseHeaders, metricFetcher);
 
         final TopNMetricsHandler topNMetricsHandler =
-                new TopNMetricsHandler(leaderRetriever, timeout, responseHeaders, metricFetcher);
+                new TopNMetricsHandler(
+                        leaderRetriever,
+                        timeout,
+                        responseHeaders,
+                        metricFetcher,
+                        executionGraphCache,
+                        executor);
 
         final SubtaskMetricsHandler subtaskMetricsHandler =
                 new SubtaskMetricsHandler(leaderRetriever, timeout, responseHeaders, metricFetcher);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/metrics/TopNMetricsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/metrics/TopNMetricsHandlerTest.java
@@ -1,0 +1,344 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.job.metrics;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.runtime.dispatcher.DispatcherGateway;
+import org.apache.flink.runtime.messages.webmonitor.JobDetails;
+import org.apache.flink.runtime.messages.webmonitor.JobDetails.CurrentAttempts;
+import org.apache.flink.runtime.metrics.MetricNames;
+import org.apache.flink.runtime.metrics.dump.MetricDump;
+import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.legacy.metrics.MetricFetcher;
+import org.apache.flink.runtime.rest.handler.legacy.metrics.MetricStore;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
+import org.apache.flink.runtime.rest.messages.job.metrics.TopNMetricsMessageParameters;
+import org.apache.flink.runtime.rest.messages.job.metrics.TopNMetricsResponseBody;
+import org.apache.flink.runtime.rest.messages.job.metrics.TopNQueryParameter;
+import org.apache.flink.runtime.webmonitor.TestingDispatcherGateway;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link TopNMetricsHandler}.
+ *
+ * <p>These tests exercise the three aggregation dimensions separately: TaskManager-scoped CPU load,
+ * subtask-scoped back-pressure ratio, and TaskManager-scoped GC time summed across all reported
+ * garbage-collector names. They also verify empty-store fall-through and the topN cut-off.
+ */
+class TopNMetricsHandlerTest {
+
+    private static final String JOB_ID = new JobID().toString();
+    private static final String VERTEX_ID = "vertexA";
+
+    /** CPU load metric name as emitted by the Status.JVM.CPU metric group. */
+    private static final String CPU_LOAD_METRIC = "Status.JVM.CPU.Load";
+
+    private static final String GC_TIME_PREFIX = "Status.JVM.GarbageCollector.";
+    private static final String GC_TIME_SUFFIX = ".Time";
+
+    private MetricStore metricStore;
+    private TopNMetricsHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        metricStore = new MetricStore();
+
+        final MetricFetcher fetcher =
+                new MetricFetcher() {
+                    @Override
+                    public MetricStore getMetricStore() {
+                        return metricStore;
+                    }
+
+                    @Override
+                    public void update() {}
+
+                    @Override
+                    public long getLastUpdateTime() {
+                        return 0;
+                    }
+                };
+
+        final DispatcherGateway gateway = new TestingDispatcherGateway();
+        final GatewayRetriever<DispatcherGateway> retriever =
+                () -> CompletableFuture.completedFuture(gateway);
+
+        handler =
+                new TopNMetricsHandler(
+                        retriever, Duration.ofMillis(50), Collections.emptyMap(), fetcher);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // CPU dimension
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    void testTopCpuConsumersIsTaskManagerScopedAndSortedDescending() throws Exception {
+        addTaskManagerCpuLoad("tm-1", 0.10);
+        addTaskManagerCpuLoad("tm-2", 0.80);
+        addTaskManagerCpuLoad("tm-3", 0.45);
+
+        final TopNMetricsResponseBody body = invokeHandler();
+        final List<TopNMetricsResponseBody.CpuConsumerInfo> cpu = body.getTopCpuConsumers();
+
+        assertThat(cpu).hasSize(3);
+        assertThat(cpu.get(0).getTaskManagerId()).isEqualTo("tm-2");
+        assertThat(cpu.get(0).getCpuPercentage()).isEqualTo(80.0);
+        assertThat(cpu.get(1).getTaskManagerId()).isEqualTo("tm-3");
+        assertThat(cpu.get(2).getTaskManagerId()).isEqualTo("tm-1");
+
+        // CPU is TaskManager-scoped: subtask index is not applicable (-1) and operatorName is
+        // the literal "TaskManager" so the frontend can render it uniformly.
+        assertThat(cpu)
+                .allSatisfy(
+                        info -> {
+                            assertThat(info.getSubtaskId()).isEqualTo(-1);
+                            assertThat(info.getOperatorName()).isEqualTo("TaskManager");
+                        });
+    }
+
+    @Test
+    void testTopCpuConsumersSkipsTaskManagersWithoutMetric() throws Exception {
+        addTaskManagerCpuLoad("tm-with-cpu", 0.42);
+        // tm-without-cpu reports only a GC metric, no CPU load
+        addTaskManagerGcTime("tm-without-cpu", "G1-Young", 100.0);
+
+        final TopNMetricsResponseBody body = invokeHandler();
+
+        assertThat(body.getTopCpuConsumers())
+                .singleElement()
+                .satisfies(info -> assertThat(info.getTaskManagerId()).isEqualTo("tm-with-cpu"));
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Backpressure dimension
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    void testTopBackpressureOperatorsAreSubtaskScopedAndClampedToUnitRatio() throws Exception {
+        registerVertex(JOB_ID, VERTEX_ID, /* subtaskCount */ 3);
+        // 0 ms/s ->  0.0, 500 ms/s -> 0.5, 1000 ms/s -> 1.0
+        addSubtaskBackpressure(JOB_ID, VERTEX_ID, 0, 0.0);
+        addSubtaskBackpressure(JOB_ID, VERTEX_ID, 1, 500.0);
+        addSubtaskBackpressure(JOB_ID, VERTEX_ID, 2, 1000.0);
+
+        final TopNMetricsResponseBody body = invokeHandler();
+        final List<TopNMetricsResponseBody.BackpressureOperatorInfo> bp =
+                body.getTopBackpressureOperators();
+
+        assertThat(bp).hasSize(3);
+        assertThat(bp.get(0).getSubtaskId()).isEqualTo(2);
+        assertThat(bp.get(0).getBackpressureRatio()).isEqualTo(1.0);
+        assertThat(bp.get(1).getSubtaskId()).isEqualTo(1);
+        assertThat(bp.get(1).getBackpressureRatio()).isEqualTo(0.5);
+        assertThat(bp.get(2).getSubtaskId()).isEqualTo(0);
+        assertThat(bp.get(2).getBackpressureRatio()).isEqualTo(0.0);
+    }
+
+    @Test
+    void testTopBackpressureOperatorsReturnsEmptyWhenJobHasNoMetricsYet() throws Exception {
+        // No vertex/subtask data added for JOB_ID at all.
+        final TopNMetricsResponseBody body = invokeHandler();
+        assertThat(body.getTopBackpressureOperators()).isEmpty();
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // GC dimension
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    void testTopGcIntensiveTaskManagersSumsAcrossAllGarbageCollectors() throws Exception {
+        addTaskManagerGcTime("tm-quiet", "G1-Young", 50.0);
+        addTaskManagerGcTime("tm-quiet", "G1-Old", 10.0); // total 60
+
+        addTaskManagerGcTime("tm-busy", "G1-Young", 400.0);
+        addTaskManagerGcTime("tm-busy", "G1-Old", 200.0); // total 600
+
+        final TopNMetricsResponseBody body = invokeHandler();
+        final List<TopNMetricsResponseBody.GcTaskInfo> gc = body.getTopGcIntensiveTasks();
+
+        assertThat(gc).hasSize(2);
+        assertThat(gc.get(0).getTaskManagerId()).isEqualTo("tm-busy");
+        assertThat(gc.get(0).getGcTimePercentage()).isEqualTo(600.0);
+        assertThat(gc.get(1).getTaskManagerId()).isEqualTo("tm-quiet");
+        assertThat(gc.get(1).getGcTimePercentage()).isEqualTo(60.0);
+    }
+
+    @Test
+    void testTopGcIntensiveTaskManagersSkipsTaskManagersWithoutGcMetrics() throws Exception {
+        addTaskManagerCpuLoad("tm-cpu-only", 0.5); // no GC metric
+        addTaskManagerGcTime("tm-with-gc", "G1-Young", 42.0);
+
+        final TopNMetricsResponseBody body = invokeHandler();
+
+        assertThat(body.getTopGcIntensiveTasks())
+                .singleElement()
+                .satisfies(info -> assertThat(info.getTaskManagerId()).isEqualTo("tm-with-gc"));
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Top-N cut-off and fault tolerance
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    void testResultsAreCappedAtDefaultTopN() throws Exception {
+        // Seed 7 TaskManagers with distinct CPU loads; expect at most 5 in the response.
+        for (int i = 0; i < 7; i++) {
+            addTaskManagerCpuLoad("tm-" + i, 0.1 * i);
+        }
+        final TopNMetricsResponseBody body = invokeHandler();
+        assertThat(body.getTopCpuConsumers()).hasSize(5);
+    }
+
+    @Test
+    void testHandlerIsResilientToCompletelyEmptyMetricStore() throws Exception {
+        final TopNMetricsResponseBody body = invokeHandler();
+        assertThat(body.getTopCpuConsumers()).isEmpty();
+        assertThat(body.getTopBackpressureOperators()).isEmpty();
+        assertThat(body.getTopGcIntensiveTasks()).isEmpty();
+    }
+
+    @Test
+    void testCustomTopNQueryParameterIsHonored() throws Exception {
+        for (int i = 0; i < 10; i++) {
+            addTaskManagerCpuLoad("tm-" + i, 0.01 * i);
+        }
+        final TopNMetricsResponseBody body = invokeHandlerWithTopN(3);
+        assertThat(body.getTopCpuConsumers()).hasSize(3);
+        // Largest three loads: tm-9 (0.09) > tm-8 (0.08) > tm-7 (0.07)
+        assertThat(body.getTopCpuConsumers().get(0).getTaskManagerId()).isEqualTo("tm-9");
+        assertThat(body.getTopCpuConsumers().get(2).getTaskManagerId()).isEqualTo("tm-7");
+    }
+
+    @Test
+    void testDefaultTopNAppliesWhenQueryParameterIsAbsent() throws Exception {
+        for (int i = 0; i < 12; i++) {
+            addTaskManagerCpuLoad("tm-" + i, 0.01 * i);
+        }
+        // Default topN is 5.
+        assertThat(invokeHandler().getTopCpuConsumers()).hasSize(5);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Test helpers
+    // ---------------------------------------------------------------------------------------------
+
+    private TopNMetricsResponseBody invokeHandler() throws Exception {
+        return invokeHandler(Collections.emptyMap());
+    }
+
+    private TopNMetricsResponseBody invokeHandlerWithTopN(int topN) throws Exception {
+        return invokeHandler(
+                Collections.singletonMap(
+                        TopNQueryParameter.KEY, Collections.singletonList(Integer.toString(topN))));
+    }
+
+    private TopNMetricsResponseBody invokeHandler(Map<String, List<String>> queryParameters)
+            throws Exception {
+        final Map<String, String> pathParameters = new HashMap<>();
+        pathParameters.put(JobIDPathParameter.KEY, JOB_ID);
+
+        final HandlerRequest<EmptyRequestBody> request =
+                HandlerRequest.resolveParametersAndCreate(
+                        EmptyRequestBody.getInstance(),
+                        new TopNMetricsMessageParameters(),
+                        pathParameters,
+                        queryParameters,
+                        Collections.emptyList());
+
+        return handler.handleRequest(request, new TestingDispatcherGateway()).get();
+    }
+
+    private void addTaskManagerCpuLoad(String tmId, double load) {
+        // CPU_LOAD_METRIC already contains the Status.JVM.CPU scope verbatim, so we register it
+        // under the empty scope to have MetricStore key it exactly as "Status.JVM.CPU.Load".
+        metricStore.add(
+                new MetricDump.GaugeDump(
+                        new QueryScopeInfo.TaskManagerQueryScopeInfo(tmId, ""),
+                        CPU_LOAD_METRIC,
+                        Double.toString(load)));
+    }
+
+    private void addTaskManagerGcTime(String tmId, String gcName, double millis) {
+        final String metricName = GC_TIME_PREFIX + gcName + GC_TIME_SUFFIX;
+        metricStore.add(
+                new MetricDump.GaugeDump(
+                        new QueryScopeInfo.TaskManagerQueryScopeInfo(tmId, ""),
+                        metricName,
+                        Double.toString(millis)));
+    }
+
+    private void addSubtaskBackpressure(
+            String jobId, String vertexId, int subtaskIndex, double bpMsPerSec) {
+        metricStore.add(
+                new MetricDump.GaugeDump(
+                        new QueryScopeInfo.TaskQueryScopeInfo(
+                                jobId, vertexId, subtaskIndex, /* attemptNumber */ 0, ""),
+                        MetricNames.TASK_BACK_PRESSURED_TIME,
+                        Double.toString(bpMsPerSec)));
+    }
+
+    /**
+     * Register a vertex with subtaskCount representative attempts for the given job. Necessary
+     * because TopNMetricsHandler iterates over MetricStore#getRepresentativeAttempts() to discover
+     * which vertices belong to the job; merely adding a TaskQueryScopeInfo dump is not enough.
+     */
+    private void registerVertex(String jobId, String vertexId, int subtaskCount) {
+        final Map<Integer, CurrentAttempts> subtaskAttempts = new HashMap<>();
+        for (int i = 0; i < subtaskCount; i++) {
+            final Set<Integer> currentAttempts = new HashSet<>();
+            currentAttempts.add(0);
+            subtaskAttempts.put(i, new CurrentAttempts(0, currentAttempts, false));
+        }
+        final Map<String, Map<Integer, CurrentAttempts>> vertices = new HashMap<>();
+        vertices.put(vertexId, subtaskAttempts);
+
+        final JobDetails job =
+                new JobDetails(
+                        JobID.fromHexString(jobId),
+                        "testJob",
+                        0L,
+                        0L,
+                        0L,
+                        JobStatus.RUNNING,
+                        0L,
+                        new int[10],
+                        1,
+                        vertices);
+
+        metricStore.updateCurrentExecutionAttempts(Collections.singletonList(job));
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/metrics/TopNMetricsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/metrics/TopNMetricsHandlerTest.java
@@ -27,15 +27,20 @@ import org.apache.flink.runtime.metrics.MetricNames;
 import org.apache.flink.runtime.metrics.dump.MetricDump;
 import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.legacy.DefaultExecutionGraphCache;
 import org.apache.flink.runtime.rest.handler.legacy.metrics.MetricFetcher;
 import org.apache.flink.runtime.rest.handler.legacy.metrics.MetricStore;
+import org.apache.flink.runtime.rest.handler.legacy.utils.ArchivedExecutionGraphBuilder;
 import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
 import org.apache.flink.runtime.rest.messages.job.metrics.TopNMetricsMessageParameters;
 import org.apache.flink.runtime.rest.messages.job.metrics.TopNMetricsResponseBody;
 import org.apache.flink.runtime.rest.messages.job.metrics.TopNQueryParameter;
+import org.apache.flink.runtime.scheduler.ExecutionGraphInfo;
 import org.apache.flink.runtime.webmonitor.TestingDispatcherGateway;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.util.concurrent.Executors;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -98,7 +103,12 @@ class TopNMetricsHandlerTest {
 
         handler =
                 new TopNMetricsHandler(
-                        retriever, Duration.ofMillis(50), Collections.emptyMap(), fetcher);
+                        retriever,
+                        Duration.ofMillis(50),
+                        Collections.emptyMap(),
+                        fetcher,
+                        new DefaultExecutionGraphCache(TestingUtils.TIMEOUT, TestingUtils.TIMEOUT),
+                        Executors.directExecutor());
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -120,13 +130,13 @@ class TopNMetricsHandlerTest {
         assertThat(cpu.get(1).getTaskManagerId()).isEqualTo("tm-3");
         assertThat(cpu.get(2).getTaskManagerId()).isEqualTo("tm-1");
 
-        // CPU is TaskManager-scoped: subtask index is not applicable (-1) and operatorName is
-        // the literal "TaskManager" so the frontend can render it uniformly.
+        // CPU is TaskManager-scoped: subtaskId is null (not applicable) and operatorName
+        // carries the TaskManager id as its user-visible label.
         assertThat(cpu)
                 .allSatisfy(
                         info -> {
-                            assertThat(info.getSubtaskId()).isEqualTo(-1);
-                            assertThat(info.getOperatorName()).isEqualTo("TaskManager");
+                            assertThat(info.getSubtaskId()).isNull();
+                            assertThat(info.getOperatorName()).isEqualTo(info.getTaskManagerId());
                         });
     }
 
@@ -229,6 +239,105 @@ class TopNMetricsHandlerTest {
         assertThat(body.getTopCpuConsumers()).isEmpty();
         assertThat(body.getTopBackpressureOperators()).isEmpty();
         assertThat(body.getTopGcIntensiveTasks()).isEmpty();
+        assertThat(body.getTopBusyOperators()).isEmpty();
+        assertThat(body.getTopLaggingSources()).isEmpty();
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Busy dimension
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    void testTopBusyOperatorsAreSubtaskScopedAndClampedToUnitRatio() throws Exception {
+        registerVertex(JOB_ID, VERTEX_ID, /* subtaskCount */ 3);
+        // 0 ms/s -> 0.0, 250 ms/s -> 0.25, 1000 ms/s -> 1.0
+        addSubtaskBusyTime(JOB_ID, VERTEX_ID, 0, 0.0);
+        addSubtaskBusyTime(JOB_ID, VERTEX_ID, 1, 250.0);
+        addSubtaskBusyTime(JOB_ID, VERTEX_ID, 2, 1000.0);
+
+        final TopNMetricsResponseBody body = invokeHandler();
+        final List<TopNMetricsResponseBody.BusyOperatorInfo> busy = body.getTopBusyOperators();
+
+        assertThat(busy).hasSize(3);
+        assertThat(busy.get(0).getSubtaskId()).isEqualTo(2);
+        assertThat(busy.get(0).getBusyRatio()).isEqualTo(1.0);
+        assertThat(busy.get(1).getSubtaskId()).isEqualTo(1);
+        assertThat(busy.get(1).getBusyRatio()).isEqualTo(0.25);
+        assertThat(busy.get(2).getSubtaskId()).isEqualTo(0);
+        assertThat(busy.get(2).getBusyRatio()).isEqualTo(0.0);
+    }
+
+    @Test
+    void testTopBusyOperatorsReturnsEmptyWhenJobHasNoMetricsYet() throws Exception {
+        final TopNMetricsResponseBody body = invokeHandler();
+        assertThat(body.getTopBusyOperators()).isEmpty();
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Source lag dimension
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    void testTopLaggingSourcesAggregatePendingRecordsAndRankDescending() throws Exception {
+        // Two source-like vertices. "src-fast" has lower backlog than "src-slow".
+        final String fast = "src-fast";
+        final String slow = "src-slow";
+        final Map<String, Integer> vertices = new HashMap<>();
+        vertices.put(fast, 2);
+        vertices.put(slow, 2);
+        registerVertices(JOB_ID, vertices);
+
+        addOperatorPendingRecords(JOB_ID, fast, 0, "Source__fast", 10.0);
+        addOperatorPendingRecords(JOB_ID, fast, 1, "Source__fast", 20.0); // sum 30
+
+        addOperatorPendingRecords(JOB_ID, slow, 0, "Source__slow", 500.0);
+        addOperatorPendingRecords(JOB_ID, slow, 1, "Source__slow", 500.0); // sum 1000
+
+        final TopNMetricsResponseBody body = invokeHandler();
+        final List<TopNMetricsResponseBody.SourceLagInfo> sources = body.getTopLaggingSources();
+
+        assertThat(sources).hasSize(2);
+        assertThat(sources.get(0).getVertexId()).isEqualTo(slow);
+        assertThat(sources.get(0).getPendingRecords()).isEqualTo(1000.0);
+        assertThat(sources.get(1).getVertexId()).isEqualTo(fast);
+        assertThat(sources.get(1).getPendingRecords()).isEqualTo(30.0);
+        // Lag metrics absent -> null (unavailable).
+        assertThat(sources.get(0).getMaxFetchEventTimeLagMs()).isNull();
+        assertThat(sources.get(0).getMaxEmitEventTimeLagMs()).isNull();
+    }
+
+    @Test
+    void testTopLaggingSourcesReportsMaxEventTimeLagAcrossSubtasks() throws Exception {
+        final String src = "src-lagged";
+        registerVertex(JOB_ID, src, /* subtaskCount */ 3);
+        // Different fetch lags across subtasks; we expect the max (9000).
+        addOperatorFetchEventTimeLag(JOB_ID, src, 0, "KafkaSource", 1000.0);
+        addOperatorFetchEventTimeLag(JOB_ID, src, 1, "KafkaSource", 9000.0);
+        addOperatorFetchEventTimeLag(JOB_ID, src, 2, "KafkaSource", 3000.0);
+        // Emit lag only on one subtask.
+        addOperatorEmitEventTimeLag(JOB_ID, src, 1, "KafkaSource", 2500.0);
+
+        final TopNMetricsResponseBody body = invokeHandler();
+        assertThat(body.getTopLaggingSources())
+                .singleElement()
+                .satisfies(
+                        info -> {
+                            assertThat(info.getVertexId()).isEqualTo(src);
+                            assertThat(info.getPendingRecords()).isNull();
+                            assertThat(info.getMaxFetchEventTimeLagMs()).isEqualTo(9000.0);
+                            assertThat(info.getMaxEmitEventTimeLagMs()).isEqualTo(2500.0);
+                        });
+    }
+
+    @Test
+    void testTopLaggingSourcesIgnoresVerticesWithNoSourceMetrics() throws Exception {
+        // Vertex with only back-pressure (not a source) must not appear in the lag list.
+        registerVertex(JOB_ID, VERTEX_ID, /* subtaskCount */ 2);
+        addSubtaskBackpressure(JOB_ID, VERTEX_ID, 0, 500.0);
+        addSubtaskBackpressure(JOB_ID, VERTEX_ID, 1, 500.0);
+
+        final TopNMetricsResponseBody body = invokeHandler();
+        assertThat(body.getTopLaggingSources()).isEmpty();
     }
 
     @Test
@@ -279,7 +388,16 @@ class TopNMetricsHandlerTest {
                         queryParameters,
                         Collections.emptyList());
 
-        return handler.handleRequest(request, new TestingDispatcherGateway()).get();
+        // The tests inject metrics directly into the MetricStore, so an empty
+        // ExecutionGraphInfo is sufficient; the handler falls back to the raw
+        // vertex id when no friendly name is available in the graph.
+        final ExecutionGraphInfo executionGraphInfo =
+                new ExecutionGraphInfo(
+                        new ArchivedExecutionGraphBuilder()
+                                .setJobID(JobID.fromHexString(JOB_ID))
+                                .build());
+
+        return handler.handleRequest(request, executionGraphInfo);
     }
 
     private void addTaskManagerCpuLoad(String tmId, double load) {
@@ -311,20 +429,93 @@ class TopNMetricsHandlerTest {
                         Double.toString(bpMsPerSec)));
     }
 
+    private void addSubtaskBusyTime(
+            String jobId, String vertexId, int subtaskIndex, double busyMsPerSec) {
+        metricStore.add(
+                new MetricDump.GaugeDump(
+                        new QueryScopeInfo.TaskQueryScopeInfo(
+                                jobId, vertexId, subtaskIndex, /* attemptNumber */ 0, ""),
+                        MetricNames.TASK_BUSY_TIME,
+                        Double.toString(busyMsPerSec)));
+    }
+
+    private void addOperatorPendingRecords(
+            String jobId, String vertexId, int subtaskIndex, String operatorName, double pending) {
+        addOperatorMetric(
+                jobId, vertexId, subtaskIndex, operatorName, MetricNames.PENDING_RECORDS, pending);
+    }
+
+    private void addOperatorFetchEventTimeLag(
+            String jobId, String vertexId, int subtaskIndex, String operatorName, double lagMs) {
+        addOperatorMetric(
+                jobId,
+                vertexId,
+                subtaskIndex,
+                operatorName,
+                MetricNames.CURRENT_FETCH_EVENT_TIME_LAG,
+                lagMs);
+    }
+
+    private void addOperatorEmitEventTimeLag(
+            String jobId, String vertexId, int subtaskIndex, String operatorName, double lagMs) {
+        addOperatorMetric(
+                jobId,
+                vertexId,
+                subtaskIndex,
+                operatorName,
+                MetricNames.CURRENT_EMIT_EVENT_TIME_LAG,
+                lagMs);
+    }
+
+    /**
+     * Inject an operator-scoped gauge. The MetricStore keys it inside the SubtaskMetricStore as
+     * {@code <operatorName>.<metricName>}; the handler discovers it via suffix match.
+     */
+    private void addOperatorMetric(
+            String jobId,
+            String vertexId,
+            int subtaskIndex,
+            String operatorName,
+            String metricName,
+            double value) {
+        metricStore.add(
+                new MetricDump.GaugeDump(
+                        new QueryScopeInfo.OperatorQueryScopeInfo(
+                                jobId,
+                                vertexId,
+                                subtaskIndex,
+                                /* attemptNumber */ 0,
+                                operatorName,
+                                ""),
+                        metricName,
+                        Double.toString(value)));
+    }
+
     /**
      * Register a vertex with subtaskCount representative attempts for the given job. Necessary
      * because TopNMetricsHandler iterates over MetricStore#getRepresentativeAttempts() to discover
      * which vertices belong to the job; merely adding a TaskQueryScopeInfo dump is not enough.
      */
     private void registerVertex(String jobId, String vertexId, int subtaskCount) {
-        final Map<Integer, CurrentAttempts> subtaskAttempts = new HashMap<>();
-        for (int i = 0; i < subtaskCount; i++) {
-            final Set<Integer> currentAttempts = new HashSet<>();
-            currentAttempts.add(0);
-            subtaskAttempts.put(i, new CurrentAttempts(0, currentAttempts, false));
-        }
+        registerVertices(jobId, Collections.singletonMap(vertexId, subtaskCount));
+    }
+
+    /**
+     * Register multiple vertices for a job in a single {@code updateCurrentExecutionAttempts}
+     * invocation. Needed because each call to that method <b>replaces</b> the job's representative
+     * attempts map; registering vertices one-by-one would leave only the last vertex visible.
+     */
+    private void registerVertices(String jobId, Map<String, Integer> vertexToSubtaskCount) {
         final Map<String, Map<Integer, CurrentAttempts>> vertices = new HashMap<>();
-        vertices.put(vertexId, subtaskAttempts);
+        for (Map.Entry<String, Integer> vertex : vertexToSubtaskCount.entrySet()) {
+            final Map<Integer, CurrentAttempts> subtaskAttempts = new HashMap<>();
+            for (int i = 0; i < vertex.getValue(); i++) {
+                final Set<Integer> currentAttempts = new HashSet<>();
+                currentAttempts.add(0);
+                subtaskAttempts.put(i, new CurrentAttempts(0, currentAttempts, false));
+            }
+            vertices.put(vertex.getKey(), subtaskAttempts);
+        }
 
         final JobDetails job =
                 new JobDetails(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/metrics/TopNQueryParameterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/metrics/TopNQueryParameterTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job.metrics;
+
+import org.apache.flink.runtime.rest.messages.ConversionException;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link TopNQueryParameter}. */
+class TopNQueryParameterTest {
+
+    private final TopNQueryParameter parameter = new TopNQueryParameter();
+
+    @Test
+    void testAcceptsValuesInRange() throws Exception {
+        assertThat(parameter.convertStringToValue("1")).isEqualTo(1);
+        assertThat(parameter.convertStringToValue("5")).isEqualTo(5);
+        assertThat(parameter.convertStringToValue(Integer.toString(TopNQueryParameter.MAX_TOP_N)))
+                .isEqualTo(TopNQueryParameter.MAX_TOP_N);
+    }
+
+    @Test
+    void testRejectsNonInteger() {
+        assertThatThrownBy(() -> parameter.convertStringToValue("abc"))
+                .isInstanceOf(ConversionException.class)
+                .hasMessageContaining("integer");
+    }
+
+    @Test
+    void testRejectsZeroAndNegative() {
+        assertThatThrownBy(() -> parameter.convertStringToValue("0"))
+                .isInstanceOf(ConversionException.class)
+                .hasMessageContaining(">= 1");
+        assertThatThrownBy(() -> parameter.convertStringToValue("-1"))
+                .isInstanceOf(ConversionException.class)
+                .hasMessageContaining(">= 1");
+    }
+
+    @Test
+    void testRejectsValuesAboveMax() {
+        assertThatThrownBy(
+                        () ->
+                                parameter.convertStringToValue(
+                                        Integer.toString(TopNQueryParameter.MAX_TOP_N + 1)))
+                .isInstanceOf(ConversionException.class)
+                .hasMessageContaining("<= " + TopNQueryParameter.MAX_TOP_N);
+    }
+
+    @Test
+    void testRoundTripConversion() throws Exception {
+        final Integer parsed = parameter.convertStringToValue("7");
+        assertThat(parameter.convertValueToString(parsed)).isEqualTo("7");
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR introduces a **Top N Metrics Dashboard** to the Flink Web UI, giving operators a single-page, at-a-glance view of the hottest spots inside a running job — from JVM pressure down to per-subtask backpressure, busy ratio and source lag.

> Related JIRA: [FLINK-39489](https://issues.apache.org/jira/browse/FLINK-39489)

<img width="1573" height="1087" alt="image" src="https://github.com/user-attachments/assets/b2bad3d0-21e8-4c03-983d-efb85c94c00b" />


## Brief change log

The dashboard surfaces **five** categories of Top N metrics per job, organised into two groups:

**Primary triage (pipeline health)**

- **Top N backpressured operators** — operator subtasks with the highest
  `backPressuredTimeMsPerSecond`, reported at the subtask level so operators can pinpoint the exact bottleneck.
- **Top N busy operators** — operator subtasks with the highest
  `busyTimeMsPerSecond` (FLIP-33), indicating subtasks that are close to CPU saturation even when not backpressured.
- **Top N lagging sources** — source operators ranked by source lag
  signals (`pendingRecords` summed across subtasks, `fetchEventTimeLag`  / `emitEventTimeLag` taken as max across subtasks). Missing signals are exposed as `-1` so the UI can render them as _n/a_ without confusing them with a legitimate zero.

**JVM diagnostics (resource pressure)**

- **Top N CPU consumers** — TaskManagers with the highest JVM CPU load (`Status.JVM.CPU.Load`), aggregated at the TaskManager level.
- **Top N GC-intensive TaskManagers** — TaskManagers with the highest cumulative `Status.JVM.GarbageCollector.<name>.Time`, summed across all GC collectors.

### Backend

- New REST endpoint: `GET /jobs/:jobid/metrics/top-n?topN=<1..100>`
  - `topN` is optional; defaults to `5`, bounded to `[1, 100]`.
- `TopNMetricsHandler` reads from the public `MetricStore` API
  (`getJobMetricStore`, `getTaskManagers`, `getAllSubtaskMetricStores`)
  — no private field access, no reflection.
- `TopNMetricsHeaders` implements `RuntimeMessageHeaders`;
  `TopNMetricsMessageParameters` / `TopNQueryParameter` /
  `TopNMetricsResponseBody` live under
  `org.apache.flink.runtime.rest.messages.job.metrics`.
- `TopNMetricsResponseBody` exposes five top-level fields:
  `topCpuConsumers`, `topBackpressureOperators`, `topGcIntensiveTasks`,
  `topBusyOperators`, `topLaggingSources`. Missing metrics degrade
  gracefully to empty lists — never `null`.
- Handler is registered in `WebMonitorEndpoint`.

### Frontend (Angular)

- `TopNMetricsService` + `topn-metrics.ts` typings wired to the new
  REST endpoint (no mock data).
- `JobTopNMetricComponent` integrated into the per-job detail view,
  polling via `jobDetailChanges()` and rendering five tables — the
  primary-triage group expanded by default, the JVM-diagnostics group
  collapsed to keep the initial view focused.
- Routing configuration updated for both running and completed jobs.

### Tests

- `TopNMetricsHandlerTest` — 10 cases covering CPU / backpressure /
  busy / source-lag / GC collection, top-N truncation, custom `topN`
  parameter, partial-metric handling, and empty-`MetricStore`
  fallback.
- `TopNQueryParameterTest` — 5 cases covering parsing, bounds
  checking, and default behaviour.

### Documentation

- `rest_v1_dispatcher.html` / `rest_v1_dispatcher.yml` regenerated via
  `./mvnw package -Dgenerate-rest-docs -pl flink-docs -am -DskipTests`.

## Release note

Adds a new REST endpoint `GET /jobs/:jobid/metrics/top-n` and a Top N Metrics Dashboard in the Flink Web UI that surfaces the top backpressured operators, busy operators and lagging sources (primary triage), plus the top CPU consumers and GC-intensive TaskManagers(JVM diagnostics), for a running job. The endpoint accepts an optional `topN` query parameter (default `5`, range `[1, 100]`). For source-lag fields (`pendingRecords`, `maxFetchEventTimeLagMs`, `maxEmitEventTimeLagMs`), a value of `-1` means the metric is not reported by the underlying source and should be rendered as _n/a_.

## Verifying this change

This change added tests and can be verified as follows:

1. `mvn clean install -DskipTests -pl flink-runtime -am`
2. `cd flink-runtime-web/web-dashboard && npm install && npm run build`
3. Start a local cluster and submit a sample job (e.g.
   `TopSpeedWindowing` or any Kafka source job to exercise source lag).
4. `curl 'http://localhost:8081/jobs/<jobId>/metrics/top-n'` — the
   response body contains the five fields
   `topCpuConsumers`, `topBackpressureOperators`,
   `topGcIntensiveTasks`, `topBusyOperators` and `topLaggingSources`.
5. `curl 'http://localhost:8081/jobs/<jobId>/metrics/top-n?topN=10'` —
   up to 10 entries per category.
6. Open the job detail page in the Web UI and confirm the Top N
   Metrics panel is populated with live data, with the primary-triage
   group expanded and JVM diagnostics collapsed by default.

## Does this pull request potentially affect one of the following parts

- Dependencies (does it add or upgrade a dependency): **no**
- The public API, i.e., is any changed class annotated with
  `@Public(Evolving)`: **no** (new REST endpoint only, additive)
- The serializers: **no**
- The runtime per-record code paths (performance sensitive): **no**
- Anything that affects deployment or recovery: **no**
- The S3 file system connector: **no**

## Documentation

- Does this pull request introduce a new feature? **yes** — a new
  REST endpoint and a Web UI dashboard.
- If yes, how is the feature documented? **JavaDocs** on the handler
  / response body, plus the auto-generated REST API reference
  (`rest_v1_dispatcher.html` / `.yml`).
