### PR TITLE
[FLINK-39340][table] Add BinaryMultiJoinToJoinRule

### DIFF
--- a/docs/layouts/shortcodes/generated/optimizer_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/optimizer_config_configuration.html
@@ -78,6 +78,12 @@ ONE_PHASE: Enforce to use one stage aggregate which only has CompleteGlobalAggre
             <td>Enables a multi-way join operator for a chain of streaming joins. This operator processes multiple inputs at once, reducing the state size considerably by avoiding intermediate results. It supports regular INNER and LEFT joins.<br /><br />Note: This is an experimental feature and not recommended for production just yet. The operator's internal implementation and state layout is subject to changes due to ongoing relevant optimizations. These might break savepoint compatibility across Flink versions and the goal is to have a stable version in the next release.</td>
         </tr>
         <tr>
+            <td><h5>table.optimizer.multi-join.use-for-binary-join</h5><br> <span class="label label-primary">Streaming</span></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Allows binary multi join (multi join with 2 inputs).</td>
+        </tr>
+        <tr>
             <td><h5>table.optimizer.multiple-input-enabled</h5><br> <span class="label label-primary">Batch</span></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/OptimizerConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/OptimizerConfigOptions.java
@@ -369,6 +369,16 @@ public class OptimizerConfigOptions {
                                     .build());
 
     @Documentation.TableOption(execMode = Documentation.ExecMode.STREAMING)
