### PR TITLE
[FLINK-37893][k8s] Make REST service port name configurable

### DIFF
--- a/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
@@ -270,7 +270,7 @@
             <td><h5>kubernetes.rest-service.port-name</h5></td>
             <td style="word-wrap: break-word;">"rest"</td>
             <td>String</td>
-            <td>The name assigned to the rest port on the JobManager rest Service. Some environments enforce port-naming policies (for example, service meshes that route by port name); this option lets operators align Flink's rest port name with such policies. Must be a valid IANA service name (lowercase alphanumeric and '-', starting and ending alphanumeric, max 15 characters). Defaults to 'rest' to preserve backward compatibility.</td>
+            <td>The name assigned to the JobManager's rest port on both the Kubernetes Service and the JobManager container. Some environments enforce port-naming policies (for example, service meshes that route by port name); this option lets operators align Flink's rest port name with such policies. Must be a valid IANA service name (lowercase alphanumeric and '-', starting and ending alphanumeric, max 15 characters). Defaults to 'rest' to preserve backward compatibility.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.secrets</h5></td>

--- a/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
@@ -267,6 +267,12 @@
             <td>The user-specified labels that are set to the rest Service. The value should be in the form of a1:v1,a2:v2</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.rest-service.port-name</h5></td>
+            <td style="word-wrap: break-word;">"rest"</td>
+            <td>String</td>
+            <td>The name assigned to the rest port on the JobManager rest Service. Some environments enforce port-naming policies (for example, service meshes that route by port name); this option lets operators align Flink's rest port name with such policies. Must be a valid IANA service name (lowercase alphanumeric and '-', starting and ending alphanumeric, max 15 characters). Defaults to 'rest' to preserve backward compatibility.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.secrets</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Map</td>

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriver.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriver.java
@@ -304,9 +304,8 @@ public class KubernetesResourceManagerDriver
         Preconditions.checkArgument(
                 restPort > 0, "Failed to parse rest port from " + webInterfaceUrl);
         final String restServiceName = ExternalServiceDecorator.getExternalServiceName(clusterId);
