### PR TITLE
[FLINK-39547][table] Fix table-planner class loading order

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-table-api/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-table-api/pom.xml
@@ -39,6 +39,13 @@ under the License.
 			<scope>provided</scope>
 		</dependency>
 
+		<!-- Incompatible Scala library in user code shouldn't break table-planner -->
+		<dependency>
+			<groupId>org.scala-lang</groupId>
+			<artifactId>scala-library</artifactId>
+			<version>2.13.18</version>
+		</dependency>
+
 		<!-- Flink Table API -->
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-end-to-end-tests/flink-end-to-end-tests-table-api/src/test/java/org/apache/flink/table/test/join/JoinWithCustomTypeExampleTest.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-table-api/src/test/java/org/apache/flink/table/test/join/JoinWithCustomTypeExampleTest.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.test.join;
+
+import org.junit.jupiter.api.Test;
+
+public class JoinWithCustomTypeExampleTest {
+
+    @Test
+    void testJoinWithCustomTypeExample() throws Exception {
+        JoinWithCustomTypeExample.main(new String[0]);
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/adaptive/AdaptiveJoinOperatorFactory.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/adaptive/AdaptiveJoinOperatorFactory.java
@@ -102,9 +102,10 @@ public class AdaptiveJoinOperatorFactory<OUT> extends AbstractStreamOperatorFact
         ClassLoader classLoader =
                 plannerModule == null
                         ? userClassLoader
-                        : FlinkUserCodeClassLoaders.parentFirst(
+                        : FlinkUserCodeClassLoaders.childFirst(
                                 plannerModule.getSubmoduleClassLoader().getURLs(),
                                 userClassLoader,
+                                new String[0],
                                 NOOP_EXCEPTION_HANDLER,
                                 checkClassLoaderLeak);
 


### PR DESCRIPTION
## What is the purpose of the change

Fix table planner class loading order so that deserialization of `AdaptiveJoinGenerator` uses classes table-planner.jar first, falling back to user classes only for missing classes.

## Verifying this change

This change added tests and can be verified as follows:

  - run `JoinWithCustomTypeExampleTest` test from the second commit - it will fail
  - run all tests using HEAD of this PR - all tests will pass

## Does this pull request potentially affect one of the following parts:

  - Dependencies: yes, a dependency in a test only subproject
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- No
