### PR TITLE
[FLINK-38997] Fix StateTransitionManager stuck in Transitioning phase on failed transition

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/DefaultStateTransitionManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/DefaultStateTransitionManager.java
@@ -151,7 +151,19 @@ public class DefaultStateTransitionManager implements StateTransitionManager {
 
     private void triggerTransitionToSubsequentState() {
         progressToPhase(new Transitioning(clock, this));
-        transitionContext.transitionToSubsequentState();
+        try {
+            transitionContext.transitionToSubsequentState();
+        } catch (Throwable t) {
+            LOG.warn(
+                    "Failed to transition to subsequent state for job {}. "
+                            + "Resetting to Idling phase to allow future transition attempts.",
+                    getJobId(),
+                    t);
+            // Reset phase directly (bypassing progressToPhase guard) so the manager
+            // can respond to future resource changes and retry the transition.
+            phase = new Idling(clock, this);
+            throw t;
+        }
     }
 
     private void progressToPhase(Phase newPhase) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/DefaultStateTransitionManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/DefaultStateTransitionManagerTest.java
@@ -365,6 +365,42 @@ class DefaultStateTransitionManagerTest {
     }
 
     @Test
+    void testManagerResetsToIdlingWhenTransitionToSubsequentStateFails() {
+        final TestingStateTransitionManagerContext ctx =
+                TestingStateTransitionManagerContext.stableContext().withDesiredResources();
+        // Make transitionToSubsequentState() throw to simulate e.g. OOM during
+        // ExecutionGraph creation (FLINK-38997).
+        ctx.failOnTransition(new RuntimeException("Simulated failure during state transition"));
+        final DefaultStateTransitionManager testInstance =
+                ctx.createTestInstanceThatPassedCooldownPhase();
+
+        assertPhaseWithoutStateTransition(ctx, testInstance, Idling.class);
+
+        // Trigger a change event to move to Stabilizing
+        testInstance.onChange();
+        assertPhaseWithoutStateTransition(ctx, testInstance, Stabilizing.class);
+
+        // onTrigger would normally transition to Transitioning, but the context throws
+        try {
+            testInstance.onTrigger();
+        } catch (RuntimeException expected) {
+            // expected: the exception from transitionToSubsequentState propagates
+        }
+
+        // The manager should have recovered to Idling, NOT stuck in Transitioning
+        assertThat(testInstance.getPhase()).isInstanceOf(Idling.class);
+
+        // Now stop failing and verify the manager can still process events
+        ctx.stopFailingOnTransition();
+        ctx.clearStateTransition();
+        ctx.withDesiredResources();
+        testInstance.onChange();
+        assertPhaseWithoutStateTransition(ctx, testInstance, Stabilizing.class);
+        testInstance.onTrigger();
+        assertFinalStateTransitionHappened(ctx, testInstance);
+    }
+
+    @Test
     void testScheduledTaskBeingIgnoredAfterStateChanged() {
         final TestingStateTransitionManagerContext ctx =
                 TestingStateTransitionManagerContext.stableContext();
@@ -459,6 +495,7 @@ class DefaultStateTransitionManagerTest {
 
         // internal state used for assertions
         private final AtomicBoolean transitionTriggered = new AtomicBoolean();
+        private RuntimeException transitionFailure = null;
         private final SortedMap<Instant, List<ScheduledTask<Object>>> scheduledTasks =
                 new TreeMap<>();
 
@@ -507,6 +544,14 @@ class DefaultStateTransitionManagerTest {
             return this;
         }
 
+        public void failOnTransition(RuntimeException failure) {
+            this.transitionFailure = failure;
+        }
+
+        public void stopFailingOnTransition() {
+            this.transitionFailure = null;
+        }
+
         // ///////////////////////////////////////////////
         // StateTransitionManager.Context interface methods
         // ///////////////////////////////////////////////
@@ -524,6 +569,9 @@ class DefaultStateTransitionManagerTest {
         @Override
         public void transitionToSubsequentState() {
             transitionTriggered.set(true);
+            if (transitionFailure != null) {
+                throw transitionFailure;
+            }
         }
 
         @Override


### PR DESCRIPTION
## What is the purpose of the change

When `transitionToSubsequentState()` throws an exception (e.g., `OutOfMemoryError` during `ExecutionGraph` creation), the `DefaultStateTransitionManager` becomes permanently stuck in the `Transitioning` phase. Since `Transitioning` has no-op `onChange()` and `onTrigger()` handlers, and the `progressToPhase()` guard prevents any phase change out of `Transitioning`, the manager becomes permanently unresponsive to resource changes. The job is stuck and cannot recover, even after resources stabilize.

This was reported in [FLINK-38997](https://issues.apache.org/jira/browse/FLINK-38997): an `OutOfMemoryError` during `createExecutionGraphWithAvailableResourcesAsync` leaves the `AdaptiveScheduler` stuck in `WaitingForResources` indefinitely.

The root cause is in `triggerTransitionToSubsequentState()`, where the phase is set to `Transitioning` *before* calling `transitionContext.transitionToSubsequentState()`. If the latter throws, the phase remains `Transitioning` with no way out.

## Brief change log

  - Wrap `transitionContext.transitionToSubsequentState()` in a try-catch in `triggerTransitionToSubsequentState()`
  - On failure, reset the phase directly to `Idling` (bypassing the `progressToPhase` guard) and re-throw the exception so the caller's error handling still applies
  - Add `failOnTransition()` / `stopFailingOnTransition()` to `TestingStateTransitionManagerContext` to simulate transition failures

## Verifying this change

This change added tests and can be verified as follows:

  - Added `testManagerResetsToIdlingWhenTransitionToSubsequentStateFails` which verifies that: (1) when `transitionToSubsequentState()` throws, the manager resets to `Idling` instead of getting stuck in `Transitioning`; (2) after the failure, the manager can still process new `onChange()` events and move to `Stabilizing`; (3) a subsequent `onTrigger()` successfully completes the transition

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes (JobManager adaptive scheduler recovery behavior)
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable