### PR TITLE
[FLINK-35180][python] Fix embedded (thread-mode) type converters

### DIFF
--- a/flink-python/pyflink/common/typeinfo.py
+++ b/flink-python/pyflink/common/typeinfo.py
@@ -755,9 +755,11 @@ class LocalTimeTypeInfo(TypeInformation):
 
 
 class ExternalTypeInfo(TypeInformation):
-    def __init__(self, type_info: TypeInformation):
+    def __init__(self, type_info: TypeInformation, _j_external_type_info=None):
         super(ExternalTypeInfo, self).__init__()
         self._type_info = type_info
+        if _j_external_type_info is not None:
+            self._j_typeinfo = _j_external_type_info
 
     def get_java_type_info(self) -> JavaObject:
         if not self._j_typeinfo:
@@ -770,6 +772,14 @@ class ExternalTypeInfo(TypeInformation):
             j_data_type = TypeInfoDataTypeConverter.toDataType(self._type_info.get_java_type_info())
             self._j_typeinfo = JExternalTypeInfo.of(j_data_type)
         return self._j_typeinfo
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state.pop('_j_typeinfo', None)
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
 
     def __eq__(self, other):
         return self.__class__ == other.__class__ and self._type_info == other._type_info
@@ -1112,8 +1122,10 @@ def _from_java_type(j_type_info: JavaObject) -> TypeInformation:
     if _is_instance_of(j_type_info, JExternalTypeInfo):
         TypeInfoDataTypeConverter = \
             gateway.jvm.org.apache.flink.table.types.utils.LegacyTypeInfoDataTypeConverter
-        return ExternalTypeInfo(_from_java_type(
-            TypeInfoDataTypeConverter.toLegacyTypeInfo(j_type_info.getDataType())))
+        return ExternalTypeInfo(
+            _from_java_type(
+                TypeInfoDataTypeConverter.toLegacyTypeInfo(j_type_info.getDataType())),
+            _j_external_type_info=j_type_info)
 
     raise TypeError("The java type info: %s is not supported in PyFlink currently." % j_type_info)
 

--- a/flink-python/pyflink/fn_execution/embedded/converters.py
+++ b/flink-python/pyflink/fn_execution/embedded/converters.py
@@ -15,6 +15,7 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+import datetime as _dt
 import pickle
 from abc import ABC, abstractmethod
 from typing import TypeVar, List, Tuple
@@ -22,22 +23,37 @@ from typing import TypeVar, List, Tuple
 from pemja import findClass
 
 from pyflink.common import Row, RowKind, TypeInformation
-from pyflink.common.typeinfo import (PickledBytesTypeInfo, PrimitiveArrayTypeInfo,
-                                     BasicArrayTypeInfo, ObjectArrayTypeInfo, RowTypeInfo,
-                                     TupleTypeInfo, MapTypeInfo, ListTypeInfo)
+from pyflink.common.typeinfo import (
+    PickledBytesTypeInfo,
+    PrimitiveArrayTypeInfo,
+    BasicArrayTypeInfo,
+    ObjectArrayTypeInfo,
+    RowTypeInfo,
+    TupleTypeInfo,
+    MapTypeInfo,
+    ListTypeInfo,
+)
 from pyflink.datastream import TimeWindow, CountWindow, GlobalWindow
 
-IN = TypeVar('IN')
-OUT = TypeVar('OUT')
+IN = TypeVar("IN")
+OUT = TypeVar("OUT")
 
 # Java Window
-JTimeWindow = findClass('org.apache.flink.table.runtime.operators.window.TimeWindow')
-JCountWindow = findClass('org.apache.flink.table.runtime.operators.window.CountWindow')
-JGlobalWindow = findClass('org.apache.flink.streaming.api.windowing.windows.GlobalWindow')
+JTimeWindow = findClass("org.apache.flink.table.runtime.operators.window.TimeWindow")
+JCountWindow = findClass("org.apache.flink.table.runtime.operators.window.CountWindow")
+JGlobalWindow = findClass(
+    "org.apache.flink.streaming.api.windowing.windows.GlobalWindow"
+)
+
+# Java time types used by the temporal converters below. Looked up once at
+# module load time so the converters don't pay the JNI cost per call.
+JLocalDateTime = findClass("java.time.LocalDateTime")
+JLocalDate = findClass("java.time.LocalDate")
+JLocalTime = findClass("java.time.LocalTime")
+JInstant = findClass("java.time.Instant")
 
 
 class DataConverter(ABC):
-
     @abstractmethod
     def to_internal(self, value) -> IN:
         pass
@@ -80,20 +96,29 @@ class FlattenRowDataConverter(DataConverter):
         if value is None:
             return None
 
-        return tuple([self._field_data_converters[i].to_internal(item)
-                      for i, item in enumerate(value)])
+        return tuple(
+            [
+                self._field_data_converters[i].to_internal(item)
+                for i, item in enumerate(value)
+            ]
+        )
 
     def to_external(self, value) -> OUT:
         if value is None:
             return None
 
-        return tuple([self._field_data_converters[i].to_external(item)
-                      for i, item in enumerate(value)])
+        return tuple(
+            [
+                self._field_data_converters[i].to_external(item)
+                for i, item in enumerate(value)
+            ]
+        )
 
 
 class RowDataConverter(DataConverter):
-
-    def __init__(self, field_data_converters: List[DataConverter], field_names: List[str]):
+    def __init__(
+        self, field_data_converters: List[DataConverter], field_names: List[str]
+    ):
         self._field_data_converters = field_data_converters
         self._field_names = field_names
 
@@ -102,8 +127,10 @@ class RowDataConverter(DataConverter):
             return None
 
         row = Row()
-        row._values = [self._field_data_converters[i].to_internal(item)
-                       for i, item in enumerate(value[1])]
+        row._values = [
+            self._field_data_converters[i].to_internal(item)
+            for i, item in enumerate(value[1])
+        ]
         row.set_field_names(self._field_names)
         row.set_row_kind(RowKind(value[0]))
 
@@ -114,13 +141,16 @@ class RowDataConverter(DataConverter):
             return None
 
         values = value._values
-        fields = tuple([self._field_data_converters[i].to_external(values[i])
-                        for i in range(len(values))])
+        fields = tuple(
+            [
+                self._field_data_converters[i].to_external(values[i])
+                for i in range(len(values))
+            ]
+        )
         return value.get_row_kind().value, fields
 
 
 class TupleDataConverter(DataConverter):
-
     def __init__(self, field_data_converters: List[DataConverter]):
         self._field_data_converters = field_data_converters
 
@@ -128,19 +158,26 @@ class TupleDataConverter(DataConverter):
         if value is None:
             return None
 
