### PR TITLE
[FLINK-38233][table] Adds support to StreamNonDeterministicUpdatePlanVisitor for PTFs

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/optimize/StreamNonDeterministicUpdatePlanVisitor.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/optimize/StreamNonDeterministicUpdatePlanVisitor.java
@@ -974,9 +974,9 @@ public class StreamNonDeterministicUpdatePlanVisitor {
         // Concern 1: PTF function itself is non-deterministic.
         // requireDeterminism is the set of PTF output columns downstream requires to be
         // deterministic (for correct retract matching). All PTF output columns are assumed to
-        // come from PTF's own computation — there are pass-through input columns potentially, but
-        // they are ignored for now. If the PTF is non-deterministic and any of those columns are
-        // required, we cannot satisfy the requirement.
+        // come from PTF's computation — there are pass-through input columns potentially, but
+        // they are not considered specially for now. If the PTF is non-deterministic and any of
+        // those columns are required, we cannot satisfy the requirement.
         if (!requireDeterminism.isEmpty()) {
             final Optional<String> ndCall = FlinkRexUtil.getNonDeterministicCallName(call);
             if (ndCall.isPresent()) {
@@ -997,17 +997,11 @@ public class StreamNonDeterministicUpdatePlanVisitor {
         // input columns need to be deterministic. requireDeterminism is therefore ignored here.
         //
         // Instead, the check is derived per-argument from the argument's input traits:
-        //   - No REQUIRE_UPDATE_BEFORE: the PTF receives updates without an old-row companion;
-        //     retracts are routed by partition key, so only partition key columns must be
-        //     deterministic.
+        //   - No REQUIRE_UPDATE_BEFORE: Retracts are routed by partition key, so only partition
+        //     key columns must be deterministic.
         //   - Has REQUIRE_UPDATE_BEFORE: the PTF explicitly requests the old row as UPDATE_BEFORE
         //     for correct state management; that row must exactly match the row previously
         //     processed, so all input columns must be deterministic.
-        //
-        // Crucially, this is based on the input argument's traits, NOT the PTF's output changelog
-        // mode. A PTF could output insert-only rows while still requiring UPDATE_BEFORE in its
-        // input (e.g., it processes retracts internally but only emits new events). The output
-        // mode does not determine what the PTF needs from its inputs.
         final List<Ord<StaticArgument>> providedInputArgs =
                 StreamPhysicalProcessTableFunction.getProvidedInputArgs(call);
         final List<RexNode> operands = call.getOperands();

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/optimize/StreamNonDeterministicUpdatePlanVisitor.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/optimize/StreamNonDeterministicUpdatePlanVisitor.java
@@ -971,12 +971,9 @@ public class StreamNonDeterministicUpdatePlanVisitor {
             final ImmutableBitSet requireDeterminism) {
         final RexCall call = ptf.getCall();
 
-        // Concern 1: PTF function itself is non-deterministic.
-        // requireDeterminism is the set of PTF output columns downstream requires to be
-        // deterministic (for correct retract matching). All PTF output columns are assumed to
-        // come from PTF's computation — there are pass-through input columns potentially, but
-        // they are not considered specially for now. If the PTF is non-deterministic and any of
-        // those columns are required, we cannot satisfy the requirement.
+  // Concern 1: PTF function itself is non-deterministic and downstream nodes                                                                                                                                                                
+  // require determinism. PTFs can have pass-through input columns, but they                                                                                                                                                                 
+  // are not considered specially for now.
         if (!requireDeterminism.isEmpty()) {
             final Optional<String> ndCall = FlinkRexUtil.getNonDeterministicCallName(call);
             if (ndCall.isPresent()) {
@@ -986,8 +983,8 @@ public class StreamNonDeterministicUpdatePlanVisitor {
         }
 
         if (inputInsertOnly(ptf)) {
-            // Insert-only input: the PTF manages retract correctness internally via its own
-            // state, so no requirement is pushed to inputs.
+            // No retracts arrive at the PTF input, so input-column determinism does                                                                                                                                                               
+           // not affect retract correctness
             return transmitDeterminismRequirement(ptf, NO_REQUIRED_DETERMINISM);
         }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/optimize/StreamNonDeterministicUpdatePlanVisitor.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/optimize/StreamNonDeterministicUpdatePlanVisitor.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.connector.source.abilities.SupportsReadingMetadata
 import org.apache.flink.table.legacy.api.TableSchema;
 import org.apache.flink.table.legacy.api.constraints.UniqueConstraint;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.planner.calcite.RexTableArgCall;
 import org.apache.flink.table.planner.connectors.DynamicSourceUtils;
 import org.apache.flink.table.planner.plan.metadata.FlinkRelMetadataQuery;
 import org.apache.flink.table.planner.plan.nodes.exec.spec.OverSpec;
@@ -48,6 +49,7 @@ import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalM
 import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalMiniBatchAssigner;
 import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalMultiJoin;
 import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalOverAggregateBase;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalProcessTableFunction;
 import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalRank;
 import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalRel;
 import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalSink;
@@ -75,12 +77,16 @@ import org.apache.flink.table.planner.utils.ShortcutUtils;
 import org.apache.flink.table.runtime.operators.join.FlinkJoinType;
 import org.apache.flink.table.runtime.operators.join.stream.utils.JoinInputSideSpec;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.inference.StaticArgument;
+import org.apache.flink.table.types.inference.StaticArgumentTrait;
 import org.apache.flink.types.RowKind;
 
+import org.apache.calcite.linq4j.Ord;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexProgram;
 import org.apache.calcite.sql.SqlExplainLevel;
@@ -218,6 +224,8 @@ public class StreamNonDeterministicUpdatePlanVisitor {
             return transmitDeterminismRequirement(rel, requireDeterminism);
         } else if (rel instanceof StreamPhysicalMatch) {
             return visitMatch((StreamPhysicalMatch) rel, requireDeterminism);
+        } else if (rel instanceof StreamPhysicalProcessTableFunction) {
+            return visitPtf((StreamPhysicalProcessTableFunction) rel, requireDeterminism);
         } else {
             throw new UnsupportedOperationException(
                     String.format(
@@ -956,6 +964,77 @@ public class StreamNonDeterministicUpdatePlanVisitor {
             inputRequireDeterminism = NO_REQUIRED_DETERMINISM;
         }
         return transmitDeterminismRequirement(rel, inputRequireDeterminism);
+    }
+
+    private StreamPhysicalRel visitPtf(
+            final StreamPhysicalProcessTableFunction ptf,
+            final ImmutableBitSet requireDeterminism) {
+        final RexCall call = ptf.getCall();
+
+        // Concern 1: PTF function itself is non-deterministic.
+        // requireDeterminism is the set of PTF output columns downstream requires to be
+        // deterministic (for correct retract matching). All PTF output columns are assumed to
+        // come from PTF's own computation — there are pass-through input columns potentially, but
+        // they are ignored for now. If the PTF is non-deterministic and any of those columns are
+        // required, we cannot satisfy the requirement.
+        if (!requireDeterminism.isEmpty()) {
+            final Optional<String> ndCall = FlinkRexUtil.getNonDeterministicCallName(call);
+            if (ndCall.isPresent()) {
+                throwNonDeterministicColumnsError(
+                        requireDeterminism.toList(), ptf.getRowType(), ptf, null, ndCall);
+            }
+        }
+
+        if (inputInsertOnly(ptf)) {
+            // Insert-only input: the PTF manages retract correctness internally via its own
+            // state, so no requirement is pushed to inputs.
+            return transmitDeterminismRequirement(ptf, NO_REQUIRED_DETERMINISM);
+        }
+
+        // Concern 2: non-deterministic input columns.
+        // The PTF is a black box: there is no way to project downstream column requirements
+        // (requireDeterminism) back through the PTF's internal computation to determine which
+        // input columns need to be deterministic. requireDeterminism is therefore ignored here.
+        //
+        // Instead, the check is derived per-argument from the argument's input traits:
+        //   - No REQUIRE_UPDATE_BEFORE: the PTF receives updates without an old-row companion;
+        //     retracts are routed by partition key, so only partition key columns must be
+        //     deterministic.
+        //   - Has REQUIRE_UPDATE_BEFORE: the PTF explicitly requests the old row as UPDATE_BEFORE
+        //     for correct state management; that row must exactly match the row previously
+        //     processed, so all input columns must be deterministic.
+        //
+        // Crucially, this is based on the input argument's traits, NOT the PTF's output changelog
+        // mode. A PTF could output insert-only rows while still requiring UPDATE_BEFORE in its
+        // input (e.g., it processes retracts internally but only emits new events). The output
+        // mode does not determine what the PTF needs from its inputs.
+        final List<Ord<StaticArgument>> providedInputArgs =
+                StreamPhysicalProcessTableFunction.getProvidedInputArgs(call);
+        final List<RexNode> operands = call.getOperands();
+
+        final List<RelNode> newInputs = new ArrayList<>();
+        for (int i = 0; i < ptf.getInputs().size(); i++) {
+            final StreamPhysicalRel input = (StreamPhysicalRel) ptf.getInput(i);
+            final StaticArgument staticArg = providedInputArgs.get(i).e;
+            final RexTableArgCall tableArgCall =
+                    (RexTableArgCall) operands.get(providedInputArgs.get(i).i);
+            final ImmutableBitSet inputReq;
+            if (staticArg.is(StaticArgumentTrait.REQUIRE_UPDATE_BEFORE)) {
+                // UPDATE_BEFORE must exactly match the previously processed row — all columns
+                // must be deterministic.
+                inputReq = ImmutableBitSet.range(input.getRowType().getFieldCount());
+            } else {
+                // Retracts are routed by partition key only — only partition key columns must
+                // be deterministic.
+                inputReq =
+                        ImmutableBitSet.of(
+                                Arrays.stream(tableArgCall.getPartitionKeys())
+                                        .boxed()
+                                        .collect(Collectors.toList()));
+            }
+            newInputs.add(visit(input, inputReq));
+        }
+        return (StreamPhysicalRel) ptf.copy(ptf.getTraitSet(), newInputs);
     }
 
     private void checkNonDeterministicRexProgram(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/optimize/StreamNonDeterministicUpdatePlanVisitor.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/optimize/StreamNonDeterministicUpdatePlanVisitor.java
@@ -972,8 +972,7 @@ public class StreamNonDeterministicUpdatePlanVisitor {
         final RexCall call = ptf.getCall();
 
         // Concern 1: PTF function itself is non-deterministic and downstream nodes
-        // require determinism. PTFs can have pass-through input columns, but they
-        // are not considered specially for now.
+        // require determinism.
         if (!requireDeterminism.isEmpty()) {
             final Optional<String> ndCall = FlinkRexUtil.getNonDeterministicCallName(call);
             if (ndCall.isPresent()) {
@@ -992,6 +991,21 @@ public class StreamNonDeterministicUpdatePlanVisitor {
         // The PTF is a black box: there is no way to project downstream column requirements
         // (requireDeterminism) back through the PTF's internal computation to determine which
         // input columns need to be deterministic. requireDeterminism is therefore ignored here.
+        //
+        // A stricter alternative would be to require all input columns to be deterministic
+        // whenever any output column downstream requires it. That avoids the gap described
+        // below but rejects legitimate queries where the PTF does not actually consume the
+        // non-deterministic column, so we keep the lenient behavior.
+        //
+        // Known gap: cases like the one below are not covered today and may produce wrong
+        // results on failover, since the requirement on {@code nb} at the retract sink never
+        // reaches {@code ndFunc(b)} upstream of the PTF.
+        //
+        // <pre>{@code
+        // CREATE VIEW v AS SELECT a, ndFunc(b) AS nb FROM upsert_src;
+        // INSERT INTO retract_sink SELECT * FROM rowPtf(TABLE v);            -- row-semantic
+        // INSERT INTO retract_sink SELECT * FROM setPtf(TABLE v PARTITION BY a); -- set-semantic
+        // }</pre>
         //
         // Note: the physical changelog the PTF receives is not solely determined by the
         // REQUIRE_UPDATE_BEFORE trait. Per the SUPPORT_UPDATES contract, the function receives
@@ -1025,11 +1039,7 @@ public class StreamNonDeterministicUpdatePlanVisitor {
             } else {
                 // The PTF does not consume UB; retract handling is keyed by partition key, so
                 // only partition key columns must be deterministic.
-                inputReq =
-                        ImmutableBitSet.of(
-                                Arrays.stream(tableArgCall.getPartitionKeys())
-                                        .boxed()
-                                        .collect(Collectors.toList()));
+                inputReq = ImmutableBitSet.of(tableArgCall.getPartitionKeys());
             }
             newInputs.add(visit(input, requireDeterminismExcludeUpsertKey(input, inputReq)));
         }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/optimize/StreamNonDeterministicUpdatePlanVisitor.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/optimize/StreamNonDeterministicUpdatePlanVisitor.java
@@ -1015,8 +1015,7 @@ public class StreamNonDeterministicUpdatePlanVisitor {
                 // must be deterministic.
                 inputReq = ImmutableBitSet.range(input.getRowType().getFieldCount());
             } else {
-                // Retracts are routed by partition key only — only partition key columns must
-                // be deterministic.
+                // Inserts, update and deletions are routed by partition key only — thus the partition key columns must be deterministic.
                 inputReq =
                         ImmutableBitSet.of(
                                 Arrays.stream(tableArgCall.getPartitionKeys())

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/optimize/StreamNonDeterministicUpdatePlanVisitor.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/optimize/StreamNonDeterministicUpdatePlanVisitor.java
@@ -971,9 +971,9 @@ public class StreamNonDeterministicUpdatePlanVisitor {
             final ImmutableBitSet requireDeterminism) {
         final RexCall call = ptf.getCall();
 
-  // Concern 1: PTF function itself is non-deterministic and downstream nodes                                                                                                                                                                
-  // require determinism. PTFs can have pass-through input columns, but they                                                                                                                                                                 
-  // are not considered specially for now.
+        // Concern 1: PTF function itself is non-deterministic and downstream nodes
+        // require determinism. PTFs can have pass-through input columns, but they
+        // are not considered specially for now.
         if (!requireDeterminism.isEmpty()) {
             final Optional<String> ndCall = FlinkRexUtil.getNonDeterministicCallName(call);
             if (ndCall.isPresent()) {
@@ -983,8 +983,8 @@ public class StreamNonDeterministicUpdatePlanVisitor {
         }
 
         if (inputInsertOnly(ptf)) {
-            // No retracts arrive at the PTF input, so input-column determinism does                                                                                                                                                               
-           // not affect retract correctness
+            // No retracts arrive at the PTF input, so input-column determinism does
+            // not affect retract correctness
             return transmitDeterminismRequirement(ptf, NO_REQUIRED_DETERMINISM);
         }
 
@@ -993,12 +993,20 @@ public class StreamNonDeterministicUpdatePlanVisitor {
         // (requireDeterminism) back through the PTF's internal computation to determine which
         // input columns need to be deterministic. requireDeterminism is therefore ignored here.
         //
-        // Instead, the check is derived per-argument from the argument's input traits:
-        //   - No REQUIRE_UPDATE_BEFORE: Retracts are routed by partition key, so only partition
-        //     key columns must be deterministic.
-        //   - Has REQUIRE_UPDATE_BEFORE: the PTF explicitly requests the old row as UPDATE_BEFORE
-        //     for correct state management; that row must exactly match the row previously
-        //     processed, so all input columns must be deterministic.
+        // Note: the physical changelog the PTF receives is not solely determined by the
+        // REQUIRE_UPDATE_BEFORE trait. Per the SUPPORT_UPDATES contract, the function receives
+        // {+I,+U,-D} only when the input is upserting on the same key as the partition key;
+        // otherwise it receives full retractions {+I,-U,+U,-D}, including UB messages, even
+        // without REQUIRE_UPDATE_BEFORE. UBs may therefore arrive regardless of the trait.
+        //
+        // What the trait controls is which messages the PTF is contractually allowed to
+        // consume for state management, and that is what drives the determinism requirement:
+        //   - No REQUIRE_UPDATE_BEFORE: the PTF does not consume UBs; retract handling is
+        //     keyed by partition key, so only partition key columns must be deterministic.
+        //     Any non-key columns on an incidentally-delivered UB are not used by the PTF.
+        //   - Has REQUIRE_UPDATE_BEFORE: the PTF explicitly opts in to consuming UB to
+        //     reconstruct the previously processed row; that row must match exactly, so all
+        //     input columns must be deterministic.
         final List<Ord<StaticArgument>> providedInputArgs =
                 StreamPhysicalProcessTableFunction.getProvidedInputArgs(call);
         final List<RexNode> operands = call.getOperands();
@@ -1011,18 +1019,19 @@ public class StreamNonDeterministicUpdatePlanVisitor {
                     (RexTableArgCall) operands.get(providedInputArgs.get(i).i);
             final ImmutableBitSet inputReq;
             if (staticArg.is(StaticArgumentTrait.REQUIRE_UPDATE_BEFORE)) {
-                // UPDATE_BEFORE must exactly match the previously processed row — all columns
-                // must be deterministic.
+                // The PTF consumes UB to reconstruct the previously processed row, which must
+                // match exactly — all input columns must be deterministic.
                 inputReq = ImmutableBitSet.range(input.getRowType().getFieldCount());
             } else {
-                // Inserts, update and deletions are routed by partition key only — thus the partition key columns must be deterministic.
+                // The PTF does not consume UB; retract handling is keyed by partition key, so
+                // only partition key columns must be deterministic.
                 inputReq =
                         ImmutableBitSet.of(
                                 Arrays.stream(tableArgCall.getPartitionKeys())
                                         .boxed()
                                         .collect(Collectors.toList()));
             }
-            newInputs.add(visit(input, inputReq));
+            newInputs.add(visit(input, requireDeterminismExcludeUpsertKey(input, inputReq)));
         }
         return (StreamPhysicalRel) ptf.copy(ptf.getTraitSet(), newInputs);
     }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/QueryOperationTestPrograms.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/QueryOperationTestPrograms.java
@@ -21,7 +21,6 @@ package org.apache.flink.table.api;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.api.config.ExecutionConfigOptions.AsyncOutputMode;
-import org.apache.flink.table.api.config.OptimizerConfigOptions;
 import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.table.operations.QueryOperation;
 import org.apache.flink.table.planner.factories.TestValuesModelFactory;
@@ -1059,11 +1058,6 @@ public class QueryOperationTestPrograms {
 
     public static final TableTestProgram PTF_ROW_SEMANTIC_TABLE =
             TableTestProgram.of("ptf-row-semantic-table", "table with row semantics")
-                    // TODO [FLINK-38233]: Remove this config when PTF support in
-                    //  StreamNonDeterministicUpdatePlanVisitor is added.
-                    .setupConfig(
-                            OptimizerConfigOptions.TABLE_OPTIMIZER_NONDETERMINISTIC_UPDATE_STRATEGY,
-                            OptimizerConfigOptions.NonDeterministicUpdateStrategy.IGNORE)
                     .setupTemporarySystemFunction("f", RowSemanticTableFunction.class)
                     .setupSql(BASIC_VALUES)
                     .setupTableSink(
@@ -1089,11 +1083,6 @@ public class QueryOperationTestPrograms {
 
     static final TableTestProgram PTF_SET_SEMANTIC_TABLE =
             TableTestProgram.of("ptf-set-semantic-table", "verifies SQL serialization")
-                    // TODO [FLINK-38233]: Remove this config when PTF support in
-                    //  StreamNonDeterministicUpdatePlanVisitor is added.
-                    .setupConfig(
-                            OptimizerConfigOptions.TABLE_OPTIMIZER_NONDETERMINISTIC_UPDATE_STRATEGY,
-                            OptimizerConfigOptions.NonDeterministicUpdateStrategy.IGNORE)
                     .setupTemporarySystemFunction("f1", ChainedSendingFunction.class)
                     .setupTemporarySystemFunction("f2", ChainedReceivingFunction.class)
                     .setupTableSource(TIMED_SOURCE)
@@ -1321,11 +1310,6 @@ public class QueryOperationTestPrograms {
 
     static final TableTestProgram PTF_ORDER_BY =
             TableTestProgram.of("ptf-order-by", "verifies SQL serialization with ORDER BY clause")
-                    // TODO [FLINK-38233]: Remove this config when PTF support in
-                    //  StreamNonDeterministicUpdatePlanVisitor is added.
-                    .setupConfig(
-                            OptimizerConfigOptions.TABLE_OPTIMIZER_NONDETERMINISTIC_UPDATE_STRATEGY,
-                            OptimizerConfigOptions.NonDeterministicUpdateStrategy.IGNORE)
                     .setupTemporarySystemFunction("f", SetSemanticTableFunction.class)
                     .setupTableSource(TIMED_SOURCE)
                     .setupTableSink(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionSemanticTests.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionSemanticTests.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.table.planner.plan.nodes.exec.stream;
 
-import org.apache.flink.table.api.TableConfig;
-import org.apache.flink.table.api.config.OptimizerConfigOptions;
 import org.apache.flink.table.planner.plan.nodes.exec.testutils.SemanticTestBase;
 import org.apache.flink.table.test.program.TableTestProgram;
 
@@ -27,16 +25,6 @@ import java.util.List;
 
 /** Semantic tests for {@link StreamExecProcessTableFunction}. */
 public class ProcessTableFunctionSemanticTests extends SemanticTestBase {
-
-    // TODO [FLINK-38233]: Remove this override when PTF support in
-    //  StreamNonDeterministicUpdatePlanVisitor is added.
-    @Override
-    protected void applyDefaultEnvironmentOptions(TableConfig config) {
-        super.applyDefaultEnvironmentOptions(config);
-        config.set(
-                OptimizerConfigOptions.TABLE_OPTIMIZER_NONDETERMINISTIC_UPDATE_STRATEGY,
-                OptimizerConfigOptions.NonDeterministicUpdateStrategy.IGNORE);
-    }
 
     @Override
     public List<TableTestProgram> programs() {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionTestUtils.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionTestUtils.java
@@ -952,6 +952,18 @@ public class ProcessTableFunctionTestUtils {
         }
     }
 
+    /**
+     * Testing function that is itself non-deterministic (isDeterministic() = false). Used to verify
+     * that Concern 1 (PTF own non-determinism) is caught by the NDU visitor when downstream
+     * requires deterministic output columns.
+     */
+    public static class NonDeterministicUpdatingRetractFunction extends UpdatingRetractFunction {
+        @Override
+        public boolean isDeterministic() {
+            return false;
+        }
+    }
+
     /** Testing function. */
     public static class UpdatingUpsertFullDeletesFunction
             extends ChangelogProcessTableFunctionBase {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionTestUtils.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionTestUtils.java
@@ -1006,6 +1006,15 @@ public class ProcessTableFunctionTestUtils {
         }
     }
 
+    /** Row-semantic counterpart of {@link NonDeterministicUpdatingRetractFunction}. */
+    public static class NonDeterministicUpdatingRetractRowSemanticFunction
+            extends UpdatingRetractRowSemanticFunction {
+        @Override
+        public boolean isDeterministic() {
+            return false;
+        }
+    }
+
     /** Testing function. */
     public static class InvalidRowKindFunction extends AppendProcessTableFunctionBase {
         public void eval(@ArgumentHint(ROW_SEMANTIC_TABLE) Row r) {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/NonDeterministicDagTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/NonDeterministicDagTest.scala
@@ -28,6 +28,7 @@ import org.apache.flink.table.data.RowData
 import org.apache.flink.table.legacy.api.TableSchema
 import org.apache.flink.table.planner.JBoolean
 import org.apache.flink.table.planner.expressions.utils.{TestNonDeterministicUdaf, TestNonDeterministicUdf, TestNonDeterministicUdtf}
+import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.{NonDeterministicUpdatingRetractFunction, UpdatingRetractFunction, UpdatingUpsertFunction}
 import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedTableFunctions.StringSplit
 import org.apache.flink.table.planner.utils.{StreamTableTestUtil, TableTestBase}
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
@@ -231,6 +232,39 @@ class NonDeterministicDagTest(nonDeterministicUpdateStrategy: NonDeterministicUp
     util.tableEnv.createTemporaryFunction("ndAggFunc", new TestNonDeterministicUdaf)
     // deterministic table function
     util.tableEnv.createTemporaryFunction("str_split", new StringSplit())
+
+    // PTF functions for NDU changelog tests
+    util.tableEnv.createTemporaryFunction("updatingUpsertFunc", new UpdatingUpsertFunction)
+    util.tableEnv.createTemporaryFunction("updatingRetractFunc", new UpdatingRetractFunction)
+    util.tableEnv.createTemporaryFunction(
+      "nonDeterministicRetractFunc",
+      new NonDeterministicUpdatingRetractFunction)
+
+    // View with ndFunc applied to the partition key column (INT -> INT)
+    util.tableEnv.executeSql("""CREATE VIEW nd_partition_key_src AS
+                               |SELECT ndFunc(a) AS nd_a, b, c, d FROM upsert_src""".stripMargin)
+
+    // View with ndFunc applied to a non-key column (BIGINT -> BIGINT)
+    util.tableEnv.executeSql("""CREATE VIEW nd_col_src AS
+                               |SELECT a, ndFunc(b) AS nd_b, c, d FROM cdc""".stripMargin)
+
+    // Upsert sink: 4 columns (INT, INT, BIGINT, STRING) matching PTF upsert output over INT sources
+    util.tableEnv.executeSql("""CREATE TABLE ptf_upsert_sink (
+                               |  f0 INT, f1 STRING, f2 BIGINT, f3 STRING,
+                               |  PRIMARY KEY (f0) NOT ENFORCED
+                               |) WITH (
+                               |  'connector' = 'values',
+                               |  'sink-insert-only' = 'false',
+                               |  'sink-changelog-mode-enforced' = 'I,UA,D'
+                               |)""".stripMargin)
+
+    // Retract sink: same column types, no primary key
+    util.tableEnv.executeSql("""CREATE TABLE ptf_retract_sink (
+                               |  f0 INT, f1 STRING, f2 BIGINT, f3 STRING
+                               |) WITH (
+                               |  'connector' = 'values',
+                               |  'sink-insert-only' = 'false'
+                               |)""".stripMargin)
   }
 
   @TestTemplate
@@ -1960,6 +1994,95 @@ class NonDeterministicDagTest(nonDeterministicUpdateStrategy: NonDeterministicUp
         ))
       .hasMessageContaining("Match Recognize doesn't support consuming update and delete changes")
       .isInstanceOf[TableException]
+  }
+
+  // ---------------------------------------------------------------------------
+  // PTF changelog NDU tests
+  // ---------------------------------------------------------------------------
+
+  /** Partition key equals the source upsert key — requirement excluded, no NDU error. */
+  @TestTemplate
+  def testPtfUpsertOutputPartitionKeyMatchesUpsertKey(): Unit = {
+    assertThatCode(
+      () =>
+        util.tableEnv.explainSql(
+          "INSERT INTO ptf_upsert_sink" +
+            " SELECT * FROM updatingUpsertFunc(TABLE upsert_src PARTITION BY a)"))
+      .doesNotThrowAnyException()
+  }
+
+  /**
+   * Non-deterministic function on the partition key column — the partition key of the PTF input
+   * must be deterministic for upsert output correctness; expect error only under TRY_RESOLVE.
+   */
+  @TestTemplate
+  def testPtfUpsertOutputNonDeterministicPartitionKey(): Unit = {
+    val callable: ThrowingCallable = () =>
+      util.tableEnv.explainSql(
+        "INSERT INTO ptf_upsert_sink" +
+          " SELECT * FROM updatingUpsertFunc(TABLE nd_partition_key_src PARTITION BY nd_a)")
+    if (tryResolve) {
+      assertThatThrownBy(callable)
+        .hasMessageContaining("non-deterministic function: ndFunc")
+        .isInstanceOf[TableException]
+    } else {
+      assertThatCode(callable).doesNotThrowAnyException()
+    }
+  }
+
+  /** All CDC input columns are deterministic — full-retract output requires no NDU error. */
+  @TestTemplate
+  def testPtfRetractOutputDeterministicInput(): Unit = {
+    assertThatCode(
+      () =>
+        util.tableEnv.explainSql(
+          "INSERT INTO ptf_retract_sink" +
+            " SELECT * FROM updatingRetractFunc(TABLE cdc PARTITION BY a)"))
+      .doesNotThrowAnyException()
+  }
+
+  /**
+   * Non-deterministic function on a non-key input column — full-retract output requires all columns
+   * to be deterministic; expect error only under TRY_RESOLVE.
+   */
+  @TestTemplate
+  def testPtfRetractOutputNonDeterministicInputColumn(): Unit = {
+    val callable: ThrowingCallable = () =>
+      util.tableEnv.explainSql(
+        "INSERT INTO ptf_retract_sink" +
+          " SELECT * FROM updatingRetractFunc(TABLE nd_col_src PARTITION BY a)")
+    if (tryResolve) {
+      assertThatThrownBy(callable)
+        .hasMessageContaining("non-deterministic function: ndFunc")
+        .isInstanceOf[TableException]
+    } else {
+      assertThatCode(callable).doesNotThrowAnyException()
+    }
+  }
+
+  /**
+   * A non-deterministic PTF writing to a retract sink (no PK): the retract sink requires all PTF
+   * output columns to be deterministic, and the retract PTF has no upsert key so nothing is zeroed
+   * by requireDeterminismExcludeUpsertKey — requireDeterminism is fully non-empty when it reaches
+   * visitPtf. The PTF claims isDeterministic() == false (Concern 1), so the NDU visitor must flag
+   * it.
+   *
+   * <p>Inputs are deterministic (cdc with no ndFunc), so Concern 2 (non-deterministic input
+   * columns) does not trigger.
+   */
+  @TestTemplate
+  def testPtfNonDeterministicFunctionWithRequiredOutputDeterminism(): Unit = {
+    val callable: ThrowingCallable = () =>
+      util.tableEnv.explainSql(
+        "INSERT INTO ptf_retract_sink" +
+          " SELECT * FROM nonDeterministicRetractFunc(TABLE cdc PARTITION BY a)")
+    if (tryResolve) {
+      assertThatThrownBy(callable)
+        .hasMessageContaining("non-deterministic function")
+        .isInstanceOf[TableException]
+    } else {
+      assertThatCode(callable).doesNotThrowAnyException()
+    }
   }
 
   /**

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/NonDeterministicDagTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/NonDeterministicDagTest.scala
@@ -28,7 +28,7 @@ import org.apache.flink.table.data.RowData
 import org.apache.flink.table.legacy.api.TableSchema
 import org.apache.flink.table.planner.JBoolean
 import org.apache.flink.table.planner.expressions.utils.{TestNonDeterministicUdaf, TestNonDeterministicUdf, TestNonDeterministicUdtf}
-import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.{NonDeterministicUpdatingRetractFunction, UpdatingRetractFunction, UpdatingUpsertFunction}
+import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.{NonDeterministicUpdatingRetractFunction, NonDeterministicUpdatingRetractRowSemanticFunction, UpdatingJoinFunction, UpdatingRetractFunction, UpdatingRetractRowSemanticFunction, UpdatingUpsertFunction}
 import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedTableFunctions.StringSplit
 import org.apache.flink.table.planner.utils.{StreamTableTestUtil, TableTestBase}
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
@@ -239,6 +239,15 @@ class NonDeterministicDagTest(nonDeterministicUpdateStrategy: NonDeterministicUp
     util.tableEnv.createTemporaryFunction(
       "nonDeterministicRetractFunc",
       new NonDeterministicUpdatingRetractFunction)
+    // PTF taking two table arguments (multi-table case)
+    util.tableEnv.createTemporaryFunction("updatingJoinFunc", new UpdatingJoinFunction)
+    // Row-semantic PTFs
+    util.tableEnv.createTemporaryFunction(
+      "updatingRetractRowSemanticFunc",
+      new UpdatingRetractRowSemanticFunction)
+    util.tableEnv.createTemporaryFunction(
+      "nonDeterministicRetractRowSemanticFunc",
+      new NonDeterministicUpdatingRetractRowSemanticFunction)
 
     // View with ndFunc applied to the partition key column (INT -> INT)
     util.tableEnv.executeSql("""CREATE VIEW nd_partition_key_src AS
@@ -265,6 +274,59 @@ class NonDeterministicDagTest(nonDeterministicUpdateStrategy: NonDeterministicUp
                                |  'connector' = 'values',
                                |  'sink-insert-only' = 'false'
                                |)""".stripMargin)
+
+    // Two upsert sources for the multi-table (join) PTF, both keyed by id.
+    util.tableEnv.executeSql("""CREATE TABLE ptf_score_src (
+                               |  id INT,
+                               |  score INT,
+                               |  PRIMARY KEY (id) NOT ENFORCED
+                               |) WITH (
+                               |  'connector' = 'values',
+                               |  'changelog-mode' = 'I,UA,D',
+                               |  'source.produces-delete-by-key' = 'true'
+                               |)""".stripMargin)
+    util.tableEnv.executeSql("""CREATE TABLE ptf_city_src (
+                               |  id INT,
+                               |  city STRING,
+                               |  PRIMARY KEY (id) NOT ENFORCED
+                               |) WITH (
+                               |  'connector' = 'values',
+                               |  'changelog-mode' = 'I,UA,D',
+                               |  'source.produces-delete-by-key' = 'true'
+                               |)""".stripMargin)
+
+    // Views applying ndFunc to each source's key column, so its upsert key no longer matches the
+    // partition key used by the PTF.
+    util.tableEnv.executeSql("""CREATE VIEW nd_score_src AS
+                               |SELECT ndFunc(id) AS id, score FROM ptf_score_src""".stripMargin)
+    util.tableEnv.executeSql("""CREATE VIEW nd_city_src AS
+                               |SELECT ndFunc(id) AS id, city FROM ptf_city_src""".stripMargin)
+
+    // Upsert sink for the join PTF output: the two table arguments are co-partitioned on the same
+    // key, so a single partition key (id) is prepended to the PTF output.
+    util.tableEnv.executeSql("""CREATE TABLE ptf_join_sink (
+                               |  id INT,
+                               |  `out` STRING,
+                               |  PRIMARY KEY (id) NOT ENFORCED
+                               |) WITH (
+                               |  'connector' = 'values',
+                               |  'sink-insert-only' = 'false',
+                               |  'sink-changelog-mode-enforced' = 'I,UA,D',
+                               |  'sink.supports-delete-by-key' = 'true'
+                               |)""".stripMargin)
+
+    // Retract sink matching the row-semantic changelog PTF output ROW<name, count, mode>, no PK.
+    util.tableEnv.executeSql("""CREATE TABLE ptf_row_retract_sink (
+                               |  f0 STRING, f1 BIGINT, f2 STRING
+                               |) WITH (
+                               |  'connector' = 'values',
+                               |  'sink-insert-only' = 'false'
+                               |)""".stripMargin)
+
+    // Insert-only source with a non-deterministic column. Feeding this to a row-semantic PTF
+    // exercises the inputInsertOnly short-circuit in visitPtf.
+    util.tableEnv.executeSql("""CREATE VIEW nd_insert_only_src AS
+                               |SELECT a, ndFunc(b) AS nd_b, c, d FROM src""".stripMargin)
   }
 
   @TestTemplate
@@ -2083,6 +2145,65 @@ class NonDeterministicDagTest(nonDeterministicUpdateStrategy: NonDeterministicUp
     } else {
       assertThatCode(callable).doesNotThrowAnyException()
     }
+  }
+
+  /** Multi-table PTF: both table arguments are partitioned by their respective upsert keys. */
+  @TestTemplate
+  def testPtfMultiInputUpsertOutputPartitionKeyMatchesUpsertKey(): Unit = {
+    assertThatCode(
+      () =>
+        util.tableEnv.explainSql(
+          "INSERT INTO ptf_join_sink SELECT id, `out` FROM updatingJoinFunc(" +
+            "scoreTable => TABLE ptf_score_src PARTITION BY id, " +
+            "cityTable => TABLE ptf_city_src PARTITION BY id)"))
+      .doesNotThrowAnyException()
+  }
+
+  /**
+   * Multi-table (join) PTF where one table argument is partitioned by a non-deterministic column
+   * (ndFunc(id)) that no longer matches the source's upsert key.
+   */
+  @TestTemplate
+  def testPtfMultiInputUpsertOutputNonDeterministicPartitionKey(): Unit = {
+    val callable: ThrowingCallable = () =>
+      util.tableEnv.explainSql(
+        "INSERT INTO ptf_join_sink SELECT id, `out` FROM updatingJoinFunc(" +
+          "scoreTable => TABLE nd_score_src PARTITION BY id, " +
+          "cityTable => TABLE ptf_city_src PARTITION BY id)")
+    if (tryResolve) {
+      assertThatThrownBy(callable)
+        .hasMessageContaining("non-deterministic function: ndFunc")
+        .isInstanceOf[TableException]
+    } else {
+      assertThatCode(callable).doesNotThrowAnyException()
+    }
+  }
+
+  /** Row-semantic PTF that is itself non-deterministic, writing to a retract sink. */
+  @TestTemplate
+  def testPtfRowSemanticNonDeterministicFunctionWithRetractSink(): Unit = {
+    val callable: ThrowingCallable = () =>
+      util.tableEnv.explainSql(
+        "INSERT INTO ptf_row_retract_sink" +
+          " SELECT * FROM nonDeterministicRetractRowSemanticFunc(TABLE cdc)")
+    if (tryResolve) {
+      assertThatThrownBy(callable)
+        .hasMessageContaining("non-deterministic function")
+        .isInstanceOf[TableException]
+    } else {
+      assertThatCode(callable).doesNotThrowAnyException()
+    }
+  }
+
+  /** Row-semantic PTF reading an insert-only input that carries a non-deterministic column. */
+  @TestTemplate
+  def testPtfRowSemanticInsertOnlyInputWithRetractSink(): Unit = {
+    assertThatCode(
+      () =>
+        util.tableEnv.explainSql(
+          "INSERT INTO ptf_row_retract_sink" +
+            " SELECT * FROM updatingRetractRowSemanticFunc(TABLE nd_insert_only_src)"))
+      .doesNotThrowAnyException()
   }
 
   /**


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Adds support for PTFs to StreamNonDeterministicUpdatePlanVisitor.  Essentially finds uses of indeterminism that are considered errors for PTFs.

## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

This change added tests and can be verified as follows:

  - By running the added unit tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **n**o / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [X] Yes (please specify the tool below)

Generated-by: Claude Code 2.1.121
