### PR TITLE
[FLINK-39423][tests] Fix PseudoRandomValueSelector.randomize() producing identical values for all boolean config options

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/PseudoRandomValueSelector.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/PseudoRandomValueSelector.java
@@ -128,7 +128,8 @@ public class PseudoRandomValueSelector {
     public static <T> T randomize(Configuration conf, ConfigOption<T> option, T... t1) {
         final String testName = TestNameProvider.getCurrentTestName();
         final PseudoRandomValueSelector valueSelector =
-                PseudoRandomValueSelector.create(testName != null ? testName : "unknown");
+                PseudoRandomValueSelector.create(
+                        (testName != null ? testName : "unknown") + option.key());
         return valueSelector.select(conf, option, t1);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/PseudoRandomValueSelectorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/PseudoRandomValueSelectorTest.java
@@ -19,6 +19,7 @@ package org.apache.flink.runtime.testutils;
 
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.runtime.util.EnvironmentInformation;
@@ -34,6 +35,7 @@ import java.util.stream.IntStream;
 import static org.apache.flink.configuration.CheckpointingOptions.SAVEPOINT_DIRECTORY;
 import static org.apache.flink.configuration.JobManagerOptions.TOTAL_PROCESS_MEMORY;
 import static org.apache.flink.configuration.TaskManagerOptions.CPU_CORES;
+import static org.apache.flink.runtime.testutils.PseudoRandomValueSelector.randomize;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assume.assumeNoException;
 import static org.junit.Assume.assumeNotNull;
@@ -107,6 +109,28 @@ class PseudoRandomValueSelectorTest {
                             selectValue(selector, SAVEPOINT_DIRECTORY, strings)));
         }
         assertThat(uniqueValues).hasSize(1);
+    }
+
+    /**
+     * Tests that randomize() produces different values for different config options within the same
+     * test. Previously, all boolean options got the same value because the seed did not include the
+     * config option key.
+     */
+    @Test
+    void testRandomizeDifferentOptionsProduceDifferentValues() {
+        final Integer[] alternatives = IntStream.range(0, 20).boxed().toArray(Integer[]::new);
+
+        final Configuration conf = new Configuration();
+        final Set<Integer> uniqueValues = new HashSet<>();
+
+        for (int i = 0; i < 100; i++) {
+            ConfigOption<Integer> option =
+                    ConfigOptions.key("test.randomize.option." + i).intType().noDefaultValue();
+            randomize(conf, option, alternatives);
+            uniqueValues.add(conf.get(option));
+        }
+        // 100 independent nextInt(20) calls should produce many distinct values
+        assertThat(uniqueValues).hasSizeGreaterThan(15);
     }
 
     /**

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
@@ -164,7 +164,8 @@ abstract class UnalignedCheckpointTestBase {
         FsStateChangelogStorageFactory.configure(
                 conf, TempDirUtils.newFolder(temp), Duration.ofMinutes(1), 10);
 
-        final StreamGraph streamGraph = getStreamGraph(settings, conf);
+        // Only used to calculate the required slots for the mini cluster.
+        StreamGraph streamGraph = getStreamGraph(settings, conf);
         final int requiredSlots =
                 streamGraph.getStreamNodes().stream()
                         .mapToInt(StreamNode::getParallelism)
@@ -180,6 +181,10 @@ abstract class UnalignedCheckpointTestBase {
                                 .setNumberSlotsPerTaskManager(slotsPerTM)
                                 .build());
         miniCluster.before();
+
+        // Rebuild stream graph via getExecutionEnvironment which now triggers
+        // TestStreamEnvironment's randomizeConfiguration via the registered factory.
+        streamGraph = getStreamGraph(settings, conf);
 
         final CheckpointGenerationMode mode = settings.checkpointGenerationMode;
         JobID jobID = null;
@@ -246,9 +251,10 @@ abstract class UnalignedCheckpointTestBase {
     }
 
     private StreamGraph getStreamGraph(UnalignedSettings settings, Configuration conf) {
-        // a dummy environment used to retrieve the DAG, mini cluster will be used later
+        // Use getExecutionEnvironment so that TestStreamEnvironment's randomizeConfiguration
+        // is triggered when the factory is registered (after miniCluster.before()).
         final StreamExecutionEnvironment setupEnv =
-                StreamExecutionEnvironment.createLocalEnvironment(conf);
+                StreamExecutionEnvironment.getExecutionEnvironment(conf);
         settings.configure(setupEnv);
 
         settings.dagCreator.create(


### PR DESCRIPTION
## What is the purpose of the change

Fix `PseudoRandomValueSelector.randomize()` producing identical values for all boolean config options within a single test.

## Problem

All boolean config options always get the **same** value within a single test — either all `true` or all `false`:

```
Randomly selected true for execution.checkpointing.unaligned.recover-output-on-downstream.enabled
Randomly selected true for execution.checkpointing.unaligned.during-recovery.enabled
Randomly selected true for execution.checkpointing.cleaner.parallel-mode
Randomly selected true for execution.checkpointing.unaligned.interruptible-timers.enabled
Randomly selected true for execution.checkpointing.snapshot-compression
Randomly selected true for execution.checkpointing.file-merging.enabled
Randomly selected true for state.backend.rocksdb.use-ingest-db-restore-mode
```

This reduces test coverage since many configuration combinations are never tested.

## Root Cause

[`randomize()`](https://github.com/apache/flink/blob/master/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/PseudoRandomValueSelector.java#L128-L133) creates a new `java.util.Random` with the same seed (commit hash + test name) for every call. Since `new Random(seed).nextInt(2)` is deterministic, all boolean options get identical results.

Introduced in [`bad18ed9aea`](https://github.com/apache/flink/commit/bad18ed9aea361836a1c49adefb4a306590419e8) ([FLINK-21448]), which replaced a shared `PseudoRandomValueSelector` instance with repeated static `randomize()` calls.

## Fix

Include the config option key in the seed so each option gets a different seed, ensuring different boolean config options are independently randomized while preserving reproducibility.

## Verifying this change

New test `testRandomizeDifferentOptionsProduceDifferentValues` verifies that different config options produce different values.

## Does this pull request potentially affect one of the following parts

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn, Mesos, Kubernetes, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable
