### PR TITLE
[hotfix] [runtime/tests] Wait for clock advance in BlobServerCleanupTest

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerCleanupTest.java
@@ -95,14 +95,12 @@ class BlobServerCleanupTest {
     }
 
     @Test
-    void testTransientBlobNoJobCleanup()
-            throws IOException, InterruptedException, ExecutionException {
+    void testTransientBlobNoJobCleanup() throws Exception {
         testTransientBlobCleanup(null);
     }
 
     @Test
-    void testTransientBlobForJobCleanup()
-            throws IOException, InterruptedException, ExecutionException {
+    void testTransientBlobForJobCleanup() throws Exception {
         testTransientBlobCleanup(new JobID());
     }
 
@@ -110,8 +108,7 @@ class BlobServerCleanupTest {
      * Tests that {@link TransientBlobCache} cleans up after a default TTL and keeps files which are
      * constantly accessed.
      */
-    private void testTransientBlobCleanup(@Nullable final JobID jobId)
-            throws IOException, InterruptedException, ExecutionException {
+    private void testTransientBlobCleanup(@Nullable final JobID jobId) throws Exception {
 
         // 1s should be a safe-enough buffer to still check for existence after a BLOB's last access
         long cleanupInterval = 1L; // in seconds
@@ -150,9 +147,11 @@ class BlobServerCleanupTest {
             final JobID jobIdHA = (jobId == null) ? new JobID() : jobId;
             final BlobKey keyHA = put(server, jobIdHA, data, PERMANENT_BLOB);
 
-            // access key1, verify expiry times (delay at least 1ms to also verify key2 expiry is
-            // unchanged)
-            Thread.sleep(1);
+            // access key1, verify expiry times (wait until wall-clock advances so we can assert
+            // key2 expiry is unchanged even on slow or contended CI hosts)
+            final long afterKey2PutMillis = System.currentTimeMillis();
+            CommonTestUtils.waitUntilCondition(
+                    () -> System.currentTimeMillis() > afterKey2PutMillis, 1L);
             cleanupLowerBound = System.currentTimeMillis() + cleanupInterval;
             verifyContents(server, jobId, key1, data);
             final Long key1ExpiryAfterGet = transientBlobExpiryTimes.get(Tuple2.of(jobId, key1));
@@ -161,9 +160,11 @@ class BlobServerCleanupTest {
             assertThat(key2ExpiryAfterPut)
                     .isEqualTo(transientBlobExpiryTimes.get(Tuple2.of(jobId, key2)));
 
-            // access key2, verify expiry times (delay at least 1ms to also verify key1 expiry is
-            // unchanged)
-            Thread.sleep(1);
+            // access key2, verify expiry times (wait until wall-clock advances so we can assert
+            // key1 expiry is unchanged even on slow or contended CI hosts)
+            final long afterKey1AccessMillis = System.currentTimeMillis();
+            CommonTestUtils.waitUntilCondition(
+                    () -> System.currentTimeMillis() > afterKey1AccessMillis, 1L);
             cleanupLowerBound = System.currentTimeMillis() + cleanupInterval;
             verifyContents(server, jobId, key2, data2);
             assertThat(key1ExpiryAfterGet)


### PR DESCRIPTION
## What is the purpose of the change

Replace fixed `Thread.sleep(1)` with `CommonTestUtils.waitUntilCondition` so the test waits until the wall clock actually moves to a new millisecond. This reduces timing assumptions on slow or heavily loaded CI agents while preserving the original intent (separate access timestamps for transient blob expiry assertions).

## Brief change log

- `BlobServerCleanupTest`: wait for `currentTimeMillis() > snapshot` instead of a 1 ms sleep (two places)
- Widen test method throws to `Exception` because `waitUntilCondition` declares it

## Verifying this change

This change is already covered by existing tests: `BlobServerCleanupTest` (same scenarios).

Local verification (optional): `mvn -pl flink-runtime -Dtest=BlobServerCleanupTest test`

## Does this pull request potentially affect one of the following parts:

- Dependencies: no
- The public API: no
- The serializers: no
- The runtime per-record code paths: no
- Deployment or recovery: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no

Made with [Cursor](https://cursor.com)