### PR TITLE
[FLINK-36843][table-planner] Remove deprecated method in table-planner

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkAggregateExpandDistinctAggregatesRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkAggregateExpandDistinctAggregatesRule.java
@@ -22,7 +22,6 @@ import org.apache.flink.table.planner.plan.utils.AggregateUtil;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.calcite.linq4j.Ord;
-import org.apache.calcite.plan.Contexts;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.rel.RelCollations;
@@ -105,20 +104,6 @@ public final class FlinkAggregateExpandDistinctAggregatesRule extends RelOptRule
             RelBuilderFactory relBuilderFactory) {
         super(operand(clazz, any()), relBuilderFactory, null);
         this.useGroupingSets = useGroupingSets;
-    }
-
-    @Deprecated // to be removed before 2.0
-    public FlinkAggregateExpandDistinctAggregatesRule(
-            Class<? extends LogicalAggregate> clazz,
-            boolean useGroupingSets,
-            RelFactories.JoinFactory joinFactory) {
-        this(clazz, useGroupingSets, RelBuilder.proto(Contexts.of(joinFactory)));
-    }
-
-    @Deprecated // to be removed before 2.0
-    public FlinkAggregateExpandDistinctAggregatesRule(
-            Class<? extends LogicalAggregate> clazz, RelFactories.JoinFactory joinFactory) {
-        this(clazz, false, RelBuilder.proto(Contexts.of(joinFactory)));
     }
 
     // ~ Methods ----------------------------------------------------------------

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkAggregateJoinTransposeRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkAggregateJoinTransposeRule.java
@@ -110,58 +110,6 @@ public class FlinkAggregateJoinTransposeRule extends RelOptRule {
         this.allowFunctions = allowFunctions;
     }
 