-        return tuple([self._field_data_converters[i].to_internal(item)
-                      for i, item in enumerate(value)])
+        return tuple(
+            [
+                self._field_data_converters[i].to_internal(item)
+                for i, item in enumerate(value)
+            ]
+        )
 
     def to_external(self, value: Tuple) -> OUT:
         if value is None:
             return None
 
-        return tuple([self._field_data_converters[i].to_external(item)
-                      for i, item in enumerate(value)])
+        return tuple(
+            [
+                self._field_data_converters[i].to_external(item)
+                for i, item in enumerate(value)
+            ]
+        )
 
 
 class ListDataConverter(DataConverter):
-
     def __init__(self, field_converter: DataConverter):
         self._field_converter = field_converter
 
@@ -158,14 +195,308 @@ class ListDataConverter(DataConverter):
 
 
 class ArrayDataConverter(ListDataConverter):
+    """Converter for ARRAY columns in embedded (thread) mode.
+
+    The return types are intentionally asymmetric:
+
+    - ``to_internal`` returns a ``list`` to match process-mode's Beam-based
+      path (UDFs see mutable sequences on both modes; returning a ``tuple``
+      would make ``arr.append(x)`` / ``arr[i] = v`` work only in process mode).
+    - ``to_external`` returns a ``tuple`` because pemja's Python→Java coercion
+      maps ``tuple`` → ``Object[]`` (what the downstream Java ``ArrayDataConverter``
+      expects) but ``list`` → ``ArrayList`` (wrong shape — would break
+      ``ArrayDataConverter.toExternalImpl``'s array-element loop).
+    """
+
     def __init__(self, field_converter: DataConverter):
         super(ArrayDataConverter, self).__init__(field_converter)
 
     def to_internal(self, value) -> IN:
-        return tuple(super(ArrayDataConverter, self).to_internal(value))
+        if value is None:
+            return None
+
+        return list(super(ArrayDataConverter, self).to_internal(value))
 
     def to_external(self, value) -> OUT:
+        if value is None:
+            return None
+
         return tuple(super(ArrayDataConverter, self).to_external(value))
+
+
+class LocalDateTimeConverter(DataConverter):
+    """Converter for TIMESTAMP(precision) columns in embedded (thread) mode.
+
+    On the input side (Java -> Python UDF argument) the value can arrive as
+    either (a) a native Python ``datetime.datetime`` — pemja's automatic
+    Java->Python conversion handles top-level ``java.sql.Timestamp`` /
+    ``LocalDateTime`` method arguments — or (b) a ``pemja.PyJObject``
+    wrapping a ``java.time.LocalDateTime``, which is what happens for values
+    nested inside arrays, rows, or map values (pemja does not recursively
+    auto-convert Object[] elements).
+
+    On the output side (Python return -> Java) the converter explicitly
+    constructs a ``java.time.LocalDateTime`` so the downstream Java converter
+    chain — which uses ``DataFormatConverters.LocalDateTimeConverter`` as the
+    default for TIMESTAMP fields in nested rows — receives the type it
+    expects instead of a pemja-defaulted ``java.sql.Timestamp``.
+
+    Precision: Python ``datetime`` is microsecond-precise, so values with
+    TIMESTAMP(p) where p <= 6 round-trip without loss. For TIMESTAMP(9) the
+    sub-microsecond nanoseconds are silently truncated.
+    """
+
+    def to_internal(self, value) -> IN:
+        if value is None:
+            return None
+        # Fast path: pemja already produced a Python datetime (happens for
+        # top-level method arguments when pemja auto-converts the bare Java
+        # value crossing the JNI boundary).
+        #
+        # We check via ``type(value) is datetime`` rather than ``isinstance``
+        # because pemja's C extension causes CPython's ``isinstance`` to raise
+        # "SystemError: <built-in function isinstance> returned NULL without
+        # setting an error" when invoked on a ``pemja.PyJObject``.
+        # ``type(value)`` uses Py_TYPE at the C level and is unaffected.
+        if type(value) is _dt.datetime:
+            return value
+        # Nested case: value is a pemja.PyJObject wrapping a Java
+        # java.time.LocalDateTime. Extract the fields via Java getters.
+        return _dt.datetime(
+            value.getYear(),
+            value.getMonthValue(),
+            value.getDayOfMonth(),
+            value.getHour(),
+            value.getMinute(),
+            value.getSecond(),
+            value.getNano() // 1000,
+        )
+
+    def to_external(self, value) -> OUT:
+        if value is None:
+            return None
+        return JLocalDateTime.of(
+            value.year,
+            value.month,
+            value.day,
+            value.hour,
+            value.minute,
+            value.second,
+            value.microsecond * 1000,
+        )
+
+
+class LocalDateConverter(DataConverter):
+    """Converter for DATE columns in embedded (thread) mode.
+
+    Mirrors LocalDateTimeConverter's pattern: the input value may be a native
+    ``datetime.date`` (top-level method arg auto-converted by pemja) or a
+    ``pemja.PyJObject`` wrapping a ``java.time.LocalDate`` (nested positions).
+    The output is always an explicit Java ``LocalDate`` to match the external
+    type the downstream Java converter chain expects.
+    """
+
+    def to_internal(self, value) -> IN:
+        if value is None:
+            return None
+        if type(value) is _dt.date:
+            return value
+        return _dt.date(
+            value.getYear(),
+            value.getMonthValue(),
+            value.getDayOfMonth(),
+        )
+
+    def to_external(self, value) -> OUT:
+        if value is None:
+            return None
+        return JLocalDate.of(value.year, value.month, value.day)
+
+
+class LocalTimeConverter(DataConverter):
+    """Converter for TIME(precision) columns in embedded (thread) mode.
+
+    Mirrors LocalDateTimeConverter's pattern against ``java.time.LocalTime``.
+    Python ``datetime.time`` is microsecond-precise so TIME(9) loses
+    sub-microsecond nanoseconds silently.
+    """
+
+    def to_internal(self, value) -> IN:
+        if value is None:
+            return None
+        if type(value) is _dt.time:
+            return value
+        return _dt.time(
+            value.getHour(),
+            value.getMinute(),
+            value.getSecond(),
+            value.getNano() // 1000,
+        )
+
+    def to_external(self, value) -> OUT:
+        if value is None:
+            return None
+        return JLocalTime.of(
+            value.hour,
+            value.minute,
+            value.second,
+            value.microsecond * 1000,
+        )
+
+
+class InstantConverter(DataConverter):
+    """Converter for TIMESTAMP_LTZ / TIMESTAMP WITH LOCAL TIME ZONE columns.
+
+    Java's ``java.time.Instant`` is absolute UTC. Python's ``datetime`` may be
+    naive or tz-aware. Process mode returns naive ``datetime`` (interpreted as
+    UTC); we match that shape to keep thread mode compatible.
+
+    On the input side we extract epoch-second and nano from the Java Instant
+    and construct a naive UTC ``datetime``.
+
+    On the output side we accept both naive (treated as UTC, matching process
+    mode) and tz-aware datetimes and convert to a Java ``Instant`` via
+    ``Instant.ofEpochSecond(seconds, nanos)``.
+    """
+
+    def to_internal(self, value) -> IN:
+        if value is None:
+            return None
+        if type(value) is _dt.datetime:
+            return value
+        # pemja.PyJObject wrapping java.time.Instant
+        epoch_s = value.getEpochSecond()
+        nano = value.getNano()
+        # Construct a naive UTC datetime. Python datetime is microsecond
+        # precise, so sub-microsecond nanoseconds are truncated.
+        return _dt.datetime(1970, 1, 1) + _dt.timedelta(
+            seconds=epoch_s, microseconds=nano // 1000
+        )
+
+    def to_external(self, value) -> OUT:
+        if value is None:
+            return None
+        # Normalise to an epoch-second + nanos. For naive datetimes we assume
+        # UTC, matching process-mode behaviour.
+        if value.tzinfo is None:
+            delta = value - _dt.datetime(1970, 1, 1)
+        else:
+            delta = value - _dt.datetime(1970, 1, 1, tzinfo=_dt.timezone.utc)
+        # Compute via integer microseconds to stay correct for pre-1970
+        # (negative) epochs: int(-99.3) == -99 truncates toward zero, which
+        # would produce a wrong (epoch_s, nano) pair. divmod flooring
+        # guarantees 0 <= us_rem < 1_000_000.
+        total_us = delta // _dt.timedelta(microseconds=1)
+        epoch_s, us_rem = divmod(total_us, 1_000_000)
+        return JInstant.ofEpochSecond(epoch_s, us_rem * 1000)
+
+
+class DataStreamLocalDateTimeConverter(DataConverter):
+    """Converter for TIMESTAMP columns on the DataStream path.
+
+    Identical to ``LocalDateTimeConverter`` on the input side (Java → Python),
+    but ``to_external`` returns the Python ``datetime`` as-is, letting pemja's
+    auto-conversion produce ``java.sql.Timestamp``.  The DataStream→Table
+    ``InputConversionOperator`` expects ``Timestamp``, whereas the Table API's
+    internal ``DataFormatConverters.RowConverter`` expects ``LocalDateTime`` —
+    hence the two separate converter classes.
+    """
+
+    def to_internal(self, value) -> IN:
+        if value is None:
+            return None
+        if type(value) is _dt.datetime:
+            return value
+        return _dt.datetime(
+            value.getYear(),
+            value.getMonthValue(),
+            value.getDayOfMonth(),
+            value.getHour(),
+            value.getMinute(),
+            value.getSecond(),
+            value.getNano() // 1000,
+        )
+
+    def to_external(self, value) -> OUT:
+        if value is None:
+            return None
+        return value
+
+
+class DataStreamLocalDateConverter(DataConverter):
+    """DataStream variant of LocalDateConverter — to_external returns as-is."""
+
+    def to_internal(self, value) -> IN:
+        if value is None:
+            return None
+        if type(value) is _dt.date:
+            return value
+        return _dt.date(
+            value.getYear(),
+            value.getMonthValue(),
+            value.getDayOfMonth(),
+        )
+
+    def to_external(self, value) -> OUT:
+        if value is None:
+            return None
+        return value
+
+
+class DataStreamLocalTimeConverter(DataConverter):
+    """DataStream/Table variant of LocalTimeConverter.
+
+    Unlike the other temporal converters, ``to_external`` must explicitly build a
+    ``java.time.LocalTime``: pemja auto-converts Python ``datetime.time`` to
+    ``java.sql.Time`` which only has seconds precision, silently dropping the
+    sub-second microseconds needed for TIME(3)+ columns. Wrapping via ``JLocalTime.of``
+    preserves nanos all the way to the Java-side converter's ``toInternalImpl``.
+    """
+
+    def to_internal(self, value) -> IN:
+        if value is None:
+            return None
+        elif type(value) is _dt.time:
+            return value
+        else:
+            return _dt.time(
+                value.getHour(),
+                value.getMinute(),
+                value.getSecond(),
+                value.getNano() // 1000,
+            )
+
+    def to_external(self, value) -> OUT:
+        return (
+            JLocalTime.of(
+                value.hour,
+                value.minute,
+                value.second,
+                value.microsecond * 1000,
+            )
+            if value is not None
+            else None
+        )
+
+
+class DataStreamInstantConverter(DataConverter):
+    """DataStream variant of InstantConverter — to_external returns as-is."""
+
+    def to_internal(self, value) -> IN:
+        if value is None:
+            return None
+        if type(value) is _dt.datetime:
+            return value
+        epoch_s = value.getEpochSecond()
+        nano = value.getNano()
+        return _dt.datetime(1970, 1, 1) + _dt.timedelta(
+            seconds=epoch_s, microseconds=nano // 1000
+        )
+
+    def to_external(self, value) -> OUT:
+        if value is None:
+            return None
+        return value
 
 
 class DictDataConverter(DataConverter):
@@ -177,15 +508,19 @@ class DictDataConverter(DataConverter):
         if value is None:
             return None
 
-        return {self._key_converter.to_internal(k): self._value_converter.to_internal(v)
-                for k, v in value.items()}
+        return {
+            self._key_converter.to_internal(k): self._value_converter.to_internal(v)
+            for k, v in value.items()
+        }
 
     def to_external(self, value) -> OUT:
         if value is None:
             return None
 
-        return {self._key_converter.to_external(k): self._value_converter.to_external(v)
-                for k, v in value.items()}
+        return {
+            self._key_converter.to_external(k): self._value_converter.to_external(v)
+            for k, v in value.items()
+        }
 
 
 class TimeWindowConverter(DataConverter):
@@ -197,7 +532,6 @@ class TimeWindowConverter(DataConverter):
 
 
 class CountWindowConverter(DataConverter):
-
     def to_internal(self, value) -> CountWindow:
         return CountWindow(value.getId())
 
@@ -206,7 +540,6 @@ class CountWindowConverter(DataConverter):
 
 
 class GlobalWindowConverter(DataConverter):
-
     def to_internal(self, value) -> IN:
         return GlobalWindow()
 
@@ -225,20 +558,40 @@ def from_type_info_proto(type_info):
         return PickleDataConverter()
     elif type_name == type_info_name.ROW:
         return RowDataConverter(
-            [from_type_info_proto(f.field_type) for f in type_info.row_type_info.fields],
-            [f.field_name for f in type_info.row_type_info.fields])
+            [
+                from_type_info_proto(f.field_type)
+                for f in type_info.row_type_info.fields
+            ],
+            [f.field_name for f in type_info.row_type_info.fields],
+        )
     elif type_name == type_info_name.TUPLE:
         return TupleDataConverter(
-            [from_type_info_proto(field_type)
-             for field_type in type_info.tuple_type_info.field_types])
-    elif type_name in (type_info_name.BASIC_ARRAY,
-                       type_info_name.OBJECT_ARRAY):
-        return ArrayDataConverter(from_type_info_proto(type_info.collection_element_type))
-    elif type_info == type_info_name.LIST:
-        return ListDataConverter(from_type_info_proto(type_info.collection_element_type))
+            [
+                from_type_info_proto(field_type)
+                for field_type in type_info.tuple_type_info.field_types
+            ]
+        )
+    elif type_name in (type_info_name.BASIC_ARRAY, type_info_name.OBJECT_ARRAY):
+        return ArrayDataConverter(
+            from_type_info_proto(type_info.collection_element_type)
+        )
+    elif type_name == type_info_name.LIST:
+        return ListDataConverter(
+            from_type_info_proto(type_info.collection_element_type)
+        )
     elif type_name == type_info_name.MAP:
-        return DictDataConverter(from_type_info_proto(type_info.map_type_info.key_type),
-                                 from_type_info_proto(type_info.map_type_info.value_type))
+        return DictDataConverter(
+            from_type_info_proto(type_info.map_type_info.key_type),
+            from_type_info_proto(type_info.map_type_info.value_type),
+        )
+    elif type_name in (type_info_name.LOCAL_DATETIME, type_info_name.SQL_TIMESTAMP):
+        return DataStreamLocalDateTimeConverter()
+    elif type_name in (type_info_name.LOCAL_DATE, type_info_name.SQL_DATE):
+        return DataStreamLocalDateConverter()
+    elif type_name in (type_info_name.LOCAL_TIME, type_info_name.SQL_TIME):
+        return DataStreamLocalTimeConverter()
+    elif type_name in (type_info_name.INSTANT, type_info_name.LOCAL_ZONED_TIMESTAMP):
+        return DataStreamInstantConverter()
 
     return IdentityDataConverter()
 
@@ -260,12 +613,25 @@ def from_field_type_proto(field_type):
     if type_name == schema_type_name.ROW:
         return RowDataConverter(
             [from_field_type_proto(f.type) for f in field_type.row_schema.fields],
-            [f.name for f in field_type.row_schema.fields])
+            [f.name for f in field_type.row_schema.fields],
+        )
     elif type_name == schema_type_name.BASIC_ARRAY:
-        return ArrayDataConverter(from_field_type_proto(field_type.collection_element_type))
+        return ArrayDataConverter(
+            from_field_type_proto(field_type.collection_element_type)
+        )
     elif type_name == schema_type_name.MAP:
-        return DictDataConverter(from_field_type_proto(field_type.map_info.key_type),
-                                 from_field_type_proto(field_type.map_info.value_type))
+        return DictDataConverter(
+            from_field_type_proto(field_type.map_info.key_type),
+            from_field_type_proto(field_type.map_info.value_type),
+        )
+    elif type_name == schema_type_name.TIMESTAMP:
+        return DataStreamLocalDateTimeConverter()
+    elif type_name == schema_type_name.LOCAL_ZONED_TIMESTAMP:
+        return DataStreamInstantConverter()
+    elif type_name == schema_type_name.DATE:
+        return DataStreamLocalDateConverter()
+    elif type_name == schema_type_name.TIME:
+        return DataStreamLocalTimeConverter()
 
     return IdentityDataConverter()
 
@@ -273,12 +639,16 @@ def from_field_type_proto(field_type):
 def from_type_info(type_info: TypeInformation):
     if isinstance(type_info, (PickledBytesTypeInfo, RowTypeInfo, TupleTypeInfo)):
         return PickleDataConverter()
-    elif isinstance(type_info, (PrimitiveArrayTypeInfo, BasicArrayTypeInfo, ObjectArrayTypeInfo)):
+    elif isinstance(
+        type_info, (PrimitiveArrayTypeInfo, BasicArrayTypeInfo, ObjectArrayTypeInfo)
+    ):
         return ArrayDataConverter(from_type_info(type_info._element_type))
     elif isinstance(type_info, ListTypeInfo):
         return ListDataConverter(from_type_info(type_info.elem_type))
     elif isinstance(type_info, MapTypeInfo):
-        return DictDataConverter(from_type_info(type_info._key_type_info),
-                                 from_type_info(type_info._value_type_info))
+        return DictDataConverter(
+            from_type_info(type_info._key_type_info),
+            from_type_info(type_info._value_type_info),
+        )
 
     return IdentityDataConverter()

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/utils/PythonTypeUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/utils/PythonTypeUtils.java
@@ -864,118 +864,240 @@ public class PythonTypeUtils {
     }
 
     /**
-     * Python Long will be converted to Long in PemJa, so we need ByteDataConverter to convert Java
-     * Long to internal Byte.
+     * Narrows any pemja-coerced {@link Number} to {@link Byte}.
+     *
+     * <p>The external generic is widened to {@link Number} (rather than the nominally-mapped
+     * {@link Long}) because pemja may hand us {@link Long} (Python int), {@link Double} (Python
+     * float), {@link Integer}, or other {@link Number} subtypes depending on source widening;
+     * keeping the generic broad avoids a bridge-method {@link ClassCastException} at the call
+     * site. The actual narrowing happens in {@link #toInternal(Number)}.
      */
-    public static final class ByteDataConverter extends DataConverter<Byte, Long> {
+    public static final class ByteDataConverter extends DataConverter<Byte, Number> {
 
         private static final long serialVersionUID = 1L;
 
         public static final ByteDataConverter INSTANCE = new ByteDataConverter();
 
         @Override
-        public Byte toInternal(Long value) {
+        public Byte toInternal(Number value) {
             if (value == null) {
                 return null;
             }
-
             return value.byteValue();
         }
 
         @Override
-        public Long toExternal(Byte value) {
+        public Number toExternal(Byte value) {
             if (value == null) {
                 return null;
             }
-
             return value.longValue();
         }
     }
 
     /**
-     * Python Long will be converted to Long in PemJa, so we need ShortDataConverter to convert Java
-     * Long to internal Short.
+     * Narrows any pemja-coerced {@link Number} to {@link Short}. See {@link ByteDataConverter} for
+     * rationale on the widened {@link Number} generic.
      */
-    public static final class ShortDataConverter extends DataConverter<Short, Long> {
+    public static final class ShortDataConverter extends DataConverter<Short, Number> {
 
         private static final long serialVersionUID = 1L;
 
         public static final ShortDataConverter INSTANCE = new ShortDataConverter();
 
         @Override
-        public Short toInternal(Long value) {
+        public Short toInternal(Number value) {
             if (value == null) {
                 return null;
             }
-
             return value.shortValue();
         }
 
         @Override
-        public Long toExternal(Short value) {
+        public Number toExternal(Short value) {
             if (value == null) {
                 return null;
             }
-
             return value.longValue();
         }
     }
 
     /**
-     * Python Long will be converted to Long in PemJa, so we need IntDataConverter to convert Java
-     * Long to internal Integer.
+     * Narrows any pemja-coerced {@link Number} to {@link Integer}. See {@link ByteDataConverter}
+     * for rationale on the widened {@link Number} generic.
      */
-    public static final class IntDataConverter extends DataConverter<Integer, Long> {
+    public static final class IntDataConverter extends DataConverter<Integer, Number> {
 
         private static final long serialVersionUID = 1L;
 
         public static final IntDataConverter INSTANCE = new IntDataConverter();
 
         @Override
-        public Integer toInternal(Long value) {
+        public Integer toInternal(Number value) {
             if (value == null) {
                 return null;
             }
-
             return value.intValue();
         }
 
         @Override
-        public Long toExternal(Integer value) {
+        public Number toExternal(Integer value) {
             if (value == null) {
                 return null;
             }
-
             return value.longValue();
         }
     }
 
     /**
-     * Python Float will be converted to Double in PemJa, so we need FloatDataConverter to convert
-     * Java Double to internal Float.
+     * Narrows any pemja-coerced {@link Number} to {@link Float}. See {@link ByteDataConverter} for
+     * rationale on the widened {@link Number} generic.
      */
-    public static final class FloatDataConverter extends DataConverter<Float, Double> {
+    public static final class FloatDataConverter extends DataConverter<Float, Number> {
 
         private static final long serialVersionUID = 1L;
 
         public static final FloatDataConverter INSTANCE = new FloatDataConverter();
 
         @Override
-        public Float toInternal(Double value) {
+        public Float toInternal(Number value) {
             if (value == null) {
                 return null;
             }
-
             return value.floatValue();
         }
 
         @Override
-        public Double toExternal(Float value) {
+        public Number toExternal(Float value) {
             if (value == null) {
                 return null;
             }
-
             return value.doubleValue();
+        }
+    }
+
+    /**
+     * Converts between pemja's auto-converted {@link java.sql.Timestamp} and {@link
+     * LocalDateTime}.
+     *
+     * <p>Pemja maps Python {@code datetime} to {@link java.sql.Timestamp} on the Python→Java
+     * boundary. In thread mode the downstream {@link
+     * org.apache.flink.table.runtime.typeutils.ExternalSerializer} expects {@link LocalDateTime}
+     * (the default bridge class for TIMESTAMP columns). This converter bridges the mismatch.
+     */
+    public static final class LocalDateTimeDataConverter
+            extends DataConverter<LocalDateTime, Object> {
+
+        private static final long serialVersionUID = 1L;
+
+        public static final LocalDateTimeDataConverter INSTANCE = new LocalDateTimeDataConverter();
+
+        @Override
+        public LocalDateTime toInternal(Object value) {
+            if (value == null) {
+                return null;
+            }
+            if (value instanceof LocalDateTime) {
+                return (LocalDateTime) value;
+            }
+            if (value instanceof Timestamp) {
+                return ((Timestamp) value).toLocalDateTime();
+            }
+            throw new IllegalArgumentException(
+                    "Expected LocalDateTime or Timestamp but got: "
+                            + value.getClass().getName());
+        }
+
+        @Override
+        public Object toExternal(LocalDateTime value) {
+            return value;
+        }
+    }
+
+    /** Converts between pemja's auto-converted {@link Date} and {@link LocalDate}. */
+    public static final class LocalDateDataConverter extends DataConverter<LocalDate, Object> {
+
+        private static final long serialVersionUID = 1L;
+
+        public static final LocalDateDataConverter INSTANCE = new LocalDateDataConverter();
+
+        @Override
+        public LocalDate toInternal(Object value) {
+            if (value == null) {
+                return null;
+            }
+            if (value instanceof LocalDate) {
+                return (LocalDate) value;
+            }
+            if (value instanceof Date) {
+                return ((Date) value).toLocalDate();
+            }
+            throw new IllegalArgumentException(
+                    "Expected LocalDate or Date but got: " + value.getClass().getName());
+        }
+
+        @Override
+        public Object toExternal(LocalDate value) {
+            return value;
+        }
+    }
+
+    /** Converts between pemja's auto-converted {@link Time} and {@link LocalTime}. */
+    public static final class LocalTimeDataConverter extends DataConverter<LocalTime, Object> {
+
+        private static final long serialVersionUID = 1L;
+
+        public static final LocalTimeDataConverter INSTANCE = new LocalTimeDataConverter();
+
+        @Override
+        public LocalTime toInternal(Object value) {
+            if (value == null) {
+                return null;
+            }
+            if (value instanceof LocalTime) {
+                return (LocalTime) value;
+            }
+            if (value instanceof Time) {
+                return ((Time) value).toLocalTime();
+            }
+            throw new IllegalArgumentException(
+                    "Expected LocalTime or Time but got: " + value.getClass().getName());
+        }
+
+        @Override
+        public Object toExternal(LocalTime value) {
+            return value;
+        }
+    }
+
+    /**
+     * Converts between pemja's auto-converted {@link Timestamp} and {@link Instant} for
+     * TIMESTAMP_WITH_LOCAL_TIME_ZONE columns.
+     */
+    public static final class InstantDataConverter extends DataConverter<Instant, Object> {
+
+        private static final long serialVersionUID = 1L;
+
+        public static final InstantDataConverter INSTANCE = new InstantDataConverter();
+
+        @Override
+        public Instant toInternal(Object value) {
+            if (value == null) {
+                return null;
+            }
+            if (value instanceof Instant) {
+                return (Instant) value;
+            }
+            if (value instanceof Timestamp) {
+                return ((Timestamp) value).toInstant();
+            }
+            throw new IllegalArgumentException(
+                    "Expected Instant or Timestamp but got: " + value.getClass().getName());
+        }
+
+        @Override
+        public Object toExternal(Instant value) {
+            return value;
         }
     }
 
@@ -988,16 +1110,9 @@ public class PythonTypeUtils {
         private static final long serialVersionUID = 1L;
 
         private final DataConverter[] fieldDataConverters;
-        private final Row reuseRow;
-        private final Object[] reuseExternalRow;
-        private final Object[] reuseExternalRowData;
 
         RowDataConverter(DataConverter[] dataConverters) {
             this.fieldDataConverters = dataConverters;
-            this.reuseRow = new Row(fieldDataConverters.length);
-            this.reuseExternalRowData = new Object[fieldDataConverters.length];
-            this.reuseExternalRow = new Object[2];
-            this.reuseExternalRow[1] = reuseExternalRowData;
         }
 
         @SuppressWarnings("unchecked")
@@ -1008,12 +1123,13 @@ public class PythonTypeUtils {
             }
 
             RowKind rowKind = RowKind.fromByteValue(((Long) value[0]).byteValue());
-            reuseRow.setKind(rowKind);
             Object[] fieldValues = (Object[]) value[1];
+            Row row = new Row(fieldDataConverters.length);
+            row.setKind(rowKind);
             for (int i = 0; i < fieldValues.length; i++) {
-                reuseRow.setField(i, fieldDataConverters[i].toInternal(fieldValues[i]));
+                row.setField(i, fieldDataConverters[i].toInternal(fieldValues[i]));
             }
-            return reuseRow;
+            return row;
         }
 
         @SuppressWarnings("unchecked")
@@ -1023,11 +1139,12 @@ public class PythonTypeUtils {
                 return null;
             }
 
-            reuseExternalRow[0] = (long) value.getKind().toByteValue();
+            // Fresh allocation per call to avoid aliasing when used inside ArrayDataConverter.
+            Object[] fields = new Object[fieldDataConverters.length];
             for (int i = 0; i < value.getArity(); i++) {
-                reuseExternalRowData[i] = fieldDataConverters[i].toExternal(value.getField(i));
+                fields[i] = fieldDataConverters[i].toExternal(value.getField(i));
             }
-            return reuseExternalRow;
+            return new Object[] {(long) value.getKind().toByteValue(), fields};
         }
 
         @Override
@@ -1101,13 +1218,9 @@ public class PythonTypeUtils {
     public static final class TupleDataConverter extends DataConverter<Tuple, Object[]> {
 
         private final DataConverter[] fieldDataConverters;
-        private final Tuple reuseTuple;
-        private final Object[] reuseExternalTuple;
 
         TupleDataConverter(DataConverter[] dataConverters) {
             this.fieldDataConverters = dataConverters;
-            this.reuseTuple = Tuple.newInstance(dataConverters.length);
-            this.reuseExternalTuple = new Object[dataConverters.length];
         }
 
         @SuppressWarnings("unchecked")
@@ -1117,10 +1230,12 @@ public class PythonTypeUtils {
                 return null;
             }
 
+            // Fresh allocation per call to avoid aliasing when used inside ArrayDataConverter.
+            Tuple tuple = Tuple.newInstance(fieldDataConverters.length);
             for (int i = 0; i < value.length; i++) {
-                reuseTuple.setField(fieldDataConverters[i].toInternal(value[i]), i);
+                tuple.setField(fieldDataConverters[i].toInternal(value[i]), i);
             }
-            return reuseTuple;
+            return tuple;
         }
 
         @SuppressWarnings("unchecked")
@@ -1130,10 +1245,11 @@ public class PythonTypeUtils {
                 return null;
             }
 
+            Object[] result = new Object[fieldDataConverters.length];
             for (int i = 0; i < value.getArity(); i++) {
-                reuseExternalTuple[i] = fieldDataConverters[i].toExternal(value.getField(i));
+                result[i] = fieldDataConverters[i].toExternal(value.getField(i));
             }
-            return reuseExternalTuple;
+            return result;
         }
 
         @Override
@@ -1356,6 +1472,18 @@ public class PythonTypeUtils {
                     BasicTypeInfo.FLOAT_TYPE_INFO.getTypeClass(), FloatDataConverter.INSTANCE);
             typeInfoToDataConverterMap.put(
                     BasicTypeInfo.BYTE_TYPE_INFO.getTypeClass(), ByteDataConverter.INSTANCE);
+            typeInfoToDataConverterMap.put(
+                    LocalTimeTypeInfo.LOCAL_DATE_TIME.getTypeClass(),
+                    LocalDateTimeDataConverter.INSTANCE);
+            typeInfoToDataConverterMap.put(
+                    LocalTimeTypeInfo.LOCAL_DATE.getTypeClass(),
+                    LocalDateDataConverter.INSTANCE);
+            typeInfoToDataConverterMap.put(
+                    LocalTimeTypeInfo.LOCAL_TIME.getTypeClass(),
+                    LocalTimeDataConverter.INSTANCE);
+            typeInfoToDataConverterMap.put(
+                    BasicTypeInfo.INSTANT_TYPE_INFO.getTypeClass(),
+                    InstantDataConverter.INSTANCE);
         }
 
         @SuppressWarnings("unchecked")

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/PythonTypeUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/PythonTypeUtils.java
@@ -33,6 +33,7 @@ import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.data.util.DataFormatConverters;
 import org.apache.flink.table.runtime.typeutils.serializers.python.ArrayDataSerializer;
 import org.apache.flink.table.runtime.typeutils.serializers.python.DecimalDataSerializer;
@@ -493,6 +494,147 @@ public final class PythonTypeUtils {
         abstract OUT toExternalImpl(INTER value);
     }
 
+    /**
+     * Converts between pemja's auto-converted {@link java.sql.Timestamp} and {@link
+     * java.time.LocalDateTime}.
+     *
+     * <p>Pemja maps Python {@code datetime} to {@link java.sql.Timestamp}. The outer {@link
+     * DataFormatConverters.RowConverter} expects {@link java.time.LocalDateTime} (the default
+     * bridge class for TIMESTAMP columns). This converter bridges the mismatch.
+     */
+    public static final class TimestampLocalDateTimeDataConverter
+            extends DataConverter<TimestampData, java.time.LocalDateTime, Object> {
+
+        TimestampLocalDateTimeDataConverter(int precision) {
+            super(new DataFormatConverters.LocalDateTimeConverter(precision));
+        }
+
+        @Override
+        java.time.LocalDateTime toInternalImpl(Object value) {
+            if (value == null) {
+                return null;
+            }
+            if (value instanceof java.time.LocalDateTime) {
+                return (java.time.LocalDateTime) value;
+            }
+            if (value instanceof java.sql.Timestamp) {
+                return ((java.sql.Timestamp) value).toLocalDateTime();
+            }
+            throw new IllegalArgumentException(
+                    "Expected LocalDateTime or Timestamp but got: "
+                            + value.getClass().getName());
+        }
+
+        @Override
+        Object toExternalImpl(java.time.LocalDateTime value) {
+            if (value == null) {
+                return null;
+            }
+            return java.sql.Timestamp.valueOf(value);
+        }
+    }
+
+    /**
+     * Converts between pemja's auto-converted {@link java.sql.Timestamp} and {@link
+     * java.time.Instant} for TIMESTAMP_WITH_LOCAL_TIME_ZONE columns.
+     */
+    public static final class TimestampInstantDataConverter
+            extends DataConverter<TimestampData, java.time.Instant, Object> {
+
+        TimestampInstantDataConverter(int precision) {
+            super(new DataFormatConverters.InstantConverter(precision));
+        }
+
+        @Override
+        java.time.Instant toInternalImpl(Object value) {
+            if (value == null) {
+                return null;
+            }
+            if (value instanceof java.time.Instant) {
+                return (java.time.Instant) value;
+            }
+            if (value instanceof java.sql.Timestamp) {
+                return ((java.sql.Timestamp) value).toInstant();
+            }
+            throw new IllegalArgumentException(
+                    "Expected Instant or Timestamp but got: "
+                            + value.getClass().getName());
+        }
+
+        @Override
+        Object toExternalImpl(java.time.Instant value) {
+            if (value == null) {
+                return null;
+            }
+            return java.sql.Timestamp.from(value);
+        }
+    }
+
+    /** Converts between pemja's auto-converted {@link java.sql.Date} and {@link java.time.LocalDate}. */
+    public static final class DateLocalDateDataConverter
+            extends DataConverter<Integer, java.time.LocalDate, Object> {
+
+        static final DateLocalDateDataConverter INSTANCE = new DateLocalDateDataConverter();
+
+        DateLocalDateDataConverter() {
+            super(DataFormatConverters.LocalDateConverter.INSTANCE);
+        }
+
+        @Override
+        java.time.LocalDate toInternalImpl(Object value) {
+            if (value == null) {
+                return null;
+            }
+            if (value instanceof java.time.LocalDate) {
+                return (java.time.LocalDate) value;
+            }
+            if (value instanceof java.sql.Date) {
+                return ((java.sql.Date) value).toLocalDate();
+            }
+            throw new IllegalArgumentException(
+                    "Expected LocalDate or Date but got: " + value.getClass().getName());
+        }
+
+        @Override
+        Object toExternalImpl(java.time.LocalDate value) {
+            if (value == null) {
+                return null;
+            }
+            return java.sql.Date.valueOf(value);
+        }
+    }
+
+    /** Converts between pemja's auto-converted {@link java.sql.Time} and {@link java.time.LocalTime}. */
+    public static final class TimeLocalTimeDataConverter
+            extends DataConverter<Integer, java.time.LocalTime, Object> {
+
+        static final TimeLocalTimeDataConverter INSTANCE = new TimeLocalTimeDataConverter();
+
+        TimeLocalTimeDataConverter() {
+            super(DataFormatConverters.LocalTimeConverter.INSTANCE);
+        }
+
+        @Override
+        java.time.LocalTime toInternalImpl(Object value) {
+            if (value == null) {
+                return null;
+            }
+            if (value instanceof java.time.LocalTime) {
+                return (java.time.LocalTime) value;
+            }
+            if (value instanceof java.sql.Time) {
+                return ((java.sql.Time) value).toLocalTime();
+            }
+            throw new IllegalArgumentException(
+                    "Expected LocalTime or Time but got: " + value.getClass().getName());
+        }
+
+        @Override
+        Object toExternalImpl(java.time.LocalTime value) {
+            return value;
+        }
+    }
+
     /** Identity data converter. */
     public static final class IdentityDataConverter<IN, OUT> extends DataConverter<IN, OUT, OUT> {
         IdentityDataConverter(
@@ -515,7 +657,7 @@ public final class PythonTypeUtils {
      * Python Long will be converted to Long in PemJa, so we need ByteDataConverter to convert Java
      * Long to internal Byte.
      */
-    public static final class ByteDataConverter extends DataConverter<Byte, Byte, Long> {
+    public static final class ByteDataConverter extends DataConverter<Byte, Byte, Number> {
 
         public static final ByteDataConverter INSTANCE = new ByteDataConverter();
 
@@ -524,12 +666,18 @@ public final class PythonTypeUtils {
         }
 
         @Override
-        Byte toInternalImpl(Long value) {
+        Byte toInternalImpl(Number value) {
+            if (value == null) {
+                return null;
+            }
             return value.byteValue();
         }
 
         @Override
-        Long toExternalImpl(Byte value) {
+        Number toExternalImpl(Byte value) {
+            if (value == null) {
+                return null;
+            }
             return value.longValue();
         }
     }
@@ -538,7 +686,7 @@ public final class PythonTypeUtils {
      * Python Long will be converted to Long in PemJa, so we need ShortDataConverter to convert Java
      * Long to internal Short.
      */
-    public static final class ShortDataConverter extends DataConverter<Short, Short, Long> {
+    public static final class ShortDataConverter extends DataConverter<Short, Short, Number> {
 
         public static final ShortDataConverter INSTANCE = new ShortDataConverter();
 
@@ -547,12 +695,18 @@ public final class PythonTypeUtils {
         }
 
         @Override
-        Short toInternalImpl(Long value) {
+        Short toInternalImpl(Number value) {
+            if (value == null) {
+                return null;
+            }
             return value.shortValue();
         }
 
         @Override
-        Long toExternalImpl(Short value) {
+        Number toExternalImpl(Short value) {
+            if (value == null) {
+                return null;
+            }
             return value.longValue();
         }
     }
@@ -561,7 +715,7 @@ public final class PythonTypeUtils {
      * Python Long will be converted to Long in PemJa, so we need IntDataConverter to convert Java
      * Long to internal Integer.
      */
-    public static final class IntDataConverter extends DataConverter<Integer, Integer, Long> {
+    public static final class IntDataConverter extends DataConverter<Integer, Integer, Number> {
 
         public static final IntDataConverter INSTANCE = new IntDataConverter();
 
@@ -570,12 +724,18 @@ public final class PythonTypeUtils {
         }
 
         @Override
-        Integer toInternalImpl(Long value) {
+        Integer toInternalImpl(Number value) {
+            if (value == null) {
+                return null;
+            }
             return value.intValue();
         }
 
         @Override
-        Long toExternalImpl(Integer value) {
+        Number toExternalImpl(Integer value) {
+            if (value == null) {
+                return null;
+            }
             return value.longValue();
         }
     }
@@ -584,7 +744,7 @@ public final class PythonTypeUtils {
      * Python Float will be converted to Double in PemJa, so we need FloatDataConverter to convert
      * Java Double to internal Float.
      */
-    public static final class FloatDataConverter extends DataConverter<Float, Float, Double> {
+    public static final class FloatDataConverter extends DataConverter<Float, Float, Number> {
 
         public static final FloatDataConverter INSTANCE = new FloatDataConverter();
 
@@ -593,36 +753,19 @@ public final class PythonTypeUtils {
         }
 
         @Override
-        Float toInternalImpl(Double value) {
+        Float toInternalImpl(Number value) {
+            if (value == null) {
+                return null;
+            }
             return value.floatValue();
         }
 
         @Override
-        Double toExternalImpl(Float value) {
+        Number toExternalImpl(Float value) {
+            if (value == null) {
+                return null;
+            }
             return value.doubleValue();
-        }
-    }
-
-    /**
-     * Python datetime.time will be converted to Time in PemJa, so we need TimeDataConverter to
-     * convert Java Double to internal Integer.
-     */
-    public static final class TimeDataConverter extends DataConverter<Integer, Integer, Time> {
-
-        public static final TimeDataConverter INSTANCE = new TimeDataConverter();
-
-        private TimeDataConverter() {
-            super(DataFormatConverters.IntConverter.INSTANCE);
-        }
-
-        @Override
-        Integer toInternalImpl(Time value) {
-            return (int) value.getTime();
-        }
-
-        @Override
-        Time toExternalImpl(Integer value) {
-            return new Time(value);
         }
     }
 
@@ -633,46 +776,35 @@ public final class PythonTypeUtils {
     public static final class RowDataConverter extends DataConverter<RowData, Row, Object[]> {
 
         private final DataConverter[] fieldDataConverters;
-        private final Row reuseRow;
-        private final Object[] reuseExternalRow;
-        private final Object[] reuseExternalRowData;
 
         RowDataConverter(
                 DataConverter[] fieldDataConverters,
                 DataFormatConverters.DataFormatConverter<RowData, Row> dataFormatConverter) {
             super(dataFormatConverter);
             this.fieldDataConverters = fieldDataConverters;
-            this.reuseRow = new Row(fieldDataConverters.length);
-            this.reuseExternalRowData = new Object[fieldDataConverters.length];
-            this.reuseExternalRow = new Object[2];
-            this.reuseExternalRow[1] = reuseExternalRowData;
         }
 
         @SuppressWarnings("unchecked")
         @Override
         Row toInternalImpl(Object[] value) {
-
             RowKind rowKind = RowKind.fromByteValue(((Long) value[0]).byteValue());
-            reuseRow.setKind(rowKind);
-
             Object[] fieldValues = (Object[]) value[1];
-
+            Row row = new Row(fieldDataConverters.length);
+            row.setKind(rowKind);
             for (int i = 0; i < fieldValues.length; i++) {
-                reuseRow.setField(i, fieldDataConverters[i].toInternalImpl(fieldValues[i]));
+                row.setField(i, fieldDataConverters[i].toInternalImpl(fieldValues[i]));
             }
-            return reuseRow;
+            return row;
         }
 
         @SuppressWarnings("unchecked")
         @Override
         Object[] toExternalImpl(Row value) {
-
-            reuseExternalRow[0] = (long) value.getKind().toByteValue();
+            Object[] fields = new Object[fieldDataConverters.length];
             for (int i = 0; i < value.getArity(); i++) {
-                reuseExternalRowData[i] = fieldDataConverters[i].toExternalImpl(value.getField(i));
+                fields[i] = fieldDataConverters[i].toExternalImpl(value.getField(i));
             }
-
-            return reuseExternalRow;
+            return new Object[] {(long) value.getKind().toByteValue(), fields};
         }
     }
 
@@ -832,25 +964,22 @@ public final class PythonTypeUtils {
 
         @Override
         public DataConverter visit(DateType dateType) {
-            return new IdentityDataConverter<>(DataFormatConverters.DateConverter.INSTANCE);
+            return DateLocalDateDataConverter.INSTANCE;
         }
 
         @Override
         public DataConverter visit(TimeType timeType) {
-            return TimeDataConverter.INSTANCE;
+            return TimeLocalTimeDataConverter.INSTANCE;
         }
 
         @Override
         public DataConverter visit(TimestampType timestampType) {
-            return new IdentityDataConverter<>(
-                    new DataFormatConverters.TimestampConverter(timestampType.getPrecision()));
+            return new TimestampLocalDateTimeDataConverter(timestampType.getPrecision());
         }
 
         @Override
         public DataConverter visit(LocalZonedTimestampType localZonedTimestampType) {
-            return new IdentityDataConverter<>(
-                    new DataFormatConverters.TimestampConverter(
-                            localZonedTimestampType.getPrecision()));
+            return new TimestampInstantDataConverter(localZonedTimestampType.getPrecision());
         }
 
         @SuppressWarnings("unchecked")


### PR DESCRIPTION
## What is the purpose of the change

In embedded (thread) mode, Pemja's JNI bridge auto-converts Python `datetime`/`date`/`time` objects to `java.sql.Timestamp`/`Date`/`Time`, but Flink's `ExternalSerializer` and `DataFormatConverters.RowConverter` expect the modern `java.time.*` bridge classes (`LocalDateTime`, `LocalDate`, `LocalTime`, `Instant`). This mismatch causes `ClassCastException` at serialization boundaries for any UDF that returns or receives temporal types. Process mode is unaffected because its Beam-based `runnerOutputTypeSerializer` resolves to the correct `java.time.*` serializers via `LegacyTypeInfoDataTypeConverter`.

This patch fixes several related type-conversion bugs in the embedded Python execution path so that all Flink-supported types work correctly in thread mode.

## Brief change log

  - Add bridge-aware `DataConverter` implementations for all temporal types (`TIMESTAMP`, `DATE`, `TIME`, `TIMESTAMP_LTZ`) on both the Table API (`PythonTypeUtils` in `flink-table-runtime`) and DataStream (`PythonTypeUtils` in `flink-streaming-java`) paths
  - Replace `IdentityDataConverter` for temporal types where it silently passed `java.sql.*` objects through without conversion
  - Fix `ROW`/`TUPLE` buffer reuse in `ArrayDataConverter` that caused silent data corruption in `ARRAY<ROW<...>>` results
  - Widen numeric `DataConverter` generics from `Long`/`Double` to `Number` to avoid bridge-method `ClassCastException` when Pemja returns `Integer`/`Float` for small values
  - Cache the original Java `ExternalTypeInfo` in the Python `ExternalTypeInfo` wrapper to prevent lossy `DECIMAL` precision round-trips through legacy `TypeInfo` conversion

## Verifying this change

This change is already covered by existing tests — the existing PyFlink Table API and DataStream test suites exercise all affected type paths.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no (fixes type conversion *before* values reach the serializer)
  - The runtime per-record code paths (performance sensitive): yes — the embedded Python UDF execution path now performs explicit type conversions for temporal/numeric types instead of relying on identity pass-through. The overhead is minimal (one `java.time.*` factory call per value).
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable