### PR TITLE
[hotfix][docs] Fix typo in Using Keyed State V2

### DIFF
--- a/docs/content/docs/dev/datastream/fault-tolerance/state_v2.md
+++ b/docs/content/docs/dev/datastream/fault-tolerance/state_v2.md
@@ -105,7 +105,7 @@ We only focus on the asynchronous ones here.
 First of all, we should get familiar with the return value of those asynchronous state access methods.
 
 `StateFuture<T>` is a future that will be completed with the result of the state access.
-The return bype is T. It provides multiple methods to handle the result, listed as:
+The return type is T. It provides multiple methods to handle the result, listed as:
 * `StateFuture<Void> thenAccept(Consumer<T>)`: This method takes a `Consumer` that will be called with the result
   when the state access is done. It returns a `StateFuture<Void>`, which will be finished when the
   `Consumer` is done.


### PR DESCRIPTION
Fix a typo in the Using Keyed State V2 section of the Flink documentation