### PR TITLE
[FLINK-39479][python] Add fromChangelog() to Python Table API

### DIFF
--- a/flink-python/pyflink/table/table.py
+++ b/flink-python/pyflink/table/table.py
@@ -1201,14 +1201,14 @@ class Table(object):
 
             >>> from pyflink.table.expressions import descriptor, map_
             >>> # Default: adds 'op' column with standard change operation names
-            >>> table.to_changelog()
+            >>> result = table.to_changelog()
             >>> # Custom op column name and mapping
-            >>> table.to_changelog(
+            >>> result = table.to_changelog(
             ...     descriptor("op_code").as_argument("op"),
             ...     map_("INSERT", "I", "UPDATE_AFTER", "U").as_argument("op_mapping")
             ... )
             >>> # Deletion flag pattern
-            >>> table.to_changelog(
+            >>> result = table.to_changelog(
             ...     descriptor("deleted").as_argument("op"),
             ...     map_("INSERT, UPDATE_AFTER", "false",
             ...          "DELETE", "true").as_argument("op_mapping")
@@ -1219,6 +1219,40 @@ class Table(object):
                  to the input columns.
         """
         return Table(self._j_table.toChangelog(to_expression_jarray(arguments)), self._t_env)
+
+    def from_changelog(self, *arguments: Expression) -> 'Table':
+        """
+        Converts this append-only table with an explicit operation code column into a
+        dynamic table using the built-in ``FROM_CHANGELOG`` process table function.
+
+        Each input row is expected to have a string operation code column (default: ``op``)
+        that indicates the change operation (e.g., INSERT, UPDATE_AFTER, UPDATE_BEFORE,
+        DELETE). The output table is a dynamic table backed by a changelog stream.
+
+        Example:
+        ::
+
+            >>> from pyflink.table.expressions import descriptor, map_
+            >>> # Default: reads 'op' column with standard change operation names
+            >>> result = cdc_stream.from_changelog()
+            >>> # With custom op column name
+            >>> result = cdc_stream.from_changelog(
+            ...     descriptor("operation").as_argument("op")
+            ... )
+            >>> # With custom op_mapping
+            >>> result = cdc_stream.from_changelog(
+            ...     descriptor("op").as_argument("op"),
+            ...     map_("c, r", "INSERT",
+            ...          "ub", "UPDATE_BEFORE",
+            ...          "ua", "UPDATE_AFTER",
+            ...          "d", "DELETE").as_argument("op_mapping")
+            ... )
+
+        :param arguments: Optional named arguments for ``op`` and ``op_mapping``.
+        :return: A dynamic :class:`~pyflink.table.Table` with the ``op`` column removed and
+                 proper change operation semantics.
+        """
+        return Table(self._j_table.fromChangelog(to_expression_jarray(arguments)), self._t_env)
 
 
 @PublicEvolving()

--- a/flink-python/pyflink/table/table.py
+++ b/flink-python/pyflink/table/table.py
@@ -1223,11 +1223,13 @@ class Table(object):
     def from_changelog(self, *arguments: Expression) -> 'Table':
         """
         Converts this append-only table with an explicit operation code column into a
-        dynamic table using the built-in ``FROM_CHANGELOG`` process table function.
+        (potentially updating) dynamic table. Each input row is expected to have a string
+        column that indicates the change operation. The operation column is interpreted by
+        the engine and removed from the output.
 
-        Each input row is expected to have a string operation code column (default: ``op``)
-        that indicates the change operation (e.g., INSERT, UPDATE_AFTER, UPDATE_BEFORE,
-        DELETE). The output table is a dynamic table backed by a changelog stream.
+        The operation code column defaults to ``op``. By default, the codes ``INSERT``,
+        ``UPDATE_BEFORE``, ``UPDATE_AFTER``, and ``DELETE`` are recognized; pass
+        ``op_mapping`` to use custom codes.
 
         Example:
         ::

--- a/flink-python/pyflink/table/tests/test_table_completeness.py
+++ b/flink-python/pyflink/table/tests/test_table_completeness.py
@@ -42,7 +42,6 @@ class TableAPICompletenessTests(PythonAPICompletenessTestCase, PyFlinkTestCase):
             'asArgument',
             'process',
             'partitionBy',
-            'fromChangelog',
         }
 
     @classmethod

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
@@ -1456,12 +1456,14 @@ public interface Table extends Explainable<Table>, Executable {
     Table toChangelog(Expression... arguments);
 
     /**
-     * Converts this append-only table with an explicit operation code column into a dynamic table
-     * using the built-in {@code FROM_CHANGELOG} process table function.
+     * Converts this append-only table with an explicit operation code column into a (potentially
+     * updating) dynamic table. Each input row is expected to have a string column that indicates
+     * the change operation. The operation column is interpreted by the engine and removed from the
+     * output.
      *
-     * <p>Each input row is expected to have a string operation code column (default: {@code "op"})
-     * that indicates the change operation (e.g., INSERT, UPDATE_AFTER, UPDATE_BEFORE, DELETE). The
-     * output table is a dynamic table backed by a changelog stream.
+     * <p>The operation code column defaults to {@code op}. By default, the codes {@code INSERT},
+     * {@code UPDATE_BEFORE}, {@code UPDATE_AFTER}, and {@code DELETE} are recognized; pass {@code
+     * op_mapping} to use custom codes.
      *
      * <p>Optional arguments can be passed using named expressions:
      *

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
@@ -1435,16 +1435,16 @@ public interface Table extends Explainable<Table>, Executable {
      *
      * <pre>{@code
      * // Default: adds 'op' column and supports all changelog modes
-     * table.toChangelog();
+     * Table result = table.toChangelog();
      *
      * // Custom op column name and mapping
-     * table.toChangelog(
+     * Table result = table.toChangelog(
      *     descriptor("op_code").asArgument("op"),
      *     map("INSERT", "I", "UPDATE_AFTER", "U").asArgument("op_mapping")
      * );
      *
      * // Deletion flag pattern: comma-separated keys map multiple change operations to the same code
-     * table.toChangelog(
+     * Table result = table.toChangelog(
      *     descriptor("deleted").asArgument("op"),
      *     map("INSERT, UPDATE_AFTER", "false", "DELETE", "true").asArgument("op_mapping")
      * );
@@ -1467,12 +1467,20 @@ public interface Table extends Explainable<Table>, Executable {
      *
      * <pre>{@code
      * // Default: reads 'op' column with standard change operation names
-     * table.fromChangelog();
+     * Table result = cdcStream.fromChangelog();
      *
-     * // Custom op column name and mapping (Debezium-style codes)
-     * table.fromChangelog(
-     *     descriptor("__op").asArgument("op"),
-     *     map("c, r", "INSERT", "u", "UPDATE_AFTER", "d", "DELETE").asArgument("op_mapping")
+     * // With custom op column name
+     * Table result = cdcStream.fromChangelog(
+     *     descriptor("operation").asArgument("op")
+     * );
+     *
+     * // With custom op_mapping
+     * Table result = cdcStream.fromChangelog(
+     *     descriptor("op").asArgument("op"),
+     *     map("c, r", "INSERT",
+     *         "ub", "UPDATE_BEFORE",
+     *         "ua", "UPDATE_AFTER",
+     *         "d", "DELETE").asArgument("op_mapping")
      * );
      * }</pre>
      *


### PR DESCRIPTION
## What is the purpose of the change

The Python Table API is missing the Table.fromChangelog() method introduced with the changelog PTFs (FLIP-564).


## Brief change log

  - Add from_changelog() to pyflink/table/table.py
  - Remove fromChangelog from completeness test exclusions


## Verifying this change

- Completeness check for python doesn't fail anymore

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs / comments)
  
---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
