### PR TITLE
[FLINK-39498][table] Day time interval with unsupported precision should fail in planning time rather than code gen

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/FlinkTypeFactory.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/FlinkTypeFactory.scala
@@ -648,9 +648,11 @@ object FlinkTypeFactory {
       case typeName if YEAR_INTERVAL_TYPES.contains(typeName) =>
         DataTypes.INTERVAL(DataTypes.MONTH).getLogicalType
       case typeName if DAY_INTERVAL_TYPES.contains(typeName) =>
-        if (relDataType.getPrecision > 3) {
+        // In INTERVAL getScale tells about fractional second precision
+        // See org.apache.calcite.sql.SqlIntervalQualifier
+        if (relDataType.getScale > 3) {
           throw new TableException(
-            s"DAY_INTERVAL_TYPES precision is not supported: ${relDataType.getPrecision}")
+            s"DAY_INTERVAL_TYPES precision is not supported: ${relDataType.getScale}")
         }
         DataTypes.INTERVAL(DataTypes.SECOND(3)).getLogicalType
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/validation/ScalarFunctionsValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/validation/ScalarFunctionsValidationTest.scala
@@ -119,6 +119,17 @@ class ScalarFunctionsValidationTest extends ScalarTypesTestBase {
         () => testSqlApi("TIMESTAMPADD(YEAR, 1.0, timestamp '2016-02-24 12:42:25')", "2016-06-16"))
   }
 
+  @Test
+  def testTimestampAddWithUnsupportedPrecision(): Unit = {
+    assertThatExceptionOfType(classOf[TableException])
+      .isThrownBy(
+        () => testSqlApi("TIMESTAMPADD(MICROSECOND, 1, timestamp '2016-02-24 12:42:25')", "2016-06-16"))
+
+    assertThatExceptionOfType(classOf[TableException])
+      .isThrownBy(
+        () => testSqlApi("TIMESTAMPADD(NANOSECOND, 1, timestamp '2016-02-24 12:42:25')", "2016-06-16"))
+  }
+
   // ----------------------------------------------------------------------------------------------
   // Sub-query functions
   // ----------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/validation/ScalarFunctionsValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/validation/ScalarFunctionsValidationTest.scala
@@ -123,11 +123,13 @@ class ScalarFunctionsValidationTest extends ScalarTypesTestBase {
   def testTimestampAddWithUnsupportedPrecision(): Unit = {
     assertThatExceptionOfType(classOf[TableException])
       .isThrownBy(
-        () => testSqlApi("TIMESTAMPADD(MICROSECOND, 1, timestamp '2016-02-24 12:42:25')", "2016-06-16"))
+        () =>
+          testSqlApi("TIMESTAMPADD(MICROSECOND, 1, timestamp '2016-02-24 12:42:25')", "2016-06-16"))
 
     assertThatExceptionOfType(classOf[TableException])
       .isThrownBy(
-        () => testSqlApi("TIMESTAMPADD(NANOSECOND, 1, timestamp '2016-02-24 12:42:25')", "2016-06-16"))
+        () =>
+          testSqlApi("TIMESTAMPADD(NANOSECOND, 1, timestamp '2016-02-24 12:42:25')", "2016-06-16"))
   }
 
   // ----------------------------------------------------------------------------------------------


### PR DESCRIPTION

## What is the purpose of the change

The query like 
```sql
SELECT TIMESTAMPADD(MICROSECOND, 1, timestamp '2016-02-24 12:42:25')
```
fails while code generation
at the same ime we have all the data to fail during planning

## Brief change log
typefactory


## Verifying this change

test added

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable )

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
