### PR TITLE
[FLINK-39519][checkpoint] Allocate pre-filter source buffers from a reusable heap segment

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
@@ -17,6 +17,9 @@
 
 package org.apache.flink.runtime.checkpoint.channel;
 
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptor;
 import org.apache.flink.runtime.checkpoint.RescaleMappings;
 import org.apache.flink.runtime.io.network.api.SubtaskConnectionDescriptor;
@@ -25,6 +28,8 @@ import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
 import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
+import org.apache.flink.runtime.io.network.buffer.BufferRecycler;
+import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
 import org.apache.flink.runtime.io.network.partition.CheckpointedResultPartition;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannel;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
@@ -39,6 +44,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.flink.runtime.checkpoint.channel.ChannelStateByteBuffer.wrap;
+import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkState;
 
 interface RecoveredChannelStateHandler<Info, Context> extends AutoCloseable {
@@ -82,22 +88,92 @@ class InputChannelRecoveredStateHandler
      */
     @Nullable private final ChannelStateFilteringHandler filteringHandler;
 
+    /** Network buffer memory segment size in bytes. Used to size the reusable pre-filter buffer. */
+    private final int memorySegmentSize;
+
+    /**
+     * Reusable heap memory segment backing the pre-filter buffer in filtering mode. Lazily
+     * allocated on the first {@link #getPreFilterBuffer} call, reused for every subsequent call,
+     * and freed in {@link #close()}.
+     *
+     * <p>Reuse is safe because at most one pre-filter buffer is in flight per task at any moment.
+     * This invariant is enforced at runtime by {@link #preFilterBufferInUse}.
+     */
+    @Nullable private MemorySegment preFilterSegment;
+
+    /**
+     * Tracks whether {@link #preFilterSegment} is currently wrapped by a live {@link Buffer} that
+     * has not yet been recycled. Flipped to {@code true} when a new buffer is issued, and flipped
+     * back to {@code false} by the custom {@link BufferRecycler} when the buffer is recycled.
+     */
+    private boolean preFilterBufferInUse;
+
     InputChannelRecoveredStateHandler(
             InputGate[] inputGates,
             InflightDataRescalingDescriptor channelMapping,
-            @Nullable ChannelStateFilteringHandler filteringHandler) {
+            @Nullable ChannelStateFilteringHandler filteringHandler,
+            int memorySegmentSize) {
         this.inputGates = inputGates;
         this.channelMapping = channelMapping;
         this.filteringHandler = filteringHandler;
+        checkArgument(
+                memorySegmentSize > 0, "memorySegmentSize must be positive: %s", memorySegmentSize);
+        this.memorySegmentSize = memorySegmentSize;
     }
 
     @Override
     public BufferWithContext<Buffer> getBuffer(InputChannelInfo channelInfo)
             throws IOException, InterruptedException {
-        // request the buffer from any mapped channel as they all will receive the same buffer
+        if (filteringHandler != null) {
+            return getPreFilterBuffer();
+        }
+        // Non-filtering mode: use existing network buffer pool allocation.
         RecoveredInputChannel channel = getMappedChannels(channelInfo);
         Buffer buffer = channel.requestBufferBlocking();
         return new BufferWithContext<>(wrap(buffer), buffer);
+    }
+
+    /**
+     * Allocates a pre-filter buffer from a reusable heap segment (isolated from the Network Buffer
+     * Pool) in filtering mode.
+     *
+     * <p>Memory management: a single {@link MemorySegment} per task is lazily allocated on first
+     * invocation and reused across every subsequent call. The custom {@link BufferRecycler} does
+     * not free the segment — it only flips {@link #preFilterBufferInUse} back to {@code false} so
+     * the next call can reuse it. The segment itself is freed in {@link #close()}.
+     *
+     * <p>Runtime invariant check: the one-at-a-time invariant on pre-filter buffers is guaranteed
+     * by Flink's serial recovery loop and the deserializer's ownership contract. This method
+     * asserts the invariant before issuing a buffer: if a previously issued buffer has not yet been
+     * recycled, it throws {@link IllegalStateException} so any future regression fails loudly
+     * instead of silently corrupting memory.
+     */
+    private BufferWithContext<Buffer> getPreFilterBuffer() {
+        checkState(
+                !preFilterBufferInUse,
+                "Previous pre-filter buffer has not been recycled. This violates the "
+                        + "one-buffer-at-a-time invariant of pre-filter buffers.");
+
+        if (preFilterSegment == null) {
+            preFilterSegment = MemorySegmentFactory.allocateUnpooledSegment(memorySegmentSize);
+        }
+        preFilterBufferInUse = true;
+
+        // The recycler keeps the segment alive for reuse; only flips the in-use flag.
+        BufferRecycler recycler = segment -> preFilterBufferInUse = false;
+        Buffer buffer = new NetworkBuffer(preFilterSegment, recycler);
+        return new BufferWithContext<>(wrap(buffer), buffer);
+    }
+
+    @VisibleForTesting
+    boolean isPreFilterBufferInUse() {
+        return preFilterBufferInUse;
+    }
+
+    @VisibleForTesting
+    @Nullable
+    MemorySegment getPreFilterSegmentForTesting() {
+        return preFilterSegment;
     }
 
     @Override
@@ -161,6 +237,11 @@ class InputChannelRecoveredStateHandler
         // note that we need to finish all RecoveredInputChannels, not just those with state
         for (final InputGate inputGate : inputGates) {
             inputGate.finishReadRecoveredState();
+        }
+        if (preFilterSegment != null) {
+            preFilterSegment.free();
+            preFilterSegment = null;
+            preFilterBufferInUse = false;
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SequentialChannelStateReaderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SequentialChannelStateReaderImpl.java
@@ -74,7 +74,8 @@ public class SequentialChannelStateReaderImpl implements SequentialChannelStateR
                         new InputChannelRecoveredStateHandler(
                                 inputGates,
                                 taskStateSnapshot.getInputRescalingDescriptor(),
-                                filteringHandler)) {
+                                filteringHandler,
+                                filterContext.getMemorySegmentSize())) {
             read(
                     stateHandler,
                     groupByDelegate(

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/io/recovery/RecordFilterContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/io/recovery/RecordFilterContext.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.runtime.io.recovery;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptor;
+import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -97,6 +98,13 @@ public class RecordFilterContext {
     private final boolean checkpointingDuringRecoveryEnabled;
 
     /**
+     * Network buffer memory segment size in bytes (from taskmanager.memory.segment-size). Used to
+     * size the reusable heap source buffer in {@code InputChannelRecoveredStateHandler} so it
+     * matches the network buffer size.
+     */
+    private final int memorySegmentSize;
+
+    /**
      * Creates a new RecordFilterContext.
      *
      * @param inputConfigs Input configurations indexed by gate index. Array elements may be null
@@ -108,6 +116,7 @@ public class RecordFilterContext {
      *     (converted to empty array).
      * @param checkpointingDuringRecoveryEnabled Whether unaligned checkpointing during recovery is
      *     enabled.
+     * @param memorySegmentSize Network buffer memory segment size in bytes. Must be positive.
      */
     public RecordFilterContext(
             InputFilterConfig[] inputConfigs,
@@ -115,13 +124,17 @@ public class RecordFilterContext {
             int subtaskIndex,
             int maxParallelism,
             String[] tmpDirectories,
-            boolean checkpointingDuringRecoveryEnabled) {
+            boolean checkpointingDuringRecoveryEnabled,
+            int memorySegmentSize) {
         this.inputConfigs = checkNotNull(inputConfigs).clone();
         this.rescalingDescriptor = checkNotNull(rescalingDescriptor);
         this.subtaskIndex = subtaskIndex;
         this.maxParallelism = maxParallelism;
         this.tmpDirectories = tmpDirectories != null ? tmpDirectories : new String[0];
         this.checkpointingDuringRecoveryEnabled = checkpointingDuringRecoveryEnabled;
+        checkArgument(
+                memorySegmentSize > 0, "memorySegmentSize must be positive: %s", memorySegmentSize);
+        this.memorySegmentSize = memorySegmentSize;
     }
 
     /**
@@ -196,6 +209,15 @@ public class RecordFilterContext {
     }
 
     /**
+     * Gets the network buffer memory segment size in bytes.
+     *
+     * @return The memory segment size. Always positive.
+     */
+    public int getMemorySegmentSize() {
+        return memorySegmentSize;
+    }
+
+    /**
      * Checks if a specific gate and subtask combination is ambiguous (requires filtering).
      *
      * @param gateIndex The gate index.
@@ -222,6 +244,7 @@ public class RecordFilterContext {
                 0,
                 0,
                 new String[0],
-                false);
+                false,
+                MemoryManager.DEFAULT_PAGE_SIZE);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -2057,7 +2057,8 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
                 getEnvironment().getTaskInfo().getIndexOfThisSubtask(),
                 getEnvironment().getTaskInfo().getMaxNumberOfParallelSubtasks(),
                 getEnvironment().getIOManager().getSpillingDirectoriesPaths(),
-                true);
+                true,
+                ConfigurationParserUtils.getPageSize(getEnvironment().getJobConfiguration()));
     }
 
     /** Check whether records can be emitted in batch. */

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/InputChannelRecoveredStateHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/InputChannelRecoveredStateHandlerTest.java
@@ -18,14 +18,17 @@
 
 package org.apache.flink.runtime.checkpoint.channel;
 
+import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptor;
 import org.apache.flink.runtime.checkpoint.RescaleMappings;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannelBuilder;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateBuilder;
+import org.apache.flink.runtime.memory.MemoryManager;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -48,7 +51,8 @@ class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandler
     @BeforeEach
     void setUp() {
         // given: Segment provider with defined number of allocated segments.
-        networkBufferPool = new NetworkBufferPool(preAllocatedSegments, 1024);
+        networkBufferPool =
+                new NetworkBufferPool(preAllocatedSegments, MemoryManager.DEFAULT_PAGE_SIZE);
 
         // and: Configured input gate with recovered channel.
         inputGate =
@@ -78,7 +82,8 @@ class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandler
                                             .InflightDataGateOrPartitionRescalingDescriptor
                                             .MappingType.IDENTITY)
                         }),
-                null);
+                null,
+                MemoryManager.DEFAULT_PAGE_SIZE);
     }
 
     private InputChannelRecoveredStateHandler buildMultiChannelHandler() {
@@ -105,7 +110,33 @@ class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandler
                                             .InflightDataGateOrPartitionRescalingDescriptor
                                             .MappingType.RESCALING)
                         }),
