### PR TITLE
[FLINK-39513][checkpoint] Parameterize allowNonRestoredState in restoreInitialCheckpointIfPresent

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -1720,9 +1720,12 @@ public class CheckpointCoordinator {
      *
      * @param tasks Set of job vertices to restore. State for these vertices is restored via {@link
      *     Execution#setInitialState(JobManagerTaskRestore)}.
+     * @param allowNonRestoredState Allow checkpoint state that cannot be mapped to any job vertex
+     *     in tasks.
      * @return True, if a checkpoint was found and its state was restored, false otherwise.
      */
-    public boolean restoreInitialCheckpointIfPresent(final Set<ExecutionJobVertex> tasks)
+    public boolean restoreInitialCheckpointIfPresent(
+            final Set<ExecutionJobVertex> tasks, final boolean allowNonRestoredState)
             throws Exception {
         final OptionalLong restoredCheckpointId =
                 restoreLatestCheckpointedStateInternal(
@@ -1730,7 +1733,7 @@ public class CheckpointCoordinator {
                         OperatorCoordinatorRestoreBehavior.RESTORE_IF_CHECKPOINT_PRESENT,
                         false, // initial checkpoints exist only on JobManager failover. ok if not
                         // present.
-                        false,
+                        allowNonRestoredState,
                         true); // JobManager failover means JobGraphs match exactly.
 
         return restoredCheckpointId.isPresent();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionGraphFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionGraphFactory.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.scheduler;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.StateRecoveryOptions;
 import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
 import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
@@ -186,7 +187,8 @@ public class DefaultExecutionGraphFactory implements ExecutionGraphFactory {
         if (checkpointCoordinator != null) {
             // check whether we find a valid checkpoint
             if (!checkpointCoordinator.restoreInitialCheckpointIfPresent(
-                    new HashSet<>(newExecutionGraph.getAllVertices().values()))) {
+                    new HashSet<>(newExecutionGraph.getAllVertices().values()),
+                    configuration.get(StateRecoveryOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE))) {
 
                 // check whether we can restore from a savepoint
                 tryRestoreExecutionGraphFromSavepoint(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorRestoringTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorRestoringTest.java
@@ -1113,7 +1113,7 @@ class CheckpointCoordinatorRestoringTest {
                         .build(graph);
 
         ExecutionJobVertex vertex = graph.getJobVertex(jobVertexID);
-        coord.restoreInitialCheckpointIfPresent(Collections.singleton(vertex));
+        coord.restoreInitialCheckpointIfPresent(Collections.singleton(vertex), false);
         TaskStateSnapshot restoredState =
                 vertex.getTaskVertices()[0]
                         .getCurrentExecutionAttempt()
@@ -1159,10 +1159,70 @@ class CheckpointCoordinatorRestoringTest {
                                         })
                         .build(graph);
         restoreCoordinator.restoreInitialCheckpointIfPresent(
-                new HashSet<>(graph.getAllVertices().values()));
+                new HashSet<>(graph.getAllVertices().values()), false);
         assertThat(checked.get())
                 .as("The finished states should be checked when job is restored on startup")
                 .isTrue();
+    }
+
+    @Test
+    void testRestoreInitialCheckpointAllowsNonRestoredStateWhenTrue() throws Exception {
+        Tuple2<CheckpointCoordinator, ExecutionJobVertex> fixture = buildNonRestoredStateFixture();
+
+        assertThat(
+                        fixture.f0.restoreInitialCheckpointIfPresent(
+                                Collections.singleton(fixture.f1), true))
+                .isTrue();
+    }
+
+    @Test
+    void testRestoreInitialCheckpointRejectsNonRestoredStateWhenFalse() throws Exception {
+        Tuple2<CheckpointCoordinator, ExecutionJobVertex> fixture = buildNonRestoredStateFixture();
+
+        assertThatThrownBy(
+                        () ->
+                                fixture.f0.restoreInitialCheckpointIfPresent(
+                                        Collections.singleton(fixture.f1), false))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("There is no operator for the state");
+    }
+
+    private Tuple2<CheckpointCoordinator, ExecutionJobVertex> buildNonRestoredStateFixture()
+            throws Exception {
+        final JobVertexID jobVertexID = new JobVertexID();
+        ExecutionGraph graph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(jobVertexID, 1, 1)
+                        .build(EXECUTOR_RESOURCE.getExecutor());
+
+        OperatorID orphanedOperatorID = new OperatorID();
+        Map<OperatorID, OperatorState> operatorStates = new HashMap<>();
+        operatorStates.put(
+                orphanedOperatorID, new OperatorState(null, null, orphanedOperatorID, 1, 1));
+
+        CompletedCheckpoint completedCheckpoint =
+                new CompletedCheckpoint(
+                        graph.getJobID(),
+                        1,
+                        System.currentTimeMillis(),
+                        System.currentTimeMillis() + 3000,
+                        operatorStates,
+                        Collections.emptyList(),
+                        CheckpointProperties.forCheckpoint(
+                                CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION),
+                        new TestCompletedCheckpointStorageLocation(),
+                        null);
+
+        CompletedCheckpointStore completedCheckpointStore = new EmbeddedCompletedCheckpointStore();
+        completedCheckpointStore.addCheckpointAndSubsumeOldestOne(
+                completedCheckpoint, new CheckpointsCleaner(), () -> {});
+
+        CheckpointCoordinator coord =
+                new CheckpointCoordinatorBuilder()
+                        .setCompletedCheckpointStore(completedCheckpointStore)
+                        .build(graph);
+
+        return Tuple2.of(coord, graph.getJobVertex(jobVertexID));
     }
 
     @Test


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

`CheckpointCoordinator.restoreInitialCheckpointIfPresent` hardcodes `allowNonRestoredState=false`, so checkpoint restore on JobManager startup rejects state that cannot be mapped to any operator in the current JobGraph, regardless of `execution.savepoint.ignore-unclaimed-state` / `execution.state-recovery.ignore-unclaimed-state`. `CheckpointCoordinator.restoreSavepoint` already honors the flag via a parameter; this PR does the same for the checkpoint-restore path.

Addresses [FLINK-39513](https://issues.apache.org/jira/browse/FLINK-39513). See the ticket for history and full context.

## Brief change log

- `CheckpointCoordinator.restoreInitialCheckpointIfPresent` takes `allowNonRestoredState` as a parameter and forwards it to `restoreLatestCheckpointedStateInternal` instead of hardcoding `false`.
- `DefaultExecutionGraphFactory.createAndRestoreExecutionGraph` reads `StateRecoveryOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE` from its `Configuration` and passes it in. `Configuration` is the source (rather than `jobGraph.getSavepointRestoreSettings()`) because `SavepointRestoreSettings.fromConfiguration` returns `.none()` when no savepoint path is set, which is always the case on this path.

## Verifying this change

This change added tests and can be verified as follows:

  - Added a pair of tests in CheckpointCoordinatorRestoringTest covering both allowNonRestoredState=true (orphaned state silently skipped) and allowNonRestoredState=false (throws IllegalStateException, preserving existing strict behavior).
  - Updated two existing CheckpointCoordinatorRestoringTest call sites to pass false explicitly.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **yes** (Checkpointing)
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Code)