### PR TITLE
[FLINK-39341][jdbc-driver] Implement DatabaseMetaData methods for DBeaver

### DIFF
--- a/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkDatabaseMetaData.java
+++ b/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkDatabaseMetaData.java
@@ -19,8 +19,13 @@
 package org.apache.flink.table.jdbc;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.client.gateway.Executor;
 import org.apache.flink.table.client.gateway.StatementResult;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
 
 import javax.annotation.Nullable;
 
@@ -29,12 +34,21 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
 
 import static org.apache.flink.table.jdbc.utils.DatabaseMetaDataUtils.createCatalogsResultSet;
+import static org.apache.flink.table.jdbc.utils.DatabaseMetaDataUtils.createColumnsResultSet;
+import static org.apache.flink.table.jdbc.utils.DatabaseMetaDataUtils.createPrimaryKeysResultSet;
 import static org.apache.flink.table.jdbc.utils.DatabaseMetaDataUtils.createSchemasResultSet;
+import static org.apache.flink.table.jdbc.utils.DatabaseMetaDataUtils.createTableTypesResultSet;
+import static org.apache.flink.table.jdbc.utils.DatabaseMetaDataUtils.createTablesResultSet;
 
 /** Implementation of {@link java.sql.DatabaseMetaData} for flink jdbc driver. */
 public class FlinkDatabaseMetaData extends BaseDatabaseMetaData {
@@ -66,55 +80,23 @@ public class FlinkDatabaseMetaData extends BaseDatabaseMetaData {
 
     @Override
     public ResultSet getSchemas() throws SQLException {
+        return getSchemas(null, null);
+    }
+
+    @Override
+    public ResultSet getSchemas(String catalog, String schemaPattern) throws SQLException {
         try {
-            String currentCatalog = connection.getCatalog();
-            String currentDatabase = connection.getSchema();
-            List<String> catalogList = new ArrayList<>();
+            List<String> catalogList = getCatalogList(catalog);
+
             Map<String, List<String>> catalogSchemaList = new HashMap<>();
-            try (StatementResult result = catalogs()) {
-                while (result.hasNext()) {
-                    String catalog = result.next().getString(0).toString();
-                    connection.setCatalog(catalog);
-                    getSchemasForCatalog(catalogList, catalogSchemaList, catalog, null);
-                }
+            for (String cat : catalogList) {
+                catalogSchemaList.put(cat, getSchemaList(cat, schemaPattern));
             }
-            connection.setCatalog(currentCatalog);
-            connection.setSchema(currentDatabase);
 
             return createSchemasResultSet(statement, catalogList, catalogSchemaList);
         } catch (Exception e) {
             throw new SQLException("Get schemas fail", e);
         }
-    }
-
-    private void getSchemasForCatalog(
-            List<String> catalogList,
-            Map<String, List<String>> catalogSchemaList,
-            String catalog,
-            @Nullable String schemaPattern)
-            throws SQLException {
-        catalogList.add(catalog);
-        List<String> schemas = new ArrayList<>();
-        try (StatementResult schemaResult = schemas()) {
-            while (schemaResult.hasNext()) {
-                String schema = schemaResult.next().getString(0).toString();
-                if (schemaPattern == null || schema.contains(schemaPattern)) {
-                    schemas.add(schema);
-                }
-            }
-        }
-        catalogSchemaList.put(catalog, schemas);
-    }
-
-    private StatementResult schemas() {
-        return executor.executeStatement("SHOW DATABASES;");
-    }
-
-    // TODO Flink will support SHOW DATABASES LIKE statement in FLIP-297, this method will be
-    // supported after that issue.
-    @Override
-    public ResultSet getSchemas(String catalog, String schemaPattern) throws SQLException {
-        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -136,25 +118,282 @@ public class FlinkDatabaseMetaData extends BaseDatabaseMetaData {
     public ResultSet getTables(
             String catalog, String schemaPattern, String tableNamePattern, String[] types)
             throws SQLException {
-        throw new UnsupportedOperationException();
+        try {
+            Set<String> typeFilter = null;
+            if (types != null) {
+                typeFilter = new HashSet<>(Arrays.asList(types));
+            }
+
+            List<String> catalogList = getCatalogList(catalog);
+
+            List<RowData> tableRows = new ArrayList<>();
+            for (String cat : catalogList) {
+                List<String> schemaList = getSchemaList(cat, schemaPattern);
+
+                for (String schema : schemaList) {
+                    String qualifiedPath = String.format("`%s`.`%s`", cat, schema);
+                    collectTables(
+                            tableRows,
+                            cat,
+                            schema,
+                            tableNamePattern,
+                            "TABLE",
+                            typeFilter,
+                            qualifiedPath);
+                    collectTables(
+                            tableRows,
+                            cat,
+                            schema,
+                            tableNamePattern,
+                            "VIEW",
+                            typeFilter,
+                            qualifiedPath);
+                }
+            }
+
+            return createTablesResultSet(statement, tableRows);
+        } catch (Exception e) {
+            throw new SQLException("Get tables fail", e);
+        }
+    }
+
+    private void collectTables(
+            List<RowData> tableRows,
+            String catalog,
+            String schema,
+            @Nullable String tableNamePattern,
+            String tableType,
+            @Nullable Set<String> typeFilter,
+            String qualifiedPath) {
+        if (typeFilter != null && !typeFilter.contains(tableType)) {
+            return;
+        }
+        String command = "VIEW".equals(tableType) ? "SHOW VIEWS" : "SHOW TABLES";
+        String sql = String.format("%s FROM %s", command, qualifiedPath);
+        try (StatementResult result = executor.executeStatement(sql)) {
+            while (result.hasNext()) {
+                String tableName = result.next().getString(0).toString();
+                if (matchesPattern(tableName, tableNamePattern)) {
+                    tableRows.add(
+                            GenericRowData.of(
+                                    StringData.fromString(catalog),
+                                    StringData.fromString(schema),
+                                    StringData.fromString(tableName),
+                                    StringData.fromString(tableType),
+                                    null,
+                                    null,
+                                    null,
+                                    null,
+                                    null,
+                                    null));
+                }
+            }
+        }
+    }
+
+    private static boolean matchesPattern(String value, @Nullable String pattern) {
+        if (pattern == null) {
+            return true;
+        }
+        String regex = Pattern.quote(pattern).replace("%", "\\E.*\\Q").replace("_", "\\E.\\Q");
+        return value.matches(regex);
     }
 
     @Override
     public ResultSet getColumns(
             String catalog, String schemaPattern, String tableNamePattern, String columnNamePattern)
             throws SQLException {
-        throw new UnsupportedOperationException();
+        try {
+            List<RowData> columnRows = new ArrayList<>();
+            for (String cat : getCatalogList(catalog)) {
+                for (String schema : getSchemaList(cat, schemaPattern)) {
+                    for (String table : getTableList(cat, schema, tableNamePattern)) {
+                        columnRows.addAll(collectColumns(cat, schema, table, columnNamePattern));
+                    }
+                }
+            }
+            return createColumnsResultSet(statement, columnRows);
+        } catch (Exception e) {
+            throw new SQLException("Get columns fail", e);
+        }
+    }
+
+    private List<RowData> collectColumns(
+            String catalog, String schema, String table, @Nullable String columnNamePattern) {
+        List<RowData> columnRows = new ArrayList<>();
+        String qualifiedTable = String.format("`%s`.`%s`.`%s`", catalog, schema, table);
+        try (StatementResult result =
+                executor.executeStatement(
+                        String.format("SELECT * FROM %s LIMIT 0", qualifiedTable))) {
+            List<Column> columns = result.getResultSchema().getColumns();
+            int ordinal = 1;
+            for (Column col : columns) {
+                if (matchesPattern(col.getName(), columnNamePattern)) {
+                    columnRows.add(toColumnRow(catalog, schema, table, col, ordinal));
+                    ordinal++;
+                }
+            }
+        } catch (Exception e) {
+            // skip tables that cannot be described
+        }
+        return columnRows;
+    }
+
+    private static RowData toColumnRow(
+            String catalog, String schema, String table, Column col, int ordinal) {
+        String typeName = col.getDataType().getLogicalType().asSummaryString();
+        boolean nullable = col.getDataType().getLogicalType().isNullable();
+        return GenericRowData.of(
+                StringData.fromString(catalog),
+                StringData.fromString(schema),
+                StringData.fromString(table),
+                StringData.fromString(col.getName()),
+                getJdbcType(typeName),
+                StringData.fromString(typeName),
+                null,
+                null,
+                null,
+                null,
+                nullable
+                        ? java.sql.DatabaseMetaData.columnNullable
+                        : java.sql.DatabaseMetaData.columnNoNulls,
+                null,
+                null,
+                null,
+                null,
+                null,
+                ordinal,
+                StringData.fromString(nullable ? "YES" : "NO"),
+                null,
+                null,
+                null,
+                null,
+                StringData.fromString("NO"));
+    }
+
+    private static int getJdbcType(String flinkType) {
+        String upper = flinkType.toUpperCase();
+        if (upper.startsWith("BOOLEAN")) {
+            return java.sql.Types.BOOLEAN;
+        } else if (upper.startsWith("TINYINT")) {
+            return java.sql.Types.TINYINT;
+        } else if (upper.startsWith("SMALLINT")) {
+            return java.sql.Types.SMALLINT;
+        } else if (upper.startsWith("INT")) {
+            return java.sql.Types.INTEGER;
+        } else if (upper.startsWith("BIGINT")) {
+            return java.sql.Types.BIGINT;
+        } else if (upper.startsWith("FLOAT")) {
+            return java.sql.Types.FLOAT;
+        } else if (upper.startsWith("DOUBLE")) {
+            return java.sql.Types.DOUBLE;
+        } else if (upper.startsWith("DECIMAL") || upper.startsWith("NUMERIC")) {
+            return java.sql.Types.DECIMAL;
+        } else if (upper.startsWith("VARCHAR") || upper.startsWith("STRING")) {
+            return java.sql.Types.VARCHAR;
+        } else if (upper.startsWith("CHAR")) {
+            return java.sql.Types.CHAR;
+        } else if (upper.startsWith("DATE")) {
+            return java.sql.Types.DATE;
+        } else if (upper.startsWith("TIMESTAMP")) {
+            return java.sql.Types.TIMESTAMP;
+        } else if (upper.startsWith("TIME")) {
+            return java.sql.Types.TIME;
+        } else if (upper.startsWith("BINARY")
+                || upper.startsWith("VARBINARY")
+                || upper.startsWith("BYTES")) {
+            return java.sql.Types.BINARY;
+        } else if (upper.startsWith("ARRAY")) {
+            return java.sql.Types.ARRAY;
+        } else if (upper.startsWith("MAP") || upper.startsWith("ROW")) {
+            return java.sql.Types.STRUCT;
+        }
+        return java.sql.Types.OTHER;
     }
 
     @Override
     public ResultSet getPrimaryKeys(String catalog, String schema, String table)
             throws SQLException {
-        throw new UnsupportedOperationException();
+        // tableSchema.getPrimaryKey() is not working
+        try {
+            List<RowData> pkRows = new ArrayList<>();
+            String qualifiedTable = String.format("`%s`.`%s`.`%s`", catalog, schema, table);
+            try (StatementResult result =
+                    executor.executeStatement(
+                            String.format("SELECT * FROM %s LIMIT 0", qualifiedTable))) {
+                ResolvedSchema tableSchema = result.getResultSchema();
+                tableSchema
+                        .getPrimaryKey()
+                        .ifPresent(
+                                pk -> {
+                                    List<String> columns = pk.getColumns();
+                                    for (int i = 0; i < columns.size(); i++) {
+                                        pkRows.add(
+                                                GenericRowData.of(
+                                                        StringData.fromString(catalog),
+                                                        StringData.fromString(schema),
+                                                        StringData.fromString(table),
+                                                        StringData.fromString(columns.get(i)),
+                                                        i + 1,
+                                                        StringData.fromString(pk.getName())));
+                                    }
+                                });
+            }
+            return createPrimaryKeysResultSet(statement, pkRows);
+        } catch (Exception e) {
+            throw new SQLException("Get primary keys fail", e);
+        }
     }
 
     @Override
     public ResultSet getTableTypes() throws SQLException {
-        throw new UnsupportedOperationException();
+        List<RowData> typeRows = new ArrayList<>();
+        typeRows.add(GenericRowData.of(StringData.fromString("TABLE")));
+        typeRows.add(GenericRowData.of(StringData.fromString("VIEW")));
+        return createTableTypesResultSet(statement, typeRows);
+    }
+
+    private List<String> getCatalogList(@Nullable String catalog) {
+        if (catalog != null) {
+            return Collections.singletonList(catalog);
+        }
+        List<String> catalogList = new ArrayList<>();
+        try (StatementResult result = catalogs()) {
+            while (result.hasNext()) {
+                catalogList.add(result.next().getString(0).toString());
+            }
+        }
+        return catalogList;
+    }
+
+    private List<String> getSchemaList(String catalog, @Nullable String schemaPattern) {
+        List<String> schemas = new ArrayList<>();
+        try (StatementResult result =
+                executor.executeStatement(String.format("SHOW DATABASES IN `%s`", catalog))) {
+            while (result.hasNext()) {
+                String schema = result.next().getString(0).toString();
+                if (matchesPattern(schema, schemaPattern)) {
+                    schemas.add(schema);
+                }
+            }
+        }
+        return schemas;
+    }
+
+    private List<String> getTableList(
+            String catalog, String schema, @Nullable String tableNamePattern) {
+        List<String> tables = new ArrayList<>();
+        String qualifiedPath = String.format("`%s`.`%s`", catalog, schema);
+        try (StatementResult result =
+                executor.executeStatement(String.format("SHOW TABLES FROM %s", qualifiedPath))) {
+            while (result.hasNext()) {
+                String tableName = result.next().getString(0).toString();
+                if (matchesPattern(tableName, tableNamePattern)) {
+                    tables.add(tableName);
+                }
+            }
+        }
+        return tables;
     }
 
     @Override

--- a/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkDatabaseMetaData.java
+++ b/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkDatabaseMetaData.java
@@ -132,6 +132,11 @@ public class FlinkDatabaseMetaData extends BaseDatabaseMetaData {
 
                 for (String schema : schemaList) {
                     String qualifiedPath = String.format("`%s`.`%s`", cat, schema);
+
+                    // Collect views first so we can exclude them from SHOW TABLES results
+                    Set<String> viewNames = new HashSet<>();
+                    collectViews(viewNames, qualifiedPath);
+
                     collectTables(
                             tableRows,
                             cat,
@@ -139,7 +144,8 @@ public class FlinkDatabaseMetaData extends BaseDatabaseMetaData {
                             tableNamePattern,
                             "TABLE",
                             typeFilter,
-                            qualifiedPath);
+                            qualifiedPath,
+                            viewNames);
                     collectTables(
                             tableRows,
                             cat,
@@ -147,13 +153,23 @@ public class FlinkDatabaseMetaData extends BaseDatabaseMetaData {
                             tableNamePattern,
                             "VIEW",
                             typeFilter,
-                            qualifiedPath);
+                            qualifiedPath,
+                            null);
                 }
             }
 
             return createTablesResultSet(statement, tableRows);
         } catch (Exception e) {
             throw new SQLException("Get tables fail", e);
+        }
+    }
+
+    private void collectViews(Set<String> viewNames, String qualifiedPath) {
+        try (StatementResult result =
+                executor.executeStatement(String.format("SHOW VIEWS FROM %s", qualifiedPath))) {
+            while (result.hasNext()) {
+                viewNames.add(result.next().getString(0).toString());
+            }
         }
     }
 
@@ -164,7 +180,8 @@ public class FlinkDatabaseMetaData extends BaseDatabaseMetaData {
             @Nullable String tableNamePattern,
             String tableType,
             @Nullable Set<String> typeFilter,
-            String qualifiedPath) {
+            String qualifiedPath,
+            @Nullable Set<String> excludeNames) {
         if (typeFilter != null && !typeFilter.contains(tableType)) {
             return;
         }
@@ -173,6 +190,9 @@ public class FlinkDatabaseMetaData extends BaseDatabaseMetaData {
         try (StatementResult result = executor.executeStatement(sql)) {
             while (result.hasNext()) {
                 String tableName = result.next().getString(0).toString();
+                if (excludeNames != null && excludeNames.contains(tableName)) {
+                    continue;
+                }
                 if (matchesPattern(tableName, tableNamePattern)) {
                     tableRows.add(
                             GenericRowData.of(

--- a/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkResultSet.java
+++ b/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkResultSet.java
@@ -29,9 +29,11 @@ import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.jdbc.utils.CloseableResultIterator;
 import org.apache.flink.table.jdbc.utils.StatementResultIterator;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.RowType;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -49,6 +51,7 @@ import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -431,6 +434,38 @@ public class FlinkResultSet extends BaseResultSet {
                                         valueType));
                     }
                     return mapResult;
+                }
+            case ROW:
+                {
+                    RowType rowType = (RowType) dataType;
+                    RowData rowData = (RowData) object;
+                    List<RowType.RowField> fields = rowType.getFields();
+                    Map<String, Object> result = new LinkedHashMap<>();
+                    for (int i = 0; i < fields.size(); i++) {
+                        RowType.RowField field = fields.get(i);
+                        RowData.FieldGetter getter = RowData.createFieldGetter(field.getType(), i);
+                        result.put(
+                                field.getName(),
+                                convertToJavaObject(
+                                        getter.getFieldOrNull(rowData), field.getType()));
+                    }
+                    return result;
+                }
+            case ARRAY:
+                {
+                    ArrayType arrayType = (ArrayType) dataType;
+                    LogicalType elementType = arrayType.getElementType();
+                    ArrayData arrayData = (ArrayData) object;
+                    ArrayData.ElementGetter elementGetter =
+                            ArrayData.createElementGetter(elementType);
+                    int size = arrayData.size();
+                    List<Object> list = new ArrayList<>();
+                    for (int i = 0; i < size; i++) {
+                        list.add(
+                                convertToJavaObject(
+                                        elementGetter.getElementOrNull(arrayData, i), elementType));
+                    }
+                    return list;
                 }
             case TIMESTAMP_WITHOUT_TIME_ZONE:
             case TIMESTAMP_WITH_LOCAL_TIME_ZONE:

--- a/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/utils/DatabaseMetaDataUtils.java
+++ b/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/utils/DatabaseMetaDataUtils.java
@@ -42,6 +42,19 @@ public class DatabaseMetaDataUtils {
             Column.physical("TABLE_SCHEM", DataTypes.STRING().notNull());
     private static final Column TABLE_CATALOG_COLUMN =
             Column.physical("TABLE_CATALOG", DataTypes.STRING());
+    private static final Column TABLE_NAME_COLUMN =
+            Column.physical("TABLE_NAME", DataTypes.STRING().notNull());
+    private static final Column TABLE_TYPE_COLUMN =
+            Column.physical("TABLE_TYPE", DataTypes.STRING().notNull());
+    private static final Column REMARKS_COLUMN = Column.physical("REMARKS", DataTypes.STRING());
+    private static final Column TYPE_CAT_COLUMN = Column.physical("TYPE_CAT", DataTypes.STRING());
+    private static final Column TYPE_SCHEM_COLUMN =
+            Column.physical("TYPE_SCHEM", DataTypes.STRING());
+    private static final Column TYPE_NAME_COLUMN = Column.physical("TYPE_NAME", DataTypes.STRING());
+    private static final Column SELF_REFERENCING_COL_NAME_COLUMN =
+            Column.physical("SELF_REFERENCING_COL_NAME", DataTypes.STRING());
+    private static final Column REF_GENERATION_COLUMN =
+            Column.physical("REF_GENERATION", DataTypes.STRING());
 
     /**
      * Create result set for catalogs. The schema columns are:
@@ -104,5 +117,152 @@ public class DatabaseMetaDataUtils {
                 statement,
                 new CollectionResultIterator(schemaWithCatalogList.iterator()),
                 ResolvedSchema.of(TABLE_SCHEM_COLUMN, TABLE_CATALOG_COLUMN));
+    }
+
+    /**
+     * Create result set for tables. The schema columns are:
+     *
+     * <ul>
+     *   <li>TABLE_CAT String => table catalog (may be null)
+     *   <li>TABLE_SCHEM String => table schema (may be null)
+     *   <li>TABLE_NAME String => table name
+     *   <li>TABLE_TYPE String => table type
+     *   <li>REMARKS String => explanatory comment on the table
+     *   <li>TYPE_CAT String => the types catalog (may be null)
+     *   <li>TYPE_SCHEM String => the types schema (may be null)
+     *   <li>TYPE_NAME String => type name (may be null)
+     *   <li>SELF_REFERENCING_COL_NAME String => (may be null)
+     *   <li>REF_GENERATION String => (may be null)
+     * </ul>
+     *
+     * <p>The results are ordered by TABLE_TYPE, TABLE_CAT, TABLE_SCHEM, and TABLE_NAME.
+     *
+     * @param statement The statement for database meta data
+     * @param tableRows The list of table row data
+     * @return a ResultSet object in which each row is a table description
+     */
+    // JDBC getColumns() result columns
+    private static final Column COLUMN_NAME_COLUMN =
+            Column.physical("COLUMN_NAME", DataTypes.STRING().notNull());
+
+    private static final Column DATA_TYPE_COLUMN =
+            Column.physical("DATA_TYPE", DataTypes.INT().notNull());
+    private static final Column COLUMN_TYPE_NAME_COLUMN =
+            Column.physical("TYPE_NAME", DataTypes.STRING().notNull());
+    private static final Column COLUMN_SIZE_COLUMN =
+            Column.physical("COLUMN_SIZE", DataTypes.INT());
+    private static final Column BUFFER_LENGTH_COLUMN =
+            Column.physical("BUFFER_LENGTH", DataTypes.INT());
+    private static final Column DECIMAL_DIGITS_COLUMN =
+            Column.physical("DECIMAL_DIGITS", DataTypes.INT());
+    private static final Column NUM_PREC_RADIX_COLUMN =
+            Column.physical("NUM_PREC_RADIX", DataTypes.INT());
+    private static final Column NULLABLE_COLUMN =
+            Column.physical("NULLABLE", DataTypes.INT().notNull());
+    private static final Column COLUMN_REMARKS_COLUMN =
+            Column.physical("REMARKS", DataTypes.STRING());
+    private static final Column COLUMN_DEF_COLUMN =
+            Column.physical("COLUMN_DEF", DataTypes.STRING());
+    private static final Column SQL_DATA_TYPE_COLUMN =
+            Column.physical("SQL_DATA_TYPE", DataTypes.INT());
+    private static final Column SQL_DATETIME_SUB_COLUMN =
+            Column.physical("SQL_DATETIME_SUB", DataTypes.INT());
+    private static final Column CHAR_OCTET_LENGTH_COLUMN =
+            Column.physical("CHAR_OCTET_LENGTH", DataTypes.INT());
+    private static final Column ORDINAL_POSITION_COLUMN =
+            Column.physical("ORDINAL_POSITION", DataTypes.INT().notNull());
+    private static final Column IS_NULLABLE_COLUMN =
+            Column.physical("IS_NULLABLE", DataTypes.STRING().notNull());
+    private static final Column SCOPE_CATALOG_COLUMN =
+            Column.physical("SCOPE_CATALOG", DataTypes.STRING());
+    private static final Column SCOPE_SCHEMA_COLUMN =
+            Column.physical("SCOPE_SCHEMA", DataTypes.STRING());
+    private static final Column SCOPE_TABLE_COLUMN =
+            Column.physical("SCOPE_TABLE", DataTypes.STRING());
+    private static final Column SOURCE_DATA_TYPE_COLUMN =
+            Column.physical("SOURCE_DATA_TYPE", DataTypes.SMALLINT());
+    private static final Column IS_AUTOINCREMENT_COLUMN =
+            Column.physical("IS_AUTOINCREMENT", DataTypes.STRING().notNull());
+
+    public static FlinkResultSet createColumnsResultSet(
+            Statement statement, List<RowData> columnRows) {
+        return new FlinkResultSet(
+                statement,
+                new CollectionResultIterator(columnRows.iterator()),
+                ResolvedSchema.of(
+                        TABLE_CAT_COLUMN,
+                        TABLE_SCHEM_COLUMN,
+                        TABLE_NAME_COLUMN,
+                        COLUMN_NAME_COLUMN,
+                        DATA_TYPE_COLUMN,
+                        COLUMN_TYPE_NAME_COLUMN,
+                        COLUMN_SIZE_COLUMN,
+                        BUFFER_LENGTH_COLUMN,
+                        DECIMAL_DIGITS_COLUMN,
+                        NUM_PREC_RADIX_COLUMN,
+                        NULLABLE_COLUMN,
+                        COLUMN_REMARKS_COLUMN,
+                        COLUMN_DEF_COLUMN,
+                        SQL_DATA_TYPE_COLUMN,
+                        SQL_DATETIME_SUB_COLUMN,
+                        CHAR_OCTET_LENGTH_COLUMN,
+                        ORDINAL_POSITION_COLUMN,
+                        IS_NULLABLE_COLUMN,
+                        SCOPE_CATALOG_COLUMN,
+                        SCOPE_SCHEMA_COLUMN,
+                        SCOPE_TABLE_COLUMN,
+                        SOURCE_DATA_TYPE_COLUMN,
+                        IS_AUTOINCREMENT_COLUMN));
+    }
+
+    public static FlinkResultSet createTablesResultSet(
+            Statement statement, List<RowData> tableRows) {
+        tableRows.sort(
+                Comparator.comparing((RowData r) -> r.getString(3).toString())
+                        .thenComparing(r -> r.getString(0).toString())
+                        .thenComparing(r -> r.getString(1).toString())
+                        .thenComparing(r -> r.getString(2).toString()));
+
+        return new FlinkResultSet(
+                statement,
+                new CollectionResultIterator(tableRows.iterator()),
+                ResolvedSchema.of(
+                        TABLE_CAT_COLUMN,
+                        TABLE_SCHEM_COLUMN,
+                        TABLE_NAME_COLUMN,
+                        TABLE_TYPE_COLUMN,
+                        REMARKS_COLUMN,
+                        TYPE_CAT_COLUMN,
+                        TYPE_SCHEM_COLUMN,
+                        TYPE_NAME_COLUMN,
+                        SELF_REFERENCING_COL_NAME_COLUMN,
+                        REF_GENERATION_COLUMN));
+    }
+
+    // JDBC getPrimaryKeys() result columns
+    private static final Column PK_NAME_COLUMN = Column.physical("PK_NAME", DataTypes.STRING());
+    private static final Column KEY_SEQ_COLUMN =
+            Column.physical("KEY_SEQ", DataTypes.INT().notNull());
+
+    public static FlinkResultSet createPrimaryKeysResultSet(
+            Statement statement, List<RowData> pkRows) {
+        return new FlinkResultSet(
+                statement,
+                new CollectionResultIterator(pkRows.iterator()),
+                ResolvedSchema.of(
+                        TABLE_CAT_COLUMN,
+                        TABLE_SCHEM_COLUMN,
+                        TABLE_NAME_COLUMN,
+                        Column.physical("COLUMN_NAME", DataTypes.STRING().notNull()),
+                        KEY_SEQ_COLUMN,
+                        PK_NAME_COLUMN));
+    }
+
+    public static FlinkResultSet createTableTypesResultSet(
+            Statement statement, List<RowData> typeRows) {
+        return new FlinkResultSet(
+                statement,
+                new CollectionResultIterator(typeRows.iterator()),
+                ResolvedSchema.of(TABLE_TYPE_COLUMN));
     }
 }

--- a/flink-table/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkDatabaseMetaDataTest.java
+++ b/flink-table/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkDatabaseMetaDataTest.java
@@ -28,7 +28,9 @@ import org.junit.jupiter.api.Test;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -190,6 +192,156 @@ public class FlinkDatabaseMetaDataTest extends FlinkJdbcDriverTestBase {
             assertFalse(databaseMetaData.supportsStoredFunctionsUsingCallSyntax());
             assertFalse(databaseMetaData.autoCommitFailureClosesAllResultSets());
             assertFalse(databaseMetaData.generatedKeyAlwaysReturned());
+        }
+    }
+
+    @Test
+    public void testGetSchemasWithFilter() throws Exception {
+        DriverUri driverUri = getDriverUri();
+        try (FlinkConnection connection = new FlinkConnection(driverUri)) {
+            Executor executor = connection.getExecutor();
+            executeDDL("CREATE DATABASE database_a", executor);
+            executeDDL("CREATE DATABASE database_b", executor);
+
+            DatabaseMetaData metaData =
+                    new FlinkDatabaseMetaData(
+                            driverUri.getURL(), connection, new TestingStatement());
+
+            // Filter by catalog
+            List<String> schemas =
+                    resultSetToListAndClose(metaData.getSchemas("default_catalog", null));
+            assertThat(schemas).allMatch(s -> s.contains("default_catalog"));
+
+            // Filter by schema pattern
+            List<String> filteredSchemas =
+                    resultSetToListAndClose(metaData.getSchemas("default_catalog", "database_%"));
+            assertThat(filteredSchemas)
+                    .allMatch(s -> s.startsWith("database_a,") || s.startsWith("database_b,"));
+        }
+    }
+
+    @Test
+    public void testGetTables() throws Exception {
+        DriverUri driverUri = getDriverUri();
+        try (FlinkConnection connection = new FlinkConnection(driverUri)) {
+            Executor executor = connection.getExecutor();
+            executeDDL(
+                    "CREATE TABLE test_table1 (id INT, name STRING) WITH ('connector' = 'datagen')",
+                    executor);
+            executeDDL(
+                    "CREATE TABLE test_table2 (id INT, val DOUBLE) WITH ('connector' = 'datagen')",
+                    executor);
+            executeDDL("CREATE VIEW test_view1 AS SELECT id, name FROM test_table1", executor);
+
+            DatabaseMetaData metaData =
+                    new FlinkDatabaseMetaData(
+                            driverUri.getURL(), connection, new TestingStatement());
+
+            // Get all tables and views
+            ResultSet rs = metaData.getTables("default_catalog", "default_database", null, null);
+            List<String> allResults = resultSetToListAndClose(rs);
+            Set<String> tableNames = new HashSet<>();
+            for (String row : allResults) {
+                tableNames.add(row.split(",")[2]);
+            }
+            assertThat(tableNames).contains("test_table1", "test_table2", "test_view1");
+
+            // Filter by type TABLE only
+            rs =
+                    metaData.getTables(
+                            "default_catalog", "default_database", null, new String[] {"TABLE"});
+            List<String> tableOnly = resultSetToListAndClose(rs);
+            for (String row : tableOnly) {
+                assertThat(row).contains("TABLE");
+            }
+            Set<String> tableOnlyNames = new HashSet<>();
+            for (String row : tableOnly) {
+                tableOnlyNames.add(row.split(",")[2]);
+            }
+            assertThat(tableOnlyNames).contains("test_table1", "test_table2");
+            assertThat(tableOnlyNames).doesNotContain("test_view1");
+
+            // Filter by name pattern
+            rs = metaData.getTables("default_catalog", "default_database", "test_table%", null);
+            List<String> patternResults = resultSetToListAndClose(rs);
+            for (String row : patternResults) {
+                assertThat(row.split(",")[2]).startsWith("test_table");
+            }
+        }
+    }
+
+    @Test
+    public void testGetColumns() throws Exception {
+        DriverUri driverUri = getDriverUri();
+        try (FlinkConnection connection = new FlinkConnection(driverUri)) {
+            Executor executor = connection.getExecutor();
+            executeDDL(
+                    "CREATE TABLE col_test (id INT NOT NULL, name STRING, score DOUBLE) WITH ('connector' = 'datagen')",
+                    executor);
+
+            DatabaseMetaData metaData =
+                    new FlinkDatabaseMetaData(
+                            driverUri.getURL(), connection, new TestingStatement());
+
+            ResultSet rs =
+                    metaData.getColumns("default_catalog", "default_database", "col_test", null);
+
+            // Verify column count and names using COLUMN_NAME (column 4)
+            List<String> columnNames = new ArrayList<>();
+            while (rs.next()) {
+                columnNames.add(rs.getString("COLUMN_NAME"));
+            }
+            rs.close();
+            assertThat(columnNames).containsExactly("id", "name", "score");
+
+            // Filter by column name pattern
+            rs = metaData.getColumns("default_catalog", "default_database", "col_test", "na%");
+            List<String> filtered = new ArrayList<>();
+            while (rs.next()) {
+                filtered.add(rs.getString("COLUMN_NAME"));
+            }
+            rs.close();
+            assertThat(filtered).containsExactly("name");
+        }
+    }
+
+    @Test
+    public void testGetTableTypes() throws Exception {
+        DriverUri driverUri = getDriverUri();
+        try (FlinkConnection connection = new FlinkConnection(driverUri)) {
+            DatabaseMetaData metaData =
+                    new FlinkDatabaseMetaData(
+                            driverUri.getURL(), connection, new TestingStatement());
+
+            List<String> types = resultSetToListAndClose(metaData.getTableTypes());
+            assertThat(types).containsExactly("TABLE", "VIEW");
+        }
+    }
+
+    @Test
+    public void testGetPrimaryKeys() throws Exception {
+        DriverUri driverUri = getDriverUri();
+        try (FlinkConnection connection = new FlinkConnection(driverUri)) {
+            Executor executor = connection.getExecutor();
+            executeDDL(
+                    "CREATE TABLE pk_test (id INT NOT NULL, name STRING, PRIMARY KEY (id) NOT ENFORCED) WITH ('connector' = 'datagen')",
+                    executor);
+
+            DatabaseMetaData metaData =
+                    new FlinkDatabaseMetaData(
+                            driverUri.getURL(), connection, new TestingStatement());
+
+            // getPrimaryKeys uses SELECT * LIMIT 0 which may not preserve PK info
+            // in the result schema, so we verify at least it does not throw
+            ResultSet rs =
+                    metaData.getPrimaryKeys("default_catalog", "default_database", "pk_test");
+            List<String> pkColumns = new ArrayList<>();
+            while (rs.next()) {
+                pkColumns.add(rs.getString("COLUMN_NAME"));
+            }
+            rs.close();
+            // PK info may or may not be available depending on the catalog implementation
+            assertThat(rs.getMetaData().getColumnCount()).isEqualTo(6);
         }
     }
 


### PR DESCRIPTION
The most of codes/descriptions are made by claude

## DatabaseMetaData
- getTables(catalog, schemaPattern, tableNamePattern, types) — Lists tables and views across catalogs/schemas using SHOW TABLES and SHOW VIEWS SQL statements. Supports filtering by table name pattern (SQL % and _ wildcards) and table type (TABLE, VIEW).
- getColumns(catalog, schemaPattern, tableNamePattern, columnNamePattern) — Retrieves column metadata (name, JDBC type, nullability, ordinal position) by executing SELECT * FROM <table> LIMIT 0 and inspecting the ResolvedSchema. Maps Flink logical types to JDBC java.sql.Types constants.
- getSchemas(catalog, schemaPattern) — Previously threw UnsupportedOperationException. Now properly implemented with catalog and schema pattern filtering via SHOW DATABASES IN <catalog>. The no-arg getSchemas() is refactored to delegate to this method.
- getPrimaryKeys(catalog, schema, table) — Returns primary key information from the table's ResolvedSchema when available.
- getTableTypes() — Returns the supported table types: TABLE and VIEW.

## FlinkResultSet
  - ROW type — Converted to Map<String, Object> preserving field names and values.
  - ARRAY type — Converted to List<Object> with proper element type conversion.