### PR TITLE
[FLINK-39404][runtime] HardwareDescription reports incorrect CPU cores in containerized environments with fractional CPU limits

### DIFF
--- a/docs/layouts/shortcodes/generated/rest_v1_dispatcher.html
+++ b/docs/layouts/shortcodes/generated/rest_v1_dispatcher.html
@@ -5851,7 +5851,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
             "id" : "urn:jsonschema:org:apache:flink:runtime:instance:HardwareDescription",
             "properties" : {
               "cpuCores" : {
-                "type" : "integer"
+                "type" : "number"
               },
               "freeMemory" : {
                 "type" : "integer"
@@ -6078,7 +6078,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
       "id" : "urn:jsonschema:org:apache:flink:runtime:instance:HardwareDescription",
       "properties" : {
         "cpuCores" : {
-          "type" : "integer"
+          "type" : "number"
         },
         "freeMemory" : {
           "type" : "integer"

--- a/docs/static/generated/rest_v1_dispatcher.yml
+++ b/docs/static/generated/rest_v1_dispatcher.yml
@@ -2346,8 +2346,8 @@ components:
       type: object
       properties:
         cpuCores:
-          type: integer
-          format: int32
+          type: number
+          format: double
         freeMemory:
           type: integer
           format: int64

--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -4363,7 +4363,7 @@
                 "id" : "urn:jsonschema:org:apache:flink:runtime:instance:HardwareDescription",
                 "properties" : {
                   "cpuCores" : {
-                    "type" : "integer"
+                    "type" : "number"
                   },
                   "physicalMemory" : {
                     "type" : "integer"
@@ -4528,7 +4528,7 @@
           "id" : "urn:jsonschema:org:apache:flink:runtime:instance:HardwareDescription",
           "properties" : {
             "cpuCores" : {
-              "type" : "integer"
+              "type" : "number"
             },
             "physicalMemory" : {
               "type" : "integer"

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypointUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypointUtils.java
@@ -115,7 +115,7 @@ public final class ClusterEntrypointUtils {
         final int poolSize =
                 config.get(
                         ClusterOptions.CLUSTER_IO_EXECUTOR_POOL_SIZE,
-                        4 * Hardware.getNumberCPUCores());
+                        (int) Math.ceil(4 * Hardware.getNumberCPUCoresAsDouble()));
         Preconditions.checkArgument(
                 poolSize > 0,
                 "Illegal pool size (%s) of io-executor, please re-configure '%s'.",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/HardwareDescription.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/HardwareDescription.java
@@ -41,7 +41,7 @@ public final class HardwareDescription implements Serializable {
 
     /** The number of CPU cores available to the JVM on the compute node. */
     @JsonProperty(FIELD_NAME_CPU_CORES)
-    private final int numberOfCPUCores;
+    private final double numberOfCPUCores;
 
     /** The size of physical memory in bytes available on the compute node. */
     @JsonProperty(FIELD_NAME_SIZE_PHYSICAL_MEMORY)
@@ -67,7 +67,7 @@ public final class HardwareDescription implements Serializable {
      */
     @JsonCreator
     public HardwareDescription(
-            @JsonProperty(FIELD_NAME_CPU_CORES) int numberOfCPUCores,
+            @JsonProperty(FIELD_NAME_CPU_CORES) double numberOfCPUCores,
             @JsonProperty(FIELD_NAME_SIZE_PHYSICAL_MEMORY) long sizeOfPhysicalMemory,
             @JsonProperty(FIELD_NAME_SIZE_JVM_HEAP) long sizeOfJvmHeap,
             @JsonProperty(FIELD_NAME_SIZE_MANAGED_MEMORY) long sizeOfManagedMemory) {
@@ -82,7 +82,7 @@ public final class HardwareDescription implements Serializable {
      *
      * @return the number of CPU cores available to the JVM on the compute node
      */
-    public int getNumberOfCPUCores() {
+    public double getNumberOfCPUCores() {
         return this.numberOfCPUCores;
     }
 
@@ -126,7 +126,7 @@ public final class HardwareDescription implements Serializable {
             return false;
         }
         HardwareDescription that = (HardwareDescription) o;
-        return numberOfCPUCores == that.numberOfCPUCores
+        return Double.compare(numberOfCPUCores, that.numberOfCPUCores) == 0
                 && sizeOfPhysicalMemory == that.sizeOfPhysicalMemory
                 && sizeOfJvmHeap == that.sizeOfJvmHeap
                 && sizeOfManagedMemory == that.sizeOfManagedMemory;
@@ -141,7 +141,7 @@ public final class HardwareDescription implements Serializable {
     @Override
     public String toString() {
         return String.format(
-                "cores=%d, physMem=%d, heap=%d, managed=%d",
+                "cores=%s, physMem=%d, heap=%d, managed=%d",
                 numberOfCPUCores, sizeOfPhysicalMemory, sizeOfJvmHeap, sizeOfManagedMemory);
     }
 
@@ -150,7 +150,7 @@ public final class HardwareDescription implements Serializable {
     // --------------------------------------------------------------------------------------------
 
     public static HardwareDescription extractFromSystem(long managedMemory) {
-        final int numberOfCPUCores = Hardware.getNumberCPUCores();
+        final double numberOfCPUCores = Hardware.getNumberCPUCoresAsDouble();
         final long sizeOfJvmHeap = Runtime.getRuntime().maxMemory();
         final long sizeOfPhysicalMemory = Hardware.getSizeOfPhysicalMemory();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/HardwareDescription.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/HardwareDescription.java
@@ -141,7 +141,7 @@ public final class HardwareDescription implements Serializable {
     @Override
     public String toString() {
         return String.format(
-                "cores=%s, physMem=%d, heap=%d, managed=%d",
+                "cores=%.2f, physMem=%d, heap=%d, managed=%d",
                 numberOfCPUCores, sizeOfPhysicalMemory, sizeOfJvmHeap, sizeOfManagedMemory);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/Hardware.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/Hardware.java
@@ -32,6 +32,9 @@ import java.lang.management.OperatingSystemMXBean;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -45,6 +48,11 @@ public class Hardware {
     private static final Pattern LINUX_MEMORY_REGEX =
             Pattern.compile("^MemTotal:\\s*(\\d+)\\s+kB$");
 
+    private static final String CGROUP_V2_CPU_MAX_PATH = "/sys/fs/cgroup/cpu.max";
+
+    private static final String CGROUP_V1_CPU_QUOTA_PATH = "/sys/fs/cgroup/cpu/cpu.cfs_quota_us";
+    private static final String CGROUP_V1_CPU_PERIOD_PATH = "/sys/fs/cgroup/cpu/cpu.cfs_period_us";
+
     // ------------------------------------------------------------------------
 
     /**
@@ -54,6 +62,168 @@ public class Hardware {
      */
     public static int getNumberCPUCores() {
         return Runtime.getRuntime().availableProcessors();
+    }
+
+    /**
+     * Gets the number of CPU cores available to the JVM as a fractional value.
+     *
+     * <p>On Linux, this method first attempts to detect a container CPU limit via cgroup files (v2,
+     * then v1). If a limit is found, it is returned as-is (e.g. 0.5, 1.5). If no container limit is
+     * detected, it falls back to {@link Runtime#availableProcessors()}.
+     *
+     * <p>Use this method when the fractional value matters, for example when displaying the CPU
+     * count in the Web UI or when performing arithmetic before rounding (e.g. {@code 4 * cores}).
+     * For call sites that need an integer (e.g. thread pool sizes), use {@link
+     * #getNumberCPUCores()} instead.
+     *
+     * @return The number of CPU cores as a double.
+     */
+    public static double getNumberCPUCoresAsDouble() {
+        double containerLimit = getContainerCpuLimit();
+        if (containerLimit > 0) {
+            LOG.debug("Using container CPU limit for core count: limit={}", containerLimit);
+            return containerLimit;
+        }
+        return Runtime.getRuntime().availableProcessors();
+    }
+
+    /**
+     * Returns the CPU limit of the container as a fractional double by reading Linux cgroup CPU
+     * quota and period values.
+     *
+     * <p>This method attempts to read the CPU limit from cgroup v2 first ({@code
+     * /sys/fs/cgroup/cpu.max}), then falls back to cgroup v1 ({@code
+     * /sys/fs/cgroup/cpu/cpu.cfs_quota_us} and {@code cpu.cfs_period_us}).
+     *
+     * <p>Examples of return values:
+     *
+     * <ul>
+     *   <li>{@code 0.5} - container limited to half a CPU core
+     *   <li>{@code 2.0} - container limited to 2 CPU cores
+     *   <li>{@code -1} - not running in a container, no CPU limit set, or unable to read cgroup
+     *       files (e.g. non-Linux OS)
+     * </ul>
+     *
+     * @return the container CPU limit as a fractional double, or {@code -1} if no limit is detected
+     */
+    public static double getContainerCpuLimit() {
+        // Try cgroup v2 first
+        double limit = getCpuLimitFromCgroupV2();
+        if (limit > 0) {
+            return limit;
+        }
+
+        // Fall back to cgroup v1
+        limit = getCpuLimitFromCgroupV1();
+        if (limit > 0) {
+            return limit;
+        }
+
+        LOG.debug(
+                "Could not detect container CPU limit from cgroup files. "
+                        + "This is expected when not running inside a container or when no CPU limit is set.");
+        return -1;
+    }
+
+    /**
+     * Reads CPU limit from cgroup v2.
+     *
+     * <p>The file {@code /sys/fs/cgroup/cpu.max} contains two space-separated values: {@code quota
+     * period}. For example, {@code "50000 100000"} means a limit of 0.5 CPU cores. The string
+     * {@code "max"} as the quota means no limit is set.
+     *
+     * @return the CPU limit as a double, or {@code -1} if unavailable or unlimited
+     */
+    private static double getCpuLimitFromCgroupV2() {
+        try {
+            Path path = Paths.get(CGROUP_V2_CPU_MAX_PATH);
+            if (!Files.exists(path)) {
+                return -1;
+            }
+
+            String content = Files.readString(path).trim();
+            String[] parts = content.split("\\s+");
+            if (parts.length != 2) {
+                LOG.debug(
+                        "Unexpected format in {}: '{}'. Expected 'quota period'.",
+                        CGROUP_V2_CPU_MAX_PATH,
+                        content);
+                return -1;
+            }
+
+            // "max" means no CPU limit is set
+            if ("max".equals(parts[0])) {
+                LOG.debug("No CPU limit set (cgroup v2 quota is 'max').");
+                return -1;
+            }
+
+            long quota = Long.parseLong(parts[0]);
+            long period = Long.parseLong(parts[1]);
+            if (quota > 0 && period > 0) {
+                double cpuLimit = (double) quota / period;
+                LOG.debug(
+                        "Detected cgroup v2 CPU limit: quota={}, period={}, limit={}",
+                        quota,
+                        period,
+                        cpuLimit);
+                return cpuLimit;
+            }
+        } catch (NumberFormatException e) {
+            LOG.debug("Failed to parse cgroup v2 CPU limit values.", e);
+        } catch (IOException e) {
+            LOG.debug("Could not read cgroup v2 CPU limit file: {}", CGROUP_V2_CPU_MAX_PATH, e);
+        } catch (Throwable t) {
+            LOG.debug("Unexpected error reading cgroup v2 CPU limit.", t);
+        }
+        return -1;
+    }
+
+    /**
+     * Reads CPU limit from cgroup v1.
+     *
+     * <p>The quota is read from {@code /sys/fs/cgroup/cpu/cpu.cfs_quota_us} and the period from
+     * {@code /sys/fs/cgroup/cpu/cpu.cfs_period_us}. Both values are in microseconds. A quota of
+     * {@code -1} means no limit is set. The CPU limit is computed as {@code quota / period}.
+     *
+     * @return the CPU limit as a double, or {@code -1} if unavailable or unlimited
+     */
+    private static double getCpuLimitFromCgroupV1() {
+        try {
+            Path quotaPath = Paths.get(CGROUP_V1_CPU_QUOTA_PATH);
+            Path periodPath = Paths.get(CGROUP_V1_CPU_PERIOD_PATH);
+            if (!Files.exists(quotaPath) || !Files.exists(periodPath)) {
+                return -1;
+            }
+
+            long quota = Long.parseLong(Files.readString(quotaPath).trim());
+            long period = Long.parseLong(Files.readString(periodPath).trim());
+
+            // quota == -1 means no CPU limit is set in cgroup v1
+            if (quota <= 0) {
+                LOG.debug("No CPU limit set (cgroup v1 quota={}).", quota);
+                return -1;
+            }
+
+            if (period <= 0) {
+                LOG.debug("Invalid cgroup v1 CPU period: {}", period);
+                return -1;
+            }
+
+            double cpuLimit = (double) quota / period;
+            LOG.debug(
+                    "Detected cgroup v1 CPU limit: quota={}, period={}, limit={}",
+                    quota,
+                    period,
+                    cpuLimit);
+            return cpuLimit;
+        } catch (NumberFormatException e) {
+            LOG.debug("Failed to parse cgroup v1 CPU limit values.", e);
+        } catch (IOException e) {
+            LOG.debug("Could not read cgroup v1 CPU limit files.", e);
+        } catch (Throwable t) {
+            LOG.debug("Unexpected error reading cgroup v1 CPU limit.", t);
+        }
+        return -1;
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/Hardware.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/Hardware.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.util;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.util.OperatingSystem;
 
 import org.slf4j.Logger;
@@ -53,10 +54,18 @@ public class Hardware {
     private static final String CGROUP_V1_CPU_QUOTA_PATH = "/sys/fs/cgroup/cpu/cpu.cfs_quota_us";
     private static final String CGROUP_V1_CPU_PERIOD_PATH = "/sys/fs/cgroup/cpu/cpu.cfs_period_us";
 
+    /** Sentinel value used by cgroup v2 in {@code cpu.max} to indicate an unlimited CPU quota. */
+    static final String CGROUP_V2_UNLIMITED = "max";
+
     // ------------------------------------------------------------------------
 
     /**
      * Gets the number of CPU cores (hardware contexts) that the JVM has access to.
+     *
+     * <p>This always returns an integer and is intended for call sites that need an {@code int}
+     * (e.g. thread-pool sizes). When the fractional value matters (e.g. for display purposes or
+     * when performing arithmetic before rounding), use {@link #getNumberCPUCoresAsDouble()}
+     * instead.
      *
      * @return The number of CPU cores.
      */
@@ -93,7 +102,9 @@ public class Hardware {
      *
      * <p>This method attempts to read the CPU limit from cgroup v2 first ({@code
      * /sys/fs/cgroup/cpu.max}), then falls back to cgroup v1 ({@code
-     * /sys/fs/cgroup/cpu/cpu.cfs_quota_us} and {@code cpu.cfs_period_us}).
+     * /sys/fs/cgroup/cpu/cpu.cfs_quota_us} and {@code cpu.cfs_period_us}). The v1 fallback also
+     * covers cgroup v2 <em>hybrid</em> mode, where the {@code cpu} controller typically remains
+     * mounted under the v1 hierarchy.
      *
      * <p>Examples of return values:
      *
@@ -108,13 +119,15 @@ public class Hardware {
      */
     public static double getContainerCpuLimit() {
         // Try cgroup v2 first
-        double limit = getCpuLimitFromCgroupV2();
+        double limit = getCpuLimitFromCgroupV2(Paths.get(CGROUP_V2_CPU_MAX_PATH));
         if (limit > 0) {
             return limit;
         }
 
-        // Fall back to cgroup v1
-        limit = getCpuLimitFromCgroupV1();
+        // Fall back to cgroup v1 (also covers v2 hybrid mode)
+        limit =
+                getCpuLimitFromCgroupV1(
+                        Paths.get(CGROUP_V1_CPU_QUOTA_PATH), Paths.get(CGROUP_V1_CPU_PERIOD_PATH));
         if (limit > 0) {
             return limit;
         }
@@ -132,28 +145,29 @@ public class Hardware {
      * period}. For example, {@code "50000 100000"} means a limit of 0.5 CPU cores. The string
      * {@code "max"} as the quota means no limit is set.
      *
+     * @param cpuMaxPath path to the cgroup v2 {@code cpu.max} file
      * @return the CPU limit as a double, or {@code -1} if unavailable or unlimited
      */
-    private static double getCpuLimitFromCgroupV2() {
+    @VisibleForTesting
+    static double getCpuLimitFromCgroupV2(Path cpuMaxPath) {
         try {
-            Path path = Paths.get(CGROUP_V2_CPU_MAX_PATH);
-            if (!Files.exists(path)) {
+            if (!Files.exists(cpuMaxPath)) {
                 return -1;
             }
 
-            String content = Files.readString(path).trim();
+            String content = Files.readString(cpuMaxPath).trim();
             String[] parts = content.split("\\s+");
             if (parts.length != 2) {
                 LOG.debug(
                         "Unexpected format in {}: '{}'. Expected 'quota period'.",
-                        CGROUP_V2_CPU_MAX_PATH,
+                        cpuMaxPath,
                         content);
                 return -1;
             }
 
             // "max" means no CPU limit is set
-            if ("max".equals(parts[0])) {
-                LOG.debug("No CPU limit set (cgroup v2 quota is 'max').");
+            if (CGROUP_V2_UNLIMITED.equals(parts[0])) {
+                LOG.debug("No CPU limit set (cgroup v2 quota is '{}').", CGROUP_V2_UNLIMITED);
                 return -1;
             }
 
@@ -171,7 +185,7 @@ public class Hardware {
         } catch (NumberFormatException e) {
             LOG.debug("Failed to parse cgroup v2 CPU limit values.", e);
         } catch (IOException e) {
-            LOG.debug("Could not read cgroup v2 CPU limit file: {}", CGROUP_V2_CPU_MAX_PATH, e);
+            LOG.debug("Could not read cgroup v2 CPU limit file: {}", cpuMaxPath, e);
         } catch (Throwable t) {
             LOG.debug("Unexpected error reading cgroup v2 CPU limit.", t);
         }
@@ -185,12 +199,13 @@ public class Hardware {
      * {@code /sys/fs/cgroup/cpu/cpu.cfs_period_us}. Both values are in microseconds. A quota of
      * {@code -1} means no limit is set. The CPU limit is computed as {@code quota / period}.
      *
+     * @param quotaPath path to the cgroup v1 {@code cpu.cfs_quota_us} file
+     * @param periodPath path to the cgroup v1 {@code cpu.cfs_period_us} file
      * @return the CPU limit as a double, or {@code -1} if unavailable or unlimited
      */
-    private static double getCpuLimitFromCgroupV1() {
+    @VisibleForTesting
+    static double getCpuLimitFromCgroupV1(Path quotaPath, Path periodPath) {
         try {
-            Path quotaPath = Paths.get(CGROUP_V1_CPU_QUOTA_PATH);
-            Path periodPath = Paths.get(CGROUP_V1_CPU_PERIOD_PATH);
             if (!Files.exists(quotaPath) || !Files.exists(periodPath)) {
                 return -1;
             }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/HardwareTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/HardwareTest.java
@@ -19,9 +19,15 @@
 package org.apache.flink.runtime.util;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.within;
 
 class HardwareTest {
 
@@ -36,6 +42,11 @@ class HardwareTest {
     }
 
     @Test
+    void testCpuCoresAsDoubleIsPositive() {
+        assertThat(Hardware.getNumberCPUCoresAsDouble()).isGreaterThan(0.0);
+    }
+
+    @Test
     void testPhysicalMemory() {
         try {
             long physMem = Hardware.getSizeOfPhysicalMemory();
@@ -44,5 +55,116 @@ class HardwareTest {
             e.printStackTrace();
             fail(e.getMessage());
         }
+    }
+
+    @Test
+    void testCgroupV2FractionalLimit(@TempDir Path tempDir) throws IOException {
+        Path cpuMax = writeFile(tempDir.resolve("cpu.max"), "50000 100000");
+        assertThat(Hardware.getCpuLimitFromCgroupV2(cpuMax)).isEqualTo(0.5);
+    }
+
+    @Test
+    void testCgroupV2SubCoreLimit(@TempDir Path tempDir) throws IOException {
+        Path cpuMax = writeFile(tempDir.resolve("cpu.max"), "30000 100000");
+        assertThat(Hardware.getCpuLimitFromCgroupV2(cpuMax)).isEqualTo(0.3);
+    }
+
+    @Test
+    void testCgroupV2RepeatingFractionalLimit(@TempDir Path tempDir) throws IOException {
+        // 33333 / 100000 = 0.33333 (one third, truncated at microsecond granularity)
+        Path cpuMax = writeFile(tempDir.resolve("cpu.max"), "33333 100000");
+        assertThat(Hardware.getCpuLimitFromCgroupV2(cpuMax)).isCloseTo(1.0 / 3.0, within(1.0e-4));
+    }
+
+    @Test
+    void testCgroupV2IntegerLimit(@TempDir Path tempDir) throws IOException {
+        Path cpuMax = writeFile(tempDir.resolve("cpu.max"), "200000 100000");
+        assertThat(Hardware.getCpuLimitFromCgroupV2(cpuMax)).isEqualTo(2.0);
+    }
+
+    @Test
+    void testCgroupV2Unlimited(@TempDir Path tempDir) throws IOException {
+        Path cpuMax = writeFile(tempDir.resolve("cpu.max"), "max 100000");
+        assertThat(Hardware.getCpuLimitFromCgroupV2(cpuMax)).isEqualTo(-1.0);
+    }
+
+    @Test
+    void testCgroupV2MissingFile(@TempDir Path tempDir) {
+        assertThat(Hardware.getCpuLimitFromCgroupV2(tempDir.resolve("does_not_exist")))
+                .isEqualTo(-1.0);
+    }
+
+    @Test
+    void testCgroupV2MalformedContent(@TempDir Path tempDir) throws IOException {
+        Path cpuMax = writeFile(tempDir.resolve("cpu.max"), "garbage");
+        assertThat(Hardware.getCpuLimitFromCgroupV2(cpuMax)).isEqualTo(-1.0);
+    }
+
+    @Test
+    void testCgroupV2NonNumericValues(@TempDir Path tempDir) throws IOException {
+        Path cpuMax = writeFile(tempDir.resolve("cpu.max"), "abc def");
+        assertThat(Hardware.getCpuLimitFromCgroupV2(cpuMax)).isEqualTo(-1.0);
+    }
+
+    @Test
+    void testCgroupV2ZeroPeriod(@TempDir Path tempDir) throws IOException {
+        Path cpuMax = writeFile(tempDir.resolve("cpu.max"), "50000 0");
+        assertThat(Hardware.getCpuLimitFromCgroupV2(cpuMax)).isEqualTo(-1.0);
+    }
+
+    @Test
+    void testCgroupV1FractionalLimit(@TempDir Path tempDir) throws IOException {
+        Path quota = writeFile(tempDir.resolve("cpu.cfs_quota_us"), "50000");
+        Path period = writeFile(tempDir.resolve("cpu.cfs_period_us"), "100000");
+        assertThat(Hardware.getCpuLimitFromCgroupV1(quota, period)).isEqualTo(0.5);
+    }
+
+    @Test
+    void testCgroupV1OneThirdCpuLimit(@TempDir Path tempDir) throws IOException {
+        Path quota = writeFile(tempDir.resolve("cpu.cfs_quota_us"), "33333");
+        Path period = writeFile(tempDir.resolve("cpu.cfs_period_us"), "100000");
+        assertThat(Hardware.getCpuLimitFromCgroupV1(quota, period)).isEqualTo(0.33333);
+        assertThat(Hardware.getCpuLimitFromCgroupV1(quota, period))
+                .isCloseTo(1.0 / 3.0, within(1.0e-4));
+    }
+
+    @Test
+    void testCgroupV1IntegerLimit(@TempDir Path tempDir) throws IOException {
+        Path quota = writeFile(tempDir.resolve("cpu.cfs_quota_us"), "150000");
+        Path period = writeFile(tempDir.resolve("cpu.cfs_period_us"), "100000");
+        assertThat(Hardware.getCpuLimitFromCgroupV1(quota, period)).isEqualTo(1.5);
+    }
+
+    @Test
+    void testCgroupV1Unlimited(@TempDir Path tempDir) throws IOException {
+        Path quota = writeFile(tempDir.resolve("cpu.cfs_quota_us"), "-1");
+        Path period = writeFile(tempDir.resolve("cpu.cfs_period_us"), "100000");
+        assertThat(Hardware.getCpuLimitFromCgroupV1(quota, period)).isEqualTo(-1.0);
+    }
+
+    @Test
+    void testCgroupV1ZeroPeriod(@TempDir Path tempDir) throws IOException {
+        Path quota = writeFile(tempDir.resolve("cpu.cfs_quota_us"), "50000");
+        Path period = writeFile(tempDir.resolve("cpu.cfs_period_us"), "0");
+        assertThat(Hardware.getCpuLimitFromCgroupV1(quota, period)).isEqualTo(-1.0);
+    }
+
+    @Test
+    void testCgroupV1MissingFiles(@TempDir Path tempDir) {
+        Path quota = tempDir.resolve("missing_quota");
+        Path period = tempDir.resolve("missing_period");
+        assertThat(Hardware.getCpuLimitFromCgroupV1(quota, period)).isEqualTo(-1.0);
+    }
+
+    @Test
+    void testCgroupV1NonNumericQuota(@TempDir Path tempDir) throws IOException {
+        Path quota = writeFile(tempDir.resolve("cpu.cfs_quota_us"), "not-a-number");
+        Path period = writeFile(tempDir.resolve("cpu.cfs_period_us"), "100000");
+        assertThat(Hardware.getCpuLimitFromCgroupV1(quota, period)).isEqualTo(-1.0);
+    }
+
+    private static Path writeFile(Path path, String content) throws IOException {
+        Files.writeString(path, content);
+        return path;
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This PR fixes inaccurate CPU core reporting in containerized environments (Kubernetes, YARN) where fractional CPU limits are used (e.g. 0.5 cores).

Currently, `Hardware.getNumberCPUCores()` relies on `Runtime.getRuntime().availableProcessors()`, which returns an `int`, ceiling-rounding fractional container CPU limits (0.5 → 1). This causes:

1. **Misleading Web UI**: The Task Manager pages display "1 CPU core" when only 0.5 is allocated.
2. **Thread pool over-provisioning**: `ClusterEntrypointUtils` computes `4 * ceil(0.5) = 4` threads instead of `ceil(4 * 0.5) = 2`.


## Brief change log

- **`Hardware.java`**:
  - Added `getContainerCpuLimit()` - reads the actual container CPU limit from Linux cgroup files (v2: `/sys/fs/cgroup/cpu.max`, v1: `cpu.cfs_quota_us` / `cpu.cfs_period_us`). Returns the fractional value (e.g. 0.5) or -1 if not in a container / no limit set.
  - Added `getNumberCPUCoresAsDouble()` - returns the fractional CPU core count (container limit with fallback to `availableProcessors()`). Use this when fractional precision matters (display, arithmetic before rounding).

- **`HardwareDescription.java`**:
  - Changed `numberOfCPUCores` from `int` to `double` (field, constructor, getter, `equals`, `toString`).
  - `extractFromSystem()` now uses `Hardware.getNumberCPUCoresAsDouble()`.
  - The REST API JSON field `cpuCores` now emits fractional values (e.g. `0.5` instead of `1`).

- **`ClusterEntrypointUtils.java`**:
  - Changed `4 * Hardware.getNumberCPUCores()` to `(int) Math.ceil(4 * Hardware.getNumberCPUCoresAsDouble())` so the multiplication happens before ceiling, avoiding thread over-provisioning (0.5 CPU → 2 threads instead of 4).


## Verifying this change

- On a non-container environment (macOS, bare-metal Linux without cgroup limits): `getContainerCpuLimit()` returns -1, `getNumberCPUCores()` falls back to `availableProcessors()`, representing **no behavioral change**.
- On a container with fractional CPU (e.g. Kubernetes with `cpu: 0.5`):
  - `getContainerCpuLimit()` returns `0.5`
  - `getNumberCPUCoresAsDouble()` returns `0.5`
  - `getNumberCPUCores()` returns `1` (ceiling)
  - Web UI displays `0.5` instead of `1`
  - IO executor pool: `ceil(4 * 0.5) = 2` threads instead of `4`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
