### PR TITLE
[FLINK-38900][runtime-web] Introduce the Rescales/Summary sub-page for streaming jobs with the adaptive scheduler enabled

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/interfaces/job-rescales.ts
+++ b/flink-runtime-web/web-dashboard/src/app/interfaces/job-rescales.ts
@@ -21,6 +21,31 @@ export interface RescalesOverview {
   latest: LatestRescales;
 }
 
+export interface RescalesSummary {
+  rescalesCounts: RescalesCounts;
+  rescalesDurationStatsInMillis: RescalesDurationStatsInMillis;
+  completedRescalesDurationStatsInMillis: DetailedRescalesDurationStatsInMillis;
+  ignoredRescalesDurationStatsInMillis: DetailedRescalesDurationStatsInMillis;
+  failedRescalesDurationStatsInMillis: DetailedRescalesDurationStatsInMillis;
+}
+
+export interface RescalesDurationStatsInMillis {
+  min: number;
+  max: number;
+  avg: number;
+}
+
+export interface DetailedRescalesDurationStatsInMillis {
+  min: number;
+  max: number;
+  avg: number;
+  p50: number | string;
+  p90: number | string;
+  p95: number | string;
+  p99: number | string;
+  p999: number | string;
+}
+
 export interface RescalesCounts {
   ignored: number;
   inProgress: number;

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/rescales/job-rescales.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/rescales/job-rescales.component.html
@@ -466,6 +466,286 @@
       </tbody>
     </nz-table>
   </nz-tab>
+  <nz-tab nzTitle="Summary">
+    <nz-table
+      class="no-border small"
+      [nzData]="rescalesSummary ? [''] : []"
+      [nzSize]="'small'"
+      [nzFrontPagination]="false"
+      [nzShowPagination]="false"
+    >
+      <thead>
+        <tr>
+          <th><strong>Item</strong></th>
+          <th><strong>Stat</strong></th>
+        </tr>
+      </thead>
+      <tbody>
+        <ng-container *ngIf="rescalesSummary">
+          <tr>
+            <td>Total Rescales</td>
+            <td>{{ getTotalRescaleCountFromSummary() }}</td>
+          </tr>
+          <tr>
+            <td>In Progress Rescales</td>
+            <td>{{ rescalesSummary['rescalesCounts'].inProgress }}</td>
+          </tr>
+          <tr>
+            <td>Ignored Rescales</td>
+            <td>{{ rescalesSummary['rescalesCounts'].ignored }}</td>
+          </tr>
+          <tr>
+            <td>Completed Rescales</td>
+            <td>{{ rescalesSummary['rescalesCounts'].completed }}</td>
+          </tr>
+          <tr>
+            <td>Failed Rescales</td>
+            <td>{{ rescalesSummary['rescalesCounts'].failed }}</td>
+          </tr>
+          <tr>
+            <td>Rescale Duration Max</td>
+            <td>{{ rescalesSummary['rescalesDurationStatsInMillis'].max | humanizeDuration }}</td>
+          </tr>
+          <tr>
+            <td>Rescale Duration Min</td>
+            <td>{{ rescalesSummary['rescalesDurationStatsInMillis'].min | humanizeDuration }}</td>
+          </tr>
+          <tr>
+            <td>Rescale Duration Average</td>
+            <td>{{ rescalesSummary['rescalesDurationStatsInMillis'].avg | humanizeDuration }}</td>
+          </tr>
+        </ng-container>
+      </tbody>
+    </nz-table>
+
+    <nz-collapse>
+      <nz-collapse-panel
+        [nzHeader]="'Rescale Duration Percentiles'"
+        [nzActive]="moreDetailsPanel.active"
+        [nzDisabled]="moreDetailsPanel.disabled"
+      >
+        <nz-table
+          *ngIf="rescalesSummary"
+          class="no-border small"
+          [nzData]="rescalesSummary ? [''] : []"
+          [nzSize]="'small'"
+          [nzFrontPagination]="false"
+          [nzShowPagination]="false"
+        >
+          <thead>
+            <tr>
+              <th></th>
+              <th><strong>Completed Rescale Duration</strong></th>
+              <th><strong>Ignored Rescale Duration</strong></th>
+              <th><strong>Failed Rescale Duration</strong></th>
+            </tr>
+          </thead>
+          <tbody>
+            <ng-container
+              *ngIf="
+                rescalesSummary['completedRescalesDurationStatsInMillis'] &&
+                rescalesSummary['ignoredRescalesDurationStatsInMillis'] &&
+                rescalesSummary['failedRescalesDurationStatsInMillis']
+              "
+            >
+              <tr>
+                <td><strong>Min</strong></td>
+                <td>
+                  {{
+                    rescalesSummary['completedRescalesDurationStatsInMillis']?.min
+                      | humanizeDuration
+                  }}
+                </td>
+                <td>
+                  {{
+                    rescalesSummary['ignoredRescalesDurationStatsInMillis']?.min | humanizeDuration
+                  }}
+                </td>
+                <td>
+                  {{
+                    rescalesSummary['failedRescalesDurationStatsInMillis']?.min | humanizeDuration
+                  }}
+                </td>
+              </tr>
+              <tr>
+                <td><strong>Max</strong></td>
+                <td>
+                  {{
+                    rescalesSummary['completedRescalesDurationStatsInMillis']?.max
+                      | humanizeDuration
+                  }}
+                </td>
+                <td>
+                  {{
+                    rescalesSummary['ignoredRescalesDurationStatsInMillis']?.max | humanizeDuration
+                  }}
+                </td>
+                <td>
+                  {{
+                    rescalesSummary['failedRescalesDurationStatsInMillis']?.max | humanizeDuration
+                  }}
+                </td>
+              </tr>
+              <tr>
+                <td><strong>Average</strong></td>
+                <td>
+                  {{
+                    rescalesSummary['completedRescalesDurationStatsInMillis']?.avg
+                      | humanizeDuration
+                  }}
+                </td>
+                <td>
+                  {{
+                    rescalesSummary['ignoredRescalesDurationStatsInMillis']?.avg | humanizeDuration
+                  }}
+                </td>
+                <td>
+                  {{
+                    rescalesSummary['failedRescalesDurationStatsInMillis']?.avg | humanizeDuration
+                  }}
+                </td>
+              </tr>
+              <tr>
+                <td><strong>50% percentile</strong></td>
+                <td>
+                  {{
+                    rescalesSummary['completedRescalesDurationStatsInMillis']?.p50 === 'NaN'
+                      ? 'n/a'
+                      : (rescalesSummary['completedRescalesDurationStatsInMillis']?.p50
+                        | humanizeDuration)
+                  }}
+                </td>
+                <td>
+                  {{
+                    rescalesSummary['ignoredRescalesDurationStatsInMillis']?.p50 === 'NaN'
+                      ? 'n/a'
+                      : (rescalesSummary['ignoredRescalesDurationStatsInMillis']?.p50
+                        | humanizeDuration)
+                  }}
+                </td>
+                <td>
+                  {{
+                    rescalesSummary['failedRescalesDurationStatsInMillis']?.p50 === 'NaN'
+                      ? 'n/a'
+                      : (rescalesSummary['failedRescalesDurationStatsInMillis']?.p50
+                        | humanizeDuration)
+                  }}
+                </td>
+              </tr>
+              <tr>
+                <td><strong>90% percentile</strong></td>
+                <td>
+                  {{
+                    rescalesSummary['completedRescalesDurationStatsInMillis']?.p90 === 'NaN'
+                      ? 'n/a'
+                      : (rescalesSummary['completedRescalesDurationStatsInMillis']?.p90
+                        | humanizeDuration)
+                  }}
+                </td>
+                <td>
+                  {{
+                    rescalesSummary['ignoredRescalesDurationStatsInMillis']?.p90 === 'NaN'
+                      ? 'n/a'
+                      : (rescalesSummary['ignoredRescalesDurationStatsInMillis']?.p90
+                        | humanizeDuration)
+                  }}
+                </td>
+                <td>
+                  {{
+                    rescalesSummary['failedRescalesDurationStatsInMillis']?.p90 === 'NaN'
+                      ? 'n/a'
+                      : (rescalesSummary['failedRescalesDurationStatsInMillis']?.p90
+                        | humanizeDuration)
+                  }}
+                </td>
+              </tr>
+              <tr>
+                <td><strong>95% percentile</strong></td>
+                <td>
+                  {{
+                    rescalesSummary['completedRescalesDurationStatsInMillis']?.p95 === 'NaN'
+                      ? 'n/a'
+                      : (rescalesSummary['completedRescalesDurationStatsInMillis']?.p95
+                        | humanizeDuration)
+                  }}
+                </td>
+                <td>
+                  {{
+                    rescalesSummary['ignoredRescalesDurationStatsInMillis']?.p95 === 'NaN'
+                      ? 'n/a'
+                      : (rescalesSummary['ignoredRescalesDurationStatsInMillis']?.p95
+                        | humanizeDuration)
+                  }}
+                </td>
+                <td>
+                  {{
+                    rescalesSummary['failedRescalesDurationStatsInMillis']?.p95 === 'NaN'
+                      ? 'n/a'
+                      : (rescalesSummary['failedRescalesDurationStatsInMillis']?.p95
+                        | humanizeDuration)
+                  }}
+                </td>
+              </tr>
+              <tr>
+                <td><strong>99% percentile</strong></td>
+                <td>
+                  {{
+                    rescalesSummary['completedRescalesDurationStatsInMillis']?.p99 === 'NaN'
+                      ? 'n/a'
+                      : (rescalesSummary['completedRescalesDurationStatsInMillis']?.p99
+                        | humanizeDuration)
+                  }}
+                </td>
+                <td>
+                  {{
+                    rescalesSummary['ignoredRescalesDurationStatsInMillis']?.p99 === 'NaN'
+                      ? 'n/a'
+                      : (rescalesSummary['ignoredRescalesDurationStatsInMillis']?.p99
+                        | humanizeDuration)
+                  }}
+                </td>
+                <td>
+                  {{
+                    rescalesSummary['failedRescalesDurationStatsInMillis']?.p99 === 'NaN'
+                      ? 'n/a'
+                      : (rescalesSummary['failedRescalesDurationStatsInMillis']?.p99
+                        | humanizeDuration)
+                  }}
+                </td>
+              </tr>
+              <tr>
+                <td><strong>99.9% percentile</strong></td>
+                <td>
+                  {{
+                    rescalesSummary['completedRescalesDurationStatsInMillis']?.p999 === 'NaN'
+                      ? 'n/a'
+                      : (rescalesSummary['completedRescalesDurationStatsInMillis']?.p999
+                        | humanizeDuration)
+                  }}
+                </td>
+                <td>
+                  {{
+                    rescalesSummary['ignoredRescalesDurationStatsInMillis']?.p999 === 'NaN'
+                      ? 'n/a'
+                      : (rescalesSummary['ignoredRescalesDurationStatsInMillis']?.p999
+                        | humanizeDuration)
+                  }}
+                </td>
+                <td>
+                  {{
+                    rescalesSummary['failedRescalesDurationStatsInMillis']?.p999 === 'NaN'
+                      ? 'n/a'
+                      : (rescalesSummary['failedRescalesDurationStatsInMillis']?.p999
+                        | humanizeDuration)
+                  }}
+                </td>
+              </tr>
+            </ng-container>
+          </tbody>
+        </nz-table>
+      </nz-collapse-panel>
+    </nz-collapse>
+  </nz-tab>
   <nz-tab nzTitle="Configuration">
     <nz-table
       class="no-border small"

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/rescales/job-rescales.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/rescales/job-rescales.component.ts
@@ -29,7 +29,8 @@ import {
   JobRescaleConfigInfo,
   JobDetail,
   RescalesHistory,
-  RescalesOverview
+  RescalesOverview,
+  RescalesSummary
 } from '@flink-runtime-web/interfaces';
 import { JobService } from '@flink-runtime-web/services';
 import { NzButtonModule } from 'ng-zorro-antd/button';
@@ -69,6 +70,7 @@ import { JobLocalService } from '../job-local.service';
 })
 export class JobRescalesComponent implements OnInit, OnDestroy {
   public rescalesOverview?: RescalesOverview;
+  public rescalesSummary?: RescalesSummary;
   public rescalesHistory?: RescalesHistory;
   public rescaleDetailsMap = new Map<string, JobRescaleDetails>();
   public rescalesConfig?: JobRescaleConfigInfo;
@@ -95,6 +97,11 @@ export class JobRescalesComponent implements OnInit, OnDestroy {
                 return of(undefined);
               })
             ),
+            this.jobService.loadRescalesSummary(this.jobDetail.jid).pipe(
+              catchError(() => {
+                return of(undefined);
+              })
+            ),
             this.jobService.loadRescalesHistory(this.jobDetail.jid).pipe(
               catchError(() => {
                 return of(undefined);
@@ -109,8 +116,9 @@ export class JobRescalesComponent implements OnInit, OnDestroy {
         ),
         takeUntil(this.destroy$)
       )
-      .subscribe(([overview, history, config]) => {
+      .subscribe(([overview, summary, history, config]) => {
         this.rescalesOverview = overview;
+        this.rescalesSummary = summary;
         this.rescalesHistory = history;
         this.rescalesConfig = config;
 
@@ -148,6 +156,8 @@ export class JobRescalesComponent implements OnInit, OnDestroy {
     this.destroy$.complete();
     this.refresh$.complete();
   }
+
+  public moreDetailsPanel = { active: false, disabled: false };
 
   public refresh(): void {
     const expandedUuids = Array.from(this.expandedRowsSet);
@@ -207,6 +217,14 @@ export class JobRescalesComponent implements OnInit, OnDestroy {
       return 0;
     }
     const counts = this.rescalesOverview.rescalesCounts;
+    return counts.inProgress + counts.completed + counts.failed + counts.ignored;
+  }
+
+  public getTotalRescaleCountFromSummary(): number {
+    if (!this.rescalesSummary?.rescalesCounts) {
+      return 0;
+    }
+    const counts = this.rescalesSummary.rescalesCounts;
     return counts.inProgress + counts.completed + counts.failed + counts.ignored;
   }
 

--- a/flink-runtime-web/web-dashboard/src/app/services/job.service.ts
+++ b/flink-runtime-web/web-dashboard/src/app/services/job.service.ts
@@ -27,6 +27,7 @@ import {
   CheckpointDetail,
   CheckpointSubTask,
   RescalesOverview,
+  RescalesSummary,
   RescalesHistory,
   JobRescaleDetails,
   JobRescaleConfigInfo,
@@ -184,6 +185,10 @@ export class JobService {
 
   public loadRescalesOverview(jobId: string): Observable<RescalesOverview> {
     return this.httpClient.get<RescalesOverview>(`${this.configService.BASE_URL}/jobs/${jobId}/rescales/overview`);
+  }
+
+  public loadRescalesSummary(jobId: string): Observable<RescalesSummary> {
+    return this.httpClient.get<RescalesSummary>(`${this.configService.BASE_URL}/jobs/${jobId}/rescales/summary`);
   }
 
   public loadRescalesHistory(jobId: string): Observable<RescalesHistory> {


### PR DESCRIPTION
## What is the purpose of the change

[[FLINK-38900](https://issues.apache.org/jira/browse/FLINK-38900)][runtime-web] Introduce the Rescales/Summary sub-page for streaming jobs with the adaptive scheduler enabled


## Brief change log

Adds the 'Rescales/Summary' tab subpage in relation to [[FLINK-38896](https://issues.apache.org/jira/browse/FLINK-38896)][Runtime/REST] Introduce the /jobs/:jobid/rescales/summary endpoint in the REST API
https://github.com/apache/flink/pull/27892


## Verifying this change

> Reference
> https://github.com/apache/flink/pull/27826

### Rescales Summary Tab

<img width="1910" height="1042" alt="image" src="https://github.com/user-attachments/assets/0ab6b1c1-56f5-4519-b9bf-a2297b50efe4" />


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
