### PR TITLE
[FLINK-39580][build] Bump Flink-controlled Java dependencies to resolve CVEs (log4j, jackson, assertj, netty)

### DIFF
--- a/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -6,7 +6,7 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-core:2.20.1
+- com.fasterxml.jackson.core:jackson-core:2.21.1
 - com.google.guava:guava:20.0
 - commons-codec:commons-codec:1.15
 - commons-logging:commons-logging:1.1.3

--- a/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -6,7 +6,7 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-core:2.21.1
+- com.fasterxml.jackson.core:jackson-core:2.21.3
 - com.google.guava:guava:20.0
 - commons-codec:commons-codec:1.15
 - commons-logging:commons-logging:1.1.3

--- a/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
@@ -7,8 +7,8 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.fasterxml.jackson.core:jackson-annotations:2.21
-- com.fasterxml.jackson.core:jackson-core:2.21.1
-- com.fasterxml.jackson.core:jackson-databind:2.21.1
+- com.fasterxml.jackson.core:jackson-core:2.21.3
+- com.fasterxml.jackson.core:jackson-databind:2.21.3
 - com.fasterxml.woodstox:woodstox-core:5.3.0
 - com.google.guava:failureaccess:1.0
 - com.google.guava:guava:27.0-jre

--- a/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
@@ -6,9 +6,9 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-annotations:2.20
-- com.fasterxml.jackson.core:jackson-core:2.20.1
-- com.fasterxml.jackson.core:jackson-databind:2.20.1
+- com.fasterxml.jackson.core:jackson-annotations:2.21
+- com.fasterxml.jackson.core:jackson-core:2.21.1
+- com.fasterxml.jackson.core:jackson-databind:2.21.1
 - com.fasterxml.woodstox:woodstox-core:5.3.0
 - com.google.guava:failureaccess:1.0
 - com.google.guava:guava:27.0-jre

--- a/flink-filesystems/flink-gs-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -6,7 +6,7 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-core:2.21.1
+- com.fasterxml.jackson.core:jackson-core:2.21.3
 - com.google.android:annotations:4.1.1.4
 - com.google.api-client:google-api-client-jackson2:2.0.1
 - com.google.api-client:google-api-client:2.2.0

--- a/flink-filesystems/flink-gs-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -6,7 +6,7 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-core:2.20.1
+- com.fasterxml.jackson.core:jackson-core:2.21.1
 - com.google.android:annotations:4.1.1.4
 - com.google.api-client:google-api-client-jackson2:2.0.1
 - com.google.api-client:google-api-client:2.2.0

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -9,10 +9,10 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.amazonaws:aws-java-sdk-s3:1.12.779
 - com.amazonaws:aws-java-sdk-sts:1.12.779
 - com.amazonaws:jmespath-java:1.12.779
-- com.fasterxml.jackson.core:jackson-annotations:2.20
-- com.fasterxml.jackson.core:jackson-core:2.20.1
-- com.fasterxml.jackson.core:jackson-databind:2.20.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.20.1
+- com.fasterxml.jackson.core:jackson-annotations:2.21
+- com.fasterxml.jackson.core:jackson-core:2.21.1
+- com.fasterxml.jackson.core:jackson-databind:2.21.1
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.21.1
 - com.fasterxml.woodstox:woodstox-core:5.3.0
 - com.google.guava:failureaccess:1.0
 - com.google.guava:guava:27.0-jre

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -10,9 +10,9 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.amazonaws:aws-java-sdk-sts:1.12.779
 - com.amazonaws:jmespath-java:1.12.779
 - com.fasterxml.jackson.core:jackson-annotations:2.21
-- com.fasterxml.jackson.core:jackson-core:2.21.1
-- com.fasterxml.jackson.core:jackson-databind:2.21.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.21.1
+- com.fasterxml.jackson.core:jackson-core:2.21.3
+- com.fasterxml.jackson.core:jackson-databind:2.21.3
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.21.3
 - com.fasterxml.woodstox:woodstox-core:5.3.0
 - com.google.guava:failureaccess:1.0
 - com.google.guava:guava:27.0-jre

--- a/flink-filesystems/flink-s3-fs-native/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-native/src/main/resources/META-INF/NOTICE
@@ -41,20 +41,17 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.httpcomponents:httpclient:4.5.13
 - org.apache.httpcomponents:httpcore:4.4.14
 - commons-logging:commons-logging:1.1.3
