### PR TITLE
[hotfix] [metrics] Document boolean parsing and extend MetricConfigTest

### DIFF
--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/MetricConfig.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/MetricConfig.java
@@ -141,6 +141,12 @@ public class MetricConfig extends Properties {
      * <p>If the value is a {@link Boolean}, it is returned directly. Otherwise, the value's string
      * representation is parsed via {@link Boolean#parseBoolean(String)}.
      *
+     * <p>Note: values stored as {@link Number} (for example {@link Integer} values produced by a
+     * configuration parser) are not interpreted as numeric booleans. They are converted with {@link
+     * Object#toString()} first, so {@code 1} becomes the string {@code "1"}, which {@link
+     * Boolean#parseBoolean(String)} treats as {@code false} (only {@code "true"}, case-insensitive,
+     * is {@code true}).
+     *
      * @param key the hashtable key.
      * @param defaultValue a default value.
      * @return the value in this property list with the specified key value as a boolean.

--- a/flink-metrics/flink-metrics-core/src/test/java/org/apache/flink/metrics/MetricConfigTest.java
+++ b/flink-metrics/flink-metrics-core/src/test/java/org/apache/flink/metrics/MetricConfigTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.math.BigInteger;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -78,12 +79,15 @@ class MetricConfigTest {
                 Arguments.of("3.14", (TypedGetter) (c, k) -> c.getFloat(k, 0.0f), 3.14f),
                 Arguments.of(
                         "2.718281828", (TypedGetter) (c, k) -> c.getDouble(k, 0.0), 2.718281828),
-                Arguments.of("true", (TypedGetter) (c, k) -> c.getBoolean(k, false), true));
+                Arguments.of("true", (TypedGetter) (c, k) -> c.getBoolean(k, false), true),
+                Arguments.of("1", (TypedGetter) (c, k) -> c.getBoolean(k, false), false));
     }
 
     private static Stream<Arguments> nativeTypeCases() {
         return Stream.of(
                 Arguments.of(42, (TypedGetter) (c, k) -> c.getInteger(k, 0), 42),
+                Arguments.of((short) 8, (TypedGetter) (c, k) -> c.getInteger(k, 0), 8),
+                Arguments.of((byte) 3, (TypedGetter) (c, k) -> c.getInteger(k, 0), 3),
                 Arguments.of(
                         123456789012345L,
                         (TypedGetter) (c, k) -> c.getLong(k, 0L),
@@ -91,7 +95,13 @@ class MetricConfigTest {
                 Arguments.of(3.14f, (TypedGetter) (c, k) -> c.getFloat(k, 0.0f), 3.14f),
                 Arguments.of(2.718281828, (TypedGetter) (c, k) -> c.getDouble(k, 0.0), 2.718281828),
                 Arguments.of(true, (TypedGetter) (c, k) -> c.getBoolean(k, false), true),
+                Arguments.of(1, (TypedGetter) (c, k) -> c.getBoolean(k, false), false),
+                Arguments.of(0, (TypedGetter) (c, k) -> c.getBoolean(k, true), false),
                 Arguments.of(42, (TypedGetter) (c, k) -> c.getString(k, "default"), "42"),
+                Arguments.of(
+                        new BigInteger("9223372036854775807"),
+                        (TypedGetter) (c, k) -> c.getLong(k, 0L),
+                        9223372036854775807L),
                 Arguments.of(
                         123456789012345L,
                         (TypedGetter) (c, k) -> c.getString(k, "default"),


### PR DESCRIPTION
## What is the purpose of the change

Clarify in JavaDoc how `MetricConfig#getBoolean` handles numeric values (they stringify to `"1"` / `"0"`, which `Boolean#parseBoolean` does not treat as true/false). Extend `MetricConfigTest` with regression cases for `short`/`byte` integers, `BigInteger` longs, and boolean edge cases (`"1"`, boxed `1`/`0`).

## Brief change log

- Expanded JavaDoc on `getBoolean` in `MetricConfig`
- Added parameterized test rows in `MetricConfigTest`

## Verifying this change

This change added tests and can be verified as follows:

- `mvn -pl flink-metrics/flink-metrics-core -Dtest=MetricConfigTest test`

## Does this pull request potentially affect one of the following parts:

- Dependencies: no
- The public API: no (behavior unchanged; JavaDoc and tests only)
- The serializers: no
- The runtime per-record code paths: no
- Deployment or recovery: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no
- JavaDoc only on existing API

Made with [Cursor](https://cursor.com)