-                null);
+                null,
+                MemoryManager.DEFAULT_PAGE_SIZE);
+    }
+
+    /** Builds a handler in filtering mode (non-null filtering handler, no-op stub). */
+    private InputChannelRecoveredStateHandler buildFilteringInputChannelStateHandler() {
+        // Empty GateFilterHandler array: filtering is "enabled" structurally, but no gate-level
+        // filter logic runs. Suitable for exercising getBuffer() routing only.
+        ChannelStateFilteringHandler stubFilteringHandler =
+                new ChannelStateFilteringHandler(
+                        new ChannelStateFilteringHandler.GateFilterHandler[0]);
+        return new InputChannelRecoveredStateHandler(
+                new InputGate[] {inputGate},
+                new InflightDataRescalingDescriptor(
+                        new InflightDataRescalingDescriptor
+                                        .InflightDataGateOrPartitionRescalingDescriptor[] {
+                            new InflightDataRescalingDescriptor
+                                    .InflightDataGateOrPartitionRescalingDescriptor(
+                                    new int[] {1},
+                                    RescaleMappings.identity(1, 1),
+                                    new HashSet<>(),
+                                    InflightDataRescalingDescriptor
+                                            .InflightDataGateOrPartitionRescalingDescriptor
+                                            .MappingType.IDENTITY)
+                        }),
+                stubFilteringHandler,
+                MemoryManager.DEFAULT_PAGE_SIZE);
     }
 
     @Test
@@ -152,5 +183,119 @@ class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandler
         // then: All pre-allocated segments should be successfully recycled.
         assertThat(networkBufferPool.getNumberOfAvailableMemorySegments())
                 .isEqualTo(preAllocatedSegments);
+    }
+
+    @Test
+    void testPreFilterBufferIsolationFromNetworkBufferPool() throws Exception {
+        try (InputChannelRecoveredStateHandler filteringHandler =
+                buildFilteringInputChannelStateHandler()) {
+            int availableBefore = networkBufferPool.getNumberOfAvailableMemorySegments();
+
+            RecoveredChannelStateHandler.BufferWithContext<Buffer> bufferWithContext =
+                    filteringHandler.getBuffer(channelInfo);
+            try {
+                Buffer buffer = bufferWithContext.context;
+                // Heap-backed: NetworkBuffer wrapping a heap (non off-heap) segment.
+                assertThat(buffer).isInstanceOf(NetworkBuffer.class);
+                assertThat(buffer.getMemorySegment().isOffHeap()).isFalse();
+                assertThat(buffer.getMemorySegment().size())
+                        .isEqualTo(MemoryManager.DEFAULT_PAGE_SIZE);
+                // Pool is untouched.
+                assertThat(networkBufferPool.getNumberOfAvailableMemorySegments())
+                        .isEqualTo(availableBefore);
+            } finally {
+                bufferWithContext.context.recycleBuffer();
+            }
+        }
+    }
+
+    @Test
+    void testNonFilteringModeUsesNetworkBufferPool() throws Exception {
+        int availableBefore = networkBufferPool.getNumberOfAvailableMemorySegments();
+
+        RecoveredChannelStateHandler.BufferWithContext<Buffer> bufferWithContext =
+                icsHandler.getBuffer(channelInfo);
+        try {
+            Buffer buffer = bufferWithContext.context;
+            // Pool allocation reduces available count.
+            assertThat(networkBufferPool.getNumberOfAvailableMemorySegments())
+                    .isLessThan(availableBefore);
+            // Memory segment comes from pre-allocated pool (off-heap).
+            assertThat(buffer.getMemorySegment().isOffHeap()).isTrue();
+        } finally {
+            bufferWithContext.context.recycleBuffer();
+        }
+    }
+
+    @Test
+    void testPreFilterSegmentReusedAcrossCalls() throws Exception {
+        try (InputChannelRecoveredStateHandler filteringHandler =
+                buildFilteringInputChannelStateHandler()) {
+            // First getBuffer() lazily allocates the segment.
+            RecoveredChannelStateHandler.BufferWithContext<Buffer> first =
+                    filteringHandler.getBuffer(channelInfo);
+            MemorySegment segment1 = first.context.getMemorySegment();
+            first.context.recycleBuffer();
+
+            // Second getBuffer() must reuse the same segment instance.
+            RecoveredChannelStateHandler.BufferWithContext<Buffer> second =
+                    filteringHandler.getBuffer(channelInfo);
+            MemorySegment segment2 = second.context.getMemorySegment();
+            second.context.recycleBuffer();
+
+            assertThat(segment2).isSameAs(segment1);
+            // Third call, same check.
+            RecoveredChannelStateHandler.BufferWithContext<Buffer> third =
+                    filteringHandler.getBuffer(channelInfo);
+            MemorySegment segment3 = third.context.getMemorySegment();
+            third.context.recycleBuffer();
+
+            assertThat(segment3).isSameAs(segment1);
+
+            // Internal assertion: inUse flipped back to false after each recycle.
+            assertThat(filteringHandler.isPreFilterBufferInUse()).isFalse();
+        }
+    }
+
+    @Test
+    void testGetBufferThrowsWhenPriorBufferNotRecycled() throws Exception {
+        try (InputChannelRecoveredStateHandler filteringHandler =
+                buildFilteringInputChannelStateHandler()) {
+            RecoveredChannelStateHandler.BufferWithContext<Buffer> first =
+                    filteringHandler.getBuffer(channelInfo);
+            try {
+                assertThat(filteringHandler.isPreFilterBufferInUse()).isTrue();
+
+                // Without recycling, requesting another buffer must fail.
+                assertThatThrownBy(() -> filteringHandler.getBuffer(channelInfo))
+                        .isInstanceOf(IllegalStateException.class)
+                        .hasMessageContaining("Previous pre-filter buffer has not been recycled");
+            } finally {
+                first.context.recycleBuffer();
+            }
+
+            // After recycling, a new getBuffer() succeeds.
+            RecoveredChannelStateHandler.BufferWithContext<Buffer> second =
+                    filteringHandler.getBuffer(channelInfo);
+            second.context.recycleBuffer();
+        }
+    }
+
+    @Test
+    void testPreFilterSegmentFreedOnClose() throws Exception {
+        InputChannelRecoveredStateHandler filteringHandler =
+                buildFilteringInputChannelStateHandler();
+        RecoveredChannelStateHandler.BufferWithContext<Buffer> bufferWithContext =
+                filteringHandler.getBuffer(channelInfo);
+        bufferWithContext.context.recycleBuffer();
+
+        MemorySegment segment = filteringHandler.getPreFilterSegmentForTesting();
+        assertThat(segment).isNotNull();
+        assertThat(segment.isFreed()).isFalse();
+
+        filteringHandler.close();
+
+        assertThat(segment.isFreed()).isTrue();
+        assertThat(filteringHandler.getPreFilterSegmentForTesting()).isNull();
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/CommonTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/CommonTestUtils.java
@@ -366,6 +366,26 @@ public class CommonTestUtils {
         return checkpointPath.get();
     }
 
+    /** Wait for at least {@code count} completed checkpoints that carry in-flight buffers. */
+    public static void waitForNCheckpointsWithInflightBuffers(
+            JobID jobID, MiniCluster miniCluster, int count) throws Exception {
+        waitForCheckpoints(
+                jobID,
+                miniCluster,
+                checkpointStatsSnapshot -> {
+                    if (checkpointStatsSnapshot == null) {
+                        return false;
+                    }
+                    long matched =
+                            checkpointStatsSnapshot.getHistory().getCheckpoints().stream()
+                                    .filter(cp -> cp instanceof CompletedCheckpointStats)
+                                    .map(cp -> (CompletedCheckpointStats) cp)
+                                    .filter(cp -> cp.getPersistedData() > 0)
+                                    .count();
+                    return matched >= count;
+                });
+    }
+
     /** Wait for (at least) the given number of successful checkpoints. */
     public static void waitForCheckpoint(JobID jobID, MiniCluster miniCluster, int numCheckpoints)
             throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/io/recovery/RecordFilterContextTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/io/recovery/RecordFilterContextTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.runtime.io.recovery;
 import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptor;
 import org.apache.flink.runtime.checkpoint.RescaleMappings;
+import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.streaming.runtime.partitioner.ForwardPartitioner;
 
 import org.junit.jupiter.api.Test;
@@ -53,7 +54,8 @@ class RecordFilterContextTest {
                         0,
                         128,
                         new String[] {"/tmp"},
-                        true);
+                        true,
+                        MemoryManager.DEFAULT_PAGE_SIZE);
 
         assertThat(context.getNumberOfGates()).isEqualTo(1);
         assertThat(context.getInputConfig(0)).isSameAs(config);
@@ -71,7 +73,8 @@ class RecordFilterContextTest {
                         0,
                         128,
                         null,
-                        false);
+                        false,
+                        MemoryManager.DEFAULT_PAGE_SIZE);
 
         assertThatThrownBy(() -> context.getInputConfig(0))
                 .isInstanceOf(IllegalArgumentException.class);
@@ -88,7 +91,8 @@ class RecordFilterContextTest {
                         0,
                         128,
                         null,
-                        false);
+                        false,
+                        MemoryManager.DEFAULT_PAGE_SIZE);
 
         assertThat(context.getTmpDirectories()).isNotNull().isEmpty();
     }
@@ -108,7 +112,8 @@ class RecordFilterContextTest {
                         0,
                         128,
                         null,
-                        false);
+                        false,
+                        MemoryManager.DEFAULT_PAGE_SIZE);
 
         assertThat(context.isAmbiguous(0, 0)).isFalse();
     }
@@ -128,7 +133,8 @@ class RecordFilterContextTest {
                         0,
                         128,
                         null,
-                        true);
+                        true,
+                        MemoryManager.DEFAULT_PAGE_SIZE);
 
         assertThat(context.isAmbiguous(0, 0)).isTrue();
     }
@@ -147,12 +153,52 @@ class RecordFilterContextTest {
                         0,
                         128,
                         null,
-                        true);
+                        true,
+                        MemoryManager.DEFAULT_PAGE_SIZE);
 
         // oldSubtask 0 is ambiguous
         assertThat(context.isAmbiguous(0, 0)).isTrue();
         // oldSubtask 1 is NOT in the ambiguous set
         assertThat(context.isAmbiguous(0, 1)).isFalse();
+    }
+
+    @Test
+    void testMemorySegmentSizeExposedAndValidated() {
+        RecordFilterContext context =
+                new RecordFilterContext(
+                        new RecordFilterContext.InputFilterConfig[0],
+                        InflightDataRescalingDescriptor.NO_RESCALE,
+                        0,
+                        128,
+                        null,
+                        false,
+                        MemoryManager.DEFAULT_PAGE_SIZE * 2);
+
+        assertThat(context.getMemorySegmentSize()).isEqualTo(MemoryManager.DEFAULT_PAGE_SIZE * 2);
+
+        // Non-positive sizes are rejected.
+        assertThatThrownBy(
+                        () ->
+                                new RecordFilterContext(
+                                        new RecordFilterContext.InputFilterConfig[0],
+                                        InflightDataRescalingDescriptor.NO_RESCALE,
+                                        0,
+                                        128,
+                                        null,
+                                        false,
+                                        0))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(
+                        () ->
+                                new RecordFilterContext(
+                                        new RecordFilterContext.InputFilterConfig[0],
+                                        InflightDataRescalingDescriptor.NO_RESCALE,
+                                        0,
+                                        128,
+                                        null,
+                                        false,
+                                        -1))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
@@ -182,7 +228,8 @@ class RecordFilterContextTest {
                         1,
                         256,
                         new String[] {"/tmp"},
-                        false);
+                        false,
+                        MemoryManager.DEFAULT_PAGE_SIZE);
 
         assertThat(context.getNumberOfGates()).isEqualTo(2);
         assertThat(context.getInputConfig(0)).isSameAs(config0);

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/io/recovery/VirtualChannelRecordFilterFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/io/recovery/VirtualChannelRecordFilterFactoryTest.java
@@ -19,6 +19,7 @@ package org.apache.flink.streaming.runtime.io.recovery;
 
 import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptor;
+import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.streaming.runtime.partitioner.RebalancePartitioner;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
@@ -63,7 +64,8 @@ class VirtualChannelRecordFilterFactoryTest {
                         1,
                         128,
                         new String[] {"/tmp"},
-                        true);
+                        true,
+                        MemoryManager.DEFAULT_PAGE_SIZE);
 
         VirtualChannelRecordFilterFactory<Long> factory =
                 VirtualChannelRecordFilterFactory.fromContext(context, 0);

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RecoveredStateFilteringLargeRecordITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RecoveredStateFilteringLargeRecordITCase.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.checkpointing;
+
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.connector.source.lib.NumberSequenceSource;
+import org.apache.flink.api.connector.source.util.ratelimit.RateLimiterStrategy;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ExternalizedCheckpointRetention;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.RestartStrategyOptions;
+import org.apache.flink.configuration.StateRecoveryOptions;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.connector.datagen.source.DataGeneratorSource;
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.runtime.testutils.CommonTestUtils;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.v2.DiscardingSink;
+import org.apache.flink.test.junit5.InjectMiniCluster;
+import org.apache.flink.test.junit5.MiniClusterExtension;
+import org.apache.flink.util.TestLoggerExtension;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.annotation.Nullable;
+
+import java.io.File;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.apache.flink.configuration.RestartStrategyOptions.RestartStrategyType.NO_RESTART_STRATEGY;
+
+/**
+ * Integration test: recovery with filtering must keep at most one pre-filter source buffer in
+ * flight per task, even when records are large enough to span many source buffers.
+ *
+ * <p>Strategy: configure the network memory segment to Flink's minimum page size and generate
+ * records several times larger. Every record therefore forces the recovery loop to allocate many
+ * consecutive pre-filter buffers, exercising the serialized getBuffer/recycle cycle that must reuse
+ * a single heap segment. A sleeping downstream operator induces back-pressure on the keyBy shuffle
+ * so that inflight buffers actually accumulate and are captured by the unaligned checkpoint;
+ * otherwise the recovery path would have nothing to filter.
+ *
+ * <p>Filtering during recovery is gated by two config options. Both are pinned on explicitly in
+ * {@link #getEnv} so the test deterministically exercises the filtering handler.
+ *
+ * <p>If the one-at-a-time invariant were violated during recovery, the runtime check in {@code
+ * InputChannelRecoveredStateHandler.getPreFilterBuffer} would fail with {@link
+ * IllegalStateException} and the job would fail. Reaching a completed post-recovery checkpoint is
+ * therefore proof that the invariant held across all buffer cycles.
+ */
+@ExtendWith({TestLoggerExtension.class})
+class RecoveredStateFilteringLargeRecordITCase {
+
+    private static final int NUM_TASK_MANAGERS = 1;
+    private static final int SLOTS_PER_TASK_MANAGER = 8;
+    private static final int MAX_SLOTS = NUM_TASK_MANAGERS * SLOTS_PER_TASK_MANAGER;
+    private static final Random RANDOM = new Random();
+
+    /**
+     * Network buffer size during the test. Pinned to the minimum Flink allows so that each record
+     * forces as many consecutive getBuffer/recycle cycles on the recovery thread as possible.
+     */
+    private static final MemorySize SEGMENT_SIZE = new MemorySize(MemoryManager.MIN_PAGE_SIZE);
+
+    /**
+     * Characters per record. ASCII chars serialize to 1 byte each in UTF-8, so a record of this
+     * many chars spans roughly {@code RECORD_CHARS / SEGMENT_SIZE} source buffers. Each such record
+     * exercises that many consecutive getBuffer/recycle cycles through the filtering handler.
+     */
+    private static final int RECORD_CHARS = 8 * (int) SEGMENT_SIZE.getBytes();
+
+    @RegisterExtension
+    private static final MiniClusterExtension MINI_CLUSTER_EXTENSION =
+            new MiniClusterExtension(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setConfiguration(
+                                    new Configuration()
+                                            .set(CheckpointingOptions.MAX_RETAINED_CHECKPOINTS, 10))
+                            .setNumberTaskManagers(NUM_TASK_MANAGERS)
+                            .setNumberSlotsPerTaskManager(SLOTS_PER_TASK_MANAGER)
+                            .build());
+
+    @TempDir private File temporaryFolder;
+
+    @Test
+    void testLargeRecordRecoveryPreservesOneBufferInvariant(
+            @InjectMiniCluster MiniCluster miniCluster) throws Exception {
+        // Random parallelisms to cover a variety of rescale (and no-rescale) combinations.
+        int parallelismPhase1 = RANDOM.nextInt(MAX_SLOTS) + 1;
+        int parallelismPhase2 = RANDOM.nextInt(MAX_SLOTS) + 1;
+        int parallelismPhase3 = RANDOM.nextInt(MAX_SLOTS) + 1;
+
+        // Phase 1: run at parallelism N and take an unaligned checkpoint with inflight buffers.
+        JobClient job1 = runJob(parallelismPhase1, null);
+        CommonTestUtils.waitForJobStatus(job1, Collections.singletonList(JobStatus.RUNNING));
+        CommonTestUtils.waitForAllTaskRunning(miniCluster, job1.getJobID(), false);
+        String checkpointPath1 =
+                CommonTestUtils.waitForCheckpointWithInflightBuffers(job1.getJobID(), miniCluster);
+        job1.cancel().get();
+
+        // Phase 2: restore from phase 1's checkpoint. Wait for one completed checkpoint with
+        // inflight buffers — that checkpoint is the one taken during recovery, which is what
+        // phase 3 will restore from to exercise the "recovery-of-a-recovered-checkpoint" path.
+        JobClient job2 = runJob(parallelismPhase2, checkpointPath1);
+        CommonTestUtils.waitForJobStatus(job2, Collections.singletonList(JobStatus.RUNNING));
+        CommonTestUtils.waitForAllTaskRunning(miniCluster, job2.getJobID(), false);
+        String checkpointPath2 =
+                CommonTestUtils.waitForCheckpointWithInflightBuffers(job2.getJobID(), miniCluster);
+        job2.cancel().get();
+
+        // Phase 3: restore from phase 2's post-recovery checkpoint. Wait for several checkpoints
+        // to run the restored job long enough to shake out stability issues beyond the first
+        // post-recovery checkpoint.
+        JobClient job3 = runJob(parallelismPhase3, checkpointPath2);
+        CommonTestUtils.waitForJobStatus(job3, Collections.singletonList(JobStatus.RUNNING));
+        CommonTestUtils.waitForAllTaskRunning(miniCluster, job3.getJobID(), false);
+        CommonTestUtils.waitForNCheckpointsWithInflightBuffers(job3.getJobID(), miniCluster, 5);
+        job3.cancel().get();
+    }
+
+    private JobClient runJob(int parallelism, @Nullable String recoveryPath) throws Exception {
+        StreamExecutionEnvironment env = getEnv(recoveryPath);
+        env.setParallelism(parallelism);
+
+        DataStream<String> source =
+                env.fromSource(
+                                createLargeRecordSource(),
+                                WatermarkStrategy.noWatermarks(),
+                                "large-record-source")
+                        .setParallelism(parallelism);
+
+        // keyBy triggers a hash shuffle, and the slow downstream map induces back-pressure so the
+        // shuffle's input channels accumulate inflight buffers — which is exactly what an
+        // unaligned checkpoint captures and the rescaled recovery must then replay through the
+        // filtering path.
+        source.keyBy((KeySelector<String, String>) value -> value)
+                .map(
+                        x -> {
+                            Thread.sleep(5);
+                            return x;
+                        })
+                .name("slow-map")
+                .setParallelism(parallelism)
+                .sinkTo(new DiscardingSink<>())
+                .name("discarding-sink")
+                .setParallelism(parallelism);
+
+        return env.executeAsync();
+    }
+
+    private StreamExecutionEnvironment getEnv(@Nullable String recoveryPath) {
+        Configuration conf = new Configuration();
+        conf.set(CheckpointingOptions.CHECKPOINTING_INTERVAL, Duration.ofSeconds(1));
+        conf.set(CheckpointingOptions.ALIGNED_CHECKPOINT_TIMEOUT, Duration.ofSeconds(0));
+        conf.set(RestartStrategyOptions.RESTART_STRATEGY, NO_RESTART_STRATEGY.getMainValue());
+        conf.set(
+                CheckpointingOptions.EXTERNALIZED_CHECKPOINT_RETENTION,
+                ExternalizedCheckpointRetention.RETAIN_ON_CANCELLATION);
+        conf.set(CheckpointingOptions.CHECKPOINTS_DIRECTORY, temporaryFolder.toURI().toString());
+        conf.set(CheckpointingOptions.ENABLE_UNALIGNED, true);
+        // Filtering during recovery requires BOTH flags: UNALIGNED_RECOVER_OUTPUT_ON_DOWNSTREAM
+        // gates the feature, and CHECKPOINTING_DURING_RECOVERY_ENABLED turns it on.
+        conf.set(CheckpointingOptions.UNALIGNED_RECOVER_OUTPUT_ON_DOWNSTREAM, true);
+        conf.set(CheckpointingOptions.CHECKPOINTING_DURING_RECOVERY_ENABLED, true);
+        conf.set(TaskManagerOptions.MEMORY_SEGMENT_SIZE, SEGMENT_SIZE);
+        if (recoveryPath != null) {
+            conf.set(StateRecoveryOptions.SAVEPOINT_PATH, recoveryPath);
+        }
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment(conf);
+        env.disableOperatorChaining();
+        return env;
+    }
+
+    private static DataGeneratorSource<String> createLargeRecordSource() {
+        return new DataGeneratorSource<>(
+                index -> {
+                    ThreadLocalRandom rnd = ThreadLocalRandom.current();
+                    char[] chars = new char[RECORD_CHARS];
+                    for (int i = 0; i < chars.length; i++) {
+                        chars[i] = (char) ('a' + rnd.nextInt(26));
+                    }
+                    return new String(chars);
+                },
+                new NumberSequenceSource(0, Long.MAX_VALUE - 1) {
+                    @Override
+                    protected List<NumberSequenceSplit> splitNumberRange(
+                            long from, long to, int numSplitsIgnored) {
+                        return super.splitNumberRange(from, to, MAX_SLOTS);
+                    }
+                },
+                RateLimiterStrategy.perSecond(2000),
+                Types.STRING) {};
+    }
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointRescaleWithMixedExchangesITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointRescaleWithMixedExchangesITCase.java
@@ -33,6 +33,7 @@ import org.apache.flink.configuration.StateRecoveryOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.connector.datagen.source.DataGeneratorSource;
 import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
@@ -180,7 +181,9 @@ class UnalignedCheckpointRescaleWithMixedExchangesITCase {
         // enabled. All buffers(records) before barrier must be consumed for aligned checkpoint.
         // The smaller the buffer size means the fewer records are needed to be consumed during
         // aligned checkpoint.
-        conf.set(TaskManagerOptions.MEMORY_SEGMENT_SIZE, MemorySize.parse("1 kb"));
+        conf.set(
+                TaskManagerOptions.MEMORY_SEGMENT_SIZE,
+                new MemorySize(MemoryManager.MIN_PAGE_SIZE));
         if (recoveryPath != null) {
             conf.set(StateRecoveryOptions.SAVEPOINT_PATH, recoveryPath);
         }


### PR DESCRIPTION
## What is the purpose of the change

Under FLINK-39519, the channel-state recovery loop can deadlock when checkpointing-during-recovery filters inflight buffers: the single-threaded recovery thread first requests buffers to read pre-filter state, then requests more buffers to write post-filter output. If pre-filter buffers exhaust the Network Buffer Pool, post-filter allocation blocks and stalls the thread, so pre-filter buffers can never be consumed and released.

This PR isolates the pre-filter buffer from the Network Buffer Pool by allocating it from a dedicated heap segment.

## Brief change log

- `InputChannelRecoveredStateHandler` lazily allocates **one** heap `MemorySegment` per task (sized to `memorySegmentSize`), reuses it across every pre-filter `getBuffer()` call, and frees it in `close()`. Non-filtering mode is unchanged.
- A runtime check (`!preFilterBufferInUse`) enforces the one-buffer-at-a-time invariant. The custom `BufferRecycler` flips the flag back on recycle without freeing the segment. Any future regression of the invariant fails loudly with `IllegalStateException` instead of silently corrupting memory.
- Wiring:
  - `RecordFilterContext` gains a required `memorySegmentSize` parameter (with `checkArgument > 0`) and a `getMemorySegmentSize()` accessor. `disabled()` factory uses `MemoryManager.DEFAULT_PAGE_SIZE`.
  - `StreamTask.createRecordFilterContext()` passes `ConfigurationParserUtils.getPageSize(jobConfiguration)`.
  - `SequentialChannelStateReaderImpl` passes `filterContext.getMemorySegmentSize()` to the handler constructor.
- Added `CommonTestUtils.waitForNCheckpointsWithInflightBuffers` to wait for N completed checkpoints that carry inflight channel state.

## Why a single reusable segment is enough

At most one pre-filter source buffer is in flight per task at any moment, guaranteed by Flink's existing recovery design:

1. `ChannelStateChunkReader.readChunk()` is a single-threaded while-loop (`getBuffer → fill → recover(finally recycle)`). The next `getBuffer()` can only start after `recover()` returns — structural concurrency = 1.
2. `SpillingAdaptiveSpanningRecordDeserializer.getNextRecord()` recycles the current buffer the instant `isBufferConsumed=true`, which happens on both `PARTIAL_RECORD` (record spans buffers) and `LAST_RECORD_FROM_BUFFER` (buffer exhausted). `filterAndRewrite()` breaks its loop on the same condition.
3. Cross-buffer bytes are always **copied out** before recycle: `SpanningWrapper.transferFrom` / `addNextChunkFromMemorySegment` copy partial bytes into an internal `byte[]` (or into `SpanningWrapper`'s own spill file for records ≥ 5 MB). The only retained segment pointer (`leftOverData` / `NonSpanningWrapper.segment`) is read via `segment.get(...)` — copies into the target — and only while `isBufferConsumed=false`.
4. Exception paths converge through `ChannelStateFilteringHandler.close() → VirtualChannel.clear() → deserializer.clear()`, which recycles any buffer the deserializer still holds.

## Verifying this change

### Unit tests (`InputChannelRecoveredStateHandlerTest`)

- `testPreFilterBufferIsolationFromNetworkBufferPool`: filtering-mode `getBuffer()` returns a heap-backed buffer; the Network Buffer Pool is untouched.
- `testNonFilteringModeUsesNetworkBufferPool`: non-filtering path preserved.
- `testPreFilterSegmentReusedAcrossCalls`: successive `getBuffer()`/recycle cycles return the same `MemorySegment` instance.
- `testGetBufferThrowsWhenPriorBufferNotRecycled`: runtime invariant check throws `IllegalStateException`.
- `testPreFilterSegmentFreedOnClose`: segment freed on handler close.
- `testMemorySegmentSizeExposedAndValidated`: context validation and getter.

### Integration test (`RecoveredStateFilteringLargeRecordITCase`)

Pins the network memory segment to Flink's minimum page size and generates records 8× the segment size so each record spans many consecutive source buffers. A sleeping downstream map induces back-pressure on the keyBy shuffle so inflight buffers actually accumulate. The test runs three phases with random parallelism per phase:

1. Phase 1: take an unaligned checkpoint with inflight buffers.
2. Phase 2: restore from phase 1 and wait for one post-recovery checkpoint with inflight buffers. That checkpoint — the one taken during recovery itself — becomes phase 3's restore target, so phase 3 exercises the "recovery-of-a-recovered-checkpoint" path.
3. Phase 3: restore from phase 2 and wait for five post-recovery checkpoints to shake out stability issues beyond the first post-recovery checkpoint.

Both filtering flags (`UNALIGNED_RECOVER_OUTPUT_ON_DOWNSTREAM` and `CHECKPOINTING_DURING_RECOVERY_ENABLED`) are pinned on so every run deterministically exercises the filtering handler.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): **no**
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
- The serializers: **no**
- The runtime per-record code paths (performance sensitive): **no** (only the recovery path)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **yes — channel state recovery with filtering**
- The S3 file system connector: **no**

## Documentation

- Does this pull request introduce a new feature? **no** (bug fix / robustness improvement)
- If yes, how is the feature documented? **not applicable**
