### PR TITLE
[FLINK-39422] [REST][docs] Fix OpenAPI spec for `SlotSharingGroupId`, `MetricCollectionResponseBody`, and `SerializedThrowable` custom serializers

### DIFF
--- a/docs/layouts/shortcodes/generated/rest_v1_dispatcher.html
+++ b/docs/layouts/shortcodes/generated/rest_v1_dispatcher.html
@@ -1518,7 +1518,32 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
           <details>
           <summary>Response</summary>
           <pre><code>{
-  "type" : "any"
+  "type" : "array",
+  "items" : {
+    "type" : "object",
+    "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:AggregatedMetric",
+    "properties" : {
+      "avg" : {
+        "type" : "number"
+      },
+      "id" : {
+        "type" : "string",
+        "required" : true
+      },
+      "max" : {
+        "type" : "number"
+      },
+      "min" : {
+        "type" : "number"
+      },
+      "skew" : {
+        "type" : "number"
+      },
+      "sum" : {
+        "type" : "number"
+      }
+    }
+  }
 }</code></pre>
         </label>
       </td>
@@ -5698,7 +5723,32 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
           <details>
           <summary>Response</summary>
           <pre><code>{
-  "type" : "any"
+  "type" : "array",
+  "items" : {
+    "type" : "object",
+    "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:AggregatedMetric",
+    "properties" : {
+      "avg" : {
+        "type" : "number"
+      },
+      "id" : {
+        "type" : "string",
+        "required" : true
+      },
+      "max" : {
+        "type" : "number"
+      },
+      "min" : {
+        "type" : "number"
+      },
+      "skew" : {
+        "type" : "number"
+      },
+      "sum" : {
+        "type" : "number"
+      }
+    }
+  }
 }</code></pre>
         </label>
       </td>
@@ -6785,7 +6835,32 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
           <details>
           <summary>Response</summary>
           <pre><code>{
-  "type" : "any"
+  "type" : "array",
+  "items" : {
+    "type" : "object",
+    "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:AggregatedMetric",
+    "properties" : {
+      "avg" : {
+        "type" : "number"
+      },
+      "id" : {
+        "type" : "string",
+        "required" : true
+      },
+      "max" : {
+        "type" : "number"
+      },
+      "min" : {
+        "type" : "number"
+      },
+      "skew" : {
+        "type" : "number"
+      },
+      "sum" : {
+        "type" : "number"
+      }
+    }
+  }
 }</code></pre>
         </label>
       </td>

--- a/docs/layouts/shortcodes/generated/rest_v1_dispatcher.html
+++ b/docs/layouts/shortcodes/generated/rest_v1_dispatcher.html
@@ -1354,7 +1354,20 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
           <details>
           <summary>Response</summary>
           <pre><code>{
-  "type" : "any"
+  "type" : "array",
+  "items" : {
+    "type" : "object",
+    "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:Metric",
+    "properties" : {
+      "id" : {
+        "type" : "string",
+        "required" : true
+      },
+      "value" : {
+        "type" : "string"
+      }
+    }
+  }
 }</code></pre>
         </label>
       </td>
@@ -3444,7 +3457,20 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
           <details>
           <summary>Response</summary>
           <pre><code>{
-  "type" : "any"
+  "type" : "array",
+  "items" : {
+    "type" : "object",
+    "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:Metric",
+    "properties" : {
+      "id" : {
+        "type" : "string",
+        "required" : true
+      },
+      "value" : {
+        "type" : "string"
+      }
+    }
+  }
 }</code></pre>
         </label>
       </td>
@@ -5444,7 +5470,20 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
           <details>
           <summary>Response</summary>
           <pre><code>{
-  "type" : "any"
+  "type" : "array",
+  "items" : {
+    "type" : "object",
+    "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:Metric",
+    "properties" : {
+      "id" : {
+        "type" : "string",
+        "required" : true
+      },
+      "value" : {
+        "type" : "string"
+      }
+    }
+  }
 }</code></pre>
         </label>
       </td>
@@ -5499,7 +5538,20 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
           <details>
           <summary>Response</summary>
           <pre><code>{
-  "type" : "any"
+  "type" : "array",
+  "items" : {
+    "type" : "object",
+    "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:Metric",
+    "properties" : {
+      "id" : {
+        "type" : "string",
+        "required" : true
+      },
+      "value" : {
+        "type" : "string"
+      }
+    }
+  }
 }</code></pre>
         </label>
       </td>
@@ -6038,7 +6090,20 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
           <details>
           <summary>Response</summary>
           <pre><code>{
-  "type" : "any"
+  "type" : "array",
+  "items" : {
+    "type" : "object",
+    "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:Metric",
+    "properties" : {
+      "id" : {
+        "type" : "string",
+        "required" : true
+      },
+      "value" : {
+        "type" : "string"
+      }
+    }
+  }
 }</code></pre>
         </label>
       </td>
