### PR TITLE
[FLINK-39419][table] Switch TO_CHANGELOG to row semantics with full deletes + require update before

### DIFF
--- a/docs/content/docs/sql/reference/queries/changelog.md
+++ b/docs/content/docs/sql/reference/queries/changelog.md
@@ -44,7 +44,7 @@ This is useful when you need to materialize changelog events into a downstream s
 
 ```sql
 SELECT * FROM TO_CHANGELOG(
-  input => TABLE source_table PARTITION BY key_col,
+  input => TABLE source_table,
   [op => DESCRIPTOR(op_column_name),]
   [op_mapping => MAP['INSERT', 'I', 'DELETE', 'D', ...]]
 )
@@ -54,7 +54,7 @@ SELECT * FROM TO_CHANGELOG(
 
 | Parameter    | Required | Description |
 |:-------------|:---------|:------------|
-| `input`      | Yes      | The input table. Must include `PARTITION BY` for parallel execution. Accepts insert-only, retract, and upsert tables. |
+| `input`      | Yes      | The input table. Accepts insert-only, retract, and upsert tables. |
 | `op`         | No       | A `DESCRIPTOR` with a single column name for the operation code column. Defaults to `op`. |
 | `op_mapping` | No       | A `MAP<STRING, STRING>` mapping change operation names to custom output codes. Keys can contain comma-separated names to map multiple operations to the same code (e.g., `'INSERT, UPDATE_AFTER'`). When provided, only mapped operations are forwarded - unmapped events are dropped. Each change operation may appear at most once across all entries. |
 
@@ -74,7 +74,7 @@ When `op_mapping` is omitted, all four change operations are mapped to their sta
 The output columns are ordered as:
 
 ```
-[partition_key_columns, op_column, remaining_columns]
+[op_column, all_input_columns]
 ```
 
 All output rows have `INSERT` - the table is always append-only.
@@ -85,25 +85,25 @@ All output rows have `INSERT` - the table is always append-only.
 
 ```sql
 -- Input: retract table from an aggregation
--- +I[id:1, name:'Alice', cnt:1]
--- +U[id:1, name:'Alice', cnt:2]
--- -D[id:2, name:'Bob',   cnt:1]
+-- +I[name:'Alice', cnt:1]
+-- +U[name:'Alice', cnt:2]
+-- -D[name:'Bob',   cnt:1]
 
 SELECT * FROM TO_CHANGELOG(
-  input => TABLE my_aggregation PARTITION BY id
+  input => TABLE my_aggregation
 )
 
 -- Output (append-only):
--- +I[id:1, op:'INSERT',       name:'Alice', cnt:1]
--- +I[id:1, op:'UPDATE_AFTER', name:'Alice', cnt:2]
--- +I[id:2, op:'DELETE',       name:'Bob',   cnt:1]
+-- +I[op:'INSERT',       name:'Alice', cnt:1]
+-- +I[op:'UPDATE_AFTER', name:'Alice', cnt:2]
+-- +I[op:'DELETE',       name:'Bob',   cnt:1]
 ```
 
 #### Custom operation column name
 
 ```sql
 SELECT * FROM TO_CHANGELOG(
-  input => TABLE my_aggregation PARTITION BY id,
+  input => TABLE my_aggregation,
   op => DESCRIPTOR(operation)
 )
 -- The op column is now named 'operation' instead of 'op'
@@ -113,7 +113,7 @@ SELECT * FROM TO_CHANGELOG(
 
 ```sql
 SELECT * FROM TO_CHANGELOG(
-  input => TABLE my_aggregation PARTITION BY id,
+  input => TABLE my_aggregation,
   op => DESCRIPTOR(op_code),
   op_mapping => MAP['INSERT', 'I', 'UPDATE_AFTER', 'U']
 )
@@ -126,7 +126,7 @@ SELECT * FROM TO_CHANGELOG(
 
 ```sql
 SELECT * FROM TO_CHANGELOG(
-  input => TABLE my_aggregation PARTITION BY id,
+  input => TABLE my_aggregation,
   op => DESCRIPTOR(deleted),
   op_mapping => MAP['INSERT, UPDATE_AFTER', 'false', 'DELETE', 'true']
 )
@@ -139,16 +139,16 @@ SELECT * FROM TO_CHANGELOG(
 
 ```java
 // Default: adds 'op' column and supports all changelog modes
-Table result = myTable.partitionBy($("id")).toChangelog();
+Table result = myTable.toChangelog();
 
 // With custom parameters
-Table result = myTable.partitionBy($("id")).toChangelog(
+Table result = myTable.toChangelog(
     descriptor("op_code").asArgument("op"),
     map("INSERT", "I", "UPDATE_AFTER", "U").asArgument("op_mapping")
 );
 
 // Deletion flag pattern: comma-separated keys map multiple change operations to the same code
-Table result = myTable.partitionBy($("id")).toChangelog(
+Table result = myTable.toChangelog(
     descriptor("deleted").asArgument("op"),
     map("INSERT, UPDATE_AFTER", "false", "DELETE", "true").asArgument("op_mapping")
 );

--- a/flink-python/pyflink/table/tests/test_table_completeness.py
+++ b/flink-python/pyflink/table/tests/test_table_completeness.py
@@ -42,6 +42,7 @@ class TableAPICompletenessTests(PythonAPICompletenessTestCase, PyFlinkTestCase):
             'asArgument',
             'process',
             'partitionBy',
+            'toChangelog',
         }
 
     @classmethod

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/PartitionedTable.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/PartitionedTable.java
@@ -20,7 +20,6 @@ package org.apache.flink.table.api;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.annotation.ArgumentTrait;
-import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.functions.ProcessTableFunction;
 import org.apache.flink.table.functions.UserDefinedFunction;
 
@@ -139,37 +138,4 @@ public interface PartitionedTable {
      * @see ProcessTableFunction
      */
     Table process(Class<? extends UserDefinedFunction> function, Object... arguments);
-
-    /**
-     * Converts this dynamic table into an append-only table with an explicit operation code column
-     * using the built-in {@code TO_CHANGELOG} process table function.
-     *
-     * <p>Each input row - regardless of its original change operation - is emitted as an
-     * INSERT-only row with a string {@code "op"} column indicating the original operation (INSERT,
-     * UPDATE_AFTER, DELETE, etc.).
-     *
-     * <p>Optional arguments can be passed using named expressions:
-     *
-     * <pre>{@code
-     * // Default: adds 'op' column and supports all changelog modes
-     * table.partitionBy($("id")).toChangelog();
-     *
-     * // Custom op column name and mapping
-     * table.partitionBy($("id")).toChangelog(
-     *     descriptor("op_code").asArgument("op"),
-     *     map("INSERT", "I", "UPDATE_AFTER", "U").asArgument("op_mapping")
-     * );
-     *
-     * // Deletion flag pattern: comma-separated keys map multiple change operations to the same code
-     * table.partitionBy($("id")).toChangelog(
-     *     descriptor("deleted").asArgument("op"),
-     *     map("INSERT, UPDATE_AFTER", "false", "DELETE", "true").asArgument("op_mapping")
-     * );
-     * }</pre>
-     *
-     * @param arguments optional named arguments for {@code op} and {@code op_mapping}
-     * @return an append-only {@link Table} with an {@code op} column prepended to the non-partition
-     *     columns
-     */
-    Table toChangelog(Expression... arguments);
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
@@ -1422,4 +1422,36 @@ public interface Table extends Explainable<Table>, Executable {
      * @see ProcessTableFunction
      */
     Table process(Class<? extends UserDefinedFunction> function, Object... arguments);
+
+    /**
+     * Converts this dynamic table into an append-only table with an explicit operation code column
+     * using the built-in {@code TO_CHANGELOG} process table function.
+     *
+     * <p>Each input row - regardless of its original change operation - is emitted as an
+     * INSERT-only row with a string {@code "op"} column indicating the original operation (INSERT,
+     * UPDATE_AFTER, DELETE, etc.).
+     *
+     * <p>Optional arguments can be passed using named expressions:
+     *
+     * <pre>{@code
+     * // Default: adds 'op' column and supports all changelog modes
+     * table.toChangelog();
+     *
+     * // Custom op column name and mapping
+     * table.toChangelog(
+     *     descriptor("op_code").asArgument("op"),
+     *     map("INSERT", "I", "UPDATE_AFTER", "U").asArgument("op_mapping")
+     * );
+     *
+     * // Deletion flag pattern: comma-separated keys map multiple change operations to the same code
+     * table.toChangelog(
+     *     descriptor("deleted").asArgument("op"),
+     *     map("INSERT, UPDATE_AFTER", "false", "DELETE", "true").asArgument("op_mapping")
+     * );
+     * }</pre>
+     *
+     * @param arguments optional named arguments for {@code op} and {@code op_mapping}
+     * @return an append-only {@link Table} with an {@code op} column prepended to the input columns
+     */
+    Table toChangelog(Expression... arguments);
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableImpl.java
@@ -514,6 +514,11 @@ public class TableImpl implements Table {
                 function, unionTableAndArguments(operationTree, tableEnvironment, arguments));
     }
 
+    @Override
+    public Table toChangelog(Expression... arguments) {
+        return process(BuiltInFunctionDefinitions.TO_CHANGELOG.getName(), (Object[]) arguments);
+    }
+
     private TablePipeline insertInto(
             ContextResolvedTable contextResolvedTable,
             @Nullable InsertConflictStrategy conflictStrategy,
@@ -899,11 +904,6 @@ public class TableImpl implements Table {
                     function,
                     unionTableAndArguments(
                             createPartitionQueryOperation(), table.tableEnvironment, arguments));
-        }
-
-        @Override
-        public Table toChangelog(Expression... arguments) {
-            return process(BuiltInFunctionDefinitions.TO_CHANGELOG.getName(), (Object[]) arguments);
         }
 
         private QueryOperation createPartitionQueryOperation() {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -782,15 +782,21 @@ public final class BuiltInFunctionDefinitions {
                     .name("TO_CHANGELOG")
                     .kind(PROCESS_TABLE)
                     .staticArguments(
+                            // Row semantics: no PARTITION BY required. The planner
+                            // inserts ChangelogNormalize for upsert sources to guarantee
+                            // UPDATE_BEFORE and full DELETE rows. REQUIRE_FULL_DELETE is
+                            // redundant without partition keys (isPtfUpsert is always false)
+                            // but documents the intent explicitly.
                             StaticArgument.table(
                                     "input",
                                     Row.class,
                                     false,
                                     EnumSet.of(
                                             StaticArgumentTrait.TABLE,
-                                            StaticArgumentTrait.SET_SEMANTIC_TABLE,
+                                            StaticArgumentTrait.ROW_SEMANTIC_TABLE,
                                             StaticArgumentTrait.SUPPORT_UPDATES,
-                                            StaticArgumentTrait.REQUIRE_UPDATE_BEFORE)),
+                                            StaticArgumentTrait.REQUIRE_UPDATE_BEFORE,
+                                            StaticArgumentTrait.REQUIRE_FULL_DELETE)),
                             StaticArgument.scalar("op", DataTypes.DESCRIPTOR(), true),
                             StaticArgument.scalar(
                                     "op_mapping",

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -782,11 +782,10 @@ public final class BuiltInFunctionDefinitions {
                     .name("TO_CHANGELOG")
                     .kind(PROCESS_TABLE)
                     .staticArguments(
-                            // Row semantics: no PARTITION BY required. The planner
-                            // inserts ChangelogNormalize for upsert sources to guarantee
-                            // UPDATE_BEFORE and full DELETE rows. REQUIRE_FULL_DELETE is
-                            // redundant without partition keys (isPtfUpsert is always false)
-                            // but documents the intent explicitly.
+                            // Row semantics (no PARTITION BY). Accepts updating
+                            // inputs. The planner inserts ChangelogNormalize for
+                            // upsert sources to produce UPDATE_BEFORE and full
+                            // DELETE rows.
                             StaticArgument.table(
                                     "input",
                                     Row.class,
@@ -796,6 +795,8 @@ public final class BuiltInFunctionDefinitions {
                                             StaticArgumentTrait.ROW_SEMANTIC_TABLE,
                                             StaticArgumentTrait.SUPPORT_UPDATES,
                                             StaticArgumentTrait.REQUIRE_UPDATE_BEFORE,
+                                            // Not strictly necessary but explicitly state that
+                                            // we require full deletes.
                                             StaticArgumentTrait.REQUIRE_FULL_DELETE)),
                             StaticArgument.scalar("op", DataTypes.DESCRIPTOR(), true),
                             StaticArgument.scalar(

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ToChangelogTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ToChangelogTypeStrategy.java
@@ -40,8 +40,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 /** Type strategies for the {@code TO_CHANGELOG} process table function. */
 @Internal
@@ -98,15 +96,10 @@ public final class ToChangelogTypeStrategy {
 
                 final String opColumnName = resolveOpColumnName(callContext);
                 final List<Field> inputFields = DataType.getFields(semantics.dataType());
-                final Set<Integer> partitionKeys = intArrayToSet(semantics.partitionByColumns());
 
                 final List<Field> outputFields = new ArrayList<>();
                 outputFields.add(DataTypes.FIELD(opColumnName, DataTypes.STRING()));
-                for (int i = 0; i < inputFields.size(); i++) {
-                    if (!partitionKeys.contains(i)) {
-                        outputFields.add(inputFields.get(i));
-                    }
-                }
+                outputFields.addAll(inputFields);
 
                 return Optional.of(DataTypes.ROW(outputFields).notNull());
             };
@@ -197,10 +190,6 @@ public final class ToChangelogTypeStrategy {
                 .filter(cl -> !cl.getNames().isEmpty())
                 .map(cl -> cl.getNames().get(0))
                 .orElse(DEFAULT_OP_COLUMN_NAME);
-    }
-
-    private static Set<Integer> intArrayToSet(final int[] array) {
-        return IntStream.of(array).boxed().collect(Collectors.toSet());
     }
 
     private ToChangelogTypeStrategy() {}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/inference/CallBindingCallContext.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/inference/CallBindingCallContext.java
@@ -368,9 +368,11 @@ public final class CallBindingCallContext extends AbstractSqlCallContext {
         final Map<String, String> map = new LinkedHashMap<>();
         try {
             for (int i = 0; i < operands.size(); i += 2) {
-                final String key = SqlLiteral.unchain(operands.get(i)).getValueAs(String.class);
+                final String key =
+                        SqlLiteral.unchain(unwrapCast(operands.get(i))).getValueAs(String.class);
                 final String value =
-                        SqlLiteral.unchain(operands.get(i + 1)).getValueAs(String.class);
+                        SqlLiteral.unchain(unwrapCast(operands.get(i + 1)))
+                                .getValueAs(String.class);
                 map.put(key, value);
             }
         } catch (Exception e) {
@@ -378,6 +380,17 @@ public final class CallBindingCallContext extends AbstractSqlCallContext {
             return null;
         }
         return map;
+    }
+
+    /**
+     * Unwraps implicit CASTs that Calcite adds to MAP literal operands when keys or values have
+     * different lengths (e.g., {@code CAST('INSERT' AS VARCHAR(12))}).
+     */
+    private static SqlNode unwrapCast(final SqlNode node) {
+        if (node.getKind() == SqlKind.CAST) {
+            return ((SqlCall) node).getOperandList().get(0);
+        }
+        return node;
     }
 
     /** A MAP constructor is a string literal if all its key-value children are string literals. */

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/inference/CallBindingCallContext.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/inference/CallBindingCallContext.java
@@ -382,13 +382,14 @@ public final class CallBindingCallContext extends AbstractSqlCallContext {
         return map;
     }
 
-    /**
-     * Unwraps implicit CASTs that Calcite adds to MAP literal operands when keys or values have
-     * different lengths (e.g., {@code CAST('INSERT' AS VARCHAR(12))}).
-     */
+    /** Unwraps implicit CHAR-type CASTs added by Calcite for length normalization. */
     private static SqlNode unwrapCast(final SqlNode node) {
-        if (node.getKind() == SqlKind.CAST) {
-            return ((SqlCall) node).getOperandList().get(0);
+        if (node.getKind() == SqlKind.CAST && node instanceof SqlCall) {
+            final SqlNode inner = ((SqlCall) node).operand(0);
+            if (inner instanceof SqlLiteral
+                    && SqlTypeName.CHAR_TYPES.contains(((SqlLiteral) inner).getTypeName())) {
+                return inner;
+            }
         }
         return node;
     }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ToChangelogSemanticTests.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ToChangelogSemanticTests.java
@@ -48,7 +48,6 @@ public class ToChangelogSemanticTests extends SemanticTestBase {
                 ToChangelogTestPrograms.LAG_ON_UPSERT_VIA_CHANGELOG,
                 ToChangelogTestPrograms.LAG_ON_RETRACT_VIA_CHANGELOG,
                 ToChangelogTestPrograms.DELETION_FLAG,
-                ToChangelogTestPrograms.REJECTS_PARTITION_BY,
                 ToChangelogTestPrograms.INVALID_DESCRIPTOR,
                 ToChangelogTestPrograms.INVALID_OP_MAPPING,
                 ToChangelogTestPrograms.DUPLICATE_ROW_KIND);

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ToChangelogSemanticTests.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ToChangelogSemanticTests.java
@@ -50,6 +50,7 @@ public class ToChangelogSemanticTests extends SemanticTestBase {
                 ToChangelogTestPrograms.DELETION_FLAG,
                 ToChangelogTestPrograms.REJECTS_PARTITION_BY,
                 ToChangelogTestPrograms.INVALID_DESCRIPTOR,
-                ToChangelogTestPrograms.INVALID_OP_MAPPING);
+                ToChangelogTestPrograms.INVALID_OP_MAPPING,
+                ToChangelogTestPrograms.DUPLICATE_ROW_KIND);
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ToChangelogSemanticTests.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ToChangelogSemanticTests.java
@@ -41,6 +41,7 @@ public class ToChangelogSemanticTests extends SemanticTestBase {
         return List.of(
                 ToChangelogTestPrograms.INSERT_ONLY_INPUT,
                 ToChangelogTestPrograms.UPDATING_INPUT,
+                ToChangelogTestPrograms.UPSERT_INPUT,
                 ToChangelogTestPrograms.CUSTOM_OP_MAPPING,
                 ToChangelogTestPrograms.CUSTOM_OP_NAME,
                 ToChangelogTestPrograms.TABLE_API_DEFAULT,

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ToChangelogSemanticTests.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ToChangelogSemanticTests.java
@@ -47,9 +47,8 @@ public class ToChangelogSemanticTests extends SemanticTestBase {
                 ToChangelogTestPrograms.LAG_ON_UPSERT_VIA_CHANGELOG,
                 ToChangelogTestPrograms.LAG_ON_RETRACT_VIA_CHANGELOG,
                 ToChangelogTestPrograms.DELETION_FLAG,
-                ToChangelogTestPrograms.MISSING_PARTITION_BY,
+                ToChangelogTestPrograms.REJECTS_PARTITION_BY,
                 ToChangelogTestPrograms.INVALID_DESCRIPTOR,
-                ToChangelogTestPrograms.INVALID_OP_MAPPING,
-                ToChangelogTestPrograms.DUPLICATE_ROW_KIND);
+                ToChangelogTestPrograms.INVALID_OP_MAPPING);
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ToChangelogTestPrograms.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ToChangelogTestPrograms.java
@@ -28,8 +28,6 @@ import org.apache.flink.types.RowKind;
 
 import java.time.Instant;
 
-import static org.apache.flink.table.api.Expressions.$;
-
 /** {@link TableTestProgram} definitions for testing the built-in TO_CHANGELOG PTF. */
 public class ToChangelogTestPrograms {
 
@@ -56,11 +54,10 @@ public class ToChangelogTestPrograms {
                                     .build())
                     .setupTableSink(
                             SinkTestStep.newBuilder("sink")
-                                    .addSchema("id INT", "op STRING", "name STRING")
-                                    .consumedValues("+I[1, INSERT, Alice]", "+I[2, INSERT, Bob]")
+                                    .addSchema("op STRING", "id INT", "name STRING")
+                                    .consumedValues("+I[INSERT, 1, Alice]", "+I[INSERT, 2, Bob]")
                                     .build())
-                    .runSql(
-                            "INSERT INTO sink SELECT * FROM TO_CHANGELOG(input => TABLE t PARTITION BY id)")
+                    .runSql("INSERT INTO sink SELECT * FROM TO_CHANGELOG(input => TABLE t)")
                     .build();
 
     public static final TableTestProgram UPDATING_INPUT =
@@ -81,16 +78,15 @@ public class ToChangelogTestPrograms {
                                     .build())
                     .setupTableSink(
                             SinkTestStep.newBuilder("sink")
-                                    .addSchema("name STRING", "op STRING", "score BIGINT")
+                                    .addSchema("op STRING", "name STRING", "score BIGINT")
                                     .consumedValues(
-                                            "+I[Alice, INSERT, 10]",
-                                            "+I[Bob, INSERT, 20]",
-                                            "+I[Alice, UPDATE_BEFORE, 10]",
-                                            "+I[Alice, UPDATE_AFTER, 30]",
-                                            "+I[Bob, DELETE, 20]")
+                                            "+I[INSERT, Alice, 10]",
+                                            "+I[INSERT, Bob, 20]",
+                                            "+I[UPDATE_BEFORE, Alice, 10]",
+                                            "+I[UPDATE_AFTER, Alice, 30]",
+                                            "+I[DELETE, Bob, 20]")
                                     .build())
-                    .runSql(
-                            "INSERT INTO sink SELECT * FROM TO_CHANGELOG(input => TABLE t PARTITION BY name)")
+                    .runSql("INSERT INTO sink SELECT * FROM TO_CHANGELOG(input => TABLE t)")
                     .build();
 
     public static final TableTestProgram CUSTOM_OP_MAPPING =
@@ -111,15 +107,15 @@ public class ToChangelogTestPrograms {
                                     .build())
                     .setupTableSink(
                             SinkTestStep.newBuilder("sink")
-                                    .addSchema("name STRING", "op_code STRING", "score BIGINT")
+                                    .addSchema("op_code STRING", "name STRING", "score BIGINT")
                                     .consumedValues(
-                                            "+I[Alice, I, 10]",
-                                            "+I[Bob, I, 20]",
-                                            "+I[Alice, U, 30]")
+                                            "+I[I, Alice, 10]",
+                                            "+I[I, Bob, 20]",
+                                            "+I[U, Alice, 30]")
                                     .build())
                     .runSql(
                             "INSERT INTO sink SELECT * FROM TO_CHANGELOG("
-                                    + "input => TABLE t PARTITION BY name, "
+                                    + "input => TABLE t, "
                                     + "op => DESCRIPTOR(op_code), "
                                     + "op_mapping => MAP['INSERT','I', 'UPDATE_AFTER','U'])")
                     .build();
@@ -135,12 +131,12 @@ public class ToChangelogTestPrograms {
                                     .build())
                     .setupTableSink(
                             SinkTestStep.newBuilder("sink")
-                                    .addSchema("id INT", "operation STRING", "name STRING")
-                                    .consumedValues("+I[1, INSERT, Alice]")
+                                    .addSchema("operation STRING", "id INT", "name STRING")
+                                    .consumedValues("+I[INSERT, 1, Alice]")
                                     .build())
                     .runSql(
                             "INSERT INTO sink SELECT * FROM TO_CHANGELOG("
-                                    + "input => TABLE t PARTITION BY id, "
+                                    + "input => TABLE t, "
                                     + "op => DESCRIPTOR(operation))")
                     .build();
 
@@ -151,7 +147,7 @@ public class ToChangelogTestPrograms {
     public static final TableTestProgram TABLE_API_DEFAULT =
             TableTestProgram.of(
                             "to-changelog-table-api-default",
-                            "PartitionedTable.toChangelog() convenience method")
+                            "Table.toChangelog() convenience method")
                     .setupTableSource(
                             SourceTestStep.newBuilder("t")
                                     .addSchema("id INT", "name STRING")
@@ -162,10 +158,10 @@ public class ToChangelogTestPrograms {
                                     .build())
                     .setupTableSink(
                             SinkTestStep.newBuilder("sink")
-                                    .addSchema("id INT", "op STRING", "name STRING")
-                                    .consumedValues("+I[1, INSERT, Alice]", "+I[2, INSERT, Bob]")
+                                    .addSchema("op STRING", "id INT", "name STRING")
+                                    .consumedValues("+I[INSERT, 1, Alice]", "+I[INSERT, 2, Bob]")
                                     .build())
-                    .runTableApi(env -> env.from("t").partitionBy($("id")).toChangelog(), "sink")
+                    .runTableApi(env -> env.from("t").toChangelog(), "sink")
                     .build();
 
     // --------------------------------------------------------------------------------------------
@@ -219,8 +215,8 @@ public class ToChangelogTestPrograms {
                                     .build())
                     .setupSql(
                             "CREATE VIEW orders_changelog AS "
-                                    + "SELECT order_id, op, status, ts FROM TO_CHANGELOG("
-                                    + "  input => TABLE orders PARTITION BY order_id, "
+                                    + "SELECT op, order_id, status, ts FROM TO_CHANGELOG("
+                                    + "  input => TABLE orders, "
                                     + "  op_mapping => MAP['INSERT', 'INSERT', 'UPDATE_AFTER', 'UPDATE_AFTER'])")
                     .setupTableSink(
                             SinkTestStep.newBuilder("sink")
@@ -299,8 +295,8 @@ public class ToChangelogTestPrograms {
                                     .build())
                     .setupSql(
                             "CREATE VIEW orders_changelog AS "
-                                    + "SELECT order_id, op, status, ts FROM TO_CHANGELOG("
-                                    + "  input => TABLE orders PARTITION BY order_id, "
+                                    + "SELECT op, order_id, status, ts FROM TO_CHANGELOG("
+                                    + "  input => TABLE orders, "
                                     + "  op_mapping => MAP['INSERT', 'INSERT', 'UPDATE_AFTER', 'UPDATE_AFTER'])")
                     .setupTableSink(
                             SinkTestStep.newBuilder("sink")
@@ -348,16 +344,16 @@ public class ToChangelogTestPrograms {
                                     .build())
                     .setupTableSink(
                             SinkTestStep.newBuilder("sink")
-                                    .addSchema("name STRING", "deleted STRING", "score BIGINT")
+                                    .addSchema("deleted STRING", "name STRING", "score BIGINT")
                                     .consumedValues(
-                                            "+I[Alice, false, 10]",
-                                            "+I[Bob, false, 20]",
-                                            "+I[Alice, false, 30]",
-                                            "+I[Bob, true, 20]")
+                                            "+I[false, Alice, 10]",
+                                            "+I[false, Bob, 20]",
+                                            "+I[false, Alice, 30]",
+                                            "+I[true, Bob, 20]")
                                     .build())
                     .runSql(
                             "INSERT INTO sink SELECT * FROM TO_CHANGELOG("
-                                    + "input => TABLE t PARTITION BY name, "
+                                    + "input => TABLE t, "
                                     + "op => DESCRIPTOR(deleted), "
                                     + "op_mapping => MAP['INSERT, UPDATE_AFTER', 'false', 'DELETE', 'true'])")
                     .build();
@@ -366,15 +362,15 @@ public class ToChangelogTestPrograms {
     // Error validation tests
     // --------------------------------------------------------------------------------------------
 
-    public static final TableTestProgram MISSING_PARTITION_BY =
+    public static final TableTestProgram REJECTS_PARTITION_BY =
             TableTestProgram.of(
-                            "to-changelog-missing-partition-by",
-                            "fails when PARTITION BY is missing")
+                            "to-changelog-rejects-partition-by",
+                            "fails when PARTITION BY is used with row semantics")
                     .setupTableSource(SIMPLE_SOURCE)
                     .runFailingSql(
-                            "SELECT * FROM TO_CHANGELOG(input => TABLE t)",
+                            "SELECT * FROM TO_CHANGELOG(input => TABLE t PARTITION BY id)",
                             ValidationException.class,
-                            "Table argument 'input' requires a PARTITION BY clause for parallel processing.")
+                            "Only tables with set semantics may be partitioned")
                     .build();
 
     public static final TableTestProgram INVALID_DESCRIPTOR =
@@ -384,7 +380,7 @@ public class ToChangelogTestPrograms {
                     .setupTableSource(SIMPLE_SOURCE)
                     .runFailingSql(
                             "SELECT * FROM TO_CHANGELOG("
-                                    + "input => TABLE t PARTITION BY id, "
+                                    + "input => TABLE t, "
                                     + "op => DESCRIPTOR(a, b))",
                             ValidationException.class,
                             "The descriptor for argument 'op' must contain exactly one column name.")
@@ -397,7 +393,7 @@ public class ToChangelogTestPrograms {
                     .setupTableSource(SIMPLE_SOURCE)
                     .runFailingSql(
                             "SELECT * FROM TO_CHANGELOG("
-                                    + "input => TABLE t PARTITION BY id, "
+                                    + "input => TABLE t, "
                                     + "op_mapping => MAP['INVALID_KIND', 'X'])",
                             ValidationException.class,
                             "Unknown change operation: 'INVALID_KIND'")
@@ -410,7 +406,7 @@ public class ToChangelogTestPrograms {
                     .setupTableSource(SIMPLE_SOURCE)
                     .runFailingSql(
                             "SELECT * FROM TO_CHANGELOG("
-                                    + "input => TABLE t PARTITION BY id, "
+                                    + "input => TABLE t, "
                                     + "op_mapping => MAP['INSERT, DELETE', 'A', 'DELETE', 'B'])",
                             ValidationException.class,
                             "Duplicate change operation: 'DELETE'")

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ToChangelogTestPrograms.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ToChangelogTestPrograms.java
@@ -89,6 +89,36 @@ public class ToChangelogTestPrograms {
                     .runSql("INSERT INTO sink SELECT * FROM TO_CHANGELOG(input => TABLE t)")
                     .build();
 
+    public static final TableTestProgram UPSERT_INPUT =
+            TableTestProgram.of(
+                            "to-changelog-upsert-input",
+                            "upsert input gets ChangelogNormalize for UPDATE_BEFORE and full deletes")
+                    .setupTableSource(
+                            SourceTestStep.newBuilder("t")
+                                    .addSchema(
+                                            "name STRING PRIMARY KEY NOT ENFORCED", "score BIGINT")
+                                    .addMode(ChangelogMode.upsert())
+                                    .producedValues(
+                                            Row.ofKind(RowKind.INSERT, "Alice", 10L),
+                                            Row.ofKind(RowKind.INSERT, "Bob", 20L),
+                                            Row.ofKind(RowKind.UPDATE_AFTER, "Alice", 30L),
+                                            // Key-only delete: ChangelogNormalize fills
+                                            // in the full row from state
+                                            Row.ofKind(RowKind.DELETE, "Bob", null))
+                                    .build())
+                    .setupTableSink(
+                            SinkTestStep.newBuilder("sink")
+                                    .addSchema("op STRING", "name STRING", "score BIGINT")
+                                    .consumedValues(
+                                            "+I[INSERT, Alice, 10]",
+                                            "+I[INSERT, Bob, 20]",
+                                            "+I[UPDATE_BEFORE, Alice, 10]",
+                                            "+I[UPDATE_AFTER, Alice, 30]",
+                                            "+I[DELETE, Bob, 20]")
+                                    .build())
+                    .runSql("INSERT INTO sink SELECT * FROM TO_CHANGELOG(input => TABLE t)")
+                    .build();
+
     public static final TableTestProgram CUSTOM_OP_MAPPING =
             TableTestProgram.of(
                             "to-changelog-custom-op-mapping",

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ToChangelogTestPrograms.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ToChangelogTestPrograms.java
@@ -392,17 +392,6 @@ public class ToChangelogTestPrograms {
     // Error validation tests
     // --------------------------------------------------------------------------------------------
 
-    public static final TableTestProgram REJECTS_PARTITION_BY =
-            TableTestProgram.of(
-                            "to-changelog-rejects-partition-by",
-                            "fails when PARTITION BY is used with row semantics")
-                    .setupTableSource(SIMPLE_SOURCE)
-                    .runFailingSql(
-                            "SELECT * FROM TO_CHANGELOG(input => TABLE t PARTITION BY id)",
-                            ValidationException.class,
-                            "Only tables with set semantics may be partitioned")
-                    .build();
-
     public static final TableTestProgram INVALID_DESCRIPTOR =
             TableTestProgram.of(
                             "to-changelog-invalid-descriptor",

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ToChangelogTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ToChangelogTest.java
@@ -57,8 +57,7 @@ public class ToChangelogTest extends TableTestBase {
                                 + "  'changelog-mode' = 'I,UB,UA,D'"
                                 + ")");
         util.verifyRelPlan(
-                "SELECT * FROM TO_CHANGELOG(input => TABLE retract_source PARTITION BY id)",
-                CHANGELOG_MODE);
+                "SELECT * FROM TO_CHANGELOG(input => TABLE retract_source)", CHANGELOG_MODE);
     }
 
     @Test
@@ -74,8 +73,7 @@ public class ToChangelogTest extends TableTestBase {
                                 + "  'changelog-mode' = 'I,UA,D'"
                                 + ")");
         util.verifyRelPlan(
-                "SELECT * FROM TO_CHANGELOG(input => TABLE upsert_source PARTITION BY id)",
-                CHANGELOG_MODE);
+                "SELECT * FROM TO_CHANGELOG(input => TABLE upsert_source)", CHANGELOG_MODE);
     }
 
     @Test
@@ -87,7 +85,6 @@ public class ToChangelogTest extends TableTestBase {
                                 + "  name STRING"
                                 + ") WITH ('connector' = 'values')");
         util.verifyRelPlan(
-                "SELECT * FROM TO_CHANGELOG(input => TABLE insert_only_source PARTITION BY id)",
-                CHANGELOG_MODE);
+                "SELECT * FROM TO_CHANGELOG(input => TABLE insert_only_source)", CHANGELOG_MODE);
     }
 }

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/ToChangelogTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/ToChangelogTest.xml
@@ -18,39 +18,60 @@ limitations under the License.
 <Root>
   <TestCase name="testInsertOnlySource">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM TO_CHANGELOG(input => TABLE insert_only_source PARTITION BY id)]]>
+      <![CDATA[SELECT * FROM TO_CHANGELOG(input => TABLE insert_only_source)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(op=[$0], id=[$1], name=[$2])
++- LogicalTableFunctionScan(invocation=[TO_CHANGELOG(TABLE(#0), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT())], rowType=[RecordType(VARCHAR(2147483647) op, INTEGER id, VARCHAR(2147483647) name)])
+   +- LogicalProject(id=[$0], name=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, insert_only_source]])
+]]>
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-ProcessTableFunction(invocation=[TO_CHANGELOG(TABLE(#0) PARTITION BY($0), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT())], uid=[TO_CHANGELOG], select=[id,op,name], rowType=[RecordType(INTEGER id, VARCHAR(2147483647) op, VARCHAR(2147483647) name)], changelogMode=[I])
-+- Exchange(distribution=[hash[id]], changelogMode=[I])
-   +- TableSourceScan(table=[[default_catalog, default_database, insert_only_source]], fields=[id, name], changelogMode=[I])
+ProcessTableFunction(invocation=[TO_CHANGELOG(TABLE(#0), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT())], uid=[null], select=[op,id,name], rowType=[RecordType(VARCHAR(2147483647) op, INTEGER id, VARCHAR(2147483647) name)], changelogMode=[I])
++- TableSourceScan(table=[[default_catalog, default_database, insert_only_source]], fields=[id, name], changelogMode=[I])
 ]]>
     </Resource>
   </TestCase>
   <TestCase name="testRetractSource">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM TO_CHANGELOG(input => TABLE retract_source PARTITION BY id)]]>
+      <![CDATA[SELECT * FROM TO_CHANGELOG(input => TABLE retract_source)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(op=[$0], id=[$1], name=[$2])
++- LogicalTableFunctionScan(invocation=[TO_CHANGELOG(TABLE(#0), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT())], rowType=[RecordType(VARCHAR(2147483647) op, INTEGER id, VARCHAR(2147483647) name)])
+   +- LogicalProject(id=[$0], name=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, retract_source]])
+]]>
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-ProcessTableFunction(invocation=[TO_CHANGELOG(TABLE(#0) PARTITION BY($0), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT())], uid=[TO_CHANGELOG], select=[id,op,name], rowType=[RecordType(INTEGER id, VARCHAR(2147483647) op, VARCHAR(2147483647) name)], changelogMode=[I])
-+- Exchange(distribution=[hash[id]], changelogMode=[I,UB,UA,D])
-   +- TableSourceScan(table=[[default_catalog, default_database, retract_source]], fields=[id, name], changelogMode=[I,UB,UA,D])
+ProcessTableFunction(invocation=[TO_CHANGELOG(TABLE(#0), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT())], uid=[null], select=[op,id,name], rowType=[RecordType(VARCHAR(2147483647) op, INTEGER id, VARCHAR(2147483647) name)], changelogMode=[I])
++- TableSourceScan(table=[[default_catalog, default_database, retract_source]], fields=[id, name], changelogMode=[I,UB,UA,D])
 ]]>
     </Resource>
   </TestCase>
   <TestCase name="testUpsertSource">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM TO_CHANGELOG(input => TABLE upsert_source PARTITION BY id)]]>
+      <![CDATA[SELECT * FROM TO_CHANGELOG(input => TABLE upsert_source)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(op=[$0], id=[$1], name=[$2])
++- LogicalTableFunctionScan(invocation=[TO_CHANGELOG(TABLE(#0), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT())], rowType=[RecordType(VARCHAR(2147483647) op, INTEGER id, VARCHAR(2147483647) name)])
+   +- LogicalProject(id=[$0], name=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, upsert_source]])
+]]>
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-ProcessTableFunction(invocation=[TO_CHANGELOG(TABLE(#0) PARTITION BY($0), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT())], uid=[TO_CHANGELOG], select=[id,op,name], rowType=[RecordType(INTEGER id, VARCHAR(2147483647) op, VARCHAR(2147483647) name)], changelogMode=[I])
-+- Exchange(distribution=[hash[id]], changelogMode=[I,UB,UA,D])
-   +- ChangelogNormalize(key=[id], changelogMode=[I,UB,UA,D])
-      +- Exchange(distribution=[hash[id]], changelogMode=[I,UA,D])
-         +- TableSourceScan(table=[[default_catalog, default_database, upsert_source]], fields=[id, name], changelogMode=[I,UA,D])
+ProcessTableFunction(invocation=[TO_CHANGELOG(TABLE(#0), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT())], uid=[null], select=[op,id,name], rowType=[RecordType(VARCHAR(2147483647) op, INTEGER id, VARCHAR(2147483647) name)], changelogMode=[I])
++- ChangelogNormalize(key=[id], changelogMode=[I,UB,UA,D])
+   +- Exchange(distribution=[hash[id]], changelogMode=[I,UA,D])
+      +- TableSourceScan(table=[[default_catalog, default_database, upsert_source]], fields=[id, name], changelogMode=[I,UA,D])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/ptf/ToChangelogFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/ptf/ToChangelogFunction.java
@@ -24,13 +24,10 @@ import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.utils.JoinedRowData;
-import org.apache.flink.table.data.utils.ProjectedRowData;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.FunctionContext;
 import org.apache.flink.table.functions.SpecializedFunction.SpecializedContext;
-import org.apache.flink.table.functions.TableSemantics;
 import org.apache.flink.table.types.inference.CallContext;
-import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.ColumnList;
 import org.apache.flink.types.RowKind;
 
@@ -38,19 +35,14 @@ import javax.annotation.Nullable;
 
 import java.util.EnumMap;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 /**
  * Runtime implementation of {@link BuiltInFunctionDefinitions#TO_CHANGELOG}.
  *
  * <p>Converts each input row into an INSERT-only output row with an operation code column. The
- * output schema is {@code [op_column, ...non_partition_columns...]} - the framework prepends
- * partition key columns automatically.
+ * output schema is {@code [op_column, ...all_input_columns...]}.
  *
- * <p>Uses {@link ProjectedRowData} for zero-copy projection of non-partition columns and {@link
- * JoinedRowData} to combine the op column with the projected input.
+ * <p>Uses {@link JoinedRowData} to combine the op column with the full input row.
  */
 @Internal
 public class ToChangelogFunction extends BuiltInProcessTableFunction<RowData> {
@@ -65,10 +57,8 @@ public class ToChangelogFunction extends BuiltInProcessTableFunction<RowData> {
                     RowKind.DELETE, "DELETE");
 
     private final Map<RowKind, String> rawOpMap;
-    private final int[] nonPartitionIndices;
 
     private transient Map<RowKind, StringData> opMap;
-    private transient ProjectedRowData projectedInput;
     private transient GenericRowData opRow;
     private transient JoinedRowData output;
 
@@ -76,18 +66,6 @@ public class ToChangelogFunction extends BuiltInProcessTableFunction<RowData> {
     public ToChangelogFunction(final SpecializedContext context) {
         super(BuiltInFunctionDefinitions.TO_CHANGELOG, context);
         final CallContext callContext = context.getCallContext();
-
-        final TableSemantics semantics =
-                callContext
-                        .getTableSemantics(0)
-                        .orElseThrow(() -> new IllegalStateException("Table argument expected."));
-        final int[] partitionKeys = semantics.partitionByColumns();
-        final Set<Integer> partitionKeySet =
-                IntStream.of(partitionKeys).boxed().collect(Collectors.toSet());
-
-        final RowType inputType = (RowType) semantics.dataType().getLogicalType();
-        this.nonPartitionIndices =
-                buildNonPartitionIndices(inputType.getFieldCount(), partitionKeySet);
 
         final Map<String, String> opMapping =
                 callContext.getArgumentValue(2, Map.class).orElse(null);
@@ -99,14 +77,8 @@ public class ToChangelogFunction extends BuiltInProcessTableFunction<RowData> {
         super.open(context);
         opMap = new EnumMap<>(RowKind.class);
         rawOpMap.forEach((kind, code) -> opMap.put(kind, StringData.fromString(code)));
-        projectedInput = ProjectedRowData.from(nonPartitionIndices);
         opRow = new GenericRowData(1);
         output = new JoinedRowData();
-    }
-
-    private static int[] buildNonPartitionIndices(
-            final int fieldCount, final Set<Integer> partitionKeySet) {
-        return IntStream.range(0, fieldCount).filter(i -> !partitionKeySet.contains(i)).toArray();
     }
 
     /**
@@ -138,7 +110,6 @@ public class ToChangelogFunction extends BuiltInProcessTableFunction<RowData> {
         }
 
         opRow.setField(0, opCode);
-        projectedInput.replaceRow(input);
-        collect(output.replace(opRow, projectedInput));
+        collect(output.replace(opRow, input));
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Switches TO_CHANGELOG from SET_SEMANTIC_TABLE to ROW_SEMANTIC_TABLE, removing the PARTITION BY requirement. The planner inserts ChangelogNormalize for upsert sources to guarantee UPDATE_BEFORE and full DELETE rows (correctness over performance)..


## Brief change log

 - Switched TO_CHANGELOG to row semantics (no PARTITION BY)                                                                                                                                                                                                                                                       
  - Added REQUIRE_UPDATE_BEFORE + REQUIRE_FULL_DELETE for correctness guarantees
  - Moved toChangelog() from PartitionedTable to Table interface                                                                                                                                                                                                                                                   
  - Simplified runtime and type strategy by removing partition key projection
  - Added UPSERT_INPUT semantic test with key-only deletes to verify ChangelogNormalize fills full rows                                                                                                                                                                                                            
  - Fixed CallBindingCallContext.convertMap() to unwrap implicit CASTs on MAP literal operands                                                                                                                                                                                                                     
  - Re-enabled DUPLICATE_ROW_KIND validation test 


## Verifying this change

- Plan tests pass
- Semantic tests pass
 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs / JavaDocs)
