### PR TITLE
[FLINK-39575][table] Fix per-arg static-arg lookup in StreamPhysicalProcessTableFunction.toUdfCall

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalProcessTableFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalProcessTableFunction.java
@@ -418,7 +418,7 @@ public class StreamPhysicalProcessTableFunction extends AbstractRelNode
                                         return 0;
                                     }
                                     final RexTableArgCall tableArg = (RexTableArgCall) operand.e;
-                                    final StaticArgument staticArg = staticArgs.get(0);
+                                    final StaticArgument staticArg = staticArgs.get(operand.i);
                                     if (staticArg.is(StaticArgumentTrait.PASS_COLUMNS_THROUGH)) {
                                         return tableArg.getType().getFieldCount();
                                     } else {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionSemanticTests.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionSemanticTests.java
@@ -60,6 +60,8 @@ public class ProcessTableFunctionSemanticTests extends SemanticTestBase {
                 ProcessTableFunctionTestPrograms.PROCESS_INTERVAL_YEAR_ARGS,
                 ProcessTableFunctionTestPrograms.PROCESS_EMPTY_ARGS,
                 ProcessTableFunctionTestPrograms.PROCESS_ROW_SEMANTIC_TABLE_PASS_THROUGH,
+                ProcessTableFunctionTestPrograms
+                        .PROCESS_ROW_SEMANTIC_TABLE_PASS_THROUGH_AFTER_SCALAR,
                 ProcessTableFunctionTestPrograms.PROCESS_SET_SEMANTIC_TABLE_PASS_THROUGH,
                 ProcessTableFunctionTestPrograms.PROCESS_UPDATING_INPUT_RETRACT,
                 ProcessTableFunctionTestPrograms.PROCESS_UPDATING_INPUT_UPSERT,

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionTestPrograms.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionTestPrograms.java
@@ -55,6 +55,7 @@ import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctio
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.RowSemanticTablePassThroughFunction;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.ScalarArgsFunction;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.ScalarArgsTimeFunction;
+import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.ScalarBeforeRowSemanticTablePassThroughFunction;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.SetSemanticTableFullDeletesArgFunction;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.SetSemanticTableFunction;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.SetSemanticTableOptionalPartitionFunction;
@@ -428,6 +429,25 @@ public class ProcessTableFunctionTestPrograms {
                                             "+I[Alice, 42, {+I[Alice, 42], 1}]")
                                     .build())
                     .runSql("INSERT INTO sink SELECT * FROM f(r => TABLE t, i => 1)")
+                    .build();
+
+    // Same as PROCESS_ROW_SEMANTIC_TABLE_PASS_THROUGH but the table argument is at operand
+    // position 1
+    public static final TableTestProgram PROCESS_ROW_SEMANTIC_TABLE_PASS_THROUGH_AFTER_SCALAR =
+            TableTestProgram.of(
+                            "process-row-pass-through-after-scalar",
+                            "pass columns through with table after scalar argument")
+                    .setupTemporarySystemFunction(
+                            "f", ScalarBeforeRowSemanticTablePassThroughFunction.class)
+                    .setupSql(BASIC_VALUES)
+                    .setupTableSink(
+                            SinkTestStep.newBuilder("sink")
+                                    .addSchema(PASS_THROUGH_BASE_SINK_SCHEMA)
+                                    .consumedValues(
+                                            "+I[Bob, 12, {+I[Bob, 12], 1}]",
+                                            "+I[Alice, 42, {+I[Alice, 42], 1}]")
+                                    .build())
+                    .runSql("INSERT INTO sink SELECT * FROM f(i => 1, r => TABLE t)")
                     .build();
 
     public static final TableTestProgram PROCESS_SET_SEMANTIC_TABLE_PASS_THROUGH =

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionTestUtils.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionTestUtils.java
@@ -383,6 +383,18 @@ public class ProcessTableFunctionTestUtils {
         }
     }
 
+    /**
+     * Same as {@link RowSemanticTablePassThroughFunction} but with the scalar argument before the
+     * pass-through table.
+     */
+    public static class ScalarBeforeRowSemanticTablePassThroughFunction
+            extends AppendProcessTableFunctionBase {
+        public void eval(
+                Integer i, @ArgumentHint({ROW_SEMANTIC_TABLE, PASS_COLUMNS_THROUGH}) Row r) {
+            collectObjects(r, i);
+        }
+    }
+
     /** Testing function. */
     public static class SetSemanticTablePassThroughFunction extends AppendProcessTableFunctionBase {
         public void eval(


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

StreamPhysicalProcessTableFunction.toUdfCall always reads staticArgs.get(0) when deciding whether a table operand has the PASS_COLUMNS_THROUGH trait. The lookup should be per-operand: staticArgs.get(operand.i). This is a leftover from the first released versions.

When the first declared argument is not the table being inspected (e.g. f(Integer i, Row r WITH PASS_COLUMNS_THROUGH)), the trait check uses the wrong static argument. This produces an incorrect prefixOutputSystemFields count and the UDF call's rowtype is not stripped of the system-prefixed columns. The wrong rowtype is then passed to ProcessTableRunnerGenerator, leading to incorrect code generation for the PTF runner.

## Brief change log

- Fix code
- Add semantic test which surfaced the issue and is now fixed


## Verifying this change

- Add semantic test

Why semantic test:

The bug only affects the internal UDF rowtype that toUdfCall produces and hands to ProcessTableRunnerGenerator for code generation. That intermediate rowtype is never serialized into the rel plan or exec plan XML — both show only the PTF's   
  outer output (e.g. [name, score, out]), which is correct in both buggy and fixed states.
                                                                                                                                                                                                                                                   A verifyRelPlan/verifyExecPlan golden-file test would produce identical XML before and after the fix, so it can't catch the bug. A semantic test actually compiles and runs the operator, so the wrong UDF rowtype trips BridgingFunctionGenUtil.verifyOutputType at code-gen time with a clear CodeGenException. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [x] Yes (please specify the tool below)

2.1.117 (Claude Code)
