### PR TITLE
[FLINK-39566][runtime-web] Add checkpoint duration Gantt view

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/app.interceptor.ts
+++ b/flink-runtime-web/web-dashboard/src/app/app.interceptor.ts
@@ -59,9 +59,18 @@ export class AppInterceptor implements HttpInterceptor {
           window.location.href = String(res.headers.get('Location'));
         }
 
+        // A per-subtask checkpoint fetch can race the JM reaping that checkpoint (or hit it
+        // before it acks), yielding a benign 404. Suppress only that case; real 5xx/auth on
+        // the same path still surface.
+        const isExpectedSubtaskNotFound =
+          res instanceof HttpResponseBase &&
+          res.status === HttpStatusCode.NotFound &&
+          /\/checkpoints\/details\/\d+\/subtasks\//.test(res.url || '');
+
         const errorMessage = res && res.error && res.error.errors && res.error.errors[0];
         if (
           errorMessage &&
+          !isExpectedSubtaskNotFound &&
           ignoreErrorUrlEndsList.every(url => !res.url.endsWith(url)) &&
           ignoreErrorMessage.every(message => errorMessage !== message)
         ) {

--- a/flink-runtime-web/web-dashboard/src/app/interfaces/job-checkpoint.ts
+++ b/flink-runtime-web/web-dashboard/src/app/interfaces/job-checkpoint.ts
@@ -57,8 +57,8 @@ export interface Checkpoint {
       is_savepoint: boolean;
       external_path: string;
     };
-    history: CheckpointHistory;
   };
+  history: CheckpointHistory[];
 }
 
 export interface CheckpointHistory {

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/checkpoints/job-checkpoints.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/checkpoints/job-checkpoints.component.html
@@ -222,11 +222,19 @@
       </tbody>
     </nz-table>
   </nz-tab>
+  <nz-tab nzTitle="Timeline">
+    <flink-job-checkpoints-timeline
+      [jobId]="jobDetail?.jid"
+      [vertices]="jobDetail?.vertices || []"
+      [history]="checkPointStats?.history || []"
+      [config]="checkPointConfig"
+    ></flink-job-checkpoints-timeline>
+  </nz-tab>
   <nz-tab nzTitle="History">
     <nz-table
       class="no-border small"
       [nzSize]="'small'"
-      [nzData]="checkPointStats['history'] || []"
+      [nzData]="checkPointStats?.history || []"
       [nzFrontPagination]="false"
       [nzShowPagination]="false"
     >
@@ -256,7 +264,7 @@
         </tr>
       </thead>
       <tbody>
-        <ng-container *ngFor="let checkpoint of checkPointStats['history']; trackBy: trackById">
+        <ng-container *ngFor="let checkpoint of checkPointStats?.history; trackBy: trackById">
           <tr>
             <td nzShowExpand [(nzExpand)]="checkpoint.expand"></td>
             <td>{{ checkpoint['id'] }}</td>

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/checkpoints/job-checkpoints.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/checkpoints/job-checkpoints.component.ts
@@ -26,6 +26,7 @@ import { HumanizeBytesPipe } from '@flink-runtime-web/components/humanize-bytes.
 import { HumanizeDurationPipe } from '@flink-runtime-web/components/humanize-duration.pipe';
 import { CheckpointConfig, CheckpointHistory, Checkpoint, JobDetailCorrect } from '@flink-runtime-web/interfaces';
 import { JobCheckpointsDetailComponent } from '@flink-runtime-web/pages/job/checkpoints/detail/job-checkpoints-detail.component';
+import { JobCheckpointsTimelineComponent } from '@flink-runtime-web/pages/job/checkpoints/timeline/job-checkpoints-timeline.component';
 import { JobService } from '@flink-runtime-web/services';
 import { NzButtonModule } from 'ng-zorro-antd/button';
 import { NzCollapseModule } from 'ng-zorro-antd/collapse';
@@ -59,7 +60,8 @@ import { JobLocalService } from '../job-local.service';
     NzButtonModule,
     NzEmptyModule,
     NzCollapseModule,
-    NzTooltipModule
+    NzTooltipModule,
+    JobCheckpointsTimelineComponent
   ]
 })
 export class JobCheckpointsComponent implements OnInit, OnDestroy {

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/checkpoints/timeline/job-checkpoints-timeline.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/checkpoints/timeline/job-checkpoints-timeline.component.html
@@ -1,0 +1,143 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<div class="timeline-wrapper">
+  <section class="strip-section">
+    <header class="strip-header">
+      <div class="strip-title">
+        <strong>Recent Checkpoints</strong>
+        <span class="hint">Click a bar to load its per-subtask timeline below.</span>
+      </div>
+      <ul class="legend">
+        <li>
+          <span class="swatch completed"></span>
+          Completed
+        </li>
+        <li>
+          <span class="swatch savepoint"></span>
+          Savepoint
+        </li>
+        <li>
+          <span class="swatch in-progress"></span>
+          In progress
+        </li>
+        <li>
+          <span class="swatch failed"></span>
+          Failed
+        </li>
+      </ul>
+    </header>
+    <div class="strip-canvas" #stripContainer></div>
+    <nz-empty
+      *ngIf="!history || history.length === 0"
+      nzNotFoundContent="No checkpoint history yet"
+    ></nz-empty>
+  </section>
+
+  <section class="timeline-section">
+    <header class="timeline-header">
+      <div class="timeline-title">
+        <strong *ngIf="selected">
+          Checkpoint #{{ selected.id }}
+          <span
+            *ngIf="userPinned"
+            class="pin-badge"
+            title="Pinned: the timeline below will not change until you click another checkpoint or 'Follow newest'."
+          >
+            pinned
+          </span>
+        </strong>
+        <strong *ngIf="!selected">Per-subtask Timeline</strong>
+        <span *ngIf="selected" class="hint">
+          {{ selected.rawStatus }}
+          <ng-container *ngIf="selected.isSavepoint">· savepoint</ng-container>
+          · triggered {{ selected.triggered | date: 'yyyy-MM-dd HH:mm:ss.SSS' }} ·
+          {{ selected.duration | humanizeDuration }} · acked {{ selected.acked }} ·
+          {{ selected.size | humanizeBytes }}
+        </span>
+        <div class="timeline-actions">
+          <button *ngIf="userPinned" type="button" class="follow-newest" (click)="followNewest()">
+            Follow newest
+          </button>
+        </div>
+      </div>
+      <ul class="legend">
+        <li>
+          <span class="swatch phase-start"></span>
+          start_delay
+        </li>
+        <li>
+          <span class="swatch phase-align"></span>
+          alignment
+        </li>
+        <li>
+          <span class="swatch phase-sync"></span>
+          sync
+        </li>
+        <li>
+          <span class="swatch phase-async"></span>
+          async
+        </li>
+        <li
+          class="outlier-swatch"
+          nz-tooltip
+          [nzTooltipTitle]="stragglerTip"
+          nzTooltipPlacement="bottom"
+        >
+          <span class="swatch outlier"></span>
+          straggler / aborted
+        </li>
+        <ng-template #stragglerTip>
+          Subtasks outlined in red were aborted, or their total duration met or exceeded this
+          checkpoint's outlier threshold — the larger of the p95 and 1.5&times; the median subtask
+          duration. They are the rows to investigate first.
+        </ng-template>
+      </ul>
+    </header>
+
+    <!-- Reserve the line while a checkpoint is selected so the chart doesn't shift. -->
+    <div *ngIf="selected" class="rotated-out-note">
+      <span *ngIf="selectedRotatedOut && !timelineEmpty">
+        Checkpoint #{{ selected?.id }} is no longer in the recent-checkpoints strip above — showing
+        the frozen snapshot from when it was pinned.
+      </span>
+    </div>
+
+    <nz-alert
+      *ngIf="failedVertexCount > 0 && !loadFailed"
+      class="partial-failure"
+      nzType="warning"
+      nzShowIcon
+      [nzMessage]="partialFailureMessage"
+    ></nz-alert>
+
+    <div class="timeline-canvas-wrapper" [class.loading]="loadingTimeline">
+      <nz-spin [nzSpinning]="loadingTimeline">
+        <div class="timeline-canvas" [class.hidden]="timelineEmpty" #timelineContainer></div>
+        <nz-empty
+          *ngIf="timelineEmpty && !loadingTimeline"
+          [nzNotFoundContent]="
+            loadFailed
+              ? 'Could not load subtask data — this checkpoint may no longer be retained by the JobManager'
+              : 'No subtask data for this checkpoint'
+          "
+        ></nz-empty>
+      </nz-spin>
+    </div>
+  </section>
+</div>

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/checkpoints/timeline/job-checkpoints-timeline.component.less
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/checkpoints/timeline/job-checkpoints-timeline.component.less
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.timeline-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.hint {
+  margin-left: 8px;
+  color: #8c8c8c;
+  font-size: 12px;
+}
+
+.legend {
+  display: flex;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  color: #595959;
+  list-style: none;
+  font-size: 12px;
+
+  li {
+    display: inline-flex;
+    align-items: center;
+  }
+
+  .swatch {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    margin-right: 4px;
+    border: 1px solid transparent;
+    border-radius: 2px;
+  }
+
+  .completed {
+    background: #52c41a;
+  }
+
+  .savepoint {
+    background: #722ed1;
+  }
+
+  .in-progress {
+    background: #faad14;
+  }
+
+  .failed {
+    background: #f5222d;
+  }
+
+  .phase-start {
+    background: #b8c0cc;
+  }
+
+  .phase-align {
+    background: #91caff;
+  }
+
+  .phase-sync {
+    background: #fa8c16;
+  }
+
+  .phase-async {
+    background: #52c41a;
+  }
+
+  .outlier {
+    border: 1.5px dashed #f5222d;
+    background: transparent;
+  }
+}
+
+.strip-canvas {
+  width: 100%;
+  min-height: 80px;
+  cursor: pointer;
+}
+
+.pin-badge {
+  display: inline-block;
+  vertical-align: middle;
+  margin-left: 8px;
+  padding: 1px 6px;
+  border-radius: 10px;
+  background: #faad14;
+  color: #fff;
+  font-weight: 600;
+  font-size: 10px;
+}
+
+.rotated-out-note {
+  // Fixed height so the chart doesn't shift when the note toggles.
+  min-height: 18px;
+  margin: 0 0 8px;
+  color: #8c8c8c;
+  font-size: 12px;
+  line-height: 18px;
+}
+
+.timeline-title {
+  display: flex;
+  flex: 1 1 auto;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  min-width: 0;
+}
+
+.timeline-actions {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+  margin-left: auto;
+}
+
+.follow-newest {
+  padding: 2px 10px;
+  border: 1px solid #d9d9d9;
+  border-radius: 4px;
+  background: #fff;
+  color: #1890ff;
+  font-size: 12px;
+  cursor: pointer;
+
+  &:hover {
+    border-color: #1890ff;
+  }
+}
+
+.partial-failure {
+  margin-bottom: 12px;
+}
+
+.timeline-canvas-wrapper {
+  position: relative;
+  min-height: 160px;
+
+  &.loading {
+    opacity: 0.7;
+  }
+}
+
+.timeline-canvas {
+  width: 100%;
+
+  &.hidden {
+    display: none;
+  }
+}

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/checkpoints/timeline/job-checkpoints-timeline.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/checkpoints/timeline/job-checkpoints-timeline.component.ts
@@ -1,0 +1,764 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DatePipe, NgIf } from '@angular/common';
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  Input,
+  OnChanges,
+  OnDestroy,
+  SimpleChanges,
+  ViewChild
+} from '@angular/core';
+import { BehaviorSubject, defer, EMPTY, of, Subject, timer } from 'rxjs';
+import { catchError, distinctUntilChanged, map, repeat, switchMap, takeUntil } from 'rxjs/operators';
+
+import * as G2 from '@antv/g2';
+import { Chart } from '@antv/g2';
+import { HumanizeBytesPipe } from '@flink-runtime-web/components/humanize-bytes.pipe';
+import { HumanizeDurationPipe } from '@flink-runtime-web/components/humanize-duration.pipe';
+import {
+  CheckpointConfig,
+  CheckpointHistory,
+  CheckpointSubTask,
+  CompletedSubTaskCheckpointStatistics,
+  SubTaskCheckpointStatisticsItem,
+  VerticesItem
+} from '@flink-runtime-web/interfaces';
+import { JobService } from '@flink-runtime-web/services';
+import { NzAlertModule } from 'ng-zorro-antd/alert';
+import { NzEmptyModule } from 'ng-zorro-antd/empty';
+import { NzSpinModule } from 'ng-zorro-antd/spin';
+import { NzToolTipModule } from 'ng-zorro-antd/tooltip';
+
+type PhaseKey = 'start_delay' | 'alignment' | 'sync' | 'async';
+
+interface StripDatum {
+  id: number;
+  idLabel: string;
+  duration: number;
+  status: 'COMPLETED' | 'SAVEPOINT' | 'IN_PROGRESS' | 'FAILED';
+  rawStatus: string;
+  isSavepoint: boolean;
+  triggered: number;
+  acked: string;
+  size: number;
+}
+
+interface TimelineDatum {
+  row: string;
+  operatorFull: string;
+  subtask: number;
+  phase: PhaseKey;
+  phaseLabel: string;
+  range: [number, number];
+  durationMs: number;
+  unaligned: boolean;
+  outlier: boolean;
+  aborted: boolean;
+  stateSize: number;
+  checkpointedSize: number;
+  totalDuration: number;
+}
+
+const STRIP_COLOR: Record<StripDatum['status'], string> = {
+  COMPLETED: '#52c41a',
+  SAVEPOINT: '#722ed1',
+  IN_PROGRESS: '#faad14',
+  FAILED: '#f5222d'
+};
+
+const PHASE_COLOR: Record<PhaseKey, string> = {
+  start_delay: '#b8c0cc',
+  alignment: '#91caff',
+  sync: '#fa8c16',
+  async: '#52c41a'
+};
+
+const PHASE_LABEL: Record<PhaseKey, string> = {
+  start_delay: 'start_delay',
+  alignment: 'alignment',
+  sync: 'sync',
+  async: 'async'
+};
+
+const OPERATOR_NAME_MAX = 60;
+
+// Local HH:MM:SS.mmm — matches the header's DatePipe default (browser timezone).
+function formatWallClock(epochMs: number): string {
+  const d = new Date(epochMs);
+  const pad = (n: number, len = 2): string => String(n).padStart(len, '0');
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}.${pad(d.getMilliseconds(), 3)}`;
+}
+
+function buildTimelineTicks(min: number, max: number, target = 5): number[] {
+  const span = Math.max(max - min, 1);
+  const niceSteps = [1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000, 30000, 60000];
+  const desired = span / target;
+  const step = niceSteps.find(s => s >= desired) ?? span;
+  const ticks: number[] = [];
+  for (let t = min; t <= max + 0.5; t += step) {
+    ticks.push(t);
+  }
+  if (ticks[ticks.length - 1] < max) {
+    ticks.push(max);
+  }
+  return ticks;
+}
+
+@Component({
+  selector: 'flink-job-checkpoints-timeline',
+  templateUrl: './job-checkpoints-timeline.component.html',
+  styleUrls: ['./job-checkpoints-timeline.component.less'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    NgIf,
+    DatePipe,
+    HumanizeDurationPipe,
+    HumanizeBytesPipe,
+    NzAlertModule,
+    NzEmptyModule,
+    NzSpinModule,
+    NzToolTipModule
+  ]
+})
+export class JobCheckpointsTimelineComponent implements AfterViewInit, OnChanges, OnDestroy {
+  @Input() public jobId: string;
+  @Input() public vertices: VerticesItem[] = [];
+  @Input() public history: CheckpointHistory[] = [];
+  @Input() public config?: CheckpointConfig;
+
+  @ViewChild('stripContainer', { static: true }) private readonly stripContainer: ElementRef<HTMLDivElement>;
+  @ViewChild('timelineContainer', { static: true }) private readonly timelineContainer: ElementRef<HTMLDivElement>;
+
+  public selected?: StripDatum;
+  public loadingTimeline = false;
+  public timelineEmpty = false;
+  public loadFailed = false;
+  public failedVertexCount = 0;
+  public requestedVertexCount = 0;
+
+  // Diverges from @Input once polling starts feeding live updates.
+  private currentHistory: CheckpointHistory[] = [];
+  public userPinned = false;
+  private stripChart?: Chart;
+  private timelineChart?: Chart;
+  private resizeObserver?: ResizeObserver;
+  private readonly destroy$ = new Subject<void>();
+  private readonly loadTimeline$ = new Subject<StripDatum>();
+  // Completed-checkpoint stats are immutable; memoize by id for instant re-selects.
+  private readonly detailsCache = new Map<number, Record<string, CheckpointSubTask | null>>();
+  private readonly visible$ = new BehaviorSubject<boolean>(false);
+  private static readonly POLL_MIN_MS = 1500;
+  private static readonly POLL_MAX_MS = 15000;
+  private static readonly STRIP_MAX_BARS = 60;
+  private static readonly DETAILS_CACHE_MAX = 100;
+  // Flink sends Long.MAX_VALUE (well above MAX_SAFE_INTEGER) when periodic checkpointing is disabled.
+  private static readonly DISABLED_INTERVAL_THRESHOLD = Number.MAX_SAFE_INTEGER;
+  private static readonly TIMELINE_ROW_HEIGHT = 22;
+  private static readonly TIMELINE_HEIGHT_BASE = 80;
+  private static readonly TIMELINE_HEIGHT_MIN = 160;
+  private static readonly LABEL_CHAR_WIDTH = 7;
+  private static readonly LABEL_PADDING_BUFFER = 24;
+  private static readonly LABEL_PADDING_MIN = 260;
+  private static readonly LABEL_PADDING_MAX = 520;
+
+  private readonly humanizeBytesPipe = new HumanizeBytesPipe();
+  private readonly humanizeDurationPipe = new HumanizeDurationPipe();
+
+  constructor(private readonly jobService: JobService, private readonly cdr: ChangeDetectorRef) {}
+
+  public ngAfterViewInit(): void {
+    this.currentHistory = this.history || [];
+    this.renderStrip();
+    this.subscribeTimelineLoads();
+    if (this.currentHistory.length > 0) {
+      this.selectInternal(this.toStripDatum(this.currentHistory[0]), false);
+    }
+    this.startPolling();
+    // G2 locks autoFit at construction; re-fit + resume polling once width is real.
+    this.visible$.next(this.stripContainer.nativeElement.clientWidth > 0);
+    if (typeof ResizeObserver !== 'undefined') {
+      this.resizeObserver = new ResizeObserver(() => {
+        const stripVisible = this.stripContainer.nativeElement.clientWidth > 0;
+        if (this.stripChart && stripVisible) {
+          this.stripChart.forceFit();
+        }
+        if (this.timelineChart && this.timelineContainer.nativeElement.clientWidth > 0) {
+          this.timelineChart.forceFit();
+        }
+        this.visible$.next(stripVisible);
+      });
+      this.resizeObserver.observe(this.stripContainer.nativeElement);
+      this.resizeObserver.observe(this.timelineContainer.nativeElement);
+    }
+  }
+
+  public ngOnChanges(changes: SimpleChanges): void {
+    if (!this.stripContainer || !this.stripContainer.nativeElement) {
+      return;
+    }
+    if (changes['jobId'] && !changes['jobId'].firstChange) {
+      this.userPinned = false;
+      this.selected = undefined;
+      this.currentHistory = [];
+      this.clearTimeline();
+      this.renderStrip();
+    }
+    if (changes['history']) {
+      this.applyHistory(this.history || []);
+    }
+    if (changes['vertices'] && !changes['vertices'].firstChange && this.selected) {
+      this.loadTimeline(this.selected);
+    }
+  }
+
+  public ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+    this.resizeObserver?.disconnect();
+    this.stripChart?.destroy();
+    this.timelineChart?.destroy();
+  }
+
+  private toStripDatum(h: CheckpointHistory): StripDatum {
+    const status: StripDatum['status'] = h.is_savepoint
+      ? 'SAVEPOINT'
+      : h.status === 'FAILED'
+      ? 'FAILED'
+      : h.status === 'IN_PROGRESS'
+      ? 'IN_PROGRESS'
+      : 'COMPLETED';
+    return {
+      id: h.id,
+      idLabel: String(h.id),
+      duration: Math.max(h.end_to_end_duration || 0, 0),
+      status,
+      rawStatus: h.status,
+      isSavepoint: h.is_savepoint,
+      triggered: h.trigger_timestamp,
+      acked: `${h.num_acknowledged_subtasks}/${h.num_subtasks}`,
+      size: h.state_size
+    };
+  }
+
+  private renderStrip(): void {
+    const data = (this.currentHistory || [])
+      .slice(0, JobCheckpointsTimelineComponent.STRIP_MAX_BARS)
+      .map(h => this.toStripDatum(h))
+      .reverse();
+
+    if (!this.stripChart) {
+      this.stripChart = new G2.Chart({
+        container: this.stripContainer.nativeElement,
+        autoFit: true,
+        height: 110,
+        padding: [16, 16, 36, 56]
+      });
+      this.stripChart.animate(false);
+      this.stripChart.legend(false);
+      this.stripChart
+        .interval()
+        .position('idLabel*duration')
+        .color('status', (s: string) => STRIP_COLOR[s as StripDatum['status']] || '#bfbfbf')
+        .size(18)
+        .style('idLabel', (idLabel: string) => {
+          const isPinned = this.userPinned && this.selected?.idLabel === idLabel;
+          return isPinned ? { stroke: '#1890ff', lineWidth: 2.5 } : { stroke: 'transparent', lineWidth: 0 };
+        })
+        .tooltip('idLabel*duration*acked*rawStatus', (idLabel, duration, acked, rawStatus) => ({
+          name: `#${idLabel}`,
+          value: `${rawStatus} · ${this.humanizeDurationPipe.transform(duration)} · acked ${acked}`
+        }));
+      this.stripChart.tooltip({
+        showTitle: false,
+        showMarkers: false
+      });
+      this.stripChart.on('element:click', (ev: { data?: { data?: StripDatum } }) => {
+        const datum = ev?.data?.data;
+        if (datum) {
+          this.select(datum);
+        }
+      });
+    }
+
+    this.stripChart.scale({
+      idLabel: { type: 'cat', values: data.map(d => d.idLabel) },
+      duration: { alias: 'ms', nice: true, min: 0 }
+    });
+    this.stripChart.axis('idLabel', { title: null, label: { autoHide: true, autoRotate: false } });
+    this.stripChart.axis('duration', { title: null });
+    this.stripChart.data(data);
+    this.stripChart.render();
+  }
+
+  public select(datum: StripDatum): void {
+    // Clicking the already-pinned bar resumes auto-follow.
+    if (this.userPinned && this.selected && this.selected.id === datum.id) {
+      this.followNewest();
+      return;
+    }
+    this.selectInternal(datum, true);
+  }
+
+  public followNewest(): void {
+    this.userPinned = false;
+    if (this.currentHistory.length > 0) {
+      this.selectInternal(this.toStripDatum(this.currentHistory[0]), false);
+    } else {
+      this.cdr.markForCheck();
+    }
+  }
+
+  private selectInternal(datum: StripDatum, pinned: boolean): void {
+    this.selected = datum;
+    if (pinned) {
+      this.userPinned = true;
+    }
+    this.cdr.markForCheck();
+    this.renderStrip();
+    this.loadTimeline(datum);
+  }
+
+  private applyHistory(next: CheckpointHistory[]): void {
+    const prevNewestId = this.currentHistory.length > 0 ? this.currentHistory[0].id : -1;
+    const nextNewestId = next.length > 0 ? next[0].id : -1;
+    this.currentHistory = next;
+    this.renderStrip();
+
+    if (next.length === 0) {
+      this.selected = undefined;
+      this.clearTimeline();
+      this.cdr.markForCheck();
+      return;
+    }
+
+    // Frozen while pinned; still markForCheck so the rotated-out note updates on poll.
+    if (this.userPinned) {
+      this.cdr.markForCheck();
+      return;
+    }
+
+    if (nextNewestId !== prevNewestId) {
+      this.selectInternal(this.toStripDatum(next[0]), false);
+    }
+  }
+
+  private startPolling(): void {
+    this.visible$
+      .pipe(
+        distinctUntilChanged(),
+        switchMap(visible =>
+          visible
+            ? defer(() =>
+                this.jobId
+                  ? this.jobService.loadCheckpointStats(this.jobId).pipe(catchError(() => of(undefined)))
+                  : of(undefined)
+              ).pipe(repeat({ delay: () => timer(this.computePollDelayMs()) }))
+            : EMPTY
+        ),
+        takeUntil(this.destroy$)
+      )
+      .subscribe(stats => {
+        if (!stats) {
+          return;
+        }
+        this.applyHistory(stats.history || []);
+      });
+  }
+
+  private computePollDelayMs(): number {
+    const interval = this.config?.interval;
+    if (
+      interval !== undefined &&
+      interval > 0 &&
+      interval < JobCheckpointsTimelineComponent.DISABLED_INTERVAL_THRESHOLD
+    ) {
+      return Math.max(
+        JobCheckpointsTimelineComponent.POLL_MIN_MS,
+        Math.min(interval, JobCheckpointsTimelineComponent.POLL_MAX_MS)
+      );
+    }
+    return JobCheckpointsTimelineComponent.POLL_MAX_MS;
+  }
+
+  private loadTimeline(datum: StripDatum): void {
+    if (!this.jobId || this.vertices.length === 0) {
+      this.showEmptyTimeline(false);
+      return;
+    }
+    this.loadingTimeline = true;
+    this.timelineEmpty = false;
+    this.loadFailed = false;
+    this.failedVertexCount = 0;
+    this.cdr.markForCheck();
+    this.loadTimeline$.next(datum);
+  }
+
+  private cacheDetails(datum: StripDatum, perVertex: Record<string, CheckpointSubTask | null>): void {
+    if (datum.status === 'IN_PROGRESS') {
+      return; // in-progress stats still change; only cache terminal checkpoints
+    }
+    this.detailsCache.set(datum.id, perVertex);
+    // Evict oldest (Map keeps insertion order).
+    while (this.detailsCache.size > JobCheckpointsTimelineComponent.DETAILS_CACHE_MAX) {
+      const oldest = this.detailsCache.keys().next().value;
+      if (oldest === undefined) {
+        break;
+      }
+      this.detailsCache.delete(oldest);
+    }
+  }
+
+  private subscribeTimelineLoads(): void {
+    this.loadTimeline$
+      .pipe(
+        switchMap(datum => {
+          const cached = this.detailsCache.get(datum.id);
+          if (cached) {
+            return of({
+              datum,
+              perVertex: cached,
+              failed: false,
+              failedCount: 0,
+              requestedCount: this.vertices.length
+            });
+          }
+          const vertexIds = this.vertices.map(v => v.id);
+          const requestedCount = vertexIds.length;
+          return this.jobService.loadCheckpointAllSubtaskDetails(this.jobId, datum.id, vertexIds).pipe(
+            map(perVertex => {
+              const succeeded = Object.values(perVertex).filter(v => v !== null).length;
+              const failedCount = requestedCount - succeeded;
+              if (failedCount === 0) {
+                this.cacheDetails(datum, perVertex);
+              }
+              return {
+                datum,
+                perVertex,
+                failed: requestedCount > 0 && succeeded === 0,
+                failedCount,
+                requestedCount
+              };
+            }),
+            catchError(() =>
+              of({
+                datum,
+                perVertex: {} as Record<string, CheckpointSubTask | null>,
+                failed: true,
+                failedCount: requestedCount,
+                requestedCount
+              })
+            )
+          );
+        }),
+        takeUntil(this.destroy$)
+      )
+      .subscribe(({ datum, perVertex, failed, failedCount, requestedCount }) => {
+        this.loadingTimeline = false;
+        if (failed) {
+          this.showEmptyTimeline(true);
+          return;
+        }
+        this.loadFailed = false;
+        this.failedVertexCount = failedCount;
+        this.requestedVertexCount = requestedCount;
+        this.renderTimeline(datum, perVertex);
+      });
+  }
+
+  private buildTimelineRows(
+    datum: StripDatum,
+    perVertex: Record<string, CheckpointSubTask | null>
+  ): { rows: TimelineDatum[]; rowOrder: string[] } {
+    const base = datum.triggered;
+    const durations: number[] = [];
+    const grouped: TimelineDatum[][] = [];
+
+    for (const vertex of this.vertices) {
+      const cp = perVertex[vertex.id];
+      if (!cp || !cp.subtasks) {
+        continue;
+      }
+      const opNameFull = (vertex.name || '').replace(/\s+/g, ' ').trim();
+      const opName = shortenOperatorName(vertex.name);
+      const items: TimelineDatum[] = [];
+
+      for (const s of cp.subtasks) {
+        if (!isCompletedSubtask(s)) {
+          continue;
+        }
+        const completed = s;
+        const startDelay = Math.max(completed.start_delay || 0, 0);
+        const alignment = Math.max(completed.alignment.duration || 0, 0);
+        const sync = Math.max(completed.checkpoint.sync || 0, 0);
+        const asyncMs = Math.max(completed.checkpoint.async || 0, 0);
+        const total = startDelay + alignment + sync + asyncMs;
+        durations.push(total);
+
+        const row = `${opName} #${completed.index}`;
+        const segs: Array<[PhaseKey, number]> = [
+          ['start_delay', startDelay],
+          ['alignment', alignment],
+          ['sync', sync],
+          ['async', asyncMs]
+        ];
+        let cursor = 0;
+        for (const [phase, ms] of segs) {
+          if (ms <= 0) {
+            cursor += ms;
+            continue;
+          }
+          items.push({
+            row,
+            operatorFull: opNameFull,
+            subtask: completed.index,
+            phase,
+            phaseLabel:
+              phase === 'alignment' && completed.unaligned_checkpoint
+                ? `${PHASE_LABEL[phase]} (unaligned)`
+                : PHASE_LABEL[phase],
+            range: [base + cursor, base + cursor + ms],
+            durationMs: ms,
+            unaligned: !!completed.unaligned_checkpoint,
+            outlier: false,
+            aborted: !!completed.aborted,
+            stateSize: completed.state_size,
+            checkpointedSize: completed.checkpointed_size,
+            totalDuration: total
+          });
+          cursor += ms;
+        }
+      }
+
+      if (items.length > 0) {
+        grouped.push(items);
+      }
+    }
+
+    if (grouped.length === 0) {
+      return { rows: [], rowOrder: [] };
+    }
+
+    // max(p95, 1.5×median): p95 alone over-marks small samples.
+    const median = percentile(durations, 0.5);
+    const p95 = percentile(durations, 0.95);
+    const outlierThreshold = Math.max(p95, median * 1.5);
+
+    const rows: TimelineDatum[] = [];
+    for (const group of grouped) {
+      group.sort((a, b) => b.totalDuration - a.totalDuration || a.subtask - b.subtask);
+      for (const item of group) {
+        if (item.totalDuration >= outlierThreshold || item.aborted) {
+          item.outlier = true;
+        }
+      }
+      rows.push(...group);
+    }
+
+    const rowOrder: string[] = [];
+    const seen = new Set<string>();
+    for (const r of rows) {
+      if (!seen.has(r.row)) {
+        seen.add(r.row);
+        rowOrder.push(r.row);
+      }
+    }
+
+    return { rows, rowOrder };
+  }
+
+  private renderTimeline(datum: StripDatum, perVertex: Record<string, CheckpointSubTask | null>): void {
+    const { rows, rowOrder } = this.buildTimelineRows(datum, perVertex);
+    if (rowOrder.length === 0) {
+      this.showEmptyTimeline(false);
+      return;
+    }
+    this.timelineEmpty = false;
+    this.cdr.markForCheck();
+
+    const C = JobCheckpointsTimelineComponent;
+    const chartHeight = Math.max(
+      rowOrder.length * C.TIMELINE_ROW_HEIGHT + C.TIMELINE_HEIGHT_BASE,
+      C.TIMELINE_HEIGHT_MIN
+    );
+    // Pad left to the longest label so G2 won't re-clip it.
+    const longestLabel = rowOrder.reduce((m, s) => Math.max(m, s.length), 0);
+    const leftPadding = Math.min(
+      C.LABEL_PADDING_MAX,
+      Math.max(C.LABEL_PADDING_MIN, longestLabel * C.LABEL_CHAR_WIDTH + C.LABEL_PADDING_BUFFER)
+    );
+
+    this.timelineChart?.destroy();
+    this.timelineChart = new G2.Chart({
+      container: this.timelineContainer.nativeElement,
+      autoFit: true,
+      height: chartHeight,
+      padding: [24, 32, 48, leftPadding],
+      // SVG so axis labels can host <title> tooltips; canvas has no DOM.
+      renderer: 'svg'
+    });
+    this.timelineChart.animate(false);
+    this.timelineChart.legend(false);
+    this.timelineChart.coordinate('rect').transpose().scale(1, -1);
+    const base = datum.triggered;
+    const maxTotal = rows.reduce((m, r) => Math.max(m, r.totalDuration), 0);
+    const scaleMin = base;
+    const scaleMax = base + Math.max(maxTotal, 1);
+    this.timelineChart.scale({
+      row: { type: 'cat', values: rowOrder },
+      range: {
+        alias: 'time',
+        nice: false,
+        min: scaleMin,
+        max: scaleMax,
+        ticks: buildTimelineTicks(scaleMin, scaleMax)
+      },
+      phase: { values: ['start_delay', 'alignment', 'sync', 'async'] }
+    });
+    this.timelineChart.axis('range', {
+      title: { text: 'time' },
+      label: { formatter: (v: string) => formatWallClock(Number(v)) }
+    });
+    this.timelineChart.axis('row', {
+      title: null,
+      label: {
+        autoHide: false,
+        autoRotate: false,
+        style: { fill: '#262626' }
+      }
+    });
+    this.timelineChart
+      .interval()
+      .position('row*range')
+      .color('phase', (p: string) => PHASE_COLOR[p as PhaseKey])
+      .style('outlier*unaligned*phase', (outlier: boolean, unaligned: boolean, phase: PhaseKey) => {
+        const style: { stroke?: string; lineWidth?: number; lineDash?: number[]; fillOpacity?: number } = {};
+        if (outlier) {
+          style.stroke = '#f5222d';
+          style.lineWidth = 1.5;
+          style.lineDash = [3, 2];
+        }
+        if (phase === 'alignment' && unaligned) {
+          style.fillOpacity = 0.55;
+        }
+        return style;
+      })
+      .tooltip(
+        'phaseLabel*durationMs*totalDuration*stateSize*checkpointedSize*operatorFull*subtask',
+        (phaseLabel, ms, total, state, checkpointed, operatorFull, subtask) => ({
+          name: `${operatorFull} #${subtask} · ${phaseLabel}`,
+          value:
+            `${ms}ms (total ${total}ms, state ${this.humanizeBytesPipe.transform(state)},` +
+            ` checkpointed ${this.humanizeBytesPipe.transform(checkpointed)})`
+        })
+      );
+    this.timelineChart.tooltip({ shared: false, showMarkers: false });
+    this.timelineChart.data(rows);
+    this.timelineChart.render();
+    // Defer so labels exist in the DOM.
+    setTimeout(() => this.decorateRowLabelTooltips(rows), 0);
+  }
+
+  private decorateRowLabelTooltips(rows: TimelineDatum[]): void {
+    const container = this.timelineContainer?.nativeElement;
+    if (!container) {
+      return;
+    }
+    const svg = container.querySelector('svg');
+    if (!svg) {
+      return;
+    }
+    const fullByShort = new Map<string, string>();
+    for (const row of rows) {
+      if (!fullByShort.has(row.row)) {
+        fullByShort.set(row.row, `${row.operatorFull} #${row.subtask}`);
+      }
+    }
+    const textNodes = svg.querySelectorAll('text');
+    textNodes.forEach(text => {
+      const label = (text.textContent || '').trim();
+      const full = fullByShort.get(label);
+      if (!full) {
+        return;
+      }
+      const existing = text.querySelector(':scope > title');
+      if (existing) {
+        existing.textContent = full;
+        return;
+      }
+      const title = document.createElementNS('http://www.w3.org/2000/svg', 'title');
+      title.textContent = full;
+      text.appendChild(title);
+    });
+  }
+
+  private clearTimeline(): void {
+    this.timelineChart?.destroy();
+    this.timelineChart = undefined;
+    this.loadingTimeline = false;
+    this.timelineEmpty = false;
+    this.loadFailed = false;
+  }
+
+  private showEmptyTimeline(failed: boolean): void {
+    this.clearTimeline();
+    this.timelineEmpty = true;
+    this.loadFailed = failed;
+    this.failedVertexCount = 0;
+    this.requestedVertexCount = 0;
+    this.cdr.markForCheck();
+  }
+
+  public get selectedRotatedOut(): boolean {
+    return this.userPinned && !!this.selected && !this.currentHistory.some(h => h.id === this.selected!.id);
+  }
+
+  public get partialFailureMessage(): string {
+    const operators = this.failedVertexCount === 1 ? 'operator' : 'operators';
+    return `${this.failedVertexCount} of ${this.requestedVertexCount} ${operators} failed to load — the timeline below is incomplete.`;
+  }
+}
+
+// Backend tags completed subtasks "completed" (incl. aborted) and others "pending_or_failed".
+function isCompletedSubtask(
+  s: SubTaskCheckpointStatisticsItem
+): s is SubTaskCheckpointStatisticsItem & CompletedSubTaskCheckpointStatistics {
+  return s.status === 'completed';
+}
+
+function percentile(values: number[], p: number): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const idx = Math.min(sorted.length - 1, Math.max(0, Math.floor((sorted.length - 1) * p)));
+  return sorted[idx];
+}
+
+function shortenOperatorName(name: string): string {
+  if (!name) {
+    return '';
+  }
+  const compact = name.replace(/\s+/g, ' ').trim();
+  return compact.length <= OPERATOR_NAME_MAX ? compact : `${compact.slice(0, OPERATOR_NAME_MAX - 3)}...`;
+}

