### PR TITLE
[FLINK-39578][python] Include py.typed in PyFlink distribution

### DIFF
--- a/flink-python/pyflink/py.typed
+++ b/flink-python/pyflink/py.typed
@@ -15,16 +15,3 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-
-global-exclude *.py[cod] __pycache__ .DS_Store
-graft deps/bin
-graft deps/conf
-graft deps/log
-recursive-include deps/examples *.py
-include README.md
-include LICENSE
-include NOTICE
-include pyflink/README.txt
-include pyflink/py.typed
-recursive-include pyflink/fn_execution *.pxd
-recursive-include pyflink/fn_execution *.pyx

--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -312,7 +312,7 @@ try:
         'pyflink.bin': TEMP_PATH + '/bin'}
 
     PACKAGE_DATA = {
-        'pyflink': ['README.txt'],
+        'pyflink': ['README.txt', 'py.typed'],
         'pyflink.conf': ['*'],
         'pyflink.log': ['*'],
         'pyflink.examples': ['*.py', '*/*.py'],


### PR DESCRIPTION
## What is the purpose of the change

This pull request ensures that the `py.typed` marker file is included in the PyFlink wheel distribution.

Without this file, type checkers such as `mypy` treat PyFlink as an untyped package and ignore inline type annotations. Including `py.typed` makes PyFlink compliant with [PEP 561](https://peps.python.org/pep-0561/) and enables proper static type checking for users.

---

## Brief change log

* Add `py.typed` to the `pyflink` package
* Update `MANIFEST.in` to ensure `py.typed` is packaged correctly

---

## Verifying this change

This change is a trivial packaging fix and can be verified as follows:

* Build the wheel:

  ```bash
  python setup.py bdist_wheel
  ```
* Verify `py.typed` is included:

  ```bash
  unzip -l dist/*.whl | grep py.typed
  ```
* Install the package and run `mypy` on a project importing `pyflink` to confirm it is no longer treated as untyped.

Same for the sdist:
* Build the sdit:

  ```bash
  python setup.py sdit
  ```
* Verify `py.typed` is included:

  ```bash
  tar xvfz dist/*.tar.g | grep py.typed
  ```

No additional tests are required.

---

## Does this pull request potentially affect one of the following parts:

* Dependencies (does it add or upgrade a dependency): no
* The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
* The serializers: no
* The runtime per-record code paths (performance sensitive): no
* Anything that affects deployment or recovery (JobManager, Checkpointing, Kubernetes/Yarn, ZooKeeper): no
* The S3 file system connector: no

---

## Documentation

* Does this pull request introduce a new feature? no
* If yes, how is the feature documented? not applicable
