### PR TITLE
[BP-2.3][FLINK-39551][runtime-web] Fix the styling of the ignored badge in the rescale history subpage

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/services/config.service.ts
+++ b/flink-runtime-web/web-dashboard/src/app/services/config.service.ts
@@ -33,7 +33,8 @@ export type ColorKey =
   | 'COMPLETED'
   | 'RESTARTING'
   | 'PENDING'
-  | 'INITIALIZING';
+  | 'INITIALIZING'
+  | 'IGNORED';
 
 @Injectable({
   providedIn: 'root'
@@ -56,7 +57,8 @@ export class ConfigService {
     COMPLETED: '#1890ff',
     RESTARTING: '#13c2c2',
     INITIALIZING: '#738df8',
-    PENDING: '#95a5a6'
+    PENDING: '#95a5a6',
+    IGNORED: '#faad14'
   };
 
   LONG_MIN_VALUE = -9223372036854776000;


### PR DESCRIPTION
## What is the purpose of the change

BP to 2.3 for 582342b64dae93ce078449e12724cb57016bec05 / https://github.com/apache/flink/pull/28038


## Brief change log

N.A


## Verifying this change

N.A

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
