### PR TITLE
[FLINK-39529][table] Add SQL-to-operator lifecycle and restructure planner AGENTS.md 

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,6 +252,7 @@ This section maps common types of Flink changes to the modules they touch and th
 
 ## Coding Standards
 
+- **Keep it short.** Short, easy to read code always. Match the surrounding style: no speculative abstractions, no comments restating the code. Same goes for prose - PR descriptions, commit messages, and updates. Cut detailed information, specific information not relevant for future readers and anything visible in the diff.
 - **Format Java files with Spotless immediately after editing:** `./mvnw spotless:apply`. Uses google-java-format with AOSP style.
 - **Scala formatting:** Spotless + scalafmt (config at `.scalafmt.conf`, maxColumn 100).
 - **Checkstyle:** `tools/maven/checkstyle.xml` (version defined in root `pom.xml` as `checkstyle.version`). Some modules (flink-core, flink-optimizer, flink-runtime) are not covered by checkstyle enforcement, but conventions should still be followed.

--- a/flink-table/flink-table-planner/AGENTS.md
+++ b/flink-table/flink-table-planner/AGENTS.md
@@ -21,6 +21,10 @@ under the License.
 
 Translates and optimizes SQL/Table API programs into executable plans using Apache Calcite. Bridges the Table/SQL API and the runtime by generating code and execution plans. The planner is loaded in a separate classloader (`flink-table-planner-loader`) to isolate Calcite dependencies.
 
+## Keep it short
+
+Short, easy to read code always. Match the surrounding planner/rule style: no speculative abstractions, no comments restating the code. Cut detailed information, specific information not relevant for future readers and anything visible in the diff.
+
 See also [README.md](README.md) for Immutables rule config conventions and JSON plan test regeneration.
 
 ## Build Commands

--- a/flink-table/flink-table-planner/AGENTS.md
+++ b/flink-table/flink-table-planner/AGENTS.md
@@ -38,7 +38,7 @@ After the first full build, drop `-am` for faster rebuilds when you're only chan
 - `plan/rules/physical/stream/` and `plan/rules/physical/batch/` — Physical planner rules
 - `plan/rules/logical/` — Logical optimization rules
 - `plan/nodes/exec/stream/` and `plan/nodes/exec/batch/` — ExecNodes (bridge between planner and runtime)
-- `plan/nodes/exec/spec/` — Serializable operator specifications (JoinSpec, WindowSpec, etc.)
+- `plan/nodes/exec/spec/` — Serializable operator specifications (JoinSpec, OverSpec, etc.)
 - `plan/nodes/physical/stream/` and `plan/nodes/physical/batch/` — Intermediate physical nodes (Calcite-based)
 - `plan/nodes/logical/` — Logical nodes (Calcite-based)
 - `codegen/` — Code generation
@@ -52,57 +52,170 @@ After the first full build, drop `-am` for faster rebuilds when you're only chan
 - **ExecNode**: Bridge between planner and runtime. Annotated with `@ExecNodeMetadata(name, version, minPlanVersion, minStateVersion)` for versioning and backwards compatibility. Extends `ExecNodeBase<T>` and implements either `StreamExecNode<T>` (streaming) or `BatchExecNode<T>` (batch); `T` is typically `RowData`.
 - **Physical rules**: Extend `RelRule`, use Immutables `@Value.Immutable` for config. Transform logical nodes to physical nodes. Registered in `FlinkStreamRuleSets` and/or `FlinkBatchRuleSets`.
 - **Logical optimization rules**: Also extend `RelRule`, often use `RexShuttle` for expression rewriting. Registered in rule sets.
-- **Specs**: Serializable specifications in `plan/nodes/exec/spec/` (JoinSpec, WindowSpec, etc.) that carry operator configuration.
+- **Specs**: Serializable specifications in `plan/nodes/exec/spec/` (JoinSpec, OverSpec, etc.) that carry operator configuration.
 
-## Common Change Patterns
+## SQL to Operator lifecycle
 
-### Adding a new table operator
+Every table operator traverses the same seven stages. Read the diagram top-to-bottom for the shape, then jump into the stage you need.
+
+```
+SQL string
+   │  parse
+   ▼
+SqlNode (AST)
+   │  validate            ← names resolve, types infer
+   ▼
+typed SqlNode
+   │  SqlToRel
+   ▼
+RelNode + RexNode         ← logical algebra
+   │  logical phases
+   ▼
+FlinkLogical*Node
+   │  physical phase
+   ▼
+FlinkPhysical*Node
+   │  translateToExecNode
+   ▼
+ExecNode (checkpoint-stable serializable plan)
+   │  translateToPlanInternal + codegen
+   ▼
+StreamOperator (runs on TaskManager)
+```
+
+**Five types to know:**
+
+> - **`SqlNode`** - a node in the SQL syntax tree (what you typed).
+> - **`RelNode`** - a node in the relational algebra tree (scan, project, join, ...).
+> - **`RexNode`** - an expression inside a `RelNode` (column ref, literal, function call).
+> - **`ExecNode`** - the planner-runtime bridge, JSON-serializable so a compiled plan can be saved and restored.
+> - **`StreamOperator`** - the runtime class that processes records on a TaskManager.
+
+**Two planners to know** (both used in stages 4-5, see `FlinkStreamProgram` for the chained phases):
+
+> - **HepPlanner** - deterministic, fires rules in a fixed order until no more match. Used for rewrites that don't need cost estimation: subquery elimination, decorrelation, predicate pushdown, projection cleanup, etc. Rules typically extend `RelRule` (or the older `RelOptRule`) and rewrite within the same calling convention (logical → logical, physical → physical).
+> - **VolcanoPlanner** - cost-based, explores alternative plans and picks the cheapest using a cost model. Used for convention conversion (Calcite logical → Flink logical in the `LOGICAL` phase, Flink logical → Flink physical in the `PHYSICAL` phase) and for picking among physical strategies (e.g., interval join vs regular join). Rules typically extend `ConverterRule`, change calling convention via `Config.INSTANCE.withConversion(...)`, and participate in the cost-based search.
+
+Each stage below names the framework piece, then shows where binary join and PTF land in it.
+
+### 1. Parsing (SQL text → SqlNode tree)
+SQL string is tokenized and parsed into a `SqlNode` AST by the generated parser (grammar in `flink-sql-parser/parserImpls.ftl`, driver in `planner/parse/CalciteParser`).
+
+  Examples:
+  - Binary join: `a JOIN b ON a.x = b.y` becomes a `SqlJoin` node.
+  - PTF: `TABLE(my_ptf(TABLE t1 PARTITION BY a))` becomes a `SqlBasicCall` holding the function call with table args.
+
+### 2. Validation (resolve names, infer types)
+`FlinkPlannerImpl.validate` runs `FlinkCalciteSqlValidator` over the AST: identifiers (tables, functions, columns) get resolved, types are inferred, arg counts/types are checked. Function calls are matched to a `SqlOperator` via the `SqlOperatorTable`. Extension points: register a function in the operator table; provide a `TypeInference` for typing.
+
+  Examples:
+  - Binary join: the `SqlJoin` operator is validated; equality predicates resolve to standard `SqlBinaryOperator`s.
+  - PTF: `FunctionCatalogOperatorTable.lookupOperatorOverloads` resolves the function name; `BridgingSqlFunction` wraps the user's `TypeInference` via `SystemTypeInference` (system args, output column derivation).
+
+### 3. SqlToRel (SqlNode → RelNode + RexNode)
+`FlinkPlannerImpl.rel` invokes Calcite's `SqlToRelConverter` to produce the initial `RelNode` tree with `RexNode` expressions. Customizable via convertlets registered in `FlinkConvertletTable`.
+
+  Examples:
+  - Binary join: produces a `LogicalJoin` with the ON condition as a `RexNode`.
+  - PTF: `FlinkConvertletTable.convertTableArgs` rewrites table arguments into `RexTableArgCall` operands.
+
+### 4. Logical plan (rewrite to a cheaper equivalent tree)
+`FlinkStreamProgram` chains the phases that run during this stage. HepPlanner drives the rewrite phases (`SUBQUERY_REWRITE`, `TEMPORAL_JOIN_REWRITE`, `DECORRELATE`, `DEFAULT_REWRITE`, `PREDICATE_PUSHDOWN`, `JOIN_REORDER`, `MULTI_JOIN`, `PROJECT_REWRITE`, `LOGICAL_REWRITE`); VolcanoPlanner drives the `LOGICAL` phase that converts Calcite logical nodes to Flink logical nodes (required output trait `FlinkConventions.LOGICAL`); `TIME_INDICATOR` runs the dedicated `FlinkRelTimeIndicatorProgram`. All rule sets live in `FlinkStreamRuleSets`.
+
+  Examples:
+  - Binary join: `FlinkLogicalJoinConverter` produces `FlinkLogicalJoin`.
+  - PTF: `FlinkLogicalTableFunctionScanConverter` produces `FlinkLogicalTableFunctionScan`, then calls `BridgingSqlFunction.resolveCallTraits(call)` to bake conditional traits into the operator's static args.
+
+### 5. Physical plan (pick a concrete execution strategy)
+VolcanoPlanner runs the `PHYSICAL` phase, cost-picking a physical strategy via `ConverterRule`s. The `PHYSICAL_REWRITE` phase runs post-passes such as `FlinkChangelogModeInferenceProgram`.
+
+  Examples:
+  - Binary join: depending on predicate shape, `StreamPhysicalJoinRule` / `StreamPhysicalIntervalJoinRule` / `StreamPhysicalTemporalJoinRule` produces `StreamPhysicalJoin`, `StreamPhysicalIntervalJoin`, or `StreamPhysicalTemporalJoin`.
+  - PTF: `StreamPhysicalProcessTableFunctionRule` produces `StreamPhysicalProcessTableFunction`.
+
+### 6. Exec node & compiled plan (serializable handoff to the runtime)
+`physicalNode.translateToExecNode()` produces an `@ExecNodeMetadata`-annotated `ExecNode` (the bridge to runtime). JSON serde via `ExecNodeGraphJsonSerializer/Deserializer` (and `RexNodeJsonSerializer/Deserializer` for expressions) supports compiled-plan write and restore. Each `ExecNode` is rebuilt via its `@JsonCreator` constructor on restore.
+
+  Examples:
+  - Binary join: `StreamExecJoin`.
+  - PTF: `StreamExecProcessTableFunction`. Compiled-plan restore re-runs `BridgingSqlFunction.resolveCallTraits` from the `StreamExecProcessTableFunction` `@JsonCreator` constructor so the runtime still sees the resolved signature.
+
+### 7. Runtime (codegen and build the operator)
+`ExecNode.translateToPlanInternal` drives codegen, wraps the generated runner in an operator factory, and emits a `Transformation`. At task startup the factory instantiates the actual operator and `open()` wires state, timers, collectors, then opens the runner; `processElement` feeds records into the runner. Runtime classes live in `flink-table-runtime` (see [its AGENTS.md](../flink-table-runtime/AGENTS.md)).
+
+  Examples:
+  - Binary join (streaming): `StreamExecJoin` wires a `StreamingJoinOperator` (or `MiniBatchStreamingJoinOperator` / `AsyncStateStreamingJoinOperator` depending on config). Batch counterparts (`BatchExecHashJoin`, `BatchExecSortMergeJoin`) wire `HashJoinOperator` (codegen via `LongHashJoinGenerator`) or `SortMergeJoinOperator` instead.
+  - PTF: `ProcessTableRunnerGenerator` produces a `GeneratedProcessTableRunner` wrapped in `ProcessTableOperatorFactory`; the factory creates either `ProcessSetTableOperator` (set semantics, keyed) or `ProcessRowTableOperator` (row semantics or no table args), both extending `AbstractProcessTableOperator`.
+
+### Worked examples (side-by-side)
+
+| Stage         | Binary join: `SELECT * FROM a JOIN b ON a.x = b.y` | PTF: `SELECT * FROM TABLE(my_ptf(TABLE t1 PARTITION BY a))` |
+| ------------- | -------------------------------------------------- | ----------------------------------------------------------- |
+| Parsing       | `SqlJoin`                                          | `SqlBasicCall`                                              |
+| Validation    | `SqlJoin` operator                                 | `BridgingSqlFunction`                                       |
+| SqlToRel      | `LogicalJoin` with ON `RexNode`                    | `RexCall` with `RexTableArgCall` operand                    |
+| Logical       | `FlinkLogicalJoin`                                 | `FlinkLogicalTableFunctionScan`                             |
+| Physical      | `StreamPhysicalJoin`                               | `StreamPhysicalProcessTableFunction`                        |
+| Exec / plan   | `StreamExecJoin`                                   | `StreamExecProcessTableFunction`                            |
+| Runtime       | `StreamingJoinOperator`                            | `ProcessTableOperatorFactory` -> `ProcessSetTableOperator`  |
+
+## Common workflows
+
+Recipes organized by the lifecycle stage they target. Stage numbering matches the lifecycle above; stages without recipes today are omitted. The final "Cross-stage" subsection groups workflows that touch more than one stage.
+
+### 1. Parsing
+
+#### 1.1 Extending SQL syntax
+
+1. Modify parser grammar in `flink-sql-parser` (`parserImpls.ftl`)
+2. Add operation conversion logic in `SqlNodeToOperationConversion.java`
+3. Test with parser tests and SQL gateway integration tests (`.q` files)
+
+### 6. Exec node & compiled plan
+
+#### 6.1 Plan serialization changes
+
+- ExecNode specs use Jackson for JSON serialization. Source/sink specs should use `@JsonIgnoreProperties(ignoreUnknown = true)` for forward compatibility.
+- When adding new ExecNode features, update `RexNodeJsonDeserializer` or related serde classes if new function kinds or types are introduced.
+
+#### 6.2 ExecNode versioning
+
+When bumping an ExecNode version, update the `@ExecNodeMetadata` annotation's `version` and `minPlanVersion`/`minStateVersion` fields. Add restore test snapshots for the new version.
+
+### 7. Runtime
+
+#### 7.1 Code generation changes
+
+- Cast rules live in `functions/casting/`. Each extends `AbstractExpressionCodeGeneratorCastRule` or similar.
+- Custom call generators for functions live in `codegen/calls/` (e.g., `JsonCallGen.scala`). Simple scalar functions typically don't need these; the planner handles them uniformly through the function definition.
+- Immutables library is used for rule configs (`@Value.Immutable`, `@Value.Enclosing`). See [README.md](README.md).
+
+### Cross-stage
+
+#### Adding a new table operator
 
 Components involved (can be developed top-down or bottom-up):
 
-1. **Runtime operator** in `flink-table-runtime` under `operators/` (extend `TableStreamOperator`, implement `OneInputStreamOperator` or `TwoInputStreamOperator`). Test with harness tests. See [flink-table-runtime AGENTS.md](../flink-table-runtime/AGENTS.md).
-2. **ExecNode** in `plan/nodes/exec/stream/` and/or `plan/nodes/exec/batch/` (extend `ExecNodeBase<T>`; implement `StreamExecNode<T>` for streaming or `BatchExecNode<T>` for batch; annotate with `@ExecNodeMetadata`; `T` is typically `RowData`)
-3. **Physical Node + Physical Rules** in `plan/rules/physical/stream/` and/or `plan/rules/physical/batch/` (physical rules usually extend `ConverterRule` via `Config.INSTANCE.withConversion(...)`; same-convention rewrites extend `RelRule` with an `@Value.Immutable` config)
-4. **Logical Node + Planner rule**
+1. **(Runtime)** Runtime operator in `flink-table-runtime` under `operators/` ((extend TableStreamOperator, implement OneInputStreamOperator, TwoInputStreamOperator, or MultipleInputStreamOperator for N-ary inputs). Test with harness tests. See [flink-table-runtime AGENTS.md](../flink-table-runtime/AGENTS.md).
+2. **(Exec node & compiled plan)** ExecNode in `plan/nodes/exec/stream/` and/or `plan/nodes/exec/batch/` (extend `ExecNodeBase<T>`; implement `StreamExecNode<T>` for streaming or `BatchExecNode<T>` for batch; annotate with `@ExecNodeMetadata`; `T` is typically `RowData`)
+3. **(Physical plan)** Physical Node + Physical Rules in `plan/rules/physical/stream/` and/or `plan/rules/physical/batch/` (physical rules usually extend `ConverterRule` via `Config.INSTANCE.withConversion(...)`; same-convention rewrites extend `RelRule` with an `@Value.Immutable` config)
+4. **(Logical plan)** Logical Node + Planner rule
 5. Tests: semantic tests, plan tests, restore tests (if stateful)
 
 Both `stream/` and `batch/` directories exist for rules and ExecNodes. Consider whether your change applies to one or both.
 
-### Adding a planner optimization rule
+#### Adding a planner optimization rule
 
 Pick the base class by what the rule does:
-- Converts a node from one calling convention to another (for example, logical → stream physical): extend `ConverterRule`. 
-Call `ConverterRule.Config.INSTANCE.withConversion(...)` in the constructor, do not define your own config.
-- Rewrites nodes within the same convention (logical → logical, physical → physical): extend `RelRule` with an `@Value.Immutable` config. 
-Some existing rules still use Calcite's older `RelOptRule`; prefer `RelRule` for new code.
+- Converts a node from one calling convention to another (for example, logical → stream physical, **Physical plan**): extend `ConverterRule`. Call `ConverterRule.Config.INSTANCE.withConversion(...)` in the constructor, do not define your own config.
+- Rewrites nodes within the same convention (logical → logical at **Logical plan**, physical → physical at **Physical plan**): extend `RelRule` with an `@Value.Immutable` config. Some existing rules still use Calcite's older `RelOptRule`; prefer `RelRule` for new code.
 
 Then:
 1. Register in `FlinkStreamRuleSets.scala` and/or `FlinkBatchRuleSets.scala`
 2. Plan tests with XML golden files — when the test fails, copy the framework's generated log file over the reference `.xml` (cases are ordered alphabetically by method name)
 3. A same-convention rewrite needs no runtime changes. A `ConverterRule` that produces a new physical node also needs the physical node, ExecNode, and runtime operator — see "Adding a new table operator" above.
 
-### Extending SQL syntax
-
-1. Modify parser grammar in `flink-sql-parser` (`parserImpls.ftl`)
-2. Add operation conversion logic in `SqlNodeToOperationConversion.java`
-3. Test with parser tests and SQL gateway integration tests (`.q` files)
-
-### Code generation changes
-
-- Cast rules live in `functions/casting/`. Each extends `AbstractExpressionCodeGeneratorCastRule` or similar.
-- Custom call generators for functions live in `codegen/calls/` (e.g., `JsonCallGen.scala`). Simple scalar functions typically don't need these; the planner handles them uniformly through the function definition.
-- Immutables library is used for rule configs (`@Value.Immutable`, `@Value.Enclosing`). See [README.md](README.md).
-
-### Plan serialization changes
-
-- ExecNode specs use Jackson for JSON serialization. Source/sink specs should use `@JsonIgnoreProperties(ignoreUnknown = true)` for forward compatibility.
-- When adding new ExecNode features, update `RexNodeJsonDeserializer` or related serde classes if new function kinds or types are introduced.
-
-### ExecNode versioning
-
-When bumping an ExecNode version, update the `@ExecNodeMetadata` annotation's `version` and `minPlanVersion`/`minStateVersion` fields. Add restore test snapshots for the new version.
-
-### Configuration options
+## Configuration options
 
 New features often introduce `ExecutionConfigOptions` entries (in `flink-table-api-java`) for runtime tunability (e.g., cache sizes, timeouts, batch sizes).
 

--- a/flink-table/flink-table-runtime/AGENTS.md
+++ b/flink-table/flink-table-runtime/AGENTS.md
@@ -21,6 +21,10 @@ under the License.
 
 Contains classes required by TaskManagers for execution of table programs. Implements runtime operators, built-in functions, and code generation support. Bundles janino (Java compiler for code generation) and flink-shaded-jsonpath.
 
+## Keep it short
+
+Short, easy to read code always. Runtime code is on the hot path - match the surrounding style, no speculative abstractions, no comments restating the code. Cut detailed information, specific information not relevant for future readers and anything visible in the diff.
+
 ## Key Directory Structure
 
 - `functions/scalar/` — Scalar function implementations (47+)


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

As recently discussed in the mailing list, we want to work towards have more extensive and high quality Agents.md context files to make the codebase work better with AI. In that sense, we want to add a more detailed sql to operator lifecycle section to help AI tools to navigate the codebase. 


## Brief change log

- Add detailed sql to operator lifecycle
- Restructure Agents.md for future common tasks to be added


## Verifying this change

- Review the information
- Fact check

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (Agents.md)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [x] Yes (please specify the tool below)

Generated-by: [2.1.117 (Claude Code)
