### PR TITLE
[FLINK-39490][runtime-web] Improve feedback when cluster is unreachable

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/app.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/app.component.ts
@@ -84,5 +84,7 @@ export class AppComponent {
   constructor(
     public statusService: StatusService,
     private cdr: ChangeDetectorRef
-  ) {}
+  ) {
+    this.statusService.registerAppCdr(this.cdr);
+  }
 }

--- a/flink-runtime-web/web-dashboard/src/app/app.interceptor.ts
+++ b/flink-runtime-web/web-dashboard/src/app/app.interceptor.ts
@@ -21,12 +21,13 @@ import {
   HttpHandler,
   HttpInterceptor,
   HttpRequest,
+  HttpResponse,
   HttpResponseBase,
   HttpStatusCode
 } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable, throwError } from 'rxjs';
-import { catchError } from 'rxjs/operators';
+import { catchError, tap } from 'rxjs/operators';
 
 import { StatusService } from '@flink-runtime-web/services';
 import { NzNotificationService, NzNotificationDataOptions } from 'ng-zorro-antd/notification';
@@ -48,6 +49,16 @@ export class AppInterceptor implements HttpInterceptor {
     };
 
     return next.handle(req.clone({ withCredentials: true })).pipe(
+      tap(event => {
+        if (event instanceof HttpResponse) {
+          if (this.statusService.networkFailureCount > 0) {
+            this.statusService.networkFailureCount = 0;
+          }
+          if (this.statusService.networkErrorNotificationId) {
+            this.notificationService.remove(this.statusService.networkErrorNotificationId);
+          }
+        }
+      }),
       catchError(res => {
         if (
           res instanceof HttpResponseBase &&
@@ -67,6 +78,20 @@ export class AppInterceptor implements HttpInterceptor {
         ) {
           this.statusService.listOfErrorMessage.push(errorMessage);
           this.notificationService.info('Server Response Message:', errorMessage.replaceAll(' at ', '\n at '), option);
+          this.statusService.markAppForCheck();
+        } else if (res.status === 0 || res.status >= 500) {
+          this.statusService.networkFailureCount += 1;
+          if (
+            this.statusService.networkFailureCount >= this.statusService.networkFailureThreshold &&
+            !this.statusService.networkErrorNotificationId
+          ) {
+            const ref = this.notificationService.warning('Network Error:', 'Connection lost or server error.', option);
+            this.statusService.networkErrorNotificationId = ref.messageId;
+            ref.onClose.subscribe(() => {
+              this.statusService.networkErrorNotificationId = null;
+              this.statusService.networkFailureCount = 0;
+            });
+          }
         }
         return throwError(res);
       })

--- a/flink-runtime-web/web-dashboard/src/app/services/job.service.ts
+++ b/flink-runtime-web/web-dashboard/src/app/services/job.service.ts
@@ -94,9 +94,10 @@ export class JobService {
   }
 
   public loadJob(jobId: string): Observable<JobDetailCorrect> {
-    return this.httpClient
-      .get<JobDetail>(`${this.configService.BASE_URL}/jobs/${jobId}`)
-      .pipe(map(job => this.convertJob(job)));
+    return this.httpClient.get<JobDetail>(`${this.configService.BASE_URL}/jobs/${jobId}`).pipe(
+      map(job => this.convertJob(job)),
+      catchError(() => EMPTY)
+    );
   }
 
   public loadAccumulators(jobId: string, vertexId: string): Observable<JobAccumulators> {

--- a/flink-runtime-web/web-dashboard/src/app/services/status.service.ts
+++ b/flink-runtime-web/web-dashboard/src/app/services/status.service.ts
@@ -17,7 +17,7 @@
  */
 
 import { HttpClient } from '@angular/common/http';
-import { inject, Injectable } from '@angular/core';
+import { ChangeDetectorRef, inject, Injectable } from '@angular/core';
 import { NavigationEnd, Router } from '@angular/router';
 import { EMPTY, fromEvent, interval, merge, Observable, Subject } from 'rxjs';
 import { debounceTime, filter, map, share, startWith, switchMap, tap } from 'rxjs/operators';
@@ -36,6 +36,23 @@ export class StatusService {
 
   /** Error server response message cache list. */
   public listOfErrorMessage: string[] = [];
+
+  /** Threshold of consecutive network failures before surfacing an error to the user. */
+  public readonly networkFailureThreshold = 5;
+  /** Count of consecutive network failures (status 0 or >=500) across all requests. */
+  public networkFailureCount = 0;
+  /** messageId of the currently-visible network-error notification, if any. */
+  public networkErrorNotificationId: string | null = null;
+
+  private appCdr?: ChangeDetectorRef;
+
+  public registerAppCdr(cdr: ChangeDetectorRef): void {
+    this.appCdr = cdr;
+  }
+
+  public markAppForCheck(): void {
+    this.appCdr?.markForCheck();
+  }
 
   /** Flink configuration from backend. */
   public configuration: Configuration;


### PR DESCRIPTION
## What is the purpose of the change

When the Flink cluster becomes unreachable (JobManager down, network blip, proxy returning 5xx), the dashboard gives no clear signal — pages sit with stale data and scattered per-request errors. This change detects persistent unreachability and surfaces a single, clear notification.

## Brief change log

- Track consecutive network failures (status `0` / `>=500`) in `StatusService` and show a single persistent `"Network Error"` toast once 5 consecutive failures occur. The toast auto-dismisses on the next successful response and re-triggers after another streak if the user dismissed it during an ongoing outage.
- Minor fixes in the same area: `JobService.loadJob` now returns `EMPTY` on error instead of breaking the Job Detail view, and the header badge refreshes immediately when a new server error arrives.

## Verifying this change

Verified manually: kill the JobManager and confirm the toast appears once after ~5 failed polls; restart and confirm it auto-dismisses; dismiss manually during an outage and confirm it reappears after another 5 failures.
<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/f2f3e44c-5684-4f05-906d-45f627997b29" />

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no