### PR TITLE
[FLINK-39431][s3] Add .value suffix key aliases in S3FileSystemFactory to support Flink v2 standard YAML

### DIFF
--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/S3FileSystemFactory.java
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/S3FileSystemFactory.java
@@ -43,7 +43,16 @@ public class S3FileSystemFactory extends AbstractS3FileSystemFactory {
     private static final String[][] MIRRORED_CONFIG_KEYS = {
         {"fs.s3a.access-key", "fs.s3a.access.key"},
         {"fs.s3a.secret-key", "fs.s3a.secret.key"},
-        {"fs.s3a.path-style-access", "fs.s3a.path.style.access"}
+        {"fs.s3a.path-style-access", "fs.s3a.path.style.access"},
+        // Flink v2 uses standard YAML which cannot represent a key that is both a scalar value and
+        // a parent of other keys (e.g. fs.s3a.endpoint and fs.s3a.endpoint.region conflict).
+        // These aliases allow users to set the scalar key via a ".value" suffix to avoid the
+        // collision, e.g. fs.s3a.endpoint.value maps to fs.s3a.endpoint in Hadoop config.
+        {"fs.s3a.endpoint.value", "fs.s3a.endpoint"},
+        {"fs.s3a.assumed.role.sts.endpoint.value", "fs.s3a.assumed.role.sts.endpoint"},
+        {"fs.s3a.fast.upload.value", "fs.s3a.fast.upload"},
+        {"fs.s3a.multipart.purge.value", "fs.s3a.multipart.purge"},
+        {"fs.s3a.s3guard.ddb.table.value", "fs.s3a.s3guard.ddb.table"},
     };
 
     public S3FileSystemFactory() {

--- a/flink-filesystems/flink-s3-fs-hadoop/src/test/java/org/apache/flink/fs/s3hadoop/HadoopS3FileSystemTest.java
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/test/java/org/apache/flink/fs/s3hadoop/HadoopS3FileSystemTest.java
@@ -80,6 +80,51 @@ class HadoopS3FileSystemTest {
         checkHadoopAccessKeys(conf, "clé d'accès", "clef secrète");
     }
 
+    /**
+     * Test that keys with the ".value" suffix are mapped to their Hadoop equivalents, allowing
+     * users to avoid YAML key prefix collisions in Flink v2's standard config.yaml format.
+     *
+     * <p>For example, "fs.s3a.endpoint" and "fs.s3a.endpoint.region" cannot coexist in standard
+     * YAML. Users can instead set "fs.s3a.endpoint.value" which is remapped to "fs.s3a.endpoint".
+     */
+    @Test
+    void testValueSuffixMappingForYamlCollisionAvoidance() {
+        Configuration conf = new Configuration();
+        conf.setString("fs.s3a.endpoint.value", "https://s3.eu-west-1.amazonaws.com");
+        conf.setString("fs.s3a.endpoint.region", "eu-west-1");
+        conf.setString(
+                "fs.s3a.assumed.role.sts.endpoint.value", "https://sts.eu-west-1.amazonaws.com");
+        conf.setString("fs.s3a.assumed.role.sts.endpoint.region", "eu-west-1");
+        conf.setString("fs.s3a.fast.upload.value", "true");
+        conf.setString("fs.s3a.fast.upload.buffer", "disk");
+        conf.setString("fs.s3a.multipart.purge.value", "true");
+        conf.setString("fs.s3a.multipart.purge.age", "86400");
+        conf.setString("fs.s3a.s3guard.ddb.table.value", "my-table");
+        conf.setString("fs.s3a.s3guard.ddb.table.capacity.read", "10");
+
+        HadoopConfigLoader configLoader = S3FileSystemFactory.createHadoopConfigLoader();
+        configLoader.setFlinkConfig(conf);
+
+        org.apache.hadoop.conf.Configuration hadoopConf = configLoader.getOrLoadHadoopConfig();
+
+        // ".value" keys must be remapped to their Hadoop equivalents
+        assertThat(hadoopConf.get("fs.s3a.endpoint", null))
+                .isEqualTo("https://s3.eu-west-1.amazonaws.com");
+        assertThat(hadoopConf.get("fs.s3a.assumed.role.sts.endpoint", null))
+                .isEqualTo("https://sts.eu-west-1.amazonaws.com");
+        assertThat(hadoopConf.get("fs.s3a.fast.upload", null)).isEqualTo("true");
+        assertThat(hadoopConf.get("fs.s3a.multipart.purge", null)).isEqualTo("true");
+        assertThat(hadoopConf.get("fs.s3a.s3guard.ddb.table", null)).isEqualTo("my-table");
+
+        // sibling keys must pass through unchanged
+        assertThat(hadoopConf.get("fs.s3a.endpoint.region", null)).isEqualTo("eu-west-1");
+        assertThat(hadoopConf.get("fs.s3a.assumed.role.sts.endpoint.region", null))
+                .isEqualTo("eu-west-1");
+        assertThat(hadoopConf.get("fs.s3a.fast.upload.buffer", null)).isEqualTo("disk");
+        assertThat(hadoopConf.get("fs.s3a.multipart.purge.age", null)).isEqualTo("86400");
+        assertThat(hadoopConf.get("fs.s3a.s3guard.ddb.table.capacity.read", null)).isEqualTo("10");
+    }
+
     private static void checkHadoopAccessKeys(
             Configuration flinkConf, String accessKey, String secretKey) {
         HadoopConfigLoader configLoader = S3FileSystemFactory.createHadoopConfigLoader();


### PR DESCRIPTION
## What is the purpose of the change

Problem

Flink 2.0 switched from flink-conf.yaml to config.yaml (standard YAML format). Standard YAML cannot represent a key that is simultaneously a scalar value and a parent node. This causes a structural conflict for several S3A config key pair where one key is a dot-prefix of another:

- `fs.s3a.endpoint` vs `fs.s3a.endpoint.region`
- `fs.s3a.assumed.role.sts.endpoint` vs `fs.s3a.assumed.role.sts.endpoint.region`
- `fs.s3a.fast.upload` vs `fs.s3a.fast.upload.buffer` / `fs.s3a.fast.upload.active.blocks`
- `fs.s3a.multipart.purge` vs `fs.s3a.multipart.purge.age`
- `fs.s3a.s3guard.ddb.table` vs `fs.s3a.s3guard.ddb.table.create` / `.capacity.read` / `.capacity.write` / etc.

When both keys are present in flinkConfiguration, the standard YAML serializer silently drops the longer key. For example, fs.s3a.endpoint.region disappears from config.yaml without any error, causing the S3 client to use the wrong signing region.

Solution

Add .value suffix aliases for the affected scalar keys to MIRRORED_CONFIG_KEYS in S3FileSystemFactory. The existing mirrorCertainHadoopConfig() mechanism in HadoopConfigLoader already supports this pattern — it copies the value of the alias key to the actual Hadoop key before the S3A filesystem is initialized.

Users on Flink 2.x can now write:

```
# config.yaml - no collision, both are children of the same parent node
fs:
  s3a:
    endpoint:
      value: https://s3.eu-west-1.amazonaws.com   # remapped to fs.s3a.endpoint
      region: eu-west-1                            # passed through as-is
    fast:
      upload:
        value: "true"                              # remapped to fs.s3a.fast.upload
        buffer: disk
```

The .value convention is intentionally uniform across all aliases so users can immediately understand the pattern without consulting documentation.

This follows the same approach already used for `fs.s3a.access-key` → `fs.s3a.access.key` and `fs.s3a.path-style-access` → `fs.s3a.path.style.access`.

## Brief change log

Add `.value` suffix key aliases in `S3FileSystemFactory` to support Flink v2 standard YAML.

## Verifying this change

Additional unit test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: yes

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
