### PR TITLE
[hotfix] [docs] Link documentation contribution guide from CONTRIBUTING

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,4 +8,5 @@ To make the process smooth for the project *committers* (those who review and ac
 
 Please check out the [How to Contribute guide](https://flink.apache.org/contributing/how-to-contribute.html) to understand how contributions are made.
 A detailed explanation can be found in our [Contribute Code Guide](https://flink.apache.org/contributing/contribute-code.html) which also contains a list of coding guidelines that you should follow.
+Documentation-only changes are described in the [Documentation Contribution Guide](https://flink.apache.org/how-to-contribute/contribute-documentation/) (including how to build and preview docs under `docs/`).
 For pull requests, there is a [check list](PULL_REQUEST_TEMPLATE.md) with criteria taken from the How to Contribute Guide and the Coding Guidelines.


### PR DESCRIPTION
## What is the purpose of the change

Point new contributors from `.github/CONTRIBUTING.md` to the official Documentation Contribution Guide so doc-only work (preview under `docs/`, JIRA expectations) is discoverable next to the code contribution links.

## Brief change log

- Added one sentence and link to https://flink.apache.org/how-to-contribute/contribute-documentation/

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

- Dependencies: no
- The public API: no
- The serializers: no
- The runtime per-record code paths: no
- Deployment or recovery: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no

Made with [Cursor](https://cursor.com)