### PR TITLE
[hotfix][ci] Set correct maven repo folder in flink-ci

### DIFF
--- a/.github/workflows/template.flink-ci.yml
+++ b/.github/workflows/template.flink-ci.yml
@@ -259,7 +259,7 @@ jobs:
           done
           mkdir -p \
             ${{ env.CONTAINER_LOCAL_WORKING_DIR }} \
-            ${{ env.CONTAINER_LOCAL_WORKING_DIR }} \
+            ${{ env.MAVEN_REPO_FOLDER }} \
             ${{ env.DOCKER_IMAGES_CACHE_FOLDER }}
           chown -R flink:flink ${{ env.CONTAINER_LOCAL_WORKING_DIR }}
           chown -R flink:flink ${{ env.MAVEN_REPO_FOLDER }}


### PR DESCRIPTION


## What is the purpose of the change

there was a wrong folder in ci template to set permissions

## Brief change log
gha


## Verifying this change

GHA

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