-    @Deprecated // to be removed before 2.0
-    public FlinkAggregateJoinTransposeRule(
-            Class<? extends Aggregate> aggregateClass,
-            RelFactories.AggregateFactory aggregateFactory,
-            Class<? extends Join> joinClass,
-            RelFactories.JoinFactory joinFactory) {
-        this(aggregateClass, joinClass, RelBuilder.proto(aggregateFactory, joinFactory), false);
-    }
-
-    @Deprecated // to be removed before 2.0
-    public FlinkAggregateJoinTransposeRule(
-            Class<? extends Aggregate> aggregateClass,
-            RelFactories.AggregateFactory aggregateFactory,
-            Class<? extends Join> joinClass,
-            RelFactories.JoinFactory joinFactory,
-            boolean allowFunctions) {
-        this(
-                aggregateClass,
-                joinClass,
-                RelBuilder.proto(aggregateFactory, joinFactory),
-                allowFunctions);
-    }
-
-    @Deprecated // to be removed before 2.0
-    public FlinkAggregateJoinTransposeRule(
-            Class<? extends Aggregate> aggregateClass,
-            RelFactories.AggregateFactory aggregateFactory,
-            Class<? extends Join> joinClass,
-            RelFactories.JoinFactory joinFactory,
-            RelFactories.ProjectFactory projectFactory) {
-        this(
-                aggregateClass,
-                joinClass,
-                RelBuilder.proto(aggregateFactory, joinFactory, projectFactory),
-                false);
-    }
-
-    @Deprecated // to be removed before 2.0
-    public FlinkAggregateJoinTransposeRule(
-            Class<? extends Aggregate> aggregateClass,
-            RelFactories.AggregateFactory aggregateFactory,
-            Class<? extends Join> joinClass,
-            RelFactories.JoinFactory joinFactory,
-            RelFactories.ProjectFactory projectFactory,
-            boolean allowFunctions) {
-        this(
-                aggregateClass,
-                joinClass,
-                RelBuilder.proto(aggregateFactory, joinFactory, projectFactory),
-                allowFunctions);
-    }
-
     private boolean containsSnapshot(RelNode relNode) {
         RelNode original = null;
         if (relNode instanceof RelSubset) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkAggregateRemoveRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkAggregateRemoveRule.java
@@ -52,11 +52,6 @@ public class FlinkAggregateRemoveRule extends RelOptRule {
 
     // ~ Constructors -----------------------------------------------------------
 
-    @Deprecated // to be removed before 2.0
-    public FlinkAggregateRemoveRule(Class<? extends Aggregate> aggregateClass) {
-        this(aggregateClass, RelFactories.LOGICAL_BUILDER);
-    }
-
     /** Creates an FlinkAggregateRemoveRule. */
     public FlinkAggregateRemoveRule(
             Class<? extends Aggregate> aggregateClass, RelBuilderFactory relBuilderFactory) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkBushyJoinReorderRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkBushyJoinReorderRule.java
@@ -27,7 +27,6 @@ import org.apache.calcite.plan.RelRule;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Join;
 import org.apache.calcite.rel.core.JoinRelType;
-import org.apache.calcite.rel.core.RelFactories;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.rules.LoptMultiJoin;
 import org.apache.calcite.rel.rules.MultiJoin;
@@ -39,7 +38,6 @@ import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexShuttle;
 import org.apache.calcite.tools.RelBuilder;
-import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.immutables.value.Value;
 
@@ -86,19 +84,6 @@ public class FlinkBushyJoinReorderRule extends RelRule<FlinkBushyJoinReorderRule
     /** Creates a FlinkBushyJoinReorderRule. */
     protected FlinkBushyJoinReorderRule(Config config) {
         super(config);
-    }
-
-    @Deprecated // to be removed before 2.0
-    public FlinkBushyJoinReorderRule(RelBuilderFactory relBuilderFactory) {
-        this(Config.DEFAULT.withRelBuilderFactory(relBuilderFactory).as(Config.class));
-    }
-
-    @Deprecated // to be removed before 2.0
-    public FlinkBushyJoinReorderRule(
-            RelFactories.JoinFactory joinFactory,
-            RelFactories.ProjectFactory projectFactory,
-            RelFactories.FilterFactory filterFactory) {
-        this(RelBuilder.proto(joinFactory, projectFactory, filterFactory));
     }
 
     @Override

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkJoinReorderRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkJoinReorderRule.java
@@ -23,12 +23,9 @@ import org.apache.flink.table.planner.utils.ShortcutUtils;
 
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.RelRule;
-import org.apache.calcite.rel.core.RelFactories;
 import org.apache.calcite.rel.rules.LoptOptimizeJoinRule;
 import org.apache.calcite.rel.rules.MultiJoin;
 import org.apache.calcite.rel.rules.TransformationRule;
-import org.apache.calcite.tools.RelBuilder;
-import org.apache.calcite.tools.RelBuilderFactory;
 import org.immutables.value.Value;
 
 /**
@@ -57,22 +54,6 @@ public class FlinkJoinReorderRule extends RelRule<FlinkJoinReorderRule.Config>
     /** Creates a FlinkJoinReorderRule. */
     protected FlinkJoinReorderRule(FlinkJoinReorderRule.Config config) {
         super(config);
-    }
-
-    @Deprecated // to be removed before 2.0
-    public FlinkJoinReorderRule(RelBuilderFactory relBuilderFactory) {
-        this(
-                FlinkJoinReorderRule.Config.DEFAULT
-                        .withRelBuilderFactory(relBuilderFactory)
-                        .as(FlinkJoinReorderRule.Config.class));
-    }
-
-    @Deprecated // to be removed before 2.0
-    public FlinkJoinReorderRule(
-            RelFactories.JoinFactory joinFactory,
-            RelFactories.ProjectFactory projectFactory,
-            RelFactories.FilterFactory filterFactory) {
-        this(RelBuilder.proto(joinFactory, projectFactory, filterFactory));
     }
 
     @Override

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/JoinToMultiJoinRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/JoinToMultiJoinRule.java
@@ -56,7 +56,6 @@ import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.rex.RexVisitorImpl;
-import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.ImmutableIntList;
 import org.apache.calcite.util.Pair;
@@ -137,21 +136,6 @@ public class JoinToMultiJoinRule extends RelRule<JoinToMultiJoinRule.Config>
     /** Creates a JoinToMultiJoinRule. */
     public JoinToMultiJoinRule(Config config) {
         super(config);
-    }
-
-    @Deprecated // to be removed before 2.0
-    public JoinToMultiJoinRule(Class<? extends Join> clazz) {
-        this(Config.DEFAULT.withOperandFor(clazz));
-    }
-
-    @Deprecated // to be removed before 2.0
-    public JoinToMultiJoinRule(
-            Class<? extends Join> joinClass, RelBuilderFactory relBuilderFactory) {
-        this(
-                Config.DEFAULT
-                        .withRelBuilderFactory(relBuilderFactory)
-                        .as(Config.class)
-                        .withOperandFor(joinClass));
     }
 
     // ~ Methods ----------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

Remove deprecated methods that annotated with `Deprecated` and commented with `to be removed before 2.0` in flink-table-planner.

## Brief change log

  - Removed methods marked as deprecated.

## Verifying this change

This change removes methods. No new tests have been added, existing tests are run.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
