### PR TITLE
[FLINK-39531][table-planner] Fix duplicated Python UDF extraction in calc split rule

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/RemoteCalcSplitRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/RemoteCalcSplitRule.scala
@@ -432,9 +432,7 @@ class ScalarFunctionSplitter(
     callFinder: RemoteCallFinder)
   extends RexDefaultVisitor[RexNode] {
 
-  private var fieldsRexCall: Map[Int, Int] = Map[Int, Int]()
-
-  private val extractedRexNodeRefs: mutable.HashSet[RexNode] = mutable.HashSet[RexNode]()
+  private val extractedRexNodeToIndex = mutable.HashMap.empty[RexNode, Int]
 
   override def visitCall(call: RexCall): RexNode = {
     if (needConvert(call)) {
@@ -474,29 +472,32 @@ class ScalarFunctionSplitter(
 
   private def convertInputRefToLocalRefIfNecessary(node: RexNode): RexNode = {
     node match {
-      case inputRef: RexInputRef if extractedRexNodeRefs.contains(node) =>
+      case inputRef: RexInputRef if inputRef.getIndex >= extractedFunctionOffset =>
         new RexLocalRef(inputRef.getIndex, node.getType)
       case _ => node
     }
   }
 
   private def getExtractedRexNode(node: RexNode): RexNode = {
-    val newNode = new RexInputRef(extractedFunctionOffset + extractedRexNodes.length, node.getType)
-    extractedRexNodes.append(node)
-    extractedRexNodeRefs.add(newNode)
-    newNode
+    new RexInputRef(extractedFunctionOffset + getExtractedRexNodeIndex(node), node.getType)
   }
 
   private def getExtractedRexFieldAccess(node: RexFieldAccess, rexCallIndex: Int): RexNode = {
     val remoteCall: RexCall =
       program.expandLocalRef(node.getReferenceExpr.asInstanceOf[RexLocalRef]).asInstanceOf[RexCall]
-    if (!fieldsRexCall.contains(rexCallIndex)) {
-      extractedRexNodes.append(remoteCall)
-      fieldsRexCall += rexCallIndex -> (extractedFunctionOffset + extractedRexNodes.length - 1)
-    }
     rexBuilder.makeFieldAccess(
-      new RexInputRef(fieldsRexCall(rexCallIndex), remoteCall.getType),
+      new RexInputRef(
+        extractedFunctionOffset + getExtractedRexNodeIndex(remoteCall),
+        remoteCall.getType),
       node.getField.getIndex)
+  }
+
+  private def getExtractedRexNodeIndex(node: RexNode): Int = {
+    extractedRexNodeToIndex.getOrElseUpdate(
+      node, {
+        extractedRexNodes.append(node)
+        extractedRexNodes.length - 1
+      })
   }
 
   override def visitNodeAndFieldIndex(nodeAndFieldIndex: RexNodeAndFieldIndex): RexNode = {

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/AsyncCalcSplitRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/AsyncCalcSplitRuleTest.xml
@@ -716,12 +716,10 @@ LogicalProject(EXPR$0=[func1(func1($0))], EXPR$1=[func1(func1(func1($0)))], EXPR
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-AsyncCalc(select=[f0 AS EXPR$0, func1(f1) AS EXPR$1, f2 AS EXPR$2])
-+- AsyncCalc(select=[f2, f0, func1(f1) AS f1])
-   +- AsyncCalc(select=[f2, f1, func1(f0) AS f0])
-      +- Calc(select=[f0, f0 AS f1, f0 AS f2])
-         +- AsyncCalc(select=[func1(a) AS f0])
-            +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, e])
+AsyncCalc(select=[f00 AS EXPR$0, func1(f00) AS EXPR$1, f0 AS EXPR$2])
++- AsyncCalc(select=[f0, func1(f0) AS f00])
+   +- AsyncCalc(select=[func1(a) AS f0])
+      +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, e])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRuleTest.xml
@@ -523,24 +523,6 @@ FlinkLogicalCalc(select=[a, f0 AS EXPR$1, b])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testSamePythonFunctionUsedInMultipleProjectionExpressions">
-    <Resource name="sql">
-      <![CDATA[SELECT pyFunc1(a, c) + 1, pyFunc1(a, c) + 2 FROM MyTable]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalProject(EXPR$0=[+(pyFunc1($0, $2), 1)], EXPR$1=[+(pyFunc1($0, $2), 2)])
-+- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-]]>
-    </Resource>
-    <Resource name="optimized rel plan">
-      <![CDATA[
-FlinkLogicalCalc(select=[+(f0, 1) AS EXPR$0, +(f0, 2) AS EXPR$1])
-+- FlinkLogicalCalc(select=[pyFunc1(a, c) AS f0])
-   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d])
-]]>
-    </Resource>
-  </TestCase>
   <TestCase name="testSamePythonFunctionUsedInBothSelectAndWhere">
     <Resource name="sql">
       <![CDATA[SELECT a, pyFunc1(a, c) FROM MyTable where pyFunc1(a, c) > 0]]>
