### PR TITLE
[FLINK-39293][table-planner] Fix MATCH_RECOGNIZE uses through view

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConvertUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConvertUtils.java
@@ -87,7 +87,7 @@ class SqlNodeConvertUtils {
                 context.getSqlValidator().getNamespace(validateQuery);
         validateDuplicatedColumnNames(validateQuery, viewFields, validatedNamespace);
 
-        String expandedQuery = context.toQuotedSqlString(validateQuery);
+        String expandedQuery = context.expandSqlIdentifiers(originalQuery);
 
         PlannerQueryOperation operation = toQueryOperation(validateQuery, context);
         ResolvedSchema schema = operation.getResolvedSchema();

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/MatchRecognizeITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/MatchRecognizeITCase.java
@@ -111,6 +111,48 @@ class MatchRecognizeITCase {
     }
 
     @Test
+    void testSimplePatternInProcTimeWithTemporaryView() {
+        tEnv.createTemporaryView(
+                "MyTable",
+                tEnv.fromDataStream(
+                        env.fromData(
+                                        Row.of(1, "a"),
+                                        Row.of(2, "z"),
+                                        Row.of(3, "b"),
+                                        Row.of(4, "c"),
+                                        Row.of(5, "d"),
+                                        Row.of(6, "a"),
+                                        Row.of(7, "b"),
+                                        Row.of(8, "c"),
+                                        Row.of(9, "h"))
+                                .returns(ROW_NAMED(new String[] {"id", "name"}, INT, STRING)),
+                        Schema.newBuilder()
+                                .column("id", DataTypes.INT())
+                                .column("name", DataTypes.STRING())
+                                .columnByExpression("proctime", "PROCTIME()")
+                                .build()));
+        tEnv.executeSql(
+                "CREATE TEMPORARY VIEW test_t AS \n"
+                        + "SELECT T.aid, T.bid, T.cid\n"
+                        + "FROM MyTable\n"
+                        + "MATCH_RECOGNIZE (\n"
+                        + "  ORDER BY proctime\n"
+                        + "  MEASURES\n"
+                        + "    `A\"`.id AS aid,\n"
+                        + "    \u006C.id AS bid,\n"
+                        + "    C.id AS cid\n"
+                        + "  PATTERN (`A\"` \u006C C)\n"
+                        + "  DEFINE\n"
+                        + "    `A\"` AS name = 'a',\n"
+                        + "    \u006C AS name = 'b',\n"
+                        + "    C AS name = 'c'\n"
+                        + ") AS T");
+        TableResult tableResult = tEnv.executeSql("SELECT * FROM test_t");
+        assertThat(CollectionUtil.iteratorToList(tableResult.collect()))
+                .containsExactly(Row.of(6, 7, 8));
+    }
+
+    @Test
     void testSimplePatternInEventTime() {
         Instant now = Instant.parse("2023-12-01T12:00:00.000Z");
         tEnv.createTemporaryView(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/catalog/CatalogViewITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/catalog/CatalogViewITCase.scala
@@ -356,7 +356,7 @@ class CatalogViewITCase(isStreamingMode: Boolean) extends TableITCaseBase {
            |  `c`
            |)
            |AS SELECT `T1`.`a`, `T1`.`b`, `T1`.`c`
-           |FROM `default_catalog`.`default_database`.`T1` AS `T1`
+           |FROM `default_catalog`.`default_database`.`T1`
            |""".stripMargin
       )
     )
@@ -376,7 +376,7 @@ class CatalogViewITCase(isStreamingMode: Boolean) extends TableITCaseBase {
            |  `f`
            |)
            |AS SELECT `T1`.`a`, `T1`.`b`, `T1`.`c`
-           |FROM `default_catalog`.`default_database`.`T1` AS `T1`
+           |FROM `default_catalog`.`default_database`.`T1`
            |""".stripMargin
       )
     )
@@ -403,7 +403,7 @@ class CatalogViewITCase(isStreamingMode: Boolean) extends TableITCaseBase {
              |  `c`
              |)
              |AS SELECT `T1`.`a`, `T1`.`b`, `T1`.`c`
-             |FROM `default_catalog`.`default_database`.`T1` AS `T1`
+             |FROM `default_catalog`.`default_database`.`T1`
              |""".stripMargin
         )
       )
@@ -423,7 +423,7 @@ class CatalogViewITCase(isStreamingMode: Boolean) extends TableITCaseBase {
            |  `z`
            |)
            |AS SELECT `T1`.`a`, `T1`.`b`, `T1`.`c`
-           |FROM `default_catalog`.`default_database`.`T1` AS `T1`
+           |FROM `default_catalog`.`default_database`.`T1`
            |""".stripMargin
       )
     )
@@ -450,8 +450,8 @@ class CatalogViewITCase(isStreamingMode: Boolean) extends TableITCaseBase {
            |  `max_value`
            |)
            |AS SELECT MAX(`t1`.`a`) AS `max_value`