+    public static final ConfigOption<Boolean> TABLE_OPTIMIZER_USE_MULTI_JOIN_FOR_BINARY_JOIN =
+            key("table.optimizer.multi-join.use-for-binary-join")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            Description.builder()
+                                    .text("Allows binary multi join (multi join with 2 inputs).")
+                                    .build());
+
+    @Documentation.TableOption(execMode = Documentation.ExecMode.STREAMING)
     public static final ConfigOption<Boolean> TABLE_OPTIMIZER_INCREMENTAL_AGG_ENABLED =
             key("table.optimizer.incremental-agg-enabled")
                     .booleanType()

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/BinaryMultiJoinToJoinRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/BinaryMultiJoinToJoinRule.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.logical;
+
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.config.OptimizerConfigOptions;
+import org.apache.flink.table.planner.utils.ShortcutUtils;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Join;
+import org.apache.calcite.rel.logical.LogicalJoin;
+import org.apache.calcite.rel.rules.MultiJoin;
+import org.apache.calcite.rel.rules.TransformationRule;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.tools.RelBuilderFactory;
+import org.immutables.value.Value;
+
+/** Rule for transform {@link MultiJoin} with 2 inputs back to {@link Join}. */
+@Value.Enclosing
+public class BinaryMultiJoinToJoinRule extends RelRule<BinaryMultiJoinToJoinRule.Config>
+        implements TransformationRule {
+
+    public static final BinaryMultiJoinToJoinRule INSTANCE =
+            BinaryMultiJoinToJoinRule.Config.DEFAULT.toRule();
+
+    /** Creates a JoinToMultiJoinRule. */
+    public BinaryMultiJoinToJoinRule(BinaryMultiJoinToJoinRule.Config config) {
+        super(config);
+    }
+
+    @Deprecated // to be removed before 2.0
+    public BinaryMultiJoinToJoinRule(Class<? extends MultiJoin> clazz) {
+        this(BinaryMultiJoinToJoinRule.Config.DEFAULT.withOperandFor(clazz));
+    }
+
+    @Deprecated // to be removed before 2.0
+    public BinaryMultiJoinToJoinRule(
+            Class<? extends MultiJoin> joinClass, RelBuilderFactory relBuilderFactory) {
+        this(
+                BinaryMultiJoinToJoinRule.Config.DEFAULT
+                        .withRelBuilderFactory(relBuilderFactory)
+                        .as(BinaryMultiJoinToJoinRule.Config.class)
+                        .withOperandFor(joinClass));
+    }
+
+    /** This rule matches binary multi joins. */
+    @Override
+    public boolean matches(RelOptRuleCall call) {
+        MultiJoin multiJoin = call.rel(0);
+        return isEnabledViaConfig(multiJoin) && multiJoin.getInputs().size() < 3;
+    }
+
+    /** This rule transform binary multi joins to regular joins. */
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+        MultiJoin multiJoin = call.rel(0);
+        Preconditions.checkArgument(
+                multiJoin.getInputs().size() == 2,
+                "Only binary multi-join can be transformed into regular join.");
+
+        RexNode condition = multiJoin.getOuterJoinConditions().get(1);
+        Join join =
+                LogicalJoin.create(
+                        multiJoin.getInputs().get(0),
+                        multiJoin.getInputs().get(1),
+                        multiJoin.getHints(),
+                        Preconditions.checkNotNull(condition),
+                        multiJoin.getVariablesSet(),
+                        multiJoin.getJoinTypes().get(1));
+        call.transformTo(join);
+    }
+
+    /**
+     * Checks if multi-join optimization and not use binary multi join option are enabled via
+     * configuration.
+     *
+     * @param multiJoin the multi join node
+     * @return true if TABLE_OPTIMIZER_MULTI_JOIN_ENABLED is set to true
+     */
+    private boolean isEnabledViaConfig(MultiJoin multiJoin) {
+        final TableConfig tableConfig = ShortcutUtils.unwrapTableConfig(multiJoin);
+        return tableConfig.get(OptimizerConfigOptions.TABLE_OPTIMIZER_MULTI_JOIN_ENABLED)
+                && tableConfig.get(
+                        OptimizerConfigOptions.TABLE_OPTIMIZER_USE_MULTI_JOIN_FOR_BINARY_JOIN);
+    }
+
+    /** Rule configuration. */
+    @Value.Immutable(singleton = false)
+    public interface Config extends RelRule.Config {
+        BinaryMultiJoinToJoinRule.Config DEFAULT =
+                ImmutableBinaryMultiJoinToJoinRule.Config.builder()
+                        .build()
+                        .as(BinaryMultiJoinToJoinRule.Config.class)
+                        .withOperandFor(MultiJoin.class);
+
+        @Override
+        default BinaryMultiJoinToJoinRule toRule() {
+            return new BinaryMultiJoinToJoinRule(this);
+        }
+
+        /** Defines an operand tree for the given classes. */
+        default BinaryMultiJoinToJoinRule.Config withOperandFor(
+                Class<? extends MultiJoin> joinClass) {
+            return withOperandSupplier(
+                            b0 ->
+                                    b0.operand(joinClass)
+                                            .inputs(
+                                                    b1 -> b1.operand(RelNode.class).anyInputs(),
+                                                    b2 -> b2.operand(RelNode.class).anyInputs()))
+                    .as(BinaryMultiJoinToJoinRule.Config.class);
+        }
+    }
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkStreamProgram.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkStreamProgram.scala
@@ -36,6 +36,7 @@ object FlinkStreamProgram {
   val PREDICATE_PUSHDOWN = "predicate_pushdown"
   val JOIN_REORDER = "join_reorder"
   val MULTI_JOIN = "multi_join"
+  val BINARY_MULTI_JOIN = "binary_multi_join"
   val PROJECT_REWRITE = "project_rewrite"
   val LOGICAL = "logical"
   val LOGICAL_REWRITE = "logical_rewrite"
@@ -244,6 +245,21 @@ object FlinkStreamProgram {
             .add(FlinkStreamRuleSets.MULTI_JOIN_RULES)
             .build(),
           "merge binary regular joins into MultiJoin"
+        )
+        .build()
+    )
+
+    chainedProgram.addLast(
+      BINARY_MULTI_JOIN,
+      FlinkGroupProgramBuilder
+        .newBuilder[StreamOptimizeContext]
+        .addProgram(
+          FlinkHepRuleSetProgramBuilder.newBuilder
+            .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_SEQUENCE)
+            .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
+            .add(FlinkStreamRuleSets.BINARY_MULTI_JOIN_RULES)
+            .build(),
+          "transform binary multi joins back into regular join"
         )
         .build()
     )

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -248,6 +248,11 @@ object FlinkStreamRuleSets {
     JoinToMultiJoinRule.INSTANCE
   )
 
+  val BINARY_MULTI_JOIN_RULES: RuleSet = RuleSets.ofList(
+    // transform binary MultiJoin back into regular join
+    BinaryMultiJoinToJoinRule.INSTANCE
+  )
+
   /** RuleSet to do logical optimize. This RuleSet is a sub-set of [[LOGICAL_OPT_RULES]]. */
   private val LOGICAL_RULES: RuleSet = RuleSets.ofList(
     // scan optimization

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/MultiJoinTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/MultiJoinTest.java
@@ -210,6 +210,28 @@ public class MultiJoinTest extends TableTestBase {
     }
 
     @Test
+    @Tag("no-common-join-key")
+    void testThreeWayInnerJoinRelPlanNoCommonJoinKeyAllowedBinaryMultiJoin() {
+        util.getTableEnv()
+                .getConfig()
+                .set(OptimizerConfigOptions.TABLE_OPTIMIZER_USE_MULTI_JOIN_FOR_BINARY_JOIN, true);
+        util.verifyRelPlan(
+                "\nSELECT\n"
+                        + "    u.user_id,\n"
+                        + "    u.name,\n"
+                        + "    o.order_id,\n"
+                        + "    p.payment_id\n"
+                        + "FROM Users u\n"
+                        + "INNER JOIN Orders o\n"
+                        + "    ON u.user_id = o.user_id\n"
+                        + "INNER JOIN Payments p\n"
+                        + "    ON u.cash = p.price");
+        util.getTableEnv()
+                .getConfig()
+                .set(OptimizerConfigOptions.TABLE_OPTIMIZER_USE_MULTI_JOIN_FOR_BINARY_JOIN, false);
+    }
+
+    @Test
     void testThreeWayInnerJoinExecPlan() {
         util.verifyExecPlan(
                 "\nSELECT\n"

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/MultiJoinTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/MultiJoinTest.xml
@@ -2100,6 +2100,48 @@ Calc(select=[user_id, name, order_id, payment_id])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testThreeWayInnerJoinRelPlanNoCommonJoinKeyAllowedBinaryMultiJoin">
+    <Resource name="sql">
+      <![CDATA[
+SELECT
+    u.user_id,
+    u.name,
+    o.order_id,
+    p.payment_id
+FROM Users u
+INNER JOIN Orders o
+    ON u.user_id = o.user_id
+INNER JOIN Payments p
+    ON u.cash = p.price]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(user_id=[$0], name=[$1], order_id=[$3], payment_id=[$6])
++- LogicalJoin(condition=[=($2, $7)], joinType=[inner])
+   :- LogicalJoin(condition=[=($0, $4)], joinType=[inner])
+   :  :- LogicalTableScan(table=[[default_catalog, default_database, Users]])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, Orders]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, Payments]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[user_id, name, order_id, payment_id])
++- Join(joinType=[InnerJoin], where=[=(cash, price)], select=[user_id, name, cash, order_id, payment_id, price], leftInputSpec=[NoUniqueKey], rightInputSpec=[HasUniqueKey], stateTtlHints=[[[STATE_TTL options:[0s, 0s]]]])
+   :- Exchange(distribution=[hash[cash]])
+   :  +- Calc(select=[user_id, name, cash, order_id])
+   :     +- Join(joinType=[InnerJoin], where=[=(user_id, user_id0)], select=[user_id, name, cash, order_id, user_id0], leftInputSpec=[JoinKeyContainsUniqueKey], rightInputSpec=[HasUniqueKey], stateTtlHints=[[[STATE_TTL options:[0s, 0s]]]])
+   :        :- Exchange(distribution=[hash[user_id]])
+   :        :  +- ChangelogNormalize(key=[user_id])
+   :        :     +- Exchange(distribution=[hash[user_id]])
+   :        :        +- TableSourceScan(table=[[default_catalog, default_database, Users]], fields=[user_id, name, cash])
+   :        +- Exchange(distribution=[hash[user_id]])
+   :           +- TableSourceScan(table=[[default_catalog, default_database, Orders, project=[order_id, user_id], metadata=[]]], fields=[order_id, user_id])
+   +- Exchange(distribution=[hash[price]])
+      +- TableSourceScan(table=[[default_catalog, default_database, Payments, project=[payment_id, price], metadata=[]]], fields=[payment_id, price])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testThreeWayInnerJoinWithSingleTttlHint">
     <Resource name="sql">
       <![CDATA[


### PR DESCRIPTION
## What is the purpose of the change

Add rule to transform binary multi join (with 2 inputs) back to regular join.  According [FLINK-39340](https://issues.apache.org/jira/browse/FLINK-39340)

## Verifying this change

Run MultiJoinTest#testThreeWayInnerJoinRelPlanNoCommonJoinKeyAllowedBinaryMultiJoin


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
