### PR TITLE
[FLINK-39437][table] Support interruptible timers in PTFs

### DIFF
--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/process/AbstractProcessTableOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/process/AbstractProcessTableOperator.java
@@ -31,6 +31,7 @@ import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.state.StateTtlConfig;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.runtime.state.VoidNamespace;
 import org.apache.flink.runtime.state.VoidNamespaceSerializer;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperatorV2;
@@ -146,10 +147,19 @@ public abstract class AbstractProcessTableOperator extends AbstractStreamOperato
     }
 
     @Override
+    public boolean useInterruptibleTimers(ReadableConfig config) {
+        return true;
+    }
+
+    @Override
     public void processWatermark(Watermark mark) throws Exception {
-        super.processWatermark(mark);
-        // TODO this line has issues with interruptible timers, see FLINK-39437
+        // Update the runner's watermark before firing timers so that all timer callbacks
+        // (including those deferred across mailbox iterations by interruptible timers) see
+        // a consistent watermark. This matches WritableInternalTimeContext.currentWatermark(),
+        // which reads from the timer service and is also set to the new watermark before
+        // any timer fires.
         processTableRunner.ingestCurrentWatermarkEvent(mark.getTimestamp());
+        super.processWatermark(mark);
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

Enable interruptible timers for PTFs.

## Brief change log

* Override `useInterruptibleTimers()` in `AbstractProcessTableOperator` to return `true`, activating the `MailboxWatermarkProcessor` for PTF operators. This allows timer firing to be interrupted between mailbox iterations, improving throughput by not blocking mailbox processing during large timer batches.

* Also reorder `processWatermark()` to call `ingestWatermarkEvent()` before `super.processWatermark()`, ensuring all timer callbacks (including those deferred across mailbox iterations) see a consistent watermark in the runner. This matches the behavior of `WritableInternalTimeContext.currentWatermark()`, which reads from the timer service and already sees the new watermark before any timer fires.

## Verifying this change

TODO: add tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **n/a**
