### PR TITLE
[FLINK-39537][table] Apply conditional SET_SEMANTIC_TABLE trait to FROM_CHANGELOG

### DIFF
--- a/docs/content/docs/sql/reference/queries/changelog.md
+++ b/docs/content/docs/sql/reference/queries/changelog.md
@@ -61,7 +61,7 @@ SELECT * FROM FROM_CHANGELOG(
 
 | Parameter    | Required | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 |:-------------|:---------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `input`      | Yes      | The input table. Must be append-only. Use `PARTITION BY` to ensure rows for the same key are processed together. This is required when downstream operators are keyed on that column.                                                                                                                                                                                                                                                                                                          |
+| `input`      | Yes      | The input table. Must be append-only. Use `PARTITION BY` to ensure rows for the same key are processed together.                                                                                                                                                                                                                                                                                                          |
 | `op`         | No       | A `DESCRIPTOR` with a single column name for the operation code column. Defaults to `op`. The column must exist in the input table and be of type STRING.                                                                                                                                                                                                                                                                                                                                       |
 | `op_mapping` | No       | A `MAP<STRING, STRING>` mapping user-defined codes to Flink change operation names. Keys are user-defined codes (e.g., `'c'`, `'u'`, `'d'`), values are Flink change operation names (`INSERT`, `UPDATE_BEFORE`, `UPDATE_AFTER`, `DELETE`). Keys can contain comma-separated codes to map multiple codes to the same operation (e.g., `'c, r'`). Each change operation may appear at most once across all entries. |
 | `error_handling` | No | Controls behavior when an input row's operation code is `NULL` or not present in the `op_mapping`. Valid values: `FAIL` (default) — throw a `TableRuntimeException`, `SKIP` — silently drop the row. |
@@ -128,6 +128,10 @@ SELECT * FROM FROM_CHANGELOG(
 ```
 
 #### Partitioning by a key
+
+Prefer row semantics. `PARTITION BY` is currently only necessary if your rows for the same key are spread across partitions. In this case, consider also using `ORDER BY` to fix the ordering within a key.
+
+If you are producing an upsert table — that is, you are emitting `UPDATE_AFTER` but no `UPDATE_BEFORE` from your CDC input stream — the partition key you select here will be considered both the primary key and the upsert key by the engine. Make sure the `PARTITION BY` key matches your primary key exactly.
 
 ```sql
 SELECT * FROM FROM_CHANGELOG(

--- a/docs/content/docs/sql/reference/queries/changelog.md
+++ b/docs/content/docs/sql/reference/queries/changelog.md
@@ -45,7 +45,7 @@ Note: This version requires that your CDC data encodes updates using a full imag
 
 ```sql
 SELECT * FROM FROM_CHANGELOG(
-  input => TABLE source_table,
+  input => TABLE source_table [PARTITION BY key_col],
   [op => DESCRIPTOR(op_column_name),]
   [op_mapping => MAP[
       'c, r', 'INSERT',
@@ -61,7 +61,7 @@ SELECT * FROM FROM_CHANGELOG(
 
 | Parameter    | Required | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 |:-------------|:---------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `input`      | Yes      | The input table. Must be append-only.                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `input`      | Yes      | The input table. Must be append-only. Use `PARTITION BY` to ensure rows for the same key are processed together. This is required when downstream operators are keyed on that column.                                                                                                                                                                                                                                                                                                          |
 | `op`         | No       | A `DESCRIPTOR` with a single column name for the operation code column. Defaults to `op`. The column must exist in the input table and be of type STRING.                                                                                                                                                                                                                                                                                                                                       |
 | `op_mapping` | No       | A `MAP<STRING, STRING>` mapping user-defined codes to Flink change operation names. Keys are user-defined codes (e.g., `'c'`, `'u'`, `'d'`), values are Flink change operation names (`INSERT`, `UPDATE_BEFORE`, `UPDATE_AFTER`, `DELETE`). Keys can contain comma-separated codes to map multiple codes to the same operation (e.g., `'c, r'`). Each change operation may appear at most once across all entries. |
 | `error_handling` | No | Controls behavior when an input row's operation code is `NULL` or not present in the `op_mapping`. Valid values: `FAIL` (default) — throw a `TableRuntimeException`, `SKIP` — silently drop the row. |
@@ -125,6 +125,14 @@ SELECT * FROM FROM_CHANGELOG(
   op => DESCRIPTOR(operation)
 )
 -- The operation column named 'operation' is used instead of 'op'
+```
+
+#### Partitioning by a key
+
+```sql
+SELECT * FROM FROM_CHANGELOG(
+  input => TABLE cdc_stream PARTITION BY id
+)
 ```
 
 #### Invalid operation code handling

--- a/docs/content/docs/sql/reference/queries/changelog.md
+++ b/docs/content/docs/sql/reference/queries/changelog.md
@@ -129,15 +129,25 @@ SELECT * FROM FROM_CHANGELOG(
 
 #### Partitioning by a key
 
-Prefer row semantics. `PARTITION BY` is currently only necessary if your rows for the same key are spread across partitions. In this case, consider also using `ORDER BY` to fix the ordering within a key.
-
-If you are producing an upsert table — that is, you are emitting `UPDATE_AFTER` but no `UPDATE_BEFORE` from your CDC input stream — the partition key you select here will be considered both the primary key and the upsert key by the engine. Make sure the `PARTITION BY` key matches your primary key exactly.
-
 ```sql
+-- Input table 'cdc_stream' with columns (name, id, op, doc)
+-- Default output schema:           [name, id, doc]
+-- Output schema with PARTITION BY: [id, name, doc]
+
 SELECT * FROM FROM_CHANGELOG(
   input => TABLE cdc_stream PARTITION BY id
 )
 ```
+
+When `PARTITION BY` is provided, **the output schema changes**. The partition key columns are moved to the front by the engine, and the function emits the remaining input columns (excluding the op column). The order becomes:
+
+```
+[partition_keys, non_partition_input_columns_excluding_op]
+```
+
+Prefer row semantics, when possible. `PARTITION BY` is only necessary when downstream operators are keyed on that column and you want to co-locate rows for the same key in the same parallel operator instance.
+
+If you are producing an upsert table — that is, you are emitting `UPDATE_AFTER` but no `UPDATE_BEFORE` from your CDC input stream — the partition key you select here will be considered both the primary key and the upsert key by the engine. Make sure the `PARTITION BY` key matches your primary key exactly.
 
 #### Invalid operation code handling
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
@@ -1467,6 +1467,17 @@ public interface Table extends Explainable<Table>, Executable {
      * TableRuntimeException} when an input row's op code is {@code NULL} or not present in the
      * mapping; pass {@code error_handling => 'SKIP'} to silently drop those rows instead.
      *
+     * <p>By default, the input is processed with row semantics (each row independently). To
+     * co-locate rows with the same key in the same parallel operator instance, partition the input
+     * first via {@link #partitionBy(Expression...)} and invoke the function via {@link
+     * PartitionedTable#process(String, Object...)}:
+     *
+     * <pre>{@code
+     * Table result = cdcStream
+     *     .partitionBy($("id"))
+     *     .process("FROM_CHANGELOG");
+     * }</pre>
+     *
      * <p>Optional arguments can be passed using named expressions:
      *
      * <pre>{@code

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -839,12 +839,15 @@ public final class BuiltInFunctionDefinitions {
                     .kind(PROCESS_TABLE)
                     .staticArguments(
                             StaticArgument.table(
-                                    "input",
-                                    Row.class,
-                                    false,
-                                    EnumSet.of(
-                                            StaticArgumentTrait.TABLE,
-                                            StaticArgumentTrait.ROW_SEMANTIC_TABLE)),
+                                            "input",
+                                            Row.class,
+                                            false,
+                                            EnumSet.of(
+                                                    StaticArgumentTrait.TABLE,
+                                                    StaticArgumentTrait.ROW_SEMANTIC_TABLE))
+                                    .withConditionalTrait(
+                                            StaticArgumentTrait.SET_SEMANTIC_TABLE,
+                                            TraitCondition.hasPartitionBy()),
                             StaticArgument.scalar("op", DataTypes.DESCRIPTOR(), true),
                             StaticArgument.scalar(
                                     "op_mapping",

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ChangelogTypeStrategyUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ChangelogTypeStrategyUtils.java
@@ -21,16 +21,32 @@ package org.apache.flink.table.types.inference.strategies;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.functions.TableSemantics;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.CallContext;
+import org.apache.flink.types.ColumnList;
 
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.apache.flink.table.types.inference.strategies.FromChangelogTypeStrategy.ARG_OP;
+
 /** Shared helpers for changelog-style PTFs ({@code TO_CHANGELOG}, {@code FROM_CHANGELOG}). */
 @Internal
 public final class ChangelogTypeStrategyUtils {
+    private static final String DEFAULT_OP_COLUMN_NAME = "op";
+
+    /**
+     * Resolves the op column name from the {@code op} descriptor argument, falling back to {@link
+     * #DEFAULT_OP_COLUMN_NAME} when the argument is omitted or empty.
+     */
+    public static String resolveOpColumnName(final CallContext callContext) {
+        return callContext
+                .getArgumentValue(ARG_OP, ColumnList.class)
+                .filter(cl -> !cl.getNames().isEmpty())
+                .map(cl -> cl.getNames().get(0))
+                .orElse(DEFAULT_OP_COLUMN_NAME);
+    }
 
     /**
      * Returns the input column indices that pass through to the function's output, excluding the
@@ -61,10 +77,9 @@ public final class ChangelogTypeStrategyUtils {
     }
 
     private static Set<Integer> collectPartitionKeyIndices(final TableSemantics tableSemantics) {
-        return new HashSet<>(
-                Arrays.stream(tableSemantics.partitionByColumns())
+        return Arrays.stream(tableSemantics.partitionByColumns())
                         .boxed()
-                        .collect(Collectors.toSet()));
+                        .collect(Collectors.toSet());
     }
 
     private ChangelogTypeStrategyUtils() {}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ChangelogTypeStrategyUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ChangelogTypeStrategyUtils.java
@@ -25,6 +25,8 @@ import org.apache.flink.table.types.inference.CallContext;
 import org.apache.flink.types.ColumnList;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -46,6 +48,18 @@ public final class ChangelogTypeStrategyUtils {
                 .filter(cl -> !cl.getNames().isEmpty())
                 .map(cl -> cl.getNames().get(0))
                 .orElse(DEFAULT_OP_COLUMN_NAME);
+    }
+
+    /**
+     * Returns the index of the column matching {@code opColumnName} within the input schema, or
+     * empty if no field matches.
+     */
+    public static OptionalInt resolveOpColumnIndex(
+            final TableSemantics tableSemantics, final String opColumnName) {
+        final List<String> fieldNames = DataType.getFieldNames(tableSemantics.dataType());
+        return IntStream.range(0, fieldNames.size())
+                .filter(i -> fieldNames.get(i).equals(opColumnName))
+                .findFirst();
     }
 
     /**
@@ -78,8 +92,8 @@ public final class ChangelogTypeStrategyUtils {
 
     private static Set<Integer> collectPartitionKeyIndices(final TableSemantics tableSemantics) {
         return Arrays.stream(tableSemantics.partitionByColumns())
-                        .boxed()
-                        .collect(Collectors.toSet());
+                .boxed()
+                .collect(Collectors.toSet());
     }
 
     private ChangelogTypeStrategyUtils() {}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/FromChangelogTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/FromChangelogTypeStrategy.java
@@ -54,8 +54,6 @@ public final class FromChangelogTypeStrategy {
     public static final int ARG_OP_MAPPING = 2;
     public static final int ARG_ERROR_HANDLING = 3;
 
-    private static final String DEFAULT_OP_COLUMN_NAME = "op";
-
     private static final Set<String> VALID_ROW_KIND_NAMES =
             Set.of("INSERT", "UPDATE_BEFORE", "UPDATE_AFTER", "DELETE");
 
@@ -90,7 +88,8 @@ public final class FromChangelogTypeStrategy {
                                                 new ValidationException(
                                                         "First argument must be a table for FROM_CHANGELOG."));
 
-                final String opColumnName = resolveOpColumnName(callContext);
+                final String opColumnName =
+                        ChangelogTypeStrategyUtils.resolveOpColumnName(callContext);
 
                 final List<Field> outputFields = buildOutputFields(tableSemantics, opColumnName);
 
@@ -159,7 +158,7 @@ public final class FromChangelogTypeStrategy {
             final CallContext callContext, final boolean throwOnFailure) {
 
         final TableSemantics tableSemantics = callContext.getTableSemantics(ARG_TABLE).get();
-        final String opColumnName = resolveOpColumnName(callContext);
+        final String opColumnName = ChangelogTypeStrategyUtils.resolveOpColumnName(callContext);
         final List<Field> inputFields = DataType.getFields(tableSemantics.dataType());
         final OptionalInt opIndex = resolveOpColumnIndex(inputFields, opColumnName);
         if (opIndex.isEmpty()) {
@@ -277,41 +276,12 @@ public final class FromChangelogTypeStrategy {
         return Optional.empty();
     }
 
-    /**
-     * Resolves the op column name from the {@code op} descriptor argument, falling back to {@link
-     * #DEFAULT_OP_COLUMN_NAME} when the argument is omitted or empty.
-     */
-    public static String resolveOpColumnName(final CallContext callContext) {
-        return callContext
-                .getArgumentValue(ARG_OP, ColumnList.class)
-                .filter(cl -> !cl.getNames().isEmpty())
-                .map(cl -> cl.getNames().get(0))
-                .orElse(DEFAULT_OP_COLUMN_NAME);
-    }
-
-    /**
-     * Computes the indices of input columns that pass through to the function's output. Excludes
-     * the op column (becomes RowKind) and partition key columns, if present (which the framework
-     * prepends automatically when the input has set semantics).
-     *
-     * <p>Used by both the output type strategy and the runtime function so that the declared output
-     * schema and the actual emitted rows stay in sync.
-     */
-    public static int[] computeOutputIndices(
-            final TableSemantics tableSemantics, final String opColumnName) {
-        final List<Field> inputFields = DataType.getFields(tableSemantics.dataType());
-        final Set<Integer> excluded = new HashSet<>();
-        for (final int idx : tableSemantics.partitionByColumns()) {
-            excluded.add(idx);
-        }
-        resolveOpColumnIndex(inputFields, opColumnName).ifPresent(excluded::add);
-        return IntStream.range(0, inputFields.size()).filter(i -> !excluded.contains(i)).toArray();
-    }
-
     private static List<Field> buildOutputFields(
             final TableSemantics tableSemantics, final String opColumnName) {
         final List<Field> inputFields = DataType.getFields(tableSemantics.dataType());
-        return Arrays.stream(computeOutputIndices(tableSemantics, opColumnName))
+        return Arrays.stream(
+                        ChangelogTypeStrategyUtils.computeOutputIndices(
+                                tableSemantics, opColumnName))
                 .mapToObj(inputFields::get)
                 .collect(Collectors.toList());
     }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/FromChangelogTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/FromChangelogTypeStrategy.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.inference.CallContext;
 import org.apache.flink.table.types.inference.InputTypeStrategy;
 import org.apache.flink.table.types.inference.TypeStrategy;
+import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeFamily;
 import org.apache.flink.types.ColumnList;
 import org.apache.flink.types.RowKind;
@@ -36,6 +37,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -159,21 +161,22 @@ public final class FromChangelogTypeStrategy {
         final TableSemantics tableSemantics = callContext.getTableSemantics(ARG_TABLE).get();
         final String opColumnName = resolveOpColumnName(callContext);
         final List<Field> inputFields = DataType.getFields(tableSemantics.dataType());
-        final Integer opIndex = buildFieldNameToIndex(inputFields).get(opColumnName);
-        if (opIndex == null) {
+        final OptionalInt opIndex = resolveOpColumnIndex(inputFields, opColumnName);
+        if (opIndex.isEmpty()) {
             return callContext.fail(
                     throwOnFailure,
                     String.format(
                             "The op column '%s' does not exist in the input schema.",
                             opColumnName));
         }
-        final Field opField = inputFields.get(opIndex);
-        if (!opField.getDataType().getLogicalType().is(LogicalTypeFamily.CHARACTER_STRING)) {
+        final Field opField = inputFields.get(opIndex.getAsInt());
+        final LogicalType opFieldType = opField.getDataType().getLogicalType();
+        if (!opFieldType.is(LogicalTypeFamily.CHARACTER_STRING)) {
             return callContext.fail(
                     throwOnFailure,
                     String.format(
                             "The op column '%s' must be of STRING type, but was '%s'.",
-                            opColumnName, opField.getDataType().getLogicalType()));
+                            opColumnName, opFieldType));
         }
         return Optional.empty();
     }
@@ -288,8 +291,8 @@ public final class FromChangelogTypeStrategy {
 
     /**
      * Computes the indices of input columns that pass through to the function's output. Excludes
-     * the op column (becomes RowKind) and partition key columns (which the framework prepends
-     * automatically when the input has set semantics).
+     * the op column (becomes RowKind) and partition key columns, if present (which the framework
+     * prepends automatically when the input has set semantics).
      *
      * <p>Used by both the output type strategy and the runtime function so that the declared output
      * schema and the actual emitted rows stay in sync.
@@ -301,10 +304,7 @@ public final class FromChangelogTypeStrategy {
         for (final int idx : tableSemantics.partitionByColumns()) {
             excluded.add(idx);
         }
-        final Integer opIndex = buildFieldNameToIndex(inputFields).get(opColumnName);
-        if (opIndex != null) {
-            excluded.add(opIndex);
-        }
+        resolveOpColumnIndex(inputFields, opColumnName).ifPresent(excluded::add);
         return IntStream.range(0, inputFields.size()).filter(i -> !excluded.contains(i)).toArray();
     }
 
@@ -316,11 +316,15 @@ public final class FromChangelogTypeStrategy {
                 .collect(Collectors.toList());
     }
 
-    /** Builds a field-name → index lookup map for the given input fields. */
-    private static Map<String, Integer> buildFieldNameToIndex(final List<Field> fields) {
-        return IntStream.range(0, fields.size())
-                .boxed()
-                .collect(Collectors.toMap(i -> fields.get(i).getName(), i -> i));
+    /**
+     * Returns the index of the column matching {@code opColumnName} within the given input fields,
+     * or empty if no field matches.
+     */
+    private static OptionalInt resolveOpColumnIndex(
+            final List<Field> inputFields, final String opColumnName) {
+        return IntStream.range(0, inputFields.size())
+                .filter(i -> inputFields.get(i).getName().equals(opColumnName))
+                .findFirst();
     }
 
     private FromChangelogTypeStrategy() {}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/FromChangelogTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/FromChangelogTypeStrategy.java
@@ -40,7 +40,6 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 /** Type strategies for the {@code FROM_CHANGELOG} process table function. */
 @Internal
@@ -159,8 +158,8 @@ public final class FromChangelogTypeStrategy {
 
         final TableSemantics tableSemantics = callContext.getTableSemantics(ARG_TABLE).get();
         final String opColumnName = ChangelogTypeStrategyUtils.resolveOpColumnName(callContext);
-        final List<Field> inputFields = DataType.getFields(tableSemantics.dataType());
-        final OptionalInt opIndex = resolveOpColumnIndex(inputFields, opColumnName);
+        final OptionalInt opIndex =
+                ChangelogTypeStrategyUtils.resolveOpColumnIndex(tableSemantics, opColumnName);
         if (opIndex.isEmpty()) {
             return callContext.fail(
                     throwOnFailure,
@@ -168,8 +167,10 @@ public final class FromChangelogTypeStrategy {
                             "The op column '%s' does not exist in the input schema.",
                             opColumnName));
         }
-        final Field opField = inputFields.get(opIndex.getAsInt());
-        final LogicalType opFieldType = opField.getDataType().getLogicalType();
+        final LogicalType opFieldType =
+                DataType.getFieldDataTypes(tableSemantics.dataType())
+                        .get(opIndex.getAsInt())
+                        .getLogicalType();
         if (!opFieldType.is(LogicalTypeFamily.CHARACTER_STRING)) {
             return callContext.fail(
                     throwOnFailure,
@@ -284,17 +285,6 @@ public final class FromChangelogTypeStrategy {
                                 tableSemantics, opColumnName))
                 .mapToObj(inputFields::get)
                 .collect(Collectors.toList());
-    }
-
-    /**
-     * Returns the index of the column matching {@code opColumnName} within the given input fields,
-     * or empty if no field matches.
-     */
-    private static OptionalInt resolveOpColumnIndex(
-            final List<Field> inputFields, final String opColumnName) {
-        return IntStream.range(0, inputFields.size())
-                .filter(i -> inputFields.get(i).getName().equals(opColumnName))
-                .findFirst();
     }
 
     private FromChangelogTypeStrategy() {}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/FromChangelogTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/FromChangelogTypeStrategy.java
@@ -31,12 +31,14 @@ import org.apache.flink.table.types.logical.LogicalTypeFamily;
 import org.apache.flink.types.ColumnList;
 import org.apache.flink.types.RowKind;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /** Type strategies for the {@code FROM_CHANGELOG} process table function. */
 @Internal
@@ -50,7 +52,7 @@ public final class FromChangelogTypeStrategy {
     public static final int ARG_OP_MAPPING = 2;
     public static final int ARG_ERROR_HANDLING = 3;
 
-    public static final String DEFAULT_OP_COLUMN_NAME = "op";
+    private static final String DEFAULT_OP_COLUMN_NAME = "op";
 
     private static final Set<String> VALID_ROW_KIND_NAMES =
             Set.of("INSERT", "UPDATE_BEFORE", "UPDATE_AFTER", "DELETE");
@@ -97,7 +99,6 @@ public final class FromChangelogTypeStrategy {
     // Helpers
     // --------------------------------------------------------------------------------------------
 
-    @SuppressWarnings("rawtypes")
     private static Optional<List<DataType>> validateInputs(
             final CallContext callContext, final boolean throwOnFailure) {
         Optional<List<DataType>> error;
@@ -158,21 +159,21 @@ public final class FromChangelogTypeStrategy {
         final TableSemantics tableSemantics = callContext.getTableSemantics(ARG_TABLE).get();
         final String opColumnName = resolveOpColumnName(callContext);
         final List<Field> inputFields = DataType.getFields(tableSemantics.dataType());
-        final Optional<Field> opField =
-                inputFields.stream().filter(f -> f.getName().equals(opColumnName)).findFirst();
-        if (opField.isEmpty()) {
+        final Integer opIndex = buildFieldNameToIndex(inputFields).get(opColumnName);
+        if (opIndex == null) {
             return callContext.fail(
                     throwOnFailure,
                     String.format(
                             "The op column '%s' does not exist in the input schema.",
                             opColumnName));
         }
-        if (!opField.get().getDataType().getLogicalType().is(LogicalTypeFamily.CHARACTER_STRING)) {
+        final Field opField = inputFields.get(opIndex);
+        if (!opField.getDataType().getLogicalType().is(LogicalTypeFamily.CHARACTER_STRING)) {
             return callContext.fail(
                     throwOnFailure,
                     String.format(
                             "The op column '%s' must be of STRING type, but was '%s'.",
-                            opColumnName, opField.get().getDataType().getLogicalType()));
+                            opColumnName, opField.getDataType().getLogicalType()));
         }
         return Optional.empty();
     }
@@ -273,7 +274,11 @@ public final class FromChangelogTypeStrategy {
         return Optional.empty();
     }
 
-    private static String resolveOpColumnName(final CallContext callContext) {
+    /**
+     * Resolves the op column name from the {@code op} descriptor argument, falling back to {@link
+     * #DEFAULT_OP_COLUMN_NAME} when the argument is omitted or empty.
+     */
+    public static String resolveOpColumnName(final CallContext callContext) {
         return callContext
                 .getArgumentValue(ARG_OP, ColumnList.class)
                 .filter(cl -> !cl.getNames().isEmpty())
@@ -281,14 +286,41 @@ public final class FromChangelogTypeStrategy {
                 .orElse(DEFAULT_OP_COLUMN_NAME);
     }
 
+    /**
+     * Computes the indices of input columns that pass through to the function's output. Excludes
+     * the op column (becomes RowKind) and partition key columns (which the framework prepends
+     * automatically when the input has set semantics).
+     *
+     * <p>Used by both the output type strategy and the runtime function so that the declared output
+     * schema and the actual emitted rows stay in sync.
+     */
+    public static int[] computeOutputIndices(
+            final TableSemantics tableSemantics, final String opColumnName) {
+        final List<Field> inputFields = DataType.getFields(tableSemantics.dataType());
+        final Set<Integer> excluded = new HashSet<>();
+        for (final int idx : tableSemantics.partitionByColumns()) {
+            excluded.add(idx);
+        }
+        final Integer opIndex = buildFieldNameToIndex(inputFields).get(opColumnName);
+        if (opIndex != null) {
+            excluded.add(opIndex);
+        }
+        return IntStream.range(0, inputFields.size()).filter(i -> !excluded.contains(i)).toArray();
+    }
+
     private static List<Field> buildOutputFields(
             final TableSemantics tableSemantics, final String opColumnName) {
         final List<Field> inputFields = DataType.getFields(tableSemantics.dataType());
-
-        // Exclude the op column (becomes RowKind), keep all other columns
-        return inputFields.stream()
-                .filter(f -> !f.getName().equals(opColumnName))
+        return Arrays.stream(computeOutputIndices(tableSemantics, opColumnName))
+                .mapToObj(inputFields::get)
                 .collect(Collectors.toList());
+    }
+
+    /** Builds a field-name → index lookup map for the given input fields. */
+    private static Map<String, Integer> buildFieldNameToIndex(final List<Field> fields) {
+        return IntStream.range(0, fields.size())
+                .boxed()
+                .collect(Collectors.toMap(i -> fields.get(i).getName(), i -> i));
     }
 
     private FromChangelogTypeStrategy() {}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/FromChangelogSemanticTests.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/FromChangelogSemanticTests.java
@@ -39,7 +39,7 @@ public class FromChangelogSemanticTests extends SemanticTestBase {
     @Override
     public List<TableTestProgram> programs() {
         return List.of(
-                FromChangelogTestPrograms.DEFAULT_OP_MAPPING,
+                FromChangelogTestPrograms.RETRACT,
                 FromChangelogTestPrograms.CUSTOM_OP_MAPPING,
                 FromChangelogTestPrograms.CUSTOM_OP_NAME,
                 FromChangelogTestPrograms.RETRACT_PARTITION_BY,

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/FromChangelogSemanticTests.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/FromChangelogSemanticTests.java
@@ -42,6 +42,8 @@ public class FromChangelogSemanticTests extends SemanticTestBase {
                 FromChangelogTestPrograms.DEFAULT_OP_MAPPING,
                 FromChangelogTestPrograms.CUSTOM_OP_MAPPING,
                 FromChangelogTestPrograms.CUSTOM_OP_NAME,
+                FromChangelogTestPrograms.SET_SEMANTICS_PARTITION_BY,
+                FromChangelogTestPrograms.DELETION_FLAG_PARTITION_BY,
                 FromChangelogTestPrograms.SKIP_INVALID_OP_HANDLING,
                 FromChangelogTestPrograms.SKIP_NULL_OP_CODE,
                 FromChangelogTestPrograms.TABLE_API_DEFAULT,

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/FromChangelogSemanticTests.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/FromChangelogSemanticTests.java
@@ -42,7 +42,7 @@ public class FromChangelogSemanticTests extends SemanticTestBase {
                 FromChangelogTestPrograms.DEFAULT_OP_MAPPING,
                 FromChangelogTestPrograms.CUSTOM_OP_MAPPING,
                 FromChangelogTestPrograms.CUSTOM_OP_NAME,
-                FromChangelogTestPrograms.SET_SEMANTICS_PARTITION_BY,
+                FromChangelogTestPrograms.RETRACT_PARTITION_BY,
                 FromChangelogTestPrograms.DELETION_FLAG_PARTITION_BY,
                 FromChangelogTestPrograms.SKIP_INVALID_OP_HANDLING,
                 FromChangelogTestPrograms.SKIP_NULL_OP_CODE,

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/FromChangelogTestPrograms.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/FromChangelogTestPrograms.java
@@ -35,10 +35,8 @@ public class FromChangelogTestPrograms {
     // SQL tests
     // --------------------------------------------------------------------------------------------
 
-    public static final TableTestProgram DEFAULT_OP_MAPPING =
-            TableTestProgram.of(
-                            "from-changelog-default-op-mapping",
-                            "default mapping with standard op names")
+    public static final TableTestProgram RETRACT =
+            TableTestProgram.of("from-changelog-retract", "retract changelog with default mapping")
                     .setupTableSource(
                             SourceTestStep.newBuilder("cdc_stream")
                                     .addSchema(SIMPLE_CDC_SCHEMA)

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/FromChangelogTestPrograms.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/FromChangelogTestPrograms.java
@@ -146,7 +146,6 @@ public class FromChangelogTestPrograms {
                                     + "error_handling => 'SKIP')")
                     .build();
 
-    /** Custom op column name via DESCRIPTOR. */
     public static final TableTestProgram CUSTOM_OP_NAME =
             TableTestProgram.of(
                             "from-changelog-custom-op-name", "custom op column name via DESCRIPTOR")
@@ -172,28 +171,19 @@ public class FromChangelogTestPrograms {
                                     + "op => DESCRIPTOR(operation))")
                     .build();
 
-    // --------------------------------------------------------------------------------------------
-    // Set semantics with PARTITION BY
-    // --------------------------------------------------------------------------------------------
-
-    /**
-     * Verifies that {@code FROM_CHANGELOG(TABLE t PARTITION BY id)} produces the same logical
-     * output as the row-semantic call. The conditional {@code SET_SEMANTIC_TABLE} trait switches
-     * the execution to a co-located parallel mode but must not change row-level semantics.
-     */
-    public static final TableTestProgram SET_SEMANTICS_PARTITION_BY =
+    public static final TableTestProgram RETRACT_PARTITION_BY =
             TableTestProgram.of(
-                            "from-changelog-set-semantics-partition-by",
-                            "PARTITION BY enables set semantics without altering output rows")
+                            "from-changelog-retract-partition-by",
+                            "retract changelog with PARTITION BY")
                     .setupTableSource(
                             SourceTestStep.newBuilder("cdc_stream")
-                                    .addSchema(SIMPLE_CDC_SCHEMA)
+                                    .addSchema("name STRING", "id INT", "op STRING")
                                     .producedValues(
-                                            Row.of(1, "INSERT", "Alice"),
-                                            Row.of(2, "INSERT", "Bob"),
-                                            Row.of(1, "UPDATE_BEFORE", "Alice"),
-                                            Row.of(1, "UPDATE_AFTER", "Alice2"),
-                                            Row.of(2, "DELETE", "Bob"))
+                                            Row.of("Alice", 1, "INSERT"),
+                                            Row.of("Bob", 2, "INSERT"),
+                                            Row.of("Alice", 1, "UPDATE_BEFORE"),
+                                            Row.of("Alice2", 1, "UPDATE_AFTER"),
+                                            Row.of("Bob", 2, "DELETE"))
                                     .build())
                     .setupTableSink(
                             SinkTestStep.newBuilder("sink")

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/FromChangelogTestPrograms.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/FromChangelogTestPrograms.java
@@ -173,6 +173,71 @@ public class FromChangelogTestPrograms {
                     .build();
 
     // --------------------------------------------------------------------------------------------
+    // Set semantics with PARTITION BY
+    // --------------------------------------------------------------------------------------------
+
+    /**
+     * Verifies that {@code FROM_CHANGELOG(TABLE t PARTITION BY id)} produces the same logical
+     * output as the row-semantic call. The conditional {@code SET_SEMANTIC_TABLE} trait switches
+     * the execution to a co-located parallel mode but must not change row-level semantics.
+     */
+    public static final TableTestProgram SET_SEMANTICS_PARTITION_BY =
+            TableTestProgram.of(
+                            "from-changelog-set-semantics-partition-by",
+                            "PARTITION BY enables set semantics without altering output rows")
+                    .setupTableSource(
+                            SourceTestStep.newBuilder("cdc_stream")
+                                    .addSchema(SIMPLE_CDC_SCHEMA)
+                                    .producedValues(
+                                            Row.of(1, "INSERT", "Alice"),
+                                            Row.of(2, "INSERT", "Bob"),
+                                            Row.of(1, "UPDATE_BEFORE", "Alice"),
+                                            Row.of(1, "UPDATE_AFTER", "Alice2"),
+                                            Row.of(2, "DELETE", "Bob"))
+                                    .build())
+                    .setupTableSink(
+                            SinkTestStep.newBuilder("sink")
+                                    .addSchema("id INT", "name STRING")
+                                    .consumedValues(
+                                            Row.ofKind(RowKind.INSERT, 1, "Alice"),
+                                            Row.ofKind(RowKind.INSERT, 2, "Bob"),
+                                            Row.ofKind(RowKind.UPDATE_BEFORE, 1, "Alice"),
+                                            Row.ofKind(RowKind.UPDATE_AFTER, 1, "Alice2"),
+                                            Row.ofKind(RowKind.DELETE, 2, "Bob"))
+                                    .build())
+                    .runSql(
+                            "INSERT INTO sink SELECT * FROM FROM_CHANGELOG("
+                                    + "input => TABLE cdc_stream PARTITION BY id)")
+                    .build();
+
+    public static final TableTestProgram DELETION_FLAG_PARTITION_BY =
+            TableTestProgram.of(
+                            "from-changelog-deletion-flag-partition-by",
+                            "deletion flag mapping with PARTITION BY: 'false' -> INSERT, 'true' -> DELETE")
+                    .setupTableSource(
+                            SourceTestStep.newBuilder("cdc_stream")
+                                    .addSchema("id INT", "deleted STRING", "name STRING")
+                                    .producedValues(
+                                            Row.of(1, "false", "Alice"),
+                                            Row.of(2, "false", "Bob"),
+                                            Row.of(2, "true", "Bob"))
+                                    .build())
+                    .setupTableSink(
+                            SinkTestStep.newBuilder("sink")
+                                    .addSchema("id INT", "name STRING")
+                                    .consumedValues(
+                                            Row.ofKind(RowKind.INSERT, 1, "Alice"),
+                                            Row.ofKind(RowKind.INSERT, 2, "Bob"),
+                                            Row.ofKind(RowKind.DELETE, 2, "Bob"))
+                                    .build())
+                    .runSql(
+                            "INSERT INTO sink SELECT * FROM FROM_CHANGELOG("
+                                    + "input => TABLE cdc_stream PARTITION BY id, "
+                                    + "op => DESCRIPTOR(deleted), "
+                                    + "op_mapping => MAP['false', 'INSERT', 'true', 'DELETE'])")
+                    .build();
+
+    // --------------------------------------------------------------------------------------------
     // Table API test
     // --------------------------------------------------------------------------------------------
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/FromChangelogTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/FromChangelogTest.java
@@ -46,7 +46,7 @@ public class FromChangelogTest extends TableTestBase {
     }
 
     @Test
-    void testInsertOnlySource() {
+    void testRetract() {
         util.tableEnv()
                 .executeSql(
                         "CREATE TABLE cdc_stream ("
@@ -59,25 +59,7 @@ public class FromChangelogTest extends TableTestBase {
     }
 
     @Test
-    void testCustomOpMapping() {
-        util.tableEnv()
-                .executeSql(
-                        "CREATE TABLE cdc_stream ("
-                                + "  id INT,"
-                                + "  __op STRING,"
-                                + "  name STRING"
-                                + ") WITH ('connector' = 'values')");
-        util.verifyRelPlan(
-                "SELECT * FROM FROM_CHANGELOG("
-                        + "input => TABLE cdc_stream, "
-                        + "op => DESCRIPTOR(__op), "
-                        + "op_mapping => MAP['c, r', 'INSERT', 'ub', 'UPDATE_BEFORE', 'ua', 'UPDATE_AFTER', 'd', 'DELETE'], "
-                        + "error_handling => 'SKIP')",
-                CHANGELOG_MODE);
-    }
-
-    @Test
-    void testSetSemanticsWithPartitionBy() {
+    void testRetractPartitionBy() {
         util.tableEnv()
                 .executeSql(
                         "CREATE TABLE cdc_stream ("

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/FromChangelogTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/FromChangelogTest.java
@@ -75,4 +75,18 @@ public class FromChangelogTest extends TableTestBase {
                         + "error_handling => 'SKIP')",
                 CHANGELOG_MODE);
     }
+
+    @Test
+    void testSetSemanticsWithPartitionBy() {
+        util.tableEnv()
+                .executeSql(
+                        "CREATE TABLE cdc_stream ("
+                                + "  id INT,"
+                                + "  op STRING,"
+                                + "  name STRING"
+                                + ") WITH ('connector' = 'values')");
+        util.verifyRelPlan(
+                "SELECT * FROM FROM_CHANGELOG(input => TABLE cdc_stream PARTITION BY id)",
+                CHANGELOG_MODE);
+    }
 }

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/FromChangelogTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/FromChangelogTest.xml
@@ -54,4 +54,24 @@ ProcessTableFunction(invocation=[FROM_CHANGELOG(TABLE(#0), DEFAULT(), DEFAULT(),
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testSetSemanticsWithPartitionBy">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM FROM_CHANGELOG(input => TABLE cdc_stream PARTITION BY id)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], name=[$1])
++- LogicalTableFunctionScan(invocation=[FROM_CHANGELOG(TABLE(#0) PARTITION BY($0), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT())], rowType=[RecordType(INTEGER id, VARCHAR(2147483647) name)])
+   +- LogicalProject(id=[$0], op=[$1], name=[$2])
+      +- LogicalTableScan(table=[[default_catalog, default_database, cdc_stream]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+ProcessTableFunction(invocation=[FROM_CHANGELOG(TABLE(#0) PARTITION BY($0), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT())], uid=[FROM_CHANGELOG], select=[id,name], rowType=[RecordType(INTEGER id, VARCHAR(2147483647) name)], changelogMode=[I,UB,UA,D])
++- Exchange(distribution=[hash[id]], changelogMode=[I])
+   +- TableSourceScan(table=[[default_catalog, default_database, cdc_stream]], fields=[id, op, name], changelogMode=[I])
+]]>
+    </Resource>
+  </TestCase>
 </Root>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/FromChangelogTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/FromChangelogTest.xml
@@ -16,26 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <Root>
-  <TestCase name="testCustomOpMapping">
-    <Resource name="sql">
-      <![CDATA[SELECT * FROM FROM_CHANGELOG(input => TABLE cdc_stream, op => DESCRIPTOR(__op), op_mapping => MAP['c, r', 'INSERT', 'ub', 'UPDATE_BEFORE', 'ua', 'UPDATE_AFTER', 'd', 'DELETE'], error_handling => 'SKIP')]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalProject(id=[$0], name=[$1])
-+- LogicalTableFunctionScan(invocation=[FROM_CHANGELOG(TABLE(#0), DESCRIPTOR(_UTF-16LE'__op'), MAP(_UTF-16LE'c, r':VARCHAR(4) CHARACTER SET "UTF-16LE", _UTF-16LE'INSERT':VARCHAR(13) CHARACTER SET "UTF-16LE", _UTF-16LE'ub':VARCHAR(4) CHARACTER SET "UTF-16LE", _UTF-16LE'UPDATE_BEFORE':VARCHAR(13) CHARACTER SET "UTF-16LE", _UTF-16LE'ua':VARCHAR(4) CHARACTER SET "UTF-16LE", _UTF-16LE'UPDATE_AFTER':VARCHAR(13) CHARACTER SET "UTF-16LE", _UTF-16LE'd':VARCHAR(4) CHARACTER SET "UTF-16LE", _UTF-16LE'DELETE':VARCHAR(13) CHARACTER SET "UTF-16LE"), _UTF-16LE'SKIP', DEFAULT(), DEFAULT())], rowType=[RecordType(INTEGER id, VARCHAR(2147483647) name)])
-   +- LogicalProject(id=[$0], __op=[$1], name=[$2])
-      +- LogicalTableScan(table=[[default_catalog, default_database, cdc_stream]])
-]]>
-    </Resource>
-    <Resource name="optimized rel plan">
-      <![CDATA[
-ProcessTableFunction(invocation=[FROM_CHANGELOG(TABLE(#0), DESCRIPTOR(_UTF-16LE'__op'), MAP(_UTF-16LE'c, r':VARCHAR(4) CHARACTER SET "UTF-16LE", _UTF-16LE'INSERT':VARCHAR(13) CHARACTER SET "UTF-16LE", _UTF-16LE'ub':VARCHAR(4) CHARACTER SET "UTF-16LE", _UTF-16LE'UPDATE_BEFORE':VARCHAR(13) CHARACTER SET "UTF-16LE", _UTF-16LE'ua':VARCHAR(4) CHARACTER SET "UTF-16LE", _UTF-16LE'UPDATE_AFTER':VARCHAR(13) CHARACTER SET "UTF-16LE", _UTF-16LE'd':VARCHAR(4) CHARACTER SET "UTF-16LE", _UTF-16LE'DELETE':VARCHAR(13) CHARACTER SET "UTF-16LE"), _UTF-16LE'SKIP', DEFAULT(), DEFAULT())], uid=[null], select=[id,name], rowType=[RecordType(INTEGER id, VARCHAR(2147483647) name)], changelogMode=[I,UB,UA,D])
-+- TableSourceScan(table=[[default_catalog, default_database, cdc_stream]], fields=[id, __op, name], changelogMode=[I])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testInsertOnlySource">
+  <TestCase name="testRetract">
     <Resource name="sql">
       <![CDATA[SELECT * FROM FROM_CHANGELOG(input => TABLE cdc_stream)]]>
     </Resource>
@@ -54,7 +35,7 @@ ProcessTableFunction(invocation=[FROM_CHANGELOG(TABLE(#0), DEFAULT(), DEFAULT(),
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testSetSemanticsWithPartitionBy">
+  <TestCase name="testRetractPartitionBy">
     <Resource name="sql">
       <![CDATA[SELECT * FROM FROM_CHANGELOG(input => TABLE cdc_stream PARTITION BY id)]]>
     </Resource>

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/ptf/FromChangelogFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/ptf/FromChangelogFunction.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.functions.FunctionContext;
 import org.apache.flink.table.functions.SpecializedFunction.SpecializedContext;
 import org.apache.flink.table.functions.TableSemantics;
 import org.apache.flink.table.types.inference.CallContext;
+import org.apache.flink.table.types.inference.strategies.ChangelogTypeStrategyUtils;
 import org.apache.flink.table.types.inference.strategies.ErrorHandlingMode;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.ColumnList;
@@ -44,8 +45,6 @@ import java.util.stream.Collectors;
 import static org.apache.flink.table.types.inference.strategies.FromChangelogTypeStrategy.ARG_ERROR_HANDLING;
 import static org.apache.flink.table.types.inference.strategies.FromChangelogTypeStrategy.ARG_OP_MAPPING;
 import static org.apache.flink.table.types.inference.strategies.FromChangelogTypeStrategy.ARG_TABLE;
-import static org.apache.flink.table.types.inference.strategies.FromChangelogTypeStrategy.computeOutputIndices;
-import static org.apache.flink.table.types.inference.strategies.FromChangelogTypeStrategy.resolveOpColumnName;
 
 /**
  * Runtime implementation of {@link BuiltInFunctionDefinitions#FROM_CHANGELOG}.
@@ -87,9 +86,10 @@ public class FromChangelogFunction extends BuiltInProcessTableFunction<RowData> 
                         .orElseThrow(() -> new IllegalStateException("Table argument expected."));
 
         final RowType inputType = (RowType) tableSemantics.dataType().getLogicalType();
-        final String opColumnName = resolveOpColumnName(callContext);
+        final String opColumnName = ChangelogTypeStrategyUtils.resolveOpColumnName(callContext);
         this.opColumnIndex = inputType.getFieldNames().indexOf(opColumnName);
-        this.outputIndices = computeOutputIndices(tableSemantics, opColumnName);
+        this.outputIndices =
+                ChangelogTypeStrategyUtils.computeOutputIndices(tableSemantics, opColumnName);
 
         this.rawOpMap = buildOpMap(callContext);
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/ptf/FromChangelogFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/ptf/FromChangelogFunction.java
@@ -40,13 +40,12 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import static org.apache.flink.table.types.inference.strategies.FromChangelogTypeStrategy.ARG_ERROR_HANDLING;
-import static org.apache.flink.table.types.inference.strategies.FromChangelogTypeStrategy.ARG_OP;
 import static org.apache.flink.table.types.inference.strategies.FromChangelogTypeStrategy.ARG_OP_MAPPING;
 import static org.apache.flink.table.types.inference.strategies.FromChangelogTypeStrategy.ARG_TABLE;
-import static org.apache.flink.table.types.inference.strategies.FromChangelogTypeStrategy.DEFAULT_OP_COLUMN_NAME;
+import static org.apache.flink.table.types.inference.strategies.FromChangelogTypeStrategy.computeOutputIndices;
+import static org.apache.flink.table.types.inference.strategies.FromChangelogTypeStrategy.resolveOpColumnName;
 
 /**
  * Runtime implementation of {@link BuiltInFunctionDefinitions#FROM_CHANGELOG}.
@@ -90,12 +89,7 @@ public class FromChangelogFunction extends BuiltInProcessTableFunction<RowData> 
         final RowType inputType = (RowType) tableSemantics.dataType().getLogicalType();
         final String opColumnName = resolveOpColumnName(callContext);
         this.opColumnIndex = inputType.getFieldNames().indexOf(opColumnName);
-
-        // Exclude only the op column from output — all other columns pass through
-        this.outputIndices =
-                IntStream.range(0, inputType.getFieldCount())
-                        .filter(i -> i != opColumnIndex)
-                        .toArray();
+        this.outputIndices = computeOutputIndices(tableSemantics, opColumnName);
 
         this.rawOpMap = buildOpMap(callContext);
 
@@ -112,13 +106,6 @@ public class FromChangelogFunction extends BuiltInProcessTableFunction<RowData> 
         opMap = new HashMap<>();
         rawOpMap.forEach((code, kind) -> opMap.put(StringData.fromString(code), kind));
         projectedOutput = ProjectedRowData.from(outputIndices);
-    }
-
-    private static String resolveOpColumnName(final CallContext callContext) {
-        return callContext
-                .getArgumentValue(ARG_OP, ColumnList.class)
-                .map(cl -> cl.getNames().get(0))
-                .orElse(DEFAULT_OP_COLUMN_NAME);
     }
 
     /**


### PR DESCRIPTION
  ## What is the purpose of the change                                                                                                 
`FROM_CHANGELOG` is currently locked to row semantics — each row is processed independently, with no way to co-locate rows for the same key in the same parallel operator instance. This is fine for stateless downstreams but limits use cases where the resulting changelog feeds into a stateful operator keyed on the same column.                                                                
                                                            
This PR uses the conditional-traits machinery introduced for `TO_CHANGELOG` in [FLINK-39392](https://issues.apache.org/jira/browse/FLINK-39392) to switch `FROM_CHANGELOG` to set semantics when the call provides `PARTITION BY`. Behavior without `PARTITION BY` is unchanged.                                                            
                                                            
  ```sql
  -- Row semantics (unchanged)
  SELECT * FROM FROM_CHANGELOG(input => TABLE cdc_stream);                                                                          
                                                                                                                                    
  -- Set semantics: planner inserts Exchange(hash[id])                                                                              
  SELECT * FROM FROM_CHANGELOG(input => TABLE cdc_stream PARTITION BY id);                                                          
```                                                                                                                 
### Brief change log

  - `BuiltInFunctionDefinitions.FROM_CHANGELOG`: input table argument adds withConditionalTrait(`SET_SEMANTIC_TABLE`, `hasPartitionBy()`) 
  - Added a plan test (`FromChangelogTest#testSetSemanticsWithPartitionBy`) verifying the `Exchange(hash[...])` propagation
  - Added a semantic test program (`FromChangelogTestPrograms#SET_SEMANTICS_PARTITION_BY`) verifying end-to-end output equivalence    
  - Updated SQL reference docs (`docs/.../changelog.md`) and `Table#fromChangelog` JavaDoc                                              
                                                                                                                                    
### Verifying this change                                                                                                             
                                                                                                                                    
  This change added tests and can be verified as follows:                                                                           
                                                            
  - FromChangelogTest#testSetSemanticsWithPartitionBy — plan test asserting the optimized rel plan contains  Exchange(distribution=[hash[id]]) when `PARTITION BY` id is specified, and the output changelogMode propagates correctly
  - FromChangelogSemanticTests (via `SET_SEMANTICS_PARTITION_BY` program) — end-to-end run verifying that adding `PARTITION BY` changes he parallel execution layout but does NOT alter row-level output (same +I, -U, +U, -D sequence as the row-semantics tests)       
  - All existing `FromChangelogTest` and `FromChangelogSemanticTests` cases continue to pass without modification, confirming the conditional trait does not regress the row-semantics path                                                                         
                                                            
### Does this pull request potentially affect one of the following parts:                                                             
                                                            
  - Dependencies (does it add or upgrade a dependency): no                                                                          
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no (only FROM_CHANGELOG's declared traits change; the function signature and Table#fromChangelog API are unchanged)                                                                 
  - The serializers: no                                     
  - The runtime per-record code paths (performance sensitive): no (runtime function FromChangelogFunction is unchanged)             
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no    
  - The S3 file system connector: no                                                                                                
                                                                                                                                    
### Documentation                                                                                                                     
                                                                                                                                    
  - Does this pull request introduce a new feature? yes     
  - If yes, how is the feature documented? docs (`docs/content/docs/sql/reference/queries/changelog.md`) and JavaDocs
  (`Table#fromChangelog`)                                                                                                             
   
  ---                                                                                                                               
  Was generative AI tooling used to co-author this PR?      
                                                      
  - Yes (Claude Code / Opus 4.7)