@@ -556,6 +538,24 @@ LogicalProject(a=[$0], EXPR$1=[pyFunc1($0, $2)])
       <![CDATA[
 FlinkLogicalCalc(select=[a, f0 AS EXPR$1], where=[>(f0, 0)])
 +- FlinkLogicalCalc(select=[a, pyFunc1(a, c) AS f0])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSamePythonFunctionUsedInMultipleProjectionExpressions">
+    <Resource name="sql">
+      <![CDATA[SELECT pyFunc1(a, c) + 1, pyFunc1(a, c) + 2 FROM MyTable]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(EXPR$0=[+(pyFunc1($0, $2), 1)], EXPR$1=[+(pyFunc1($0, $2), 2)])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+FlinkLogicalCalc(select=[+(f0, 1) AS EXPR$0, +(f0, 2) AS EXPR$1])
++- FlinkLogicalCalc(select=[pyFunc1(a, c) AS f0])
    +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d])
 ]]>
     </Resource>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRuleTest.xml
@@ -523,6 +523,24 @@ FlinkLogicalCalc(select=[a, f0 AS EXPR$1, b])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testSamePythonFunctionUsedInMultipleProjectionExpressions">
+    <Resource name="sql">
+      <![CDATA[SELECT pyFunc1(a, c) + 1, pyFunc1(a, c) + 2 FROM MyTable]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(EXPR$0=[+(pyFunc1($0, $2), 1)], EXPR$1=[+(pyFunc1($0, $2), 2)])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+FlinkLogicalCalc(select=[+(f0, 1) AS EXPR$0, +(f0, 2) AS EXPR$1])
++- FlinkLogicalCalc(select=[pyFunc1(a, c) AS f0])
+   +- FlinkLogicalLegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testSamePythonFunctionUsedInBothSelectAndWhere">
     <Resource name="sql">
       <![CDATA[SELECT a, pyFunc1(a, c) FROM MyTable where pyFunc1(a, c) > 0]]>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRuleTest.xml
@@ -530,14 +530,14 @@ FlinkLogicalCalc(select=[a, f0 AS EXPR$1, b])
     <Resource name="ast">
       <![CDATA[
 LogicalProject(EXPR$0=[+(pyFunc1($0, $2), 1)], EXPR$1=[+(pyFunc1($0, $2), 2)])
-+- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
 ]]>
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
 FlinkLogicalCalc(select=[+(f0, 1) AS EXPR$0, +(f0, 2) AS EXPR$1])
 +- FlinkLogicalCalc(select=[pyFunc1(a, c) AS f0])
-   +- FlinkLogicalLegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRuleTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRuleTest.scala
@@ -121,6 +121,12 @@ class PythonCalcSplitRuleTest extends TableTestBase {
   }
 
   @Test
+  def testSamePythonFunctionUsedInMultipleProjectionExpressions(): Unit = {
+    val sqlQuery = "SELECT pyFunc1(a, c) + 1, pyFunc1(a, c) + 2 FROM MyTable"
+    util.verifyRelPlan(sqlQuery)
+  }
+
+  @Test
   def testReorderPythonCalc(): Unit = {
     val sqlQuery = "SELECT a, pyFunc1(a, c), b FROM MyTable"
     util.verifyRelPlan(sqlQuery)


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Currently, ScalarFunctionSplitter bookkeeps extracted RexNodes to deduplicate identical remote functions during calc splitting, but the bookkeeping is keyed on the RexInputRef rather than the original RexNode. Therefore, when the same Python or Async UDF call appears in the input of multiple projections of one SELECT, each occurrence is extracted once and the UDF is invoked every time.

This PR solves this problem by making the bookkeeping keyed on the original RexNodes, not the RexInputRef.


## Brief change log

- Make the bookkeeping in ScalarFunctionSplitter keyed on the original RexNodes, not the RexInputRef.


## Verifying this change

This change added tests and can be verified as follows:

- Added a test on duplicated Python async functions

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [x] Yes (please specify the tool below)

Generated-by: Claude Opus 4.7