-- io.netty:netty-buffer:4.2.6.Final
-- io.netty:netty-codec:4.2.6.Final
-- io.netty:netty-codec-base:4.2.6.Final
-- io.netty:netty-codec-compression:4.2.6.Final
-- io.netty:netty-codec-http:4.2.6.Final
-- io.netty:netty-codec-http2:4.2.6.Final
-- io.netty:netty-codec-marshalling:4.2.6.Final
-- io.netty:netty-codec-protobuf:4.2.6.Final
-- io.netty:netty-common:4.2.6.Final
-- io.netty:netty-handler:4.2.6.Final
-- io.netty:netty-resolver:4.2.6.Final
-- io.netty:netty-transport:4.2.6.Final
-- io.netty:netty-transport-classes-epoll:4.2.6.Final
-- io.netty:netty-transport-native-unix-common:4.2.6.Final
+- io.netty:netty-buffer:4.2.11.Final
+- io.netty:netty-codec:4.2.11.Final
+- io.netty:netty-codec-http2:4.2.11.Final
+- io.netty:netty-codec-marshalling:4.2.11.Final
+- io.netty:netty-codec-protobuf:4.2.11.Final
+- io.netty:netty-common:4.2.11.Final
+- io.netty:netty-handler:4.2.11.Final
+- io.netty:netty-resolver:4.2.11.Final
+- io.netty:netty-transport:4.2.11.Final
+- io.netty:netty-transport-classes-epoll:4.2.11.Final
+- io.netty:netty-transport-native-unix-common:4.2.11.Final
 
 This project bundles the following dependencies under the MIT License (https://opensource.org/licenses/MIT)
 

--- a/flink-filesystems/flink-s3-fs-native/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-native/src/main/resources/META-INF/NOTICE
@@ -41,17 +41,17 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.httpcomponents:httpclient:4.5.13
 - org.apache.httpcomponents:httpcore:4.4.14
 - commons-logging:commons-logging:1.1.3
-- io.netty:netty-buffer:4.2.11.Final
-- io.netty:netty-codec:4.2.11.Final
-- io.netty:netty-codec-http2:4.2.11.Final
-- io.netty:netty-codec-marshalling:4.2.11.Final
-- io.netty:netty-codec-protobuf:4.2.11.Final
-- io.netty:netty-common:4.2.11.Final
-- io.netty:netty-handler:4.2.11.Final
-- io.netty:netty-resolver:4.2.11.Final
-- io.netty:netty-transport:4.2.11.Final
-- io.netty:netty-transport-classes-epoll:4.2.11.Final
-- io.netty:netty-transport-native-unix-common:4.2.11.Final
+- io.netty:netty-buffer:4.2.12.Final
+- io.netty:netty-codec:4.2.12.Final
+- io.netty:netty-codec-http2:4.2.12.Final
+- io.netty:netty-codec-marshalling:4.2.12.Final
+- io.netty:netty-codec-protobuf:4.2.12.Final
+- io.netty:netty-common:4.2.12.Final
+- io.netty:netty-handler:4.2.12.Final
+- io.netty:netty-resolver:4.2.12.Final
+- io.netty:netty-transport:4.2.12.Final
+- io.netty:netty-transport-classes-epoll:4.2.12.Final
+- io.netty:netty-transport-native-unix-common:4.2.12.Final
 
 This project bundles the following dependencies under the MIT License (https://opensource.org/licenses/MIT)
 

--- a/flink-filesystems/flink-s3-fs-native/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-native/src/main/resources/META-INF/NOTICE
@@ -43,6 +43,9 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-logging:commons-logging:1.1.3
 - io.netty:netty-buffer:4.2.12.Final
 - io.netty:netty-codec:4.2.12.Final
+- io.netty:netty-codec-base:4.2.12.Final
+- io.netty:netty-codec-compression:4.2.12.Final
+- io.netty:netty-codec-http:4.2.12.Final
 - io.netty:netty-codec-http2:4.2.12.Final
 - io.netty:netty-codec-marshalling:4.2.12.Final
 - io.netty:netty-codec-protobuf:4.2.12.Final

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
@@ -20,10 +20,10 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.facebook.presto:presto-hive-common:0.272
 - com.facebook.presto:presto-hive-metastore:0.272
 - com.facebook.presto:presto-hive:0.272
-- com.fasterxml.jackson.core:jackson-annotations:2.20
-- com.fasterxml.jackson.core:jackson-core:2.20.1
-- com.fasterxml.jackson.core:jackson-databind:2.20.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.20.1
+- com.fasterxml.jackson.core:jackson-annotations:2.21
+- com.fasterxml.jackson.core:jackson-core:2.21.1
+- com.fasterxml.jackson.core:jackson-databind:2.21.1
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.21.1
 - com.fasterxml.woodstox:woodstox-core:5.3.0
 - com.google.guava:guava:26.0-jre
 - com.google.inject:guice:4.2.2

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
@@ -21,9 +21,9 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.facebook.presto:presto-hive-metastore:0.272
 - com.facebook.presto:presto-hive:0.272
 - com.fasterxml.jackson.core:jackson-annotations:2.21
-- com.fasterxml.jackson.core:jackson-core:2.21.1
-- com.fasterxml.jackson.core:jackson-databind:2.21.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.21.1
+- com.fasterxml.jackson.core:jackson-core:2.21.3
+- com.fasterxml.jackson.core:jackson-databind:2.21.3
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.21.3
 - com.fasterxml.woodstox:woodstox-core:5.3.0
 - com.google.guava:guava:26.0-jre
 - com.google.inject:guice:4.2.2

--- a/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
@@ -6,9 +6,9 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-annotations:2.20
-- com.fasterxml.jackson.core:jackson-core:2.20.1
-- com.fasterxml.jackson.core:jackson-databind:2.20.1
+- com.fasterxml.jackson.core:jackson-annotations:2.21
+- com.fasterxml.jackson.core:jackson-core:2.21.1
+- com.fasterxml.jackson.core:jackson-databind:2.21.1
 - com.google.guava:guava:32.0.1-jre
 - commons-io:commons-io:2.15.1
 - io.confluent:common-utils:7.5.3

--- a/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
@@ -7,8 +7,8 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.fasterxml.jackson.core:jackson-annotations:2.21
-- com.fasterxml.jackson.core:jackson-core:2.21.1
-- com.fasterxml.jackson.core:jackson-databind:2.21.1
+- com.fasterxml.jackson.core:jackson-core:2.21.3
+- com.fasterxml.jackson.core:jackson-databind:2.21.3
 - com.google.guava:guava:32.0.1-jre
 - commons-io:commons-io:2.15.1
 - io.confluent:common-utils:7.5.3

--- a/flink-formats/flink-sql-avro/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-avro/src/main/resources/META-INF/NOTICE
@@ -7,7 +7,7 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - org.apache.avro:avro:1.11.5
-- com.fasterxml.jackson.core:jackson-core:2.21.1
-- com.fasterxml.jackson.core:jackson-databind:2.21.1
+- com.fasterxml.jackson.core:jackson-core:2.21.3
+- com.fasterxml.jackson.core:jackson-databind:2.21.3
 - com.fasterxml.jackson.core:jackson-annotations:2.21
 - org.apache.commons:commons-compress:1.26.0

--- a/flink-formats/flink-sql-avro/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-avro/src/main/resources/META-INF/NOTICE
@@ -7,7 +7,7 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - org.apache.avro:avro:1.11.5
-- com.fasterxml.jackson.core:jackson-core:2.20.1
-- com.fasterxml.jackson.core:jackson-databind:2.20.1
-- com.fasterxml.jackson.core:jackson-annotations:2.20
+- com.fasterxml.jackson.core:jackson-core:2.21.1
+- com.fasterxml.jackson.core:jackson-databind:2.21.1
+- com.fasterxml.jackson.core:jackson-annotations:2.21
 - org.apache.commons:commons-compress:1.26.0

--- a/flink-kubernetes/src/main/resources/META-INF/NOTICE
+++ b/flink-kubernetes/src/main/resources/META-INF/NOTICE
@@ -6,11 +6,11 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-annotations:2.20
-- com.fasterxml.jackson.core:jackson-core:2.20.1
-- com.fasterxml.jackson.core:jackson-databind:2.20.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.20.1
-- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.20.1
+- com.fasterxml.jackson.core:jackson-annotations:2.21
+- com.fasterxml.jackson.core:jackson-core:2.21.1
+- com.fasterxml.jackson.core:jackson-databind:2.21.1
+- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.21.1
+- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.21.1
 - com.squareup.okhttp3:logging-interceptor:3.14.9
 - com.squareup.okhttp3:okhttp:3.14.9
 - com.squareup.okio:okio:1.17.2

--- a/flink-kubernetes/src/main/resources/META-INF/NOTICE
+++ b/flink-kubernetes/src/main/resources/META-INF/NOTICE
@@ -7,10 +7,10 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.fasterxml.jackson.core:jackson-annotations:2.21
-- com.fasterxml.jackson.core:jackson-core:2.21.1
-- com.fasterxml.jackson.core:jackson-databind:2.21.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.21.1
-- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.21.1
+- com.fasterxml.jackson.core:jackson-core:2.21.3
+- com.fasterxml.jackson.core:jackson-databind:2.21.3
+- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.21.3
+- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.21.3
 - com.squareup.okhttp3:logging-interceptor:3.14.9
 - com.squareup.okhttp3:okhttp:3.14.9
 - com.squareup.okio:okio:1.17.2

--- a/flink-models/flink-model-openai/src/main/resources/META-INF/NOTICE
+++ b/flink-models/flink-model-openai/src/main/resources/META-INF/NOTICE
@@ -7,11 +7,11 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.fasterxml.jackson.core:jackson-annotations:2.21
-- com.fasterxml.jackson.core:jackson-core:2.21.1
-- com.fasterxml.jackson.core:jackson-databind:2.21.1
-- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.21.1
-- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.21.1
-- com.fasterxml.jackson.module:jackson-module-kotlin:2.21.1
+- com.fasterxml.jackson.core:jackson-core:2.21.3
+- com.fasterxml.jackson.core:jackson-databind:2.21.3
+- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.21.3
+- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.21.3
+- com.fasterxml.jackson.module:jackson-module-kotlin:2.21.3
 - com.google.errorprone:error_prone_annotations:2.33.0
 - com.openai:openai-java:1.6.1
 - com.openai:openai-java-client-okhttp:1.6.1

--- a/flink-models/flink-model-openai/src/main/resources/META-INF/NOTICE
+++ b/flink-models/flink-model-openai/src/main/resources/META-INF/NOTICE
@@ -6,12 +6,12 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-annotations:2.20
-- com.fasterxml.jackson.core:jackson-core:2.20.1
-- com.fasterxml.jackson.core:jackson-databind:2.20.1
-- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.20.1
-- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.20.1
-- com.fasterxml.jackson.module:jackson-module-kotlin:2.20.1
+- com.fasterxml.jackson.core:jackson-annotations:2.21
+- com.fasterxml.jackson.core:jackson-core:2.21.1
+- com.fasterxml.jackson.core:jackson-databind:2.21.1
+- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.21.1
+- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.21.1
+- com.fasterxml.jackson.module:jackson-module-kotlin:2.21.1
 - com.google.errorprone:error_prone_annotations:2.33.0
 - com.openai:openai-java:1.6.1
 - com.openai:openai-java-client-okhttp:1.6.1

--- a/flink-python/src/main/resources/META-INF/NOTICE
+++ b/flink-python/src/main/resources/META-INF/NOTICE
@@ -58,8 +58,8 @@ The bundled Apache Beam dependencies bundle the following dependencies under the
 - io.grpc:grpc-protobuf:1.59.1
 - io.grpc:grpc-stub:1.59.1
 - io.grpc:grpc-testing:1.59.1
-- io.netty:netty-buffer:4.2.11.Final
-- io.netty:netty-common:4.2.11.Final
+- io.netty:netty-buffer:4.2.12.Final
+- io.netty:netty-common:4.2.12.Final
 - io.opencensus:opencensus-api:0.31.0
 - io.opencensus:opencensus-contrib-grpc-metrics:0.31.0
 - io.perfmark:perfmark-api:0.26.0

--- a/flink-python/src/main/resources/META-INF/NOTICE
+++ b/flink-python/src/main/resources/META-INF/NOTICE
@@ -58,8 +58,8 @@ The bundled Apache Beam dependencies bundle the following dependencies under the
 - io.grpc:grpc-protobuf:1.59.1
 - io.grpc:grpc-stub:1.59.1
 - io.grpc:grpc-testing:1.59.1
-- io.netty:netty-buffer:4.2.6.Final
-- io.netty:netty-common:4.2.6.Final
+- io.netty:netty-buffer:4.2.11.Final
+- io.netty:netty-common:4.2.11.Final
 - io.opencensus:opencensus-api:0.31.0
 - io.opencensus:opencensus-contrib-grpc-metrics:0.31.0
 - io.perfmark:perfmark-api:0.26.0

--- a/flink-python/src/main/resources/META-INF/NOTICE
+++ b/flink-python/src/main/resources/META-INF/NOTICE
@@ -7,9 +7,9 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.fasterxml.jackson.core:jackson-annotations:2.21
-- com.fasterxml.jackson.core:jackson-core:2.21.1
-- com.fasterxml.jackson.core:jackson-databind:2.21.1
-- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.21.1
+- com.fasterxml.jackson.core:jackson-core:2.21.3
+- com.fasterxml.jackson.core:jackson-databind:2.21.3
+- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.21.3
 - com.google.flatbuffers:flatbuffers-java:25.2.10
 - joda-time:joda-time:2.5
 - org.apache.arrow:arrow-format:19.0.0

--- a/flink-python/src/main/resources/META-INF/NOTICE
+++ b/flink-python/src/main/resources/META-INF/NOTICE
@@ -6,10 +6,10 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-annotations:2.20
-- com.fasterxml.jackson.core:jackson-core:2.20.1
-- com.fasterxml.jackson.core:jackson-databind:2.20.1
-- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.20.1
+- com.fasterxml.jackson.core:jackson-annotations:2.21
+- com.fasterxml.jackson.core:jackson-core:2.21.1
+- com.fasterxml.jackson.core:jackson-databind:2.21.1
+- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.21.1
 - com.google.flatbuffers:flatbuffers-java:25.2.10
 - joda-time:joda-time:2.5
 - org.apache.arrow:arrow-format:19.0.0

--- a/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/NOTICE
+++ b/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/NOTICE
@@ -19,6 +19,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - io.netty:netty-buffer:4.2.12.Final
 - io.netty:netty-transport-native-unix-common:4.2.12.Final
 - io.netty:netty-common:4.2.12.Final
+- io.netty:netty-codec-base:4.2.12.Final
 - io.netty:netty-handler:4.2.12.Final
 - io.netty:netty-resolver:4.2.12.Final
 - io.netty:netty-transport:4.2.12.Final

--- a/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/NOTICE
+++ b/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/NOTICE
@@ -16,12 +16,12 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.pekko:pekko-protobuf-v3_2.12:1.4.0
 - org.apache.pekko:pekko-slf4j_2.12:1.4.0
 - org.apache.pekko:pekko-stream_2.12:1.4.0
-- io.netty:netty-buffer:4.2.11.Final
-- io.netty:netty-transport-native-unix-common:4.2.11.Final
-- io.netty:netty-common:4.2.11.Final
-- io.netty:netty-handler:4.2.11.Final
-- io.netty:netty-resolver:4.2.11.Final
-- io.netty:netty-transport:4.2.11.Final
+- io.netty:netty-buffer:4.2.12.Final
+- io.netty:netty-transport-native-unix-common:4.2.12.Final
+- io.netty:netty-common:4.2.12.Final
+- io.netty:netty-handler:4.2.12.Final
+- io.netty:netty-resolver:4.2.12.Final
+- io.netty:netty-transport:4.2.12.Final
 
 
 The following dependencies all share the same BSD license which you find under licenses/LICENSE.scala.

--- a/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/NOTICE
+++ b/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/NOTICE
@@ -16,13 +16,12 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.pekko:pekko-protobuf-v3_2.12:1.4.0
 - org.apache.pekko:pekko-slf4j_2.12:1.4.0
 - org.apache.pekko:pekko-stream_2.12:1.4.0
-- io.netty:netty-buffer:4.2.6.Final
-- io.netty:netty-transport-native-unix-common:4.2.6.Final
-- io.netty:netty-common:4.2.6.Final
-- io.netty:netty-codec-base:4.2.6.Final
-- io.netty:netty-handler:4.2.6.Final
-- io.netty:netty-resolver:4.2.6.Final
-- io.netty:netty-transport:4.2.6.Final
+- io.netty:netty-buffer:4.2.11.Final
+- io.netty:netty-transport-native-unix-common:4.2.11.Final
+- io.netty:netty-common:4.2.11.Final
+- io.netty:netty-handler:4.2.11.Final
+- io.netty:netty-resolver:4.2.11.Final
+- io.netty:netty-transport:4.2.11.Final
 
 
 The following dependencies all share the same BSD license which you find under licenses/LICENSE.scala.

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@ under the License.
 		<avro.version>1.11.5</avro.version>
 		<!-- Version for transitive Jackson dependencies that are not used within Flink itself.-->
 		<jackson.mapper.asl.version>1.9.14.jdk17-redhat-00001</jackson.mapper.asl.version>
-		<jackson-bom.version>2.21.1</jackson-bom.version>
+		<jackson-bom.version>2.21.3</jackson-bom.version>
 		<javax.activation.api.version>1.2.0</javax.activation.api.version>
 		<jaxb.api.version>2.3.1</jaxb.api.version>
 		<junit4.version>4.13.2</junit4.version>

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@ under the License.
 		<source.java.version>11</source.java.version>
 		<target.java.version>17</target.java.version>
 		<slf4j.version>1.7.36</slf4j.version>
-		<log4j.version>2.25.3</log4j.version>
+		<log4j.version>2.25.4</log4j.version>
 		<!-- Overwrite default values from parent pom.
 			 IntelliJ IDEA is (sometimes?) using those values to choose target language level
 			 and thus is changing back to java 1.6 on each maven re-import -->
@@ -151,7 +151,7 @@ under the License.
 		<avro.version>1.11.5</avro.version>
 		<!-- Version for transitive Jackson dependencies that are not used within Flink itself.-->
 		<jackson.mapper.asl.version>1.9.14.jdk17-redhat-00001</jackson.mapper.asl.version>
-		<jackson-bom.version>2.20.1</jackson-bom.version>
+		<jackson-bom.version>2.21.1</jackson-bom.version>
 		<javax.activation.api.version>1.2.0</javax.activation.api.version>
 		<jaxb.api.version>2.3.1</jaxb.api.version>
 		<junit4.version>4.13.2</junit4.version>
@@ -159,7 +159,7 @@ under the License.
 		<archunit.version>1.4.1</archunit.version>
 		<mockito.version>5.19.0</mockito.version>
 		<hamcrest.version>1.3</hamcrest.version>
-		<assertj.version>3.27.3</assertj.version>
+		<assertj.version>3.27.7</assertj.version>
 		<py4j.version>0.10.9.7</py4j.version>
 		<beam.version>2.54.0</beam.version>
 		<protoc.version>4.32.1</protoc.version>
@@ -914,7 +914,7 @@ under the License.
 			<dependency>
 				<groupId>io.netty</groupId>
 				<artifactId>netty-bom</artifactId>
-				<version>4.2.6.Final</version>
+				<version>4.2.11.Final</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -914,7 +914,7 @@ under the License.
 			<dependency>
 				<groupId>io.netty</groupId>
 				<artifactId>netty-bom</artifactId>
-				<version>4.2.11.Final</version>
+				<version>4.2.12.Final</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>


### PR DESCRIPTION
## What is the purpose of the change

Bumps four Flink-controlled Java deps in root `pom.xml` to resolve CVEs, with matching `META-INF/NOTICE` updates for shaded fat-jars that bundle them.

**Scope:** non-shaded `io.netty:*` and `com.fasterxml.jackson:*` only. Shaded counterparts (`org.apache.flink.shaded.*`) are tracked in apache/flink-shaded#159 and apache/flink-shaded#160; that sync lands as a separate follow-up PR. No merge dependency between the two.

## Brief change log

- `log4j-core` 2.25.3 → 2.25.4 — CVE-2026-34477/34478/34480
- `jackson-bom` 2.20.1 → 2.21.3 — GHSA-72hv-8253-57qq (matches flink-shaded#160 target)
- `assertj-core` 3.27.3 → 3.27.7 (test scope) — CVE-2026-24400
- `netty-bom` 4.2.6.Final → 4.2.12.Final — CVE-2025-59419, CVE-2025-67735, CVE-2026-33870, CVE-2026-33871 (matches flink-shaded#159 target)

NOTICE files updated where the shaded jar's bundled artifact set changed.

## Verifying this change

Covered by existing tests; CI's `NoticeFileChecker` and `JarFileChecker` validate the NOTICE updates against the staged deployment.

## Does this pull request potentially affect one of the following parts:

- Dependencies (add/upgrade): **yes**
- Public API (`@Public(Evolving)`): no
- Serializers: no
- Runtime per-record code paths: no
- Deployment/recovery (JobManager/Checkpointing/K8s/Yarn/ZK): no
- S3 file system connector: no

## Documentation

- Introduces a new feature? no

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code