### PR TITLE
[FLINK-39532][python] Fix race condition in Python AsyncScalarFunctionOperation

### DIFF
--- a/flink-python/pyflink/fn_execution/table/async_function/operations.py
+++ b/flink-python/pyflink/fn_execution/table/async_function/operations.py
@@ -60,6 +60,11 @@ class AsyncScalarFunctionOperation(Operation, AsyncOperationMixin):
             operation_utils.extract_user_defined_function(
                 serialized_fn.udfs[0], one_arg_optimization=False)
 
+        # Mirror PythonScalarFunctionOperator.createInputCoderInfoDescriptor:
+        # Java picks FlattenRowCoder unless some UDF takes a row as input.
+        self._input_is_flatten_row = not any(
+            udf.takes_row_as_input for udf in serialized_fn.udfs)
+
         # Create the eval function
         self._eval_func = eval('lambda value: %s' % scalar_function, variable_dict)
 
@@ -139,6 +144,12 @@ class AsyncScalarFunctionOperation(Operation, AsyncOperationMixin):
         allowing multiple operations to be in-flight simultaneously.
         """
         self._raise_exception_if_exists()
+
+        # The Cython FlattenRowCoderImpl returns a reused list whose slots are
+        # overwritten by the next decode, so we must snapshot the row before
+        # the async closure can capture it.
+        if self._input_is_flatten_row:
+            value = list(value)
 
         entry = self._queue.put(None, 0, 0, value)
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Currently in AsyncScalarFunctionOperation, the process_element method submits the input value to an asyncio event loop and returns immediately. For flatten row, the input comes from FlattenRowCoderImpl.decode_from_stream. In the Cython implementation in coder_impl_fast.pyx, this method returns a reused list; by the time the async function runs, this reused list has already been overwritten by the next decoded row. This will make Python async UDFs receive wrong input values, causing corrupted results.

This pull request snapshots input flatten rows in Python AsyncScalarFunctionOperation to avoid race conditions. 

## Brief change log

- Snapshots input flatten rows in Python AsyncScalarFunctionOperation to avoid race conditions

## Verifying this change

This change is verified by manually running SQL jobs containing Python async UDFs in a production cluster.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [x] Yes (please specify the tool below)

Generated-by: Claude Opus 4.7