@@ -6318,7 +6383,20 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
           <details>
           <summary>Response</summary>
           <pre><code>{
-  "type" : "any"
+  "type" : "array",
+  "items" : {
+    "type" : "object",
+    "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:Metric",
+    "properties" : {
+      "id" : {
+        "type" : "string",
+        "required" : true
+      },
+      "value" : {
+        "type" : "string"
+      }
+    }
+  }
 }</code></pre>
         </label>
       </td>
@@ -7082,7 +7160,20 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
           <details>
           <summary>Response</summary>
           <pre><code>{
-  "type" : "any"
+  "type" : "array",
+  "items" : {
+    "type" : "object",
+    "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:Metric",
+    "properties" : {
+      "id" : {
+        "type" : "string",
+        "required" : true
+      },
+      "value" : {
+        "type" : "string"
+      }
+    }
+  }
 }</code></pre>
         </label>
       </td>

--- a/docs/static/generated/rest_v1_dispatcher.yml
+++ b/docs/static/generated/rest_v1_dispatcher.yml
@@ -3410,7 +3410,7 @@ components:
           type: string
         serialized-throwable:
           type: string
-          format: binary
+          format: byte
         stack-trace:
           type: string
     SerializedValueOptionalFailureObject:

--- a/docs/static/generated/rest_v1_dispatcher.yml
+++ b/docs/static/generated/rest_v1_dispatcher.yml
@@ -3385,17 +3385,8 @@ components:
         resource:
           $ref: "#/components/schemas/ResourceProfileInfo"
     SlotSharingGroupId:
-      type: object
-      properties:
-        bytes:
-          type: string
-          format: byte
-        lowerPart:
-          type: integer
-          format: int64
-        upperPart:
-          type: integer
-          format: int64
+      pattern: "[0-9a-f]{32}"
+      type: string
     SlotSharingGroupRescaleInfo:
       type: object
       properties:

--- a/docs/static/generated/rest_v1_dispatcher.yml
+++ b/docs/static/generated/rest_v1_dispatcher.yml
@@ -443,7 +443,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/MetricCollectionResponseBody"
+                type: array
+                items:
+                  $ref: "#/components/schemas/Metric"
   /jobmanager/thread-dump:
     get:
       description: Returns the thread dump of the JobManager.
@@ -897,7 +899,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/MetricCollectionResponseBody"
+                type: array
+                items:
+                  $ref: "#/components/schemas/Metric"
   /jobs/{jobid}/plan:
     get:
       description: Returns the dataflow plan of a job.
@@ -1366,7 +1370,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/MetricCollectionResponseBody"
+                type: array
+                items:
+                  $ref: "#/components/schemas/Metric"
   /jobs/{jobid}/vertices/{vertexid}/metrics:
     get:
       description: Provides access to task metrics.
@@ -1397,7 +1403,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/MetricCollectionResponseBody"
+                type: array
+                items:
+                  $ref: "#/components/schemas/Metric"
   /jobs/{jobid}/vertices/{vertexid}/subtasks/accumulators:
     get:
       description: Returns all user-defined accumulators for all subtasks of a task.
@@ -1616,7 +1624,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/MetricCollectionResponseBody"
+                type: array
+                items:
+                  $ref: "#/components/schemas/Metric"
   /jobs/{jobid}/vertices/{vertexid}/subtasktimes:
     get:
       description: Returns time-related information for all subtasks of a task.
@@ -1688,7 +1698,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/MetricCollectionResponseBody"
+                type: array
+                items:
+                  $ref: "#/components/schemas/Metric"
   /overview:
     get:
       description: Returns an overview over the Flink cluster.
@@ -1842,7 +1854,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/MetricCollectionResponseBody"
+                type: array
+                items:
+                  $ref: "#/components/schemas/Metric"
   /taskmanagers/{taskmanagerid}/thread-dump:
     get:
       description: Returns the thread dump of the requested TaskManager.

--- a/docs/static/generated/rest_v1_dispatcher.yml
+++ b/docs/static/generated/rest_v1_dispatcher.yml
@@ -3362,9 +3362,13 @@ components:
     SerializedThrowable:
       type: object
       properties:
+        class:
+          type: string
         serialized-throwable:
           type: string
           format: binary
+        stack-trace:
+          type: string
     SerializedValueOptionalFailureObject:
       type: object
       properties:

--- a/docs/static/generated/rest_v1_dispatcher.yml
+++ b/docs/static/generated/rest_v1_dispatcher.yml
@@ -502,7 +502,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AggregatedMetricsResponseBody"
+                type: array
+                items:
+                  $ref: "#/components/schemas/AggregatedMetric"
   /jobs/overview:
     get:
       description: Returns an overview over all jobs.
@@ -1476,7 +1478,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AggregatedMetricsResponseBody"
+                type: array
+                items:
+                  $ref: "#/components/schemas/AggregatedMetric"
   /jobs/{jobid}/vertices/{vertexid}/subtasks/{subtaskindex}:
     get:
       description: Returns details of the current or latest execution attempt of a
@@ -1793,7 +1797,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AggregatedMetricsResponseBody"
+                type: array
+                items:
+                  $ref: "#/components/schemas/AggregatedMetric"
   /taskmanagers/{taskmanagerid}:
     get:
       description: Returns details for a task manager.
@@ -1877,8 +1883,32 @@ paths:
                 $ref: "#/components/schemas/ThreadDumpInfo"
 components:
   schemas:
-    AggregatedMetricsResponseBody:
+    AggregatedMetric:
+      required:
+      - id
       type: object
+      properties:
+        avg:
+          type: number
+          format: double
+        id:
+          type: string
+        max:
+          type: number
+          format: double
+        min:
+          type: number
+          format: double
+        skew:
+          type: number
+          format: double
+        sum:
+          type: number
+          format: double
+    AggregatedMetricsResponseBody:
+      type: array
+      items:
+        $ref: "#/components/schemas/AggregatedMetric"
     AggregatedTaskDetailsInfo:
       type: object
       properties:

--- a/docs/static/generated/rest_v1_dispatcher.yml
+++ b/docs/static/generated/rest_v1_dispatcher.yml
@@ -3109,12 +3109,9 @@ components:
         value:
           type: string
     MetricCollectionResponseBody:
-      type: object
-      properties:
-        metrics:
-          type: array
-          items:
-            $ref: "#/components/schemas/Metric"
+      type: array
+      items:
+        $ref: "#/components/schemas/Metric"
     MultipleApplicationsDetails:
       type: object
       properties:

--- a/docs/static/generated/rest_v1_sql_gateway.yml
+++ b/docs/static/generated/rest_v1_sql_gateway.yml
@@ -541,9 +541,13 @@ components:
     SerializedThrowable:
       type: object
       properties:
+        class:
+          type: string
         serialized-throwable:
           type: string
           format: binary
+        stack-trace:
+          type: string
     SessionHandle:
       type: object
       properties:

--- a/docs/static/generated/rest_v1_sql_gateway.yml
+++ b/docs/static/generated/rest_v1_sql_gateway.yml
@@ -546,6 +546,9 @@ components:
         identifier:
           type: string
           format: uuid
+    SlotSharingGroupId:
+      pattern: "[0-9a-f]{32}"
+      type: string
     TriggerId:
       pattern: "[0-9a-f]{32}"
       type: string

--- a/docs/static/generated/rest_v1_sql_gateway.yml
+++ b/docs/static/generated/rest_v1_sql_gateway.yml
@@ -403,10 +403,6 @@ components:
       - DESCRIPTOR
       - VARIANT
       - BITMAP
-    MetricCollectionResponseBody:
-      type: array
-      items:
-        $ref: "#/components/schemas/Metric"
     OpenSessionRequestBody:
       type: object
       properties:

--- a/docs/static/generated/rest_v1_sql_gateway.yml
+++ b/docs/static/generated/rest_v1_sql_gateway.yml
@@ -541,7 +541,7 @@ components:
           type: string
         serialized-throwable:
           type: string
-          format: binary
+          format: byte
         stack-trace:
           type: string
     SessionHandle:

--- a/docs/static/generated/rest_v1_sql_gateway.yml
+++ b/docs/static/generated/rest_v1_sql_gateway.yml
@@ -403,6 +403,10 @@ components:
       - DESCRIPTOR
       - VARIANT
       - BITMAP
+    MetricCollectionResponseBody:
+      type: array
+      items:
+        $ref: "#/components/schemas/Metric"
     OpenSessionRequestBody:
       type: object
       properties:

--- a/docs/static/generated/rest_v2_sql_gateway.yml
+++ b/docs/static/generated/rest_v2_sql_gateway.yml
@@ -477,10 +477,6 @@ components:
       - DESCRIPTOR
       - VARIANT
       - BITMAP
-    MetricCollectionResponseBody:
-      type: array
-      items:
-        $ref: "#/components/schemas/Metric"
     OpenSessionRequestBody:
       type: object
       properties:

--- a/docs/static/generated/rest_v2_sql_gateway.yml
+++ b/docs/static/generated/rest_v2_sql_gateway.yml
@@ -615,9 +615,13 @@ components:
     SerializedThrowable:
       type: object
       properties:
+        class:
+          type: string
         serialized-throwable:
           type: string
           format: binary
+        stack-trace:
+          type: string
     SessionHandle:
       type: object
       properties:

--- a/docs/static/generated/rest_v2_sql_gateway.yml
+++ b/docs/static/generated/rest_v2_sql_gateway.yml
@@ -477,6 +477,10 @@ components:
       - DESCRIPTOR
       - VARIANT
       - BITMAP
+    MetricCollectionResponseBody:
+      type: array
+      items:
+        $ref: "#/components/schemas/Metric"
     OpenSessionRequestBody:
       type: object
       properties:

--- a/docs/static/generated/rest_v2_sql_gateway.yml
+++ b/docs/static/generated/rest_v2_sql_gateway.yml
@@ -620,6 +620,9 @@ components:
         identifier:
           type: string
           format: uuid
+    SlotSharingGroupId:
+      pattern: "[0-9a-f]{32}"
+      type: string
     TriggerId:
       pattern: "[0-9a-f]{32}"
       type: string

--- a/docs/static/generated/rest_v2_sql_gateway.yml
+++ b/docs/static/generated/rest_v2_sql_gateway.yml
@@ -615,7 +615,7 @@ components:
           type: string
         serialized-throwable:
           type: string
-          format: binary
+          format: byte
         stack-trace:
           type: string
     SessionHandle:

--- a/docs/static/generated/rest_v3_sql_gateway.yml
+++ b/docs/static/generated/rest_v3_sql_gateway.yml
@@ -675,6 +675,9 @@ components:
         identifier:
           type: string
           format: uuid
+    SlotSharingGroupId:
+      pattern: "[0-9a-f]{32}"
+      type: string
     TriggerId:
       pattern: "[0-9a-f]{32}"
       type: string

--- a/docs/static/generated/rest_v3_sql_gateway.yml
+++ b/docs/static/generated/rest_v3_sql_gateway.yml
@@ -670,7 +670,7 @@ components:
           type: string
         serialized-throwable:
           type: string
-          format: binary
+          format: byte
         stack-trace:
           type: string
     SessionHandle:

--- a/docs/static/generated/rest_v3_sql_gateway.yml
+++ b/docs/static/generated/rest_v3_sql_gateway.yml
@@ -670,9 +670,13 @@ components:
     SerializedThrowable:
       type: object
       properties:
+        class:
+          type: string
         serialized-throwable:
           type: string
           format: binary
+        stack-trace:
+          type: string
     SessionHandle:
       type: object
       properties:

--- a/docs/static/generated/rest_v3_sql_gateway.yml
+++ b/docs/static/generated/rest_v3_sql_gateway.yml
@@ -506,6 +506,10 @@ components:
       - DESCRIPTOR
       - VARIANT
       - BITMAP
+    MetricCollectionResponseBody:
+      type: array
+      items:
+        $ref: "#/components/schemas/Metric"
     OpenSessionRequestBody:
       type: object
       properties:

--- a/docs/static/generated/rest_v3_sql_gateway.yml
+++ b/docs/static/generated/rest_v3_sql_gateway.yml
@@ -506,10 +506,6 @@ components:
       - DESCRIPTOR
       - VARIANT
       - BITMAP
-    MetricCollectionResponseBody:
-      type: array
-      items:
-        $ref: "#/components/schemas/Metric"
     OpenSessionRequestBody:
       type: object
       properties:

--- a/docs/static/generated/rest_v4_sql_gateway.yml
+++ b/docs/static/generated/rest_v4_sql_gateway.yml
@@ -685,6 +685,9 @@ components:
         identifier:
           type: string
           format: uuid
+    SlotSharingGroupId:
+      pattern: "[0-9a-f]{32}"
+      type: string
     TriggerId:
       pattern: "[0-9a-f]{32}"
       type: string

--- a/docs/static/generated/rest_v4_sql_gateway.yml
+++ b/docs/static/generated/rest_v4_sql_gateway.yml
@@ -516,6 +516,10 @@ components:
       - DESCRIPTOR
       - VARIANT
       - BITMAP
+    MetricCollectionResponseBody:
+      type: array
+      items:
+        $ref: "#/components/schemas/Metric"
     OpenSessionRequestBody:
       type: object
       properties:

--- a/docs/static/generated/rest_v4_sql_gateway.yml
+++ b/docs/static/generated/rest_v4_sql_gateway.yml
@@ -516,10 +516,6 @@ components:
       - DESCRIPTOR
       - VARIANT
       - BITMAP
-    MetricCollectionResponseBody:
-      type: array
-      items:
-        $ref: "#/components/schemas/Metric"
     OpenSessionRequestBody:
       type: object
       properties:

--- a/docs/static/generated/rest_v4_sql_gateway.yml
+++ b/docs/static/generated/rest_v4_sql_gateway.yml
@@ -680,7 +680,7 @@ components:
           type: string
         serialized-throwable:
           type: string
-          format: binary
+          format: byte
         stack-trace:
           type: string
     SessionHandle:

--- a/docs/static/generated/rest_v4_sql_gateway.yml
+++ b/docs/static/generated/rest_v4_sql_gateway.yml
@@ -680,9 +680,13 @@ components:
     SerializedThrowable:
       type: object
       properties:
+        class:
+          type: string
         serialized-throwable:
           type: string
           format: binary
+        stack-trace:
+          type: string
     SessionHandle:
       type: object
       properties:

--- a/flink-docs/src/main/java/org/apache/flink/docs/rest/OpenApiSpecGenerator.java
+++ b/flink-docs/src/main/java/org/apache/flink/docs/rest/OpenApiSpecGenerator.java
@@ -21,6 +21,7 @@ package org.apache.flink.docs.rest;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.instance.SlotSharingGroupId;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.rest.FileUploadHandler;
@@ -279,7 +280,8 @@ public class OpenApiSpecGenerator {
                 .addSchemas(JobVertexID.class.getSimpleName(), idSchema)
                 .addSchemas(IntermediateDataSetID.class.getSimpleName(), idSchema)
                 .addSchemas(TriggerId.class.getSimpleName(), idSchema)
-                .addSchemas(ResourceID.class.getSimpleName(), idSchema);
+                .addSchemas(ResourceID.class.getSimpleName(), idSchema)
+                .addSchemas(SlotSharingGroupId.class.getSimpleName(), idSchema);
     }
 
     private static void overrideSerializeThrowableSchema(final OpenAPI openAPI) {

--- a/flink-docs/src/main/java/org/apache/flink/docs/rest/OpenApiSpecGenerator.java
+++ b/flink-docs/src/main/java/org/apache/flink/docs/rest/OpenApiSpecGenerator.java
@@ -36,6 +36,7 @@ import org.apache.flink.runtime.rest.messages.MessagePathParameter;
 import org.apache.flink.runtime.rest.messages.MessageQueryParameter;
 import org.apache.flink.runtime.rest.messages.TriggerId;
 import org.apache.flink.runtime.rest.messages.job.JobSubmitHeaders;
+import org.apache.flink.runtime.rest.messages.job.metrics.MetricCollectionResponseBody;
 import org.apache.flink.runtime.rest.messages.json.SerializedThrowableSerializer;
 import org.apache.flink.runtime.rest.util.DocumentingRestEndpoint;
 import org.apache.flink.runtime.rest.versioning.RestAPIVersion;
@@ -152,6 +153,7 @@ public class OpenApiSpecGenerator {
 
         overrideIdSchemas(openApi);
         overrideSerializeThrowableSchema(openApi);
+        overrideMetricCollectionSchema(openApi);
 
         sortProperties(openApi);
         sortSchemas(openApi);
@@ -282,6 +284,19 @@ public class OpenApiSpecGenerator {
                 .addSchemas(TriggerId.class.getSimpleName(), idSchema)
                 .addSchemas(ResourceID.class.getSimpleName(), idSchema)
                 .addSchemas(SlotSharingGroupId.class.getSimpleName(), idSchema);
+    }
+
+    /**
+     * Overrides the schema for {@link MetricCollectionResponseBody} which uses a custom Jackson
+     * serializer that writes the metrics collection as a raw JSON array, not as an object with a
+     * "metrics" field.
+     */
+    private static void overrideMetricCollectionSchema(final OpenAPI openApi) {
+        final ArraySchema metricArraySchema =
+                new ArraySchema().items(new Schema().$ref("#/components/schemas/Metric"));
+
+        openApi.getComponents()
+                .addSchemas(MetricCollectionResponseBody.class.getSimpleName(), metricArraySchema);
     }
 
     private static void overrideSerializeThrowableSchema(final OpenAPI openAPI) {

--- a/flink-docs/src/main/java/org/apache/flink/docs/rest/OpenApiSpecGenerator.java
+++ b/flink-docs/src/main/java/org/apache/flink/docs/rest/OpenApiSpecGenerator.java
@@ -152,8 +152,8 @@ public class OpenApiSpecGenerator {
         injectAsyncOperationResultSchema(openApi, asyncOperationSchemas);
 
         overrideIdSchemas(openApi);
-        overrideSerializeThrowableSchema(openApi);
         overrideMetricCollectionSchema(openApi);
+        overrideSerializeThrowableSchema(openApi);
 
         sortProperties(openApi);
         sortSchemas(openApi);
@@ -304,7 +304,11 @@ public class OpenApiSpecGenerator {
                 new Schema<>()
                         .type("object")
                         .properties(
-                                Collections.singletonMap(
+                                Map.of(
+                                        SerializedThrowableSerializer.FIELD_NAME_CLASS,
+                                        new Schema().type("string"),
+                                        SerializedThrowableSerializer.FIELD_NAME_STACK_TRACE,
+                                        new Schema().type("string"),
                                         SerializedThrowableSerializer
                                                 .FIELD_NAME_SERIALIZED_THROWABLE,
                                         new Schema().type("string").format("binary")));

--- a/flink-docs/src/main/java/org/apache/flink/docs/rest/OpenApiSpecGenerator.java
+++ b/flink-docs/src/main/java/org/apache/flink/docs/rest/OpenApiSpecGenerator.java
@@ -296,7 +296,7 @@ public class OpenApiSpecGenerator {
                                         new Schema().type("string"),
                                         SerializedThrowableSerializer
                                                 .FIELD_NAME_SERIALIZED_THROWABLE,
-                                        new Schema().type("string").format("binary")));
+                                        new Schema().type("string").format("byte")));
 
         openAPI.getComponents()
                 .addSchemas(SerializedThrowable.class.getSimpleName(), serializedThrowableSchema);

--- a/flink-docs/src/main/java/org/apache/flink/docs/rest/OpenApiSpecGenerator.java
+++ b/flink-docs/src/main/java/org/apache/flink/docs/rest/OpenApiSpecGenerator.java
@@ -36,7 +36,6 @@ import org.apache.flink.runtime.rest.messages.MessagePathParameter;
 import org.apache.flink.runtime.rest.messages.MessageQueryParameter;
 import org.apache.flink.runtime.rest.messages.TriggerId;
 import org.apache.flink.runtime.rest.messages.job.JobSubmitHeaders;
-import org.apache.flink.runtime.rest.messages.job.metrics.MetricCollectionResponseBody;
 import org.apache.flink.runtime.rest.messages.json.SerializedThrowableSerializer;
 import org.apache.flink.runtime.rest.util.DocumentingRestEndpoint;
 import org.apache.flink.runtime.rest.versioning.RestAPIVersion;
@@ -152,7 +151,6 @@ public class OpenApiSpecGenerator {
         injectAsyncOperationResultSchema(openApi, asyncOperationSchemas);
 
         overrideIdSchemas(openApi);
-        overrideMetricCollectionSchema(openApi);
         overrideSerializeThrowableSchema(openApi);
 
         sortProperties(openApi);
@@ -284,19 +282,6 @@ public class OpenApiSpecGenerator {
                 .addSchemas(TriggerId.class.getSimpleName(), idSchema)
                 .addSchemas(ResourceID.class.getSimpleName(), idSchema)
                 .addSchemas(SlotSharingGroupId.class.getSimpleName(), idSchema);
-    }
-
-    /**
-     * Overrides the schema for {@link MetricCollectionResponseBody} which uses a custom Jackson
-     * serializer that writes the metrics collection as a raw JSON array, not as an object with a
-     * "metrics" field.
-     */
-    private static void overrideMetricCollectionSchema(final OpenAPI openApi) {
-        final ArraySchema metricArraySchema =
-                new ArraySchema().items(new Schema().$ref("#/components/schemas/Metric"));
-
-        openApi.getComponents()
-                .addSchemas(MetricCollectionResponseBody.class.getSimpleName(), metricArraySchema);
     }
 
     private static void overrideSerializeThrowableSchema(final OpenAPI openAPI) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/AggregatedMetricsResponseBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/AggregatedMetricsResponseBody.java
@@ -43,7 +43,7 @@ import static java.util.Objects.requireNonNull;
 public class AggregatedMetricsResponseBody extends ArrayList<AggregatedMetric>
         implements ResponseBody {
 
-    private static final long serialVersionUID = -1170348873871206965L;
+    private static final long serialVersionUID = -1170348478297775429L;
 
     // a default constructor is required for collection type marshalling
     public AggregatedMetricsResponseBody() {}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/AggregatedMetricsResponseBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/AggregatedMetricsResponseBody.java
@@ -21,19 +21,11 @@ package org.apache.flink.runtime.rest.messages.job.metrics;
 import org.apache.flink.runtime.rest.messages.ResponseBody;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonParser;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.type.TypeReference;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.DeserializationContext;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.SerializerProvider;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.deser.std.StdDeserializer;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
-import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Response type for a collection of aggregated metrics.
@@ -46,62 +38,28 @@ import java.util.List;
  * [{"id": "metricName", "min": "1"}]
  * }</pre>
  *
- * @see AggregatedMetricsResponseBody.Serializer
- * @see AggregatedMetricsResponseBody.Deserializer
  * @see org.apache.flink.runtime.rest.handler.legacy.metrics.MetricStore
  */
-@JsonSerialize(using = AggregatedMetricsResponseBody.Serializer.class)
-@JsonDeserialize(using = AggregatedMetricsResponseBody.Deserializer.class)
-public class AggregatedMetricsResponseBody implements ResponseBody {
+public class AggregatedMetricsResponseBody extends ArrayList<AggregatedMetric>
+        implements ResponseBody {
 
-    private final Collection<AggregatedMetric> metrics;
+    private static final long serialVersionUID = -1170348873871206965L;
+
+    // a default constructor is required for collection type marshalling
+    public AggregatedMetricsResponseBody() {}
 
     public AggregatedMetricsResponseBody(Collection<AggregatedMetric> metrics) {
-
-        this.metrics = metrics;
+        super(requireNonNull(metrics, "metrics must not be null"));
     }
 
     @JsonIgnore
     public Collection<AggregatedMetric> getMetrics() {
-        return metrics;
+        return this;
     }
 
-    /** JSON serializer for {@link AggregatedMetricsResponseBody}. */
-    public static class Serializer extends StdSerializer<AggregatedMetricsResponseBody> {
-
-        private static final long serialVersionUID = 1L;
-
-        protected Serializer() {
-            super(AggregatedMetricsResponseBody.class);
-        }
-
-        @Override
-        public void serialize(
-                AggregatedMetricsResponseBody metricCollectionResponseBody,
-                JsonGenerator jsonGenerator,
-                SerializerProvider serializerProvider)
-                throws IOException {
-
-            jsonGenerator.writeObject(metricCollectionResponseBody.getMetrics());
-        }
-    }
-
-    /** JSON deserializer for {@link AggregatedMetricsResponseBody}. */
-    public static class Deserializer extends StdDeserializer<AggregatedMetricsResponseBody> {
-
-        private static final long serialVersionUID = 1L;
-
-        protected Deserializer() {
-            super(AggregatedMetricsResponseBody.class);
-        }
-
-        @Override
-        public AggregatedMetricsResponseBody deserialize(
-                JsonParser jsonParser, DeserializationContext deserializationContext)
-                throws IOException {
-
-            return new AggregatedMetricsResponseBody(
-                    jsonParser.readValueAs(new TypeReference<List<AggregatedMetric>>() {}));
-        }
+    @Override
+    @JsonIgnore
+    public boolean isEmpty() {
+        return super.isEmpty();
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/MetricCollectionResponseBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/MetricCollectionResponseBody.java
@@ -20,21 +20,10 @@ package org.apache.flink.runtime.rest.messages.job.metrics;
 
 import org.apache.flink.runtime.rest.messages.ResponseBody;
 
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonParser;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.type.TypeReference;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.DeserializationContext;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.SerializerProvider;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.deser.std.StdDeserializer;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
 
-import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
-
-import static java.util.Objects.requireNonNull;
 
 /**
  * Response type for a collection of metrics.
@@ -46,61 +35,23 @@ import static java.util.Objects.requireNonNull;
  * <pre>{@code
  * [{"id": "metricName", "value": "1"}]
  * }</pre>
- *
- * @see Serializer
- * @see Deserializer
- * @see org.apache.flink.runtime.rest.handler.legacy.metrics.MetricStore
  */
-@JsonSerialize(using = MetricCollectionResponseBody.Serializer.class)
-@JsonDeserialize(using = MetricCollectionResponseBody.Deserializer.class)
-public final class MetricCollectionResponseBody implements ResponseBody {
-
-    private final Collection<Metric> metrics;
+public final class MetricCollectionResponseBody extends ArrayList<Metric> implements ResponseBody {
+    // a default constructor is required for collection type marshaling
+    public MetricCollectionResponseBody() {}
 
     public MetricCollectionResponseBody(Collection<Metric> metrics) {
-        this.metrics = requireNonNull(metrics, "metrics must not be null");
+        super(metrics);
     }
 
+    @JsonIgnore
     public Collection<Metric> getMetrics() {
-        return metrics;
+        return this;
     }
 
-    /** JSON serializer for {@link MetricCollectionResponseBody}. */
-    public static class Serializer extends StdSerializer<MetricCollectionResponseBody> {
-
-        private static final long serialVersionUID = 1L;
-
-        protected Serializer() {
-            super(MetricCollectionResponseBody.class);
-        }
-
-        @Override
-        public void serialize(
-                MetricCollectionResponseBody metricCollectionResponseBody,
-                JsonGenerator jsonGenerator,
-                SerializerProvider serializerProvider)
-                throws IOException {
-
-            jsonGenerator.writeObject(metricCollectionResponseBody.getMetrics());
-        }
-    }
-
-    /** JSON deserializer for {@link MetricCollectionResponseBody}. */
-    public static class Deserializer extends StdDeserializer<MetricCollectionResponseBody> {
-
-        private static final long serialVersionUID = 1L;
-
-        protected Deserializer() {
-            super(MetricCollectionResponseBody.class);
-        }
-
-        @Override
-        public MetricCollectionResponseBody deserialize(
-                JsonParser jsonParser, DeserializationContext deserializationContext)
-                throws IOException {
-
-            return new MetricCollectionResponseBody(
-                    jsonParser.readValueAs(new TypeReference<List<Metric>>() {}));
-        }
+    @Override
+    @JsonIgnore
+    public boolean isEmpty() {
+        return super.isEmpty();
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/MetricCollectionResponseBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/MetricCollectionResponseBody.java
@@ -37,12 +37,14 @@ import static java.util.Objects.requireNonNull;
  * <pre>{@code
  * [{"id": "metricName", "value": "1"}]
  * }</pre>
+ *
+ * @see org.apache.flink.runtime.rest.handler.legacy.metrics.MetricStore
  */
 public final class MetricCollectionResponseBody extends ArrayList<Metric> implements ResponseBody {
 
     private static final long serialVersionUID = -1170348873871206965L;
 
-    // a default constructor is required for collection type marshaling
+    // a default constructor is required for collection type marshalling
     public MetricCollectionResponseBody() {}
 
     public MetricCollectionResponseBody(Collection<Metric> metrics) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/MetricCollectionResponseBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/MetricCollectionResponseBody.java
@@ -25,6 +25,8 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgn
 import java.util.ArrayList;
 import java.util.Collection;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Response type for a collection of metrics.
  *
@@ -37,11 +39,14 @@ import java.util.Collection;
  * }</pre>
  */
 public final class MetricCollectionResponseBody extends ArrayList<Metric> implements ResponseBody {
+
+    private static final long serialVersionUID = -1170348873871206965L;
+
     // a default constructor is required for collection type marshaling
     public MetricCollectionResponseBody() {}
 
     public MetricCollectionResponseBody(Collection<Metric> metrics) {
-        super(metrics);
+        super(requireNonNull(metrics, "metrics must not be null"));
     }
 
     @JsonIgnore

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/json/SerializedThrowableSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/json/SerializedThrowableSerializer.java
@@ -32,9 +32,9 @@ public class SerializedThrowableSerializer extends StdSerializer<SerializedThrow
 
     private static final long serialVersionUID = 1L;
 
-    static final String FIELD_NAME_CLASS = "class";
+    public static final String FIELD_NAME_CLASS = "class";
 
-    static final String FIELD_NAME_STACK_TRACE = "stack-trace";
+    public static final String FIELD_NAME_STACK_TRACE = "stack-trace";
 
     public static final String FIELD_NAME_SERIALIZED_THROWABLE = "serialized-throwable";
 


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes three Flink request/response DTOs that use custom Jackson serializers, while their OpenAPI specs are generated from the DTO schema. This leads to a mismatch between the actual wire format and what the generated spec describes, breaking downstream clients:

1. **`SlotSharingGroupId`**: Serialized as a hex string by `SlotSharingGroupIDSerializer` (added in [FLINK-20090](https://issues.apache.org/jira/browse/FLINK-20090)), but the spec incorrectly defines it as an object with `bytes`, `lowerPart`, `upperPart` fields because `overrideIdSchemas()` does not include `SlotSharingGroupId`.

2. **`MetricCollectionResponseBody`**: Serialized as a raw JSON array `[{"id": "metricName", "value": "1"}]` by a custom `Serializer` (annotated with `@JsonSerialize`), but the spec incorrectly defines it as an object with a `metrics` property.

3. **`SerializedThrowable`**: Serialized with three fields (`class`, `stack-trace`, `serialized-throwable`) by `SerializedThrowableSerializer`, but the spec override only included `serialized-throwable` and used `format: binary` for that field. `format: binary` is the OAS format for raw file/octet-stream bodies and maps to file types in generators; `format: byte` is the correct format for Base64-encoded data in JSON properties, which is what `JsonGenerator.writeBinaryField()` produces. The fix adds the missing `class` and `stack-trace` string fields and corrects the format to `byte`.

None of these changes break backward compatibility - the previous schemas never matched the actual wire format, so any client generated from the spec would have already failed to decode these fields correctly.

#### Affected endpoints

- `GET /jobs/:jobid` (`SlotSharingGroupId` in `JobDetailsInfo.JobVertexDetailsInfo`)
- `GET /jobmanager/metrics`
- `GET /jobs/:jobid/metrics`
- `GET /jobs/:jobid/vertices/:vertexid/metrics`
- `GET /jobs/:jobid/vertices/:vertexid/subtasks/metrics`
- `GET /jobs/:jobid/vertices/:vertexid/watermarks`
- `GET /taskmanagers/:taskmanagerid/metrics`
- `GET /taskmanagers/metrics`
- Any endpoint returning `SerializedThrowable` (savepoint/checkpoint failure responses)

## Brief change log

- Added `SlotSharingGroupId` to `OpenApiSpecGenerator.overrideIdSchemas()` as `type: string, pattern: [0-9a-f]{32}`
- Refactored `MetricCollectionResponseBody` to extend `ArrayList<Metric>`, removing the custom serializer/deserializer. The wire format is identical (JSON array), but the class structure now matches, so the spec generator produces the correct schema without a manual override.
- Added `class` and `stack-trace` fields to the `SerializedThrowable` schema override in `OpenApiSpecGenerator`, using public constants from `SerializedThrowableSerializer`.
- Changed `serialized-throwable` field format from `binary` to `byte` in the `SerializedThrowable` schema override. `format: byte` correctly describes a Base64-encoded JSON string, which is what `JsonGenerator.writeBinaryField()` produces; `format: binary` incorrectly implies raw octet-stream content.

## Verifying this change

This change is already covered by existing tests, such as `OpenApiSpecGeneratorTest` and `MetricCollectionResponseBodyTest`.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: yes (`MetricCollectionResponseBody` custom serializer/deserializer removed, replaced by extending `ArrayList<Metric>` which Jackson serializes identically as a JSON array)
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable