### PR TITLE
[FLINK-39480][ci] Python wheel on MacOS fails for all 2.x branches

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -101,7 +101,10 @@ jobs:
         with:
           python-version: '3.x'
       - name: "Install cibuildwheel"
-        run: python -m pip install cibuildwheel==2.16.5
+        # Need to limit setuptools here in order to apply limitations for transitive dependencies
+        run: |
+          python -m pip install cibuildwheel==2.16.5
+          echo "setuptools<82" > /tmp/build-constraints.txt
       - name: "Build python wheels for ${{ matrix.os_name }}"
         run: python -m cibuildwheel --output-dir flink-python/dist flink-python
         env:
@@ -116,6 +119,7 @@ jobs:
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair -w {dest_dir} {wheel}"
           # Skip repair on MacOS
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: ""
+          PIP_CONSTRAINT: /tmp/build-constraints.txt
       - name: "Upload python wheels"
         uses: actions/upload-artifact@v4
         with:

--- a/flink-python/pyproject.toml
+++ b/flink-python/pyproject.toml
@@ -19,7 +19,7 @@
 # Minimum requirements for the build system to execute.
 requires = [
     "packaging>=20.5; platform_machine=='arm64'",  # macos M1
-    "setuptools>=75.3",
+    "setuptools>=75.3,<82",
     "wheel",
     "cython>=0.29.24,<3; sys_platform == 'darwin' and python_version == '3.8'",
     "fastavro==1.7.4; sys_platform == 'darwin' and python_version == '3.8'",
@@ -30,7 +30,7 @@ requires = [
 [dependency-groups]
 dev = [
   "pip>=20.3",
-  "setuptools>=75.3",
+  "setuptools>=75.3,<82",
   "wheel",
   "apache-beam>=2.54.0,<=2.61.0",
   "cython>=0.29.24",


### PR DESCRIPTION

## What is the purpose of the change

fixes python wheel for macos in GHA

## Brief change log

nightly, toml


## Verifying this change

I ran on my own fork https://github.com/snuyanzin/flink/actions/runs/24560735230/job/71808434739
it passes

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
