### PR TITLE
[FLINK-38544] Add spill-to-disk for channel state recovery with filtering

### DIFF
--- a/docs/layouts/shortcodes/generated/checkpointing_configuration.html
+++ b/docs/layouts/shortcodes/generated/checkpointing_configuration.html
@@ -159,6 +159,12 @@
             <td>The tolerable checkpoint consecutive failure number. If set to 0, that means we do not tolerance any checkpoint failure. This only applies to the following failure reasons: IOException on the Job Manager, failures in the async phase on the Task Managers and checkpoint expiration due to a timeout. Failures originating from the sync phase on the Task Managers are always forcing failover of an affected task. Other types of checkpoint failures (such as checkpoint being subsumed) are being ignored.</td>
         </tr>
         <tr>
+            <td><h5>execution.checkpointing.unaligned.during-recovery.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to enable checkpointing during recovery from an unaligned checkpoint. When enabled, the job can take checkpoints while still recovering channel state (inflight data) from a previous unaligned checkpoint. This avoids the need to wait for full recovery before the first checkpoint can be triggered, which reduces the window of vulnerability to failures during recovery.<br /><br />This option requires <code class="highlighter-rouge">execution.checkpointing.unaligned.recover-output-on-downstream.enabled</code> to be enabled. It does not require unaligned checkpoints to be currently enabled, because a job may restore from an unaligned checkpoint while having unaligned checkpoints disabled for the new execution.</td>
+        </tr>
+        <tr>
             <td><h5>execution.checkpointing.unaligned.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/docs/layouts/shortcodes/generated/common_checkpointing_section.html
+++ b/docs/layouts/shortcodes/generated/common_checkpointing_section.html
@@ -57,6 +57,12 @@
             <td>The maximum number of completed checkpoints to retain.</td>
         </tr>
         <tr>
+            <td><h5>execution.checkpointing.unaligned.during-recovery.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to enable checkpointing during recovery from an unaligned checkpoint. When enabled, the job can take checkpoints while still recovering channel state (inflight data) from a previous unaligned checkpoint. This avoids the need to wait for full recovery before the first checkpoint can be triggered, which reduces the window of vulnerability to failures during recovery.<br /><br />This option requires <code class="highlighter-rouge">execution.checkpointing.unaligned.recover-output-on-downstream.enabled</code> to be enabled. It does not require unaligned checkpoints to be currently enabled, because a job may restore from an unaligned checkpoint while having unaligned checkpoints disabled for the new execution.</td>
+        </tr>
+        <tr>
             <td><h5>execution.checkpointing.unaligned.recover-output-on-downstream.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
@@ -670,8 +670,7 @@ public class CheckpointingOptions {
                                     + "when job restores from the unaligned checkpoint.");
 
     @Experimental
-    @Documentation.ExcludeFromDocumentation(
-            "This option is not yet ready for public use, will be documented in a follow-up commit")
+    @Documentation.Section(Documentation.Sections.COMMON_CHECKPOINTING)
     public static final ConfigOption<Boolean> UNALIGNED_DURING_RECOVERY_ENABLED =
             ConfigOptions.key("execution.checkpointing.unaligned.during-recovery.enabled")
                     .booleanType()

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/TestStreamEnvironment.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/TestStreamEnvironment.java
@@ -148,6 +148,7 @@ public class TestStreamEnvironment extends StreamExecutionEnvironment {
             randomize(conf, CheckpointingOptions.ENABLE_UNALIGNED, true, false);
             randomize(
                     conf, CheckpointingOptions.UNALIGNED_RECOVER_OUTPUT_ON_DOWNSTREAM, true, false);
+            randomize(conf, CheckpointingOptions.UNALIGNED_DURING_RECOVERY_ENABLED, true, false);
             randomize(
                     conf,
                     CheckpointingOptions.ALIGNED_CHECKPOINT_TIMEOUT,


### PR DESCRIPTION
## What is the purpose of the change

Add spill-to-disk infrastructure for channel state recovery during unaligned checkpoint recovery with filtering (FLINK-38544).

When unaligned checkpoint recovery runs with state filtering (rescaling), the current implementation holds all recovered buffers in memory (Network Buffer Pool), which can cause memory pressure and deadlocks. This PR introduces a spill-to-disk mechanism that:

1. **Decouples Source Buffers from Network Buffer Pool**: Uses heap-allocated buffers for reading S3 data (Source Buffers), avoiding competition with the Network Buffer Pool
2. **Three-path routing for filtered buffers**:
   - **P1 (Memory)**: When no disk data exists, deliver filtered buffers directly
   - **P2 (Spill)**: When Network Buffer Pool is exhausted, spill to local disk
   - **P3 (Replay)**: When disk has data, spill current buffer and replay from disk (FIFO ordering)
3. **Phase 2 drain**: After all S3 data is read, drain remaining disk data using blocking buffer requests (safe because all heap Source Buffers are released)

### Core Components

- `SpillFileWriter`: Writes raw buffer bytes to spill files
- `SpillFileReader`: Reads raw buffer bytes back from spill files  
- `SpillingBufferManager`: Manages spill/replay lifecycle with FIFO ordering, 64MB file rotation, reference counting, and old attempt cleanup
- `ChannelStateSerializer.wrapWithoutRecycle()`: Supports heap buffer lifecycle where caller manages recycling

### Integration Changes

- `InputChannelRecoveredStateHandler`: Updated with heap buffer allocation, three-path routing, and Phase 2 drain
- `SequentialChannelStateReaderImpl`: Passes spill directories and calls `drainDiskData()` after read phase
- `RecoveredInputChannel`: Changed `requestBufferBlocking` to non-blocking `requestBuffer`

## Brief change log

- Add `SpillFileWriter`, `SpillFileReader`, and `SpillingBufferManager` for spill-to-disk infrastructure
- Add `ChannelStateSerializer.wrapWithoutRecycle()` for filtering buffer lifecycle
- Update `InputChannelRecoveredStateHandler` with heap buffer allocation, three-path routing, and Phase 2 disk drain
- Update `SequentialChannelStateReaderImpl` to pass spill dirs and trigger Phase 2 drain
- Change `RecoveredInputChannel.requestBufferBlocking` to non-blocking `requestBuffer`

## Verifying this change

This change is verified by new unit tests:

- `SpillFileWriterReaderTest`: Covers spill file I/O, file rotation, large buffers
- `SpillingBufferManagerTest`: Covers replay ordering, checkpoint iterator, concurrent ref counting, FIFO guarantee
- `InputChannelRecoveredStateHandlerTest`: Covers heap buffer allocation, source buffer isolation, sequential channel processing, no-filtering compatibility

## Does this pull request potentially affect one of the following parts

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: **yes** (recovery with state filtering)
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no (internal improvement to existing recovery mechanism)
- If yes, how is the feature documented? not applicable