--- a/flink-runtime-web/web-dashboard/src/app/services/job.service.ts
+++ b/flink-runtime-web/web-dashboard/src/app/services/job.service.ts
@@ -18,7 +18,7 @@
 
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { EMPTY, forkJoin, mergeMap, Observable } from 'rxjs';
+import { EMPTY, forkJoin, mergeMap, Observable, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 
 import {
@@ -181,6 +181,23 @@ export class JobService {
     return this.httpClient.get<CheckpointSubTask>(
       `${this.configService.BASE_URL}/jobs/${jobId}/checkpoints/details/${checkPointId}/subtasks/${vertexId}`
     );
+  }
+
+  public loadCheckpointAllSubtaskDetails(
+    jobId: string,
+    checkPointId: number,
+    vertexIds: string[]
+  ): Observable<Record<string, CheckpointSubTask | null>> {
+    if (vertexIds.length === 0) {
+      return of({} as Record<string, CheckpointSubTask | null>);
+    }
+    const requests = vertexIds.map(vid =>
+      this.loadCheckpointSubtaskDetails(jobId, checkPointId, vid).pipe(
+        catchError(() => of<CheckpointSubTask | null>(null)),
+        map(result => ({ [vid]: result }))
+      )
+    );
+    return forkJoin(requests).pipe(map(parts => Object.assign({}, ...parts)));
   }
 
   public loadRescalesOverview(jobId: string): Observable<RescalesOverview> {


### PR DESCRIPTION
## What is the purpose of the change

Adds a Timeline view to the job's Checkpoints tab so operators can see at a glance *why* a checkpoint was slow. The same information already exists in the per-subtask table, but it's spread across many rows of numbers; this view makes stragglers and stuck phases visually obvious instead of requiring a manual scan.

## Brief change log

- New **Timeline** tab on the job Checkpoints page (frontend only, no backend changes)
- **Recent Checkpoints strip**: last 60 checkpoints as colored bars (completed / savepoint / in-progress / failed); click a bar to drill in
- **Per-checkpoint timeline**: one row per subtask with stacked bars for the four checkpoint phases, plotted against wall-clock time on the x-axis and sorted by duration so the slowest subtasks rise to the top
- **Pin / Follow newest** toggle so a chosen checkpoint stays put for analysis
- Auto-refresh aligned to checkpoint cadence; polling pauses when the Timeline view is hidden (you're on another Checkpoints sub-tab) and stops when you leave the Checkpoints page
- Suppresses the global error toast for the per-checkpoint details endpoint while a checkpoint is still in progress (it returns 404 until ack), so users don't see spurious notifications

## Verifying this change

This change is frontend-only and is verified manually:

- Run a Flink cluster with a streaming job that has periodic checkpoints
- Open the job's **Checkpoints** tab and switch to the new **Timeline** view
- Confirm the recent-checkpoint strip populates and updates as new checkpoints complete
- Click a bar — the per-subtask timeline renders for that checkpoint and the view stays pinned
- Click **Follow newest** — auto-tracking resumes
- Trigger a savepoint and a failed checkpoint and confirm they render with the right colors
- Switch to another Checkpoints sub-tab (e.g. History) and confirm polling pauses; switch back to Timeline and confirm it resumes

<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/1ece7261-0e1b-4e15-a2d6-1a654605becc" />

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no (uses `@antv/g2`, already a project dependency)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not applicable (UI-only feature, discoverable from the Checkpoints tab)

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Code)

<!--
Generated-by: Claude Code
-->


