### PR TITLE
[FLINK-39310][web-ui] Use programArgsList in JSON body instead of program-args query parameter

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/interfaces/jar.ts
+++ b/flink-runtime-web/web-dashboard/src/app/interfaces/jar.ts
@@ -22,6 +22,17 @@ export interface JarList {
   error?: boolean;
 }
 
+export interface JarPlanRequestBody {
+  entryClass?: string;
+  programArgsList?: string[];
+  parallelism?: number;
+}
+
+export interface JarRunRequestBody extends JarPlanRequestBody {
+  savepointPath?: string;
+  allowNonRestoredState?: boolean;
+}
+
 export interface JarFilesItem {
   id: string;
   name: string;

--- a/flink-runtime-web/web-dashboard/src/app/services/jar.service.ts
+++ b/flink-runtime-web/web-dashboard/src/app/services/jar.service.ts
@@ -16,12 +16,20 @@
  * limitations under the License.
  */
 
-import { HttpClient, HttpEvent, HttpParams, HttpRequest } from '@angular/common/http';
+import { HttpClient, HttpEvent, HttpRequest } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 
-import { JarList, NodesItemCorrect, Plan, PlanDetail, VerticesLink } from '@flink-runtime-web/interfaces';
+import {
+  JarList,
+  JarPlanRequestBody,
+  JarRunRequestBody,
+  NodesItemCorrect,
+  Plan,
+  PlanDetail,
+  VerticesLink
+} from '@flink-runtime-web/interfaces';
 
 import { ConfigService } from './config.service';
 
@@ -64,40 +72,19 @@ export class JarService {
     savepointPath: string,
     allowNonRestoredState: string
   ): Observable<{ jobid: string }> {
-    const requestParam = { entryClass, parallelism, programArgs, savepointPath, allowNonRestoredState };
-    let params = new HttpParams();
-    if (entryClass) {
-      params = params.append('entry-class', entryClass);
-    }
-    if (parallelism) {
-      params = params.append('parallelism', parallelism);
-    }
-    if (programArgs) {
-      params = params.append('program-args', programArgs);
-    }
+    const requestBody: JarRunRequestBody = this.buildBaseRequestBody(entryClass, parallelism, programArgs);
     if (savepointPath) {
-      params = params.append('savepointPath', programArgs);
+      requestBody.savepointPath = savepointPath;
     }
     if (allowNonRestoredState) {
-      params = params.append('allowNonRestoredState', allowNonRestoredState);
+      requestBody.allowNonRestoredState = true;
     }
-    return this.httpClient.post<{ jobid: string }>(`${this.configService.BASE_URL}/jars/${jarId}/run`, requestParam, {
-      params
-    });
+    return this.httpClient.post<{ jobid: string }>(`${this.configService.BASE_URL}/jars/${jarId}/run`, requestBody);
   }
 
   public getPlan(jarId: string, entryClass: string, parallelism: string, programArgs: string): Observable<PlanDetail> {
-    let params = new HttpParams();
-    if (entryClass) {
-      params = params.append('entry-class', entryClass);
-    }
-    if (parallelism) {
-      params = params.append('parallelism', parallelism);
-    }
-    if (programArgs) {
-      params = params.append('program-args', programArgs);
-    }
-    return this.httpClient.get<Plan>(`${this.configService.BASE_URL}/jars/${jarId}/plan`, { params }).pipe(
+    const requestBody: JarPlanRequestBody = this.buildBaseRequestBody(entryClass, parallelism, programArgs);
+    return this.httpClient.post<Plan>(`${this.configService.BASE_URL}/jars/${jarId}/plan`, requestBody).pipe(
       map(data => {
         const links: VerticesLink[] = [];
         let nodes: NodesItemCorrect[] = [];
@@ -119,5 +106,50 @@ export class JarService {
         return { nodes, links };
       })
     );
+  }
+
+  private buildBaseRequestBody(entryClass: string, parallelism: string, programArgs: string): JarPlanRequestBody {
+    const requestBody: JarPlanRequestBody = {};
+    if (entryClass) {
+      requestBody.entryClass = entryClass;
+    }
+    if (parallelism) {
+      requestBody.parallelism = parseInt(parallelism, 10);
+    }
+    if (programArgs) {
+      requestBody.programArgsList = this.parseArgs(programArgs);
+    }
+    return requestBody;
+  }
+
+  private parseArgs(programArgs: string): string[] {
+    const args: string[] = [];
+    let current = '';
+    let inSingleQuote = false;
+    let inDoubleQuote = false;
+    let hasQuote = false;
+
+    for (let i = 0; i < programArgs.length; i++) {
+      const char = programArgs[i];
+      if (char === "'" && !inDoubleQuote) {
+        inSingleQuote = !inSingleQuote;
+        hasQuote = true;
+      } else if (char === '"' && !inSingleQuote) {
+        inDoubleQuote = !inDoubleQuote;
+        hasQuote = true;
+      } else if (char === ' ' && !inSingleQuote && !inDoubleQuote) {
+        if (current.length > 0 || hasQuote) {
+          args.push(current);
+          current = '';
+          hasQuote = false;
+        }
+      } else {
+        current += char;
+      }
+    }
+    if (current.length > 0 || hasQuote) {
+      args.push(current);
+    }
+    return args;
   }
 }


### PR DESCRIPTION
## Problem

The Web UI's `jar.service.ts` uses the deprecated `program-args` query parameter (string) instead of the Flink 2.0 REST API's `programArgsList` (string array) in the JSON request body. This causes JAR submission with program arguments to fail on Flink 2.0+ — arguments are silently ignored or rejected because the server expects `programArgsList` in the request body.

Additionally, there was a pre-existing bug where the `savepointPath` query parameter was incorrectly set to the `programArgs` value instead of the actual `savepointPath`.

## Root Cause

Both `runJob()` and `getPlan()` methods were sending parameters via HTTP query parameters with incorrect names (`program-args`, `entry-class`) instead of using JSON request body fields with the correct names expected by `JarRunRequestBody`/`JarRequestBody` (`programArgsList`, `entryClass`, etc.).

## Fix

Updated both `runJob()` and `getPlan()` in `jar.service.ts` to:

- **Send parameters via JSON request body** with field names matching the server-side `JarRunRequestBody`/`JarRequestBody` classes: `entryClass`, `programArgsList`, `parallelism`, `savepointPath`, `allowNonRestoredState`
- **Parse program arguments** from a single input string into a `string[]` (`programArgsList`) with proper handling of single and double quoted arguments
- **Switch `getPlan()` from GET to POST** with JSON body (both are supported by the server, POST is recommended per API docs)
- **Fix savepointPath bug** where the query param value was incorrectly set to `programArgs`
- **Correct types**: send `parallelism` as integer and `allowNonRestoredState` as boolean to match server-side expectations

## Tests

The Flink web-dashboard Angular project has `skipTests: true` configured globally and no test framework (no Karma/Jest config, no `.spec.ts` files). Therefore:

- Verified TypeScript compilation passes (`tsc --noEmit`)
- Verified ESLint passes
- Performed 3-round manual code review verifying field names match `JarRequestBody.java` and `JarRunRequestBody.java`
- Existing Java-side tests (`JarRunHandlerParameterTest`, `JarPlanHandlerParameterTest`, `JarHandlerUtilsTest`) already validate the REST API handling of `programArgsList`

## Impact

- Only affects `jar.service.ts` in the web-dashboard
- Fixes JAR submission with program arguments on Flink 2.0+
- Fixes the savepointPath bug that was silently breaking savepoint restore on job submission
- No breaking changes — the server already accepts the JSON body format

Fixes FLINK-39310