### PR TITLE
[hotfix] Fix grammatical errors in Materialized Table and related code

### DIFF
--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/materializedtable/MaterializedTableManager.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/materializedtable/MaterializedTableManager.java
@@ -232,13 +232,14 @@ public class MaterializedTableManager {
                     Collections.emptyMap(),
                     Optional.empty());
         } catch (Exception e) {
-            // drop materialized table while submit flink streaming job occur exception. Thus, weak
+            // drop materialized table if submitting the Flink streaming job encounters an
+            // exception. Thus, weak
             // atomicity is guaranteed
             operationExecutor.callExecutableOperation(
                     handle, new DropMaterializedTableOperation(materializedTableIdentifier, true));
             throw new SqlExecutionException(
                     String.format(
-                            "Submit continuous refresh job for materialized table %s occur exception.",
+                            "Failed to submit continuous refresh job for materialized table %s.",
                             materializedTableIdentifier),
                     e);
         }
@@ -288,7 +289,8 @@ public class MaterializedTableManager {
                     refreshHandler.asSummaryString(),
                     serializedRefreshHandler);
         } catch (Exception e) {
-            // drop materialized table while create refresh workflow occur exception. Thus, weak
+            // drop materialized table if creating the refresh workflow encounters an exception.
+            // Thus, weak
             // atomicity is guaranteed
             operationExecutor.callExecutableOperation(
                     handle, new DropMaterializedTableOperation(materializedTableIdentifier, true));
@@ -651,7 +653,7 @@ public class MaterializedTableManager {
 
         try {
             LOG.info(
-                    "Begin to refreshing the materialized table {}, statement: {}",
+                    "Starting refresh of the materialized table {}, statement: {}",
                     materializedTableIdentifier,
                     insertStatement);
             JobExecutionResult result =
@@ -682,7 +684,7 @@ public class MaterializedTableManager {
         } catch (Exception e) {
             throw new SqlExecutionException(
                     String.format(
-                            "Refreshing the materialized table %s occur exception.",
+                            "Failed to refresh the materialized table %s.",
                             materializedTableIdentifier),
                     e);
         }
@@ -1128,8 +1130,7 @@ public class MaterializedTableManager {
             return ContinuousRefreshHandlerSerializer.INSTANCE.deserialize(
                     serializedRefreshHandler, userCodeClassLoader);
         } catch (IOException | ClassNotFoundException e) {
-            throw new SqlExecutionException(
-                    "Deserialize ContinuousRefreshHandler occur exception.", e);
+            throw new SqlExecutionException("Failed to deserialize ContinuousRefreshHandler.", e);
         }
     }
 
@@ -1137,8 +1138,7 @@ public class MaterializedTableManager {
         try {
             return ContinuousRefreshHandlerSerializer.INSTANCE.serialize(refreshHandler);
         } catch (IOException e) {
-            throw new SqlExecutionException(
-                    "Serialize ContinuousRefreshHandler occur exception.", e);
+            throw new SqlExecutionException("Failed to serialize ContinuousRefreshHandler.", e);
         }
     }
 

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/MaterializedTableStatementITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/MaterializedTableStatementITCase.java
@@ -492,7 +492,7 @@ class MaterializedTableStatementITCase extends AbstractMaterializedTableStatemen
                 .cause()
                 .hasMessageContaining(
                         String.format(
-                                "Submit continuous refresh job for materialized table %s occur exception.",
+                                "Failed to submit continuous refresh job for materialized table %s.",
                                 userShopsIdentifier.asSerializableString()));
 
         // verify the materialized table is not created

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/workflow/WorkflowScheduler.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/workflow/WorkflowScheduler.java
@@ -36,7 +36,7 @@ public interface WorkflowScheduler<T extends RefreshHandler> {
      * Open this workflow scheduler instance. Used for any required preparation in initialization
      * phase.
      *
-     * @throws WorkflowException if initializing workflow scheduler occur exception
+     * @throws WorkflowException if initializing the workflow scheduler fails
      */
     void open() throws WorkflowException;
 

--- a/flink-test-utils-parent/flink-table-filesystem-test-utils/src/main/java/org/apache/flink/table/file/testutils/catalog/TestFileSystemCatalog.java
+++ b/flink-test-utils-parent/flink-table-filesystem-test-utils/src/main/java/org/apache/flink/table/file/testutils/catalog/TestFileSystemCatalog.java
@@ -129,7 +129,7 @@ public class TestFileSystemCatalog extends AbstractCatalog {
             }
         } catch (IOException e) {
             throw new CatalogException(
-                    String.format("Checking catalog path %s exists occur exception.", catalogPath),
+                    String.format("Error checking whether catalog path %s exists.", catalogPath),
                     e);
         }
     }
@@ -146,7 +146,7 @@ public class TestFileSystemCatalog extends AbstractCatalog {
                     .map(fileStatus -> fileStatus.getPath().getName())
                     .collect(Collectors.toList());
         } catch (IOException e) {
-            throw new CatalogException("Listing database occur exception.", e);
+            throw new CatalogException("Error listing databases.", e);
         }
     }
 
@@ -189,8 +189,7 @@ public class TestFileSystemCatalog extends AbstractCatalog {
         try {
             fs.mkdirs(dbPath);
         } catch (IOException e) {
-            throw new CatalogException(
-                    String.format("Creating database %s occur exception.", name), e);
+            throw new CatalogException(String.format("Error creating database %s.", name), e);
         }
     }
 
@@ -220,7 +219,7 @@ public class TestFileSystemCatalog extends AbstractCatalog {
             fs.delete(dbPath, true);
         } catch (IOException e) {
             throw new CatalogException(
-                    String.format("Dropping database %s occur exception.", databaseName), e);
+                    String.format("Error dropping database %s.", databaseName), e);
         }
     }
 
@@ -246,7 +245,7 @@ public class TestFileSystemCatalog extends AbstractCatalog {
                     .collect(Collectors.toList());
         } catch (IOException e) {
             throw new CatalogException(
-                    String.format("Listing table in database %s occur exception.", dbPath), e);
+                    String.format("Error listing tables in database %s.", dbPath), e);
         }
     }
 
@@ -276,8 +275,7 @@ public class TestFileSystemCatalog extends AbstractCatalog {
                     tableInfo.getCatalogTableInfo(),
                     tableDataPath.toString());
         } catch (IOException e) {
-            throw new CatalogException(
-                    String.format("Getting table %s occur exception.", tablePath), e);
+            throw new CatalogException(String.format("Error getting table %s.", tablePath), e);
         }
     }
 
@@ -298,7 +296,7 @@ public class TestFileSystemCatalog extends AbstractCatalog {
             return fs.exists(path) && fs.exists(tableSchemaFilePath);
         } catch (IOException e) {
             throw new CatalogException(
-                    String.format("Checking table %s exists occur exception.", tablePath), e);
+                    String.format("Error checking whether table %s exists.", tablePath), e);
         }
     }
 
@@ -317,8 +315,7 @@ public class TestFileSystemCatalog extends AbstractCatalog {
         try {
             fs.delete(path, true);
         } catch (IOException e) {
-            throw new CatalogException(
-                    String.format("Dropping table %s occur exception.", tablePath), e);
+            throw new CatalogException(String.format("Error dropping table %s.", tablePath), e);
         }
     }
 
@@ -374,8 +371,7 @@ public class TestFileSystemCatalog extends AbstractCatalog {
             }
 
         } catch (IOException e) {
-            throw new CatalogException(
-                    String.format("Create table %s occur exception.", tablePath), e);
+            throw new CatalogException(String.format("Error creating table %s.", tablePath), e);
         }
     }
 
@@ -404,7 +400,7 @@ public class TestFileSystemCatalog extends AbstractCatalog {
             if (!fs.exists(tableSchemaPath)) {
                 throw new CatalogException(
                         String.format(
-                                "Table %s schema file %s doesn't exists.",
+                                "Table %s schema file %s doesn't exist.",
                                 tablePath, tableSchemaPath));
             }
             // write new table schema
@@ -416,8 +412,7 @@ public class TestFileSystemCatalog extends AbstractCatalog {
             }
 
         } catch (IOException e) {
-            throw new CatalogException(
-                    String.format("Altering table %s occur exception.", tablePath), e);
+            throw new CatalogException(String.format("Error altering table %s.", tablePath), e);
         }
     }
 


### PR DESCRIPTION
## Summary

- Fix 17 instances of "X occur exception" (subject-verb disagreement) across error messages, log messages, comments, and Javadoc. Replaced with idiomatic "Error doing X" / "Failed to X" phrasing.
- Fix "Begin to refreshing" to "Beginning to refresh" (incorrect verb form)
- Fix "doesn't exists" to "doesn't exist" (incorrect conjugation)