### PR TITLE
[FLINK-39487][ci] Python wheel on Linux fails for 2.0.x

### DIFF
--- a/flink-python/dev/build-wheels.sh
+++ b/flink-python/dev/build-wheels.sh
@@ -41,7 +41,7 @@ if [[ "$(uname)" != "Darwin" ]]; then
     echo "Converting linux_x86_64 wheel to manylinux1"
     source `pwd`/dev/.conda/bin/activate
     # 4.1 install patchelf
-    conda install -c conda-forge patchelf=0.11 -y
+    conda install -c conda-forge patchelf=0.17 -y
     # 4.2 install auditwheel
     pip install auditwheel==6.6.0
     # 4.3 convert Linux wheel


### PR DESCRIPTION

## What is the purpose of the change

The PR is to fix blocker for 2.0.x release to fix python wheels on linux

## Brief change log
build-wheels


## Verifying this change

I verified on my fork
here it is a link https://dev.azure.com/snuyanzin/flink/_build/results?buildId=4414&view=results

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
