### PR TITLE
[FLINK-39036][formats] Honor microsecond Avro timestamp logical types

### DIFF
--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroToRowDataConverters.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroToRowDataConverters.java
@@ -29,8 +29,10 @@ import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.utils.LogicalTypeUtils;
 
 import org.apache.avro.generic.GenericFixed;
@@ -128,12 +130,13 @@ public class AvroToRowDataConverters {
             case TIME_WITHOUT_TIME_ZONE:
                 return AvroToRowDataConverters::convertToTime;
             case TIMESTAMP_WITHOUT_TIME_ZONE:
-                return AvroToRowDataConverters::convertToTimestamp;
+                return createTimestampConverter(((TimestampType) type).getPrecision());
             case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
                 if (legacyTimestampMapping) {
                     throw new UnsupportedOperationException("Unsupported type: " + type);
                 } else {
-                    return AvroToRowDataConverters::convertToTimestamp;
+                    return createTimestampConverter(
+                            ((LocalZonedTimestampType) type).getPrecision());
                 }
             case CHAR:
             case VARCHAR:
@@ -211,10 +214,27 @@ public class AvroToRowDataConverters {
         };
     }
 
-    private static TimestampData convertToTimestamp(Object object) {
+    private static AvroToRowDataConverter createTimestampConverter(int precision) {
+        // AvroSchemaConverter maps timestamp-millis to TIMESTAMP precision <= 3 and
+        // timestamp-micros to precision in (3, 6] in both directions, so the Flink
+        // precision is enough to decide how to interpret the incoming epoch value.
+        final boolean isMicros = precision > 3;
+        return object -> convertToTimestamp(object, isMicros);
+    }
+
+    private static TimestampData convertToTimestamp(Object object, boolean isMicros) {
         final long millis;
         if (object instanceof Long) {
-            millis = (Long) object;
+            final long value = (Long) object;
+            if (isMicros) {
+                // Use floor semantics so negative epoch values (pre-1970) split into
+                // a non-positive millis component and a non-negative nano remainder,
+                // which is what TimestampData.fromEpochMillis(long, int) expects.
+                return TimestampData.fromEpochMillis(
+                        Math.floorDiv(value, 1_000L),
+                        (int) (Math.floorMod(value, 1_000L) * 1_000L));
+            }
+            millis = value;
         } else if (object instanceof Instant) {
             millis = ((Instant) object).toEpochMilli();
         } else if (object instanceof LocalDateTime) {

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/RowDataToAvroConverters.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/RowDataToAvroConverters.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.CollectionUtil;
 
+import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
@@ -36,6 +37,7 @@ import org.apache.avro.util.Utf8;
 
 import java.io.Serializable;
 import java.nio.ByteBuffer;
+import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
@@ -166,7 +168,11 @@ public class RowDataToAvroConverters {
 
                                 @Override
                                 public Object convert(Schema schema, Object object) {
-                                    return ((TimestampData) object).toInstant().toEpochMilli();
+                                    final TimestampData timestampData = (TimestampData) object;
+                                    if (isMicrosLogicalType(schema)) {
+                                        return toEpochMicros(timestampData.toInstant());
+                                    }
+                                    return timestampData.toInstant().toEpochMilli();
                                 }
                             };
                 } else {
@@ -176,7 +182,14 @@ public class RowDataToAvroConverters {
 
                                 @Override
                                 public Object convert(Schema schema, Object object) {
-                                    return ((TimestampData) object)
+                                    final TimestampData timestampData = (TimestampData) object;
+                                    if (isMicrosLogicalType(schema)) {
+                                        return toEpochMicros(
+                                                timestampData
+                                                        .toLocalDateTime()
+                                                        .toInstant(ZoneOffset.UTC));
+                                    }
+                                    return timestampData
                                             .toLocalDateTime()
                                             .toInstant(ZoneOffset.UTC)
                                             .toEpochMilli();
@@ -194,7 +207,11 @@ public class RowDataToAvroConverters {
 
                                 @Override
                                 public Object convert(Schema schema, Object object) {
-                                    return ((TimestampData) object).toInstant().toEpochMilli();
+                                    final TimestampData timestampData = (TimestampData) object;
+                                    if (isMicrosLogicalType(schema)) {
+                                        return toEpochMicros(timestampData.toInstant());
+                                    }
+                                    return timestampData.toInstant().toEpochMilli();
                                 }
                             };
                 }
@@ -352,5 +369,17 @@ public class RowDataToAvroConverters {
                 return map;
             }
         };
+    }
+
+    private static boolean isMicrosLogicalType(Schema schema) {
+        final org.apache.avro.LogicalType logicalType = schema.getLogicalType();
+        return logicalType == LogicalTypes.timestampMicros()
+                || logicalType == LogicalTypes.localTimestampMicros();
+    }
+
+    private static long toEpochMicros(Instant instant) {
+        return Math.addExact(
+                Math.multiplyExact(instant.getEpochSecond(), 1_000_000L),
+                instant.getNano() / 1_000L);
     }
 }

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroToRowDataConvertersTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroToRowDataConvertersTest.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro;
+
+import org.apache.flink.formats.avro.AvroToRowDataConverters.AvroToRowDataConverter;
+import org.apache.flink.formats.avro.RowDataToAvroConverters.RowDataToAvroConverter;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.TimestampType;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link AvroToRowDataConverters}. */
+class AvroToRowDataConvertersTest {
+
+    private static final String TIMESTAMP_MICROS_RECORD_SCHEMA =
+            "{\"type\":\"record\",\"name\":\"R\",\"fields\":["
+                    + "{\"name\":\"ts\",\"type\":{\"type\":\"long\","
+                    + "\"logicalType\":\"timestamp-micros\"}}]}";
+    private static final String TIMESTAMP_MILLIS_RECORD_SCHEMA =
+            "{\"type\":\"record\",\"name\":\"R\",\"fields\":["
+                    + "{\"name\":\"ts\",\"type\":{\"type\":\"long\","
+                    + "\"logicalType\":\"timestamp-millis\"}}]}";
+    private static final String LOCAL_TIMESTAMP_MICROS_RECORD_SCHEMA =
+            "{\"type\":\"record\",\"name\":\"R\",\"fields\":["
+                    + "{\"name\":\"ts\",\"type\":{\"type\":\"long\","
+                    + "\"logicalType\":\"local-timestamp-micros\"}}]}";
+
+    @Test
+    void testTimestampMicrosLogicalTypeReadAsMicros() {
+        // FLINK-39036: when the Flink type is TIMESTAMP_WITH_LOCAL_TIME_ZONE(6) (mapped
+        // from timestamp-micros), the reader must interpret the incoming long as
+        // microseconds, not milliseconds.
+        final RowType rowType = RowType.of(new LocalZonedTimestampType(6));
+        final AvroToRowDataConverter converter =
+                AvroToRowDataConverters.createRowConverter(rowType, false);
+
+        final GenericRecord record =
+                new GenericData.Record(new Schema.Parser().parse(TIMESTAMP_MICROS_RECORD_SCHEMA));
+        record.put(0, 1_704_164_645_123_456L);
+
+        final RowData row = (RowData) converter.convert(record);
+        assertThat(row.getTimestamp(0, 6))
+                .isEqualTo(
+                        TimestampData.fromLocalDateTime(
+                                LocalDateTime.parse("2024-01-02T03:04:05.123456")));
+    }
+
+    @Test
+    void testLocalTimestampMicrosLogicalTypeReadAsMicros() {
+        // local-timestamp-micros maps to TIMESTAMP(6) under the new (non-legacy) mapping.
+        final RowType rowType = RowType.of(new TimestampType(6));
+        final AvroToRowDataConverter converter =
+                AvroToRowDataConverters.createRowConverter(rowType, false);
+
+        final GenericRecord record =
+                new GenericData.Record(
+                        new Schema.Parser().parse(LOCAL_TIMESTAMP_MICROS_RECORD_SCHEMA));
+        record.put(0, 1_704_164_645_123_456L);
+
+        final RowData row = (RowData) converter.convert(record);
+        assertThat(row.getTimestamp(0, 6))
+                .isEqualTo(
+                        TimestampData.fromLocalDateTime(
+                                LocalDateTime.parse("2024-01-02T03:04:05.123456")));
+    }
+
+    @Test
+    void testTimestampMillisPrecisionPreservesExistingBehavior() {
+        // Regression: when precision <= 3, the incoming long must continue to be
+        // interpreted as milliseconds. This guards the most common existing usage.
+        final RowType rowType = RowType.of(new TimestampType(3));
+        final AvroToRowDataConverter converter =
+                AvroToRowDataConverters.createRowConverter(rowType, false);
+
+        final GenericRecord record =
+                new GenericData.Record(new Schema.Parser().parse(TIMESTAMP_MILLIS_RECORD_SCHEMA));
+        record.put(0, 1_704_164_645_123L);
+
+        final RowData row = (RowData) converter.convert(record);
+        assertThat(row.getTimestamp(0, 3))
+                .isEqualTo(TimestampData.fromEpochMillis(1_704_164_645_123L));
+    }
+
+    @Test
+    void testNegativeMicrosTimestampHandlesFloorSemantics() {
+        // 1ms before epoch = -1000 micros. Naive division would yield millis=-1,
+        // nanoOfMillis=0, but TimestampData.fromEpochMillis(long, int) requires
+        // nanoOfMillis in [0, 999_999], so floor-div / floor-mod must be used.
+        final RowType rowType = RowType.of(new LocalZonedTimestampType(6));
+        final AvroToRowDataConverter converter =
+                AvroToRowDataConverters.createRowConverter(rowType, false);
+
+        final GenericRecord record =
+                new GenericData.Record(new Schema.Parser().parse(TIMESTAMP_MICROS_RECORD_SCHEMA));
+        record.put(0, -1_500L); // 1.5ms before epoch (-1500 micros)
+
+        final RowData row = (RowData) converter.convert(record);
+        // -1500 micros = floor(-1500 / 1000) ms + floorMod(-1500, 1000) micros
+        //              = -2 ms + 500 micros = -2 ms + 500_000 nanos
+        assertThat(row.getTimestamp(0, 6)).isEqualTo(TimestampData.fromEpochMillis(-2L, 500_000));
+    }
+
+    @Test
+    void testRoundTripPreservesMicrosPrecision() {
+        // End-to-end guard against the original FLINK-39036 bug pattern: the
+        // writer-only fix used to silently break Flink-internal round-trips with a
+        // timestamp-micros schema because the reader still interpreted the value as
+        // millis. Both halves must honor the logical type for a round-trip to be a
+        // no-op.
+        final TimestampData original =
+                TimestampData.fromLocalDateTime(LocalDateTime.parse("2024-01-02T03:04:05.123456"));
+
+        final Schema fieldSchema =
+                new Schema.Parser()
+                        .parse("{\"type\":\"long\",\"logicalType\":\"timestamp-micros\"}");
+        final RowDataToAvroConverter writer =
+                RowDataToAvroConverters.createConverter(new LocalZonedTimestampType(6), false);
+        final Long encoded = (Long) writer.convert(fieldSchema, original);
+        assertThat(encoded).isEqualTo(1_704_164_645_123_456L);
+
+        final RowType rowType = RowType.of(new LocalZonedTimestampType(6));
+        final AvroToRowDataConverter reader =
+                AvroToRowDataConverters.createRowConverter(rowType, false);
+        final GenericRecord record =
+                new GenericData.Record(new Schema.Parser().parse(TIMESTAMP_MICROS_RECORD_SCHEMA));
+        record.put(0, encoded);
+        final RowData row = (RowData) reader.convert(record);
+
+        assertThat(row.getTimestamp(0, 6)).isEqualTo(original);
+    }
+
+    @Test
+    void testRoundTripPreservesMillisPrecision() {
+        // Regression guard for the common timestamp-millis case.
+        final TimestampData original =
+                TimestampData.fromLocalDateTime(LocalDateTime.parse("2024-01-02T03:04:05.123"));
+
+        final Schema fieldSchema =
+                new Schema.Parser()
+                        .parse("{\"type\":\"long\",\"logicalType\":\"timestamp-millis\"}");
+        final RowDataToAvroConverter writer =
+                RowDataToAvroConverters.createConverter(new LocalZonedTimestampType(3), false);
+        final Long encoded = (Long) writer.convert(fieldSchema, original);
+        assertThat(encoded).isEqualTo(1_704_164_645_123L);
+
+        final RowType rowType = RowType.of(new LocalZonedTimestampType(3));
+        final AvroToRowDataConverter reader =
+                AvroToRowDataConverters.createRowConverter(rowType, false);
+        final GenericRecord record =
+                new GenericData.Record(new Schema.Parser().parse(TIMESTAMP_MILLIS_RECORD_SCHEMA));
+        record.put(0, encoded);
+        final RowData row = (RowData) reader.convert(record);
+
+        assertThat(row.getTimestamp(0, 3)).isEqualTo(original);
+    }
+}

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/RowDataToAvroConvertersTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/RowDataToAvroConvertersTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro;
+
+import org.apache.flink.formats.avro.RowDataToAvroConverters.RowDataToAvroConverter;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
+import org.apache.flink.table.types.logical.TimestampType;
+
+import org.apache.avro.Schema;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link RowDataToAvroConverters}. */
+class RowDataToAvroConvertersTest {
+
+    private static final String TIMESTAMP_MILLIS_SCHEMA =
+            "{\"type\":\"long\",\"logicalType\":\"timestamp-millis\"}";
+    private static final String TIMESTAMP_MICROS_SCHEMA =
+            "{\"type\":\"long\",\"logicalType\":\"timestamp-micros\"}";
+    private static final String LOCAL_TIMESTAMP_MILLIS_SCHEMA =
+            "{\"type\":\"long\",\"logicalType\":\"local-timestamp-millis\"}";
+    private static final String LOCAL_TIMESTAMP_MICROS_SCHEMA =
+            "{\"type\":\"long\",\"logicalType\":\"local-timestamp-micros\"}";
+
+    @Test
+    void testTimestampWithLocalTimeZoneRespectsMicrosLogicalType() {
+        // FLINK-39036: writer must produce micros when the Avro schema declares
+        // logicalType=timestamp-micros, otherwise downstream readers that respect
+        // the logical type interpret the millis value as micros and shift the
+        // timestamp by a factor of 1000.
+        final RowDataToAvroConverter converter =
+                RowDataToAvroConverters.createConverter(new LocalZonedTimestampType(6), false);
+
+        final TimestampData timestamp =
+                TimestampData.fromLocalDateTime(LocalDateTime.parse("2024-01-02T03:04:05.123456"));
+
+        final long micros =
+                (long)
+                        converter.convert(
+                                new Schema.Parser().parse(TIMESTAMP_MICROS_SCHEMA), timestamp);
+        assertThat(micros).isEqualTo(1_704_164_645_123_456L);
+
+        final long millis =
+                (long)
+                        converter.convert(
+                                new Schema.Parser().parse(TIMESTAMP_MILLIS_SCHEMA), timestamp);
+        assertThat(millis).isEqualTo(1_704_164_645_123L);
+    }
+
+    @Test
+    void testTimestampWithoutTimeZoneRespectsLocalMicrosLogicalType() {
+        // TIMESTAMP_WITHOUT_TIME_ZONE maps to Avro local-timestamp-* logical types
+        // under the new mapping. The converter must honor local-timestamp-micros
+        // and emit microseconds instead of milliseconds.
+        final RowDataToAvroConverter converter =
+                RowDataToAvroConverters.createConverter(new TimestampType(6), false);
+
+        final TimestampData timestamp =
+                TimestampData.fromLocalDateTime(LocalDateTime.parse("2024-01-02T03:04:05.123456"));
+
+        final long micros =
+                (long)
+                        converter.convert(
+                                new Schema.Parser().parse(LOCAL_TIMESTAMP_MICROS_SCHEMA),
+                                timestamp);
+        assertThat(micros).isEqualTo(1_704_164_645_123_456L);
+
+        final long millis =
+                (long)
+                        converter.convert(
+                                new Schema.Parser().parse(LOCAL_TIMESTAMP_MILLIS_SCHEMA),
+                                timestamp);
+        assertThat(millis).isEqualTo(1_704_164_645_123L);
+    }
+
+    @Test
+    void testLegacyTimestampMappingRespectsMicrosLogicalType() {
+        // The legacy mapping path also has to honor timestamp-micros when present
+        // in the Avro schema, since users may serialize against an externally
+        // provided schema with the micros logical type.
+        final RowDataToAvroConverter converter =
+                RowDataToAvroConverters.createConverter(new TimestampType(6), true);
+
+        final TimestampData timestamp =
+                TimestampData.fromLocalDateTime(LocalDateTime.parse("2024-01-02T03:04:05.123456"));
+
+        final long micros =
+                (long)
+                        converter.convert(
+                                new Schema.Parser().parse(TIMESTAMP_MICROS_SCHEMA), timestamp);
+        assertThat(micros).isEqualTo(1_704_164_645_123_456L);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Fix [FLINK-39036](https://issues.apache.org/jira/browse/FLINK-39036): both directions of the flink-avro RowData ⇄ GenericRecord conversion ignored the Avro `timestamp-micros` / `local-timestamp-micros` logical types and treated the long-encoded epoch value as milliseconds. Because the bug was symmetric, a Flink-internal round-trip happened to round-trip correctly while any cross-system round-trip drifted by a factor of 1000. The first revision of this PR addressed only the writer, which would have flipped that asymmetry the wrong way (writes correct, reads still wrong → internal round-trip broken). The current revision fixes both sides so reads and writes agree on the logical type.

## Brief change log

- `flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/RowDataToAvroConverters.java`
  - In each `TIMESTAMP_WITHOUT_TIME_ZONE` and `TIMESTAMP_WITH_LOCAL_TIME_ZONE` converter (legacy and non-legacy mapping) check whether the target schema declares `timestamp-micros` / `local-timestamp-micros`. If yes, emit the value in microseconds; otherwise keep the existing millisecond output.
  - Add private helpers `isMicrosLogicalType(Schema)` and `toEpochMicros(Instant)`.
- `flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroToRowDataConverters.java`
  - `convertToTimestamp` now takes the Flink type's precision and treats the incoming `Long` as microseconds when `precision > 3`, matching the precision mapping that `AvroSchemaConverter` already establishes between the Avro logical type and the Flink `TIMESTAMP` / `TIMESTAMP_WITH_LOCAL_TIME_ZONE` precision.
  - Negative epoch values are split with `Math.floorDiv` / `Math.floorMod` so the sub-millisecond component stays in the `[0, 999_999]` range that `TimestampData.fromEpochMillis(long, int)` requires.
- `flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/RowDataToAvroConvertersTest.java` (new)
  - Three writer test cases covering each updated branch under both micros and millis schemas.
- `flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroToRowDataConvertersTest.java` (new)
  - Reader cases for `timestamp-micros`, `local-timestamp-micros`, the millis regression case, and a pre-1970 negative micros case that exercises floor semantics.
  - Two end-to-end round-trip tests (writer + reader together) that assert a `TimestampData` round-trips through a `timestamp-micros` schema and a `timestamp-millis` schema.

## Verifying this change

This change is covered by the new tests:

- `RowDataToAvroConvertersTest#testTimestampWithLocalTimeZoneRespectsMicrosLogicalType` — `LocalZonedTimestampType(6)` writer emits `1_704_164_645_123_456L` under the micros schema and `1_704_164_645_123L` under the millis schema.
- `RowDataToAvroConvertersTest#testTimestampWithoutTimeZoneRespectsLocalMicrosLogicalType` — `TimestampType(6)` writer emits the same numeric values for the `local-timestamp-micros` / `-millis` schemas.
- `RowDataToAvroConvertersTest#testLegacyTimestampMappingRespectsMicrosLogicalType` — `legacyTimestampMapping=true` path still honours `timestamp-micros`.
- `AvroToRowDataConvertersTest#testTimestampMicrosLogicalTypeReadAsMicros` and `#testLocalTimestampMicrosLogicalTypeReadAsMicros` — reader returns the correct sub-millisecond `TimestampData` for the two micros logical types.
- `AvroToRowDataConvertersTest#testTimestampMillisPrecisionPreservesExistingBehavior` — guards the existing millis behaviour for `precision <= 3`.
- `AvroToRowDataConvertersTest#testNegativeMicrosTimestampHandlesFloorSemantics` — pre-1970 micros value (`-1500L`) decodes to `(-2 ms, 500_000 ns)`.
- `AvroToRowDataConvertersTest#testRoundTripPreservesMicrosPrecision` and `#testRoundTripPreservesMillisPrecision` — write-then-read round-trips of a `TimestampData` are no-ops under both `timestamp-micros` and `timestamp-millis` schemas.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): **no**
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
- The serializers: **no**
- The runtime per-record code paths (performance sensitive): **no** (one schema-logical-type check on the writer side before the existing branch; a captured-`isMicros` boolean on the reader side)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
- The S3 file system connector: **no**

## Documentation

- Does this pull request introduce a new feature: **no** (bug fix)
- If yes, how is the feature documented: **not applicable**
