### PR TITLE
[FLINK-30514] Fix HybridSourceReader's method calling order for underlying subsources during source switch

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReader.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReader.java
@@ -227,7 +227,6 @@ public class HybridSourceReader<T> implements SourceReader<T, HybridSourceSplit>
         }
         currentSourceIndex = index;
         currentReader = reader;
-        
         // add restored splits
         if (!restoredSplits.isEmpty()) {
             List<HybridSourceSplit> splits = new ArrayList<>(restoredSplits.size());

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReader.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReader.java
@@ -225,6 +225,7 @@ public class HybridSourceReader<T> implements SourceReader<T, HybridSourceSplit>
         } catch (Exception e) {
             throw new RuntimeException("Failed tp create reader", e);
         }
+        // currentReader must be switched before `addSplits` is called.
         currentSourceIndex = index;
         currentReader = reader;
         // add restored splits

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReader.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReader.java
@@ -225,15 +225,9 @@ public class HybridSourceReader<T> implements SourceReader<T, HybridSourceSplit>
         } catch (Exception e) {
             throw new RuntimeException("Failed tp create reader", e);
         }
-        reader.start();
         currentSourceIndex = index;
         currentReader = reader;
-        availabilityFuture.complete(null);
-        LOG.debug(
-                "Reader started: subtask={} sourceIndex={} {}",
-                readerContext.getIndexOfSubtask(),
-                currentSourceIndex,
-                reader);
+        
         // add restored splits
         if (!restoredSplits.isEmpty()) {
             List<HybridSourceSplit> splits = new ArrayList<>(restoredSplits.size());
@@ -247,6 +241,14 @@ public class HybridSourceReader<T> implements SourceReader<T, HybridSourceSplit>
             }
             addSplits(splits);
         }
+
+        reader.start();
+        availabilityFuture.complete(null);
+        LOG.debug(
+                "Reader started: subtask={} sourceIndex={} {}",
+                readerContext.getIndexOfSubtask(),
+                currentSourceIndex,
+                reader);
     }
 
     @Override

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReaderTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReaderTest.java
@@ -323,7 +323,7 @@ class HybridSourceReaderTest {
 
         recoveredReader.handleSourceEvents(new SwitchSourceEvent(0, spySource, false));
 
-        // Verify addSplits was called before start on the underlying reader
+        // Verify the contract: addSplits() must be called before start() during recovery
         InOrder inOrder = Mockito.inOrder(spyHolder[0]);
         inOrder.verify(spyHolder[0]).addSplits(Mockito.anyList());
         inOrder.verify(spyHolder[0]).start();

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReaderTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReaderTest.java
@@ -36,6 +36,7 @@ import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.mock.Whitebox;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 import org.mockito.Mockito;
 
 import java.util.Collections;
@@ -279,6 +280,55 @@ class HybridSourceReaderTest {
         assertThat(reader.snapshotState(1)).contains(hybridSplit);
 
         reader.close();
+    }
+
+    @Test
+    void testReaderRecoveryInitializationOrder() throws Exception {
+        TestingReaderContext readerContext = new TestingReaderContext();
+        MockBaseSource source = new MockBaseSource(1, 1, Boundedness.BOUNDED);
+
+        // First pass: create a snapshot with an in-progress split
+        HybridSourceReader<Integer> reader = new HybridSourceReader<>(readerContext);
+        reader.start();
+        assertAndClearSourceReaderFinishedEvent(readerContext, -1);
+        reader.handleSourceEvents(new SwitchSourceEvent(0, source, false));
+
+        MockSourceSplit mockSplit = new MockSourceSplit(0, 0, 2147483647);
+        SwitchedSources switchedSources = new SwitchedSources();
+        switchedSources.put(0, source);
+        HybridSourceSplit hybridSplit = HybridSourceSplit.wrapSplit(mockSplit, 0, switchedSources);
+        reader.addSplits(Collections.singletonList(hybridSplit));
+        List<HybridSourceSplit> snapshot = reader.snapshotState(0);
+        reader.close();
+
+        // Recovery: capture the underlying reader as a spy to verify call order
+        readerContext.clearSentEvents();
+        SourceReader<Integer, MockSourceSplit>[] spyHolder = new SourceReader[1];
+        Source spySource =
+                new MockSource(null, 0) {
+                    @Override
+                    public SourceReader<Integer, MockSourceSplit> createReader(
+                            SourceReaderContext ctx) {
+                        SourceReader<Integer, MockSourceSplit> spy =
+                                Mockito.spy(source.createReader(ctx));
+                        spyHolder[0] = spy;
+                        return spy;
+                    }
+                };
+
+        HybridSourceReader<Integer> recoveredReader = new HybridSourceReader<>(readerContext);
+        recoveredReader.addSplits(snapshot);
+        recoveredReader.start();
+        assertAndClearSourceReaderFinishedEvent(readerContext, -1);
+
+        recoveredReader.handleSourceEvents(new SwitchSourceEvent(0, spySource, false));
+
+        // Verify addSplits was called before start on the underlying reader
+        InOrder inOrder = Mockito.inOrder(spyHolder[0]);
+        inOrder.verify(spyHolder[0]).addSplits(Mockito.anyList());
+        inOrder.verify(spyHolder[0]).start();
+
+        recoveredReader.close();
     }
 
     @Test


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This MR is intended to fix the method calling order of the HybridSourceReader described in FLINK-30514. We found it not only affects the File connector but also the Iceberg connector.

In our usage, we'd like to use Iceberg Connector as the first source of the HybridSource, however, we found due to the HybridSource is calling `start` before `addSplits`(which will be called during recovery), it breaks IcebergSourceSplitReader's assumption: the recovered splits will be added before `start`.

In the `start` method, the IcebergSourceSplitReader with [check if there is recovered splits on start, and decide if to request new splits](https://github.com/apache/iceberg/blob/main/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/reader/IcebergSourceReader.java#L54-L56). The wrong order in the HybridSource will lead to a undesired requests of new splits, which breaks watermark, slows down the reading and endangers the stability of a job.


## Brief change log

- Fixed the order of method call: calling `start()` after the recovered splits were added to the reader first.
- Updated unit tests to test the behavior.

## Verifying this change

Unit tests was updated to verify the behavior.

## Does this pull request potentially affect one of the following parts:

- The behavior of HybridSource on switching sources should have been fixed to match the correct order.

## Documentation

  - Does this pull request introduce a new feature?  (no)

---
