### PR TITLE
[FLINK-39396][table] Simplify early return condition in SqlLikeChainC…

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/LikeFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/LikeFunctionITCase.java
@@ -148,8 +148,22 @@ class LikeFunctionITCase extends BuiltInFunctionTestBase {
                                 DataTypes.STRING(),
                                 DataTypes.STRING())
                         // Empty strings in pattern or escape
-                        .testSqlResult("f0 LIKE 'test\"end' ESCAPE ''", false, DataTypes.BOOLEAN())
                         .testSqlResult("f0 LIKE '' ESCAPE ''", false, DataTypes.BOOLEAN())
+                        .testSqlResult("f0 LIKE '' ESCAPE '!'", false, DataTypes.BOOLEAN())
+                        .testSqlResult("f0 LIKE 'test\"end' ESCAPE ''", false, DataTypes.BOOLEAN())
+                        // Escaped _ in quick path: startsWith (BEGIN_PATTERN)
+                        .testSqlResult("f2 LIKE 'te!_%' ESCAPE '!'", true, DataTypes.BOOLEAN())
+                        .testSqlResult("f0 LIKE 'te!_%' ESCAPE '!'", false, DataTypes.BOOLEAN())
+
+                        // Escaped _ in quick path: endsWith (END_PATTERN)
+                        .testSqlResult("f2 LIKE '%!_st' ESCAPE '!'", true, DataTypes.BOOLEAN())
+
+                        // Escaped _ in quick path: contains (MIDDLE_PATTERN)
+                        .testSqlResult("f2 LIKE '%!_s%' ESCAPE '!'", true, DataTypes.BOOLEAN())
+
+                        // Escaped _ in quick path: multi-segment (ChainChecker)
+                        .testSqlResult("f2 LIKE 'te!_%st' ESCAPE '!'", true, DataTypes.BOOLEAN())
+                        .testSqlResult("f0 LIKE 'te!_%st' ESCAPE '!'", false, DataTypes.BOOLEAN())
                         // Escaping with emoji
                         .testSqlResult("f0 LIKE 'test' ESCAPE '✅'", true, DataTypes.BOOLEAN())
                         .testSqlResult("f1 LIKE 'test✅%' ESCAPE '✅'", true, DataTypes.BOOLEAN())

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlLikeChainChecker.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlLikeChainChecker.java
@@ -45,15 +45,13 @@ public class SqlLikeChainChecker {
     private final int[] midLens;
     private final int beginLen;
     private final int endLen;
-    private final boolean leftAnchor;
-    private final boolean rightAnchor;
-    private final boolean emptyPattern;
+    private final boolean isEmptyPattern;
 
     public SqlLikeChainChecker(String pattern) {
         final StringTokenizer tokens = new StringTokenizer(pattern, "%");
-        leftAnchor = !pattern.startsWith("%");
-        rightAnchor = !pattern.endsWith("%");
-        emptyPattern = pattern.isEmpty();
+        boolean leftAnchor = !pattern.startsWith("%");
+        boolean rightAnchor = !pattern.endsWith("%");
+        isEmptyPattern = pattern.isEmpty();
         int len = 0;
         // at least 2 checkers always
         BinaryStringData leftPattern = null;
@@ -65,7 +63,7 @@ public class SqlLikeChainChecker {
 
         for (int i = 0; tokens.hasMoreTokens(); i++) {
             String chunk = tokens.nextToken();
-            if (chunk.length() == 0) {
+            if (chunk.isEmpty()) {
                 // %% is folded in the .*?.*? regex usually into .*?
                 continue;
             }
@@ -100,7 +98,7 @@ public class SqlLikeChainChecker {
         // Returns false early if either:
         // the input is too short to match the pattern, or
         // the pattern is empty but the input is not.
-        if (mark < minLen || mark > 0 && emptyPattern) {
+        if (mark < minLen || mark > 0 && isEmptyPattern) {
             return false;
         }
         // prefix, extend start

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlLikeChainChecker.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlLikeChainChecker.java
@@ -47,11 +47,13 @@ public class SqlLikeChainChecker {
     private final int endLen;
     private final boolean leftAnchor;
     private final boolean rightAnchor;
+    private final boolean emptyPattern;
 
     public SqlLikeChainChecker(String pattern) {
         final StringTokenizer tokens = new StringTokenizer(pattern, "%");
         leftAnchor = !pattern.startsWith("%");
         rightAnchor = !pattern.endsWith("%");
+        emptyPattern = pattern.isEmpty();
         int len = 0;
         // at least 2 checkers always
         BinaryStringData leftPattern = null;
@@ -97,13 +99,8 @@ public class SqlLikeChainChecker {
         int mark = str.getSizeInBytes();
         // Returns false early if either:
         // the input is too short to match the pattern, or
-        // the pattern is empty (or anchored with no literals) but the input is not empty.
-        if (mark < minLen
-                || beginPattern == null
-                        && endPattern == null
-                        && middlePatterns.length == 0
-                        && mark > 0
-                        && (leftAnchor || rightAnchor)) {
+        // the pattern is empty but the input is not.
+        if (mark < minLen || mark > 0 && emptyPattern) {
             return false;
         }
         // prefix, extend start


### PR DESCRIPTION


## What is the purpose of the change

Simplify the early return condition in `SqlLikeChainChecker.check()` by replacing a complex 7-line compound expression with a single `emptyPattern` boolean flag, improving readability without changing semantics.

## Brief change log

  - Added `emptyPattern` field to `SqlLikeChainChecker` and simplified the early return condition to `mark < minLen || mark > 0 && emptyPattern`
  - Added test cases for escaped `_` going through all quick path branches in `LikeFunctionITCase`

## Verifying this change

This change is already covered by existing tests in `LikeFunctionITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable