### PR TITLE
[FLINK-38397][table] Fix stale sort trait on BatchPhysicalLocalHashAggregate causing ArrayIndexOutOfBoundsException

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalHashAggRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalHashAggRule.scala
@@ -30,7 +30,7 @@ import org.apache.flink.table.planner.utils.TableConfigUtils.isOperatorDisabled
 
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
 import org.apache.calcite.plan.RelOptRule.{any, operand}
-import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.{RelCollations, RelNode}
 
 import scala.collection.JavaConversions._
 
@@ -101,7 +101,9 @@ class BatchPhysicalHashAggRule
       // create BatchPhysicalLocalHashAggregate
       val localRequiredTraitSet = input.getTraitSet.replace(FlinkConventions.BATCH_PHYSICAL)
       val newInput = RelOptRule.convert(input, localRequiredTraitSet)
-      val providedTraitSet = localRequiredTraitSet
+      // A hash aggregate does not preserve input ordering; reset the collation to EMPTY
+      // so the local agg does not advertise a stale collation from its input.
+      val providedTraitSet = localRequiredTraitSet.replace(RelCollations.EMPTY)
       val localHashAgg = createLocalAgg(
         agg.getCluster,
         providedTraitSet,

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/table/AggregateTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/table/AggregateTest.xml
@@ -74,6 +74,19 @@ HashAggregate(isMerge=[true], select=[Final_AVG(sum$0, count$1) AS EXPR$0, Final
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testGroupAggregateAfterOrderBy">
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[EXPR$0 AS cnt])
++- HashAggregate(isMerge=[true], groupBy=[d], select=[d, Final_COUNT(count$0) AS EXPR$0])
+   +- Exchange(distribution=[hash[d]])
+      +- LocalHashAggregate(groupBy=[d], select=[d, Partial_COUNT(e) AS count$0])
+         +- Sort(orderBy=[c ASC])
+            +- Exchange(distribution=[single])
+               +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, e])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testGroupAggregateWithFilter">
     <Resource name="ast">
       <![CDATA[

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/table/AggregateTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/table/AggregateTest.scala
@@ -73,4 +73,20 @@ class AggregateTest extends TableTestBase {
 
     util.verifyExecPlan(resultTable)
   }
+
+  @Test
+  def testGroupAggregateAfterOrderBy(): Unit = {
+    // order_by before a group_by that prunes the sort-key column must not
+    // leave a stale collation on the local hash aggregate.
+    val util = batchTestUtil()
+    val sourceTable = util
+      .addTableSource[(Int, Long, Int, String, Double)]("MyTable", 'a, 'b, 'c, 'd, 'e)
+
+    val resultTable = sourceTable
+      .orderBy('c)
+      .groupBy('d)
+      .select('e.count.as('cnt))
+
+    util.verifyExecPlan(resultTable)
+  }
 }


### PR DESCRIPTION

## What is the purpose of the change

Fix stale sort trait on BatchPhysicalLocalHashAggregate causing ArrayIndexOutOfBoundsException

## Brief change log

  - Reset the collation in localRequired RaitSet to null (EMPTY), as hash aggregation does not preserve input order, avoiding outdated collation in local aggregation operations

## Verifying this change

This change is verified by new and existing tests in `AggregateTest` and `AggregateTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable