### PR TITLE
[FLINK-39427][build] Use Apache Parent POM 35

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ under the License.
 	<parent>
 		<groupId>org.apache</groupId>
 		<artifactId>apache</artifactId>
-		<version>20</version>
+		<version>35</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>
@@ -2177,6 +2177,8 @@ under the License.
 						<!-- Make sure that we only use Java 11 compatible APIs -->
 						<source>${source.java.version}</source>
 						<target>${target.java.version}</target>
+						<!-- Starting Apache parent pom 31 it uses release which makes impossible to use add-exports -->
+						<release combine.self="override"/>
 						<!-- The semantics of this option are reversed, see MCOMPILER-209. -->
 						<useIncrementalCompilation>false</useIncrementalCompilation>
 						<compilerArgs>


### PR DESCRIPTION

## What is the purpose of the change

The PR bumps apache parent to 35 (newer version requires minimum maven 3.9+ which should be discussed first, so only 35 for now)

## Brief change log
pom

## Verifying this change

existing tests/ci
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
