### PR TITLE
[FLINK-39550][runtime-web] Fix the Rescales tab order error on the job page

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/pages/job/job-detail/status/job-status.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/job-detail/status/job-status.component.ts
@@ -79,7 +79,8 @@ export class JobStatusComponent implements OnInit, OnDestroy {
     private readonly router: Router,
     @Inject(JOB_MODULE_CONFIG) readonly moduleConfig: JobModuleConfig
   ) {
-    this.listOfNavigation = moduleConfig.routerTabs || JOB_MODULE_DEFAULT_CONFIG.routerTabs;
+    // Create a copy to avoid mutating the shared config
+    this.listOfNavigation = [...(moduleConfig.routerTabs || JOB_MODULE_DEFAULT_CONFIG.routerTabs)];
     this.checkpointIndexOfNavigation = this.checkpointIndexOfNav();
     this.rescalesIndexOfNavigation = this.rescalesIndexOfNav();
   }


### PR DESCRIPTION
## What is the purpose of the change

This is [FLIP-487](https://issues.apache.org/jira/browse/FLINK-22258) non-blocking issue.

When navigating between BATCH and STREAMING job pages, the tab order becomes inconsistent. Specifically, the "Configuration" and "Rescales" tabs swap positions.


<b> root cause </b>
The listOfNavigation array was directly assigned from a shared singleton object (moduleConfig.routerTabs), causing all job detail page component instances to reference the same array.

When one component mutates this shared array using splice() to dynamically add/remove tabs (Checkpoints for STREAMING/BATCH, Rescales for Adaptive Scheduler), the mutation persists and affects other component instances.

### Excpected:
<img width="1819" height="896" alt="image" src="https://github.com/user-attachments/assets/4aa72db0-26dd-4a4f-9d30-827387250be4" />

### After Bug
<img width="1231" height="654" alt="image" src="https://github.com/user-attachments/assets/9879428b-5225-45b3-ab16-ff8b072cfabc" />


## Brief change log

Create a shallow copy of the routerTabs array in the constructor using the spread operator, ensuring each component instance has its own independent array.

## Verifying this change



This change can be verified by:
1. Navigate to a STREAMING job with Adaptive Scheduler
2. Navigate to a BATCH job
3. Navigate back to the STREAMING job
4. Verify tab order remains: `... → Checkpoints → Configuration → Rescales`


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
