### PR TITLE
[FLINK-39483][build] Bump dependency check maven plugin to 12.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2452,16 +2452,18 @@ under the License.
 					<!-- run via "mvn org.owasp:dependency-check-maven:aggregate" -->
 					<groupId>org.owasp</groupId>
 					<artifactId>dependency-check-maven</artifactId>
-					<version>5.0.0-M2</version>
+					<version>12.2.1</version>
 					<configuration>
 						<format>ALL</format>
 						<skipSystemScope>true</skipSystemScope>
 						<skipProvidedScope>true</skipProvidedScope>
 						<excludes>
+							<exclude>*flink-architecture-tests*</exclude>
 							<exclude>*flink-docs</exclude>
 							<exclude>*flink-end-to-end-tests</exclude>
 							<exclude>*flink-fs-tests*</exclude>
 							<exclude>*flink-yarn-tests*</exclude>
+							<exclude>*flink-test*</exclude>
 						</excludes>
 					</configuration>
 				</plugin>


### PR DESCRIPTION
## What is the purpose of the change

The PR fixes the execution of  dependency check maven plugin which fails with current version

## Brief change log

pom

## Verifying this change
manual invocation, as mentioned in comments

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes )
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no )
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
