### PR TITLE
[hotfix][tests] Replace deprecated Thread#stop

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/iterative/concurrent/SuperstepKickoffLatchTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/iterative/concurrent/SuperstepKickoffLatchTest.java
@@ -224,7 +224,8 @@ public class SuperstepKickoffLatchTest {
 
                     toWatch.join(2000);
                     if (toWatch.isAlive()) {
-                        toWatch.stop();
+                        this.failed =
+                                new Exception("Watched thread did not respond to interrupt within 2s");
                     }
                 }
             } catch (Throwable t) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/iterative/concurrent/SuperstepKickoffLatchTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/iterative/concurrent/SuperstepKickoffLatchTest.java
@@ -225,7 +225,8 @@ public class SuperstepKickoffLatchTest {
                     toWatch.join(2000);
                     if (toWatch.isAlive()) {
                         this.failed =
-                                new Exception("Watched thread did not respond to interrupt within 2s");
+                                new Exception(
+                                        "Watched thread did not respond to interrupt within 2s");
                     }
                 }
             } catch (Throwable t) {


### PR DESCRIPTION
## What is the purpose of the change

The main reason is to make repo compilable with jdk26
like this command
```
./mvnw clean install -DskipTests -Pfast -Pskip-webui-build  -U -T 1C4
```
in jdk 26 `Thread#stop` was removed, so shold be fixed


## Verifying this change

test itself is a change
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
