### PR TITLE
[FLINK-39283][Formats/avro] Upgrade `org.apache.avro:avro` to 1.12.1

### DIFF
--- a/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
@@ -13,7 +13,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-io:commons-io:2.15.1
 - io.confluent:common-utils:7.5.3
 - io.confluent:kafka-schema-registry-client:7.5.3
-- org.apache.avro:avro:1.11.4
+- org.apache.avro:avro:1.12.1
 - org.apache.commons:commons-compress:1.26.0
 - org.apache.commons:commons-lang3:3.18.0
 - org.apache.kafka:kafka-clients:7.5.3-ccs

--- a/flink-formats/flink-sql-avro/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-avro/src/main/resources/META-INF/NOTICE
@@ -6,7 +6,7 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- org.apache.avro:avro:1.11.4
+- org.apache.avro:avro:1.12.1
 - com.fasterxml.jackson.core:jackson-core:2.20.1
 - com.fasterxml.jackson.core:jackson-databind:2.20.1
 - com.fasterxml.jackson.core:jackson-annotations:2.20

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@ under the License.
 		<!-- Project `flink-benchmarks` uses zk testing server in `curator-test` for performance
 		benchmark, please confirm it will not affect the benchmarks when the version is bumped. -->
 		<curator.version>5.4.0</curator.version>
-		<avro.version>1.11.4</avro.version>
+		<avro.version>1.12.1</avro.version>
 		<!-- Version for transitive Jackson dependencies that are not used within Flink itself.-->
 		<jackson.mapper.asl.version>1.9.14.jdk17-redhat-00001</jackson.mapper.asl.version>
 		<jackson-bom.version>2.20.1</jackson-bom.version>


### PR DESCRIPTION
## What is the purpose of the change
as mentioned source (https://avro.apache.org/blog/2025/10/16/avro-1.12.1/)
>Security Fixes
>
>This release addresses 4 security fixes:
>
>Prevent class with empty Java package being trusted by SpecificDatumReader (#3311)
Remove the default serializable packages and deprecated the property to introduce org.apache.avro.SERIALIZABLE_CLASSES instead (#3376)
java-[key-]class allowed packages must be packages (#3453)
[AVRO-4053](https://issues.apache.org/jira/browse/AVRO-4053): doc consistency in velocity templates (#3150)

## Brief change log
pom and NOTICE files


## Verifying this change

existing tests
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes )
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
