### PR TITLE
[FLINK-39548][table-planner] Fix projected primary key indices for ch…

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecTableSourceScan.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecTableSourceScan.java
@@ -259,10 +259,6 @@ public abstract class CommonExecTableSourceScan extends ExecNodeBase<RowData>
         }
     }
 
-    protected RowType getPhysicalRowType(ResolvedSchema schema) {
-        return (RowType) schema.toPhysicalRowDataType().getLogicalType();
-    }
-
     protected int[] getPrimaryKeyIndices(RowType sourceRowType, ResolvedSchema schema) {
         return schema.getPrimaryKey()
                 .map(k -> k.getColumns().stream().mapToInt(sourceRowType::getFieldIndex).toArray())

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecTableSourceScan.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecTableSourceScan.java
@@ -283,8 +283,8 @@ public abstract class CommonExecTableSourceScan extends ExecNodeBase<RowData>
         if (!changelogMode.containsOnly(RowKind.INSERT)) {
             final ResolvedSchema schema =
                     tableSourceSpec.getContextResolvedTable().getResolvedSchema();
-            final RowType physicalRowType = getPhysicalRowType(schema);
-            final int[] primaryKeys = getPrimaryKeyIndices(physicalRowType, schema);
+            final RowType outputRowType = (RowType) getOutputType();
+            final int[] primaryKeys = getPrimaryKeyIndices(outputRowType, schema);
             final boolean hasPk = primaryKeys.length > 0;
             if (!hasPk) {
                 throw new TableException(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/TransformationsTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/TransformationsTest.java
@@ -26,7 +26,9 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.ProcessFunction;
 import org.apache.flink.streaming.api.lineage.LineageDataset;
 import org.apache.flink.streaming.api.transformations.LegacySourceTransformation;
+import org.apache.flink.streaming.api.transformations.PartitionTransformation;
 import org.apache.flink.streaming.api.transformations.WithBoundedness;
+import org.apache.flink.streaming.runtime.partitioner.KeyGroupStreamPartitioner;
 import org.apache.flink.table.api.CompiledPlan;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.EnvironmentSettings;
@@ -40,11 +42,14 @@ import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.api.internal.CompiledPlanUtils;
 import org.apache.flink.table.connector.ProviderContext;
 import org.apache.flink.table.connector.source.DataStreamScanProvider;
+import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.planner.factories.TableFactoryHarness;
 import org.apache.flink.table.planner.factories.TableFactoryHarness.ScanSourceBase;
 import org.apache.flink.table.planner.lineage.TableSourceLineageVertex;
 import org.apache.flink.table.planner.utils.JsonTestUtils;
+import org.apache.flink.table.runtime.keyselector.RowDataKeySelector;
 import org.apache.flink.util.Collector;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
@@ -54,6 +59,7 @@ import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
@@ -156,6 +162,52 @@ class TransformationsTest {
         testUidGeneration(c -> c.set(TABLE_EXEC_UID_GENERATION, PLAN_ONLY), true, false);
         testUidGeneration(c -> c.set(TABLE_EXEC_UID_GENERATION, ALWAYS), true, true);
         testUidGeneration(c -> c.set(TABLE_EXEC_UID_GENERATION, DISABLED), false, false);
+    }
+
+    @Test
+    void testSourcePartitionerUsesProjectedPrimaryKeyFields() {
+        final StreamTableEnvironment env =
+                StreamTableEnvironment.create(
+                        StreamExecutionEnvironment.getExecutionEnvironment(),
+                        EnvironmentSettings.newInstance().inStreamingMode().build());
+
+        env.executeSql(
+                "CREATE TABLE upsert_src (\n"
+                        + "  user_id STRING,\n"
+                        + "  user_name STRING,\n"
+                        + "  email STRING,\n"
+                        + "  balance DECIMAL(18, 2),\n"
+                        + "  balance2 AS balance * 2,\n"
+                        + "  PRIMARY KEY (user_name, user_id) NOT ENFORCED\n"
+                        + ") WITH (\n"
+                        + "  'connector' = 'values',\n"
+                        + "  'bounded' = 'true',\n"
+                        + "  'runtime-source' = 'DataStream',\n"
+                        + "  'disable-lookup' = 'true',\n"
+                        + "  'scan.parallelism' = '5',\n"
+                        + "  'changelog-mode' = 'UA,D'\n"
+                        + ")");
+
+        final PartitionTransformation<?> partitionTransform =
+                getSinglePartitionTransformation(
+                        env, env.sqlQuery("SELECT email, user_name, user_id FROM upsert_src"));
+
+        final RowDataKeySelector keySelector = getPartitionKeySelector(partitionTransform);
+        final RowData row =
+                GenericRowData.of(
+                        StringData.fromString("alice@example.com"),
+                        StringData.fromString("alice"),
+                        StringData.fromString("42"));
+
+        final RowData key;
+        try {
+            key = keySelector.getKey(row);
+        } catch (Exception e) {
+            throw new AssertionError("Failed to extract partition key from projected row.", e);
+        }
+
+        assertThat(key.getString(0).toString()).isEqualTo("alice");
+        assertThat(key.getString(1).toString()).isEqualTo("42");
     }
 
     @Test
@@ -494,6 +546,37 @@ class TransformationsTest {
         }
         assertThat(transform).isInstanceOf(LegacySourceTransformation.class);
         return (LegacySourceTransformation<?>) transform;
+    }
+
+    private static PartitionTransformation<?> getSinglePartitionTransformation(
+            StreamTableEnvironment env, Table table) {
+        final List<PartitionTransformation<?>> partitionTransforms =
+                env
+                        .toChangelogStream(table)
+                        .getTransformation()
+                        .getTransitivePredecessors()
+                        .stream()
+                        .filter(PartitionTransformation.class::isInstance)
+                        .map(t -> (PartitionTransformation<?>) t)
+                        .collect(Collectors.toList());
+        assertThat(partitionTransforms).hasSize(1);
+        return partitionTransforms.get(0);
+    }
+
+    private static RowDataKeySelector getPartitionKeySelector(
+            PartitionTransformation<?> partitionTransformation) {
+        assertThat(partitionTransformation.getPartitioner())
+                .isInstanceOf(KeyGroupStreamPartitioner.class);
+
+        try {
+            final Field keySelectorField =
+                    KeyGroupStreamPartitioner.class.getDeclaredField("keySelector");
+            keySelectorField.setAccessible(true);
+            return (RowDataKeySelector)
+                    keySelectorField.get(partitionTransformation.getPartitioner());
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("Failed to inspect source partitioner key selector.", e);
+        }
     }
 
     private static void assertBoundedness(Boundedness boundedness, Transformation<?> transform) {


### PR DESCRIPTION
## What is the purpose of the change

Fix primary key index derivation for changelog sources when the scan output is projected.

`CommonExecTableSourceScan` previously derived primary key field indices from the physical row type, which can differ from the projected output type (e.g., after reordering / projection). This could misalign the partitioner/key selector with the declared primary key fields. This PR derives indices from the projected output type instead.

## Brief change log

- Derive primary key indices from the projected output type for changelog sources.
- Add a regression test covering primary key extraction with projected/reordered output.
- Remove the now-unused physical row type helper.

## Verifying this change

This change added tests and can be verified as follows:

- `./mvnw -pl flink-table/flink-table-planner -Dtest=TransformationsTest test`

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (TraeCli / GPT-5.4)

Generated-by: TraeCli (GPT-5.4)