### PR TITLE
[FLINK-39308][runtime] Skip empty file-merging operator state snapshots

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackendSnapshotStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackendSnapshotStrategy.java
@@ -123,6 +123,21 @@ class DefaultOperatorStateBackendSnapshotStrategy
                 syncPartResource.getRegisteredBroadcastStatesDeepCopies();
 
         if (registeredBroadcastStatesDeepCopies.isEmpty()
+                && hasOnlyEmptyOperatorListStates(registeredOperatorStatesDeepCopies)) {
+            if (streamFactory instanceof FsMergingCheckpointStorageLocation) {
+                FsMergingCheckpointStorageLocation location =
+                        (FsMergingCheckpointStorageLocation) streamFactory;
+                return snapshotCloseableRegistry ->
+                        SnapshotResult.of(
+                                EmptyFileMergingOperatorStreamStateHandle.create(
+                                        location.getExclusiveStateHandle(),
+                                        location.getSharedStateHandle()));
+            } else {
+                return snapshotCloseableRegistry -> SnapshotResult.empty();
+            }
+        }
+
+        if (registeredBroadcastStatesDeepCopies.isEmpty()
                 && registeredOperatorStatesDeepCopies.isEmpty()) {
             if (streamFactory instanceof FsMergingCheckpointStorageLocation) {
                 FsMergingCheckpointStorageLocation location =
@@ -234,6 +249,20 @@ class DefaultOperatorStateBackendSnapshotStrategy
                 throw new IOException("Stream was already unregistered.");
             }
         };
+    }
+
+    private boolean hasOnlyEmptyOperatorListStates(
+            Map<String, PartitionableListState<?>> registeredOperatorStatesDeepCopies) {
+        if (registeredOperatorStatesDeepCopies.isEmpty()) {
+            return false;
+        }
+
+        for (PartitionableListState<?> listState : registeredOperatorStatesDeepCopies.values()) {
+            if (listState == null || listState.get().iterator().hasNext()) {
+                return false;
+            }
+        }
+        return true;
     }
 
     static class DefaultOperatorStateBackendSnapshotResources implements SnapshotResources {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/OperatorStateBackendTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/OperatorStateBackendTest.java
@@ -44,6 +44,7 @@ import org.apache.flink.runtime.checkpoint.filemerging.FileMergingSnapshotManage
 import org.apache.flink.runtime.checkpoint.filemerging.FileMergingType;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.state.filemerging.EmptyFileMergingOperatorStreamStateHandle;
 import org.apache.flink.runtime.state.filemerging.FileMergingOperatorStreamStateHandle;
 import org.apache.flink.runtime.state.filesystem.AbstractFsCheckpointStorageAccess;
 import org.apache.flink.runtime.state.filesystem.FsMergingCheckpointStorageLocation;
@@ -487,6 +488,124 @@ class OperatorStateBackendTest {
                 FutureUtils.runIfNotDoneAndGet(snapshot);
         OperatorStateHandle stateHandle = snapshotResult.getJobManagerOwnedSnapshot();
         assertThat(stateHandle).isInstanceOf(FileMergingOperatorStreamStateHandle.class);
+    }
+
+    @Test
+    void testSnapshotWithEmptyRegisteredOperatorState() throws Exception {
+        final AbstractStateBackend abstractStateBackend = new HashMapStateBackend();
+        CloseableRegistry cancelStreamRegistry = new CloseableRegistry();
+
+        Environment env = createMockEnvironment();
+        final OperatorStateBackend operatorStateBackend =
+                abstractStateBackend.createOperatorStateBackend(
+                        new OperatorStateBackendParametersImpl(
+                                env, "testOperator", emptyStateHandles, cancelStreamRegistry));
+
+        ListStateDescriptor<Integer> stateDescriptor =
+                new ListStateDescriptor<>("test-empty-list-state", IntSerializer.INSTANCE);
+        try {
+            ListState<Integer> listState = operatorStateBackend.getListState(stateDescriptor);
+            assertThat(listState.get()).isEmpty();
+
+            CheckpointStreamFactory streamFactory = new MemCheckpointStreamFactory(4096);
+
+            RunnableFuture<SnapshotResult<OperatorStateHandle>> snapshot =
+                    operatorStateBackend.snapshot(
+                            0L,
+                            0L,
+                            streamFactory,
+                            CheckpointOptions.forCheckpointWithDefaultLocation());
+
+            SnapshotResult<OperatorStateHandle> snapshotResult =
+                    FutureUtils.runIfNotDoneAndGet(snapshot);
+            OperatorStateHandle stateHandle = snapshotResult.getJobManagerOwnedSnapshot();
+            assertThat(stateHandle).isNull();
+        } finally {
+            operatorStateBackend.close();
+            operatorStateBackend.dispose();
+        }
+    }
+
+    @Test
+    void testFileMergingSnapshotRestoreWithEmptyRegisteredUnionState(@TempDir File tmpFolder)
+            throws Exception {
+        final AbstractStateBackend abstractStateBackend = new HashMapStateBackend();
+        CloseableRegistry cancelStreamRegistry = new CloseableRegistry();
+
+        Environment env = createMockEnvironment();
+        OperatorStateBackend operatorStateBackend =
+                abstractStateBackend.createOperatorStateBackend(
+                        new OperatorStateBackendParametersImpl(
+                                env, "testOperator", emptyStateHandles, cancelStreamRegistry));
+
+        ListStateDescriptor<Integer> stateDescriptor =
+                new ListStateDescriptor<>("test-empty-union-state", IntSerializer.INSTANCE);
+        ListState<Integer> unionState = operatorStateBackend.getUnionListState(stateDescriptor);
+        assertThat(unionState.get()).isEmpty();
+
+        Path checkpointBaseDir = new Path(tmpFolder.toString());
+        Path sharedStateDir =
+                new Path(
+                        checkpointBaseDir,
+                        AbstractFsCheckpointStorageAccess.CHECKPOINT_SHARED_STATE_DIR);
+        Path taskOwnedStateDir =
+                new Path(
+                        checkpointBaseDir,
+                        AbstractFsCheckpointStorageAccess.CHECKPOINT_TASK_OWNED_STATE_DIR);
+
+        JobID jobId = JobID.generate();
+        final FileMergingSnapshotManager.SubtaskKey subtaskKey =
+                new FileMergingSnapshotManager.SubtaskKey(jobId.toHexString(), "opId", 1, 1);
+        LocalFileSystem fs = getSharedInstance();
+        CheckpointStorageLocationReference cslReference =
+                AbstractFsCheckpointStorageAccess.encodePathAsReference(
+                        fromLocalFile(fs.pathToFile(checkpointBaseDir)));
+        FileMergingSnapshotManager snapshotManager =
+                createFileMergingSnapshotManager(
+                        checkpointBaseDir, sharedStateDir, taskOwnedStateDir, subtaskKey);
+        CheckpointStreamFactory streamFactory =
+                new FsMergingCheckpointStorageLocation(
+                        subtaskKey,
+                        fs,
+                        checkpointBaseDir,
+                        sharedStateDir,
+                        taskOwnedStateDir,
+                        cslReference,
+                        1024,
+                        1024,
+                        snapshotManager,
+                        0);
+
+        OperatorStateHandle stateHandle = null;
+        try {
+            RunnableFuture<SnapshotResult<OperatorStateHandle>> snapshot =
+                    operatorStateBackend.snapshot(
+                            0L,
+                            0L,
+                            streamFactory,
+                            CheckpointOptions.forCheckpointWithDefaultLocation());
+
+            SnapshotResult<OperatorStateHandle> snapshotResult =
+                    FutureUtils.runIfNotDoneAndGet(snapshot);
+            stateHandle = snapshotResult.getJobManagerOwnedSnapshot();
+
+            assertThat(stateHandle).isInstanceOf(EmptyFileMergingOperatorStreamStateHandle.class);
+
+            operatorStateBackend =
+                    recreateOperatorStateBackend(
+                            operatorStateBackend,
+                            abstractStateBackend,
+                            StateObjectCollection.singleton(stateHandle));
+
+            unionState = operatorStateBackend.getUnionListState(stateDescriptor);
+            assertThat(unionState.get()).isEmpty();
+        } finally {
+            operatorStateBackend.close();
+            operatorStateBackend.dispose();
+            if (stateHandle != null) {
+                stateHandle.discardState();
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

This pull request avoids materializing file-merging operator state handles when operator list state is registered but empty.

Today `DefaultOperatorStateBackendSnapshotStrategy` only takes the empty fast path when there are no registered operator states at all. If empty operator list states are registered, file-merging checkpoints can still create tiny segment-backed handles. During restore, `OperatorStateRestoreOperation` opens those handles even though they contain no operator-state partitions. On object stores this adds avoidable restore overhead.

## Brief change log

- Detect the case where there are no broadcast states and all registered operator list states are empty
- Reuse the existing empty snapshot fast path for that case
- Return `EmptyFileMergingOperatorStreamStateHandle` for file-merging checkpoints and `SnapshotResult.empty()` otherwise
- Add tests for empty registered operator state snapshots and file-merging restore

## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

This change added tests and can be verified as follows:

- Added `testSnapshotWithEmptyRegisteredOperatorState`
- Added `testFileMergingSnapshotRestoreWithEmptyRegisteredUnionState`
- Ran `JAVA_HOME=$(/usr/libexec/java_home -v 17) ./mvnw -pl flink-runtime -Dtest=OperatorStateBackendTest,OperatorStateRestoreOperationTest,SharedStateRegistryTest test -Djdk17 -Pjava17-target`

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable
