### PR TITLE
[FLINK-39512][api] extend plugin with open and close life cycle

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/plugin/DefaultPluginManager.java
+++ b/flink-core/src/main/java/org/apache/flink/core/plugin/DefaultPluginManager.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -60,6 +61,9 @@ public class DefaultPluginManager implements PluginManager {
     @GuardedBy("pluginLoadersLock")
     private final Map<String, PluginLoader> pluginLoaders;
 
+    @GuardedBy("pluginLoadersLock")
+    private final Map<Class<?>, List<?>> pluginInstancesCache;
+
     /** List of patterns for classes that should always be resolved from the parent ClassLoader. */
     private final String[] alwaysParentFirstPatterns;
 
@@ -70,6 +74,7 @@ public class DefaultPluginManager implements PluginManager {
         pluginLoadersLock = null;
         pluginLoaders = null;
         alwaysParentFirstPatterns = null;
+        pluginInstancesCache = null;
     }
 
     public DefaultPluginManager(
@@ -87,12 +92,26 @@ public class DefaultPluginManager implements PluginManager {
         this.pluginDescriptors = pluginDescriptors;
         this.pluginLoadersLock = new ReentrantLock();
         this.pluginLoaders = new HashMap<>();
+        this.pluginInstancesCache = new HashMap<>();
         this.parentClassLoader = parentClassLoader;
         this.alwaysParentFirstPatterns = alwaysParentFirstPatterns;
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <P> Iterator<P> load(Class<P> service) {
+        pluginLoadersLock.lock();
+        try {
+            if (pluginInstancesCache.containsKey(service)) {
+                LOG.info(
+                        "Returning cached singleton instances for plugin type: {}",
+                        service.getName());
+                return ((List<P>) pluginInstancesCache.get(service)).iterator();
+            }
+        } finally {
+            pluginLoadersLock.unlock();
+        }
+
         ArrayList<Iterator<P>> combinedIterators = new ArrayList<>(pluginDescriptors.size());
         for (PluginDescriptor pluginDescriptor : pluginDescriptors) {
             PluginLoader pluginLoader;
@@ -114,7 +133,61 @@ public class DefaultPluginManager implements PluginManager {
             }
             combinedIterators.add(pluginLoader.load(service));
         }
-        return Iterators.concat(combinedIterators.iterator());
+
+        List<P> instances = new ArrayList<>();
+        Iterators.concat(combinedIterators.iterator()).forEachRemaining(instances::add);
+
+        pluginLoadersLock.lock();
+        try {
+            pluginInstancesCache.putIfAbsent(service, instances);
+            return ((List<P>) pluginInstancesCache.get(service)).iterator();
+        } finally {
+            pluginLoadersLock.unlock();
+        }
+    }
+
+    @Override
+    public void open(PluginContext context) {
+        pluginLoadersLock.lock();
+        try {
+            for (List<?> instances : pluginInstancesCache.values()) {
+                for (Object instance : instances) {
+                    if (instance instanceof Plugin) {
+                        ((Plugin) instance).open(context);
+                    }
+                }
+            }
+        } finally {
+            pluginLoadersLock.unlock();
+        }
+    }
+
+    @Override
+    public void close() {
+        pluginLoadersLock.lock();
+        try {
+            for (List<?> instances : pluginInstancesCache.values()) {
+                for (Object instance : instances) {
+                    if (instance instanceof Plugin) {
+                        ((Plugin) instance).close();
+                    }
+                }
+            }
+        } finally {
+            pluginLoadersLock.unlock();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @VisibleForTesting
+    public <P> void injectForTesting(Class<P> service, P instance) {
+        pluginLoadersLock.lock();
+        try {
+            ((List<P>) pluginInstancesCache.computeIfAbsent(service, k -> new ArrayList<>()))
+                    .add(instance);
+        } finally {
+            pluginLoadersLock.unlock();
+        }
     }
 
     @Override

--- a/flink-core/src/main/java/org/apache/flink/core/plugin/Plugin.java
+++ b/flink-core/src/main/java/org/apache/flink/core/plugin/Plugin.java
@@ -48,4 +48,15 @@ public interface Plugin {
      * @param config The configuration to apply to the plugin.
      */
     default void configure(Configuration config) {}
+
+    /**
+     * Called when the plugin is opened, providing context information such as the hosting task
+     * manager ID.
+     *
+     * @param context The context for this plugin.
+     */
+    default void open(PluginContext context) {}
+
+    /** Called when the plugin is closed to release any held resources. */
+    default void close() {}
 }

--- a/flink-core/src/main/java/org/apache/flink/core/plugin/PluginContext.java
+++ b/flink-core/src/main/java/org/apache/flink/core/plugin/PluginContext.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,29 +18,28 @@
 
 package org.apache.flink.core.plugin;
 
-import org.apache.commons.collections.IteratorUtils;
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.util.Preconditions;
 
-import java.util.Iterator;
-import java.util.Map;
+/**
+ * Context information provided to plugins at initialization time, including the ID of the task
+ * manager that hosts the plugin.
+ */
+@PublicEvolving
+public class PluginContext {
+    private final String taskManagerId;
 
-/** {@link PluginManager} for testing purpose. */
-public class TestingPluginManager implements PluginManager {
-
-    private final Map<Class<?>, Iterator<?>> plugins;
-
-    public TestingPluginManager(Map<Class<?>, Iterator<?>> plugins) {
-        this.plugins = plugins;
+    public PluginContext(String taskManagerId) {
+        this.taskManagerId =
+                Preconditions.checkNotNull(taskManagerId, "taskManagerId must not be null");
     }
 
-    @SuppressWarnings("unchecked")
-    @Override
-    public <P> Iterator<P> load(Class<P> service) {
-        return (Iterator<P>) plugins.getOrDefault(service, IteratorUtils.emptyIterator());
+    public String getTaskManagerId() {
+        return taskManagerId;
     }
 
     @Override
-    public void open(PluginContext context) {}
-
-    @Override
-    public void close() {}
+    public String toString() {
+        return "PluginContext{taskManagerId='" + taskManagerId + "'}";
+    }
 }

--- a/flink-core/src/main/java/org/apache/flink/core/plugin/PluginManager.java
+++ b/flink-core/src/main/java/org/apache/flink/core/plugin/PluginManager.java
@@ -36,4 +36,14 @@ public interface PluginManager {
      *     known plugins.
      */
     <P> Iterator<P> load(Class<P> service);
+
+    /**
+     * Opens all cached plugin instances by invoking {@link Plugin#open(PluginContext)} on each.
+     *
+     * @param context The context to pass to each plugin.
+     */
+    void open(PluginContext context);
+
+    /** Closes all cached plugin instances by invoking {@link Plugin#close()} on each. */
+    void close();
 }

--- a/flink-core/src/main/java/org/apache/flink/core/plugin/PluginUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/core/plugin/PluginUtils.java
@@ -24,16 +24,24 @@ import org.apache.flink.util.FlinkRuntimeException;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
 
 /** Utility functions for the plugin mechanism. */
 public final class PluginUtils {
+
+    private static final AtomicReference<PluginManager> INSTANCE = new AtomicReference<>();
 
     private PluginUtils() {
         throw new AssertionError("Singleton class.");
     }
 
     public static PluginManager createPluginManagerFromRootFolder(Configuration configuration) {
-        return createPluginManagerFromRootFolder(PluginConfig.fromConfiguration(configuration));
+        return INSTANCE.updateAndGet(
+                existing ->
+                        existing != null
+                                ? existing
+                                : createPluginManagerFromRootFolder(
+                                        PluginConfig.fromConfiguration(configuration)));
     }
 
     private static PluginManager createPluginManagerFromRootFolder(PluginConfig pluginConfig) {

--- a/flink-core/src/test/java/org/apache/flink/core/fs/FileSystemTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/FileSystemTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.core.fs;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.core.fs.local.LocalFileSystem;
+import org.apache.flink.core.plugin.PluginContext;
 import org.apache.flink.core.plugin.PluginManager;
 import org.apache.flink.util.WrappingProxy;
 import org.apache.flink.util.WrappingProxyUtil;
@@ -246,6 +247,12 @@ class FileSystemTest {
                 }
                 return Collections.emptyIterator();
             }
+
+            @Override
+            public void open(PluginContext context) {}
+
+            @Override
+            public void close() {}
         };
     }
 

--- a/flink-core/src/test/java/org/apache/flink/core/plugin/PluginContextTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/plugin/PluginContextTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.core.plugin;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link PluginContext}. */
+class PluginContextTest {
+
+    @Test
+    void testGetTaskManagerIdReturnsConstructedValue() {
+        final PluginContext ctx = new PluginContext("tm-001");
+        assertThat(ctx.getTaskManagerId()).isEqualTo("tm-001");
+    }
+
+    @Test
+    void testNullTaskManagerIdIsRejected() {
+        assertThatThrownBy(() -> new PluginContext(null)).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void testToStringContainsTaskManagerId() {
+        final PluginContext ctx = new PluginContext("tm-42");
+        assertThat(ctx.toString()).contains("tm-42");
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -26,6 +26,8 @@ import org.apache.flink.configuration.RpcOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.configuration.TaskManagerOptionsInternal;
 import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.plugin.Plugin;
+import org.apache.flink.core.plugin.PluginContext;
 import org.apache.flink.core.plugin.PluginManager;
 import org.apache.flink.core.plugin.PluginUtils;
 import org.apache.flink.core.security.FlinkSecurityManager;
@@ -271,10 +273,15 @@ public class TaskManagerRunner implements FatalErrorHandler {
                             this,
                             delegationTokenReceiverRepository);
 
+            // This to be replaced the concrete plugin class name
+            pluginManager.load(Plugin.class).forEachRemaining(p -> p.configure(configuration));
+
             handleUnexpectedTaskExecutorServiceTermination();
 
             MemoryLogger.startIfConfigured(
                     LOG, configuration, terminationFuture.thenAccept(ignored -> {}));
+
+            pluginManager.open(new PluginContext(resourceId.unwrap().getStringWithMetadata()));
         }
     }
 
@@ -359,6 +366,8 @@ public class TaskManagerRunner implements FatalErrorHandler {
                             terminationFuture.complete(terminationResult);
                         }
                     });
+
+            pluginManager.close();
 
             shutdown = true;
             return terminationFuture;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorStateChangelogStoragesManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorStateChangelogStoragesManagerTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.operators.MailboxExecutor;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.StateChangelogOptions;
+import org.apache.flink.core.plugin.PluginContext;
 import org.apache.flink.core.plugin.PluginManager;
 import org.apache.flink.runtime.metrics.groups.TaskManagerJobMetricGroup;
 import org.apache.flink.runtime.state.changelog.ChangelogStateHandle;
@@ -230,6 +231,12 @@ class TaskExecutorStateChangelogStoragesManagerTest {
                         return (Iterator<P>)
                                 singletonList(new TestStateChangelogStorageFactory()).iterator();
                     }
+
+                    @Override
+                    public void open(PluginContext context) {}
+
+                    @Override
+                    public void close() {}
                 };
 
         @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/changelog/inmemory/StateChangelogStorageLoaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/changelog/inmemory/StateChangelogStorageLoaderTest.java
@@ -21,6 +21,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.operators.MailboxExecutor;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.StateChangelogOptions;
+import org.apache.flink.core.plugin.PluginContext;
 import org.apache.flink.core.plugin.PluginManager;
 import org.apache.flink.runtime.metrics.groups.TaskManagerJobMetricGroup;
 import org.apache.flink.runtime.state.KeyGroupRange;
@@ -100,6 +101,12 @@ class StateChangelogStorageLoaderTest {
                 //noinspection unchecked
                 return (Iterator<P>) iterator;
             }
+
+            @Override
+            public void open(PluginContext context) {}
+
+            @Override
+            public void close() {}
         };
     }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/plugin/DefaultPluginManagerTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/plugin/DefaultPluginManagerTest.java
@@ -20,6 +20,8 @@ package org.apache.flink.test.plugin;
 
 import org.apache.flink.core.plugin.DefaultPluginManager;
 import org.apache.flink.core.plugin.DirectoryBasedPluginFinder;
+import org.apache.flink.core.plugin.Plugin;
+import org.apache.flink.core.plugin.PluginContext;
 import org.apache.flink.core.plugin.PluginDescriptor;
 import org.apache.flink.core.plugin.PluginFinder;
 import org.apache.flink.core.plugin.PluginManager;
@@ -102,6 +104,185 @@ class DefaultPluginManagerTest extends PluginTestBase {
         for (OtherTestSpi otherTestSpi : otherServiceImplList) {
             assertThat(otherTestSpi.otherTestMethod()).isNotNull();
             assertThat(classLoaders.add(otherTestSpi.getClass().getClassLoader())).isFalse();
+        }
+    }
+
+    @Test
+    void testLoadReturnsSingletonInstances() {
+        String[] parentPatterns = {TestSpi.class.getName(), OtherTestSpi.class.getName()};
+        final DefaultPluginManager pluginManager =
+                new DefaultPluginManager(descriptors, PARENT_CLASS_LOADER, parentPatterns);
+
+        final List<TestSpi> firstLoad = Lists.newArrayList(pluginManager.load(TestSpi.class));
+        final List<TestSpi> secondLoad = Lists.newArrayList(pluginManager.load(TestSpi.class));
+
+        assertThat(firstLoad).hasSize(2);
+        assertThat(secondLoad).hasSize(2);
+
+        final Set<TestSpi> firstLoadIdentitySet =
+                Collections.newSetFromMap(new IdentityHashMap<>());
+        firstLoadIdentitySet.addAll(firstLoad);
+        for (TestSpi instance : secondLoad) {
+            assertThat(firstLoadIdentitySet).contains(instance);
+        }
+    }
+
+    @Test
+    void testOpenDispatchesContextToCachedPlugins() {
+        final DefaultPluginManager pluginManager =
+                new DefaultPluginManager(Collections.emptyList(), new String[0]);
+
+        final TrackingPlugin plugin = new TrackingPlugin();
+        pluginManager.injectForTesting(Plugin.class, plugin);
+
+        final PluginContext context = new PluginContext("test-task-manager-id");
+        pluginManager.open(context);
+
+        assertThat(plugin.openCalled).isTrue();
+        assertThat(plugin.openContext).isSameAs(context);
+    }
+
+    @Test
+    void testCloseDispatchesToCachedPlugins() {
+        final DefaultPluginManager pluginManager =
+                new DefaultPluginManager(Collections.emptyList(), new String[0]);
+
+        final TrackingPlugin plugin = new TrackingPlugin();
+        pluginManager.injectForTesting(Plugin.class, plugin);
+
+        pluginManager.close();
+
+        assertThat(plugin.closeCalled).isTrue();
+    }
+
+    @Test
+    void testOpenAndCloseOnEmptyCache() {
+        final DefaultPluginManager pluginManager =
+                new DefaultPluginManager(Collections.emptyList(), new String[0]);
+        final PluginContext context = new PluginContext("test-task-manager-id");
+        // should complete without exception when cache is empty
+        pluginManager.open(context);
+        pluginManager.close();
+    }
+
+    @Test
+    void testOpenAndCloseDispatchToAllCachedInstances() {
+        final DefaultPluginManager pluginManager =
+                new DefaultPluginManager(Collections.emptyList(), new String[0]);
+
+        final TrackingPlugin pluginA = new TrackingPlugin();
+        final TrackingPlugin pluginB = new TrackingPlugin();
+        pluginManager.injectForTesting(Plugin.class, pluginA);
+        pluginManager.injectForTesting(Plugin.class, pluginB);
+
+        final PluginContext context = new PluginContext("test-task-manager-id");
+        pluginManager.open(context);
+
+        assertThat(pluginA.openCalled).isTrue();
+        assertThat(pluginA.openContext).isSameAs(context);
+        assertThat(pluginB.openCalled).isTrue();
+        assertThat(pluginB.openContext).isSameAs(context);
+
+        pluginManager.close();
+
+        assertThat(pluginA.closeCalled).isTrue();
+        assertThat(pluginB.closeCalled).isTrue();
+    }
+
+    @Test
+    void testOpenSkipsNonPluginCachedInstances() {
+        final DefaultPluginManager pluginManager =
+                new DefaultPluginManager(Collections.emptyList(), new String[0]);
+        pluginManager.injectForTesting(String.class, "not-a-plugin");
+        // Should not throw even though the cached instance does not implement Plugin
+        pluginManager.open(new PluginContext("tm-id"));
+    }
+
+    @Test
+    void testCloseSkipsNonPluginCachedInstances() {
+        final DefaultPluginManager pluginManager =
+                new DefaultPluginManager(Collections.emptyList(), new String[0]);
+        pluginManager.injectForTesting(String.class, "not-a-plugin");
+        // Should not throw even though the cached instance does not implement Plugin
+        pluginManager.close();
+    }
+
+    @Test
+    void testOpenAndCloseAcrossDistinctServiceTypes() {
+        final DefaultPluginManager pluginManager =
+                new DefaultPluginManager(Collections.emptyList(), new String[0]);
+
+        final PluginForServiceA pluginA = new PluginForServiceA();
+        final PluginForServiceB pluginB = new PluginForServiceB();
+        pluginManager.injectForTesting(ServiceA.class, pluginA);
+        pluginManager.injectForTesting(ServiceB.class, pluginB);
+
+        final PluginContext context = new PluginContext("tm-multi");
+        pluginManager.open(context);
+
+        assertThat(pluginA.openCalled).isTrue();
+        assertThat(pluginA.openContext).isSameAs(context);
+        assertThat(pluginB.openCalled).isTrue();
+        assertThat(pluginB.openContext).isSameAs(context);
+
+        pluginManager.close();
+
+        assertThat(pluginA.closeCalled).isTrue();
+        assertThat(pluginB.closeCalled).isTrue();
+    }
+
+    private interface ServiceA extends Plugin {}
+
+    private interface ServiceB extends Plugin {}
+
+    private static class PluginForServiceA implements ServiceA {
+        boolean openCalled;
+        PluginContext openContext;
+        boolean closeCalled;
+
+        @Override
+        public void open(PluginContext ctx) {
+            openCalled = true;
+            openContext = ctx;
+        }
+
+        @Override
+        public void close() {
+            closeCalled = true;
+        }
+    }
+
+    private static class PluginForServiceB implements ServiceB {
+        boolean openCalled;
+        PluginContext openContext;
+        boolean closeCalled;
+
+        @Override
+        public void open(PluginContext ctx) {
+            openCalled = true;
+            openContext = ctx;
+        }
+
+        @Override
+        public void close() {
+            closeCalled = true;
+        }
+    }
+
+    private static class TrackingPlugin implements Plugin {
+        boolean openCalled;
+        PluginContext openContext;
+        boolean closeCalled;
+
+        @Override
+        public void open(PluginContext context) {
+            openCalled = true;
+            openContext = context;
+        }
+
+        @Override
+        public void close() {
+            closeCalled = true;
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Extend plugin interface with open and close life cycle for adding metadata of runtime to plugin and also release external resource needed for plugin


## Brief change log

  - Add open and close default interface for plugin
  - Make plugin manager singleton and support open and close for all registered plugins
  - Add plugin open and close in TaskManagerRunner.


## Verifying this change

  - Added test cases for PluginManager for testing the singleton of each type of loaded plugins
  - Added test cases for PluginUtils for testing the singleton of PluginManager.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