-        flinkKubeClient
-                .updateServiceTargetPort(restServiceName, Constants.REST_PORT_NAME, restPort)
-                .get();
+        final String restPortName = flinkConfig.get(KubernetesConfigOptions.REST_SERVICE_PORT_NAME);
+        flinkKubeClient.updateServiceTargetPort(restServiceName, restPortName, restPort).get();
         if (!HighAvailabilityMode.isHighAvailabilityModeActivated(flinkConfig)) {
             final String internalServiceName =
                     InternalServiceDecorator.getInternalServiceName(clusterId);

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -390,7 +390,8 @@ public class KubernetesConfigOptions {
                     .stringType()
                     .defaultValue(Constants.REST_PORT_NAME)
                     .withDescription(
-                            "The name assigned to the rest port on the JobManager rest Service. "
+                            "The name assigned to the JobManager's rest port on both the "
+                                    + "Kubernetes Service and the JobManager container. "
                                     + "Some environments enforce port-naming policies (for example, "
                                     + "service meshes that route by port name); this option lets operators "
                                     + "align Flink's rest port name with such policies. "

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -385,6 +385,21 @@ public class KubernetesConfigOptions {
                             "The user-specified labels that are set to the rest Service. The value should be "
                                     + "in the form of a1:v1,a2:v2");
 
+    public static final ConfigOption<String> REST_SERVICE_PORT_NAME =
+            key("kubernetes.rest-service.port-name")
+                    .stringType()
+                    .defaultValue(Constants.REST_PORT_NAME)
+                    .withDescription(
+                            "The name assigned to the rest port on the JobManager rest Service. "
+                                    + "Some environments enforce port-naming policies (for example, "
+                                    + "service meshes that route by port name); this option lets operators "
+                                    + "align Flink's rest port name with such policies. "
+                                    + "Must be a valid IANA service name (lowercase alphanumeric and '-', "
+                                    + "starting and ending alphanumeric, max 15 characters). "
+                                    + "Defaults to '"
+                                    + Constants.REST_PORT_NAME
+                                    + "' to preserve backward compatibility.");
+
     public static final ConfigOption<Map<String, String>> INTERNAL_SERVICE_ANNOTATIONS =
             key("kubernetes.internal-service.annotations")
                     .mapType()

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecorator.java
@@ -189,7 +189,7 @@ public class InitJobManagerDecorator extends AbstractKubernetesStepDecorator {
         }
         return Arrays.asList(
                 new ContainerPortBuilder()
-                        .withName(Constants.REST_PORT_NAME)
+                        .withName(kubernetesJobManagerParameters.getRestServicePortName())
                         .withContainerPort(kubernetesJobManagerParameters.getRestPort())
                         .build(),
                 new ContainerPortBuilder()

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesJobManagerParameters.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesJobManagerParameters.java
@@ -200,6 +200,10 @@ public class KubernetesJobManagerParameters extends AbstractKubernetesParameters
         return flinkConfig.get(KubernetesConfigOptions.REST_SERVICE_EXPOSED_TYPE);
     }
 
+    public String getRestServicePortName() {
+        return flinkConfig.get(KubernetesConfigOptions.REST_SERVICE_PORT_NAME);
+    }
+
     public boolean isInternalServiceEnabled() {
         return !HighAvailabilityMode.isHighAvailabilityModeActivated(flinkConfig);
     }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/services/ServiceType.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/services/ServiceType.java
@@ -109,18 +109,25 @@ public abstract class ServiceType {
     public abstract String getType();
 
     /**
-     * Get rest port from the external Service. The rest Service is built with a single port (whose
-     * name is configurable via {@link KubernetesConfigOptions#REST_SERVICE_PORT_NAME}), so the
-     * lookup does not depend on the port name.
+     * Get rest port from the external Service. The rest Service is built with exactly one port
+     * (whose name is configurable via {@link KubernetesConfigOptions#REST_SERVICE_PORT_NAME}), so
+     * the lookup does not depend on the port name. If the Service has zero or more than one port,
+     * this method throws — the invariant comes from {@link #buildUpExternalRestService}.
      */
     public int getRestPortFromExternalService(Service externalService) {
         final List<ServicePort> ports = externalService.getSpec().getPorts();
+        final String serviceName = externalService.getMetadata().getName();
 
         if (ports == null || ports.isEmpty()) {
             throw new RuntimeException(
-                    "Failed to find any port in Service \""
-                            + externalService.getMetadata().getName()
-                            + "\"");
+                    "Failed to find any port in Service \"" + serviceName + "\"");
+        }
+        if (ports.size() > 1) {
+            throw new RuntimeException(
+                    "Expected exactly one port in Service \""
+                            + serviceName
+                            + "\" but found "
+                            + ports.size());
         }
 
         return getRestPort(ports.get(0));

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/services/ServiceType.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/services/ServiceType.java
@@ -31,7 +31,6 @@ import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /** An abstract class represents the service type that flink supported. */
 public abstract class ServiceType {
@@ -64,7 +63,7 @@ public abstract class ServiceType {
                                 .getType())
                 .withSelector(kubernetesJobManagerParameters.getSelectors())
                 .addNewPort()
-                .withName(Constants.REST_PORT_NAME)
+                .withName(kubernetesJobManagerParameters.getRestServicePortName())
                 .withPort(kubernetesJobManagerParameters.getRestPort())
                 .withNewTargetPort(kubernetesJobManagerParameters.getRestBindPort())
                 .endPort()
@@ -109,25 +108,22 @@ public abstract class ServiceType {
      */
     public abstract String getType();
 
-    /** Get rest port from the external Service. */
+    /**
+     * Get rest port from the external Service. The rest Service is built with a single port (whose
+     * name is configurable via {@link KubernetesConfigOptions#REST_SERVICE_PORT_NAME}), so the
+     * lookup does not depend on the port name.
+     */
     public int getRestPortFromExternalService(Service externalService) {
-        final List<ServicePort> servicePortCandidates =
-                externalService.getSpec().getPorts().stream()
-                        .filter(x -> x.getName().equals(Constants.REST_PORT_NAME))
-                        .collect(Collectors.toList());
+        final List<ServicePort> ports = externalService.getSpec().getPorts();
 
-        if (servicePortCandidates.isEmpty()) {
+        if (ports == null || ports.isEmpty()) {
             throw new RuntimeException(
-                    "Failed to find port \""
-                            + Constants.REST_PORT_NAME
-                            + "\" in Service \""
+                    "Failed to find any port in Service \""
                             + externalService.getMetadata().getName()
                             + "\"");
         }
 
-        final ServicePort externalServicePort = servicePortCandidates.get(0);
-
-        return getRestPort(externalServicePort);
+        return getRestPort(ports.get(0));
     }
 
     // Helper method

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/ExternalServiceDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/ExternalServiceDecoratorTest.java
@@ -131,4 +131,34 @@ class ExternalServiceDecoratorTest extends KubernetesJobManagerTestBase {
         assertThat(((Service) servicesWithHeadlessClusterIP.get(0)).getSpec().getClusterIP())
                 .isEqualTo(HeadlessClusterIPService.HEADLESS_CLUSTER_IP);
     }
+
+    @Test
+    void testDefaultRestServicePortName() throws IOException {
+        final List<HasMetadata> resources =
+                this.externalServiceDecorator.buildAccompanyingKubernetesResources();
+        final Service restService = (Service) resources.get(0);
+
+        assertThat(restService.getSpec().getPorts())
+                .singleElement()
+                .extracting(ServicePort::getName)
+                .isEqualTo(Constants.REST_PORT_NAME);
+    }
+
+    @Test
+    void testCustomRestServicePortName() throws IOException {
+        final String customPortName = "flink-rest";
+        this.flinkConfig.set(KubernetesConfigOptions.REST_SERVICE_PORT_NAME, customPortName);
+        // Rebuild the decorator so it picks up the updated configuration.
+        this.externalServiceDecorator =
+                new ExternalServiceDecorator(this.kubernetesJobManagerParameters);
+
+        final List<HasMetadata> resources =
+                this.externalServiceDecorator.buildAccompanyingKubernetesResources();
+        final Service restService = (Service) resources.get(0);
+
+        assertThat(restService.getSpec().getPorts())
+                .singleElement()
+                .extracting(ServicePort::getName)
+                .isEqualTo(customPortName);
+    }
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecoratorTest.java
@@ -149,6 +149,23 @@ class InitJobManagerDecoratorTest extends KubernetesJobManagerTestBase {
     }
 
     @Test
+    void testMainContainerRestPortNameWithCustomConfig() {
+        final String customPortName = "flink-rest";
+        this.flinkConfig.set(KubernetesConfigOptions.REST_SERVICE_PORT_NAME, customPortName);
+        final InitJobManagerDecorator decorator =
+                new InitJobManagerDecorator(this.kubernetesJobManagerParameters);
+        final Container mainContainer =
+                decorator.decorateFlinkPod(this.baseFlinkPod).getMainContainer();
+
+        assertThat(mainContainer.getPorts())
+                .extracting(ContainerPort::getName)
+                .containsExactly(
+                        customPortName,
+                        Constants.JOB_MANAGER_RPC_PORT_NAME,
+                        Constants.BLOB_SERVER_PORT_NAME);
+    }
+
+    @Test
     void testMainContainerEnv() {
         final List<EnvVar> envVars = this.resultMainContainer.getEnv();
 

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/services/ServiceTypeTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/services/ServiceTypeTest.java
@@ -21,9 +21,12 @@ package org.apache.flink.kubernetes.kubeclient.services;
 import org.apache.flink.kubernetes.KubernetesClientTestBase;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link ServiceType}. */
 class ServiceTypeTest extends KubernetesClientTestBase {
@@ -39,5 +42,52 @@ class ServiceTypeTest extends KubernetesClientTestBase {
                 .isEqualByComparingTo(KubernetesConfigOptions.ServiceExposedType.NodePort);
         assertThat(ServiceType.classify(buildExternalServiceWithLoadBalancer("", "")))
                 .isEqualByComparingTo(KubernetesConfigOptions.ServiceExposedType.LoadBalancer);
+    }
+
+    @Test
+    void testGetRestPortFromExternalServiceWithDefaultName() {
+        final int restPort =
+                ClusterIPService.INSTANCE.getRestPortFromExternalService(
+                        buildExternalServiceWithClusterIP());
+        assertThat(restPort).isEqualTo(REST_PORT);
+    }
+
+    @Test
+    void testGetRestPortFromExternalServiceWithCustomName() {
+        final Service service =
+                new ServiceBuilder()
+                        .withNewMetadata()
+                        .withName("flink-cluster-rest")
+                        .endMetadata()
+                        .withNewSpec()
+                        .withType(KubernetesConfigOptions.ServiceExposedType.ClusterIP.name())
+                        .addNewPort()
+                        .withName("flink-rest")
+                        .withPort(REST_PORT)
+                        .withNewTargetPort(REST_PORT)
+                        .endPort()
+                        .endSpec()
+                        .build();
+
+        final int restPort = ClusterIPService.INSTANCE.getRestPortFromExternalService(service);
+        assertThat(restPort).isEqualTo(REST_PORT);
+    }
+
+    @Test
+    void testGetRestPortFromExternalServiceFailsWhenNoPorts() {
+        final Service service =
+                new ServiceBuilder()
+                        .withNewMetadata()
+                        .withName("flink-cluster-rest")
+                        .endMetadata()
+                        .withNewSpec()
+                        .withType(KubernetesConfigOptions.ServiceExposedType.ClusterIP.name())
+                        .endSpec()
+                        .build();
+
+        assertThatThrownBy(() -> ClusterIPService.INSTANCE.getRestPortFromExternalService(service))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Failed to find any port")
+                .hasMessageContaining("flink-cluster-rest");
     }
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/services/ServiceTypeTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/services/ServiceTypeTest.java
@@ -90,4 +90,33 @@ class ServiceTypeTest extends KubernetesClientTestBase {
                 .hasMessageContaining("Failed to find any port")
                 .hasMessageContaining("flink-cluster-rest");
     }
+
+    @Test
+    void testGetRestPortFromExternalServiceFailsWhenMultiplePorts() {
+        final Service service =
+                new ServiceBuilder()
+                        .withNewMetadata()
+                        .withName("flink-cluster-rest")
+                        .endMetadata()
+                        .withNewSpec()
+                        .withType(KubernetesConfigOptions.ServiceExposedType.ClusterIP.name())
+                        .addNewPort()
+                        .withName("rest")
+                        .withPort(REST_PORT)
+                        .withNewTargetPort(REST_PORT)
+                        .endPort()
+                        .addNewPort()
+                        .withName("extra")
+                        .withPort(REST_PORT + 1)
+                        .withNewTargetPort(REST_PORT + 1)
+                        .endPort()
+                        .endSpec()
+                        .build();
+
+        assertThatThrownBy(() -> ClusterIPService.INSTANCE.getRestPortFromExternalService(service))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Expected exactly one port")
+                .hasMessageContaining("flink-cluster-rest")
+                .hasMessageContaining("but found 2");
+    }
 }


### PR DESCRIPTION
## What is the purpose of the change

The Kubernetes REST service exposed by the JobManager hardcodes its port name to `"rest"` (`Constants.REST_PORT_NAME`). Operators in environments with port-naming policies, such as service meshes that route by port name, cannot make Flink's REST service match those policies.

This change adds a new config option, `kubernetes.rest-service.port-name` (string, default `"rest"`), that controls the port name on the REST Service. The default preserves existing behavior.

## Brief change log

- New config option `kubernetes.rest-service.port-name` in `KubernetesConfigOptions` (default `"rest"`)
- New getter `KubernetesJobManagerParameters#getRestServicePortName()`
- `ServiceType#buildUpExternalRestService` uses the configured name instead of `Constants.REST_PORT_NAME`
- `ServiceType#getRestPortFromExternalService` no longer filters ports by name. Flink always builds the rest Service with a single port, so the lookup can return that port. This lets the reader work for any configured name without changing the public `getRestEndpoint` signature on `ServiceType` or updating all subclasses.
- `KubernetesResourceManagerDriver#updateKubernetesServiceTargetPortIfNecessary` reads the configured port name from `flinkConfig` when updating the rest service's target port in host-network mode

## Verifying this change

This change added tests and can be verified as follows:

- `ExternalServiceDecoratorTest#testDefaultRestServicePortName`: verifies the default port name `"rest"` is used when the option is unset
- `ExternalServiceDecoratorTest#testCustomRestServicePortName`: verifies a custom port name (`"flink-rest"`) propagates to the built Service
- `ServiceTypeTest#testGetRestPortFromExternalServiceWithDefaultName`: verifies the reader works for a Service with the default port name
- `ServiceTypeTest#testGetRestPortFromExternalServiceWithCustomName`: verifies the reader works for a Service with a custom port name
- `ServiceTypeTest#testGetRestPortFromExternalServiceFailsWhenNoPorts`: verifies the error path when the Service has no ports
- Existing tests in the kubeclient/services/decorators packages continue to pass (`mvn -pl flink-kubernetes -Dtest='*KubeClient*,*ServiceType*,*ServiceDecorator*,*JobManagerDecorator*,KubernetesResourceManagerDriverTest,KubernetesUtilsTest' test`)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes, `KubernetesConfigOptions` is `@PublicEvolving`. Adds a new option (additive).
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes, affects native Kubernetes JobManager Service builder and `KubernetesResourceManagerDriver`. No behavior change at default.
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? config option `withDescription` (auto-generated into the Flink config docs)