-           |FROM `default_catalog`.`default_database`.`t1` AS `t1`
-           |LEFT JOIN `default_catalog`.`default_database`.`t2` AS `t2` ON `t1`.`c` = `t2`.`c`
+           |FROM `default_catalog`.`default_database`.`t1`
+           |LEFT JOIN `default_catalog`.`default_database`.`t2` ON `t1`.`c` = `t2`.`c`
            |""".stripMargin
       )
     )
@@ -485,8 +485,8 @@ class CatalogViewITCase(isStreamingMode: Boolean) extends TableITCaseBase {
            |  `b2`
            |)
            |AS SELECT `udfEqualsOne`() AS `a`, `t1`.`a` AS `a1`, `t2`.`b` AS `b2`
-           |FROM `default_catalog`.`default_database`.`t1` AS `t1`
-           |CROSS JOIN `default_catalog`.`default_database`.`t2` AS `t2`
+           |FROM `default_catalog`.`default_database`.`t1`
+           |CROSS JOIN `default_catalog`.`default_database`.`t2`
            |""".stripMargin
       )
     )
@@ -515,8 +515,8 @@ class CatalogViewITCase(isStreamingMode: Boolean) extends TableITCaseBase {
            |  `b2`
            |)
            |AS SELECT `t1`.`a` AS `a1`, `t2`.`b` AS `b2`
-           |FROM `default_catalog`.`default_database`.`t1` AS `t1`
-           |INNER JOIN `default_catalog`.`default_database`.`t2` AS `t2` ON `t1`.`c` = `t2`.`c`
+           |FROM `default_catalog`.`default_database`.`t1`
+           |INNER JOIN `default_catalog`.`default_database`.`t2` ON `t1`.`c` = `t2`.`c`
            |""".stripMargin
       )
     )
@@ -543,10 +543,9 @@ class CatalogViewITCase(isStreamingMode: Boolean) extends TableITCaseBase {
         s"""CREATE VIEW `default_catalog`.`default_database`.`tumbleWindowViewWithOrderBy` (
            |  `a`
            |)
-           |AS SELECT `EXPR$$0`.`a`
-           |FROM TABLE(TUMBLE((SELECT `t1`.`a`, `t1`.`b`, `t1`.`c`, `t1`.`ts`
-           |FROM `default_catalog`.`default_database`.`t1` AS `t1`), DESCRIPTOR(`ts`), INTERVAL '1' MINUTE)) AS `EXPR$$0`
-           |ORDER BY `EXPR$$0`.`ts`
+           |AS SELECT `a`
+           |FROM TABLE(TUMBLE(TABLE `default_catalog`.`default_database`.`t1`, DESCRIPTOR(`ts`), INTERVAL '1' MINUTE))
+           |ORDER BY `ts`
            |""".stripMargin
       )
     )

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/common/ViewsExpandingTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/common/ViewsExpandingTest.scala
@@ -150,7 +150,7 @@ class ViewsExpandingTest(tableTestUtil: TableTestBase => TableTestUtil) extends 
       .getTable(objectID.toObjectPath)
     assertThat(
       view.asInstanceOf[CatalogView].getExpandedQuery
-    ).isEqualTo("SELECT CONCAT('a', 'bc', 'def')")
+    ).isEqualTo("SELECT `CONCAT`('a', 'bc', 'def')")
   }
 
   @TestTemplate
@@ -172,7 +172,7 @@ class ViewsExpandingTest(tableTestUtil: TableTestBase => TableTestUtil) extends 
       .getTable(objectID.toObjectPath)
     assertThat(
       view.asInstanceOf[CatalogView].getExpandedQuery
-    ).isEqualTo("SELECT `default_catalog`.`default_database`.`func`(1, CAST(2 AS BIGINT), 'abc')")
+    ).isEqualTo("SELECT `default_catalog`.`default_database`.`func`(1, 2, 'abc')")
   }
 
   @TestTemplate
@@ -201,12 +201,12 @@ class ViewsExpandingTest(tableTestUtil: TableTestBase => TableTestUtil) extends 
     assertThat(
       view.asInstanceOf[CatalogView].getExpandedQuery
     ).isEqualTo(
-      "SELECT `EXPR$0`.`f0`, `EXPR$0`.`rowNum`\n"
+      "SELECT *\n"
         + "FROM (SELECT `source`.`f0`, "
         + "ROW_NUMBER() "
         + "OVER (PARTITION BY `source`.`f0` ORDER BY `source`.`f0` DESC) AS `rowNum`\n"
-        + "FROM `default_catalog`.`default_database`.`source` AS `source`) AS `EXPR$0`\n"
-        + "WHERE `EXPR$0`.`rowNum` = 1")
+        + "FROM `default_catalog`.`default_database`.`source`)\n"
+        + "WHERE `rowNum` = 1")
   }
 
   private def createSqlView(originTable: String): CatalogView = {


### PR DESCRIPTION
## What is the purpose of the change

Fix for [FLINK-39293](https://issues.apache.org/jira/browse/FLINK-39293), partially revert for [FLINK-38493](https://issues.apache.org/jira/browse/FLINK-38493) 

## Verifying this change

Run MatchRecognizeITCase#testSimplePatternInProcTimeWithTemporaryView


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
