### PR TITLE
[FLINK-34022][core] Fix ArithmeticException in TimeUtils.formatWithHighestUnit for large Duration values

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/util/TimeUtilsPrettyPrintingTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/TimeUtilsPrettyPrintingTest.java
@@ -43,7 +43,11 @@ class TimeUtilsPrettyPrintingTest {
                 Arguments.of(Duration.ofHours(23), "23 h"),
                 Arguments.of(Duration.ofMillis(-1), "-1 ms"),
                 Arguments.of(Duration.ofMillis(TimeUnit.DAYS.toMillis(1)), "1 d"),
-                Arguments.of(Duration.ofHours(24), "1 d"));
+                Arguments.of(Duration.ofHours(24), "1 d"),
+                Arguments.of(Duration.ofMillis(Long.MAX_VALUE), "9223372036854775807 ms"),
+                Arguments.of(
+                        Duration.ofMillis(Long.MAX_VALUE).plusNanos(1),
+                        "9223372036854775807000001 ns"));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## What is the purpose of the change

Backport of FLINK-35820 to release-1.20.

`TimeUtils.formatWithHighestUnit()` internally called `Duration.toNanos()` which throws an `ArithmeticException` when the nanosecond value overflows a `long` (e.g. `Duration.ofMillis(Long.MAX_VALUE)`).

## Brief change log
- Convert internal nanosecond computation from `long`  to `BigInteger` to avoid arithmetic overflow
- Add test cases in `TimeUtilsPrettyPrintingTest` covering `Long.MAX_VALUE` ms  and values beyond `long` range

## Verifying this change
 - New parameterized test cases added to `TimeUtilsPrettyPrintingTest`
