### PR TITLE
[FLINK-39534][python] Bump pemja to 0.5.7

### DIFF
--- a/flink-python/dev/dev-requirements.txt
+++ b/flink-python/dev/dev-requirements.txt
@@ -28,7 +28,7 @@ numpy>=1.22.4,<2.3.0
 fastavro>=1.1.0,!=1.8.0
 grpcio>=1.29.0,<=1.50.0
 grpcio-tools>=1.29.0,<=1.50.0
-pemja>=0.5.6,<0.5.7; platform_system != 'Windows'
+pemja>=0.5.7,<0.5.8; platform_system != 'Windows'
 httplib2>=0.19.0
 protobuf>=3.19.0
 pytest~=7.0

--- a/flink-python/pom.xml
+++ b/flink-python/pom.xml
@@ -133,7 +133,7 @@ under the License.
 		<dependency>
 			<groupId>com.alibaba</groupId>
 			<artifactId>pemja</artifactId>
-			<version>0.5.6</version>
+			<version>0.5.7</version>
 			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 

--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -324,7 +324,7 @@ try:
                         'numpy>=1.22.4',
                         'pandas>=1.3.0,<2.3',  # FLINK-38513: 2.3+ drops cp39 wheels
                         'pyarrow>=5.0.0,<21.0.0',
-                        'pemja>=0.5.6,<0.5.7;platform_system != "Windows"',
+                        'pemja>=0.5.7,<0.5.8;platform_system != "Windows"',
                         'httplib2>=0.19.0',
                         'ruamel.yaml>=0.18.4',
                         'setuptools>=75.3,<82.0.0',

--- a/flink-python/src/main/resources/META-INF/NOTICE
+++ b/flink-python/src/main/resources/META-INF/NOTICE
@@ -28,7 +28,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.beam:beam-sdks-java-transform-service-launcher:2.54.0
 - org.apache.beam:beam-vendor-guava-32_1_2-jre:0.1
 - org.apache.beam:beam-vendor-grpc-1_60_1:0.1
-- com.alibaba:pemja:0.5.6
+- com.alibaba:pemja:0.5.7
 
 This project bundles the following dependencies under the BSD license.
 See bundled license files for details


### PR DESCRIPTION

## What is the purpose of the change

Bump pemja to 0.5.7.


## Brief change log

Bump pemja to 0.5.7.


## Verifying this change


This change is already covered by existing tests, such as *(please describe tests)*.

* Origional tests

This change added tests and can be verified as follows:

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no 

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
