### PR TITLE
[Flink-39425] [flink-metrics-otel] OpenTelemetryEventReporter logger fix for missing service.name

### DIFF
--- a/flink-metrics/flink-metrics-otel/src/main/java/org/apache/flink/events/otel/OpenTelemetryEventReporter.java
+++ b/flink-metrics/flink-metrics-otel/src/main/java/org/apache/flink/events/otel/OpenTelemetryEventReporter.java
@@ -65,6 +65,7 @@ public class OpenTelemetryEventReporter extends OpenTelemetryReporterBase implem
     @Override
     public void open(MetricConfig metricConfig) {
         LOG.info("Starting OpenTelemetryEventReporter");
+        super.open(metricConfig);
         final String protocol =
                 Optional.ofNullable(
                                 metricConfig.getProperty(

--- a/flink-metrics/flink-metrics-otel/src/test/java/org/apache/flink/metrics/otel/OpenTelemetryEventReporterTest.java
+++ b/flink-metrics/flink-metrics-otel/src/test/java/org/apache/flink/metrics/otel/OpenTelemetryEventReporterTest.java
@@ -31,7 +31,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -55,6 +57,14 @@ public class OpenTelemetryEventReporterTest extends OpenTelemetryTestBase {
     @Test
     public void testReportLogRecord() throws Exception {
         MetricConfig metricConfig = createMetricConfig();
+
+        String serviceName = "flink-job";
+        String serviceVersion = "1.0.0";
+
+        metricConfig.setProperty(OpenTelemetryReporterOptions.SERVICE_NAME.key(), serviceName);
+        metricConfig.setProperty(
+                OpenTelemetryReporterOptions.SERVICE_VERSION.key(), serviceVersion);
+
         String scope = this.getClass().getCanonicalName();
         String attribute1Key = "foo";
         String attribute1Value = "bar";
@@ -100,6 +110,19 @@ public class OpenTelemetryEventReporterTest extends OpenTelemetryTestBase {
 
         eventuallyConsumeJson(
                 (json) -> {
+                    Map<String, String> resourceAttributes = new HashMap<>();
+                    json.findPath("resourceLogs")
+                            .findPath("resource")
+                            .findPath("attributes")
+                            .forEach(
+                                    attribute ->
+                                            resourceAttributes.put(
+                                                    attribute.get("key").asText(),
+                                                    attribute.at("/value/stringValue").asText()));
+                    assertThat(resourceAttributes)
+                            .containsEntry("service.name", serviceName)
+                            .containsEntry("service.version", serviceVersion);
+
                     JsonNode resourceLogs = json.findPath("resourceLogs").findPath("scopeLogs");
                     assertThat(resourceLogs.findPath("scope").findPath("name").asText())
                             .isEqualTo(scope);


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*OpenTelemetryEventReporter logger has a missing init method call  this  means the service.name and service.version config options, defined in OpenTelemetryReporterOptions, are silently ignored for the event reporter. The resource field in OpenTelemetryReporterBase remains as Resource.getDefault() (which sets service.name = unknown_service:java), and that default is then baked into the SdkLoggerProvider at construction time.*


## Brief change log

  - *OpenTelemetryEventReporter call to super method of OpenTelemetryReporterBase that will merge the resource config (service.name)*


## Verifying this change

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for validating service.name is correctly added into logs*
  - *Added unit test that validates the loggers to have the resource service.name value*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
