### PR TITLE
First pass working source-reuse. Tested with BQ connector

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/OptimizerConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/OptimizerConfigOptions.java
@@ -106,6 +106,18 @@ public class OptimizerConfigOptions {
                                     + " is true.");
 
     @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH_STREAMING)
+    public static final ConfigOption<Boolean> TABLE_OPTIMIZER_REUSE_SOURCE_FILTER =
+            key("table.optimizer.source.reuse-filter")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "When it is true, the optimizer will try to reuse table sources that differ "
+                                    + "only in their pushed-down filters by moving filters into Calc nodes "
+                                    + "and sharing a single source reader. This works only when "
+                                    + TABLE_OPTIMIZER_REUSE_SOURCE_ENABLED.key()
+                                    + " is true.");
+
+    @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH_STREAMING)
     public static final ConfigOption<Boolean> TABLE_OPTIMIZER_REUSE_SINK_ENABLED =
             key("table.optimizer.reuse-sink-enabled")
                     .booleanType()

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/reuse/ReusableScanVisitor.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/reuse/ReusableScanVisitor.java
@@ -33,14 +33,21 @@ import static org.apache.flink.table.planner.plan.reuse.ScanReuserUtils.getDiges
 /** Find reusable sources. */
 public class ReusableScanVisitor extends RelVisitor {
 
+    private final boolean escapeFilter;
+
     private final Map<String, List<CommonPhysicalTableSourceScan>> digestToReusableScans =
             new HashMap<>();
+
+    // Todo don't love this, want to see if I can do this so getDigest gets this at constant level
+    public ReusableScanVisitor(boolean escapeFilter) {
+        this.escapeFilter = escapeFilter;
+    }
 
     @Override
     public void visit(RelNode node, int ordinal, RelNode parent) {
         if (node instanceof CommonPhysicalTableSourceScan) {
             CommonPhysicalTableSourceScan scan = (CommonPhysicalTableSourceScan) node;
-            String digest = getDigest(scan, true);
+            String digest = getDigest(scan, true, escapeFilter);
             digestToReusableScans.computeIfAbsent(digest, k -> new ArrayList<>()).add(scan);
             // If the scan has input such as dpp dynamic scan node, so also need to consider the
             // input

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/reuse/ScanReuser.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/reuse/ScanReuser.java
@@ -21,11 +21,15 @@ package org.apache.flink.table.planner.plan.reuse;
 import org.apache.flink.table.connector.Projection;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.connector.source.abilities.SupportsFilterPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsReadingMetadata;
 import org.apache.flink.table.planner.calcite.FlinkContext;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.planner.connectors.DynamicSourceUtils;
+import org.apache.flink.table.planner.plan.utils.FlinkRexUtil;
+import org.apache.flink.table.planner.plan.abilities.source.FilterPushDownSpec;
+import org.apache.flink.table.planner.plan.abilities.source.SourceAbilityContext;
 import org.apache.flink.table.planner.plan.abilities.source.ProjectPushDownSpec;
 import org.apache.flink.table.planner.plan.abilities.source.ReadingMetadataSpec;
 import org.apache.flink.table.planner.plan.abilities.source.SourceAbilitySpec;
@@ -38,7 +42,11 @@ import org.apache.flink.table.types.logical.RowType;
 
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexProgramBuilder;
+import org.apache.calcite.rex.RexShuttle;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -56,6 +64,7 @@ import static org.apache.flink.table.planner.plan.reuse.ScanReuserUtils.abilityS
 import static org.apache.flink.table.planner.plan.reuse.ScanReuserUtils.concatProjectedFields;
 import static org.apache.flink.table.planner.plan.reuse.ScanReuserUtils.createCalcForScan;
 import static org.apache.flink.table.planner.plan.reuse.ScanReuserUtils.enforceMetadataKeyOrder;
+import static org.apache.flink.table.planner.plan.reuse.ScanReuserUtils.getAbilitySpec;
 import static org.apache.flink.table.planner.plan.reuse.ScanReuserUtils.getAdjustedWatermarkSpec;
 import static org.apache.flink.table.planner.plan.reuse.ScanReuserUtils.indexOf;
 import static org.apache.flink.table.planner.plan.reuse.ScanReuserUtils.metadataKeys;
@@ -100,6 +109,13 @@ import static org.apache.flink.table.planner.plan.reuse.ScanReuserUtils.reusable
  *    :     +- TableSourceScan(table=[[MyTable, project=[a, b, c]]], fields=[a, b, c])
  * }</pre>
  *
+ * <p>When {@code filterReuseEnabled} is set, scans with different pushed-down filters can also be
+ * merged. The per-scan filters are OR'd into a combined predicate. Before committing to the merge,
+ * the OR'd predicate is tested against a copy of the source via {@link
+ * SupportsFilterPushDown#applyFilters}. If the connector accepts it, the merged source pushes the
+ * OR'd filter and each consumer's Calc applies its original filter. If the connector rejects it,
+ * the group is skipped and scans remain separate — no full-table read occurs.
+ *
  * <p>This class do not reuse all sources, sources with same digest will be reused by {@link
  * SubplanReuser}.
  *
@@ -128,14 +144,27 @@ public class ScanReuser {
 
     private final FlinkContext flinkContext;
     private final FlinkTypeFactory flinkTypeFactory;
+    private final boolean filterReuseEnabled;
 
     public ScanReuser(FlinkContext flinkContext, FlinkTypeFactory flinkTypeFactory) {
+        this(flinkContext, flinkTypeFactory, false);
+    }
+
+    public ScanReuser(
+            FlinkContext flinkContext,
+            FlinkTypeFactory flinkTypeFactory,
+            boolean filterReuseEnabled) {
         this.flinkContext = flinkContext;
         this.flinkTypeFactory = flinkTypeFactory;
+        this.filterReuseEnabled = filterReuseEnabled;
     }
 
     public List<RelNode> reuseDuplicatedScan(List<RelNode> relNodes) {
-        ReusableScanVisitor visitor = new ReusableScanVisitor();
+        // When filterReuseEnabled, escape filters in digest so scans with different
+        // filters are grouped together. Per-group, we check SupportsFilteredSourceReuse
+        // to decide whether to OR filters. If the source doesn't support it, we skip
+        // groups where filters differ (same-filter groups proceed normally for projection merge).
+        ReusableScanVisitor visitor = new ReusableScanVisitor(filterReuseEnabled);
         relNodes.forEach(visitor::go);
 
         for (List<CommonPhysicalTableSourceScan> reusableNodes :
@@ -148,6 +177,13 @@ public class ScanReuser {
                     .anyMatch(ScanReuserUtils::containsRexNodeSpecAfterProjection)) {
                 continue;
             }
+
+            // Determine if we should attempt to merge different filters (OR them).
+            // Requires: config enabled + source supports filter pushdown.
+            DynamicTableSource tableSource =
+                    reusableNodes.get(0).tableSourceTable().tableSource();
+            boolean mergeFilters =
+                    filterReuseEnabled && tableSource instanceof SupportsFilterPushDown;
 
             CommonPhysicalTableSourceScan pickScan = pickScanWithWatermark(reusableNodes);
             TableSourceTable pickTable = pickScan.tableSourceTable();
@@ -165,12 +201,18 @@ public class ScanReuser {
                 allMetaKeySet.addAll(metadataKeys(source));
             }
 
+            // 1.1 When merging filters, add filter-referenced columns to projection so Calc can filter.
+            if (mergeFilters) {
+                collectFilterReferencedColumns(reusableNodes, allProjectFieldSet);
+            }
+
             int[][] allProjectFields = allProjectFieldSet.toArray(new int[0][]);
             List<String> allMetaKeys =
                     enforceMetadataKeyOrder(allMetaKeySet, pickTable.tableSource());
 
             // 2. Create new source.
-            List<SourceAbilitySpec> specs = abilitySpecsWithoutEscaped(pickTable);
+            List<SourceAbilitySpec> specs =
+                    abilitySpecsWithoutEscaped(pickTable, mergeFilters);
 
             // 2.1 Create produced type.
             // The source produced type is the input type into the runtime. The format looks as:
@@ -182,7 +224,7 @@ public class ScanReuser {
                             pickTable.contextResolvedTable().getResolvedSchema(),
                             pickTable.tableSource());
 
-            // 2.2 Apply projections
+            // 2.2 Apply projections and metadata
             List<SourceAbilitySpec> newSpecs = new ArrayList<>();
             RowType newSourceType =
                     applyPhysicalAndMetadataPushDown(
@@ -206,7 +248,13 @@ public class ScanReuser {
                 newSourceType = watermarkSpec.get().getProducedType().get();
             }
 
-            // 2.4 Create a new ScanTableSource. ScanTableSource can not be pushed down twice.
+            // 2.4 OR all per-scan filters into combined predicate for the source.
+            if (mergeFilters) {
+                buildOrFilterSpec(reusableNodes, newSourceType, rexBuilder)
+                        .ifPresent(specs::add);
+            }
+
+            // 2.5 Create a new ScanTableSource. ScanTableSource can not be pushed down twice.
             DynamicTableSourceSpec tableSourceSpec =
                     new DynamicTableSourceSpec(pickTable.contextResolvedTable(), specs);
             ScanTableSource newTableSource =
@@ -221,15 +269,24 @@ public class ScanReuser {
 
             RelNode newScan = pickScan.copy(newSourceTable);
 
-            // 3. Create projects.
+            // 3. Create per-consumer Calc nodes.
             for (CommonPhysicalTableSourceScan scan : reusableNodes) {
                 TableSourceTable source = scan.tableSourceTable();
                 int[][] projectedFields = projectedFields(source);
                 List<String> metaKeys = metadataKeys(source);
 
+                // check to see if we have any merged filters we need to create Calc nodes for
+                FilterPushDownSpec filterSpec =
+                        getAbilitySpec(source.abilitySpecs(), FilterPushDownSpec.class);
+                boolean hasFilter =
+                        mergeFilters
+                                && filterSpec != null
+                                && !filterSpec.getPredicates().isEmpty();
+
                 // Don't need add calc
                 if (Arrays.deepEquals(projectedFields, allProjectFields)
-                        && metaKeys.equals(allMetaKeys)) {
+                        && metaKeys.equals(allMetaKeys)
+                        && !hasFilter) {
                     // full project may be pushed into source, update to the new source
                     replaceMap.put(scan, newScan);
                     continue;
@@ -247,6 +304,14 @@ public class ScanReuser {
                     builder.addProject(index, newScan.getRowType().getFieldNames().get(index));
                 }
 
+                // Add original filter as Calc condition with remapped indices
+                if (hasFilter) {
+                    RexShuttle remap = createFieldNameRemap(
+                            physicalFieldNames(source), newScan.getRowType().getFieldNames());
+                    RexNode condition = andPredicates(filterSpec.getPredicates(), remap, rexBuilder);
+                    builder.addCondition(condition);
+                }
+
                 replaceMap.put(scan, createCalcForScan(newScan, builder.getProgram()));
             }
         }
@@ -255,6 +320,119 @@ public class ScanReuser {
         return relNodes.stream()
                 .map(rel -> rel.accept(replaceShuttle))
                 .collect(Collectors.toList());
+    }
+
+    /** Add all columns referenced by the filters to the projection set. */
+    private static void collectFilterReferencedColumns(
+            List<CommonPhysicalTableSourceScan> scans,
+            TreeSet<int[]> allProjectFieldSet) {
+        for (CommonPhysicalTableSourceScan scan : scans) {
+            FilterPushDownSpec fs =
+                    getAbilitySpec(scan.tableSourceTable().abilitySpecs(), FilterPushDownSpec.class);
+            if (fs == null) continue;
+            for (RexNode pred : fs.getPredicates()) {
+                for (RexInputRef ref : FlinkRexUtil.findAllInputRefs(pred)) {
+                    allProjectFieldSet.add(new int[] {ref.getIndex()});
+                }
+            }
+        }
+    }
+
+    /**
+     * OR all table scan filter into a combined FilterPushDownSpec for the unified source. Before
+     * returning, verifies the connector accepts the OR'd predicate by calling applyFilters on a
+     * throwaway copy. Returns empty if any scan has no filter or the connector rejects the OR.
+     * TODO, still on the fence if this should return empty or throw exception indicating source
+     * incompatible with this source reuse
+     */
+    // todo remove extra comments once finalized approach
+    private Optional<FilterPushDownSpec> buildOrFilterSpec(
+            List<CommonPhysicalTableSourceScan> scans,
+            RowType newSourceType,
+            RexBuilder rexBuilder) {
+        List<RexNode> perScanFilters = new ArrayList<>();
+        // Get on Node per table source scan
+        for (CommonPhysicalTableSourceScan scan : scans) {
+            FilterPushDownSpec fs =
+                    getAbilitySpec(scan.tableSourceTable().abilitySpecs(), FilterPushDownSpec.class);
+            if (fs == null || fs.getPredicates().isEmpty()) {
+                // OR with empty filter -> no filter
+                return Optional.empty();
+            }
+            RexShuttle remap = createFieldNameRemap(
+                    physicalFieldNames(scan.tableSourceTable()), newSourceType.getFieldNames());
+            perScanFilters.add(andPredicates(fs.getPredicates(), remap, rexBuilder));
+        }
+        // todo figure out when this could happen
+        if (perScanFilters.isEmpty()) {
+            return Optional.empty();
+        }
+
+        // more efficient way to write this
+        RexNode combined = perScanFilters.get(0);
+        for (int i = 1; i < perScanFilters.size(); i++) {
+            combined = rexBuilder.makeCall(SqlStdOperatorTable.OR, combined, perScanFilters.get(i));
+        }
+
+        if (!connectorAcceptsFilter(scans.get(0).tableSourceTable().tableSource(), combined, newSourceType)) {
+            // todo decide if exception thrown here instead of no filter being passed
+            // could be dangerous passing no filter
+            return Optional.empty();
+        }
+
+        return Optional.of(new FilterPushDownSpec(List.of(combined), false));
+    }
+
+    /**
+     * Test whether the connector accepts a filter predicate by calling applyFilters on a
+     * throwaway copy. No calls to actual data-source is used.
+     */
+    private boolean connectorAcceptsFilter(
+            DynamicTableSource source, RexNode filter, RowType sourceType) {
+        DynamicTableSource copy = source.copy();
+        SourceAbilityContext context =
+                new SourceAbilityContext(flinkContext, flinkTypeFactory, sourceType);
+        // todo triple check the apply here is proper way to do this check is valid for ORs
+        SupportsFilterPushDown.Result result =
+                FilterPushDownSpec.apply(List.of(filter), copy, context);
+        return !result.getAcceptedFilters().isEmpty();
+    }
+
+    /** Create a RexShuttle that remaps RexInputRef indices by matching field names. */
+    private static RexShuttle createFieldNameRemap(
+            List<String> oldNames, List<String> newNames) {
+        return new RexShuttle() {
+            @Override
+            public RexNode visitInputRef(RexInputRef ref) {
+                String fieldName = oldNames.get(ref.getIndex());
+                int newIndex = newNames.indexOf(fieldName);
+                if (newIndex < 0) {
+                    throw new org.apache.flink.table.api.TableException(
+                            String.format(
+                                    "Field '%s' not found in target type %s during filter remap.",
+                                    fieldName, newNames));
+                }
+                return new RexInputRef(newIndex, ref.getType());
+            }
+        };
+    }
+
+    /** Get physical column field names from a TableSourceTable. */
+    // needed because want to remap indicies from filter predicates to our unified scan
+    private static List<String> physicalFieldNames(TableSourceTable source) {
+        return ((RowType) source.contextResolvedTable().getResolvedSchema()
+                .toPhysicalRowDataType().getLogicalType()).getFieldNames();
+    }
+
+    /** AND a list of predicates together, applying a remap shuttle to each. */
+    // used for or'ing all our statements together
+    private static RexNode andPredicates(
+            List<RexNode> predicates, RexShuttle remap, RexBuilder rexBuilder) {
+        RexNode result = predicates.get(0).accept(remap);
+        for (int i = 1; i < predicates.size(); i++) {
+            result = rexBuilder.makeCall(SqlStdOperatorTable.AND, result, predicates.get(i).accept(remap));
+        }
+        return result;
     }
 
     /**

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/reuse/ScanReuserUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/reuse/ScanReuserUtils.java
@@ -91,10 +91,15 @@ public class ScanReuserUtils {
      * ProjectPushDownSpec}. These abilities don't need before do scan reuse.
      */
     public static List<SourceAbilitySpec> abilitySpecsWithoutEscaped(TableSourceTable table) {
+        return abilitySpecsWithoutEscaped(table, false);
+    }
+
+    public static List<SourceAbilitySpec> abilitySpecsWithoutEscaped(
+            TableSourceTable table, boolean escapeFilter) {
         List<SourceAbilitySpec> ret = new ArrayList<>();
         SourceAbilitySpec[] specs = table.abilitySpecs();
         for (SourceAbilitySpec spec : specs) {
-            if (!isEscapeDigest(spec)) {
+            if (!isEscapeDigest(spec, escapeFilter)) {
                 ret.add(spec);
             }
         }
@@ -117,21 +122,23 @@ public class ScanReuserUtils {
         return false;
     }
 
-    public static boolean isEscapeDigest(SourceAbilitySpec spec) {
+    public static boolean isEscapeDigest(SourceAbilitySpec spec, boolean reuseSourceFilter) {
         // WatermarkPushDownSpec is based on index, which is unstable by projection push down.
         // We can ignore Watermark, because sources will produce same watermark.
         return spec instanceof ProjectPushDownSpec
                 || spec instanceof ReadingMetadataSpec
-                || spec instanceof WatermarkPushDownSpec;
+                || spec instanceof WatermarkPushDownSpec
+                || (spec instanceof FilterPushDownSpec && reuseSourceFilter);
     }
 
-    private static List<String> extraDigestsWithoutEscapedAndIgnored(TableSourceTable table) {
+    private static List<String> extraDigestsWithoutEscapedAndIgnored(
+            TableSourceTable table, boolean escapeFilter) {
         List<String> ret = new ArrayList<>();
         List<String> digests = table.getSpecDigests();
         SourceAbilitySpec[] specs = table.abilitySpecs();
         for (int i = 0; i < specs.length; i++) {
             SourceAbilitySpec spec = specs[i];
-            if (!isEscapeDigest(spec) && !isIgnoreDigest(spec)) {
+            if (!isEscapeDigest(spec, escapeFilter) && !isIgnoreDigest(spec)) {
                 ret.add(digests.get(i));
             }
         }
@@ -343,6 +350,11 @@ public class ScanReuserUtils {
      * @return the digest that ignore certain {@link SourceAbilitySpec}.
      */
     public static String getDigest(CommonPhysicalTableSourceScan scan, boolean withoutEscape) {
+        return getDigest(scan, withoutEscape, false);
+    }
+
+    public static String getDigest(
+            CommonPhysicalTableSourceScan scan, boolean withoutEscape, boolean escapeFilter) {
         TableSourceTable table = scan.tableSourceTable();
         List<String> digest = new ArrayList<>();
         digest.addAll(table.getNames());
@@ -358,7 +370,7 @@ public class ScanReuserUtils {
         }
 
         if (withoutEscape) {
-            digest.addAll(extraDigestsWithoutEscapedAndIgnored(table));
+            digest.addAll(extraDigestsWithoutEscapedAndIgnored(table, escapeFilter));
         } else {
             digest.addAll(extraDigestsWithoutIgnored(table));
         }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/reuse/SubplanReuser.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/reuse/SubplanReuser.scala
@@ -66,9 +66,13 @@ object SubplanReuser {
     val tableSinkReuseEnabled =
       tableConfig.get(OptimizerConfigOptions.TABLE_OPTIMIZER_REUSE_SINK_ENABLED)
 
+    val filterReuseEnabled =
+      tableConfig.get(OptimizerConfigOptions.TABLE_OPTIMIZER_REUSE_SOURCE_FILTER)
+
     var newRels = rels
     if (tableSourceReuseEnabled) {
-      newRels = new ScanReuser(flinkContext, flinkTypeFactory).reuseDuplicatedScan(rels)
+      newRels = new ScanReuser(flinkContext, flinkTypeFactory, filterReuseEnabled)
+        .reuseDuplicatedScan(rels)
     }
 
     if (tableSinkReuseEnabled) {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/optimize/ScanReuseTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/optimize/ScanReuseTest.java
@@ -192,6 +192,15 @@ class ScanReuseTest extends TableTestBase {
     }
 
     @TestTemplate
+    void testUnionWithDifferentProjections() {
+        // Leg 1 needs project=[a, b], leg 2 needs project=[a, b, c] due to filter on c.
+        // ScanReuser should unify to a single source with project=[a, b, c].
+        String sqlQuery =
+                "SELECT a, b FROM MyTable UNION ALL SELECT a, b FROM MyTable WHERE c = 'test'";
+        util.verifyExecPlan(sqlQuery);
+    }
+
+    @TestTemplate
     void testProjectWithHints() {
         String sqlQuery =
                 "SELECT T1.a, T1.c, T2.c FROM"


### PR DESCRIPTION
Adds option to re-use sources and create unified source (when possible) with all filters combined by ORs (or attempts to). Filtering for proper projections then handled by Calc nodes on Flink side. Best for use with connectors that charge by bytes scanned  i.e BQ connector


TODO DESCRP BELOW
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
