### PR TITLE
[FLINK-39552][s3] Add native-s3-fs in DIRECTLY_SUPPORTED_FILESYSTEM

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
@@ -254,7 +254,9 @@ public abstract class FileSystem implements IFileSystem {
                     .put("oss", "flink-oss-fs-hadoop")
                     .put("s3", "flink-s3-fs-hadoop")
                     .put("s3", "flink-s3-fs-presto")
+                    .put("s3", "flink-s3-fs-native")
                     .put("s3a", "flink-s3-fs-hadoop")
+                    .put("s3a", "flink-s3-fs-native")
                     .put("s3p", "flink-s3-fs-presto")
                     .put("gs", "flink-gs-fs-hadoop")
                     .build();

--- a/flink-core/src/test/java/org/apache/flink/core/fs/FileSystemTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/FileSystemTest.java
@@ -88,14 +88,15 @@ class FileSystemTest {
         exception should be:
         org.apache.flink.core.fs.UnsupportedFileSystemSchemeException: Could not find a file
         system implementation for scheme 's3'. The scheme is directly supported by Flink through the following
-        plugins: flink-s3-fs-hadoop, flink-s3-fs-presto. Please ensure that each plugin resides within its own
-        subfolder within the plugins directory.
+        plugins: flink-s3-fs-hadoop, flink-s3-fs-presto, flink-s3-fs-native. Please ensure that each plugin
+        resides within its own subfolder within the plugins directory.
         See https://nightlies.apache.org/flink/flink-docs-stable/docs/deployment/filesystems/plugins/ for more information. */
         assertThatThrownBy(() -> getFileSystemWithoutSafetyNet("s3://authority/"))
                 .isInstanceOf(UnsupportedFileSystemSchemeException.class)
                 .hasMessageContaining("is directly supported")
                 .hasMessageContaining("flink-s3-fs-hadoop")
                 .hasMessageContaining("flink-s3-fs-presto")
+                .hasMessageContaining("flink-s3-fs-native")
                 .hasMessageNotContaining("no Hadoop file system to support this scheme");
     }
 
@@ -110,14 +111,16 @@ class FileSystemTest {
             exception should be:
             org.apache.flink.core.fs.UnsupportedFileSystemSchemeException: Could not find a file
             system implementation for scheme 's3'. File system schemes are supported by Flink through the following
-            plugin(s): flink-s3-fs-hadoop, flink-s3-fs-presto. No file system to support this scheme could be loaded.
-            Please ensure that each plugin is configured properly and resides within its own subfolder in the plugins directory.
+            plugin(s): flink-s3-fs-hadoop, flink-s3-fs-presto, flink-s3-fs-native. No file system to support this
+            scheme could be loaded. Please ensure that each plugin is configured properly and resides within its own
+            subfolder in the plugins directory.
             See https://nightlies.apache.org/flink/flink-docs-stable/docs/deployment/filesystems/plugins/ for more information. */
             assertThatThrownBy(() -> getFileSystemWithoutSafetyNet("s3://authority/"))
                     .isInstanceOf(UnsupportedFileSystemSchemeException.class)
                     .hasMessageContaining("File system schemes are supported")
                     .hasMessageContaining("flink-s3-fs-hadoop")
                     .hasMessageContaining("flink-s3-fs-presto")
+                    .hasMessageContaining("flink-s3-fs-native")
                     .hasMessageContaining("Please ensure that each plugin is configured properly");
         } finally {
             FileSystem.initialize(new Configuration(), null);


### PR DESCRIPTION


## What is the purpose of the change

Add native-s3-fs in DIRECTLY_SUPPORTED_FILESYSTEM


## Brief change log

add native-s3-fs in recognised plugin for s3 filesystem


## Verifying this change
Existing UT and improved assertions

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: yes

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) no

---

##### Was generative AI tooling used to co-author this PR?
No
