### PR TITLE
[WIP][FLINK-39519] Allocate pre-filter source buffers from heap in filtering mode

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/BufferRequester.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/BufferRequester.java
@@ -24,35 +24,21 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 
-/**
- * Supplies per-channel network buffers to the recovery pipeline.
- *
- * <p>Two semantics are exposed: a non-blocking request used on the fast path where the caller must
- * not stall (e.g. while writing on the recovery thread), and a blocking request used where
- * backpressure is acceptable (e.g. the close() drain).
- */
+/** Supplies per-channel network buffers to the recovery pipeline. */
 @Internal
 interface BufferRequester {
 
-    /** Non-blocking request; returns {@code null} when no buffer is currently available. */
+    /** Non-blocking; returns {@code null} when no buffer is currently available. */
     @Nullable
     Buffer requestBuffer(InputChannelInfo channelInfo) throws IOException;
 
-    /** Blocking request; waits until a buffer becomes available. */
     Buffer requestBufferBlocking(InputChannelInfo channelInfo)
             throws InterruptedException, IOException;
 
     /**
-     * Releases the exclusive buffers held by every channel served by this requester. Must be
-     * called after the dispatcher's drain has finished so the underlying pools are no longer
-     * being read from. Idempotent.
-     *
-     * <p>Symmetric tear-down counterpart of {@link #requestBuffer} / {@link #requestBufferBlocking}:
-     * whoever supplies the buffers also owns their final disposal. Centralising the release here
-     * lets {@code convertRecoveredInputChannels} stop calling {@code releaseAllResources()} on the
-     * {@link org.apache.flink.runtime.io.network.partition.consumer.RecoveredInputChannel} —
-     * which would otherwise wipe the recovered store and exclusive segments while drain is still
-     * in flight.
+     * Releases exclusive buffers for every channel served by this requester. Idempotent. Must run
+     * after the dispatcher's drain has finished so the underlying pools are no longer being read
+     * from.
      */
     void releaseExclusiveBuffers() throws IOException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/BufferRequester.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/BufferRequester.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+
+/**
+ * Supplies per-channel network buffers to the recovery pipeline.
+ *
+ * <p>Two semantics are exposed: a non-blocking request used on the fast path where the caller must
+ * not stall (e.g. while writing on the recovery thread), and a blocking request used where
+ * backpressure is acceptable (e.g. the close() drain).
+ */
+@Internal
+interface BufferRequester {
+
+    /** Non-blocking request; returns {@code null} when no buffer is currently available. */
+    @Nullable
+    Buffer requestBuffer(InputChannelInfo channelInfo) throws IOException;
+
+    /** Blocking request; waits until a buffer becomes available. */
+    Buffer requestBufferBlocking(InputChannelInfo channelInfo)
+            throws InterruptedException, IOException;
+
+    /**
+     * Releases the exclusive buffers held by every channel served by this requester. Must be
+     * called after the dispatcher's drain has finished so the underlying pools are no longer
+     * being read from. Idempotent.
+     *
+     * <p>Symmetric tear-down counterpart of {@link #requestBuffer} / {@link #requestBufferBlocking}:
+     * whoever supplies the buffers also owns their final disposal. Centralising the release here
+     * lets {@code convertRecoveredInputChannels} stop calling {@code releaseAllResources()} on the
+     * {@link org.apache.flink.runtime.io.network.partition.consumer.RecoveredInputChannel} —
+     * which would otherwise wipe the recovered store and exclusive segments while drain is still
+     * in flight.
+     */
+    void releaseExclusiveBuffers() throws IOException;
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateCheckpointWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateCheckpointWriter.java
@@ -26,6 +26,8 @@ import org.apache.flink.runtime.state.AbstractChannelStateHandle.StateContentMet
 import org.apache.flink.runtime.state.CheckpointStateOutputStream;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.util.CloseableIterator;
+import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.function.RunnableWithException;
 
@@ -178,6 +180,45 @@ class ChannelStateCheckpointWriter {
         } finally {
             buffer.recycleBuffer();
         }
+    }
+
+    /**
+     * Writes spilled input channel state chunks to the checkpoint DataOutputStream. Each chunk is
+     * written as [4-byte length prefix][data bytes], matching the format of the buffer-based path.
+     *
+     * <p>Iterates over all chunks from the iterator, grouping consecutive chunks of the same
+     * channel into a single offset entry. The iterator is closed when done.
+     */
+    void writeInputFromSpill(
+            JobVertexID jobVertexID,
+            int subtaskIndex,
+            CloseableIterator<FilteredSpillFile.Chunk> chunks) {
+        if (isDone()) {
+            IOUtils.closeQuietly(chunks);
+            return;
+        }
+        ChannelStatePendingResult pendingResult =
+                getChannelStatePendingResult(jobVertexID, subtaskIndex);
+        runWithChecks(
+                () -> {
+                    checkState(!pendingResult.isAllInputsReceived());
+                    try {
+                        while (chunks.hasNext()) {
+                            FilteredSpillFile.Chunk chunk = chunks.next();
+                            InputChannelInfo info = chunk.getChannelInfo();
+                            long offset = checkpointStream.getPos();
+                            dataStream.writeInt(chunk.getLength());
+                            dataStream.write(chunk.getData(), 0, chunk.getLength());
+                            long size = checkpointStream.getPos() - offset;
+                            pendingResult
+                                    .getInputChannelOffsets()
+                                    .computeIfAbsent(info, unused -> new StateContentMetaInfo())
+                                    .withDataAdded(offset, size);
+                        }
+                    } finally {
+                        chunks.close();
+                    }
+                });
     }
 
     private <K> void write(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateCheckpointWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateCheckpointWriter.java
@@ -183,11 +183,8 @@ class ChannelStateCheckpointWriter {
     }
 
     /**
-     * Writes spilled input channel state chunks to the checkpoint DataOutputStream. Each chunk is
-     * written as [4-byte length prefix][data bytes], matching the format of the buffer-based path.
-     *
-     * <p>Iterates over all chunks from the iterator, grouping consecutive chunks of the same
-     * channel into a single offset entry. The iterator is closed when done.
+     * Writes spilled input-channel state chunks as [4-byte length prefix][data bytes], matching the
+     * buffer-based path. The iterator is closed when done.
      */
     void writeInputFromSpill(
             JobVertexID jobVertexID,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateFilteringHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateFilteringHandler.java
@@ -49,17 +49,14 @@ import java.util.Map;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
- * Filters recovered channel state buffers during the channel-state-unspilling phase, removing
- * records that do not belong to the current subtask after rescaling.
- *
- * <p>Uses a per-gate architecture: each {@link InputGate} gets its own {@link GateFilterHandler}
- * with the correct serializer, so multi-input tasks (e.g., TwoInputStreamTask) correctly
- * deserialize different record types on different gates.
+ * Filters recovered channel-state buffers during the unspilling phase, dropping records that don't
+ * belong to the current subtask after rescaling. Each {@link InputGate} has its own {@link
+ * GateFilterHandler} with the correct serializer so multi-input tasks deserialize different record
+ * types on different gates.
  */
 @Internal
 public class ChannelStateFilteringHandler implements Closeable {
 
-    // Wildcard allows heterogeneous record types across gates.
     private final GateFilterHandler<?>[] gateHandlers;
 
     ChannelStateFilteringHandler(GateFilterHandler<?>[] gateHandlers) {
@@ -67,14 +64,12 @@ public class ChannelStateFilteringHandler implements Closeable {
     }
 
     /**
-     * Creates a handler from the recovery context, building per-gate virtual channels based on
-     * rescaling descriptors. Returns {@code null} if no filtering is needed (e.g., source tasks or
-     * no rescaling).
+     * Builds per-gate virtual channels from the rescaling descriptor. Returns {@code null} when no
+     * filtering is needed (source tasks, no rescaling).
      */
     @Nullable
     public static ChannelStateFilteringHandler createFromContext(
             RecordFilterContext filterContext, InputGate[] inputGates) {
-        // Source tasks have no network inputs
         if (filterContext.getNumberOfGates() == 0) {
             return null;
         }
@@ -101,14 +96,9 @@ public class ChannelStateFilteringHandler implements Closeable {
     }
 
     /**
-     * Filters a recovered buffer from the specified virtual channel, writing surviving records to
-     * the given {@link FilteredBufferDispatcher}. The dispatcher manages buffer allocation, disk
-     * spilling, and delivery to the target channel's store.
-     *
-     * <p>One source buffer may produce 0 to N records written to the dispatcher: 0 if all records
-     * are filtered out, and potentially more than 1 when a spanning record completes in this
-     * buffer. The deserializer caches partial record data from previous buffers, so the output may
-     * contain data that was not in the current source buffer.
+     * Filters records from {@code sourceBuffer} on the given virtual channel and writes survivors
+     * to {@code dispatcher}. One source buffer may yield 0..N records (the deserializer caches
+     * partial-record data across buffers).
      */
     public void filterAndRewrite(
             int gateIndex,
@@ -138,7 +128,6 @@ public class ChannelStateFilteringHandler implements Closeable {
                 oldSubtaskIndex, oldChannelIndex, sourceBuffer, dispatcher, targetChannelInfo);
     }
 
-    /** Returns {@code true} if any virtual channel has a partial (spanning) record pending. */
     public boolean hasPartialData() {
         for (GateFilterHandler<?> handler : gateHandlers) {
             if (handler != null && handler.hasPartialData()) {
@@ -157,14 +146,7 @@ public class ChannelStateFilteringHandler implements Closeable {
         }
     }
 
-    // -------------------------------------------------------------------------------------------
-    // Private static helper methods
-    // -------------------------------------------------------------------------------------------
-
-    /**
-     * Creates a {@link GateFilterHandler} for a single gate. The method-level type parameter
-     * ensures type safety within each gate while allowing different gates to have different types.
-     */
+    /** Method-level {@code <T>} keeps each gate type-safe while allowing heterogeneous gates. */
     @SuppressWarnings("unchecked")
     @Nullable
     private static <T> GateFilterHandler<T> createGateHandler(
@@ -205,7 +187,7 @@ public class ChannelStateFilteringHandler implements Closeable {
                     continue;
                 }
 
-                // Only ambiguous channels need actual filtering; non-ambiguous ones pass through
+                // Only ambiguous channels need filtering; non-ambiguous ones pass through.
                 boolean isAmbiguous = rescalingDescriptor.isAmbiguous(gateIndex, oldSubtaskIndex);
 
                 RecordFilter<T> recordFilter =
@@ -228,10 +210,7 @@ public class ChannelStateFilteringHandler implements Closeable {
         return new GateFilterHandler<>(gateVirtualChannels, elementSerializer);
     }
 
-    /**
-     * Collects all old channel indexes that are mapped from any new channel index in this gate.
-     * channelMapping is new-to-old, so we iterate new indexes and collect their old counterparts.
-     */
+    /** {@code channelMapping} is new-to-old; iterate new indexes and collect the old ones. */
     private static int[] getOldChannelIndexes(RescaleMappings channelMapping, int numChannels) {
         List<Integer> oldIndexes = new ArrayList<>();
         for (int newIndex = 0; newIndex < numChannels; newIndex++) {
@@ -255,14 +234,7 @@ public class ChannelStateFilteringHandler implements Closeable {
         }
     }
 
-    // -------------------------------------------------------------------------------------------
-    // Inner classes
-    // -------------------------------------------------------------------------------------------
-
-    /**
-     * Handles record filtering for a single input gate. Each gate has its own serializer and set of
-     * virtual channels, allowing different gates to handle different record types independently.
-     */
+    /** Filters records for a single input gate; owns its own serializer and virtual channels. */
     static class GateFilterHandler<T> {
 
         private final Map<SubtaskConnectionDescriptor, VirtualChannel<T>> virtualChannels;
@@ -280,10 +252,6 @@ public class ChannelStateFilteringHandler implements Closeable {
             this.outputSerializer = new DataOutputSerializer(128);
         }
 
-        /**
-         * Deserializes records from {@code sourceBuffer}, applies the virtual channel's record
-         * filter, and writes each surviving record to the {@link FilteredBufferDispatcher}.
-         */
         void filterAndRewrite(
                 int oldSubtaskIndex,
                 int oldChannelIndex,
@@ -328,10 +296,7 @@ public class ChannelStateFilteringHandler implements Closeable {
             }
         }
 
-        /**
-         * Serializes a single stream element using the length-prefixed format (4-byte big-endian
-         * length + record bytes) and writes it to the {@link FilteredBufferDispatcher}.
-         */
+        /** Length-prefixed format: 4-byte big-endian length + record bytes. */
         private void serializeElement(
                 StreamElement element,
                 FilteredBufferDispatcher dispatcher,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateFilteringHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateFilteringHandler.java
@@ -101,23 +101,22 @@ public class ChannelStateFilteringHandler implements Closeable {
     }
 
     /**
-     * Filters a recovered buffer from the specified virtual channel, returning new buffers
-     * containing only the records that belong to the current subtask.
+     * Filters a recovered buffer from the specified virtual channel, writing surviving records to
+     * the given {@link FilteredBufferDispatcher}. The dispatcher manages buffer allocation, disk
+     * spilling, and delivery to the target channel's store.
      *
-     * <p>One source buffer may produce 0 to N result buffers: 0 if all records are filtered out,
-     * and potentially more than 1 when a spanning record completes in this buffer. The deserializer
-     * caches partial record data from previous buffers, so the output may contain data that was not
-     * in the current source buffer, causing the total output size to exceed one buffer capacity.
-     * This can happen with any spanning record regardless of its size.
-     *
-     * @return filtered buffers, possibly empty if all records were filtered out.
+     * <p>One source buffer may produce 0 to N records written to the dispatcher: 0 if all records
+     * are filtered out, and potentially more than 1 when a spanning record completes in this
+     * buffer. The deserializer caches partial record data from previous buffers, so the output may
+     * contain data that was not in the current source buffer.
      */
-    public List<Buffer> filterAndRewrite(
+    public void filterAndRewrite(
             int gateIndex,
             int oldSubtaskIndex,
             int oldChannelIndex,
             Buffer sourceBuffer,
-            BufferSupplier bufferSupplier)
+            FilteredBufferDispatcher dispatcher,
+            InputChannelInfo targetChannelInfo)
             throws IOException, InterruptedException {
 
         if (gateIndex < 0 || gateIndex >= gateHandlers.length) {
@@ -135,8 +134,8 @@ public class ChannelStateFilteringHandler implements Closeable {
                             + gateIndex
                             + ". This gate is not a network input and should not have recovered buffers.");
         }
-        return gateHandler.filterAndRewrite(
-                oldSubtaskIndex, oldChannelIndex, sourceBuffer, bufferSupplier);
+        gateHandler.filterAndRewrite(
+                oldSubtaskIndex, oldChannelIndex, sourceBuffer, dispatcher, targetChannelInfo);
     }
 
     /** Returns {@code true} if any virtual channel has a partial (spanning) record pending. */
@@ -260,12 +259,6 @@ public class ChannelStateFilteringHandler implements Closeable {
     // Inner classes
     // -------------------------------------------------------------------------------------------
 
-    /** Provides buffers for re-serializing filtered records. Implementations may block. */
-    @FunctionalInterface
-    public interface BufferSupplier {
-        Buffer requestBufferBlocking() throws IOException, InterruptedException;
-    }
-
     /**
      * Handles record filtering for a single input gate. Each gate has its own serializer and set of
      * virtual channels, allowing different gates to handle different record types independently.
@@ -289,18 +282,17 @@ public class ChannelStateFilteringHandler implements Closeable {
 
         /**
          * Deserializes records from {@code sourceBuffer}, applies the virtual channel's record
-         * filter, and immediately re-serializes each surviving record into output buffers.
+         * filter, and writes each surviving record to the {@link FilteredBufferDispatcher}.
          */
-        List<Buffer> filterAndRewrite(
+        void filterAndRewrite(
                 int oldSubtaskIndex,
                 int oldChannelIndex,
                 Buffer sourceBuffer,
-                BufferSupplier bufferSupplier)
+                FilteredBufferDispatcher dispatcher,
+                InputChannelInfo targetChannelInfo)
                 throws IOException, InterruptedException {
 
             boolean sourceBufferOwnershipTransferred = false;
-            List<Buffer> resultBuffers = new ArrayList<>();
-            Buffer currentBuffer = null;
             try {
                 SubtaskConnectionDescriptor key =
                         new SubtaskConnectionDescriptor(oldSubtaskIndex, oldChannelIndex);
@@ -319,82 +311,41 @@ public class ChannelStateFilteringHandler implements Closeable {
                 while (true) {
                     DeserializationResult result = vc.getNextRecord(deserializationDelegate);
                     if (result.isFullRecord()) {
-                        if (currentBuffer == null) {
-                            currentBuffer = bufferSupplier.requestBufferBlocking();
-                        }
-                        currentBuffer =
-                                serializeElement(
-                                        deserializationDelegate.getInstance(),
-                                        currentBuffer,
-                                        resultBuffers,
-                                        bufferSupplier);
+                        serializeElement(
+                                deserializationDelegate.getInstance(),
+                                dispatcher,
+                                targetChannelInfo);
                     }
                     if (result.isBufferConsumed()) {
                         break;
                     }
                 }
-
-                if (currentBuffer != null) {
-                    if (currentBuffer.readableBytes() > 0) {
-                        resultBuffers.add(currentBuffer);
-                    } else {
-                        currentBuffer.recycleBuffer();
-                    }
-                    currentBuffer = null;
-                }
-
-                return resultBuffers;
             } catch (Throwable t) {
                 if (!sourceBufferOwnershipTransferred) {
                     sourceBuffer.recycleBuffer();
                 }
-                // Avoid double-recycle: currentBuffer may already be the last element in
-                // resultBuffers if serializeElement added it before the exception.
-                if (currentBuffer != null
-                        && (resultBuffers.isEmpty()
-                                || resultBuffers.get(resultBuffers.size() - 1) != currentBuffer)) {
-                    currentBuffer.recycleBuffer();
-                }
-                for (Buffer buf : resultBuffers) {
-                    buf.recycleBuffer();
-                }
-                resultBuffers.clear();
                 throw t;
             }
         }
 
         /**
-         * Serializes a single stream element into the current buffer using the length-prefixed
-         * format (4-byte big-endian length + record bytes) expected by Flink's record
-         * deserializers. Spills into new buffers from {@code bufferSupplier} when needed.
-         *
-         * @return the buffer to continue writing into (may differ from the input buffer).
+         * Serializes a single stream element using the length-prefixed format (4-byte big-endian
+         * length + record bytes) and writes it to the {@link FilteredBufferDispatcher}.
          */
-        private Buffer serializeElement(
+        private void serializeElement(
                 StreamElement element,
-                Buffer currentBuffer,
-                List<Buffer> resultBuffers,
-                BufferSupplier bufferSupplier)
+                FilteredBufferDispatcher dispatcher,
+                InputChannelInfo targetChannelInfo)
                 throws IOException, InterruptedException {
             outputSerializer.clear();
             serializer.serialize(element, outputSerializer);
             int recordLength = outputSerializer.length();
 
             writeLengthToBuffer(recordLength);
-            currentBuffer =
-                    writeDataToBuffer(
-                            lengthBuffer, 0, 4, currentBuffer, resultBuffers, bufferSupplier);
+            dispatcher.write(lengthBuffer, 4, targetChannelInfo);
 
             byte[] serializedData = outputSerializer.getSharedBuffer();
-            currentBuffer =
-                    writeDataToBuffer(
-                            serializedData,
-                            0,
-                            recordLength,
-                            currentBuffer,
-                            resultBuffers,
-                            bufferSupplier);
-            return currentBuffer;
+            dispatcher.write(serializedData, recordLength, targetChannelInfo);
         }
 
         private void writeLengthToBuffer(int length) {
@@ -402,49 +353,6 @@ public class ChannelStateFilteringHandler implements Closeable {
             lengthBuffer[1] = (byte) (length >> 16);
             lengthBuffer[2] = (byte) (length >> 8);
             lengthBuffer[3] = (byte) length;
-        }
-
-        /**
-         * Writes data to the current buffer, spilling into new buffers from {@code bufferSupplier}
-         * when the current one is full.
-         *
-         * @return the buffer to continue writing into (may differ from the input buffer).
-         */
-        private Buffer writeDataToBuffer(
-                byte[] data,
-                int dataOffset,
-                int dataLength,
-                Buffer currentBuffer,
-                List<Buffer> resultBuffers,
-                BufferSupplier bufferSupplier)
-                throws IOException, InterruptedException {
-            int offset = dataOffset;
-            int remaining = dataLength;
-
-            while (remaining > 0) {
-                int writableBytes = currentBuffer.getMaxCapacity() - currentBuffer.getSize();
-
-                if (writableBytes == 0) {
-                    // Buffer is full, transfer ownership to resultBuffers
-                    resultBuffers.add(currentBuffer);
-                    currentBuffer = bufferSupplier.requestBufferBlocking();
-                    writableBytes = currentBuffer.getMaxCapacity();
-                }
-
-                int bytesToWrite = Math.min(remaining, writableBytes);
-                currentBuffer
-                        .getMemorySegment()
-                        .put(
-                                currentBuffer.getMemorySegmentOffset() + currentBuffer.getSize(),
-                                data,
-                                offset,
-                                bytesToWrite);
-                currentBuffer.setSize(currentBuffer.getSize() + bytesToWrite);
-
-                offset += bytesToWrite;
-                remaining -= bytesToWrite;
-            }
-            return currentBuffer;
         }
 
         boolean hasPartialData() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriteRequest.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriteRequest.java
@@ -234,6 +234,20 @@ abstract class ChannelStateWriteRequest {
                 throwable -> iterator.close());
     }
 
+    static ChannelStateWriteRequest buildSpillWriteRequest(
+            JobVertexID jobVertexID,
+            int subtaskIndex,
+            long checkpointId,
+            CloseableIterator<FilteredSpillFile.Chunk> chunks) {
+        return new CheckpointInProgressRequest(
+                "writeInputFromSpill",
+                jobVertexID,
+                subtaskIndex,
+                checkpointId,
+                writer -> writer.writeInputFromSpill(jobVertexID, subtaskIndex, chunks),
+                throwable -> chunks.close());
+    }
+
     static void checkBufferIsBuffer(Buffer buffer) {
         try {
             checkArgument(buffer.isBuffer());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriter.java
@@ -126,8 +126,8 @@ public interface ChannelStateWriter extends Closeable {
             CloseableIterator<Buffer> data);
 
     /**
-     * Drains spill-file chunks into the checkpoint. Called by the dispatcher once all ready
-     * buffers are snapshotted and the wait-set is empty. The implementation closes the iterator.
+     * Drains spill-file chunks into the checkpoint. Called by the dispatcher once all ready buffers
+     * are snapshotted and the wait-set is empty. The implementation closes the iterator.
      */
     void addInputDataFromSpill(
             long checkpointId, CloseableIterator<FilteredSpillFile.Chunk> chunks);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriter.java
@@ -126,13 +126,8 @@ public interface ChannelStateWriter extends Closeable {
             CloseableIterator<Buffer> data);
 
     /**
-     * Add spilled input data for checkpoint by draining chunks from spill-file Readers. Used by
-     * the dispatcher after all ready buffers have been snapshotted and the checkpoint wait-set is
-     * empty. The iterator is closed by the implementation when drain is complete.
-     *
-     * @param checkpointId checkpoint identifier
-     * @param chunks iterator over {@link FilteredSpillFile.Chunk}s ordered by channel; closed by
-     *     the implementation
+     * Drains spill-file chunks into the checkpoint. Called by the dispatcher once all ready
+     * buffers are snapshotted and the wait-set is empty. The implementation closes the iterator.
      */
     void addInputDataFromSpill(
             long checkpointId, CloseableIterator<FilteredSpillFile.Chunk> chunks);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriter.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.state.InputChannelStateHandle;
 import org.apache.flink.runtime.state.ResultSubpartitionStateHandle;
 import org.apache.flink.util.CloseableIterator;
+import org.apache.flink.util.IOUtils;
 
 import java.io.Closeable;
 import java.util.Collection;
@@ -125,6 +126,18 @@ public interface ChannelStateWriter extends Closeable {
             CloseableIterator<Buffer> data);
 
     /**
+     * Add spilled input data for checkpoint by draining chunks from spill-file Readers. Used by
+     * the dispatcher after all ready buffers have been snapshotted and the checkpoint wait-set is
+     * empty. The iterator is closed by the implementation when drain is complete.
+     *
+     * @param checkpointId checkpoint identifier
+     * @param chunks iterator over {@link FilteredSpillFile.Chunk}s ordered by channel; closed by
+     *     the implementation
+     */
+    void addInputDataFromSpill(
+            long checkpointId, CloseableIterator<FilteredSpillFile.Chunk> chunks);
+
+    /**
      * Add in-flight buffers from the {@link
      * org.apache.flink.runtime.io.network.partition.ResultSubpartition ResultSubpartition}. Must be
      * called after {@link #start} and before {@link #finishOutput(long)}. Buffers are recycled
@@ -203,6 +216,12 @@ public interface ChannelStateWriter extends Closeable {
                 InputChannelInfo info,
                 int startSeqNum,
                 CloseableIterator<Buffer> data) {}
+
+        @Override
+        public void addInputDataFromSpill(
+                long checkpointId, CloseableIterator<FilteredSpillFile.Chunk> chunks) {
+            IOUtils.closeQuietly(chunks);
+        }
 
         @Override
         public void addOutputData(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriterImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriterImpl.java
@@ -40,6 +40,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.apache.flink.runtime.checkpoint.channel.ChannelStateWriteRequest.buildSpillWriteRequest;
 import static org.apache.flink.runtime.checkpoint.channel.ChannelStateWriteRequest.completeInput;
 import static org.apache.flink.runtime.checkpoint.channel.ChannelStateWriteRequest.completeOutput;
 import static org.apache.flink.runtime.checkpoint.channel.ChannelStateWriteRequest.write;
@@ -192,6 +193,16 @@ public class ChannelStateWriterImpl implements ChannelStateWriter {
                 info,
                 startSeqNum);
         enqueue(write(jobVertexID, subtaskIndex, checkpointId, info, iterator), false);
+    }
+
+    @Override
+    public void addInputDataFromSpill(
+            long checkpointId, CloseableIterator<FilteredSpillFile.Chunk> chunks) {
+        LOG.trace(
+                "{} adding spill input data, checkpoint {}",
+                taskName,
+                checkpointId);
+        enqueue(buildSpillWriteRequest(jobVertexID, subtaskIndex, checkpointId, chunks), false);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriterImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriterImpl.java
@@ -198,10 +198,7 @@ public class ChannelStateWriterImpl implements ChannelStateWriter {
     @Override
     public void addInputDataFromSpill(
             long checkpointId, CloseableIterator<FilteredSpillFile.Chunk> chunks) {
-        LOG.trace(
-                "{} adding spill input data, checkpoint {}",
-                taskName,
-                checkpointId);
+        LOG.trace("{} adding spill input data, checkpoint {}", taskName, checkpointId);
         enqueue(buildSpillWriteRequest(jobVertexID, subtaskIndex, checkpointId, chunks), false);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/EntryPosition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/EntryPosition.java
@@ -23,8 +23,8 @@ import java.util.Objects;
 
 /**
  * Position of a spill entry inside a {@link FilteredSpillFile}: physical file index in the spill
- * file's {@code readers} list plus absolute byte offset within that file. Lexicographic ordering
- * on {@code (fileIndex, offset)} matches the FIFO drain sequence. {@link #END} compares strictly
+ * file's {@code readers} list plus absolute byte offset within that file. Lexicographic ordering on
+ * {@code (fileIndex, offset)} matches the FIFO drain sequence. {@link #END} compares strictly
  * greater than any real position and serves as the post-drain sentinel.
  */
 @Internal

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/EntryPosition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/EntryPosition.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.apache.flink.annotation.Internal;
+
+import java.util.Objects;
+
+/**
+ * Position of a spill entry inside a {@link FilteredSpillFile}: the index of the owning physical
+ * file in the spill file's {@code readers} list and the absolute byte offset within that file.
+ *
+ * <p>Total ordering is lexicographic on {@code (fileIndex, offset)} — files are drained in list
+ * order, and entries within a file are drained in offset-ascending order, so this matches the
+ * actual FIFO drain sequence. {@link #END} is the sentinel that compares strictly greater than any
+ * real position; it is used as the {@code drainHead} once every entry has been drained.
+ */
+@Internal
+public final class EntryPosition implements Comparable<EntryPosition> {
+
+    /** Sentinel position that compares greater than every real entry position. */
+    public static final EntryPosition END = new EntryPosition(Integer.MAX_VALUE, Long.MAX_VALUE);
+
+    private final int fileIndex;
+    private final long offset;
+
+    public EntryPosition(int fileIndex, long offset) {
+        this.fileIndex = fileIndex;
+        this.offset = offset;
+    }
+
+    public int getFileIndex() {
+        return fileIndex;
+    }
+
+    public long getOffset() {
+        return offset;
+    }
+
+    @Override
+    public int compareTo(EntryPosition other) {
+        int byFile = Integer.compare(this.fileIndex, other.fileIndex);
+        if (byFile != 0) {
+            return byFile;
+        }
+        return Long.compare(this.offset, other.offset);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof EntryPosition)) {
+            return false;
+        }
+        EntryPosition that = (EntryPosition) o;
+        return fileIndex == that.fileIndex && offset == that.offset;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(fileIndex, offset);
+    }
+
+    @Override
+    public String toString() {
+        if (this == END) {
+            return "EntryPosition{END}";
+        }
+        return "EntryPosition{fileIndex=" + fileIndex + ", offset=" + offset + "}";
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/EntryPosition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/EntryPosition.java
@@ -22,18 +22,14 @@ import org.apache.flink.annotation.Internal;
 import java.util.Objects;
 
 /**
- * Position of a spill entry inside a {@link FilteredSpillFile}: the index of the owning physical
- * file in the spill file's {@code readers} list and the absolute byte offset within that file.
- *
- * <p>Total ordering is lexicographic on {@code (fileIndex, offset)} — files are drained in list
- * order, and entries within a file are drained in offset-ascending order, so this matches the
- * actual FIFO drain sequence. {@link #END} is the sentinel that compares strictly greater than any
- * real position; it is used as the {@code drainHead} once every entry has been drained.
+ * Position of a spill entry inside a {@link FilteredSpillFile}: physical file index in the spill
+ * file's {@code readers} list plus absolute byte offset within that file. Lexicographic ordering
+ * on {@code (fileIndex, offset)} matches the FIFO drain sequence. {@link #END} compares strictly
+ * greater than any real position and serves as the post-drain sentinel.
  */
 @Internal
 public final class EntryPosition implements Comparable<EntryPosition> {
 
-    /** Sentinel position that compares greater than every real entry position. */
     public static final EntryPosition END = new EntryPosition(Integer.MAX_VALUE, Long.MAX_VALUE);
 
     private final int fileIndex;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FilteredBufferDispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FilteredBufferDispatcher.java
@@ -22,65 +22,31 @@ import org.apache.flink.annotation.Internal;
 import java.io.IOException;
 
 /**
- * Dispatches filtered channel state data across multiple channels' {@link
- * org.apache.flink.runtime.io.network.partition.consumer.RecoveredBufferStore}s, managing the
- * buffer/disk backend transparently. Callers use {@link #write(byte[], int, InputChannelInfo)} to
- * push data for a target channel, and the implementation decides whether to use a network buffer
- * (P1), spill to disk (P2), or replay from disk (P3).
+ * Dispatches filtered channel-state data across multiple channels' {@link
+ * org.apache.flink.runtime.io.network.partition.consumer.RecoveredBufferStore}s. {@link
+ * #write(byte[], int, InputChannelInfo)} pushes data for a target channel; the implementation
+ * decides whether to use a network buffer (P1), spill to disk (P2), or replay from disk (P3).
  */
 @Internal
 public interface FilteredBufferDispatcher extends AutoCloseable {
 
-    /**
-     * Writes data for the given channel.
-     *
-     * @param data the byte array containing the data
-     * @param length the number of bytes to write from the data array
-     * @param channelInfo the target input channel
-     * @throws IOException if an I/O error occurs
-     * @throws InterruptedException if the thread is interrupted while waiting for resources
-     */
     void write(byte[] data, int length, InputChannelInfo channelInfo)
             throws IOException, InterruptedException;
 
-    /**
-     * Flushes any buffered data. After flush, no more writes are accepted.
-     *
-     * @throws IOException if an I/O error occurs
-     */
+    /** Flushes any buffered data. After flush, no more writes are accepted. */
     void flush() throws IOException;
 
     /**
-     * Blocking drain of all remaining disk data into target stores. Producer-consumer semantics:
-     * blocks waiting for network buffers; Thread.interrupt() unblocks the wait.
-     *
-     * <p>Call sequence: {@link #flush()} -> stateHandler.finishRecovery() ->
-     * {@link #drainPendingSpill()} -> {@link #close()}. Runs concurrently with Task thread
-     * consumption and checkpoint on converted InputChannels.
-     *
-     * <p>Contract:
-     * - Must be called after {@link #flush()} so all Readers are sealed.
-     * - Does NOT hold the dispatcher monitor while blocking; coordinator callbacks
-     *   (e.g. onChannelCheckpointStopped) remain free to acquire the monitor.
-     * - Skipped on the abort path: callers that are cancelling go straight to close().
-     *
-     * @throws IOException if an I/O error occurs
-     * @throws InterruptedException if the thread is interrupted during the blocking drain
+     * Blocking drain of all remaining disk data into target stores. Must be called after
+     * {@link #flush()} so all Readers are sealed. Skipped on the abort path: callers that are
+     * cancelling go straight to {@link #close()}. Does not hold the dispatcher monitor while
+     * blocking; coordinator callbacks remain free to acquire it.
      */
     void drainPendingSpill() throws IOException, InterruptedException;
 
     /**
-     * Releases resources held by this dispatcher (spill file channel, internal state fields).
-     * Idempotent: calling close() multiple times is safe.
-     *
-     * <p>Contract:
-     * - Pure resource release: does NOT drain remaining disk data. Call {@link #drainPendingSpill()}
-     *   first on the normal path.
-     * - Short lock: may hold the dispatcher monitor briefly to protect state fields, but never
-     *   blocks on I/O or buffer allocation inside the lock.
-     * - Does not throw business exceptions.
-     *
-     * @throws IOException if closing the spill file channel fails
+     * Releases resources held by this dispatcher. Idempotent. Pure resource release: does NOT
+     * drain remaining disk data — call {@link #drainPendingSpill()} first on the normal path.
      */
     @Override
     void close() throws IOException;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FilteredBufferDispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FilteredBufferDispatcher.java
@@ -37,16 +37,16 @@ public interface FilteredBufferDispatcher extends AutoCloseable {
     void flush() throws IOException;
 
     /**
-     * Blocking drain of all remaining disk data into target stores. Must be called after
-     * {@link #flush()} so all Readers are sealed. Skipped on the abort path: callers that are
-     * cancelling go straight to {@link #close()}. Does not hold the dispatcher monitor while
-     * blocking; coordinator callbacks remain free to acquire it.
+     * Blocking drain of all remaining disk data into target stores. Must be called after {@link
+     * #flush()} so all Readers are frozen. Skipped on the abort path: callers that are cancelling
+     * go straight to {@link #close()}. Does not hold the dispatcher monitor while blocking;
+     * coordinator callbacks remain free to acquire it.
      */
     void drainPendingSpill() throws IOException, InterruptedException;
 
     /**
-     * Releases resources held by this dispatcher. Idempotent. Pure resource release: does NOT
-     * drain remaining disk data — call {@link #drainPendingSpill()} first on the normal path.
+     * Releases resources held by this dispatcher. Idempotent. Pure resource release: does NOT drain
+     * remaining disk data — call {@link #drainPendingSpill()} first on the normal path.
      */
     @Override
     void close() throws IOException;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FilteredBufferDispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FilteredBufferDispatcher.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.apache.flink.annotation.Internal;
+
+import java.io.IOException;
+
+/**
+ * Dispatches filtered channel state data across multiple channels' {@link
+ * org.apache.flink.runtime.io.network.partition.consumer.RecoveredBufferStore}s, managing the
+ * buffer/disk backend transparently. Callers use {@link #write(byte[], int, InputChannelInfo)} to
+ * push data for a target channel, and the implementation decides whether to use a network buffer
+ * (P1), spill to disk (P2), or replay from disk (P3).
+ */
+@Internal
+public interface FilteredBufferDispatcher extends AutoCloseable {
+
+    /**
+     * Writes data for the given channel.
+     *
+     * @param data the byte array containing the data
+     * @param length the number of bytes to write from the data array
+     * @param channelInfo the target input channel
+     * @throws IOException if an I/O error occurs
+     * @throws InterruptedException if the thread is interrupted while waiting for resources
+     */
+    void write(byte[] data, int length, InputChannelInfo channelInfo)
+            throws IOException, InterruptedException;
+
+    /**
+     * Flushes any buffered data. After flush, no more writes are accepted.
+     *
+     * @throws IOException if an I/O error occurs
+     */
+    void flush() throws IOException;
+
+    /**
+     * Blocking drain of all remaining disk data into target stores. Producer-consumer semantics:
+     * blocks waiting for network buffers; Thread.interrupt() unblocks the wait.
+     *
+     * <p>Call sequence: {@link #flush()} -> stateHandler.finishRecovery() ->
+     * {@link #drainPendingSpill()} -> {@link #close()}. Runs concurrently with Task thread
+     * consumption and checkpoint on converted InputChannels.
+     *
+     * <p>Contract:
+     * - Must be called after {@link #flush()} so all Readers are sealed.
+     * - Does NOT hold the dispatcher monitor while blocking; coordinator callbacks
+     *   (e.g. onChannelCheckpointStopped) remain free to acquire the monitor.
+     * - Skipped on the abort path: callers that are cancelling go straight to close().
+     *
+     * @throws IOException if an I/O error occurs
+     * @throws InterruptedException if the thread is interrupted during the blocking drain
+     */
+    void drainPendingSpill() throws IOException, InterruptedException;
+
+    /**
+     * Releases resources held by this dispatcher (spill file channel, internal state fields).
+     * Idempotent: calling close() multiple times is safe.
+     *
+     * <p>Contract:
+     * - Pure resource release: does NOT drain remaining disk data. Call {@link #drainPendingSpill()}
+     *   first on the normal path.
+     * - Short lock: may hold the dispatcher monitor briefly to protect state fields, but never
+     *   blocks on I/O or buffer allocation inside the lock.
+     * - Does not throw business exceptions.
+     *
+     * @throws IOException if closing the spill file channel fails
+     */
+    @Override
+    void close() throws IOException;
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FilteredBufferDispatcherImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FilteredBufferDispatcherImpl.java
@@ -39,35 +39,27 @@ import java.util.Set;
 import static org.apache.flink.util.IOUtils.closeQuietly;
 
 /**
- * Implementation of {@link FilteredBufferDispatcher} that manages three data paths:
+ * {@link FilteredBufferDispatcher} implementation managing three data paths:
  *
  * <ul>
- *   <li><b>P1 (buffer)</b>: Data is written directly to a network buffer and delivered to the
- *       target store.
- *   <li><b>P2 (spill to disk)</b>: When no buffer is available, data is written to a spill file via
- *       {@link FilteredSpillFile#writeEntry}.
- *   <li><b>P3 (eager drain)</b>: When buffers become available later, spilled entries are eagerly
- *       replayed from disk into buffers and delivered to stores.
+ *   <li><b>P1</b>: write directly to a network buffer and deliver to the target store
+ *   <li><b>P2</b>: when no buffer is available, write to a spill file
+ *   <li><b>P3</b>: when buffers become available later, eagerly replay spilled entries
  * </ul>
  *
- * <p>A byte[] memory cache accumulates payload bytes for the active channel. On channel change or
- * cache full, {@link #flushCache()} is invoked: if the spill writer is idle and a buffer is
- * available the cached bytes go directly to a network buffer (P1); otherwise they are written to
- * the spill file (P2). After {@link #flush()} seals all Readers, {@link #drainPendingSpill()}
- * drains any remaining spill entries via {@link BufferRequester#requestBufferBlocking(InputChannelInfo)}.
- * {@link #close()} then releases spill file resources without performing any drain.
+ * <p>A byte[] cache accumulates payload bytes for the active channel. On channel change or cache
+ * full, {@link #flushCache()} commits the bytes via P1 if the spill writer is idle and a buffer is
+ * available, otherwise via P2. After {@link #flush()} seals all Readers, {@link
+ * #drainPendingSpill()} drains the remainder; {@link #close()} releases resources.
  */
 @Internal
 public class FilteredBufferDispatcherImpl
         implements FilteredBufferDispatcher, RecoveredBufferStoreCoordinator {
 
     /**
-     * Per-channel stores used by this dispatcher. Typed as the concrete {@link
-     * RecoveredBufferStoreImpl} rather than {@link
-     * org.apache.flink.runtime.io.network.partition.consumer.RecoveredBufferStore} because the
-     * producer-side methods (addBuffer, incrementPending) are intentionally not part of the public
-     * interface — they are only called by FilteredBufferDispatcher, which is the sole producer of
-     * buffers for the stores.
+     * Typed as {@link RecoveredBufferStoreImpl} (not the interface) because the producer-side
+     * mutators ({@code addBuffer}, {@code incrementPending}) are deliberately not on the public
+     * interface — only this dispatcher calls them.
      */
     private final Map<InputChannelInfo, RecoveredBufferStoreImpl> storesByChannel;
 
@@ -76,63 +68,39 @@ public class FilteredBufferDispatcherImpl
     private final int memorySegmentSize;
     private final BufferRequester bufferRequester;
 
-    // Memory cache state: accumulates bytes for the active channel before committing to P1 or P2
     private final byte[] cache;
     private int cachePosition;
     private InputChannelInfo cacheChannel;
 
-    // Spill infrastructure (P2/P3 paths)
     private FilteredSpillFile spillFile;
 
-    // Checkpoint wait-set state machine
     private long currentCheckpointId = -1L;
     private long lastStoppedCheckpointId = -1L;
     private Set<InputChannelInfo> waitSet;
 
     /**
-     * Phase-2 snapshot Readers captured at the first {@link #onChannelCheckpointStarted} call for
-     * the in-flight checkpoint. Held until the wait-set converges and the iterator is handed off
-     * to the {@link ChannelStateWriter}, or until the checkpoint is stopped early. {@code null}
-     * when no checkpoint is in progress.
+     * Phase-2 snapshot Readers pinned at the first {@link #onChannelCheckpointStarted} for the
+     * in-flight checkpoint. {@code null} when no checkpoint is in progress.
      */
     private List<FilteredSpillFile.Reader> checkpointSnapshots;
 
     /**
-     * Per-channel drain head captured atomically with each channel's Step 1 ready snapshot. Used
-     * by phase-2 to filter snapshot entries: entries strictly before {@code startPos[X]} were
-     * already in {@code store_X.readyBuffers} when X's barrier passed (and were therefore captured
-     * by Step 1), so phase 2 must skip them; entries at or after {@code startPos[X]} were still on
-     * disk at X's barrier and must be written to X's channel state. {@code null} when no
-     * checkpoint is in progress.
+     * Per-channel drain-head captured atomically with each channel's Step 1 ready snapshot. Phase-2
+     * skips entries strictly below {@code startPos[X]} for channel X (already covered by Step 1)
+     * and writes entries at or after as that channel's checkpoint state.
      */
     private Map<InputChannelInfo, EntryPosition> checkpointStartPos;
 
     /**
-     * Position of the next spill entry the drain bundle will pop from the global FIFO across all
-     * sealed Readers. The drain bundle commits addBuffer (which folds in the matching pending
-     * decrement) and then advances this field as its last action under {@code synchronized(store_X)};
-     * the volatile semantics provide cross-channel visibility for {@code Step 1} of any other
-     * channel reading the field under its own store lock. {@code null} until the first spill entry
-     * is seen.
+     * Position of the next spill entry the drain bundle will pop from the global FIFO. Volatile
+     * publication provides cross-channel visibility: any other channel's Step 1 read under its own
+     * store lock observes drain progress without needing the dispatcher monitor.
      */
     private volatile EntryPosition drainHead;
 
-    // Lifecycle flags
     private boolean flushed;
     private boolean closed;
 
-    /**
-     * Creates a new FilteredBufferDispatcherImpl.
-     *
-     * @param storesByChannel per-channel stores for delivering recovered buffers
-     * @param channelStateWriter writer used during phase2 to stream spill chunks to checkpoint
-     *     storage without allocating network buffers
-     * @param spillDirs directories for spill files
-     * @param memorySegmentSize the size of a memory segment / network buffer
-     * @param bufferRequester per-channel buffer source. The non-blocking variant is used for the
-     *     fast path (P1) and eager replay (P3); the blocking variant is used by drainPendingSpill()
-     * @throws IOException if spillDirs is empty
-     */
     public FilteredBufferDispatcherImpl(
             Map<InputChannelInfo, RecoveredBufferStoreImpl> storesByChannel,
             ChannelStateWriter channelStateWriter,
@@ -151,10 +119,6 @@ public class FilteredBufferDispatcherImpl
         this.cache = new byte[memorySegmentSize];
         this.cachePosition = 0;
 
-        // Register this dispatcher as the coordinator on every per-channel store. The store calls
-        // back into the coordinator from checkpoint() and releaseAll() so the dispatcher can
-        // maintain its wait-set and drop still-pending on-disk spill entries the moment a channel
-        // is released, instead of holding the disk resources until dispatcher close().
         for (RecoveredBufferStoreImpl store : storesByChannel.values()) {
             synchronized (store) {
                 store.setCoordinator(this);
@@ -169,16 +133,13 @@ public class FilteredBufferDispatcherImpl
             throw new IllegalStateException("Cannot write after " + (closed ? "close" : "flush"));
         }
 
-        // P3: eagerly replay any pending spill entries while non-blocking buffers are available
         eagerDrain();
 
-        // Channel change: flush cached bytes for the previous channel before accumulating new data
         if (cacheChannel != null && !cacheChannel.equals(channelInfo) && cachePosition > 0) {
             flushCache();
         }
         cacheChannel = channelInfo;
 
-        // Copy bytes into cache; flush whenever the cache fills up
         int pos = 0;
         while (pos < length) {
             int space = memorySegmentSize - cachePosition;
@@ -202,10 +163,8 @@ public class FilteredBufferDispatcherImpl
         flushCache();
         if (spillFile != null) {
             spillFile.finish();
-            // Initialise drainHead to the first remaining entry across all sealed Readers (or END
-            // if eagerDrain consumed everything). This is the value Step 1 of any channel will
-            // observe before the first drainPendingSpill bundle commits — so we never publish an
-            // unset / null drainHead during the live checkpoint window.
+            // Initial value Step 1 of any channel will observe before the first drainPendingSpill
+            // bundle commits — never publish an unset drainHead during the live checkpoint window.
             drainHead = computeDrainHeadFrom(0);
         }
         flushed = true;
@@ -215,7 +174,7 @@ public class FilteredBufferDispatcherImpl
     public void drainPendingSpill() throws IOException, InterruptedException {
         Preconditions.checkState(flushed, "drainPendingSpill requires flush() to be called first");
         if (closed) {
-            return; // already cleaned up; nothing to drain
+            return;
         }
         if (spillFile == null) {
             return;
@@ -224,9 +183,7 @@ public class FilteredBufferDispatcherImpl
         for (int i = 0; i < readers.size(); i++) {
             FilteredSpillFile.Reader reader = readers.get(i);
             while (true) {
-                // Section 1 (lock-free peek): inspect the head entry of the current Reader to
-                // decide which channel's buffer pool to pull from. The original Reader is mutated
-                // only by this Recovery thread, so peek does not race with another drain consumer.
+                // Lock-free peek: the original Reader is mutated only by this Recovery thread.
                 FilteredSpillFile.Reader.Entry entry = reader.peekNextEntry();
                 if (entry == null) {
                     break;
@@ -235,22 +192,18 @@ public class FilteredBufferDispatcherImpl
                 long entryOffset = entry.getOffset();
                 int entryLength = entry.getLength();
 
-                // Section 2 (lock-free I/O): allocate the network buffer (may block on the pool)
-                // and copy the spilled bytes from disk into it. Both operations are kept outside
-                // any lock to avoid serialising channel checkpoints behind buffer-pool waits or
-                // page-cache misses.
+                // Lock-free I/O: buffer allocation may block on the pool and disk reads may miss
+                // the page cache; keep both outside any lock so channel checkpoints are not
+                // serialised behind them.
                 Buffer buffer = bufferRequester.requestBufferBlocking(ch);
                 byte[] data = new byte[entryLength];
                 reader.readBytesAt(entryOffset, entryLength, data, 0);
 
-                // Section 3 (commit under store lock + fire listener outside): pop the entry from
-                // the Reader, hand the populated buffer to the store (which folds in the matching
-                // pending decrement), and advance drainHead. The pop-then-add ordering keeps
-                // Step 1 from observing an entry popped from disk but not yet in readyBuffers.
-                // drainHead must be the last write so its volatile publication signals "drainHead
-                // crossed e ⇒ e is in store_C.readyBuffers" to cross-channel readers. The
-                // data-available listener is captured inside the store lock and fired afterwards
-                // to avoid an AB-BA deadlock with the task thread (gate lock → store lock).
+                // Commit under store lock then fire listener outside. drainHead must be the last
+                // write so its volatile publication signals "drainHead crossed e ⇒ e is in
+                // store_C.readyBuffers" to cross-channel Step 1 readers. Listener is captured
+                // inside the lock and fired after to avoid AB-BA with the task thread (gate →
+                // store).
                 RecoveredBufferStoreImpl store =
                         Preconditions.checkNotNull(
                                 storesByChannel.get(ch), "No store for channel %s", ch);
@@ -274,8 +227,8 @@ public class FilteredBufferDispatcherImpl
             return;
         }
         closed = true;
-        // Defensive: caller should have called flush() before close(); honour the historical
-        // fallback to seal lingering data so spillFile.close() can clean up consistently.
+        // Defensive: caller should have called flush() before close(); seal lingering data so
+        // spillFile.close() cleans up consistently.
         if (!flushed) {
             flushCache();
             if (spillFile != null) {
@@ -283,17 +236,12 @@ public class FilteredBufferDispatcherImpl
             }
             flushed = true;
         }
-        // Resource release only. drainSpillThroughBuffers is the responsibility of
-        // drainPendingSpill().
         if (spillFile != null) {
             spillFile.close();
             spillFile = null;
         }
-        // Hand off the symmetric tear-down: the BufferRequester returns each RecoveredInputChannel's
-        // exclusive segments to the global pool now that drain is no longer reading from them.
-        // Doing this here (post-drain, post-flush) guarantees no spill entry was abandoned mid-load
-        // and lets task threads still consuming buffers from the recovered store recycle them
-        // straight to the global pool (BufferManager.recycle's released-channel shortcut).
+        // Symmetric tear-down: returns each channel's exclusive segments to the global pool now
+        // that drain is no longer reading from them.
         bufferRequester.releaseExclusiveBuffers();
     }
 
@@ -305,43 +253,27 @@ public class FilteredBufferDispatcherImpl
 
     /**
      * Called by each per-channel store when that channel's ready buffers have been snapshotted into
-     * the {@link ChannelStateWriter}.
+     * the {@link ChannelStateWriter}. On the first callback for a checkpointId, pins an immutable
+     * phase-2 view of every sealed Reader and seeds the wait-set with the pending channels.
+     * Subsequent callbacks remove their channel; the empty wait-set triggers {@link
+     * #drainSpillEntriesToCheckpoint}.
      *
-     * <p>On the first callback for a given checkpointId we capture an immutable phase-2 view of the
-     * disk side: each sealed Reader has {@link FilteredSpillFile.Reader#snapshot()} called and the
-     * results are pinned in {@code checkpointSnapshots}, so subsequent {@link #drainPendingSpill}
-     * pops on the original Readers cannot drop entries out of the in-flight checkpoint. The
-     * wait-set is populated from those snapshots' pending channels. Subsequent callbacks remove
-     * their channel from the wait-set; when the set becomes empty, all channels with disk data
-     * have reported in and {@link #drainSpillEntriesToCheckpoint} is triggered.
-     *
-     * <p>{@code startPos} is the per-channel drain-head value the calling store captured atomically
-     * with its ready-buffer snapshot; phase 2 uses it to filter the captured snapshot entries
-     * (skip entries below the channel's startPos — they were already in readyBuffers and are
-     * covered by Step 1).
-     *
-     * <p>Called from the Task thread; synchronized on {@code this} to be mutually exclusive with
-     * the Recovery thread's {@link #write} / {@link #flush} / {@link #close}.
+     * <p>{@code startPos} is the per-channel drain-head captured atomically with the ready-buffer
+     * snapshot; phase-2 uses it to skip entries already covered by that channel's Step 1.
      */
     public synchronized void onChannelCheckpointStarted(
             long checkpointId, InputChannelInfo channelInfo, EntryPosition startPos) {
         if (checkpointId < currentCheckpointId) {
-            // Stale callback from a superseded checkpoint: we have already moved on to a newer
-            // one. Ignoring it keeps the current wait-set intact so the in-flight checkpoint
-            // converges correctly.
             return;
         }
         if (checkpointId <= lastStoppedCheckpointId) {
-            // Stale callback for a checkpoint the task has already stopped (finished or aborted).
-            // The ChannelStateWriter for this id is gone; phase-2 drain into it would be wasted
-            // work and would require relying on writer.isDone() to silently swallow the data.
+            // ChannelStateWriter for this id is gone; phase-2 drain into it would rely on
+            // writer.isDone() to silently swallow the data.
             return;
         }
         if (checkpointId > currentCheckpointId) {
-            // New checkpoint: pin a snapshot of every sealed Reader before any further drain pops
-            // can mutate their entry deques, then build the wait-set from the snapshot's pending
-            // channels. Invariant: checkpoint only starts after recovery ends (writer.finish());
-            // all Readers are sealed at this point.
+            // Pin snapshots before any drain pop can mutate entry deques. Invariant: checkpoint
+            // only starts after recovery ends, so all Readers are sealed.
             currentCheckpointId = checkpointId;
             checkpointStartPos = new HashMap<>();
             checkpointSnapshots = new ArrayList<>();
@@ -369,7 +301,6 @@ public class FilteredBufferDispatcherImpl
                 }
             }
         }
-        // checkpointId == currentCheckpointId: accumulate toward the same wait-set.
         if (checkpointStartPos != null) {
             checkpointStartPos.put(channelInfo, startPos);
         }
@@ -382,20 +313,10 @@ public class FilteredBufferDispatcherImpl
     }
 
     /**
-     * Called by a per-channel store from {@link RecoveredBufferStore#notifyCheckpointStopped} when
-     * the owning channel has finished or aborted the given checkpoint. Drops the wait-set tied to
-     * that checkpoint so a later {@link #onChannelReleased} cannot drain spill entries into a
-     * checkpoint the task has already concluded; also bumps {@code lastStoppedCheckpointId} so a
-     * late {@link #onChannelCheckpointStarted} for the same id is short-circuited as stale.
-     *
-     * <p>Closes any pinned phase-2 snapshot Readers and clears {@code checkpointStartPos} /
-     * {@code checkpointSnapshots} so the next checkpoint starts from a clean slate and the per-
-     * snapshot {@code FileChannel}s are released promptly (otherwise every aborted checkpoint
-     * leaks one fd per spill file).
-     *
-     * <p>Called from the Task thread; synchronized on {@code this} to be mutually exclusive with
-     * other coordinator callbacks and the Recovery thread's
-     * {@link #write} / {@link #flush} / {@link #close}.
+     * Drops the wait-set tied to a finished/aborted checkpoint and bumps {@code
+     * lastStoppedCheckpointId} so a late {@link #onChannelCheckpointStarted} for the same id is
+     * short-circuited as stale. Closes any pinned phase-2 snapshot Readers — otherwise every
+     * aborted checkpoint leaks one fd per spill file.
      */
     public synchronized void onChannelCheckpointStopped(
             long checkpointId, InputChannelInfo channelInfo) {
@@ -403,27 +324,15 @@ public class FilteredBufferDispatcherImpl
             lastStoppedCheckpointId = checkpointId;
         }
         if (currentCheckpointId == checkpointId) {
-            // The wait-set we were collecting belongs to the now-stopped checkpoint; releasing
-            // any remaining channel must not retroactively trigger phase-2 drain into it.
             resetCheckpointState();
         }
     }
 
     /**
-     * Called by a per-channel store from {@link RecoveredBufferStoreImpl#releaseAll()}. Drops every
-     * pending spill entry belonging to {@code channelInfo} from all Readers so the disk-side
-     * bookkeeping is freed immediately; also removes the channel from an in-flight checkpoint
-     * wait-set so the wait-set can still converge after the channel goes away.
-     *
-     * <p>Phase-2 snapshots intentionally are <em>not</em> mutated here: an entry left in the
-     * snapshot whose channel has been released will be dropped by the filtering iterator because
-     * {@code checkpointStartPos.get(channelInfo)} returns null (treated as "channel gone, skip
-     * everything"). Mutating the live snapshot would require coordinating with the executor thread
-     * already iterating it for an in-flight phase-2 drain.
-     *
-     * <p>Called from the Task thread; synchronized on {@code this} to be mutually exclusive with
-     * the Recovery thread's {@link #write} / {@link #flush} / {@link #close} and with {@link
-     * #onChannelCheckpointStarted}.
+     * Drops every pending spill entry belonging to {@code channelInfo} from all Readers. Phase-2
+     * snapshots are intentionally not mutated: the filtering iterator drops snapshot entries whose
+     * channel has no recorded startPos. Mutating the live snapshot would race the executor thread
+     * already iterating it.
      */
     public synchronized void onChannelReleased(InputChannelInfo channelInfo) {
         if (spillFile != null) {
@@ -437,9 +346,10 @@ public class FilteredBufferDispatcherImpl
     }
 
     /**
-     * Hands the previously pinned snapshot Readers (with the captured per-channel startPos cutoffs)
-     * off to the {@link ChannelStateWriter} via a filtering iterator. Ownership of the snapshot
-     * Readers transfers to the iterator's {@link FilteringDrainChunkIterator#close()}.
+     * Hands pinned snapshot Readers off to the {@link ChannelStateWriter}. Ownership of the
+     * snapshot Readers transfers to the iterator's {@link FilteringDrainChunkIterator#close()},
+     * which releases the FileChannels even if the writer never advances the iterator (e.g. on
+     * abort).
      */
     private void drainSpillEntriesToCheckpoint(long checkpointId) {
         if (checkpointSnapshots == null || checkpointSnapshots.isEmpty()) {
@@ -448,9 +358,6 @@ public class FilteredBufferDispatcherImpl
         }
         List<FilteredSpillFile.Reader> snapshots = checkpointSnapshots;
         Map<InputChannelInfo, EntryPosition> startPos = checkpointStartPos;
-        // Hand the snapshot Readers to the iterator so its close() releases the FileChannels even
-        // if the writer never advances the iterator (e.g. on abort). Clear local state so a later
-        // onChannelCheckpointStopped for the same id does not double-close.
         checkpointSnapshots = null;
         checkpointStartPos = null;
         waitSet = null;
@@ -470,7 +377,6 @@ public class FilteredBufferDispatcherImpl
     }
 
     /**
-     * Next-to-pop {@link EntryPosition}, scanning readers from list position {@code fromListIndex}.
      * {@code fromListIndex} is a list cursor, distinct from {@link
      * FilteredSpillFile.Reader#getFileIndex()} which is the globally monotonic file-id.
      */
@@ -490,12 +396,9 @@ public class FilteredBufferDispatcherImpl
     }
 
     /**
-     * Flushes the cache for the current channel via P1 (buffer) or P2 (spill). After calling, the
-     * cache is empty and cacheChannel is null.
-     *
-     * <p>P1 is chosen when the spill writer is idle (no pending disk entries) AND a non-blocking
-     * buffer can be obtained. Otherwise the bytes are spilled (P2). This ensures FIFO ordering:
-     * once any data has been spilled, all subsequent data must also spill to preserve order.
+     * Commits the cache via P1 (direct buffer) or P2 (spill). P1 requires the spill writer idle AND
+     * a non-blocking buffer available; otherwise spill, which preserves FIFO ordering — once
+     * anything has been spilled, all subsequent data must also spill.
      */
     private void flushCache() throws IOException {
         if (cachePosition == 0) {
@@ -508,7 +411,6 @@ public class FilteredBufferDispatcherImpl
         cachePosition = 0;
         cacheChannel = null;
 
-        // P1: spill writer idle and a buffer is available — write directly to network buffer
         if (isSpillIdle()) {
             Buffer buffer = bufferRequester.requestBuffer(channelInfo);
             if (buffer != null) {
@@ -523,15 +425,9 @@ public class FilteredBufferDispatcherImpl
             }
         }
 
-        // P2: spill writer not idle or no buffer available — write to spill file
         writeToSpillFile(cache, bytesToFlush, channelInfo);
     }
 
-    /**
-     * Copies {@code length} bytes from {@code data} into the given network buffer. Assumes the
-     * buffer is freshly acquired (writerIndex == 0); after this call, {@code buffer.getSize() ==
-     * length}.
-     */
     private static void writeChunkToBuffer(Buffer buffer, byte[] data, int length) {
         Preconditions.checkState(
                 buffer.getMaxCapacity() >= length,
@@ -541,33 +437,26 @@ public class FilteredBufferDispatcherImpl
         buffer.asByteBuf().writeBytes(data, 0, length);
     }
 
-    /** Writes bytes to the spill file, creating the Writer lazily if needed. */
     private void writeToSpillFile(byte[] data, int length, InputChannelInfo channelInfo)
             throws IOException {
         if (spillFile == null) {
             spillFile = new FilteredSpillFile(spillDirs, memorySegmentSize);
         }
         spillFile.writeEntry(data, length, channelInfo);
-        // Increment pending count so store.isEmpty() correctly reflects outstanding data
         RecoveredBufferStoreImpl store =
                 Preconditions.checkNotNull(
-                        storesByChannel.get(channelInfo),
-                        "No store for channel %s",
-                        channelInfo);
+                        storesByChannel.get(channelInfo), "No store for channel %s", channelInfo);
         synchronized (store) {
             store.incrementPending();
         }
     }
 
     /**
-     * Eagerly replays spill entries while non-blocking buffers are available.
-     *
-     * <p>Runs only on the {@link #write} path before {@link #flush}, so by construction it cannot
-     * race with {@link #onChannelCheckpointStarted}: physical {@code InputChannel}s exist only
-     * after recovery's {@code finishRecovery()} (which itself runs after flush), and checkpoint
-     * triggers can only fire on those physical channels. {@code drainHead} is initialised at
-     * {@link #flush} time from whatever entries this method left behind, so eagerDrain does not
-     * need to maintain it.
+     * Eagerly replays spill entries while non-blocking buffers are available. Runs only on the
+     * {@link #write} path before {@link #flush}, so by construction it cannot race {@link
+     * #onChannelCheckpointStarted}: physical channels (and thus checkpoint triggers) only exist
+     * after recovery's {@code finishRecovery()}, which runs after flush. Does not maintain {@code
+     * drainHead} — that field is initialised at flush time.
      */
     private void eagerDrain() throws IOException {
         if (spillFile == null) {
@@ -594,21 +483,14 @@ public class FilteredBufferDispatcherImpl
         }
     }
 
-    /** Returns true if no spill entries have been written yet (P1 is safe). */
     private boolean isSpillIdle() {
         return spillFile == null || spillFile.isIdle();
     }
 
-    // -------------------------------------------------------------------------
-    // FilteringDrainChunkIterator — CloseableIterator over snapshot Readers with per-channel cutoff
-    // -------------------------------------------------------------------------
-
     /**
-     * Iterates over chunks from a sequence of snapshot {@link FilteredSpillFile.Reader}s, skipping
-     * entries that fall below the channel's recorded {@code startPos} cutoff (those entries were
-     * already in the channel's Step 1 ready snapshot and are covered there). Each Reader is
-     * drained in order; once exhausted it is popped and closed immediately. {@link #close()} closes
-     * whatever Readers remain (i.e. those not yet consumed by the iterator).
+     * Iterates chunks from snapshot Readers, skipping entries below each channel's recorded {@code
+     * startPos} cutoff (those are covered by Step 1). Each Reader is closed eagerly when exhausted;
+     * {@link #close()} closes whatever Readers remain.
      */
     private static final class FilteringDrainChunkIterator
             implements CloseableIterator<FilteredSpillFile.Chunk> {
@@ -643,11 +525,10 @@ public class FilteredBufferDispatcherImpl
         }
 
         /**
-         * Skips entries whose channel either has no recorded startPos (channel was released before
-         * triggering checkpoint, drop everything for that channel) or whose position is strictly
-         * below the channel's startPos (entry was already covered by Step 1). Pops empty readers
-         * along the way and closes them eagerly so FileChannel fds are released even if the writer
-         * never finishes draining the iterator.
+         * Skips entries whose channel either has no recorded startPos (released before checkpoint
+         * trigger — drop everything for that channel) or whose position is strictly below the
+         * channel's startPos. Closes empty readers eagerly so FileChannel fds are released even if
+         * the writer never finishes draining the iterator.
          */
         private void advanceToIncluded() {
             while (!remaining.isEmpty()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FilteredBufferDispatcherImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FilteredBufferDispatcherImpl.java
@@ -24,22 +24,19 @@ import org.apache.flink.runtime.io.network.partition.consumer.RecoveredBufferSto
 import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.Preconditions;
 
+import javax.annotation.concurrent.GuardedBy;
+
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Deque;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.flink.util.IOUtils.closeQuietly;
 
@@ -57,26 +54,16 @@ import static org.apache.flink.util.IOUtils.closeQuietly;
  * available, otherwise via P2. After {@link #flush()} seals all Readers, {@link
  * #drainPendingSpill()} drains the remainder; {@link #close()} releases resources.
  *
- * <h3>Locking discipline (post-iter_6)</h3>
+ * <h3>Lock ordering</h3>
  *
- * <p>This class holds <b>no monitor of its own</b>. The previous {@code synchronized} methods
- * have been replaced with lock-free primitives so the per-channel store lock (held by task
- * threads inside {@code ChannelStatePersister}) can call back into the coordinator without
- * forming an AB-BA cycle.
- *
- * <ul>
- *   <li>Recovery-thread state ({@code cache}, {@code cachePosition}, {@code cacheChannel},
- *       {@code spillFile}, {@code flushed}, {@code closed}): single-writer; cross-thread reads
- *       use {@code volatile}.
- *   <li>Per-checkpoint state ({@link CheckpointWindow}) is bundled into one immutable object
- *       and published via {@link AtomicReference}. Channel-arrival uses {@link
- *       ConcurrentHashMap}-backed sets and an {@link AtomicInteger} counter; the channel that
- *       drives the counter to zero fires {@link #drainSpillEntriesToCheckpoint(CheckpointWindow)}
- *       at most once via an {@link AtomicBoolean} guard.
- *   <li>{@link AtomicLong} {@code lastStoppedCheckpointId} advances monotonically via CAS.
- *   <li>{@code drainHead} stays {@code volatile} as before; cross-channel Step-1 readers use
- *       its publication to observe drain progress without taking any dispatcher-level lock.
- * </ul>
+ * <p>Two locks meet on the recovery → checkpoint hand-off: each per-channel store's intrinsic
+ * monitor (<i>SMALL</i>) and this dispatcher's {@link #dispatcherLock} (<i>BIG</i>). They must
+ * always be acquired in the order <b>SMALL → BIG</b>. Code holding BIG must never reach back to
+ * any SMALL — neither directly nor through a callee — otherwise the AB-BA cycle returns. Forbidden
+ * callees from inside a {@code synchronized(dispatcherLock)} block: {@link
+ * RecoveredBufferStoreImpl#addBuffer}, {@link RecoveredBufferStoreImpl#addBufferAndCaptureListener},
+ * {@link RecoveredBufferStoreImpl#incrementPending}, any {@code synchronized(store)} block, and any
+ * {@link org.apache.flink.runtime.io.network.partition.consumer.ChannelStatePersister} entrypoint.
  */
 @Internal
 public class FilteredBufferDispatcherImpl
@@ -94,36 +81,50 @@ public class FilteredBufferDispatcherImpl
     private final int memorySegmentSize;
     private final BufferRequester bufferRequester;
 
-    /** Recovery-thread private. */
-    private final byte[] cache;
+    /**
+     * Explicit lock object instead of {@code synchronized} methods so every callsite that takes
+     * BIG is grep-visible.
+     */
+    private final Object dispatcherLock = new Object();
 
+    private final byte[] cache;
     private int cachePosition;
     private InputChannelInfo cacheChannel;
 
     /**
-     * Lazily initialized by recovery thread inside {@link #writeToSpillFile}. Volatile so task
+     * Lazily initialized by the recovery thread inside {@link #writeToSpillFile}; volatile so task
      * threads observing it after {@link #flushed} see a fully-constructed instance.
      */
     private volatile FilteredSpillFile spillFile;
 
-    /**
-     * Highest stopped checkpoint id seen so far. CAS-advanced from
-     * {@link #onChannelCheckpointStopped}; read by {@link #onChannelCheckpointStarted} to short-
-     * circuit late callbacks for already-finalized checkpoints.
-     */
-    private final AtomicLong lastStoppedCheckpointId = new AtomicLong(-1L);
+    @GuardedBy("dispatcherLock")
+    private long currentCheckpointId = -1L;
+
+    @GuardedBy("dispatcherLock")
+    private long lastStoppedCheckpointId = -1L;
+
+    @GuardedBy("dispatcherLock")
+    private Set<InputChannelInfo> waitSet;
 
     /**
-     * Per-checkpoint window installed by the first {@link #onChannelCheckpointStarted} for a new
-     * id. The reference is replaced (or cleared) via CAS so the bundled snapshots/wait-set/start-
-     * pos all become visible together with no torn intermediate state.
+     * Phase-2 snapshot Readers pinned at the first {@link #onChannelCheckpointStarted} for the
+     * in-flight checkpoint. {@code null} when no checkpoint is in progress.
      */
-    private final AtomicReference<CheckpointWindow> currentWindow = new AtomicReference<>();
+    @GuardedBy("dispatcherLock")
+    private List<FilteredSpillFile.Reader> checkpointSnapshots;
+
+    /**
+     * Per-channel drain-head captured atomically with each channel's Step 1 ready snapshot.
+     * Phase-2 skips entries strictly below {@code startPos[X]} for channel X (already covered by
+     * Step 1) and writes entries at or after as that channel's checkpoint state.
+     */
+    @GuardedBy("dispatcherLock")
+    private Map<InputChannelInfo, EntryPosition> checkpointStartPos;
 
     /**
      * Position of the next spill entry the drain bundle will pop from the global FIFO. Volatile
      * publication provides cross-channel visibility: any other channel's Step 1 read under its own
-     * store lock observes drain progress without needing a dispatcher monitor.
+     * SMALL observes drain progress without acquiring BIG.
      */
     private volatile EntryPosition drainHead;
 
@@ -212,7 +213,6 @@ public class FilteredBufferDispatcherImpl
         for (int i = 0; i < readers.size(); i++) {
             FilteredSpillFile.Reader reader = readers.get(i);
             while (true) {
-                // Lock-free peek: the original Reader is mutated only by this Recovery thread.
                 FilteredSpillFile.Reader.Entry entry = reader.peekNextEntry();
                 if (entry == null) {
                     break;
@@ -221,18 +221,13 @@ public class FilteredBufferDispatcherImpl
                 long entryOffset = entry.getOffset();
                 int entryLength = entry.getLength();
 
-                // Lock-free I/O: buffer allocation may block on the pool and disk reads may miss
-                // the page cache; keep both outside any lock so channel checkpoints are not
+                // Buffer allocation may block on the pool and disk reads may miss the page
+                // cache; keep both outside the store lock so channel checkpoints are not
                 // serialised behind them.
                 Buffer buffer = bufferRequester.requestBufferBlocking(ch);
                 byte[] data = new byte[entryLength];
                 reader.readBytesAt(entryOffset, entryLength, data, 0);
 
-                // Commit under store lock then fire listener outside. drainHead must be the last
-                // write so its volatile publication signals "drainHead crossed e ⇒ e is in
-                // store_C.readyBuffers" to cross-channel Step 1 readers. Listener is captured
-                // inside the lock and fired after to avoid AB-BA with the task thread (gate →
-                // store).
                 RecoveredBufferStoreImpl store =
                         Preconditions.checkNotNull(
                                 storesByChannel.get(ch), "No store for channel %s", ch);
@@ -241,8 +236,13 @@ public class FilteredBufferDispatcherImpl
                     reader.skipNextEntry();
                     writeChunkToBuffer(buffer, data, entryLength);
                     listener = store.addBufferAndCaptureListener(buffer);
+                    // drainHead is the last write inside the lock so its volatile publication
+                    // signals "drainHead crossed e ⇒ e is in store_C.readyBuffers" to
+                    // cross-channel Step 1 readers.
                     drainHead = computeDrainHeadFrom(i);
                 }
+                // Listener is captured inside the lock and fired here so the gate → store
+                // wake-up does not run while we hold the store lock (would AB-BA the task).
                 if (listener != null) {
                     listener.onDataAvailable();
                 }
@@ -255,9 +255,10 @@ public class FilteredBufferDispatcherImpl
         if (closed) {
             return;
         }
-        closed = true;
-        // Defensive: caller should have called flush() before close(); seal lingering data so
-        // spillFile.close() cleans up consistently.
+
+        // Phase 1 (abort path only): caller skipped flush(). flushCache reaches store.addBuffer,
+        // which acquires SMALL — must run outside dispatcherLock to keep the lock-order rule.
+        // The happy path enters with flushed=true and skips this block.
         if (!flushed) {
             flushCache();
             if (spillFile != null) {
@@ -265,20 +266,21 @@ public class FilteredBufferDispatcherImpl
             }
             flushed = true;
         }
-        if (spillFile != null) {
-            spillFile.close();
-            spillFile = null;
+
+        // Setting closed=true before deleting the spill file is what closes the
+        // close-vs-snapshot race: a concurrent onChannelCheckpointStarted either pinned its
+        // FileChannels before this block ran (POSIX keeps the file alive after unlink) or
+        // observes closed and returns before opening the file.
+        synchronized (dispatcherLock) {
+            closed = true;
+            if (spillFile != null) {
+                spillFile.close();
+                spillFile = null;
+            }
+            resetCheckpointState();
         }
-        // Symmetric tear-down: returns each channel's exclusive segments to the global pool now
-        // that drain is no longer reading from them.
+
         bufferRequester.releaseExclusiveBuffers();
-        // Drop any still-pinned phase-2 snapshots so their fds are released even if the writer
-        // never advanced the iterator. The drainTriggered CAS keeps this from racing a final
-        // in-flight maybeTriggerDrain — whichever side wins owns and closes the snapshots.
-        CheckpointWindow w = currentWindow.getAndSet(null);
-        if (w != null && w.drainTriggered.compareAndSet(false, true)) {
-            closeSnapshots(w.snapshots);
-        }
     }
 
     @Override
@@ -288,12 +290,9 @@ public class FilteredBufferDispatcherImpl
     }
 
     /**
-     * Called by each per-channel store when that channel's ready buffers have been snapshotted
-     * into the {@link ChannelStateWriter}. The first arrival for a new checkpoint id installs an
-     * immutable {@link CheckpointWindow} via CAS (pinning frozen Reader snapshots and seeding the
-     * wait-set with the pending channels); subsequent arrivals only mark themselves done and the
-     * channel that drives {@code remaining} to zero triggers
-     * {@link #drainSpillEntriesToCheckpoint(CheckpointWindow)}.
+     * On the first callback for a checkpoint id, pins an immutable phase-2 view of every frozen
+     * Reader and seeds the wait-set with their pending channels. Subsequent callbacks remove
+     * their channel; the empty wait-set triggers {@link #drainSpillEntriesToCheckpoint}.
      *
      * <p>{@code startPos} is the per-channel drain-head captured atomically with the ready-buffer
      * snapshot; phase-2 uses it to skip entries already covered by that channel's Step 1.
@@ -301,18 +300,36 @@ public class FilteredBufferDispatcherImpl
     @Override
     public void onChannelCheckpointStarted(
             long checkpointId, InputChannelInfo channelInfo, EntryPosition startPos) {
-        if (checkpointId <= lastStoppedCheckpointId.get()) {
-            // ChannelStateWriter for this id is gone; phase-2 drain into it would rely on
-            // writer.isDone() to silently swallow the data.
-            return;
-        }
-        CheckpointWindow window = ensureCheckpointWindow(checkpointId);
-        if (window == null) {
-            return; // a newer checkpoint already advanced past us
-        }
-        window.startPos.put(channelInfo, startPos);
-        if (window.waitSet.remove(channelInfo)) {
-            maybeTriggerDrain(window);
+        synchronized (dispatcherLock) {
+            if (closed) {
+                return;
+            }
+            if (checkpointId < currentCheckpointId) {
+                return;
+            }
+            if (checkpointId <= lastStoppedCheckpointId) {
+                // ChannelStateWriter for this id is gone; phase-2 drain into it would rely on
+                // writer.isDone() to silently swallow the data.
+                return;
+            }
+            if (checkpointId > currentCheckpointId) {
+                currentCheckpointId = checkpointId;
+                checkpointStartPos = new HashMap<>();
+                checkpointSnapshots = new ArrayList<>();
+                waitSet = new HashSet<>();
+                if (spillFile != null) {
+                    pinSpillSnapshots();
+                }
+            }
+            if (checkpointStartPos != null) {
+                checkpointStartPos.put(channelInfo, startPos);
+            }
+            if (waitSet != null) {
+                waitSet.remove(channelInfo);
+                if (waitSet.isEmpty()) {
+                    drainSpillEntriesToCheckpoint(checkpointId);
+                }
+            }
         }
     }
 
@@ -324,142 +341,100 @@ public class FilteredBufferDispatcherImpl
      */
     @Override
     public void onChannelCheckpointStopped(long checkpointId, InputChannelInfo channelInfo) {
-        long prev;
-        do {
-            prev = lastStoppedCheckpointId.get();
-            if (checkpointId <= prev) {
-                break;
+        synchronized (dispatcherLock) {
+            if (closed) {
+                return;
             }
-        } while (!lastStoppedCheckpointId.compareAndSet(prev, checkpointId));
-
-        CheckpointWindow w = currentWindow.get();
-        if (w != null && w.checkpointId == checkpointId) {
-            // Snapshot ownership is claimed via the drainTriggered flag: a concurrent
-            // maybeTriggerDrain that has already CAS'd drainTriggered to true now owns the
-            // snapshots and will hand them to the channel-state writer's iterator. Detach the
-            // window unconditionally so a duplicate stop does not double-close, but only the
-            // first claimant of drainTriggered closes the snapshots here.
-            currentWindow.compareAndSet(w, null);
-            if (w.drainTriggered.compareAndSet(false, true)) {
-                closeSnapshots(w.snapshots);
+            if (checkpointId > lastStoppedCheckpointId) {
+                lastStoppedCheckpointId = checkpointId;
+            }
+            if (currentCheckpointId == checkpointId) {
+                resetCheckpointState();
             }
         }
     }
 
     /**
-     * Drops every pending spill entry belonging to {@code channelInfo} from all Readers. Phase-2
-     * snapshots are intentionally not mutated: the filtering iterator drops snapshot entries whose
-     * channel has no recorded startPos. Mutating the live snapshot would race the executor thread
-     * already iterating it.
+     * Drops every pending spill entry belonging to {@code channelInfo} from all live Readers.
+     * Phase-2 snapshots are intentionally not mutated: the filtering iterator drops snapshot
+     * entries whose channel has no recorded startPos. Mutating the live snapshot would race the
+     * executor thread already iterating it.
      */
     @Override
     public void onChannelReleased(InputChannelInfo channelInfo) {
-        FilteredSpillFile sf = spillFile;
-        if (sf != null) {
-            for (FilteredSpillFile.Reader reader : sf.getReaders()) {
-                reader.removeEntriesForChannel(channelInfo);
+        synchronized (dispatcherLock) {
+            if (closed) {
+                return;
             }
-        }
-        CheckpointWindow w = currentWindow.get();
-        if (w != null && w.waitSet.remove(channelInfo)) {
-            maybeTriggerDrain(w);
-        }
-    }
-
-    /**
-     * CAS-installs (or reuses) the {@link CheckpointWindow} for {@code checkpointId}. When this
-     * call is the first to advance to a higher id, it pins phase-2 Reader snapshots and seeds the
-     * wait-set; if it loses the CAS race against a concurrent caller, the speculative snapshots
-     * it created are closed before retrying so we never leak fds.
-     *
-     * @return the published window for {@code checkpointId}, or {@code null} if a strictly newer
-     *     checkpoint has already advanced past {@code checkpointId} and this caller is now stale.
-     */
-    private CheckpointWindow ensureCheckpointWindow(long checkpointId) {
-        while (true) {
-            // Re-check on each spin: a concurrent stop may have advanced lastStoppedCheckpointId
-            // past us while we were preparing snapshots, in which case we must abort.
-            if (checkpointId <= lastStoppedCheckpointId.get()) {
-                return null;
-            }
-            CheckpointWindow current = currentWindow.get();
-            if (current != null && current.checkpointId > checkpointId) {
-                return null;
-            }
-            if (current != null && current.checkpointId == checkpointId) {
-                return current;
-            }
-            // current is null or has a stale id — try to install a new window for checkpointId.
-            CheckpointWindow candidate = createCheckpointWindow(checkpointId);
-            if (currentWindow.compareAndSet(current, candidate)) {
-                if (current != null && current.drainTriggered.compareAndSet(false, true)) {
-                    closeSnapshots(current.snapshots);
+            if (spillFile != null) {
+                // reader.removeEntriesForChannel mutates the same Reader.entries deque that
+                // drainPendingSpill (holds SMALL_C, not BIG) pops from, so the deque must be
+                // a ConcurrentLinkedDeque — that is its load-bearing role, not a decoration.
+                for (FilteredSpillFile.Reader reader : spillFile.getReaders()) {
+                    reader.removeEntriesForChannel(channelInfo);
                 }
-                return candidate;
             }
-            // Lost the CAS race; close the speculative snapshots we just pinned and retry. We
-            // own them exclusively at this point — they have not been published to any other
-            // thread — so no drainTriggered claim is needed.
-            closeSnapshots(candidate.snapshots);
+            if (waitSet != null && waitSet.remove(channelInfo) && waitSet.isEmpty()) {
+                drainSpillEntriesToCheckpoint(currentCheckpointId);
+            }
         }
     }
 
-    private CheckpointWindow createCheckpointWindow(long checkpointId) {
-        FilteredSpillFile sf = spillFile;
+    @GuardedBy("dispatcherLock")
+    private void pinSpillSnapshots() {
         List<FilteredSpillFile.Reader> snapshots = new ArrayList<>();
-        Set<InputChannelInfo> pendingChannels = new HashSet<>();
-        if (sf != null) {
-            try {
-                for (FilteredSpillFile.Reader reader : sf.getReaders()) {
-                    Preconditions.checkState(
-                            reader.isFrozen(),
-                            "Reader must be frozen when checkpoint starts; writer.finish() "
-                                    + "must be called before checkpoint trigger.");
-                    FilteredSpillFile.Reader snap = reader.snapshot();
-                    snapshots.add(snap);
-                    pendingChannels.addAll(snap.getPendingChannels());
-                }
-            } catch (IOException e) {
-                closeSnapshots(snapshots);
-                throw new RuntimeException(
-                        "Failed to snapshot spill readers for checkpoint", e);
+        try {
+            for (FilteredSpillFile.Reader reader : spillFile.getReaders()) {
+                Preconditions.checkState(
+                        reader.isFrozen(),
+                        "Reader must be frozen when checkpoint starts; writer.finish() "
+                                + "must be called before checkpoint trigger.");
+                snapshots.add(reader.snapshot());
             }
+        } catch (IOException e) {
+            for (FilteredSpillFile.Reader snap : snapshots) {
+                closeQuietly(snap);
+            }
+            throw new RuntimeException("Failed to snapshot spill readers for checkpoint", e);
         }
-        return new CheckpointWindow(checkpointId, snapshots, pendingChannels);
+        checkpointSnapshots = snapshots;
+        for (FilteredSpillFile.Reader snap : snapshots) {
+            waitSet.addAll(snap.getPendingChannels());
+        }
     }
 
     /**
-     * Hands pinned snapshot Readers off to the {@link ChannelStateWriter}. Ownership of the
-     * snapshot Readers transfers to the iterator's {@link FilteringDrainChunkIterator#close()},
-     * which releases the FileChannels even if the writer never advances the iterator (e.g. on
-     * abort).
-     *
-     * <p>The {@link AtomicBoolean} guard inside {@link CheckpointWindow} ensures this fires at
-     * most once even if {@code remove + decrementAndGet} races between
-     * {@link #onChannelCheckpointStarted} and {@link #onChannelReleased}.
+     * Hands pinned snapshot Readers off to the {@link ChannelStateWriter}. Ownership transfers to
+     * the iterator's {@link FilteringDrainChunkIterator#close()} so the FileChannels are released
+     * even if the writer never advances the iterator (e.g. on abort).
      */
-    private void maybeTriggerDrain(CheckpointWindow window) {
-        if (window.remaining.decrementAndGet() != 0) {
+    @GuardedBy("dispatcherLock")
+    private void drainSpillEntriesToCheckpoint(long checkpointId) {
+        if (checkpointSnapshots == null || checkpointSnapshots.isEmpty()) {
+            resetCheckpointState();
             return;
         }
-        if (!window.drainTriggered.compareAndSet(false, true)) {
-            return;
-        }
-        // Detach the window so a stop callback after drain doesn't double-close snapshots; the
-        // iterator now owns them.
-        currentWindow.compareAndSet(window, null);
-        if (window.snapshots.isEmpty()) {
-            return;
-        }
+        List<FilteredSpillFile.Reader> snapshots = checkpointSnapshots;
+        Map<InputChannelInfo, EntryPosition> startPos = checkpointStartPos;
+        checkpointSnapshots = null;
+        checkpointStartPos = null;
+        waitSet = null;
+        // addInputDataFromSpill submits to an async writer thread and does not reach back into
+        // any store SMALL — required for any callee invoked while holding BIG.
         channelStateWriter.addInputDataFromSpill(
-                window.checkpointId,
-                new FilteringDrainChunkIterator(window.snapshots, window.startPos));
+                checkpointId, new FilteringDrainChunkIterator(snapshots, startPos));
     }
 
-    private static void closeSnapshots(List<FilteredSpillFile.Reader> snapshots) {
-        for (FilteredSpillFile.Reader snap : snapshots) {
-            closeQuietly(snap);
+    @GuardedBy("dispatcherLock")
+    private void resetCheckpointState() {
+        if (checkpointSnapshots != null) {
+            for (FilteredSpillFile.Reader snap : checkpointSnapshots) {
+                closeQuietly(snap);
+            }
+            checkpointSnapshots = null;
         }
+        checkpointStartPos = null;
+        waitSet = null;
     }
 
     /**
@@ -482,8 +457,8 @@ public class FilteredBufferDispatcherImpl
     }
 
     /**
-     * Commits the cache via P1 (direct buffer) or P2 (spill). P1 requires the spill writer idle AND
-     * a non-blocking buffer available; otherwise spill, which preserves FIFO ordering — once
+     * Commits the cache via P1 (direct buffer) or P2 (spill). P1 requires the spill writer idle
+     * AND a non-blocking buffer available; otherwise spill, which preserves FIFO ordering — once
      * anything has been spilled, all subsequent data must also spill.
      */
     private void flushCache() throws IOException {
@@ -574,40 +549,9 @@ public class FilteredBufferDispatcherImpl
     }
 
     /**
-     * Immutable bundle of per-checkpoint coordination state. Replaces the old triple of nullable
-     * fields ({@code checkpointSnapshots} / {@code waitSet} / {@code checkpointStartPos}) with a
-     * single {@link AtomicReference}-published object so the snapshots and the wait-set become
-     * visible together with no torn intermediate state.
-     */
-    private static final class CheckpointWindow {
-
-        final long checkpointId;
-        final List<FilteredSpillFile.Reader> snapshots;
-        final Map<InputChannelInfo, EntryPosition> startPos = new ConcurrentHashMap<>();
-        final Set<InputChannelInfo> waitSet;
-        final AtomicInteger remaining;
-        final AtomicBoolean drainTriggered = new AtomicBoolean(false);
-
-        CheckpointWindow(
-                long checkpointId,
-                List<FilteredSpillFile.Reader> snapshots,
-                Set<InputChannelInfo> pendingChannels) {
-            this.checkpointId = checkpointId;
-            this.snapshots = Collections.unmodifiableList(new ArrayList<>(snapshots));
-            // ConcurrentHashMap-backed set: O(1) thread-safe remove + a plug-in source for the
-            // remaining counter without holding a lock.
-            this.waitSet = ConcurrentHashMap.newKeySet();
-            this.waitSet.addAll(pendingChannels);
-            // Counter mirrors waitSet size at construction so each successful remove drives one
-            // decrement.
-            this.remaining = new AtomicInteger(this.waitSet.size());
-        }
-    }
-
-    /**
-     * Iterates chunks from snapshot Readers, skipping entries below each channel's recorded {@code
-     * startPos} cutoff (those are covered by Step 1). Each Reader is closed eagerly when exhausted;
-     * {@link #close()} closes whatever Readers remain.
+     * Iterates chunks from snapshot Readers, skipping entries below each channel's recorded
+     * {@code startPos} cutoff (those are covered by Step 1). Each Reader is closed eagerly when
+     * exhausted; {@link #close()} closes whatever Readers remain.
      */
     private static final class FilteringDrainChunkIterator
             implements CloseableIterator<FilteredSpillFile.Chunk> {
@@ -641,12 +585,6 @@ public class FilteredBufferDispatcherImpl
             }
         }
 
-        /**
-         * Skips entries whose channel either has no recorded startPos (released before checkpoint
-         * trigger — drop everything for that channel) or whose position is strictly below the
-         * channel's startPos. Closes empty readers eagerly so FileChannel fds are released even if
-         * the writer never finishes draining the iterator.
-         */
         private void advanceToIncluded() {
             while (!remaining.isEmpty()) {
                 FilteredSpillFile.Reader r = remaining.peekFirst();
@@ -657,6 +595,9 @@ public class FilteredBufferDispatcherImpl
                 FilteredSpillFile.Reader.Entry e = r.peekNextEntry();
                 EntryPosition cutoff = startPos.get(e.getChannelInfo());
                 EntryPosition entryPos = new EntryPosition(r.getFileIndex(), e.getOffset());
+                // No startPos means the channel was released before checkpoint trigger — drop
+                // every snapshot entry for it. Below-cutoff entries are already covered by
+                // Step 1 in store_C.readyBuffers.
                 if (cutoff == null || entryPos.compareTo(cutoff) < 0) {
                     r.skipNextEntry();
                 } else {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FilteredBufferDispatcherImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FilteredBufferDispatcherImpl.java
@@ -57,12 +57,12 @@ import static org.apache.flink.util.IOUtils.closeQuietly;
  *
  * <p>Two locks meet on the recovery → checkpoint hand-off: each per-channel store's intrinsic
  * monitor (<i>SMALL</i>) and this dispatcher's {@link #dispatcherLock} (<i>BIG</i>). They must
- * always be acquired in the order <b>SMALL → BIG</b>. Code holding BIG must never reach back to
- * any SMALL — neither directly nor through a callee — otherwise the AB-BA cycle returns. Forbidden
+ * always be acquired in the order <b>SMALL → BIG</b>. Code holding BIG must never reach back to any
+ * SMALL — neither directly nor through a callee — otherwise the AB-BA cycle returns. Forbidden
  * callees from inside a {@code synchronized(dispatcherLock)} block: {@link
- * RecoveredBufferStoreImpl#addBuffer}, {@link RecoveredBufferStoreImpl#addBufferAfterDisk},
- * {@link RecoveredBufferStoreImpl#incrementPending}, any {@code synchronized(store)} block, and any
- * {@link org.apache.flink.runtime.io.network.partition.consumer.ChannelStatePersister} entrypoint.
+ * RecoveredBufferStoreImpl#addBuffer}, {@link RecoveredBufferStoreImpl#addBufferAfterDisk}, {@link
+ * RecoveredBufferStoreImpl#incrementPending}, any {@code synchronized(store)} block, and any {@link
+ * org.apache.flink.runtime.io.network.partition.consumer.ChannelStatePersister} entrypoint.
  */
 @Internal
 public class FilteredBufferDispatcherImpl
@@ -81,8 +81,8 @@ public class FilteredBufferDispatcherImpl
     private final BufferRequester bufferRequester;
 
     /**
-     * Explicit lock object instead of {@code synchronized} methods so every callsite that takes
-     * BIG is grep-visible.
+     * Explicit lock object instead of {@code synchronized} methods so every callsite that takes BIG
+     * is grep-visible.
      */
     private final Object dispatcherLock = new Object();
 
@@ -113,9 +113,9 @@ public class FilteredBufferDispatcherImpl
     private List<FilteredSpillFile.Reader> checkpointSnapshots;
 
     /**
-     * Per-channel drain-head captured atomically with each channel's Step 1 ready snapshot.
-     * Phase-2 skips entries strictly below {@code startPos[X]} for channel X (already covered by
-     * Step 1) and writes entries at or after as that channel's checkpoint state.
+     * Per-channel drain-head captured atomically with each channel's Step 1 ready snapshot. Phase-2
+     * skips entries strictly below {@code startPos[X]} for channel X (already covered by Step 1)
+     * and writes entries at or after as that channel's checkpoint state.
      */
     @GuardedBy("dispatcherLock")
     private Map<InputChannelInfo, EntryPosition> checkpointStartPos;
@@ -284,8 +284,8 @@ public class FilteredBufferDispatcherImpl
 
     /**
      * On the first callback for a checkpoint id, pins an immutable phase-2 view of every frozen
-     * Reader and seeds the wait-set with their pending channels. Subsequent callbacks remove
-     * their channel; the empty wait-set triggers {@link #drainSpillEntriesToCheckpoint}.
+     * Reader and seeds the wait-set with their pending channels. Subsequent callbacks remove their
+     * channel; the empty wait-set triggers {@link #drainSpillEntriesToCheckpoint}.
      *
      * <p>{@code startPos} is the per-channel drain-head captured atomically with the ready-buffer
      * snapshot; phase-2 uses it to skip entries already covered by that channel's Step 1.
@@ -450,8 +450,8 @@ public class FilteredBufferDispatcherImpl
     }
 
     /**
-     * Commits the cache via P1 (direct buffer) or P2 (spill). P1 requires the spill writer idle
-     * AND a non-blocking buffer available; otherwise spill, which preserves FIFO ordering — once
+     * Commits the cache via P1 (direct buffer) or P2 (spill). P1 requires the spill writer idle AND
+     * a non-blocking buffer available; otherwise spill, which preserves FIFO ordering — once
      * anything has been spilled, all subsequent data must also spill.
      */
     private void flushCache() throws IOException {
@@ -546,9 +546,9 @@ public class FilteredBufferDispatcherImpl
     }
 
     /**
-     * Iterates chunks from snapshot Readers, skipping entries below each channel's recorded
-     * {@code startPos} cutoff (those are covered by Step 1). Each Reader is closed eagerly when
-     * exhausted; {@link #close()} closes whatever Readers remain.
+     * Iterates chunks from snapshot Readers, skipping entries below each channel's recorded {@code
+     * startPos} cutoff (those are covered by Step 1). Each Reader is closed eagerly when exhausted;
+     * {@link #close()} closes whatever Readers remain.
      */
     private static final class FilteringDrainChunkIterator
             implements CloseableIterator<FilteredSpillFile.Chunk> {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FilteredBufferDispatcherImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FilteredBufferDispatcherImpl.java
@@ -254,7 +254,7 @@ public class FilteredBufferDispatcherImpl
     /**
      * Called by each per-channel store when that channel's ready buffers have been snapshotted into
      * the {@link ChannelStateWriter}. On the first callback for a checkpointId, pins an immutable
-     * phase-2 view of every sealed Reader and seeds the wait-set with the pending channels.
+     * phase-2 view of every frozen Reader and seeds the wait-set with the pending channels.
      * Subsequent callbacks remove their channel; the empty wait-set triggers {@link
      * #drainSpillEntriesToCheckpoint}.
      *
@@ -273,7 +273,7 @@ public class FilteredBufferDispatcherImpl
         }
         if (checkpointId > currentCheckpointId) {
             // Pin snapshots before any drain pop can mutate entry deques. Invariant: checkpoint
-            // only starts after recovery ends, so all Readers are sealed.
+            // only starts after recovery ends, so all Readers are frozen.
             currentCheckpointId = checkpointId;
             checkpointStartPos = new HashMap<>();
             checkpointSnapshots = new ArrayList<>();
@@ -283,8 +283,8 @@ public class FilteredBufferDispatcherImpl
                 try {
                     for (FilteredSpillFile.Reader reader : spillFile.getReaders()) {
                         Preconditions.checkState(
-                                reader.isSealed(),
-                                "Reader must be sealed when checkpoint starts; writer.finish() "
+                                reader.isFrozen(),
+                                "Reader must be frozen when checkpoint starts; writer.finish() "
                                         + "must be called before checkpoint trigger.");
                         snapshots.add(reader.snapshot());
                     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FilteredBufferDispatcherImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FilteredBufferDispatcherImpl.java
@@ -1,0 +1,677 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.partition.consumer.RecoveredBufferStore;
+import org.apache.flink.runtime.io.network.partition.consumer.RecoveredBufferStoreImpl;
+import org.apache.flink.util.CloseableIterator;
+import org.apache.flink.util.Preconditions;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+import static org.apache.flink.util.IOUtils.closeQuietly;
+
+/**
+ * Implementation of {@link FilteredBufferDispatcher} that manages three data paths:
+ *
+ * <ul>
+ *   <li><b>P1 (buffer)</b>: Data is written directly to a network buffer and delivered to the
+ *       target store.
+ *   <li><b>P2 (spill to disk)</b>: When no buffer is available, data is written to a spill file via
+ *       {@link FilteredSpillFile#writeEntry}.
+ *   <li><b>P3 (eager drain)</b>: When buffers become available later, spilled entries are eagerly
+ *       replayed from disk into buffers and delivered to stores.
+ * </ul>
+ *
+ * <p>A byte[] memory cache accumulates payload bytes for the active channel. On channel change or
+ * cache full, {@link #flushCache()} is invoked: if the spill writer is idle and a buffer is
+ * available the cached bytes go directly to a network buffer (P1); otherwise they are written to
+ * the spill file (P2). After {@link #flush()} seals all Readers, {@link #drainPendingSpill()}
+ * drains any remaining spill entries via {@link BufferRequester#requestBufferBlocking(InputChannelInfo)}.
+ * {@link #close()} then releases spill file resources without performing any drain.
+ */
+@Internal
+public class FilteredBufferDispatcherImpl
+        implements FilteredBufferDispatcher, RecoveredBufferStoreCoordinator {
+
+    /**
+     * Per-channel stores used by this dispatcher. Typed as the concrete {@link
+     * RecoveredBufferStoreImpl} rather than {@link
+     * org.apache.flink.runtime.io.network.partition.consumer.RecoveredBufferStore} because the
+     * producer-side methods (addBuffer, incrementPending) are intentionally not part of the public
+     * interface — they are only called by FilteredBufferDispatcher, which is the sole producer of
+     * buffers for the stores.
+     */
+    private final Map<InputChannelInfo, RecoveredBufferStoreImpl> storesByChannel;
+
+    private final ChannelStateWriter channelStateWriter;
+    private final String[] spillDirs;
+    private final int memorySegmentSize;
+    private final BufferRequester bufferRequester;
+
+    // Memory cache state: accumulates bytes for the active channel before committing to P1 or P2
+    private final byte[] cache;
+    private int cachePosition;
+    private InputChannelInfo cacheChannel;
+
+    // Spill infrastructure (P2/P3 paths)
+    private FilteredSpillFile spillFile;
+
+    // Checkpoint wait-set state machine
+    private long currentCheckpointId = -1L;
+    private long lastStoppedCheckpointId = -1L;
+    private Set<InputChannelInfo> waitSet;
+
+    /**
+     * Phase-2 snapshot Readers captured at the first {@link #onChannelCheckpointStarted} call for
+     * the in-flight checkpoint. Held until the wait-set converges and the iterator is handed off
+     * to the {@link ChannelStateWriter}, or until the checkpoint is stopped early. {@code null}
+     * when no checkpoint is in progress.
+     */
+    private List<FilteredSpillFile.Reader> checkpointSnapshots;
+
+    /**
+     * Per-channel drain head captured atomically with each channel's Step 1 ready snapshot. Used
+     * by phase-2 to filter snapshot entries: entries strictly before {@code startPos[X]} were
+     * already in {@code store_X.readyBuffers} when X's barrier passed (and were therefore captured
+     * by Step 1), so phase 2 must skip them; entries at or after {@code startPos[X]} were still on
+     * disk at X's barrier and must be written to X's channel state. {@code null} when no
+     * checkpoint is in progress.
+     */
+    private Map<InputChannelInfo, EntryPosition> checkpointStartPos;
+
+    /**
+     * Position of the next spill entry the drain bundle will pop from the global FIFO across all
+     * sealed Readers. The drain bundle commits addBuffer (which folds in the matching pending
+     * decrement) and then advances this field as its last action under {@code synchronized(store_X)};
+     * the volatile semantics provide cross-channel visibility for {@code Step 1} of any other
+     * channel reading the field under its own store lock. {@code null} until the first spill entry
+     * is seen.
+     */
+    private volatile EntryPosition drainHead;
+
+    // Lifecycle flags
+    private boolean flushed;
+    private boolean closed;
+
+    /**
+     * Creates a new FilteredBufferDispatcherImpl.
+     *
+     * @param storesByChannel per-channel stores for delivering recovered buffers
+     * @param channelStateWriter writer used during phase2 to stream spill chunks to checkpoint
+     *     storage without allocating network buffers
+     * @param spillDirs directories for spill files
+     * @param memorySegmentSize the size of a memory segment / network buffer
+     * @param bufferRequester per-channel buffer source. The non-blocking variant is used for the
+     *     fast path (P1) and eager replay (P3); the blocking variant is used by drainPendingSpill()
+     * @throws IOException if spillDirs is empty
+     */
+    public FilteredBufferDispatcherImpl(
+            Map<InputChannelInfo, RecoveredBufferStoreImpl> storesByChannel,
+            ChannelStateWriter channelStateWriter,
+            String[] spillDirs,
+            int memorySegmentSize,
+            BufferRequester bufferRequester)
+            throws IOException {
+        if (spillDirs.length == 0) {
+            throw new IOException("Spill directories must not be empty");
+        }
+        this.storesByChannel = storesByChannel;
+        this.channelStateWriter = channelStateWriter;
+        this.spillDirs = spillDirs;
+        this.memorySegmentSize = memorySegmentSize;
+        this.bufferRequester = bufferRequester;
+        this.cache = new byte[memorySegmentSize];
+        this.cachePosition = 0;
+
+        // Register this dispatcher as the coordinator on every per-channel store. The store calls
+        // back into the coordinator from checkpoint() and releaseAll() so the dispatcher can
+        // maintain its wait-set and drop still-pending on-disk spill entries the moment a channel
+        // is released, instead of holding the disk resources until dispatcher close().
+        for (RecoveredBufferStoreImpl store : storesByChannel.values()) {
+            synchronized (store) {
+                store.setCoordinator(this);
+            }
+        }
+    }
+
+    @Override
+    public synchronized void write(byte[] data, int length, InputChannelInfo channelInfo)
+            throws IOException, InterruptedException {
+        if (flushed || closed) {
+            throw new IllegalStateException("Cannot write after " + (closed ? "close" : "flush"));
+        }
+
+        // P3: eagerly replay any pending spill entries while non-blocking buffers are available
+        eagerDrain();
+
+        // Channel change: flush cached bytes for the previous channel before accumulating new data
+        if (cacheChannel != null && !cacheChannel.equals(channelInfo) && cachePosition > 0) {
+            flushCache();
+        }
+        cacheChannel = channelInfo;
+
+        // Copy bytes into cache; flush whenever the cache fills up
+        int pos = 0;
+        while (pos < length) {
+            int space = memorySegmentSize - cachePosition;
+            int toCopy = Math.min(space, length - pos);
+            System.arraycopy(data, pos, cache, cachePosition, toCopy);
+            cachePosition += toCopy;
+            pos += toCopy;
+
+            if (cachePosition == memorySegmentSize) {
+                flushCache();
+                cacheChannel = channelInfo;
+            }
+        }
+    }
+
+    @Override
+    public synchronized void flush() throws IOException {
+        if (flushed || closed) {
+            return;
+        }
+        flushCache();
+        if (spillFile != null) {
+            spillFile.finish();
+            // Initialise drainHead to the first remaining entry across all sealed Readers (or END
+            // if eagerDrain consumed everything). This is the value Step 1 of any channel will
+            // observe before the first drainPendingSpill bundle commits — so we never publish an
+            // unset / null drainHead during the live checkpoint window.
+            drainHead = computeDrainHeadFrom(0);
+        }
+        flushed = true;
+    }
+
+    @Override
+    public void drainPendingSpill() throws IOException, InterruptedException {
+        Preconditions.checkState(flushed, "drainPendingSpill requires flush() to be called first");
+        if (closed) {
+            return; // already cleaned up; nothing to drain
+        }
+        if (spillFile == null) {
+            return;
+        }
+        List<FilteredSpillFile.Reader> readers = spillFile.getReaders();
+        for (int i = 0; i < readers.size(); i++) {
+            FilteredSpillFile.Reader reader = readers.get(i);
+            while (true) {
+                // Section 1 (lock-free peek): inspect the head entry of the current Reader to
+                // decide which channel's buffer pool to pull from. The original Reader is mutated
+                // only by this Recovery thread, so peek does not race with another drain consumer.
+                FilteredSpillFile.Reader.Entry entry = reader.peekNextEntry();
+                if (entry == null) {
+                    break;
+                }
+                InputChannelInfo ch = entry.getChannelInfo();
+                long entryOffset = entry.getOffset();
+                int entryLength = entry.getLength();
+
+                // Section 2 (lock-free I/O): allocate the network buffer (may block on the pool)
+                // and copy the spilled bytes from disk into it. Both operations are kept outside
+                // any lock to avoid serialising channel checkpoints behind buffer-pool waits or
+                // page-cache misses.
+                Buffer buffer = bufferRequester.requestBufferBlocking(ch);
+                byte[] data = new byte[entryLength];
+                reader.readBytesAt(entryOffset, entryLength, data, 0);
+
+                // Section 3 (commit under store lock + fire listener outside): pop the entry from
+                // the Reader, hand the populated buffer to the store (which folds in the matching
+                // pending decrement), and advance drainHead. The pop-then-add ordering keeps
+                // Step 1 from observing an entry popped from disk but not yet in readyBuffers.
+                // drainHead must be the last write so its volatile publication signals "drainHead
+                // crossed e ⇒ e is in store_C.readyBuffers" to cross-channel readers. The
+                // data-available listener is captured inside the store lock and fired afterwards
+                // to avoid an AB-BA deadlock with the task thread (gate lock → store lock).
+                RecoveredBufferStoreImpl store =
+                        Preconditions.checkNotNull(
+                                storesByChannel.get(ch), "No store for channel %s", ch);
+                RecoveredBufferStore.DataAvailableListener listener;
+                synchronized (store) {
+                    reader.skipNextEntry();
+                    writeChunkToBuffer(buffer, data, entryLength);
+                    listener = store.addBufferAndCaptureListener(buffer);
+                    drainHead = computeDrainHeadFrom(i);
+                }
+                if (listener != null) {
+                    listener.onDataAvailable();
+                }
+            }
+        }
+    }
+
+    @Override
+    public synchronized void close() throws IOException {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        // Defensive: caller should have called flush() before close(); honour the historical
+        // fallback to seal lingering data so spillFile.close() can clean up consistently.
+        if (!flushed) {
+            flushCache();
+            if (spillFile != null) {
+                spillFile.finish();
+            }
+            flushed = true;
+        }
+        // Resource release only. drainSpillThroughBuffers is the responsibility of
+        // drainPendingSpill().
+        if (spillFile != null) {
+            spillFile.close();
+            spillFile = null;
+        }
+        // Hand off the symmetric tear-down: the BufferRequester returns each RecoveredInputChannel's
+        // exclusive segments to the global pool now that drain is no longer reading from them.
+        // Doing this here (post-drain, post-flush) guarantees no spill entry was abandoned mid-load
+        // and lets task threads still consuming buffers from the recovered store recycle them
+        // straight to the global pool (BufferManager.recycle's released-channel shortcut).
+        bufferRequester.releaseExclusiveBuffers();
+    }
+
+    @Override
+    public EntryPosition getCurrentDrainHead() {
+        EntryPosition head = drainHead;
+        return head == null ? EntryPosition.END : head;
+    }
+
+    /**
+     * Called by each per-channel store when that channel's ready buffers have been snapshotted into
+     * the {@link ChannelStateWriter}.
+     *
+     * <p>On the first callback for a given checkpointId we capture an immutable phase-2 view of the
+     * disk side: each sealed Reader has {@link FilteredSpillFile.Reader#snapshot()} called and the
+     * results are pinned in {@code checkpointSnapshots}, so subsequent {@link #drainPendingSpill}
+     * pops on the original Readers cannot drop entries out of the in-flight checkpoint. The
+     * wait-set is populated from those snapshots' pending channels. Subsequent callbacks remove
+     * their channel from the wait-set; when the set becomes empty, all channels with disk data
+     * have reported in and {@link #drainSpillEntriesToCheckpoint} is triggered.
+     *
+     * <p>{@code startPos} is the per-channel drain-head value the calling store captured atomically
+     * with its ready-buffer snapshot; phase 2 uses it to filter the captured snapshot entries
+     * (skip entries below the channel's startPos — they were already in readyBuffers and are
+     * covered by Step 1).
+     *
+     * <p>Called from the Task thread; synchronized on {@code this} to be mutually exclusive with
+     * the Recovery thread's {@link #write} / {@link #flush} / {@link #close}.
+     */
+    public synchronized void onChannelCheckpointStarted(
+            long checkpointId, InputChannelInfo channelInfo, EntryPosition startPos) {
+        if (checkpointId < currentCheckpointId) {
+            // Stale callback from a superseded checkpoint: we have already moved on to a newer
+            // one. Ignoring it keeps the current wait-set intact so the in-flight checkpoint
+            // converges correctly.
+            return;
+        }
+        if (checkpointId <= lastStoppedCheckpointId) {
+            // Stale callback for a checkpoint the task has already stopped (finished or aborted).
+            // The ChannelStateWriter for this id is gone; phase-2 drain into it would be wasted
+            // work and would require relying on writer.isDone() to silently swallow the data.
+            return;
+        }
+        if (checkpointId > currentCheckpointId) {
+            // New checkpoint: pin a snapshot of every sealed Reader before any further drain pops
+            // can mutate their entry deques, then build the wait-set from the snapshot's pending
+            // channels. Invariant: checkpoint only starts after recovery ends (writer.finish());
+            // all Readers are sealed at this point.
+            currentCheckpointId = checkpointId;
+            checkpointStartPos = new HashMap<>();
+            checkpointSnapshots = new ArrayList<>();
+            waitSet = new HashSet<>();
+            if (spillFile != null) {
+                List<FilteredSpillFile.Reader> snapshots = new ArrayList<>();
+                try {
+                    for (FilteredSpillFile.Reader reader : spillFile.getReaders()) {
+                        Preconditions.checkState(
+                                reader.isSealed(),
+                                "Reader must be sealed when checkpoint starts; writer.finish() "
+                                        + "must be called before checkpoint trigger.");
+                        snapshots.add(reader.snapshot());
+                    }
+                } catch (IOException e) {
+                    for (FilteredSpillFile.Reader snap : snapshots) {
+                        closeQuietly(snap);
+                    }
+                    throw new RuntimeException(
+                            "Failed to snapshot spill readers for checkpoint", e);
+                }
+                checkpointSnapshots = snapshots;
+                for (FilteredSpillFile.Reader snap : snapshots) {
+                    waitSet.addAll(snap.getPendingChannels());
+                }
+            }
+        }
+        // checkpointId == currentCheckpointId: accumulate toward the same wait-set.
+        if (checkpointStartPos != null) {
+            checkpointStartPos.put(channelInfo, startPos);
+        }
+        if (waitSet != null) {
+            waitSet.remove(channelInfo);
+            if (waitSet.isEmpty()) {
+                drainSpillEntriesToCheckpoint(checkpointId);
+            }
+        }
+    }
+
+    /**
+     * Called by a per-channel store from {@link RecoveredBufferStore#notifyCheckpointStopped} when
+     * the owning channel has finished or aborted the given checkpoint. Drops the wait-set tied to
+     * that checkpoint so a later {@link #onChannelReleased} cannot drain spill entries into a
+     * checkpoint the task has already concluded; also bumps {@code lastStoppedCheckpointId} so a
+     * late {@link #onChannelCheckpointStarted} for the same id is short-circuited as stale.
+     *
+     * <p>Closes any pinned phase-2 snapshot Readers and clears {@code checkpointStartPos} /
+     * {@code checkpointSnapshots} so the next checkpoint starts from a clean slate and the per-
+     * snapshot {@code FileChannel}s are released promptly (otherwise every aborted checkpoint
+     * leaks one fd per spill file).
+     *
+     * <p>Called from the Task thread; synchronized on {@code this} to be mutually exclusive with
+     * other coordinator callbacks and the Recovery thread's
+     * {@link #write} / {@link #flush} / {@link #close}.
+     */
+    public synchronized void onChannelCheckpointStopped(
+            long checkpointId, InputChannelInfo channelInfo) {
+        if (checkpointId > lastStoppedCheckpointId) {
+            lastStoppedCheckpointId = checkpointId;
+        }
+        if (currentCheckpointId == checkpointId) {
+            // The wait-set we were collecting belongs to the now-stopped checkpoint; releasing
+            // any remaining channel must not retroactively trigger phase-2 drain into it.
+            resetCheckpointState();
+        }
+    }
+
+    /**
+     * Called by a per-channel store from {@link RecoveredBufferStoreImpl#releaseAll()}. Drops every
+     * pending spill entry belonging to {@code channelInfo} from all Readers so the disk-side
+     * bookkeeping is freed immediately; also removes the channel from an in-flight checkpoint
+     * wait-set so the wait-set can still converge after the channel goes away.
+     *
+     * <p>Phase-2 snapshots intentionally are <em>not</em> mutated here: an entry left in the
+     * snapshot whose channel has been released will be dropped by the filtering iterator because
+     * {@code checkpointStartPos.get(channelInfo)} returns null (treated as "channel gone, skip
+     * everything"). Mutating the live snapshot would require coordinating with the executor thread
+     * already iterating it for an in-flight phase-2 drain.
+     *
+     * <p>Called from the Task thread; synchronized on {@code this} to be mutually exclusive with
+     * the Recovery thread's {@link #write} / {@link #flush} / {@link #close} and with {@link
+     * #onChannelCheckpointStarted}.
+     */
+    public synchronized void onChannelReleased(InputChannelInfo channelInfo) {
+        if (spillFile != null) {
+            for (FilteredSpillFile.Reader reader : spillFile.getReaders()) {
+                reader.removeEntriesForChannel(channelInfo);
+            }
+        }
+        if (waitSet != null && waitSet.remove(channelInfo) && waitSet.isEmpty()) {
+            drainSpillEntriesToCheckpoint(currentCheckpointId);
+        }
+    }
+
+    /**
+     * Hands the previously pinned snapshot Readers (with the captured per-channel startPos cutoffs)
+     * off to the {@link ChannelStateWriter} via a filtering iterator. Ownership of the snapshot
+     * Readers transfers to the iterator's {@link FilteringDrainChunkIterator#close()}.
+     */
+    private void drainSpillEntriesToCheckpoint(long checkpointId) {
+        if (checkpointSnapshots == null || checkpointSnapshots.isEmpty()) {
+            resetCheckpointState();
+            return;
+        }
+        List<FilteredSpillFile.Reader> snapshots = checkpointSnapshots;
+        Map<InputChannelInfo, EntryPosition> startPos = checkpointStartPos;
+        // Hand the snapshot Readers to the iterator so its close() releases the FileChannels even
+        // if the writer never advances the iterator (e.g. on abort). Clear local state so a later
+        // onChannelCheckpointStopped for the same id does not double-close.
+        checkpointSnapshots = null;
+        checkpointStartPos = null;
+        waitSet = null;
+        channelStateWriter.addInputDataFromSpill(
+                checkpointId, new FilteringDrainChunkIterator(snapshots, startPos));
+    }
+
+    private void resetCheckpointState() {
+        if (checkpointSnapshots != null) {
+            for (FilteredSpillFile.Reader snap : checkpointSnapshots) {
+                closeQuietly(snap);
+            }
+            checkpointSnapshots = null;
+        }
+        checkpointStartPos = null;
+        waitSet = null;
+    }
+
+    /**
+     * Next-to-pop {@link EntryPosition}, scanning readers from list position {@code fromListIndex}.
+     * {@code fromListIndex} is a list cursor, distinct from {@link
+     * FilteredSpillFile.Reader#getFileIndex()} which is the globally monotonic file-id.
+     */
+    private EntryPosition computeDrainHeadFrom(int fromListIndex) {
+        if (spillFile == null) {
+            return EntryPosition.END;
+        }
+        List<FilteredSpillFile.Reader> readers = spillFile.getReaders();
+        for (int i = fromListIndex; i < readers.size(); i++) {
+            FilteredSpillFile.Reader r = readers.get(i);
+            FilteredSpillFile.Reader.Entry next = r.peekNextEntry();
+            if (next != null) {
+                return new EntryPosition(r.getFileIndex(), next.getOffset());
+            }
+        }
+        return EntryPosition.END;
+    }
+
+    /**
+     * Flushes the cache for the current channel via P1 (buffer) or P2 (spill). After calling, the
+     * cache is empty and cacheChannel is null.
+     *
+     * <p>P1 is chosen when the spill writer is idle (no pending disk entries) AND a non-blocking
+     * buffer can be obtained. Otherwise the bytes are spilled (P2). This ensures FIFO ordering:
+     * once any data has been spilled, all subsequent data must also spill to preserve order.
+     */
+    private void flushCache() throws IOException {
+        if (cachePosition == 0) {
+            cacheChannel = null;
+            return;
+        }
+
+        InputChannelInfo channelInfo = cacheChannel;
+        int bytesToFlush = cachePosition;
+        cachePosition = 0;
+        cacheChannel = null;
+
+        // P1: spill writer idle and a buffer is available — write directly to network buffer
+        if (isSpillIdle()) {
+            Buffer buffer = bufferRequester.requestBuffer(channelInfo);
+            if (buffer != null) {
+                writeChunkToBuffer(buffer, cache, bytesToFlush);
+                RecoveredBufferStoreImpl store =
+                        Preconditions.checkNotNull(
+                                storesByChannel.get(channelInfo),
+                                "No store for channel %s",
+                                channelInfo);
+                store.addBuffer(buffer);
+                return;
+            }
+        }
+
+        // P2: spill writer not idle or no buffer available — write to spill file
+        writeToSpillFile(cache, bytesToFlush, channelInfo);
+    }
+
+    /**
+     * Copies {@code length} bytes from {@code data} into the given network buffer. Assumes the
+     * buffer is freshly acquired (writerIndex == 0); after this call, {@code buffer.getSize() ==
+     * length}.
+     */
+    private static void writeChunkToBuffer(Buffer buffer, byte[] data, int length) {
+        Preconditions.checkState(
+                buffer.getMaxCapacity() >= length,
+                "Buffer capacity %s is smaller than chunk length %s",
+                buffer.getMaxCapacity(),
+                length);
+        buffer.asByteBuf().writeBytes(data, 0, length);
+    }
+
+    /** Writes bytes to the spill file, creating the Writer lazily if needed. */
+    private void writeToSpillFile(byte[] data, int length, InputChannelInfo channelInfo)
+            throws IOException {
+        if (spillFile == null) {
+            spillFile = new FilteredSpillFile(spillDirs, memorySegmentSize);
+        }
+        spillFile.writeEntry(data, length, channelInfo);
+        // Increment pending count so store.isEmpty() correctly reflects outstanding data
+        RecoveredBufferStoreImpl store =
+                Preconditions.checkNotNull(
+                        storesByChannel.get(channelInfo),
+                        "No store for channel %s",
+                        channelInfo);
+        synchronized (store) {
+            store.incrementPending();
+        }
+    }
+
+    /**
+     * Eagerly replays spill entries while non-blocking buffers are available.
+     *
+     * <p>Runs only on the {@link #write} path before {@link #flush}, so by construction it cannot
+     * race with {@link #onChannelCheckpointStarted}: physical {@code InputChannel}s exist only
+     * after recovery's {@code finishRecovery()} (which itself runs after flush), and checkpoint
+     * triggers can only fire on those physical channels. {@code drainHead} is initialised at
+     * {@link #flush} time from whatever entries this method left behind, so eagerDrain does not
+     * need to maintain it.
+     */
+    private void eagerDrain() throws IOException {
+        if (spillFile == null) {
+            return;
+        }
+        for (FilteredSpillFile.Reader reader : spillFile.getReaders()) {
+            while (reader.hasEntries()) {
+                InputChannelInfo ch = reader.peekNextChannel();
+                Buffer buffer = bufferRequester.requestBuffer(ch);
+                if (buffer == null) {
+                    return;
+                }
+                FilteredSpillFile.Chunk chunk = reader.readNext();
+                if (chunk == null) {
+                    buffer.recycleBuffer();
+                    return;
+                }
+                writeChunkToBuffer(buffer, chunk.getData(), chunk.getLength());
+                RecoveredBufferStoreImpl store =
+                        Preconditions.checkNotNull(
+                                storesByChannel.get(ch), "No store for channel %s", ch);
+                store.addBuffer(buffer);
+            }
+        }
+    }
+
+    /** Returns true if no spill entries have been written yet (P1 is safe). */
+    private boolean isSpillIdle() {
+        return spillFile == null || spillFile.isIdle();
+    }
+
+    // -------------------------------------------------------------------------
+    // FilteringDrainChunkIterator — CloseableIterator over snapshot Readers with per-channel cutoff
+    // -------------------------------------------------------------------------
+
+    /**
+     * Iterates over chunks from a sequence of snapshot {@link FilteredSpillFile.Reader}s, skipping
+     * entries that fall below the channel's recorded {@code startPos} cutoff (those entries were
+     * already in the channel's Step 1 ready snapshot and are covered there). Each Reader is
+     * drained in order; once exhausted it is popped and closed immediately. {@link #close()} closes
+     * whatever Readers remain (i.e. those not yet consumed by the iterator).
+     */
+    private static final class FilteringDrainChunkIterator
+            implements CloseableIterator<FilteredSpillFile.Chunk> {
+
+        private final Deque<FilteredSpillFile.Reader> remaining;
+        private final Map<InputChannelInfo, EntryPosition> startPos;
+
+        FilteringDrainChunkIterator(
+                List<FilteredSpillFile.Reader> snapshots,
+                Map<InputChannelInfo, EntryPosition> startPos) {
+            this.remaining = new ArrayDeque<>(snapshots);
+            this.startPos = startPos;
+        }
+
+        @Override
+        public boolean hasNext() {
+            advanceToIncluded();
+            return !remaining.isEmpty();
+        }
+
+        @Override
+        public FilteredSpillFile.Chunk next() {
+            advanceToIncluded();
+            if (remaining.isEmpty()) {
+                throw new NoSuchElementException();
+            }
+            try {
+                return remaining.peekFirst().readNext();
+            } catch (IOException e) {
+                throw new UncheckedIOException("Failed to read spill chunk", e);
+            }
+        }
+
+        /**
+         * Skips entries whose channel either has no recorded startPos (channel was released before
+         * triggering checkpoint, drop everything for that channel) or whose position is strictly
+         * below the channel's startPos (entry was already covered by Step 1). Pops empty readers
+         * along the way and closes them eagerly so FileChannel fds are released even if the writer
+         * never finishes draining the iterator.
+         */
+        private void advanceToIncluded() {
+            while (!remaining.isEmpty()) {
+                FilteredSpillFile.Reader r = remaining.peekFirst();
+                if (!r.hasEntries()) {
+                    closeQuietly(remaining.pollFirst());
+                    continue;
+                }
+                FilteredSpillFile.Reader.Entry e = r.peekNextEntry();
+                EntryPosition cutoff = startPos.get(e.getChannelInfo());
+                EntryPosition entryPos = new EntryPosition(r.getFileIndex(), e.getOffset());
+                if (cutoff == null || entryPos.compareTo(cutoff) < 0) {
+                    r.skipNextEntry();
+                } else {
+                    return;
+                }
+            }
+        }
+
+        @Override
+        public void close() {
+            while (!remaining.isEmpty()) {
+                closeQuietly(remaining.pollFirst());
+            }
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FilteredBufferDispatcherImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FilteredBufferDispatcherImpl.java
@@ -28,13 +28,18 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Deque;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.flink.util.IOUtils.closeQuietly;
 
@@ -51,6 +56,27 @@ import static org.apache.flink.util.IOUtils.closeQuietly;
  * full, {@link #flushCache()} commits the bytes via P1 if the spill writer is idle and a buffer is
  * available, otherwise via P2. After {@link #flush()} seals all Readers, {@link
  * #drainPendingSpill()} drains the remainder; {@link #close()} releases resources.
+ *
+ * <h3>Locking discipline (post-iter_6)</h3>
+ *
+ * <p>This class holds <b>no monitor of its own</b>. The previous {@code synchronized} methods
+ * have been replaced with lock-free primitives so the per-channel store lock (held by task
+ * threads inside {@code ChannelStatePersister}) can call back into the coordinator without
+ * forming an AB-BA cycle.
+ *
+ * <ul>
+ *   <li>Recovery-thread state ({@code cache}, {@code cachePosition}, {@code cacheChannel},
+ *       {@code spillFile}, {@code flushed}, {@code closed}): single-writer; cross-thread reads
+ *       use {@code volatile}.
+ *   <li>Per-checkpoint state ({@link CheckpointWindow}) is bundled into one immutable object
+ *       and published via {@link AtomicReference}. Channel-arrival uses {@link
+ *       ConcurrentHashMap}-backed sets and an {@link AtomicInteger} counter; the channel that
+ *       drives the counter to zero fires {@link #drainSpillEntriesToCheckpoint(CheckpointWindow)}
+ *       at most once via an {@link AtomicBoolean} guard.
+ *   <li>{@link AtomicLong} {@code lastStoppedCheckpointId} advances monotonically via CAS.
+ *   <li>{@code drainHead} stays {@code volatile} as before; cross-channel Step-1 readers use
+ *       its publication to observe drain progress without taking any dispatcher-level lock.
+ * </ul>
  */
 @Internal
 public class FilteredBufferDispatcherImpl
@@ -68,38 +94,41 @@ public class FilteredBufferDispatcherImpl
     private final int memorySegmentSize;
     private final BufferRequester bufferRequester;
 
+    /** Recovery-thread private. */
     private final byte[] cache;
+
     private int cachePosition;
     private InputChannelInfo cacheChannel;
 
-    private FilteredSpillFile spillFile;
-
-    private long currentCheckpointId = -1L;
-    private long lastStoppedCheckpointId = -1L;
-    private Set<InputChannelInfo> waitSet;
+    /**
+     * Lazily initialized by recovery thread inside {@link #writeToSpillFile}. Volatile so task
+     * threads observing it after {@link #flushed} see a fully-constructed instance.
+     */
+    private volatile FilteredSpillFile spillFile;
 
     /**
-     * Phase-2 snapshot Readers pinned at the first {@link #onChannelCheckpointStarted} for the
-     * in-flight checkpoint. {@code null} when no checkpoint is in progress.
+     * Highest stopped checkpoint id seen so far. CAS-advanced from
+     * {@link #onChannelCheckpointStopped}; read by {@link #onChannelCheckpointStarted} to short-
+     * circuit late callbacks for already-finalized checkpoints.
      */
-    private List<FilteredSpillFile.Reader> checkpointSnapshots;
+    private final AtomicLong lastStoppedCheckpointId = new AtomicLong(-1L);
 
     /**
-     * Per-channel drain-head captured atomically with each channel's Step 1 ready snapshot. Phase-2
-     * skips entries strictly below {@code startPos[X]} for channel X (already covered by Step 1)
-     * and writes entries at or after as that channel's checkpoint state.
+     * Per-checkpoint window installed by the first {@link #onChannelCheckpointStarted} for a new
+     * id. The reference is replaced (or cleared) via CAS so the bundled snapshots/wait-set/start-
+     * pos all become visible together with no torn intermediate state.
      */
-    private Map<InputChannelInfo, EntryPosition> checkpointStartPos;
+    private final AtomicReference<CheckpointWindow> currentWindow = new AtomicReference<>();
 
     /**
      * Position of the next spill entry the drain bundle will pop from the global FIFO. Volatile
      * publication provides cross-channel visibility: any other channel's Step 1 read under its own
-     * store lock observes drain progress without needing the dispatcher monitor.
+     * store lock observes drain progress without needing a dispatcher monitor.
      */
     private volatile EntryPosition drainHead;
 
-    private boolean flushed;
-    private boolean closed;
+    private volatile boolean flushed;
+    private volatile boolean closed;
 
     public FilteredBufferDispatcherImpl(
             Map<InputChannelInfo, RecoveredBufferStoreImpl> storesByChannel,
@@ -127,7 +156,7 @@ public class FilteredBufferDispatcherImpl
     }
 
     @Override
-    public synchronized void write(byte[] data, int length, InputChannelInfo channelInfo)
+    public void write(byte[] data, int length, InputChannelInfo channelInfo)
             throws IOException, InterruptedException {
         if (flushed || closed) {
             throw new IllegalStateException("Cannot write after " + (closed ? "close" : "flush"));
@@ -156,7 +185,7 @@ public class FilteredBufferDispatcherImpl
     }
 
     @Override
-    public synchronized void flush() throws IOException {
+    public void flush() throws IOException {
         if (flushed || closed) {
             return;
         }
@@ -222,7 +251,7 @@ public class FilteredBufferDispatcherImpl
     }
 
     @Override
-    public synchronized void close() throws IOException {
+    public void close() throws IOException {
         if (closed) {
             return;
         }
@@ -243,6 +272,13 @@ public class FilteredBufferDispatcherImpl
         // Symmetric tear-down: returns each channel's exclusive segments to the global pool now
         // that drain is no longer reading from them.
         bufferRequester.releaseExclusiveBuffers();
+        // Drop any still-pinned phase-2 snapshots so their fds are released even if the writer
+        // never advanced the iterator. The drainTriggered CAS keeps this from racing a final
+        // in-flight maybeTriggerDrain — whichever side wins owns and closes the snapshots.
+        CheckpointWindow w = currentWindow.getAndSet(null);
+        if (w != null && w.drainTriggered.compareAndSet(false, true)) {
+            closeSnapshots(w.snapshots);
+        }
     }
 
     @Override
@@ -252,63 +288,31 @@ public class FilteredBufferDispatcherImpl
     }
 
     /**
-     * Called by each per-channel store when that channel's ready buffers have been snapshotted into
-     * the {@link ChannelStateWriter}. On the first callback for a checkpointId, pins an immutable
-     * phase-2 view of every frozen Reader and seeds the wait-set with the pending channels.
-     * Subsequent callbacks remove their channel; the empty wait-set triggers {@link
-     * #drainSpillEntriesToCheckpoint}.
+     * Called by each per-channel store when that channel's ready buffers have been snapshotted
+     * into the {@link ChannelStateWriter}. The first arrival for a new checkpoint id installs an
+     * immutable {@link CheckpointWindow} via CAS (pinning frozen Reader snapshots and seeding the
+     * wait-set with the pending channels); subsequent arrivals only mark themselves done and the
+     * channel that drives {@code remaining} to zero triggers
+     * {@link #drainSpillEntriesToCheckpoint(CheckpointWindow)}.
      *
      * <p>{@code startPos} is the per-channel drain-head captured atomically with the ready-buffer
      * snapshot; phase-2 uses it to skip entries already covered by that channel's Step 1.
      */
-    public synchronized void onChannelCheckpointStarted(
+    @Override
+    public void onChannelCheckpointStarted(
             long checkpointId, InputChannelInfo channelInfo, EntryPosition startPos) {
-        if (checkpointId < currentCheckpointId) {
-            return;
-        }
-        if (checkpointId <= lastStoppedCheckpointId) {
+        if (checkpointId <= lastStoppedCheckpointId.get()) {
             // ChannelStateWriter for this id is gone; phase-2 drain into it would rely on
             // writer.isDone() to silently swallow the data.
             return;
         }
-        if (checkpointId > currentCheckpointId) {
-            // Pin snapshots before any drain pop can mutate entry deques. Invariant: checkpoint
-            // only starts after recovery ends, so all Readers are frozen.
-            currentCheckpointId = checkpointId;
-            checkpointStartPos = new HashMap<>();
-            checkpointSnapshots = new ArrayList<>();
-            waitSet = new HashSet<>();
-            if (spillFile != null) {
-                List<FilteredSpillFile.Reader> snapshots = new ArrayList<>();
-                try {
-                    for (FilteredSpillFile.Reader reader : spillFile.getReaders()) {
-                        Preconditions.checkState(
-                                reader.isFrozen(),
-                                "Reader must be frozen when checkpoint starts; writer.finish() "
-                                        + "must be called before checkpoint trigger.");
-                        snapshots.add(reader.snapshot());
-                    }
-                } catch (IOException e) {
-                    for (FilteredSpillFile.Reader snap : snapshots) {
-                        closeQuietly(snap);
-                    }
-                    throw new RuntimeException(
-                            "Failed to snapshot spill readers for checkpoint", e);
-                }
-                checkpointSnapshots = snapshots;
-                for (FilteredSpillFile.Reader snap : snapshots) {
-                    waitSet.addAll(snap.getPendingChannels());
-                }
-            }
+        CheckpointWindow window = ensureCheckpointWindow(checkpointId);
+        if (window == null) {
+            return; // a newer checkpoint already advanced past us
         }
-        if (checkpointStartPos != null) {
-            checkpointStartPos.put(channelInfo, startPos);
-        }
-        if (waitSet != null) {
-            waitSet.remove(channelInfo);
-            if (waitSet.isEmpty()) {
-                drainSpillEntriesToCheckpoint(checkpointId);
-            }
+        window.startPos.put(channelInfo, startPos);
+        if (window.waitSet.remove(channelInfo)) {
+            maybeTriggerDrain(window);
         }
     }
 
@@ -318,13 +322,27 @@ public class FilteredBufferDispatcherImpl
      * short-circuited as stale. Closes any pinned phase-2 snapshot Readers — otherwise every
      * aborted checkpoint leaks one fd per spill file.
      */
-    public synchronized void onChannelCheckpointStopped(
-            long checkpointId, InputChannelInfo channelInfo) {
-        if (checkpointId > lastStoppedCheckpointId) {
-            lastStoppedCheckpointId = checkpointId;
-        }
-        if (currentCheckpointId == checkpointId) {
-            resetCheckpointState();
+    @Override
+    public void onChannelCheckpointStopped(long checkpointId, InputChannelInfo channelInfo) {
+        long prev;
+        do {
+            prev = lastStoppedCheckpointId.get();
+            if (checkpointId <= prev) {
+                break;
+            }
+        } while (!lastStoppedCheckpointId.compareAndSet(prev, checkpointId));
+
+        CheckpointWindow w = currentWindow.get();
+        if (w != null && w.checkpointId == checkpointId) {
+            // Snapshot ownership is claimed via the drainTriggered flag: a concurrent
+            // maybeTriggerDrain that has already CAS'd drainTriggered to true now owns the
+            // snapshots and will hand them to the channel-state writer's iterator. Detach the
+            // window unconditionally so a duplicate stop does not double-close, but only the
+            // first claimant of drainTriggered closes the snapshots here.
+            currentWindow.compareAndSet(w, null);
+            if (w.drainTriggered.compareAndSet(false, true)) {
+                closeSnapshots(w.snapshots);
+            }
         }
     }
 
@@ -334,15 +352,80 @@ public class FilteredBufferDispatcherImpl
      * channel has no recorded startPos. Mutating the live snapshot would race the executor thread
      * already iterating it.
      */
-    public synchronized void onChannelReleased(InputChannelInfo channelInfo) {
-        if (spillFile != null) {
-            for (FilteredSpillFile.Reader reader : spillFile.getReaders()) {
+    @Override
+    public void onChannelReleased(InputChannelInfo channelInfo) {
+        FilteredSpillFile sf = spillFile;
+        if (sf != null) {
+            for (FilteredSpillFile.Reader reader : sf.getReaders()) {
                 reader.removeEntriesForChannel(channelInfo);
             }
         }
-        if (waitSet != null && waitSet.remove(channelInfo) && waitSet.isEmpty()) {
-            drainSpillEntriesToCheckpoint(currentCheckpointId);
+        CheckpointWindow w = currentWindow.get();
+        if (w != null && w.waitSet.remove(channelInfo)) {
+            maybeTriggerDrain(w);
         }
+    }
+
+    /**
+     * CAS-installs (or reuses) the {@link CheckpointWindow} for {@code checkpointId}. When this
+     * call is the first to advance to a higher id, it pins phase-2 Reader snapshots and seeds the
+     * wait-set; if it loses the CAS race against a concurrent caller, the speculative snapshots
+     * it created are closed before retrying so we never leak fds.
+     *
+     * @return the published window for {@code checkpointId}, or {@code null} if a strictly newer
+     *     checkpoint has already advanced past {@code checkpointId} and this caller is now stale.
+     */
+    private CheckpointWindow ensureCheckpointWindow(long checkpointId) {
+        while (true) {
+            // Re-check on each spin: a concurrent stop may have advanced lastStoppedCheckpointId
+            // past us while we were preparing snapshots, in which case we must abort.
+            if (checkpointId <= lastStoppedCheckpointId.get()) {
+                return null;
+            }
+            CheckpointWindow current = currentWindow.get();
+            if (current != null && current.checkpointId > checkpointId) {
+                return null;
+            }
+            if (current != null && current.checkpointId == checkpointId) {
+                return current;
+            }
+            // current is null or has a stale id — try to install a new window for checkpointId.
+            CheckpointWindow candidate = createCheckpointWindow(checkpointId);
+            if (currentWindow.compareAndSet(current, candidate)) {
+                if (current != null && current.drainTriggered.compareAndSet(false, true)) {
+                    closeSnapshots(current.snapshots);
+                }
+                return candidate;
+            }
+            // Lost the CAS race; close the speculative snapshots we just pinned and retry. We
+            // own them exclusively at this point — they have not been published to any other
+            // thread — so no drainTriggered claim is needed.
+            closeSnapshots(candidate.snapshots);
+        }
+    }
+
+    private CheckpointWindow createCheckpointWindow(long checkpointId) {
+        FilteredSpillFile sf = spillFile;
+        List<FilteredSpillFile.Reader> snapshots = new ArrayList<>();
+        Set<InputChannelInfo> pendingChannels = new HashSet<>();
+        if (sf != null) {
+            try {
+                for (FilteredSpillFile.Reader reader : sf.getReaders()) {
+                    Preconditions.checkState(
+                            reader.isFrozen(),
+                            "Reader must be frozen when checkpoint starts; writer.finish() "
+                                    + "must be called before checkpoint trigger.");
+                    FilteredSpillFile.Reader snap = reader.snapshot();
+                    snapshots.add(snap);
+                    pendingChannels.addAll(snap.getPendingChannels());
+                }
+            } catch (IOException e) {
+                closeSnapshots(snapshots);
+                throw new RuntimeException(
+                        "Failed to snapshot spill readers for checkpoint", e);
+            }
+        }
+        return new CheckpointWindow(checkpointId, snapshots, pendingChannels);
     }
 
     /**
@@ -350,30 +433,33 @@ public class FilteredBufferDispatcherImpl
      * snapshot Readers transfers to the iterator's {@link FilteringDrainChunkIterator#close()},
      * which releases the FileChannels even if the writer never advances the iterator (e.g. on
      * abort).
+     *
+     * <p>The {@link AtomicBoolean} guard inside {@link CheckpointWindow} ensures this fires at
+     * most once even if {@code remove + decrementAndGet} races between
+     * {@link #onChannelCheckpointStarted} and {@link #onChannelReleased}.
      */
-    private void drainSpillEntriesToCheckpoint(long checkpointId) {
-        if (checkpointSnapshots == null || checkpointSnapshots.isEmpty()) {
-            resetCheckpointState();
+    private void maybeTriggerDrain(CheckpointWindow window) {
+        if (window.remaining.decrementAndGet() != 0) {
             return;
         }
-        List<FilteredSpillFile.Reader> snapshots = checkpointSnapshots;
-        Map<InputChannelInfo, EntryPosition> startPos = checkpointStartPos;
-        checkpointSnapshots = null;
-        checkpointStartPos = null;
-        waitSet = null;
+        if (!window.drainTriggered.compareAndSet(false, true)) {
+            return;
+        }
+        // Detach the window so a stop callback after drain doesn't double-close snapshots; the
+        // iterator now owns them.
+        currentWindow.compareAndSet(window, null);
+        if (window.snapshots.isEmpty()) {
+            return;
+        }
         channelStateWriter.addInputDataFromSpill(
-                checkpointId, new FilteringDrainChunkIterator(snapshots, startPos));
+                window.checkpointId,
+                new FilteringDrainChunkIterator(window.snapshots, window.startPos));
     }
 
-    private void resetCheckpointState() {
-        if (checkpointSnapshots != null) {
-            for (FilteredSpillFile.Reader snap : checkpointSnapshots) {
-                closeQuietly(snap);
-            }
-            checkpointSnapshots = null;
+    private static void closeSnapshots(List<FilteredSpillFile.Reader> snapshots) {
+        for (FilteredSpillFile.Reader snap : snapshots) {
+            closeQuietly(snap);
         }
-        checkpointStartPos = null;
-        waitSet = null;
     }
 
     /**
@@ -485,6 +571,37 @@ public class FilteredBufferDispatcherImpl
 
     private boolean isSpillIdle() {
         return spillFile == null || spillFile.isIdle();
+    }
+
+    /**
+     * Immutable bundle of per-checkpoint coordination state. Replaces the old triple of nullable
+     * fields ({@code checkpointSnapshots} / {@code waitSet} / {@code checkpointStartPos}) with a
+     * single {@link AtomicReference}-published object so the snapshots and the wait-set become
+     * visible together with no torn intermediate state.
+     */
+    private static final class CheckpointWindow {
+
+        final long checkpointId;
+        final List<FilteredSpillFile.Reader> snapshots;
+        final Map<InputChannelInfo, EntryPosition> startPos = new ConcurrentHashMap<>();
+        final Set<InputChannelInfo> waitSet;
+        final AtomicInteger remaining;
+        final AtomicBoolean drainTriggered = new AtomicBoolean(false);
+
+        CheckpointWindow(
+                long checkpointId,
+                List<FilteredSpillFile.Reader> snapshots,
+                Set<InputChannelInfo> pendingChannels) {
+            this.checkpointId = checkpointId;
+            this.snapshots = Collections.unmodifiableList(new ArrayList<>(snapshots));
+            // ConcurrentHashMap-backed set: O(1) thread-safe remove + a plug-in source for the
+            // remaining counter without holding a lock.
+            this.waitSet = ConcurrentHashMap.newKeySet();
+            this.waitSet.addAll(pendingChannels);
+            // Counter mirrors waitSet size at construction so each successful remove drives one
+            // decrement.
+            this.remaining = new AtomicInteger(this.waitSet.size());
+        }
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FilteredBufferDispatcherImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FilteredBufferDispatcherImpl.java
@@ -19,7 +19,6 @@ package org.apache.flink.runtime.checkpoint.channel;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
-import org.apache.flink.runtime.io.network.partition.consumer.RecoveredBufferStore;
 import org.apache.flink.runtime.io.network.partition.consumer.RecoveredBufferStoreImpl;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.Preconditions;
@@ -61,7 +60,7 @@ import static org.apache.flink.util.IOUtils.closeQuietly;
  * always be acquired in the order <b>SMALL → BIG</b>. Code holding BIG must never reach back to
  * any SMALL — neither directly nor through a callee — otherwise the AB-BA cycle returns. Forbidden
  * callees from inside a {@code synchronized(dispatcherLock)} block: {@link
- * RecoveredBufferStoreImpl#addBuffer}, {@link RecoveredBufferStoreImpl#addBufferAndCaptureListener},
+ * RecoveredBufferStoreImpl#addBuffer}, {@link RecoveredBufferStoreImpl#addBufferAfterDisk},
  * {@link RecoveredBufferStoreImpl#incrementPending}, any {@code synchronized(store)} block, and any
  * {@link org.apache.flink.runtime.io.network.partition.consumer.ChannelStatePersister} entrypoint.
  */
@@ -231,20 +230,14 @@ public class FilteredBufferDispatcherImpl
                 RecoveredBufferStoreImpl store =
                         Preconditions.checkNotNull(
                                 storesByChannel.get(ch), "No store for channel %s", ch);
-                RecoveredBufferStore.DataAvailableListener listener;
-                synchronized (store) {
+                synchronized (store.getGateLock()) {
                     reader.skipNextEntry();
                     writeChunkToBuffer(buffer, data, entryLength);
-                    listener = store.addBufferAndCaptureListener(buffer);
-                    // drainHead is the last write inside the lock so its volatile publication
-                    // signals "drainHead crossed e ⇒ e is in store_C.readyBuffers" to
-                    // cross-channel Step 1 readers.
+                    store.addBuffer(buffer);
+                    // drainHead's volatile write happens-after addBuffer's store-lock release —
+                    // preserves "drainHead crossed e ⇒ e is in store_C.readyBuffers" for
+                    // cross-channel readers.
                     drainHead = computeDrainHeadFrom(i);
-                }
-                // Listener is captured inside the lock and fired here so the gate → store
-                // wake-up does not run while we hold the store lock (would AB-BA the task).
-                if (listener != null) {
-                    listener.onDataAvailable();
                 }
             }
         }
@@ -481,7 +474,9 @@ public class FilteredBufferDispatcherImpl
                                 storesByChannel.get(channelInfo),
                                 "No store for channel %s",
                                 channelInfo);
-                store.addBuffer(buffer);
+                synchronized (store.getGateLock()) {
+                    store.addBuffer(buffer);
+                }
                 return;
             }
         }
@@ -539,7 +534,9 @@ public class FilteredBufferDispatcherImpl
                 RecoveredBufferStoreImpl store =
                         Preconditions.checkNotNull(
                                 storesByChannel.get(ch), "No store for channel %s", ch);
-                store.addBuffer(buffer);
+                synchronized (store.getGateLock()) {
+                    store.addBuffer(buffer);
+                }
             }
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FilteredSpillFile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FilteredSpillFile.java
@@ -213,14 +213,13 @@ public class FilteredSpillFile implements Closeable {
     }
 
     /**
-     * Reads entries from a single spill file. The original Reader is mutated by the recovery
-     * thread (write path, replay drain) and concurrently by task threads via {@link
-     * #removeEntriesForChannel} on channel release. To avoid undefined behavior on the entry
-     * deque, the backing storage is a {@link ConcurrentLinkedDeque} — its weakly consistent
-     * iterator and atomic poll/peek tolerate the writer-vs-release race that the post-iter_6
-     * dispatcher no longer wraps in any monitor. The internal byte buffer is reused across
-     * {@link #readNext()} calls; callers must consume each {@link Chunk} before calling readNext
-     * again.
+     * Reads entries from a single spill file. The original Reader is mutated by the recovery thread
+     * (write path, replay drain) and concurrently by task threads via {@link
+     * #removeEntriesForChannel} on channel release. To avoid undefined behavior on the entry deque,
+     * the backing storage is a {@link ConcurrentLinkedDeque} — its weakly consistent iterator and
+     * atomic poll/peek tolerate the writer-vs-release race that the post-iter_6 dispatcher no
+     * longer wraps in any monitor. The internal byte buffer is reused across {@link #readNext()}
+     * calls; callers must consume each {@link Chunk} before calling readNext again.
      */
     public static class Reader implements Closeable {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FilteredSpillFile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FilteredSpillFile.java
@@ -43,18 +43,15 @@ import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * Spill file for the {@code filterAndRewrite} recovery path. Appends raw bytes to one or more
- * physical files on disk; each logical entry is tracked in the corresponding {@link Reader}'s entry
- * deque. Readers support both replay ({@link Reader#readNext}) and checkpoint snapshot ({@link
- * Reader#snapshot}).
- *
- * <p>Rotates to a new file when the current one exceeds 64 MB; each rotation seals the outgoing
- * Reader and opens a new one. All Readers are sealed on {@link #finish()}. Files are created lazily
- * on the first {@link #writeEntry} call.
+ * physical files; each logical entry is tracked in the corresponding {@link Reader}'s entry
+ * deque. Readers support replay ({@link Reader#readNext}) and checkpoint snapshot
+ * ({@link Reader#snapshot}). Rotates to a new file when the current one exceeds 64 MB; each
+ * rotation seals the outgoing Reader. Files are created lazily on the first {@link #writeEntry}.
  */
 @Internal
 public class FilteredSpillFile implements Closeable {
 
-    private static final long FILE_ROTATION_THRESHOLD = 64L * 1024 * 1024; // 64 MB
+    private static final long FILE_ROTATION_THRESHOLD = 64L * 1024 * 1024;
 
     private final String[] spillDirs;
     private final int memorySegmentSize;
@@ -62,18 +59,13 @@ public class FilteredSpillFile implements Closeable {
     private FileChannel currentChannel;
     private long currentFileOffset;
     private final List<Reader> readers;
-    /** Monotonic file-id counter; never reused even if a finished Reader is removed from the list. */
+    /** Monotonic file-id counter; never reused. */
     private int nextFileIndex;
     private boolean finished;
 
     /**
-     * Creates a new spill file (lazy: the first physical file is opened on the first {@link
-     * #writeEntry} call). Arguments are assumed pre-validated by the caller (non-empty spillDirs,
-     * positive memorySegmentSize).
-     *
-     * @param spillDirs directories for writing spill files
-     * @param memorySegmentSize max bytes per spill entry. Each entry is 1:1 aligned with a network
-     *     buffer of this size; longer payloads must be split upstream.
+     * @param memorySegmentSize max bytes per spill entry — each entry is 1:1 aligned with a
+     *     network buffer of this size, so longer payloads must be split upstream.
      */
     public FilteredSpillFile(String[] spillDirs, int memorySegmentSize) {
         this.spillDirs = spillDirs;
@@ -86,12 +78,9 @@ public class FilteredSpillFile implements Closeable {
     }
 
     /**
-     * Appends {@code len} bytes from {@code data[0..len)} to the current spill file, registering an
-     * entry for {@code channelInfo} in the current Reader. Lazily opens the first file; rotates
-     * when the current file exceeds {@link #FILE_ROTATION_THRESHOLD}.
-     *
-     * <p>Entries must fit within {@code memorySegmentSize} bytes (1:1 alignment with network
-     * buffers on replay). Oversize entries fail fast via {@link IllegalArgumentException}.
+     * Appends {@code len} bytes for {@code channelInfo}, lazily opening the first file and
+     * rotating when the current file exceeds {@link #FILE_ROTATION_THRESHOLD}. Oversize entries
+     * (> {@code memorySegmentSize}) fail fast.
      */
     public void writeEntry(byte[] data, int len, InputChannelInfo channelInfo) throws IOException {
         checkState(!finished, "writeEntry after finish");
@@ -122,11 +111,7 @@ public class FilteredSpillFile implements Closeable {
         }
     }
 
-    /**
-     * Finishes (if not already done), closes the write channel, chain-closes all Readers, and
-     * deletes all spill files on disk. After close() returns, no physical spill files remain and
-     * this spill file cannot be reused.
-     */
+    /** Closes all Readers and deletes the underlying spill files. */
     @Override
     public void close() throws IOException {
         finish();
@@ -139,8 +124,6 @@ public class FilteredSpillFile implements Closeable {
             for (Reader r : readers) {
                 r.close();
             }
-            // Best-effort cleanup of all spill files. Called unconditionally so callers do not
-            // need a separate delete step.
             for (Reader r : readers) {
                 try {
                     Files.deleteIfExists(r.filePath);
@@ -151,16 +134,13 @@ public class FilteredSpillFile implements Closeable {
         }
     }
 
-    /** Returns true after {@link #finish()} has been called. */
     public boolean isFinished() {
         return finished;
     }
 
     /**
-     * Returns true when no entry is currently pending on disk — either no file was ever opened, or
-     * every entry previously written has already been consumed (via {@link Reader#readNext()}) back
-     * into memory. While idle, the dispatcher prefers P1 (direct buffer) over P2 (spill); FIFO
-     * ordering is still preserved because there are no on-disk entries to jump ahead of.
+     * True when no entry is pending on disk. While idle, the dispatcher prefers P1; FIFO ordering
+     * is preserved because there are no on-disk entries to jump ahead of.
      */
     public boolean isIdle() {
         for (Reader r : readers) {
@@ -171,7 +151,6 @@ public class FilteredSpillFile implements Closeable {
         return true;
     }
 
-    /** Returns an unmodifiable view of all Readers created so far. */
     public List<Reader> getReaders() {
         return Collections.unmodifiableList(readers);
     }
@@ -196,20 +175,16 @@ public class FilteredSpillFile implements Closeable {
     }
 
     private void rotateFile() throws IOException {
-        // Seal the current Reader before opening a new file.
         currentReader().seal();
         currentChannel.close();
         currentChannel = null;
         openNewFile();
     }
 
-    // -------------------------------------------------------------------------
-    // Chunk — the payload unit returned by Reader.readNext()
-    // -------------------------------------------------------------------------
-
     /**
-     * A single spilled-data chunk returned by {@link Reader#readNext()}. The {@code data} array is
-     * reused between calls on the same Reader; callers must consume bytes before the next readNext.
+     * Spilled-data chunk returned by {@link Reader#readNext()}. The {@code data} array is the
+     * Reader's internal buffer, reused between calls; callers must consume bytes before the next
+     * readNext.
      */
     public static final class Chunk {
 
@@ -227,26 +202,20 @@ public class FilteredSpillFile implements Closeable {
             return channelInfo;
         }
 
-        /** Returns the internal data buffer; valid bytes are {@code [0, length)}. */
+        /** Internal data buffer; valid bytes are {@code [0, length)}. */
         public byte[] getData() {
             return data;
         }
 
-        /** Number of valid bytes at the start of {@link #getData()}. */
         public int getLength() {
             return length;
         }
     }
 
-    // -------------------------------------------------------------------------
-    // Reader — per-physical-file reader with entry deque and sealed state
-    // -------------------------------------------------------------------------
-
     /**
      * Reads entries from a single spill file. Each instance is owned by exactly one consumer
-     * thread: the original Reader by the replay path, a snapshot Reader by a checkpoint drain.
-     *
-     * <p>The internal buffer is reused across {@link #readNext()} calls; callers must consume each
+     * thread (the original Reader by the replay path, a snapshot Reader by a checkpoint drain).
+     * The internal buffer is reused across {@link #readNext()} calls; callers must consume each
      * Chunk before calling readNext again.
      */
     public static class Reader implements Closeable {
@@ -264,46 +233,36 @@ public class FilteredSpillFile implements Closeable {
             this.channel = FileChannel.open(filePath, StandardOpenOption.READ);
             this.memorySegmentSize = memorySegmentSize;
             this.fileIndex = fileIndex;
-            // Pre-allocated to memorySegmentSize; every entry is guaranteed to fit because
-            // FilteredSpillFile#writeEntry rejects oversized payloads at write time.
+            // writeEntry rejects oversized payloads, so every entry is guaranteed to fit.
             this.buf = new byte[memorySegmentSize];
         }
 
-        /** Index of this Reader's file in the spill file's {@code readers} list (0-based). */
         public int getFileIndex() {
             return fileIndex;
         }
 
-        // ---- Write side (called by FilteredSpillFile) ----
-
-        /** Registers an entry at {@code offset} with {@code length} bytes for {@code channelInfo}. */
         void addEntry(InputChannelInfo channelInfo, long offset, int length) {
             checkState(!sealed, "addEntry after seal");
             entries.addLast(new Entry(channelInfo, offset, length));
         }
 
-        /** Returns the head pending entry without consuming it, or null if empty. */
+        /** Head entry without consuming it; null if empty. */
         public Entry peekNextEntry() {
             return entries.peekFirst();
         }
 
         /**
-         * Removes the head pending entry without performing any disk I/O. Returns the dropped entry
-         * for callers that still need its metadata, or null if the deque was already empty. Use this
-         * when the caller has already read the entry's bytes via {@link #readBytesAt} or has chosen
-         * to discard it (e.g. phase-2 filter skipping an entry whose channel has already snapshotted
-         * it via Step 1).
+         * Removes the head entry without disk I/O. Use after reading via {@link #readBytesAt} or
+         * to discard (e.g. phase-2 filter skipping an entry already covered by Step 1).
          */
         public Entry skipNextEntry() {
             return entries.pollFirst();
         }
 
         /**
-         * Reads {@code length} bytes starting at absolute {@code offset} from this file into
-         * {@code dest} starting at {@code destOffset}. Throws {@link IOException} on truncation or
-         * an underlying read failure. Unlike {@link #readNext()} this method does <em>not</em>
-         * mutate the entry deque, so callers can safely perform the disk I/O outside any lock that
-         * also protects the deque.
+         * Reads {@code length} bytes from absolute {@code offset} into {@code dest}. Unlike
+         * {@link #readNext()} this does not mutate the entry deque, so callers can perform the
+         * I/O outside any lock that protects the deque.
          */
         public void readBytesAt(long offset, int length, byte[] dest, int destOffset)
                 throws IOException {
@@ -324,7 +283,6 @@ public class FilteredSpillFile implements Closeable {
             }
         }
 
-        /** Seals this Reader; no more addEntry calls are allowed after this point. */
         void seal() {
             sealed = true;
         }
@@ -333,32 +291,26 @@ public class FilteredSpillFile implements Closeable {
             return sealed;
         }
 
-        // ---- Consume side (replay or checkpoint drain) ----
-
-        /** Returns true if there are pending entries to consume. */
         public boolean hasEntries() {
             return !entries.isEmpty();
         }
 
-        /**
-         * Returns the channel of the next pending entry without consuming it, or null if empty.
-         */
+        /** Channel of the next pending entry; null if empty. */
         public InputChannelInfo peekNextChannel() {
             Entry e = entries.peekFirst();
             return e != null ? e.channelInfo : null;
         }
 
         /**
-         * Reads and returns the next pending entry as a {@link Chunk}. The Chunk's data array is
-         * the Reader's internal buffer; it is overwritten by the next readNext call. Returns null
-         * when there are no more entries.
+         * Reads the next pending entry as a {@link Chunk}; null when there are no more entries.
+         * The Chunk's data array is the Reader's internal buffer and is overwritten by the next
+         * readNext.
          */
         public Chunk readNext() throws IOException {
             Entry entry = entries.pollFirst();
             if (entry == null) {
                 return null;
             }
-            // writeEntry enforces entry.length <= memorySegmentSize, so buf always fits.
             ByteBuffer bb = ByteBuffer.wrap(buf, 0, entry.length);
             long position = entry.offset;
             while (bb.hasRemaining()) {
@@ -378,9 +330,8 @@ public class FilteredSpillFile implements Closeable {
         }
 
         /**
-         * Returns an independent Reader over the same file with a shallow copy of the current
-         * entries. The snapshot is pre-sealed. Must be called only after this Reader is sealed.
-         * The caller owns and must close the returned Reader.
+         * Independent Reader over the same file with a shallow copy of the current entries,
+         * pre-sealed. The caller owns and must close the returned Reader.
          */
         public Reader snapshot() throws IOException {
             checkState(sealed, "snapshot requires sealed Reader");
@@ -390,7 +341,6 @@ public class FilteredSpillFile implements Closeable {
             return snap;
         }
 
-        /** Returns the set of channels that still have pending entries. */
         public Set<InputChannelInfo> getPendingChannels() {
             Set<InputChannelInfo> channels = new HashSet<>();
             for (Entry e : entries) {
@@ -400,10 +350,8 @@ public class FilteredSpillFile implements Closeable {
         }
 
         /**
-         * Removes all pending entries belonging to {@code channelInfo} and returns how many were
-         * dropped. Used when a per-channel store is released so that the dispatcher can free the
-         * channel's disk-side bookkeeping eagerly instead of leaving it to {@link
-         * FilteredSpillFile#close()}.
+         * Drops all pending entries for {@code channelInfo}; returns the count. Used when a store
+         * is released so disk-side bookkeeping is freed eagerly.
          */
         public int removeEntriesForChannel(InputChannelInfo channelInfo) {
             int removed = 0;
@@ -422,14 +370,7 @@ public class FilteredSpillFile implements Closeable {
             channel.close();
         }
 
-        // ---- Entry metadata ----
-
-        /**
-         * Immutable metadata for a single spilled entry: the target channel, the byte offset in
-         * the owning file, and the payload length. Exposed publicly so the dispatcher can inspect
-         * the next entry (channel + offset + length) and perform disk I/O outside the deque-mutating
-         * commit section without re-implementing the metadata accessor surface.
-         */
+        /** Immutable metadata for a single spilled entry: target channel, offset, length. */
         public static final class Entry {
             private final InputChannelInfo channelInfo;
             private final long offset;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FilteredSpillFile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FilteredSpillFile.java
@@ -28,7 +28,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Deque;
@@ -37,6 +36,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentLinkedDeque;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -213,10 +213,14 @@ public class FilteredSpillFile implements Closeable {
     }
 
     /**
-     * Reads entries from a single spill file. Each instance is owned by exactly one consumer thread
-     * (the original Reader by the replay path, a snapshot Reader by a checkpoint drain). The
-     * internal buffer is reused across {@link #readNext()} calls; callers must consume each Chunk
-     * before calling readNext again.
+     * Reads entries from a single spill file. The original Reader is mutated by the recovery
+     * thread (write path, replay drain) and concurrently by task threads via {@link
+     * #removeEntriesForChannel} on channel release. To avoid undefined behavior on the entry
+     * deque, the backing storage is a {@link ConcurrentLinkedDeque} — its weakly consistent
+     * iterator and atomic poll/peek tolerate the writer-vs-release race that the post-iter_6
+     * dispatcher no longer wraps in any monitor. The internal byte buffer is reused across
+     * {@link #readNext()} calls; callers must consume each {@link Chunk} before calling readNext
+     * again.
      */
     public static class Reader implements Closeable {
 
@@ -224,7 +228,7 @@ public class FilteredSpillFile implements Closeable {
         final Path filePath; // accessed by FilteredSpillFile.close() to delete spill files
         private final int memorySegmentSize;
         private final int fileIndex;
-        private final Deque<Entry> entries = new ArrayDeque<>();
+        private final Deque<Entry> entries = new ConcurrentLinkedDeque<>();
         private volatile boolean frozen = false;
         private final byte[] buf;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FilteredSpillFile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FilteredSpillFile.java
@@ -43,10 +43,10 @@ import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * Spill file for the {@code filterAndRewrite} recovery path. Appends raw bytes to one or more
- * physical files; each logical entry is tracked in the corresponding {@link Reader}'s entry
- * deque. Readers support replay ({@link Reader#readNext}) and checkpoint snapshot
- * ({@link Reader#snapshot}). Rotates to a new file when the current one exceeds 64 MB; each
- * rotation seals the outgoing Reader. Files are created lazily on the first {@link #writeEntry}.
+ * physical files; each logical entry is tracked in the corresponding {@link Reader}'s entry deque.
+ * Readers support replay ({@link Reader#readNext}) and checkpoint snapshot ({@link
+ * Reader#snapshot}). Rotates to a new file when the current one exceeds 64 MB; each rotation
+ * freezes the outgoing Reader. Files are created lazily on the first {@link #writeEntry}.
  */
 @Internal
 public class FilteredSpillFile implements Closeable {
@@ -59,13 +59,15 @@ public class FilteredSpillFile implements Closeable {
     private FileChannel currentChannel;
     private long currentFileOffset;
     private final List<Reader> readers;
+
     /** Monotonic file-id counter; never reused. */
     private int nextFileIndex;
+
     private boolean finished;
 
     /**
-     * @param memorySegmentSize max bytes per spill entry — each entry is 1:1 aligned with a
-     *     network buffer of this size, so longer payloads must be split upstream.
+     * @param memorySegmentSize max bytes per spill entry — each entry is 1:1 aligned with a network
+     *     buffer of this size, so longer payloads must be split upstream.
      */
     public FilteredSpillFile(String[] spillDirs, int memorySegmentSize) {
         this.spillDirs = spillDirs;
@@ -78,9 +80,9 @@ public class FilteredSpillFile implements Closeable {
     }
 
     /**
-     * Appends {@code len} bytes for {@code channelInfo}, lazily opening the first file and
-     * rotating when the current file exceeds {@link #FILE_ROTATION_THRESHOLD}. Oversize entries
-     * (> {@code memorySegmentSize}) fail fast.
+     * Appends {@code len} bytes for {@code channelInfo}, lazily opening the first file and rotating
+     * when the current file exceeds {@link #FILE_ROTATION_THRESHOLD}. Oversize entries (> {@code
+     * memorySegmentSize}) fail fast.
      */
     public void writeEntry(byte[] data, int len, InputChannelInfo channelInfo) throws IOException {
         checkState(!finished, "writeEntry after finish");
@@ -100,14 +102,14 @@ public class FilteredSpillFile implements Closeable {
         currentReader().addEntry(channelInfo, entryOffset, len);
     }
 
-    /** Seals the last Reader. After finish, no more writeEntry calls are accepted. */
+    /** Freezes the last Reader. After finish, no more writeEntry calls are accepted. */
     public void finish() {
         if (finished) {
             return;
         }
         finished = true;
         if (!readers.isEmpty()) {
-            currentReader().seal();
+            currentReader().freeze();
         }
     }
 
@@ -167,15 +169,13 @@ public class FilteredSpillFile implements Closeable {
         Path currentFilePath = dirPath.resolve("spill-" + UUID.randomUUID() + ".bin");
         currentChannel =
                 FileChannel.open(
-                        currentFilePath,
-                        StandardOpenOption.CREATE_NEW,
-                        StandardOpenOption.WRITE);
+                        currentFilePath, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
         currentFileOffset = 0;
         readers.add(new Reader(currentFilePath, memorySegmentSize, nextFileIndex++));
     }
 
     private void rotateFile() throws IOException {
-        currentReader().seal();
+        currentReader().freeze();
         currentChannel.close();
         currentChannel = null;
         openNewFile();
@@ -213,10 +213,10 @@ public class FilteredSpillFile implements Closeable {
     }
 
     /**
-     * Reads entries from a single spill file. Each instance is owned by exactly one consumer
-     * thread (the original Reader by the replay path, a snapshot Reader by a checkpoint drain).
-     * The internal buffer is reused across {@link #readNext()} calls; callers must consume each
-     * Chunk before calling readNext again.
+     * Reads entries from a single spill file. Each instance is owned by exactly one consumer thread
+     * (the original Reader by the replay path, a snapshot Reader by a checkpoint drain). The
+     * internal buffer is reused across {@link #readNext()} calls; callers must consume each Chunk
+     * before calling readNext again.
      */
     public static class Reader implements Closeable {
 
@@ -225,7 +225,7 @@ public class FilteredSpillFile implements Closeable {
         private final int memorySegmentSize;
         private final int fileIndex;
         private final Deque<Entry> entries = new ArrayDeque<>();
-        private volatile boolean sealed = false;
+        private volatile boolean frozen = false;
         private final byte[] buf;
 
         Reader(Path filePath, int memorySegmentSize, int fileIndex) throws IOException {
@@ -242,7 +242,7 @@ public class FilteredSpillFile implements Closeable {
         }
 
         void addEntry(InputChannelInfo channelInfo, long offset, int length) {
-            checkState(!sealed, "addEntry after seal");
+            checkState(!frozen, "addEntry after freeze");
             entries.addLast(new Entry(channelInfo, offset, length));
         }
 
@@ -252,17 +252,17 @@ public class FilteredSpillFile implements Closeable {
         }
 
         /**
-         * Removes the head entry without disk I/O. Use after reading via {@link #readBytesAt} or
-         * to discard (e.g. phase-2 filter skipping an entry already covered by Step 1).
+         * Removes the head entry without disk I/O. Use after reading via {@link #readBytesAt} or to
+         * discard (e.g. phase-2 filter skipping an entry already covered by Step 1).
          */
         public Entry skipNextEntry() {
             return entries.pollFirst();
         }
 
         /**
-         * Reads {@code length} bytes from absolute {@code offset} into {@code dest}. Unlike
-         * {@link #readNext()} this does not mutate the entry deque, so callers can perform the
-         * I/O outside any lock that protects the deque.
+         * Reads {@code length} bytes from absolute {@code offset} into {@code dest}. Unlike {@link
+         * #readNext()} this does not mutate the entry deque, so callers can perform the I/O outside
+         * any lock that protects the deque.
          */
         public void readBytesAt(long offset, int length, byte[] dest, int destOffset)
                 throws IOException {
@@ -283,12 +283,12 @@ public class FilteredSpillFile implements Closeable {
             }
         }
 
-        void seal() {
-            sealed = true;
+        void freeze() {
+            frozen = true;
         }
 
-        public boolean isSealed() {
-            return sealed;
+        public boolean isFrozen() {
+            return frozen;
         }
 
         public boolean hasEntries() {
@@ -302,8 +302,8 @@ public class FilteredSpillFile implements Closeable {
         }
 
         /**
-         * Reads the next pending entry as a {@link Chunk}; null when there are no more entries.
-         * The Chunk's data array is the Reader's internal buffer and is overwritten by the next
+         * Reads the next pending entry as a {@link Chunk}; null when there are no more entries. The
+         * Chunk's data array is the Reader's internal buffer and is overwritten by the next
          * readNext.
          */
         public Chunk readNext() throws IOException {
@@ -331,13 +331,13 @@ public class FilteredSpillFile implements Closeable {
 
         /**
          * Independent Reader over the same file with a shallow copy of the current entries,
-         * pre-sealed. The caller owns and must close the returned Reader.
+         * pre-frozen. The caller owns and must close the returned Reader.
          */
         public Reader snapshot() throws IOException {
-            checkState(sealed, "snapshot requires sealed Reader");
+            checkState(frozen, "snapshot requires frozen Reader");
             Reader snap = new Reader(filePath, memorySegmentSize, fileIndex);
             snap.entries.addAll(this.entries);
-            snap.sealed = true;
+            snap.frozen = true;
             return snap;
         }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FilteredSpillFile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FilteredSpillFile.java
@@ -1,0 +1,457 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.FileUtils;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * Spill file for the {@code filterAndRewrite} recovery path. Appends raw bytes to one or more
+ * physical files on disk; each logical entry is tracked in the corresponding {@link Reader}'s entry
+ * deque. Readers support both replay ({@link Reader#readNext}) and checkpoint snapshot ({@link
+ * Reader#snapshot}).
+ *
+ * <p>Rotates to a new file when the current one exceeds 64 MB; each rotation seals the outgoing
+ * Reader and opens a new one. All Readers are sealed on {@link #finish()}. Files are created lazily
+ * on the first {@link #writeEntry} call.
+ */
+@Internal
+public class FilteredSpillFile implements Closeable {
+
+    private static final long FILE_ROTATION_THRESHOLD = 64L * 1024 * 1024; // 64 MB
+
+    private final String[] spillDirs;
+    private final int memorySegmentSize;
+    private int currentDirIndex;
+    private FileChannel currentChannel;
+    private long currentFileOffset;
+    private final List<Reader> readers;
+    /** Monotonic file-id counter; never reused even if a finished Reader is removed from the list. */
+    private int nextFileIndex;
+    private boolean finished;
+
+    /**
+     * Creates a new spill file (lazy: the first physical file is opened on the first {@link
+     * #writeEntry} call). Arguments are assumed pre-validated by the caller (non-empty spillDirs,
+     * positive memorySegmentSize).
+     *
+     * @param spillDirs directories for writing spill files
+     * @param memorySegmentSize max bytes per spill entry. Each entry is 1:1 aligned with a network
+     *     buffer of this size; longer payloads must be split upstream.
+     */
+    public FilteredSpillFile(String[] spillDirs, int memorySegmentSize) {
+        this.spillDirs = spillDirs;
+        this.memorySegmentSize = memorySegmentSize;
+        this.currentDirIndex = 0;
+        this.currentFileOffset = 0;
+        this.readers = new ArrayList<>();
+        this.nextFileIndex = 0;
+        this.finished = false;
+    }
+
+    /**
+     * Appends {@code len} bytes from {@code data[0..len)} to the current spill file, registering an
+     * entry for {@code channelInfo} in the current Reader. Lazily opens the first file; rotates
+     * when the current file exceeds {@link #FILE_ROTATION_THRESHOLD}.
+     *
+     * <p>Entries must fit within {@code memorySegmentSize} bytes (1:1 alignment with network
+     * buffers on replay). Oversize entries fail fast via {@link IllegalArgumentException}.
+     */
+    public void writeEntry(byte[] data, int len, InputChannelInfo channelInfo) throws IOException {
+        checkState(!finished, "writeEntry after finish");
+        checkArgument(
+                len <= memorySegmentSize,
+                "Entry length %s exceeds memorySegmentSize %s",
+                len,
+                memorySegmentSize);
+        if (currentChannel == null) {
+            openNewFile();
+        } else if (currentFileOffset > FILE_ROTATION_THRESHOLD) {
+            rotateFile();
+        }
+        long entryOffset = currentFileOffset;
+        FileUtils.writeCompletely(currentChannel, ByteBuffer.wrap(data, 0, len));
+        currentFileOffset += len;
+        currentReader().addEntry(channelInfo, entryOffset, len);
+    }
+
+    /** Seals the last Reader. After finish, no more writeEntry calls are accepted. */
+    public void finish() {
+        if (finished) {
+            return;
+        }
+        finished = true;
+        if (!readers.isEmpty()) {
+            currentReader().seal();
+        }
+    }
+
+    /**
+     * Finishes (if not already done), closes the write channel, chain-closes all Readers, and
+     * deletes all spill files on disk. After close() returns, no physical spill files remain and
+     * this spill file cannot be reused.
+     */
+    @Override
+    public void close() throws IOException {
+        finish();
+        try {
+            if (currentChannel != null) {
+                currentChannel.close();
+                currentChannel = null;
+            }
+        } finally {
+            for (Reader r : readers) {
+                r.close();
+            }
+            // Best-effort cleanup of all spill files. Called unconditionally so callers do not
+            // need a separate delete step.
+            for (Reader r : readers) {
+                try {
+                    Files.deleteIfExists(r.filePath);
+                } catch (IOException ignored) {
+                    // best-effort cleanup
+                }
+            }
+        }
+    }
+
+    /** Returns true after {@link #finish()} has been called. */
+    public boolean isFinished() {
+        return finished;
+    }
+
+    /**
+     * Returns true when no entry is currently pending on disk — either no file was ever opened, or
+     * every entry previously written has already been consumed (via {@link Reader#readNext()}) back
+     * into memory. While idle, the dispatcher prefers P1 (direct buffer) over P2 (spill); FIFO
+     * ordering is still preserved because there are no on-disk entries to jump ahead of.
+     */
+    public boolean isIdle() {
+        for (Reader r : readers) {
+            if (r.hasEntries()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /** Returns an unmodifiable view of all Readers created so far. */
+    public List<Reader> getReaders() {
+        return Collections.unmodifiableList(readers);
+    }
+
+    private Reader currentReader() {
+        return readers.get(readers.size() - 1);
+    }
+
+    private void openNewFile() throws IOException {
+        String dir = spillDirs[currentDirIndex];
+        currentDirIndex = (currentDirIndex + 1) % spillDirs.length;
+        Path dirPath = Paths.get(dir);
+        Files.createDirectories(dirPath);
+        Path currentFilePath = dirPath.resolve("spill-" + UUID.randomUUID() + ".bin");
+        currentChannel =
+                FileChannel.open(
+                        currentFilePath,
+                        StandardOpenOption.CREATE_NEW,
+                        StandardOpenOption.WRITE);
+        currentFileOffset = 0;
+        readers.add(new Reader(currentFilePath, memorySegmentSize, nextFileIndex++));
+    }
+
+    private void rotateFile() throws IOException {
+        // Seal the current Reader before opening a new file.
+        currentReader().seal();
+        currentChannel.close();
+        currentChannel = null;
+        openNewFile();
+    }
+
+    // -------------------------------------------------------------------------
+    // Chunk — the payload unit returned by Reader.readNext()
+    // -------------------------------------------------------------------------
+
+    /**
+     * A single spilled-data chunk returned by {@link Reader#readNext()}. The {@code data} array is
+     * reused between calls on the same Reader; callers must consume bytes before the next readNext.
+     */
+    public static final class Chunk {
+
+        private final InputChannelInfo channelInfo;
+        private final byte[] data;
+        private final int length;
+
+        public Chunk(InputChannelInfo channelInfo, byte[] data, int length) {
+            this.channelInfo = channelInfo;
+            this.data = data;
+            this.length = length;
+        }
+
+        public InputChannelInfo getChannelInfo() {
+            return channelInfo;
+        }
+
+        /** Returns the internal data buffer; valid bytes are {@code [0, length)}. */
+        public byte[] getData() {
+            return data;
+        }
+
+        /** Number of valid bytes at the start of {@link #getData()}. */
+        public int getLength() {
+            return length;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Reader — per-physical-file reader with entry deque and sealed state
+    // -------------------------------------------------------------------------
+
+    /**
+     * Reads entries from a single spill file. Each instance is owned by exactly one consumer
+     * thread: the original Reader by the replay path, a snapshot Reader by a checkpoint drain.
+     *
+     * <p>The internal buffer is reused across {@link #readNext()} calls; callers must consume each
+     * Chunk before calling readNext again.
+     */
+    public static class Reader implements Closeable {
+
+        private final FileChannel channel;
+        final Path filePath; // accessed by FilteredSpillFile.close() to delete spill files
+        private final int memorySegmentSize;
+        private final int fileIndex;
+        private final Deque<Entry> entries = new ArrayDeque<>();
+        private volatile boolean sealed = false;
+        private final byte[] buf;
+
+        Reader(Path filePath, int memorySegmentSize, int fileIndex) throws IOException {
+            this.filePath = filePath;
+            this.channel = FileChannel.open(filePath, StandardOpenOption.READ);
+            this.memorySegmentSize = memorySegmentSize;
+            this.fileIndex = fileIndex;
+            // Pre-allocated to memorySegmentSize; every entry is guaranteed to fit because
+            // FilteredSpillFile#writeEntry rejects oversized payloads at write time.
+            this.buf = new byte[memorySegmentSize];
+        }
+
+        /** Index of this Reader's file in the spill file's {@code readers} list (0-based). */
+        public int getFileIndex() {
+            return fileIndex;
+        }
+
+        // ---- Write side (called by FilteredSpillFile) ----
+
+        /** Registers an entry at {@code offset} with {@code length} bytes for {@code channelInfo}. */
+        void addEntry(InputChannelInfo channelInfo, long offset, int length) {
+            checkState(!sealed, "addEntry after seal");
+            entries.addLast(new Entry(channelInfo, offset, length));
+        }
+
+        /** Returns the head pending entry without consuming it, or null if empty. */
+        public Entry peekNextEntry() {
+            return entries.peekFirst();
+        }
+
+        /**
+         * Removes the head pending entry without performing any disk I/O. Returns the dropped entry
+         * for callers that still need its metadata, or null if the deque was already empty. Use this
+         * when the caller has already read the entry's bytes via {@link #readBytesAt} or has chosen
+         * to discard it (e.g. phase-2 filter skipping an entry whose channel has already snapshotted
+         * it via Step 1).
+         */
+        public Entry skipNextEntry() {
+            return entries.pollFirst();
+        }
+
+        /**
+         * Reads {@code length} bytes starting at absolute {@code offset} from this file into
+         * {@code dest} starting at {@code destOffset}. Throws {@link IOException} on truncation or
+         * an underlying read failure. Unlike {@link #readNext()} this method does <em>not</em>
+         * mutate the entry deque, so callers can safely perform the disk I/O outside any lock that
+         * also protects the deque.
+         */
+        public void readBytesAt(long offset, int length, byte[] dest, int destOffset)
+                throws IOException {
+            ByteBuffer bb = ByteBuffer.wrap(dest, destOffset, length);
+            long position = offset;
+            while (bb.hasRemaining()) {
+                int n = channel.read(bb, position);
+                if (n < 0) {
+                    throw new IOException(
+                            "Truncated spill file: "
+                                    + length
+                                    + " bytes @"
+                                    + offset
+                                    + " in "
+                                    + filePath);
+                }
+                position += n;
+            }
+        }
+
+        /** Seals this Reader; no more addEntry calls are allowed after this point. */
+        void seal() {
+            sealed = true;
+        }
+
+        public boolean isSealed() {
+            return sealed;
+        }
+
+        // ---- Consume side (replay or checkpoint drain) ----
+
+        /** Returns true if there are pending entries to consume. */
+        public boolean hasEntries() {
+            return !entries.isEmpty();
+        }
+
+        /**
+         * Returns the channel of the next pending entry without consuming it, or null if empty.
+         */
+        public InputChannelInfo peekNextChannel() {
+            Entry e = entries.peekFirst();
+            return e != null ? e.channelInfo : null;
+        }
+
+        /**
+         * Reads and returns the next pending entry as a {@link Chunk}. The Chunk's data array is
+         * the Reader's internal buffer; it is overwritten by the next readNext call. Returns null
+         * when there are no more entries.
+         */
+        public Chunk readNext() throws IOException {
+            Entry entry = entries.pollFirst();
+            if (entry == null) {
+                return null;
+            }
+            // writeEntry enforces entry.length <= memorySegmentSize, so buf always fits.
+            ByteBuffer bb = ByteBuffer.wrap(buf, 0, entry.length);
+            long position = entry.offset;
+            while (bb.hasRemaining()) {
+                int n = channel.read(bb, position);
+                if (n < 0) {
+                    throw new IOException(
+                            "Truncated spill file: "
+                                    + entry.length
+                                    + " bytes @"
+                                    + entry.offset
+                                    + " in "
+                                    + filePath);
+                }
+                position += n;
+            }
+            return new Chunk(entry.channelInfo, buf, entry.length);
+        }
+
+        /**
+         * Returns an independent Reader over the same file with a shallow copy of the current
+         * entries. The snapshot is pre-sealed. Must be called only after this Reader is sealed.
+         * The caller owns and must close the returned Reader.
+         */
+        public Reader snapshot() throws IOException {
+            checkState(sealed, "snapshot requires sealed Reader");
+            Reader snap = new Reader(filePath, memorySegmentSize, fileIndex);
+            snap.entries.addAll(this.entries);
+            snap.sealed = true;
+            return snap;
+        }
+
+        /** Returns the set of channels that still have pending entries. */
+        public Set<InputChannelInfo> getPendingChannels() {
+            Set<InputChannelInfo> channels = new HashSet<>();
+            for (Entry e : entries) {
+                channels.add(e.channelInfo);
+            }
+            return channels;
+        }
+
+        /**
+         * Removes all pending entries belonging to {@code channelInfo} and returns how many were
+         * dropped. Used when a per-channel store is released so that the dispatcher can free the
+         * channel's disk-side bookkeeping eagerly instead of leaving it to {@link
+         * FilteredSpillFile#close()}.
+         */
+        public int removeEntriesForChannel(InputChannelInfo channelInfo) {
+            int removed = 0;
+            Iterator<Entry> it = entries.iterator();
+            while (it.hasNext()) {
+                if (it.next().channelInfo.equals(channelInfo)) {
+                    it.remove();
+                    removed++;
+                }
+            }
+            return removed;
+        }
+
+        @Override
+        public void close() throws IOException {
+            channel.close();
+        }
+
+        // ---- Entry metadata ----
+
+        /**
+         * Immutable metadata for a single spilled entry: the target channel, the byte offset in
+         * the owning file, and the payload length. Exposed publicly so the dispatcher can inspect
+         * the next entry (channel + offset + length) and perform disk I/O outside the deque-mutating
+         * commit section without re-implementing the metadata accessor surface.
+         */
+        public static final class Entry {
+            private final InputChannelInfo channelInfo;
+            private final long offset;
+            private final int length;
+
+            Entry(InputChannelInfo channelInfo, long offset, int length) {
+                this.channelInfo = channelInfo;
+                this.offset = offset;
+                this.length = length;
+            }
+
+            public InputChannelInfo getChannelInfo() {
+                return channelInfo;
+            }
+
+            public long getOffset() {
+                return offset;
+            }
+
+            public int getLength() {
+                return length;
+            }
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredBufferStoreCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredBufferStoreCoordinator.java
@@ -20,60 +20,46 @@ package org.apache.flink.runtime.checkpoint.channel;
 import org.apache.flink.annotation.Internal;
 
 /**
- * Cross-channel coordinator notified by per-channel
- * {@link org.apache.flink.runtime.io.network.partition.consumer.RecoveredBufferStore} instances on
- * lifecycle events. Implementations centralise bookkeeping that spans multiple channels (such as
- * checkpoint wait-sets or shared on-disk spill state) and react to per-channel transitions.
+ * Cross-channel coordinator notified by per-channel {@link
+ * org.apache.flink.runtime.io.network.partition.consumer.RecoveredBufferStore} instances on
+ * lifecycle events. Centralises bookkeeping that spans multiple channels (checkpoint wait-sets,
+ * shared on-disk spill state).
  *
- * <p>{@link #onChannelCheckpointStarted}, {@link #onChannelCheckpointStopped} and
- * {@link #onChannelReleased} are invoked from the Task thread, <em>outside</em> the calling store's
- * lock, so implementations may freely acquire their own synchronisation without deadlock risk.
- *
- * <p>{@link #getCurrentDrainHead()} is invoked <em>inside</em> the calling store's lock so the
- * store can capture a consistent (readyBuffers, drainHead) pair atomically. Implementations must
- * therefore avoid blocking and must not acquire any lock that participates in the store-lock cycle
- * — a plain {@code volatile} read of a field maintained by the drain bundle is the intended
- * implementation.
+ * <p>The {@code onChannel*} callbacks fire from the Task thread <em>outside</em> the calling
+ * store's lock, so implementations may freely acquire their own synchronisation. {@link
+ * #getCurrentDrainHead()} fires <em>inside</em> the calling store's lock so the store can capture a
+ * consistent (readyBuffers, drainHead) pair atomically — implementations must therefore avoid
+ * blocking and must not acquire any lock participating in the store-lock cycle (a plain {@code
+ * volatile} read is the intended implementation).
  */
 @Internal
 public interface RecoveredBufferStoreCoordinator {
 
     /**
-     * Returns the current drain head — the position of the next entry the dispatcher's drain bundle
-     * will pop from the global FIFO queue. Used by {@code RecoveredBufferStore#checkpoint} to
-     * record a per-channel checkpoint cutoff (startPos) atomically with the channel's ready-buffer
-     * snapshot. Returns {@link EntryPosition#END} when the queue is empty (no more disk entries
-     * pending).
-     *
-     * <p>Reads must be cheap and lock-free; do not block, do not allocate, do not acquire any
-     * lock that the calling store holds (or that the dispatcher holds during drain).
+     * Position of the next entry the drain bundle will pop from the global FIFO. Returns {@link
+     * EntryPosition#END} when no disk entries are pending. Must be cheap and lock-free.
      */
     EntryPosition getCurrentDrainHead();
 
     /**
-     * Invoked from inside {@code RecoveredBufferStore#checkpoint} after the store has snapshotted
-     * its ready buffers. Implementations use this to maintain a wait-set across channels and, when
-     * all channels have reported in, drain pending spill entries into the checkpoint.
-     *
-     * <p>{@code startPos} is the {@code drainHead} value the store captured atomically with its
-     * ready-buffer snapshot, under the store lock. Implementations must record it as the
-     * per-channel cutoff used by phase-2 to decide which spill entries belong to this checkpoint
-     * versus this channel's Step 1 ready snapshot.
+     * Invoked from {@code RecoveredBufferStore#checkpoint} after the store has snapshotted its
+     * ready buffers. {@code startPos} is the drain-head captured atomically with that snapshot;
+     * phase-2 uses it as the per-channel cutoff to split spill entries between this channel's Step
+     * 1 snapshot and the global checkpoint drain.
      */
     void onChannelCheckpointStarted(
             long checkpointId, InputChannelInfo channelInfo, EntryPosition startPos);
 
     /**
-     * Invoked from inside {@code RecoveredBufferStore#notifyCheckpointStopped} when the owning
-     * channel has finished or aborted a checkpoint. Implementations use this to drop any wait-set
-     * still tied to the stopped checkpoint so a later {@link #onChannelReleased} or a late
-     * {@link #onChannelCheckpointStarted} cannot trigger a phase-2 drain to a checkpoint that has
-     * already been concluded by the task.
+     * Invoked from {@code RecoveredBufferStore#notifyCheckpointStopped} when the owning channel has
+     * finished or aborted a checkpoint. Used to drop a wait-set still tied to the stopped
+     * checkpoint so a later release or late start callback cannot trigger a phase-2 drain into a
+     * concluded checkpoint.
      */
     void onChannelCheckpointStopped(long checkpointId, InputChannelInfo channelInfo);
 
     /**
-     * Invoked from inside {@code RecoveredBufferStore#releaseAll} so the coordinator can drop
+     * Invoked from {@code RecoveredBufferStore#releaseAll} so the coordinator can drop
      * disk-resident spill entries still associated with the released channel.
      */
     void onChannelReleased(InputChannelInfo channelInfo);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredBufferStoreCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredBufferStoreCoordinator.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.apache.flink.annotation.Internal;
+
+/**
+ * Cross-channel coordinator notified by per-channel
+ * {@link org.apache.flink.runtime.io.network.partition.consumer.RecoveredBufferStore} instances on
+ * lifecycle events. Implementations centralise bookkeeping that spans multiple channels (such as
+ * checkpoint wait-sets or shared on-disk spill state) and react to per-channel transitions.
+ *
+ * <p>{@link #onChannelCheckpointStarted}, {@link #onChannelCheckpointStopped} and
+ * {@link #onChannelReleased} are invoked from the Task thread, <em>outside</em> the calling store's
+ * lock, so implementations may freely acquire their own synchronisation without deadlock risk.
+ *
+ * <p>{@link #getCurrentDrainHead()} is invoked <em>inside</em> the calling store's lock so the
+ * store can capture a consistent (readyBuffers, drainHead) pair atomically. Implementations must
+ * therefore avoid blocking and must not acquire any lock that participates in the store-lock cycle
+ * — a plain {@code volatile} read of a field maintained by the drain bundle is the intended
+ * implementation.
+ */
+@Internal
+public interface RecoveredBufferStoreCoordinator {
+
+    /**
+     * Returns the current drain head — the position of the next entry the dispatcher's drain bundle
+     * will pop from the global FIFO queue. Used by {@code RecoveredBufferStore#checkpoint} to
+     * record a per-channel checkpoint cutoff (startPos) atomically with the channel's ready-buffer
+     * snapshot. Returns {@link EntryPosition#END} when the queue is empty (no more disk entries
+     * pending).
+     *
+     * <p>Reads must be cheap and lock-free; do not block, do not allocate, do not acquire any
+     * lock that the calling store holds (or that the dispatcher holds during drain).
+     */
+    EntryPosition getCurrentDrainHead();
+
+    /**
+     * Invoked from inside {@code RecoveredBufferStore#checkpoint} after the store has snapshotted
+     * its ready buffers. Implementations use this to maintain a wait-set across channels and, when
+     * all channels have reported in, drain pending spill entries into the checkpoint.
+     *
+     * <p>{@code startPos} is the {@code drainHead} value the store captured atomically with its
+     * ready-buffer snapshot, under the store lock. Implementations must record it as the
+     * per-channel cutoff used by phase-2 to decide which spill entries belong to this checkpoint
+     * versus this channel's Step 1 ready snapshot.
+     */
+    void onChannelCheckpointStarted(
+            long checkpointId, InputChannelInfo channelInfo, EntryPosition startPos);
+
+    /**
+     * Invoked from inside {@code RecoveredBufferStore#notifyCheckpointStopped} when the owning
+     * channel has finished or aborted a checkpoint. Implementations use this to drop any wait-set
+     * still tied to the stopped checkpoint so a later {@link #onChannelReleased} or a late
+     * {@link #onChannelCheckpointStarted} cannot trigger a phase-2 drain to a checkpoint that has
+     * already been concluded by the task.
+     */
+    void onChannelCheckpointStopped(long checkpointId, InputChannelInfo channelInfo);
+
+    /**
+     * Invoked from inside {@code RecoveredBufferStore#releaseAll} so the coordinator can drop
+     * disk-resident spill entries still associated with the released channel.
+     */
+    void onChannelReleased(InputChannelInfo channelInfo);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
@@ -74,9 +74,9 @@ interface RecoveredChannelStateHandler<Info, Context> extends AutoCloseable {
 
     /**
      * Triggers post-recovery actions: input channels complete the buffer-filtering future and
-     * publish {@code EndOfInputChannelStateEvent} via their store; output partitions call
-     * {@code finishReadRecoveredState} on every checkpointable partition. Idempotent. Must be
-     * invoked between {@code dispatcher.flush()} and {@code dispatcher.drainPendingSpill()}.
+     * publish {@code EndOfInputChannelStateEvent} via their store; output partitions call {@code
+     * finishReadRecoveredState} on every checkpointable partition. Idempotent. Must be invoked
+     * between {@code dispatcher.flush()} and {@code dispatcher.drainPendingSpill()}.
      */
     void finishRecovery() throws IOException;
 }
@@ -141,9 +141,9 @@ class InputChannelRecoveredStateHandler
     }
 
     /**
-     * Allocates a pre-filter buffer from a reusable heap segment (isolated from the Network
-     * Buffer Pool). Flink's serial recovery loop guarantees at most one is in flight at a time;
-     * the runtime check fails loudly if that ever regresses.
+     * Allocates a pre-filter buffer from a reusable heap segment (isolated from the Network Buffer
+     * Pool). Flink's serial recovery loop guarantees at most one is in flight at a time; the
+     * runtime check fails loudly if that ever regresses.
      */
     private BufferWithContext<Buffer> getPreFilterBuffer() {
         checkState(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
@@ -71,6 +71,21 @@ interface RecoveredChannelStateHandler<Info, Context> extends AutoCloseable {
      */
     void recover(Info info, int oldSubtaskIndex, BufferWithContext<Context> bufferWithContext)
             throws IOException, InterruptedException;
+
+    /**
+     * Trigger the post-recovery business actions for this handler. For input channels this
+     * completes the per-channel buffer-filtering future and surfaces an
+     * EndOfInputChannelStateEvent via the store; for output partitions this calls
+     * finishReadRecoveredState on every checkpointable partition.
+     *
+     * <p>Must be invoked explicitly between {@code dispatcher.flush()} and
+     * {@code dispatcher.drainPendingSpill()}; see requirements/38544/close_drain_separation.md.
+     *
+     * <p>This method is idempotent: callers that hold the handler in a try-with-resources block
+     * may invoke {@code finishRecovery()} explicitly without affecting the subsequent
+     * {@link #close()} call which only releases resources.
+     */
+    void finishRecovery() throws IOException;
 }
 
 class InputChannelRecoveredStateHandler
@@ -87,6 +102,13 @@ class InputChannelRecoveredStateHandler
      * performed during recovery in the channel-state-unspilling thread.
      */
     @Nullable private final ChannelStateFilteringHandler filteringHandler;
+
+    /**
+     * Optional dispatcher for delivering filtered data. When non-null (filtering mode), filtered
+     * records are written to the dispatcher instead of directly to InputChannel buffers. The
+     * dispatcher manages buffer allocation, disk spilling, and delivery to per-channel stores.
+     */
+    @Nullable private final FilteredBufferDispatcher dispatcher;
 
     /** Network buffer memory segment size in bytes. Used to size the reusable pre-filter buffer. */
     private final int memorySegmentSize;
@@ -108,17 +130,22 @@ class InputChannelRecoveredStateHandler
      */
     private boolean preFilterBufferInUse;
 
+    /** Idempotency guard for {@link #finishRecovery()}. */
+    private boolean recoveryFinished;
+
     InputChannelRecoveredStateHandler(
             InputGate[] inputGates,
             InflightDataRescalingDescriptor channelMapping,
             @Nullable ChannelStateFilteringHandler filteringHandler,
-            int memorySegmentSize) {
+            int memorySegmentSize,
+            @Nullable FilteredBufferDispatcher dispatcher) {
         this.inputGates = inputGates;
         this.channelMapping = channelMapping;
         this.filteringHandler = filteringHandler;
         checkArgument(
                 memorySegmentSize > 0, "memorySegmentSize must be positive: %s", memorySegmentSize);
         this.memorySegmentSize = memorySegmentSize;
+        this.dispatcher = dispatcher;
     }
 
     @Override
@@ -191,12 +218,14 @@ class InputChannelRecoveredStateHandler
                     recoverWithFiltering(
                             channel, channelInfo, oldSubtaskIndex, buffer.retainBuffer());
                 } else {
-                    channel.onRecoveredStateBuffer(
-                            EventSerializer.toBuffer(
-                                    new SubtaskConnectionDescriptor(
-                                            oldSubtaskIndex, channelInfo.getInputChannelIdx()),
-                                    false));
-                    channel.onRecoveredStateBuffer(buffer.retainBuffer());
+                    channel.getStore()
+                            .addBuffer(
+                                    EventSerializer.toBuffer(
+                                            new SubtaskConnectionDescriptor(
+                                                    oldSubtaskIndex,
+                                                    channelInfo.getInputChannelIdx()),
+                                            false));
+                    channel.getStore().addBuffer(buffer.retainBuffer());
                 }
             }
         } finally {
@@ -211,33 +240,31 @@ class InputChannelRecoveredStateHandler
             Buffer retainedBuffer)
             throws IOException, InterruptedException {
         checkState(filteringHandler != null, "filtering handler not set.");
-        List<Buffer> filteredBuffers =
-                filteringHandler.filterAndRewrite(
-                        channelInfo.getGateIdx(),
-                        oldSubtaskIndex,
-                        channelInfo.getInputChannelIdx(),
-                        retainedBuffer,
-                        channel::requestBufferBlocking);
+        checkState(dispatcher != null, "dispatcher not set.");
+        InputChannelInfo targetChannelInfo = channel.getChannelInfo();
+        filteringHandler.filterAndRewrite(
+                channelInfo.getGateIdx(),
+                oldSubtaskIndex,
+                channelInfo.getInputChannelIdx(),
+                retainedBuffer,
+                dispatcher,
+                targetChannelInfo);
+    }
 
-        int i = 0;
-        try {
-            for (; i < filteredBuffers.size(); i++) {
-                channel.onRecoveredStateBuffer(filteredBuffers.get(i));
-            }
-        } catch (Throwable t) {
-            for (int j = i; j < filteredBuffers.size(); j++) {
-                filteredBuffers.get(j).recycleBuffer();
-            }
-            throw t;
+    @Override
+    public void finishRecovery() throws IOException {
+        if (recoveryFinished) {
+            return;
+        }
+        recoveryFinished = true;
+        // note that we need to finish all RecoveredInputChannels, not just those with state
+        for (final InputGate inputGate : inputGates) {
+            inputGate.finishReadRecoveredState();
         }
     }
 
     @Override
     public void close() throws IOException {
-        // note that we need to finish all RecoveredInputChannels, not just those with state
-        for (final InputGate inputGate : inputGates) {
-            inputGate.finishReadRecoveredState();
-        }
         if (preFilterSegment != null) {
             preFilterSegment.free();
             preFilterSegment = null;
@@ -278,6 +305,9 @@ class ResultSubpartitionRecoveredStateHandler
     private final ResultPartitionWriter[] writers;
     private final boolean notifyAndBlockOnCompletion;
     private final ResultSubpartitionDistributor resultSubpartitionDistributor;
+
+    /** Idempotency guard for {@link #finishRecovery()}. */
+    private boolean recoveryFinished;
 
     ResultSubpartitionRecoveredStateHandler(
             ResultPartitionWriter[] writers,
@@ -352,12 +382,21 @@ class ResultSubpartitionRecoveredStateHandler
     }
 
     @Override
-    public void close() throws IOException {
+    public void finishRecovery() throws IOException {
+        if (recoveryFinished) {
+            return;
+        }
+        recoveryFinished = true;
         for (ResultPartitionWriter writer : writers) {
             if (writer instanceof CheckpointedResultPartition) {
                 ((CheckpointedResultPartition) writer)
                         .finishReadRecoveredState(notifyAndBlockOnCompletion);
             }
         }
+    }
+
+    @Override
+    public void close() throws IOException {
+        // No resources to release; finishReadRecoveredState moved to finishRecovery().
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
@@ -73,17 +73,10 @@ interface RecoveredChannelStateHandler<Info, Context> extends AutoCloseable {
             throws IOException, InterruptedException;
 
     /**
-     * Trigger the post-recovery business actions for this handler. For input channels this
-     * completes the per-channel buffer-filtering future and surfaces an
-     * EndOfInputChannelStateEvent via the store; for output partitions this calls
-     * finishReadRecoveredState on every checkpointable partition.
-     *
-     * <p>Must be invoked explicitly between {@code dispatcher.flush()} and
-     * {@code dispatcher.drainPendingSpill()}; see requirements/38544/close_drain_separation.md.
-     *
-     * <p>This method is idempotent: callers that hold the handler in a try-with-resources block
-     * may invoke {@code finishRecovery()} explicitly without affecting the subsequent
-     * {@link #close()} call which only releases resources.
+     * Triggers post-recovery actions: input channels complete the buffer-filtering future and
+     * publish {@code EndOfInputChannelStateEvent} via their store; output partitions call
+     * {@code finishReadRecoveredState} on every checkpointable partition. Idempotent. Must be
+     * invoked between {@code dispatcher.flush()} and {@code dispatcher.drainPendingSpill()}.
      */
     void finishRecovery() throws IOException;
 }
@@ -97,40 +90,28 @@ class InputChannelRecoveredStateHandler
     private final Map<InputChannelInfo, RecoveredInputChannel> rescaledChannels = new HashMap<>();
     private final Map<Integer, RescaleMappings> oldToNewMappings = new HashMap<>();
 
-    /**
-     * Optional filtering handler for filtering recovered buffers. When non-null, filtering is
-     * performed during recovery in the channel-state-unspilling thread.
-     */
+    /** When non-null, filtering runs during recovery in the channel-state-unspilling thread. */
     @Nullable private final ChannelStateFilteringHandler filteringHandler;
 
     /**
-     * Optional dispatcher for delivering filtered data. When non-null (filtering mode), filtered
-     * records are written to the dispatcher instead of directly to InputChannel buffers. The
-     * dispatcher manages buffer allocation, disk spilling, and delivery to per-channel stores.
+     * When non-null (filtering mode), filtered records are written here instead of directly to
+     * InputChannel buffers.
      */
     @Nullable private final FilteredBufferDispatcher dispatcher;
 
-    /** Network buffer memory segment size in bytes. Used to size the reusable pre-filter buffer. */
     private final int memorySegmentSize;
 
     /**
-     * Reusable heap memory segment backing the pre-filter buffer in filtering mode. Lazily
-     * allocated on the first {@link #getPreFilterBuffer} call, reused for every subsequent call,
-     * and freed in {@link #close()}.
-     *
-     * <p>Reuse is safe because at most one pre-filter buffer is in flight per task at any moment.
-     * This invariant is enforced at runtime by {@link #preFilterBufferInUse}.
+     * Reusable heap segment backing the pre-filter buffer in filtering mode. Lazily allocated on
+     * first {@link #getPreFilterBuffer}, reused for subsequent calls, freed in {@link #close()}.
+     * Reuse is safe because at most one pre-filter buffer is in flight per task; the invariant is
+     * enforced at runtime by {@link #preFilterBufferInUse}.
      */
     @Nullable private MemorySegment preFilterSegment;
 
-    /**
-     * Tracks whether {@link #preFilterSegment} is currently wrapped by a live {@link Buffer} that
-     * has not yet been recycled. Flipped to {@code true} when a new buffer is issued, and flipped
-     * back to {@code false} by the custom {@link BufferRecycler} when the buffer is recycled.
-     */
+    /** True while {@link #preFilterSegment} is wrapped by a live, unreclaimed buffer. */
     private boolean preFilterBufferInUse;
 
-    /** Idempotency guard for {@link #finishRecovery()}. */
     private boolean recoveryFinished;
 
     InputChannelRecoveredStateHandler(
@@ -154,26 +135,15 @@ class InputChannelRecoveredStateHandler
         if (filteringHandler != null) {
             return getPreFilterBuffer();
         }
-        // Non-filtering mode: use existing network buffer pool allocation.
         RecoveredInputChannel channel = getMappedChannels(channelInfo);
         Buffer buffer = channel.requestBufferBlocking();
         return new BufferWithContext<>(wrap(buffer), buffer);
     }
 
     /**
-     * Allocates a pre-filter buffer from a reusable heap segment (isolated from the Network Buffer
-     * Pool) in filtering mode.
-     *
-     * <p>Memory management: a single {@link MemorySegment} per task is lazily allocated on first
-     * invocation and reused across every subsequent call. The custom {@link BufferRecycler} does
-     * not free the segment — it only flips {@link #preFilterBufferInUse} back to {@code false} so
-     * the next call can reuse it. The segment itself is freed in {@link #close()}.
-     *
-     * <p>Runtime invariant check: the one-at-a-time invariant on pre-filter buffers is guaranteed
-     * by Flink's serial recovery loop and the deserializer's ownership contract. This method
-     * asserts the invariant before issuing a buffer: if a previously issued buffer has not yet been
-     * recycled, it throws {@link IllegalStateException} so any future regression fails loudly
-     * instead of silently corrupting memory.
+     * Allocates a pre-filter buffer from a reusable heap segment (isolated from the Network
+     * Buffer Pool). Flink's serial recovery loop guarantees at most one is in flight at a time;
+     * the runtime check fails loudly if that ever regresses.
      */
     private BufferWithContext<Buffer> getPreFilterBuffer() {
         checkState(
@@ -186,7 +156,6 @@ class InputChannelRecoveredStateHandler
         }
         preFilterBufferInUse = true;
 
-        // The recycler keeps the segment alive for reuse; only flips the in-use flag.
         BufferRecycler recycler = segment -> preFilterBufferInUse = false;
         Buffer buffer = new NetworkBuffer(preFilterSegment, recycler);
         return new BufferWithContext<>(wrap(buffer), buffer);
@@ -306,7 +275,6 @@ class ResultSubpartitionRecoveredStateHandler
     private final boolean notifyAndBlockOnCompletion;
     private final ResultSubpartitionDistributor resultSubpartitionDistributor;
 
-    /** Idempotency guard for {@link #finishRecovery()}. */
     private boolean recoveryFinished;
 
     ResultSubpartitionRecoveredStateHandler(
@@ -316,10 +284,7 @@ class ResultSubpartitionRecoveredStateHandler
         this.writers = writers;
         this.resultSubpartitionDistributor =
                 new ResultSubpartitionDistributor(channelMapping) {
-                    /**
-                     * Override the getSubpartitionInfo to perform type checking on the
-                     * ResultPartitionWriter.
-                     */
+                    /** Adds type-checking on the ResultPartitionWriter. */
                     @Override
                     ResultSubpartitionInfo getSubpartitionInfo(
                             int partitionIndex, int subPartitionIdx) {
@@ -396,7 +361,5 @@ class ResultSubpartitionRecoveredStateHandler
     }
 
     @Override
-    public void close() throws IOException {
-        // No resources to release; finishReadRecoveredState moved to finishRecovery().
-    }
+    public void close() throws IOException {}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
@@ -187,14 +187,16 @@ class InputChannelRecoveredStateHandler
                     recoverWithFiltering(
                             channel, channelInfo, oldSubtaskIndex, buffer.retainBuffer());
                 } else {
-                    channel.getStore()
-                            .addBuffer(
-                                    EventSerializer.toBuffer(
-                                            new SubtaskConnectionDescriptor(
-                                                    oldSubtaskIndex,
-                                                    channelInfo.getInputChannelIdx()),
-                                            false));
-                    channel.getStore().addBuffer(buffer.retainBuffer());
+                    synchronized (channel.getStore().getGateLock()) {
+                        channel.getStore()
+                                .addBuffer(
+                                        EventSerializer.toBuffer(
+                                                new SubtaskConnectionDescriptor(
+                                                        oldSubtaskIndex,
+                                                        channelInfo.getInputChannelIdx()),
+                                                false));
+                        channel.getStore().addBuffer(buffer.retainBuffer());
+                    }
                 }
             }
         } finally {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SequentialChannelStateReaderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SequentialChannelStateReaderImpl.java
@@ -23,8 +23,12 @@ import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.runtime.checkpoint.StateObjectCollection;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.logger.NetworkActionsLogger;
+import org.apache.flink.runtime.io.network.partition.consumer.InputChannel;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
+import org.apache.flink.runtime.io.network.partition.consumer.RecoveredBufferStoreImpl;
+import org.apache.flink.runtime.io.network.partition.consumer.RecoveredInputChannel;
 import org.apache.flink.runtime.state.AbstractChannelStateHandle;
 import org.apache.flink.runtime.state.ChannelStateHelper;
 import org.apache.flink.runtime.state.StreamStateHandle;
@@ -33,6 +37,7 @@ import org.apache.flink.streaming.runtime.io.recovery.RecordFilterContext;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -69,13 +74,26 @@ public class SequentialChannelStateReaderImpl implements SequentialChannelStateR
                         ? ChannelStateFilteringHandler.createFromContext(filterContext, inputGates)
                         : null;
 
+        // Create per-channel stores and FilteredBufferDispatcher when filtering is enabled
+        FilteredBufferDispatcher dispatcher = null;
+        if (filteringHandler != null) {
+            Map<InputChannelInfo, RecoveredBufferStoreImpl> storesByChannel =
+                    createPerChannelStores(inputGates);
+            if (!storesByChannel.isEmpty()) {
+                dispatcher =
+                        createFilteredBufferDispatcher(inputGates, storesByChannel, filterContext);
+            }
+        }
+
         try (ChannelStateFilteringHandler ignored = filteringHandler;
+                FilteredBufferDispatcher d = dispatcher;
                 InputChannelRecoveredStateHandler stateHandler =
                         new InputChannelRecoveredStateHandler(
                                 inputGates,
                                 taskStateSnapshot.getInputRescalingDescriptor(),
                                 filteringHandler,
-                                filterContext.getMemorySegmentSize())) {
+                                filterContext.getMemorySegmentSize(),
+                                dispatcher)) {
             read(
                     stateHandler,
                     groupByDelegate(
@@ -92,6 +110,23 @@ public class SequentialChannelStateReaderImpl implements SequentialChannelStateR
                         !filteringHandler.hasPartialData(),
                         "Not all data has been fully consumed during filtering");
             }
+
+            if (d != null) {
+                d.flush();
+                // Explicit call sequence (see requirements/38544/close_drain_separation.md):
+                //   flush()              -> seal Readers
+                //   finishRecovery()     -> trigger channel conversion
+                //   drainPendingSpill()  -> blocking drain (no monitor held)
+                // try-with-resources still owns the final close() pass for resource release.
+                stateHandler.finishRecovery();
+                d.drainPendingSpill();
+            } else {
+                stateHandler.finishRecovery();
+            }
+            // try-with-resources auto-close is a pure resource release pass:
+            //   stateHandler.close() -> releases preFilterSegment if allocated
+            //   d.close()            -> deletes spill files / closes file channel
+            //   filteringHandler.close()
         }
     }
 
@@ -108,6 +143,7 @@ public class SequentialChannelStateReaderImpl implements SequentialChannelStateR
                     groupByDelegate(
                             streamSubtaskStates(),
                             ChannelStateHelper::extractUnmergedOutputHandles));
+            stateHandler.finishRecovery();
         }
     }
 
@@ -139,6 +175,113 @@ public class SequentialChannelStateReaderImpl implements SequentialChannelStateR
                         offsetAndChannelInfo.oldSubtaskIndex);
             }
         }
+    }
+
+    /**
+     * Creates a RecoveredBufferStoreImpl for each RecoveredInputChannel and wires the notification
+     * callback. Only called when filtering is enabled.
+     */
+    private Map<InputChannelInfo, RecoveredBufferStoreImpl> createPerChannelStores(
+            InputGate[] inputGates) {
+        Map<InputChannelInfo, RecoveredBufferStoreImpl> storesByChannel = new HashMap<>();
+        for (InputGate gate : inputGates) {
+            for (int i = 0; i < gate.getNumberOfInputChannels(); i++) {
+                InputChannel ch = gate.getChannel(i);
+                if (ch instanceof RecoveredInputChannel) {
+                    RecoveredInputChannel recoveredCh = (RecoveredInputChannel) ch;
+                    InputChannelInfo info = recoveredCh.getChannelInfo();
+                    // RecoveredInputChannel already creates its own store internally and wires the
+                    // notification callback. Reuse the existing store so that all paths (non-
+                    // filtering and filtering) deliver to the same store instance.
+                    RecoveredBufferStoreImpl store = recoveredCh.getStore();
+                    storesByChannel.put(info, store);
+                }
+            }
+        }
+        return storesByChannel;
+    }
+
+    /**
+     * Creates a {@link FilteredBufferDispatcher} from the per-channel stores. The requester is
+     * keyed by {@link InputChannelInfo} so each channel draws from its own pool.
+     */
+    private FilteredBufferDispatcher createFilteredBufferDispatcher(
+            InputGate[] inputGates,
+            Map<InputChannelInfo, RecoveredBufferStoreImpl> storesByChannel,
+            RecordFilterContext filterContext)
+            throws IOException {
+        Map<InputChannelInfo, RecoveredInputChannel> channelMap = buildChannelMap(inputGates);
+        String[] spillDirs = filterContext.getTmpDirectories();
+        int memorySegmentSize = filterContext.getMemorySegmentSize();
+
+        // Use the channelStateWriter from any channel (all channels share the same writer).
+        RecoveredInputChannel anyChannel = channelMap.values().iterator().next();
+
+        return new FilteredBufferDispatcherImpl(
+                storesByChannel,
+                anyChannel.getChannelStateWriter(),
+                spillDirs,
+                memorySegmentSize,
+                new RecoveredChannelBufferRequester(channelMap));
+    }
+
+    /**
+     * {@link BufferRequester} backed by a {@link RecoveredInputChannel} map, routing each channel's
+     * request to its own exclusive buffer pool.
+     */
+    private static final class RecoveredChannelBufferRequester implements BufferRequester {
+
+        private final Map<InputChannelInfo, RecoveredInputChannel> channelMap;
+
+        RecoveredChannelBufferRequester(Map<InputChannelInfo, RecoveredInputChannel> channelMap) {
+            this.channelMap = channelMap;
+        }
+
+        @Override
+        public Buffer requestBuffer(InputChannelInfo channelInfo) throws IOException {
+            return lookup(channelInfo).requestBuffer();
+        }
+
+        @Override
+        public Buffer requestBufferBlocking(InputChannelInfo channelInfo)
+                throws InterruptedException, IOException {
+            return lookup(channelInfo).requestBufferBlocking();
+        }
+
+        @Override
+        public void releaseExclusiveBuffers() throws IOException {
+            // Drain is finished. Mark each channel's drain-done flag; the actual release fires
+            // in a two-flag rendezvous (drainDone + converted) inside RecoveredInputChannel —
+            // releasing here directly would race with mailbox-driven convertRecoveredInputChannels
+            // and cause task pollNext on the not-yet-replaced gate slot to hit the released-channel
+            // checkState in RecoveredInputChannel#getNextRecoveredStateBuffer.
+            for (RecoveredInputChannel ch : channelMap.values()) {
+                ch.markDrainDone();
+            }
+        }
+
+        private RecoveredInputChannel lookup(InputChannelInfo channelInfo) {
+            RecoveredInputChannel ch = channelMap.get(channelInfo);
+            if (ch == null) {
+                throw new IllegalArgumentException(
+                        "No RecoveredInputChannel for channelInfo: " + channelInfo);
+            }
+            return ch;
+        }
+    }
+
+    private Map<InputChannelInfo, RecoveredInputChannel> buildChannelMap(InputGate[] inputGates) {
+        Map<InputChannelInfo, RecoveredInputChannel> channelMap = new HashMap<>();
+        for (InputGate gate : inputGates) {
+            for (int i = 0; i < gate.getNumberOfInputChannels(); i++) {
+                InputChannel ch = gate.getChannel(i);
+                if (ch instanceof RecoveredInputChannel) {
+                    RecoveredInputChannel recoveredCh = (RecoveredInputChannel) ch;
+                    channelMap.put(recoveredCh.getChannelInfo(), recoveredCh);
+                }
+            }
+        }
+        return channelMap;
     }
 
     private Stream<OperatorSubtaskState> streamSubtaskStates() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SequentialChannelStateReaderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SequentialChannelStateReaderImpl.java
@@ -68,13 +68,11 @@ public class SequentialChannelStateReaderImpl implements SequentialChannelStateR
     public void readInputData(InputGate[] inputGates, RecordFilterContext filterContext)
             throws IOException, InterruptedException {
 
-        // Create filtering handler if filtering is needed
         ChannelStateFilteringHandler filteringHandler =
                 filterContext.isCheckpointingDuringRecoveryEnabled()
                         ? ChannelStateFilteringHandler.createFromContext(filterContext, inputGates)
                         : null;
 
-        // Create per-channel stores and FilteredBufferDispatcher when filtering is enabled
         FilteredBufferDispatcher dispatcher = null;
         if (filteringHandler != null) {
             Map<InputChannelInfo, RecoveredBufferStoreImpl> storesByChannel =
@@ -112,21 +110,14 @@ public class SequentialChannelStateReaderImpl implements SequentialChannelStateR
             }
 
             if (d != null) {
+                // flush() seals Readers; finishRecovery() triggers channel conversion;
+                // drainPendingSpill() blocks without holding the dispatcher monitor.
                 d.flush();
-                // Explicit call sequence (see requirements/38544/close_drain_separation.md):
-                //   flush()              -> seal Readers
-                //   finishRecovery()     -> trigger channel conversion
-                //   drainPendingSpill()  -> blocking drain (no monitor held)
-                // try-with-resources still owns the final close() pass for resource release.
                 stateHandler.finishRecovery();
                 d.drainPendingSpill();
             } else {
                 stateHandler.finishRecovery();
             }
-            // try-with-resources auto-close is a pure resource release pass:
-            //   stateHandler.close() -> releases preFilterSegment if allocated
-            //   d.close()            -> deletes spill files / closes file channel
-            //   filteringHandler.close()
         }
     }
 
@@ -177,10 +168,6 @@ public class SequentialChannelStateReaderImpl implements SequentialChannelStateR
         }
     }
 
-    /**
-     * Creates a RecoveredBufferStoreImpl for each RecoveredInputChannel and wires the notification
-     * callback. Only called when filtering is enabled.
-     */
     private Map<InputChannelInfo, RecoveredBufferStoreImpl> createPerChannelStores(
             InputGate[] inputGates) {
         Map<InputChannelInfo, RecoveredBufferStoreImpl> storesByChannel = new HashMap<>();
@@ -190,9 +177,8 @@ public class SequentialChannelStateReaderImpl implements SequentialChannelStateR
                 if (ch instanceof RecoveredInputChannel) {
                     RecoveredInputChannel recoveredCh = (RecoveredInputChannel) ch;
                     InputChannelInfo info = recoveredCh.getChannelInfo();
-                    // RecoveredInputChannel already creates its own store internally and wires the
-                    // notification callback. Reuse the existing store so that all paths (non-
-                    // filtering and filtering) deliver to the same store instance.
+                    // Reuse the channel's own store so filtering and non-filtering paths deliver
+                    // to the same instance.
                     RecoveredBufferStoreImpl store = recoveredCh.getStore();
                     storesByChannel.put(info, store);
                 }
@@ -201,10 +187,6 @@ public class SequentialChannelStateReaderImpl implements SequentialChannelStateR
         return storesByChannel;
     }
 
-    /**
-     * Creates a {@link FilteredBufferDispatcher} from the per-channel stores. The requester is
-     * keyed by {@link InputChannelInfo} so each channel draws from its own pool.
-     */
     private FilteredBufferDispatcher createFilteredBufferDispatcher(
             InputGate[] inputGates,
             Map<InputChannelInfo, RecoveredBufferStoreImpl> storesByChannel,
@@ -214,7 +196,7 @@ public class SequentialChannelStateReaderImpl implements SequentialChannelStateR
         String[] spillDirs = filterContext.getTmpDirectories();
         int memorySegmentSize = filterContext.getMemorySegmentSize();
 
-        // Use the channelStateWriter from any channel (all channels share the same writer).
+        // All channels share the same writer.
         RecoveredInputChannel anyChannel = channelMap.values().iterator().next();
 
         return new FilteredBufferDispatcherImpl(
@@ -225,10 +207,7 @@ public class SequentialChannelStateReaderImpl implements SequentialChannelStateR
                 new RecoveredChannelBufferRequester(channelMap));
     }
 
-    /**
-     * {@link BufferRequester} backed by a {@link RecoveredInputChannel} map, routing each channel's
-     * request to its own exclusive buffer pool.
-     */
+    /** {@link BufferRequester} routing each channel's request to its own exclusive pool. */
     private static final class RecoveredChannelBufferRequester implements BufferRequester {
 
         private final Map<InputChannelInfo, RecoveredInputChannel> channelMap;
@@ -250,11 +229,9 @@ public class SequentialChannelStateReaderImpl implements SequentialChannelStateR
 
         @Override
         public void releaseExclusiveBuffers() throws IOException {
-            // Drain is finished. Mark each channel's drain-done flag; the actual release fires
-            // in a two-flag rendezvous (drainDone + converted) inside RecoveredInputChannel —
-            // releasing here directly would race with mailbox-driven convertRecoveredInputChannels
-            // and cause task pollNext on the not-yet-replaced gate slot to hit the released-channel
-            // checkState in RecoveredInputChannel#getNextRecoveredStateBuffer.
+            // Two-flag rendezvous (drainDone + converted): releasing here directly would race
+            // mailbox-driven convertRecoveredInputChannels and cause pollNext on the not-yet-
+            // replaced gate slot to hit the released-channel checkState.
             for (RecoveredInputChannel ch : channelMap.values()) {
                 ch.markDrainDone();
             }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SequentialChannelStateReaderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SequentialChannelStateReaderImpl.java
@@ -36,6 +36,7 @@ import org.apache.flink.streaming.runtime.io.recovery.RecordFilterContext;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -116,7 +117,16 @@ public class SequentialChannelStateReaderImpl implements SequentialChannelStateR
                 stateHandler.finishRecovery();
                 d.drainPendingSpill();
             } else {
+                // Snapshot recovered channel references BEFORE finishRecovery, because
+                // finishRecovery completes bufferFilteringCompleteFuture which can race a
+                // mailbox-driven conversion. Once conversion replaces channels[i] with a
+                // physical channel, looking up RecoveredInputChannels via inputGates would
+                // miss the converted ones, and their BufferManager rendezvous would leak.
+                List<RecoveredInputChannel> recovered = collectRecoveredChannels(inputGates);
                 stateHandler.finishRecovery();
+                for (RecoveredInputChannel ch : recovered) {
+                    ch.markDrainDone();
+                }
             }
         }
     }
@@ -166,6 +176,19 @@ public class SequentialChannelStateReaderImpl implements SequentialChannelStateR
                         offsetAndChannelInfo.oldSubtaskIndex);
             }
         }
+    }
+
+    private List<RecoveredInputChannel> collectRecoveredChannels(InputGate[] inputGates) {
+        List<RecoveredInputChannel> recovered = new ArrayList<>();
+        for (InputGate gate : inputGates) {
+            for (int i = 0; i < gate.getNumberOfInputChannels(); i++) {
+                InputChannel ch = gate.getChannel(i);
+                if (ch instanceof RecoveredInputChannel) {
+                    recovered.add((RecoveredInputChannel) ch);
+                }
+            }
+        }
+        return recovered;
     }
 
     private Map<InputChannelInfo, RecoveredBufferStoreImpl> createPerChannelStores(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersister.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersister.java
@@ -80,9 +80,9 @@ public final class ChannelStatePersister {
     }
 
     /**
-     * Snapshots the recovered store when present, otherwise writes the network inflight buffers
-     * via {@link ChannelStateWriter#addInputData}. Asserts that the two are mutually exclusive
-     * ({@code store.isEmpty() || knownBuffers.isEmpty()}).
+     * Snapshots the recovered store when present, otherwise writes the network inflight buffers via
+     * {@link ChannelStateWriter#addInputData}. Asserts that the two are mutually exclusive ({@code
+     * store.isEmpty() || knownBuffers.isEmpty()}).
      *
      * @param knownBuffers network inflight buffers (empty for LocalInputChannel)
      */
@@ -136,9 +136,9 @@ public final class ChannelStatePersister {
     }
 
     /**
-     * Marks {@code id} concluded on this channel and notifies the store. Without the
-     * notification an aborted checkpoint's wait-set could linger and a later release / late
-     * callback would trigger a phase-2 drain into a concluded checkpoint.
+     * Marks {@code id} concluded on this channel and notifies the store. Without the notification
+     * an aborted checkpoint's wait-set could linger and a later release / late callback would
+     * trigger a phase-2 drain into a concluded checkpoint.
      */
     @GuardedBy("store")
     protected void stopPersisting(long id) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersister.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersister.java
@@ -32,7 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
-import javax.annotation.concurrent.NotThreadSafe;
+import javax.annotation.concurrent.GuardedBy;
 
 import java.io.IOException;
 import java.util.List;
@@ -41,8 +41,26 @@ import java.util.OptionalLong;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
-/** Helper class for persisting channel state via {@link ChannelStateWriter}. */
-@NotThreadSafe
+/**
+ * Helper class for persisting channel state via {@link ChannelStateWriter}.
+ *
+ * <h3>Locking contract</h3>
+ *
+ * <p>The bound {@link RecoveredBufferStore}'s intrinsic monitor IS the channel-private lock.
+ * Every state-touching method on this class — {@link #startPersisting}, {@link #stopPersisting},
+ * {@link #maybePersist}, {@link #checkForBarrier}, {@link #hasBarrierReceived} — requires the
+ * caller to hold {@code synchronized(store)}. The methods enforce this with an internal {@code
+ * assert Thread.holdsLock(store)} that fires under {@code -ea}.
+ *
+ * <p>This class deliberately holds <b>no lock of its own</b>. Concurrent access between the task
+ * thread (start/stop, getNext) and the network thread (onBuffer) is serialized by the same outer
+ * {@code synchronized(store)} on each call site, mirroring the master-branch wide-lock pattern.
+ *
+ * <p>The constraint that callers may safely cross {@link #startPersisting} (which can call back
+ * into {@link RecoveredBufferStore#checkpoint}, firing the dispatcher coordinator) holds because
+ * the dispatcher coordinator is itself lock-free — see
+ * {@code FilteredBufferDispatcherImpl}'s class-level invariants.
+ */
 public final class ChannelStatePersister {
     private static final Logger LOG = LoggerFactory.getLogger(ChannelStatePersister.class);
 
@@ -54,15 +72,27 @@ public final class ChannelStatePersister {
         BARRIER_RECEIVED
     }
 
+    @GuardedBy("store")
     private CheckpointStatus checkpointStatus = CheckpointStatus.COMPLETED;
 
+    @GuardedBy("store")
     private long lastSeenBarrier = -1L;
 
     private final ChannelStateWriter channelStateWriter;
 
-    ChannelStatePersister(ChannelStateWriter channelStateWriter, InputChannelInfo channelInfo) {
+    /**
+     * Per-channel store bound at construction. Its intrinsic monitor IS the channel-private lock
+     * that callers must hold for every state-touching method on this class.
+     */
+    private final RecoveredBufferStore store;
+
+    ChannelStatePersister(
+            ChannelStateWriter channelStateWriter,
+            InputChannelInfo channelInfo,
+            RecoveredBufferStore store) {
         this.channelStateWriter = checkNotNull(channelStateWriter);
         this.channelInfo = checkNotNull(channelInfo);
+        this.store = checkNotNull(store);
     }
 
     /**
@@ -70,12 +100,12 @@ public final class ChannelStatePersister {
      * knownBuffers.isEmpty()}), then either snapshots the recovered store or writes network
      * inflight buffers via {@link ChannelStateWriter#addInputData}.
      *
-     * @param store per-channel store; {@link RecoveredBufferStore#EMPTY} when no recovery data
      * @param knownBuffers network inflight buffers (empty for LocalInputChannel)
      */
-    protected void startPersisting(
-            long barrierId, RecoveredBufferStore store, List<Buffer> knownBuffers)
+    @GuardedBy("store")
+    protected void startPersisting(long barrierId, List<Buffer> knownBuffers)
             throws CheckpointException {
+        assert Thread.holdsLock(store);
         logEvent("startPersisting", barrierId);
         if (checkpointStatus == CheckpointStatus.BARRIER_RECEIVED && lastSeenBarrier > barrierId) {
             throw new CheckpointException(
@@ -88,26 +118,16 @@ public final class ChannelStatePersister {
         if (lastSeenBarrier < barrierId) {
             // Regardless of the current checkpointStatus, if we are notified about a more recent
             // checkpoint then we have seen so far, always mark that this more recent barrier is
-            // pending.
-            // BARRIER_RECEIVED status can happen if we have seen an older barrier, that probably
-            // has not yet been processed by the task, but task is now notifying us that checkpoint
-            // has started for even newer checkpoint. We should spill the knownBuffers and mark that
-            // we are waiting for that newer barrier to arrive
+            // pending. BARRIER_RECEIVED status can happen if we have seen an older barrier, that
+            // probably has not yet been processed by the task, but task is now notifying us that
+            // checkpoint has started for even newer checkpoint. We should spill the knownBuffers
+            // and mark that we are waiting for that newer barrier to arrive.
             checkpointStatus = CheckpointStatus.BARRIER_PENDING;
             lastSeenBarrier = barrierId;
         }
 
-        // The disk-network exclusivity invariant relies on UNALIGNED_RECOVER_OUTPUT_ON_DOWNSTREAM
-        // (upstream replays no output state) AND RemoteInputChannel#getNextBuffer draining the
-        // store first. The brief lock here is released before store.checkpoint() because
-        // store.checkpoint() fires the dispatcher coordinator (which itself acquires the store
-        // lock from the recovery thread) — holding the lock across that callback would deadlock.
-        final boolean storeEmpty;
-        final int storeSize;
-        synchronized (store) {
-            storeEmpty = store.isEmpty();
-            storeSize = store.size();
-        }
+        final boolean storeEmpty = store.isEmpty();
+        final int storeSize = store.size();
         checkState(
                 storeEmpty || knownBuffers.isEmpty(),
                 "Invariant violated: store has data (size=%s) AND knownBuffers non-empty (size=%s) at barrier %s. "
@@ -140,7 +160,9 @@ public final class ChannelStatePersister {
      * any wait-set still tied to it (otherwise an aborted checkpoint's wait-set could linger and a
      * later release/late callback would trigger a phase-2 drain into a concluded checkpoint).
      */
-    protected void stopPersisting(long id, RecoveredBufferStore store) {
+    @GuardedBy("store")
+    protected void stopPersisting(long id) {
+        assert Thread.holdsLock(store);
         logEvent("stopPersisting", id);
         if (id >= lastSeenBarrier) {
             checkpointStatus = CheckpointStatus.COMPLETED;
@@ -149,7 +171,9 @@ public final class ChannelStatePersister {
         store.notifyCheckpointStopped(id);
     }
 
+    @GuardedBy("store")
     protected void maybePersist(Buffer buffer) {
+        assert Thread.holdsLock(store);
         if (checkpointStatus == CheckpointStatus.BARRIER_PENDING && buffer.isBuffer()) {
             channelStateWriter.addInputData(
                     lastSeenBarrier,
@@ -159,7 +183,9 @@ public final class ChannelStatePersister {
         }
     }
 
+    @GuardedBy("store")
     protected OptionalLong checkForBarrier(Buffer buffer) throws IOException {
+        assert Thread.holdsLock(store);
         AbstractEvent event = parseEvent(buffer);
         if (event instanceof CheckpointBarrier) {
             long barrierId = ((CheckpointBarrier) event).getId();
@@ -217,12 +243,16 @@ public final class ChannelStatePersister {
         }
     }
 
+    @GuardedBy("store")
     protected boolean hasBarrierReceived() {
+        assert Thread.holdsLock(store);
         return checkpointStatus == CheckpointStatus.BARRIER_RECEIVED;
     }
 
     @Override
     public String toString() {
+        // Best-effort debug snapshot. Reads are unsynchronized on purpose: the logger must not
+        // deadlock against callers that already hold (or are about to acquire) the store lock.
         return "ChannelStatePersister(lastSeenBarrier="
                 + lastSeenBarrier
                 + " ("

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersister.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersister.java
@@ -137,8 +137,8 @@ public final class ChannelStatePersister {
 
     /**
      * Marks {@code id} concluded on this channel and notifies the store so the coordinator drops
-     * any wait-set still tied to it (otherwise an aborted checkpoint's wait-set could linger and
-     * a later release/late callback would trigger a phase-2 drain into a concluded checkpoint).
+     * any wait-set still tied to it (otherwise an aborted checkpoint's wait-set could linger and a
+     * later release/late callback would trigger a phase-2 drain into a concluded checkpoint).
      */
     protected void stopPersisting(long id, RecoveredBufferStore store) {
         logEvent("stopPersisting", id);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersister.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersister.java
@@ -44,22 +44,10 @@ import static org.apache.flink.util.Preconditions.checkState;
 /**
  * Helper class for persisting channel state via {@link ChannelStateWriter}.
  *
- * <h3>Locking contract</h3>
- *
- * <p>The bound {@link RecoveredBufferStore}'s intrinsic monitor IS the channel-private lock.
- * Every state-touching method on this class — {@link #startPersisting}, {@link #stopPersisting},
- * {@link #maybePersist}, {@link #checkForBarrier}, {@link #hasBarrierReceived} — requires the
- * caller to hold {@code synchronized(store)}. The methods enforce this with an internal {@code
- * assert Thread.holdsLock(store)} that fires under {@code -ea}.
- *
- * <p>This class deliberately holds <b>no lock of its own</b>. Concurrent access between the task
- * thread (start/stop, getNext) and the network thread (onBuffer) is serialized by the same outer
- * {@code synchronized(store)} on each call site, mirroring the master-branch wide-lock pattern.
- *
- * <p>The constraint that callers may safely cross {@link #startPersisting} (which can call back
- * into {@link RecoveredBufferStore#checkpoint}, firing the dispatcher coordinator) holds because
- * the dispatcher coordinator is itself lock-free — see
- * {@code FilteredBufferDispatcherImpl}'s class-level invariants.
+ * <p>Holds no lock of its own. Every state-touching method requires the caller to hold the bound
+ * {@link RecoveredBufferStore}'s intrinsic monitor; an {@code assert Thread.holdsLock(store)}
+ * enforces it under {@code -ea}. This serializes the task thread (start/stop, getNext) with the
+ * network thread (onBuffer) on the same outer {@code synchronized(store)}.
  */
 public final class ChannelStatePersister {
     private static final Logger LOG = LoggerFactory.getLogger(ChannelStatePersister.class);
@@ -80,10 +68,6 @@ public final class ChannelStatePersister {
 
     private final ChannelStateWriter channelStateWriter;
 
-    /**
-     * Per-channel store bound at construction. Its intrinsic monitor IS the channel-private lock
-     * that callers must hold for every state-touching method on this class.
-     */
     private final RecoveredBufferStore store;
 
     ChannelStatePersister(
@@ -96,9 +80,9 @@ public final class ChannelStatePersister {
     }
 
     /**
-     * Asserts the disk-network exclusivity invariant ({@code store.isEmpty() ||
-     * knownBuffers.isEmpty()}), then either snapshots the recovered store or writes network
-     * inflight buffers via {@link ChannelStateWriter#addInputData}.
+     * Snapshots the recovered store when present, otherwise writes the network inflight buffers
+     * via {@link ChannelStateWriter#addInputData}. Asserts that the two are mutually exclusive
+     * ({@code store.isEmpty() || knownBuffers.isEmpty()}).
      *
      * @param knownBuffers network inflight buffers (empty for LocalInputChannel)
      */
@@ -112,16 +96,12 @@ public final class ChannelStatePersister {
                     String.format(
                             "Barrier for newer checkpoint %d has already been received compared to the requested checkpoint %d",
                             lastSeenBarrier, barrierId),
-                    CheckpointFailureReason
-                            .CHECKPOINT_SUBSUMED); // currently, at most one active unaligned
+                    CheckpointFailureReason.CHECKPOINT_SUBSUMED);
         }
         if (lastSeenBarrier < barrierId) {
-            // Regardless of the current checkpointStatus, if we are notified about a more recent
-            // checkpoint then we have seen so far, always mark that this more recent barrier is
-            // pending. BARRIER_RECEIVED status can happen if we have seen an older barrier, that
-            // probably has not yet been processed by the task, but task is now notifying us that
-            // checkpoint has started for even newer checkpoint. We should spill the knownBuffers
-            // and mark that we are waiting for that newer barrier to arrive.
+            // Override BARRIER_RECEIVED too: task is announcing a newer checkpoint than the
+            // barrier we already saw on the wire, so spill knownBuffers under the new id and
+            // wait for the newer barrier to arrive.
             checkpointStatus = CheckpointStatus.BARRIER_PENDING;
             lastSeenBarrier = barrierId;
         }
@@ -156,9 +136,9 @@ public final class ChannelStatePersister {
     }
 
     /**
-     * Marks {@code id} concluded on this channel and notifies the store so the coordinator drops
-     * any wait-set still tied to it (otherwise an aborted checkpoint's wait-set could linger and a
-     * later release/late callback would trigger a phase-2 drain into a concluded checkpoint).
+     * Marks {@code id} concluded on this channel and notifies the store. Without the
+     * notification an aborted checkpoint's wait-set could linger and a later release / late
+     * callback would trigger a phase-2 drain into a concluded checkpoint.
      */
     @GuardedBy("store")
     protected void stopPersisting(long id) {
@@ -202,7 +182,8 @@ public final class ChannelStatePersister {
                 logEvent("ignoring barrier", barrierId);
             }
         }
-        if (event instanceof EventAnnouncement) { // NOTE: only remote channels
+        if (event instanceof EventAnnouncement) {
+            // Only remote channels announce barriers ahead of the data they overtake.
             EventAnnouncement announcement = (EventAnnouncement) event;
             if (announcement.getAnnouncedEvent() instanceof CheckpointBarrier) {
                 long barrierId = ((CheckpointBarrier) announcement.getAnnouncedEvent()).getId();
@@ -225,22 +206,16 @@ public final class ChannelStatePersister {
         }
     }
 
-    /**
-     * Parses the buffer as an event and returns the {@link CheckpointBarrier} if the event is
-     * indeed a barrier or returns null in all other cases.
-     */
     @Nullable
     protected AbstractEvent parseEvent(Buffer buffer) throws IOException {
         if (buffer.isBuffer()) {
             return null;
-        } else {
-            AbstractEvent event = EventSerializer.fromBuffer(buffer, getClass().getClassLoader());
-            // reset the buffer because it would be deserialized again in SingleInputGate while
-            // getting next buffer.
-            // we can further improve to avoid double deserialization in the future.
-            buffer.setReaderIndex(0);
-            return event;
         }
+        AbstractEvent event = EventSerializer.fromBuffer(buffer, getClass().getClassLoader());
+        // SingleInputGate will deserialize the same buffer again when handing it to the task; we
+        // can drop this double deserialization in the future.
+        buffer.setReaderIndex(0);
+        return event;
     }
 
     @GuardedBy("store")
@@ -251,8 +226,8 @@ public final class ChannelStatePersister {
 
     @Override
     public String toString() {
-        // Best-effort debug snapshot. Reads are unsynchronized on purpose: the logger must not
-        // deadlock against callers that already hold (or are about to acquire) the store lock.
+        // Best-effort debug snapshot; reads are unsynchronized so the logger never blocks behind
+        // callers that already hold (or are about to acquire) the store lock.
         return "ChannelStatePersister(lastSeenBarrier="
                 + lastSeenBarrier
                 + " ("

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersister.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersister.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.OptionalLong;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /** Helper class for persisting channel state via {@link ChannelStateWriter}. */
 @NotThreadSafe
@@ -58,8 +59,8 @@ public final class ChannelStatePersister {
     private long lastSeenBarrier = -1L;
 
     /**
-     * Writer must be initialized before usage. {@link #startPersisting(long, List)} enforces this
-     * invariant.
+     * Writer must be initialized before usage. {@link #startPersisting(long, RecoveredBufferStore,
+     * List)} enforces this invariant.
      */
     private final ChannelStateWriter channelStateWriter;
 
@@ -68,7 +69,32 @@ public final class ChannelStatePersister {
         this.channelInfo = checkNotNull(channelInfo);
     }
 
-    protected void startPersisting(long barrierId, List<Buffer> knownBuffers)
+    /**
+     * Starts persisting channel state for the given checkpoint barrier.
+     *
+     * <p>Performs the following steps in order:
+     *
+     * <ol>
+     *   <li>Validates that this checkpoint has not been superseded (throws {@link
+     *       CheckpointException} if a newer barrier was already received).
+     *   <li>Asserts the disk-network exclusivity invariant: {@code store.isEmpty() || knownBuffers.isEmpty()}.
+     *       Guaranteed by {@code UNALIGNED_RECOVER_OUTPUT_ON_DOWNSTREAM=true} (upstream does not
+     *       replay output state) combined with {@link RemoteInputChannel#getNextBuffer} draining the
+     *       store before polling {@code receivedBuffers}.
+     *   <li>Delegates ready-buffer snapshot and FilteredBufferDispatcher callback to {@link
+     *       RecoveredBufferStore#checkpoint}.
+     *   <li>Writes network inflight buffers (Remote only) via {@link
+     *       ChannelStateWriter#addInputData}.
+     * </ol>
+     *
+     * @param barrierId the barrier/checkpoint ID
+     * @param store the per-channel recovered buffer store (use {@link RecoveredBufferStore#EMPTY}
+     *     when no recovery data is present)
+     * @param knownBuffers network inflight buffers to persist (empty for LocalInputChannel)
+     * @throws CheckpointException if checkpointing fails or the checkpoint has been superseded
+     */
+    protected void startPersisting(
+            long barrierId, RecoveredBufferStore store, List<Buffer> knownBuffers)
             throws CheckpointException {
         logEvent("startPersisting", barrierId);
         if (checkpointStatus == CheckpointStatus.BARRIER_RECEIVED && lastSeenBarrier > barrierId) {
@@ -90,7 +116,47 @@ public final class ChannelStatePersister {
             checkpointStatus = CheckpointStatus.BARRIER_PENDING;
             lastSeenBarrier = barrierId;
         }
-        if (knownBuffers.size() > 0) {
+
+        // Defensive invariant check: store non-empty and knownBuffers non-empty must not coexist.
+        // Guaranteed by UNALIGNED_RECOVER_OUTPUT_ON_DOWNSTREAM=true (upstream has no output state
+        // to replay, so receivedBuffers stays empty of DATA_BUFFER while the recovered store is
+        // draining) together with RemoteInputChannel#getNextBuffer draining the store first.
+        // Violations here indicate one of those assumptions broke and must fail-fast rather than
+        // silently produce corrupt channel state.
+        //
+        // The store-lock acquisition here is brief and intentionally released before
+        // {@code store.checkpoint(...)} below: store.checkpoint() fires the dispatcher coordinator
+        // callback (a synchronized method on the dispatcher) and the dispatcher acquires the store
+        // lock from the recovery thread; holding the store lock across that callback would form an
+        // AB-BA deadlock. Capturing the snapshot here is sufficient — once recovery has finished
+        // (this method only fires once a physical channel has been wired up) the only writer to
+        // the store is the post-flush spill drainer, which appends; once {@code storeEmpty} has
+        // been observed true, drainPendingSpill has nothing to add.
+        final boolean storeEmpty;
+        final int storeSize;
+        synchronized (store) {
+            storeEmpty = store.isEmpty();
+            storeSize = store.size();
+        }
+        checkState(
+                storeEmpty || knownBuffers.isEmpty(),
+                "Invariant violated: store has data (size=%s) AND knownBuffers non-empty (size=%s) at barrier %s. "
+                        + "Requires UNALIGNED_RECOVER_OUTPUT_ON_DOWNSTREAM=true so upstream does not "
+                        + "replay output state into receivedBuffers while the recovered store is still draining.",
+                storeSize,
+                knownBuffers.size(),
+                barrierId);
+
+        if (!storeEmpty) {
+            try {
+                store.checkpoint(channelStateWriter, barrierId);
+            } catch (IOException e) {
+                throw new CheckpointException(
+                        "Failed to checkpoint recovered store",
+                        CheckpointFailureReason.IO_EXCEPTION,
+                        e);
+            }
+        } else if (!knownBuffers.isEmpty()) {
             channelStateWriter.addInputData(
                     barrierId,
                     channelInfo,
@@ -99,12 +165,28 @@ public final class ChannelStatePersister {
         }
     }
 
-    protected void stopPersisting(long id) {
+    /**
+     * Marks the given checkpoint as concluded for this channel and notifies the store so that the
+     * coordinator can drop any wait-set still tied to {@code id}.
+     *
+     * <p>Called from {@code InputChannel#checkpointStopped}, which itself fires for both
+     * checkpoint completion (all barriers received) and checkpoint abort. Without notifying the
+     * store, the coordinator's wait-set for an aborted checkpoint would linger and a later
+     * release/late callback could trigger a phase-2 drain into a checkpoint the task has already
+     * given up on.
+     *
+     * @param id the checkpoint that is now stopped on this channel
+     * @param store the per-channel recovered buffer store (use {@link RecoveredBufferStore#EMPTY}
+     *     when no recovery data is present); must be the same instance the channel passes to
+     *     {@link #startPersisting}
+     */
+    protected void stopPersisting(long id, RecoveredBufferStore store) {
         logEvent("stopPersisting", id);
         if (id >= lastSeenBarrier) {
             checkpointStatus = CheckpointStatus.COMPLETED;
             lastSeenBarrier = id;
         }
+        store.notifyCheckpointStopped(id);
     }
 
     protected void maybePersist(Buffer buffer) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersister.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersister.java
@@ -58,10 +58,6 @@ public final class ChannelStatePersister {
 
     private long lastSeenBarrier = -1L;
 
-    /**
-     * Writer must be initialized before usage. {@link #startPersisting(long, RecoveredBufferStore,
-     * List)} enforces this invariant.
-     */
     private final ChannelStateWriter channelStateWriter;
 
     ChannelStatePersister(ChannelStateWriter channelStateWriter, InputChannelInfo channelInfo) {
@@ -70,28 +66,12 @@ public final class ChannelStatePersister {
     }
 
     /**
-     * Starts persisting channel state for the given checkpoint barrier.
+     * Asserts the disk-network exclusivity invariant ({@code store.isEmpty() ||
+     * knownBuffers.isEmpty()}), then either snapshots the recovered store or writes network
+     * inflight buffers via {@link ChannelStateWriter#addInputData}.
      *
-     * <p>Performs the following steps in order:
-     *
-     * <ol>
-     *   <li>Validates that this checkpoint has not been superseded (throws {@link
-     *       CheckpointException} if a newer barrier was already received).
-     *   <li>Asserts the disk-network exclusivity invariant: {@code store.isEmpty() || knownBuffers.isEmpty()}.
-     *       Guaranteed by {@code UNALIGNED_RECOVER_OUTPUT_ON_DOWNSTREAM=true} (upstream does not
-     *       replay output state) combined with {@link RemoteInputChannel#getNextBuffer} draining the
-     *       store before polling {@code receivedBuffers}.
-     *   <li>Delegates ready-buffer snapshot and FilteredBufferDispatcher callback to {@link
-     *       RecoveredBufferStore#checkpoint}.
-     *   <li>Writes network inflight buffers (Remote only) via {@link
-     *       ChannelStateWriter#addInputData}.
-     * </ol>
-     *
-     * @param barrierId the barrier/checkpoint ID
-     * @param store the per-channel recovered buffer store (use {@link RecoveredBufferStore#EMPTY}
-     *     when no recovery data is present)
-     * @param knownBuffers network inflight buffers to persist (empty for LocalInputChannel)
-     * @throws CheckpointException if checkpointing fails or the checkpoint has been superseded
+     * @param store per-channel store; {@link RecoveredBufferStore#EMPTY} when no recovery data
+     * @param knownBuffers network inflight buffers (empty for LocalInputChannel)
      */
     protected void startPersisting(
             long barrierId, RecoveredBufferStore store, List<Buffer> knownBuffers)
@@ -117,21 +97,11 @@ public final class ChannelStatePersister {
             lastSeenBarrier = barrierId;
         }
 
-        // Defensive invariant check: store non-empty and knownBuffers non-empty must not coexist.
-        // Guaranteed by UNALIGNED_RECOVER_OUTPUT_ON_DOWNSTREAM=true (upstream has no output state
-        // to replay, so receivedBuffers stays empty of DATA_BUFFER while the recovered store is
-        // draining) together with RemoteInputChannel#getNextBuffer draining the store first.
-        // Violations here indicate one of those assumptions broke and must fail-fast rather than
-        // silently produce corrupt channel state.
-        //
-        // The store-lock acquisition here is brief and intentionally released before
-        // {@code store.checkpoint(...)} below: store.checkpoint() fires the dispatcher coordinator
-        // callback (a synchronized method on the dispatcher) and the dispatcher acquires the store
-        // lock from the recovery thread; holding the store lock across that callback would form an
-        // AB-BA deadlock. Capturing the snapshot here is sufficient — once recovery has finished
-        // (this method only fires once a physical channel has been wired up) the only writer to
-        // the store is the post-flush spill drainer, which appends; once {@code storeEmpty} has
-        // been observed true, drainPendingSpill has nothing to add.
+        // The disk-network exclusivity invariant relies on UNALIGNED_RECOVER_OUTPUT_ON_DOWNSTREAM
+        // (upstream replays no output state) AND RemoteInputChannel#getNextBuffer draining the
+        // store first. The brief lock here is released before store.checkpoint() because
+        // store.checkpoint() fires the dispatcher coordinator (which itself acquires the store
+        // lock from the recovery thread) — holding the lock across that callback would deadlock.
         final boolean storeEmpty;
         final int storeSize;
         synchronized (store) {
@@ -166,19 +136,9 @@ public final class ChannelStatePersister {
     }
 
     /**
-     * Marks the given checkpoint as concluded for this channel and notifies the store so that the
-     * coordinator can drop any wait-set still tied to {@code id}.
-     *
-     * <p>Called from {@code InputChannel#checkpointStopped}, which itself fires for both
-     * checkpoint completion (all barriers received) and checkpoint abort. Without notifying the
-     * store, the coordinator's wait-set for an aborted checkpoint would linger and a later
-     * release/late callback could trigger a phase-2 drain into a checkpoint the task has already
-     * given up on.
-     *
-     * @param id the checkpoint that is now stopped on this channel
-     * @param store the per-channel recovered buffer store (use {@link RecoveredBufferStore#EMPTY}
-     *     when no recovery data is present); must be the same instance the channel passes to
-     *     {@link #startPersisting}
+     * Marks {@code id} concluded on this channel and notifies the store so the coordinator drops
+     * any wait-set still tied to it (otherwise an aborted checkpoint's wait-set could linger and
+     * a later release/late callback would trigger a phase-2 drain into a concluded checkpoint).
      */
     protected void stopPersisting(long id, RecoveredBufferStore store) {
         logEvent("stopPersisting", id);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/EmptyRecoveredBufferStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/EmptyRecoveredBufferStore.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.consumer;
+
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
+import org.apache.flink.runtime.checkpoint.channel.RecoveredBufferStoreCoordinator;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+
+import javax.annotation.Nullable;
+
+/** No-op {@link RecoveredBufferStore} sentinel for channels without recovered data. */
+class EmptyRecoveredBufferStore implements RecoveredBufferStore {
+
+    @Nullable
+    @Override
+    public Buffer tryTake() {
+        return null;
+    }
+
+    @Override
+    public Buffer.DataType peekNextDataType() {
+        return Buffer.DataType.NONE;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return true;
+    }
+
+    @Override
+    public int size() {
+        return 0;
+    }
+
+    @Override
+    public void checkpoint(ChannelStateWriter writer, long checkpointId) {}
+
+    @Override
+    public void releaseAll() {}
+
+    @Override
+    public void notifyCheckpointStopped(long checkpointId) {}
+
+    @Override
+    public void setCoordinator(RecoveredBufferStoreCoordinator coordinator) {}
+
+    @Override
+    public void setDataAvailableListener(DataAvailableListener listener) {}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -116,9 +116,10 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 
         this.partitionManager = checkNotNull(partitionManager);
         this.taskEventPublisher = checkNotNull(taskEventPublisher);
-        this.channelStatePersister = new ChannelStatePersister(stateWriter, getChannelInfo());
 
         this.recoveredStore = checkNotNull(recoveredStore);
+        this.channelStatePersister =
+                new ChannelStatePersister(stateWriter, getChannelInfo(), this.recoveredStore);
         synchronized (this.recoveredStore) {
             this.recoveredStore.setDataAvailableListener(this::notifyChannelNonEmpty);
         }
@@ -132,12 +133,15 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
         // Local channels have no network inflight buffers to snapshot (barriers and data arrive
         // together via the local subpartition view). FullyFilledBuffer splits in
         // toBeConsumedBuffers are ordinary data fragments and don't belong in channel state.
-        channelStatePersister.startPersisting(
-                barrier.getId(), recoveredStore, Collections.emptyList());
+        synchronized (recoveredStore) {
+            channelStatePersister.startPersisting(barrier.getId(), Collections.emptyList());
+        }
     }
 
     public void checkpointStopped(long checkpointId) {
-        channelStatePersister.stopPersisting(checkpointId, recoveredStore);
+        synchronized (recoveredStore) {
+            channelStatePersister.stopPersisting(checkpointId);
+        }
     }
 
     @Override
@@ -333,12 +337,11 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
                     "Expected priority event, but got %s",
                     next == null ? "null" : next.buffer().getDataType());
 
-            channelStatePersister.checkForBarrier(next.buffer());
-
             Buffer.DataType expectedNextDataType = next.getNextDataType();
-            if (!expectedNextDataType.hasPriority()) {
-                hasPendingPriorityEvent = false;
-                synchronized (recoveredStore) {
+            synchronized (recoveredStore) {
+                channelStatePersister.checkForBarrier(next.buffer());
+                if (!expectedNextDataType.hasPriority()) {
+                    hasPendingPriorityEvent = false;
                     // recoveredStore (if non-empty) is FIFO ahead of subpartitionView.
                     if (!recoveredStore.isEmpty()) {
                         expectedNextDataType = peekNextDataType();
@@ -416,8 +419,10 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 
         numBytesIn.inc(buffer.readableBytes());
         numBuffersIn.inc();
-        channelStatePersister.checkForBarrier(buffer);
-        channelStatePersister.maybePersist(buffer);
+        synchronized (recoveredStore) {
+            channelStatePersister.checkForBarrier(buffer);
+            channelStatePersister.maybePersist(buffer);
+        }
         NetworkActionsLogger.traceInput(
                 "LocalInputChannel#getNextBuffer",
                 buffer,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -43,10 +43,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
 
 import java.io.IOException;
 import java.util.ArrayDeque;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
 import java.util.Optional;
@@ -81,8 +82,14 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
     private final Deque<BufferAndBacklog> toBeConsumedBuffers = new ArrayDeque<>();
 
     /**
+     * Store for recovered buffers. Always non-null: callers with no recovered data pass {@link
+     * RecoveredBufferStore#EMPTY}.
+     */
+    private final RecoveredBufferStore recoveredStore;
+
+    /**
      * Flag indicating whether there is a pending priority event (e.g., checkpoint barrier) in the
-     * subpartitionView that should be consumed before toBeConsumedBuffers. This is set by {@link
+     * subpartitionView that should be consumed before recovered data. This is set by {@link
      * #notifyPriorityEvent} and checked in {@link #getNextBuffer()}.
      */
     private volatile boolean hasPendingPriorityEvent = false;
@@ -99,7 +106,7 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
             Counter numBytesIn,
             Counter numBuffersIn,
             ChannelStateWriter stateWriter,
-            ArrayDeque<Buffer> initialRecoveredBuffers) {
+            RecoveredBufferStore recoveredStore) {
 
         super(
                 inputGate,
@@ -115,29 +122,13 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
         this.taskEventPublisher = checkNotNull(taskEventPublisher);
         this.channelStatePersister = new ChannelStatePersister(stateWriter, getChannelInfo());
 
-        // Migrate recovered buffers from RecoveredInputChannel if provided.
-        // These buffers have been filtered but not yet consumed by the Task.
-        if (!initialRecoveredBuffers.isEmpty()) {
-            final int expectedCount = initialRecoveredBuffers.size();
-            // Sequence number starts at Integer.MIN_VALUE, consistent with RecoveredInputChannel.
-            int seqNum = Integer.MIN_VALUE;
-            while (!initialRecoveredBuffers.isEmpty()) {
-                Buffer buffer = initialRecoveredBuffers.poll();
-                // Determine next data type based on the next buffer in the queue
-                Buffer.DataType nextDataType =
-                        initialRecoveredBuffers.isEmpty()
-                                ? Buffer.DataType.NONE
-                                : initialRecoveredBuffers.peek().getDataType();
-                // buffersInBacklog is set to 0 as these are recovered buffers
-                BufferAndBacklog bufferAndBacklog =
-                        new BufferAndBacklog(buffer, 0, nextDataType, seqNum++);
-                toBeConsumedBuffers.add(bufferAndBacklog);
-            }
-            checkState(
-                    toBeConsumedBuffers.size() == expectedCount,
-                    "Buffer migration failed: expected %s buffers but got %s",
-                    expectedCount,
-                    toBeConsumedBuffers.size());
+        // Callers with no recovered data pass RecoveredBufferStore.EMPTY; unconditional assignment
+        // avoids null guards throughout the class and eliminates the buggy isEmpty() guard that
+        // would discard the store reference while FilteredBufferDispatcher still has pending
+        // writes.
+        this.recoveredStore = checkNotNull(recoveredStore);
+        synchronized (this.recoveredStore) {
+            this.recoveredStore.setDataAvailableListener(this::notifyChannelNonEmpty);
         }
     }
 
@@ -146,19 +137,22 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
     // ------------------------------------------------------------------------
 
     public void checkpointStarted(CheckpointBarrier barrier) throws CheckpointException {
-        // Collect inflight buffers from toBeConsumedBuffers to be persisted.
-        // These are buffers that have not been consumed yet when the checkpoint barrier arrives.
-        List<Buffer> inflightBuffers = new ArrayList<>();
-        for (BufferAndBacklog bufferAndBacklog : toBeConsumedBuffers) {
-            if (bufferAndBacklog.buffer().isBuffer()) {
-                inflightBuffers.add(bufferAndBacklog.buffer().retainBuffer());
-            }
-        }
-        channelStatePersister.startPersisting(barrier.getId(), inflightBuffers);
+        // Local channel has no network inflight buffers to snapshot (barriers and data arrive
+        // together via the local subpartition view). toBeConsumedBuffers contains only
+        // FullyFilledBuffer splits — ordinary data fragments that do not belong in channel state.
+        // The recoveredStore is passed so that ready buffers + FilteredBufferDispatcher callback
+        // are handled by the centralized startPersisting path. startPersisting itself manages the
+        // brief store-lock acquisition needed for the isEmpty/size assertion; it must not run
+        // under an outer store lock because store.checkpoint() fires the coordinator callback
+        // (dispatcher's synchronized method) and we must not hold the store lock when crossing
+        // into the dispatcher monitor (lock order: dispatcher → store on the recovery thread, so
+        // the reverse here would deadlock).
+        channelStatePersister.startPersisting(
+                barrier.getId(), recoveredStore, Collections.emptyList());
     }
 
     public void checkpointStopped(long checkpointId) {
-        channelStatePersister.stopPersisting(checkpointId);
+        channelStatePersister.stopPersisting(checkpointId, recoveredStore);
     }
 
     @Override
@@ -272,8 +266,18 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
     public Optional<BufferAndAvailability> getNextBuffer() throws IOException {
         checkError();
 
-        if (!toBeConsumedBuffers.isEmpty()) {
+        // Check recovered store first (recovery path). isEmpty() must run under the store lock
+        // because the store's contract requires the caller to hold it.
+        final boolean stillRecovering;
+        synchronized (recoveredStore) {
+            stillRecovering = !recoveredStore.isEmpty();
+        }
+        if (stillRecovering) {
             return getNextRecoveredBuffer();
+        }
+
+        if (!toBeConsumedBuffers.isEmpty()) {
+            return getNextSplitBuffer();
         }
 
         ResultSubpartitionView subpartitionView = this.subpartitionView;
@@ -336,12 +340,12 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
     }
 
     /**
-     * Consumes the next buffer from toBeConsumedBuffers (recovered buffers), handling pending
-     * priority events and dynamic availability detection for the last recovered buffer.
+     * Consumes the next buffer from recoveredStore, handling pending priority events and dynamic
+     * availability detection for the last recovered buffer.
      */
     private Optional<BufferAndAvailability> getNextRecoveredBuffer() throws IOException {
         // If there is a pending priority event (e.g., unaligned checkpoint barrier), fetch it
-        // from subpartitionView first, skipping toBeConsumedBuffers. This ensures priority
+        // from subpartitionView first, skipping recoveredStore. This ensures priority
         // events are processed immediately even when there are pending recovered buffers.
         if (hasPendingPriorityEvent) {
             checkState(subpartitionView != null, "No subpartition view available");
@@ -359,10 +363,13 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
             if (!expectedNextDataType.hasPriority()) {
                 // Reset hasPendingPriorityEvent to false if no more priority event
                 hasPendingPriorityEvent = false;
-                if (!toBeConsumedBuffers.isEmpty()) {
-                    // Correct nextDataType: if toBeConsumedBuffers is not empty, the actual next
-                    // element to consume is from toBeConsumedBuffers, not from subpartitionView
-                    expectedNextDataType = toBeConsumedBuffers.peek().buffer().getDataType();
+                synchronized (recoveredStore) {
+                    // If recoveredStore has data, the actual next element to consume is
+                    // from recoveredStore (FIFO), not from subpartitionView; otherwise
+                    // keep subpartitionView's hint.
+                    if (!recoveredStore.isEmpty()) {
+                        expectedNextDataType = peekNextDataType();
+                    }
                 }
             }
 
@@ -374,26 +381,64 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
                             next.getSequenceNumber()));
         }
 
-        BufferAndBacklog next = toBeConsumedBuffers.removeFirst();
+        // tryTake + peekNextDataType together must be atomic so the consumer never observes a
+        // torn (post-take, pre-peek) view.
+        final Buffer next;
+        Buffer.DataType nextDataType;
+        synchronized (recoveredStore) {
+            next = recoveredStore.tryTake();
+            if (next == null) {
+                return Optional.empty();
+            }
+            nextDataType = peekNextDataType();
+        }
+        int sequenceNumber = Integer.MIN_VALUE; // recovered buffers use MIN_VALUE sequence range
 
-        // If this is the last recovered buffer and nextDataType is NONE,
-        // dynamically check if subpartitionView has data available.
-        // The last buffer's nextDataType was preset to NONE during construction,
-        // but subpartitionView may already have data available.
-        if (toBeConsumedBuffers.isEmpty()
-                && next.getNextDataType() == Buffer.DataType.NONE
-                && subpartitionView != null) {
+        // If this is the last recovered buffer and nextDataType is NONE, dynamically check if
+        // subpartitionView has data available so the consumer is woken up without a round-trip.
+        // Done outside the recoveredStore lock: subpartitionView calls take producer-side locks
+        // and holding the store monitor across them would form an AB-BA cycle with the producer's
+        // notify path (subpartition lock -> gate.notifyChannelNonEmpty -> inputChannelsWithData
+        // lock; the consumer side already holds gate -> store, so adding store -> subpartition
+        // here would close the loop).
+        if (nextDataType == Buffer.DataType.NONE && subpartitionView != null) {
             ResultSubpartitionView.AvailabilityWithBacklog availability =
                     subpartitionView.getAvailabilityAndBacklog(true);
             if (availability.isAvailable()) {
-                next =
-                        new BufferAndBacklog(
-                                next.buffer(),
-                                availability.getBacklog(),
-                                Buffer.DataType.DATA_BUFFER,
-                                next.getSequenceNumber());
+                nextDataType = Buffer.DataType.DATA_BUFFER;
             }
         }
+
+        BufferAndBacklog bufferAndBacklog =
+                new BufferAndBacklog(next, 0, nextDataType, sequenceNumber);
+        return getBufferAndAvailability(bufferAndBacklog);
+    }
+
+    /**
+     * Returns the data type of the next consumer-visible buffer that lives behind the
+     * {@link #recoveredStore} monitor. Returns {@link Buffer.DataType#NONE} when the store
+     * has no head ready (either fully empty or only on-disk pending entries left — in the
+     * latter case the drain listener will fire once readyBuffers becomes non-empty).
+     *
+     * <p>The {@link #subpartitionView} tier is intentionally NOT consulted here: that call
+     * acquires producer-side locks, and inspecting it under the recoveredStore monitor would
+     * create an AB-BA cycle with the producer's notify path. Callers that need the
+     * subpartitionView fallback must do it outside the lock.
+     *
+     * <p>Caller MUST hold the {@link #recoveredStore} monitor.
+     */
+    @GuardedBy("recoveredStore")
+    private Buffer.DataType peekNextDataType() {
+        assert Thread.holdsLock(recoveredStore);
+        if (!recoveredStore.isEmpty()) {
+            return recoveredStore.peekNextDataType();
+        }
+        return Buffer.DataType.NONE;
+    }
+
+    /** Consumes the next buffer from toBeConsumedBuffers (split buffers from FullyFilledBuffer). */
+    private Optional<BufferAndAvailability> getNextSplitBuffer() throws IOException {
+        BufferAndBacklog next = toBeConsumedBuffers.removeFirst();
         return getBufferAndAvailability(next);
     }
 
@@ -435,7 +480,7 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
     @Override
     public void notifyPriorityEvent(int prioritySequenceNumber) {
         // Set flag so that getNextBuffer() knows to fetch priority event from subpartitionView
-        // before consuming toBeConsumedBuffers.
+        // before consuming recovered data.
         hasPendingPriorityEvent = true;
         super.notifyPriorityEvent(prioritySequenceNumber);
     }
@@ -512,8 +557,11 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
                 subpartitionView = null;
             }
 
+            // Release recovered store (EMPTY.releaseAll() is a no-op, so no null check needed).
+            recoveredStore.releaseAll();
+
             // Release any remaining buffers in toBeConsumedBuffers to avoid memory leak.
-            // These may be recovered buffers or partial buffers from FullyFilledBuffer.
+            // These may be partial buffers from FullyFilledBuffer.
             for (BufferAndBacklog bufferAndBacklog : toBeConsumedBuffers) {
                 bufferAndBacklog.buffer().recycleBuffer();
             }
@@ -534,14 +582,17 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
     @Override
     int getBuffersInUseCount() {
         ResultSubpartitionView view = this.subpartitionView;
-        return toBeConsumedBuffers.size() + (view == null ? 0 : view.getNumberOfQueuedBuffers());
+        // size() is lock-free best-effort — see RecoveredBufferStore javadoc.
+        return recoveredStore.size()
+                + toBeConsumedBuffers.size()
+                + (view == null ? 0 : view.getNumberOfQueuedBuffers());
     }
 
     @Override
     public int unsynchronizedGetNumberOfQueuedBuffers() {
         ResultSubpartitionView view = subpartitionView;
 
-        int count = toBeConsumedBuffers.size();
+        int count = recoveredStore.size() + toBeConsumedBuffers.size();
         if (view != null) {
             count += view.unsynchronizedGetNumberOfQueuedBuffers();
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -81,16 +81,12 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 
     private final Deque<BufferAndBacklog> toBeConsumedBuffers = new ArrayDeque<>();
 
-    /**
-     * Store for recovered buffers. Always non-null: callers with no recovered data pass {@link
-     * RecoveredBufferStore#EMPTY}.
-     */
+    /** Always non-null: callers with no recovered data pass {@link RecoveredBufferStore#EMPTY}. */
     private final RecoveredBufferStore recoveredStore;
 
     /**
-     * Flag indicating whether there is a pending priority event (e.g., checkpoint barrier) in the
-     * subpartitionView that should be consumed before recovered data. This is set by {@link
-     * #notifyPriorityEvent} and checked in {@link #getNextBuffer()}.
+     * True when a priority event (e.g. unaligned checkpoint barrier) sits in {@code
+     * subpartitionView} and must be consumed before recovered data.
      */
     private volatile boolean hasPendingPriorityEvent = false;
 
@@ -122,10 +118,6 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
         this.taskEventPublisher = checkNotNull(taskEventPublisher);
         this.channelStatePersister = new ChannelStatePersister(stateWriter, getChannelInfo());
 
-        // Callers with no recovered data pass RecoveredBufferStore.EMPTY; unconditional assignment
-        // avoids null guards throughout the class and eliminates the buggy isEmpty() guard that
-        // would discard the store reference while FilteredBufferDispatcher still has pending
-        // writes.
         this.recoveredStore = checkNotNull(recoveredStore);
         synchronized (this.recoveredStore) {
             this.recoveredStore.setDataAvailableListener(this::notifyChannelNonEmpty);
@@ -137,16 +129,9 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
     // ------------------------------------------------------------------------
 
     public void checkpointStarted(CheckpointBarrier barrier) throws CheckpointException {
-        // Local channel has no network inflight buffers to snapshot (barriers and data arrive
-        // together via the local subpartition view). toBeConsumedBuffers contains only
-        // FullyFilledBuffer splits — ordinary data fragments that do not belong in channel state.
-        // The recoveredStore is passed so that ready buffers + FilteredBufferDispatcher callback
-        // are handled by the centralized startPersisting path. startPersisting itself manages the
-        // brief store-lock acquisition needed for the isEmpty/size assertion; it must not run
-        // under an outer store lock because store.checkpoint() fires the coordinator callback
-        // (dispatcher's synchronized method) and we must not hold the store lock when crossing
-        // into the dispatcher monitor (lock order: dispatcher → store on the recovery thread, so
-        // the reverse here would deadlock).
+        // Local channels have no network inflight buffers to snapshot (barriers and data arrive
+        // together via the local subpartition view). FullyFilledBuffer splits in
+        // toBeConsumedBuffers are ordinary data fragments and don't belong in channel state.
         channelStatePersister.startPersisting(
                 barrier.getId(), recoveredStore, Collections.emptyList());
     }
@@ -266,8 +251,6 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
     public Optional<BufferAndAvailability> getNextBuffer() throws IOException {
         checkError();
 
-        // Check recovered store first (recovery path). isEmpty() must run under the store lock
-        // because the store's contract requires the caller to hold it.
         final boolean stillRecovering;
         synchronized (recoveredStore) {
             stillRecovering = !recoveredStore.isEmpty();
@@ -339,14 +322,9 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
         return getBufferAndAvailability(next);
     }
 
-    /**
-     * Consumes the next buffer from recoveredStore, handling pending priority events and dynamic
-     * availability detection for the last recovered buffer.
-     */
     private Optional<BufferAndAvailability> getNextRecoveredBuffer() throws IOException {
-        // If there is a pending priority event (e.g., unaligned checkpoint barrier), fetch it
-        // from subpartitionView first, skipping recoveredStore. This ensures priority
-        // events are processed immediately even when there are pending recovered buffers.
+        // Pending priority event bypasses the FIFO recovery-first rule so unaligned barriers can
+        // be processed immediately.
         if (hasPendingPriorityEvent) {
             checkState(subpartitionView != null, "No subpartition view available");
             BufferAndBacklog next = subpartitionView.getNextBuffer();
@@ -355,18 +333,13 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
                     "Expected priority event, but got %s",
                     next == null ? "null" : next.buffer().getDataType());
 
-            // Check for barrier to update channel state persister.
-            // Note: maybePersist is not needed for barriers as they are not regular data buffers.
             channelStatePersister.checkForBarrier(next.buffer());
 
             Buffer.DataType expectedNextDataType = next.getNextDataType();
             if (!expectedNextDataType.hasPriority()) {
-                // Reset hasPendingPriorityEvent to false if no more priority event
                 hasPendingPriorityEvent = false;
                 synchronized (recoveredStore) {
-                    // If recoveredStore has data, the actual next element to consume is
-                    // from recoveredStore (FIFO), not from subpartitionView; otherwise
-                    // keep subpartitionView's hint.
+                    // recoveredStore (if non-empty) is FIFO ahead of subpartitionView.
                     if (!recoveredStore.isEmpty()) {
                         expectedNextDataType = peekNextDataType();
                     }
@@ -381,8 +354,8 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
                             next.getSequenceNumber()));
         }
 
-        // tryTake + peekNextDataType together must be atomic so the consumer never observes a
-        // torn (post-take, pre-peek) view.
+        // tryTake + peekNextDataType under one lock so the consumer never observes a torn
+        // (post-take, pre-peek) view.
         final Buffer next;
         Buffer.DataType nextDataType;
         synchronized (recoveredStore) {
@@ -392,15 +365,12 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
             }
             nextDataType = peekNextDataType();
         }
-        int sequenceNumber = Integer.MIN_VALUE; // recovered buffers use MIN_VALUE sequence range
+        int sequenceNumber = Integer.MIN_VALUE;
 
-        // If this is the last recovered buffer and nextDataType is NONE, dynamically check if
-        // subpartitionView has data available so the consumer is woken up without a round-trip.
-        // Done outside the recoveredStore lock: subpartitionView calls take producer-side locks
-        // and holding the store monitor across them would form an AB-BA cycle with the producer's
-        // notify path (subpartition lock -> gate.notifyChannelNonEmpty -> inputChannelsWithData
-        // lock; the consumer side already holds gate -> store, so adding store -> subpartition
-        // here would close the loop).
+        // subpartitionView availability check is outside the store lock: it acquires producer-
+        // side locks, and the consumer already holds gate → store, so adding store →
+        // subpartition would close an AB-BA cycle with the producer's notify path
+        // (subpartition → gate.notifyChannelNonEmpty → inputChannelsWithData).
         if (nextDataType == Buffer.DataType.NONE && subpartitionView != null) {
             ResultSubpartitionView.AvailabilityWithBacklog availability =
                     subpartitionView.getAvailabilityAndBacklog(true);
@@ -415,17 +385,9 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
     }
 
     /**
-     * Returns the data type of the next consumer-visible buffer that lives behind the
-     * {@link #recoveredStore} monitor. Returns {@link Buffer.DataType#NONE} when the store
-     * has no head ready (either fully empty or only on-disk pending entries left — in the
-     * latter case the drain listener will fire once readyBuffers becomes non-empty).
-     *
-     * <p>The {@link #subpartitionView} tier is intentionally NOT consulted here: that call
-     * acquires producer-side locks, and inspecting it under the recoveredStore monitor would
-     * create an AB-BA cycle with the producer's notify path. Callers that need the
-     * subpartitionView fallback must do it outside the lock.
-     *
-     * <p>Caller MUST hold the {@link #recoveredStore} monitor.
+     * Data type of the next consumer-visible buffer behind the store. Caller MUST hold
+     * {@code recoveredStore}. The {@link #subpartitionView} tier is deliberately not consulted —
+     * doing so under the store lock would form an AB-BA cycle with the producer's notify path.
      */
     @GuardedBy("recoveredStore")
     private Buffer.DataType peekNextDataType() {
@@ -436,7 +398,6 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
         return Buffer.DataType.NONE;
     }
 
-    /** Consumes the next buffer from toBeConsumedBuffers (split buffers from FullyFilledBuffer). */
     private Optional<BufferAndAvailability> getNextSplitBuffer() throws IOException {
         BufferAndBacklog next = toBeConsumedBuffers.removeFirst();
         return getBufferAndAvailability(next);
@@ -479,8 +440,6 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 
     @Override
     public void notifyPriorityEvent(int prioritySequenceNumber) {
-        // Set flag so that getNextBuffer() knows to fetch priority event from subpartitionView
-        // before consuming recovered data.
         hasPendingPriorityEvent = true;
         super.notifyPriorityEvent(prioritySequenceNumber);
     }
@@ -557,11 +516,10 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
                 subpartitionView = null;
             }
 
-            // Release recovered store (EMPTY.releaseAll() is a no-op, so no null check needed).
+            // EMPTY.releaseAll() is a no-op, so no null check needed.
             recoveredStore.releaseAll();
 
-            // Release any remaining buffers in toBeConsumedBuffers to avoid memory leak.
-            // These may be partial buffers from FullyFilledBuffer.
+            // Release partial buffers from FullyFilledBuffer splits.
             for (BufferAndBacklog bufferAndBacklog : toBeConsumedBuffers) {
                 bufferAndBacklog.buffer().recycleBuffer();
             }
@@ -582,7 +540,6 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
     @Override
     int getBuffersInUseCount() {
         ResultSubpartitionView view = this.subpartitionView;
-        // size() is lock-free best-effort — see RecoveredBufferStore javadoc.
         return recoveredStore.size()
                 + toBeConsumedBuffers.size()
                 + (view == null ? 0 : view.getNumberOfQueuedBuffers());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -385,9 +385,9 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
     }
 
     /**
-     * Data type of the next consumer-visible buffer behind the store. Caller MUST hold
-     * {@code recoveredStore}. The {@link #subpartitionView} tier is deliberately not consulted —
-     * doing so under the store lock would form an AB-BA cycle with the producer's notify path.
+     * Data type of the next consumer-visible buffer behind the store. Caller MUST hold {@code
+     * recoveredStore}. The {@link #subpartitionView} tier is deliberately not consulted — doing so
+     * under the store lock would form an AB-BA cycle with the producer's notify path.
      */
     @GuardedBy("recoveredStore")
     private Buffer.DataType peekNextDataType() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalRecoveredInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalRecoveredInputChannel.java
@@ -19,13 +19,10 @@
 package org.apache.flink.runtime.io.network.partition.consumer;
 
 import org.apache.flink.runtime.io.network.TaskEventPublisher;
-import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.metrics.InputChannelMetrics;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartitionIndexSet;
-
-import java.util.ArrayDeque;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -64,7 +61,7 @@ public class LocalRecoveredInputChannel extends RecoveredInputChannel {
     }
 
     @Override
-    protected InputChannel toInputChannelInternal(ArrayDeque<Buffer> remainingBuffers) {
+    protected InputChannel toInputChannelInternal(RecoveredBufferStoreImpl recoveredStore) {
         return new LocalInputChannel(
                 inputGate,
                 getChannelIndex(),
@@ -77,6 +74,6 @@ public class LocalRecoveredInputChannel extends RecoveredInputChannel {
                 numBytesIn,
                 numBuffersIn,
                 channelStateWriter,
-                remainingBuffers);
+                recoveredStore);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredBufferStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredBufferStore.java
@@ -19,7 +19,6 @@ package org.apache.flink.runtime.io.network.partition.consumer;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
-import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.checkpoint.channel.RecoveredBufferStoreCoordinator;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 
@@ -28,27 +27,27 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 
 /**
- * Per-channel store for recovered buffers during unaligned checkpoint recovery. Buffers are
- * either in-memory (ready for consumption) or on disk (pending spill entries).
+ * Per-channel store for recovered buffers during unaligned checkpoint recovery. Buffers are either
+ * in-memory (ready for consumption) or on disk (pending spill entries).
  *
  * <h3>Locking contract</h3>
  *
- * <p>The store's intrinsic monitor IS the channel-private lock. Callers MUST hold
- * {@code synchronized(store)} when invoking the consumer-side queries ({@link #tryTake},
- * {@link #peekNextDataType}, {@link #isEmpty}) and the setters; implementations enforce this with
- * an internal {@code assert Thread.holdsLock(this)} that fires under {@code -ea}.
+ * <p>The store's intrinsic monitor IS the channel-private lock. Callers MUST hold {@code
+ * synchronized(store)} when invoking the consumer-side queries ({@link #tryTake}, {@link
+ * #peekNextDataType}, {@link #isEmpty}) and the setters; implementations enforce this with an
+ * internal {@code assert Thread.holdsLock(this)} that fires under {@code -ea}.
  *
  * <p>{@link #size()} is exempt and lock-free: a metric/bookkeeping read that tolerates a slightly
- * stale value. Callers that need a consistent {@code isEmpty + size} pair must take the lock
- * around both reads themselves.
+ * stale value. Callers that need a consistent {@code isEmpty + size} pair must take the lock around
+ * both reads themselves.
  *
- * <p>The lifecycle methods ({@link #checkpoint}, {@link #releaseAll},
- * {@link #notifyCheckpointStopped}) self-manage their store-level locking and fire any
- * coordinator callback <em>outside</em> the lock to avoid deadlock with the coordinator.
+ * <p>The lifecycle methods ({@link #checkpoint}, {@link #releaseAll}, {@link
+ * #notifyCheckpointStopped}) self-manage their store-level locking and fire any coordinator
+ * callback <em>outside</em> the lock to avoid deadlock with the coordinator.
  *
- * <p>Use {@link #EMPTY} as a sentinel when no recovered data is present, rather than holding
- * {@code null}; callers still wrap calls in {@code synchronized(store)} to keep the same call
- * shape regardless of which implementation backs the channel.
+ * <p>Use {@link #EMPTY} as a sentinel when no recovered data is present, rather than holding {@code
+ * null}; callers still wrap calls in {@code synchronized(store)} to keep the same call shape
+ * regardless of which implementation backs the channel.
  */
 @Internal
 public interface RecoveredBufferStore {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredBufferStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredBufferStore.java
@@ -28,129 +28,80 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 
 /**
- * Per-channel store for recovered buffers during unaligned checkpoint recovery. Buffers can be
+ * Per-channel store for recovered buffers during unaligned checkpoint recovery. Buffers are
  * either in-memory (ready for consumption) or on disk (pending spill entries).
  *
  * <h3>Locking contract</h3>
  *
- * <p>The store's intrinsic monitor IS the channel-private lock. Callers MUST hold {@code synchronized
- * (store)} when invoking the consumer-side query methods ({@link #tryTake}, {@link
- * #peekNextDataType}, {@link #isEmpty}) and the setters ({@link #setCoordinator},
- * {@link #setDataAvailableListener}). Implementations enforce this with an internal {@code assert
- * Thread.holdsLock(this)} that fires under {@code -ea}.
+ * <p>The store's intrinsic monitor IS the channel-private lock. Callers MUST hold
+ * {@code synchronized(store)} when invoking the consumer-side queries ({@link #tryTake},
+ * {@link #peekNextDataType}, {@link #isEmpty}) and the setters; implementations enforce this with
+ * an internal {@code assert Thread.holdsLock(this)} that fires under {@code -ea}.
  *
- * <p>{@link #size()} is exempt and lock-free: it is intended for metric / gate-bookkeeping paths
- * that already tolerate a slightly stale read. Callers that need a consistent {@code isEmpty +
- * size} pair must wrap both calls in a single {@code synchronized (store)} block themselves.
+ * <p>{@link #size()} is exempt and lock-free: a metric/bookkeeping read that tolerates a slightly
+ * stale value. Callers that need a consistent {@code isEmpty + size} pair must take the lock
+ * around both reads themselves.
  *
- * <p>The lifecycle methods {@link #checkpoint}, {@link #releaseAll} and {@link
- * #notifyCheckpointStopped} self-manage their store-level locking and fire any coordinator
- * callback <em>outside</em> the lock to avoid deadlock with the coordinator's own synchronisation.
+ * <p>The lifecycle methods ({@link #checkpoint}, {@link #releaseAll},
+ * {@link #notifyCheckpointStopped}) self-manage their store-level locking and fire any
+ * coordinator callback <em>outside</em> the lock to avoid deadlock with the coordinator.
  *
- * <p>Use {@link #EMPTY} as a sentinel when no recovered data is present (non-filtering mode, or
- * after recovery has fully drained), rather than holding {@code null} references. The sentinel's
- * methods are no-ops; callers still wrap them in {@code synchronized (store)} to keep the same
- * call shape regardless of which implementation backs the channel.
+ * <p>Use {@link #EMPTY} as a sentinel when no recovered data is present, rather than holding
+ * {@code null}; callers still wrap calls in {@code synchronized(store)} to keep the same call
+ * shape regardless of which implementation backs the channel.
  */
 @Internal
 public interface RecoveredBufferStore {
 
-    /**
-     * Singleton no-op store used when there is no recovered data for a channel. All query methods
-     * return their neutral/empty sentinel values; all mutating methods and callback setters are
-     * no-ops.
-     */
+    /** Singleton no-op store used when there is no recovered data for a channel. */
     RecoveredBufferStore EMPTY = new EmptyRecoveredBufferStore();
 
-    /**
-     * Takes the next buffer from the store. Returns null if no ready buffer is available.
-     *
-     * @return the next buffer, or null if no ready buffer available
-     */
+    /** Next buffer from the store; null if no ready buffer is available. */
     @Nullable
     Buffer tryTake();
 
-    /**
-     * Peeks the data type of the next ready buffer without removing it.
-     *
-     * @return the data type of the next buffer, or {@link Buffer.DataType#NONE} if empty
-     */
+    /** Data type of the next ready buffer, or {@link Buffer.DataType#NONE} if empty. */
     Buffer.DataType peekNextDataType();
 
-    /** Returns true if the ready buffer queue is empty and no pending spill entries exist. */
+    /** True if the ready queue is empty and no pending spill entries exist. */
     boolean isEmpty();
 
     /**
-     * Returns the total number of buffers held by this store for the bound channel: ready buffers
-     * already in memory plus pending entries currently spilled to disk. Callers use this for
-     * in-use / backlog accounting, which should reflect every buffer the recovery pipeline still
-     * owes the channel regardless of where it is physically stored.
+     * Total buffers held for the bound channel: ready buffers in memory plus pending entries on
+     * disk. Used for in-use / backlog accounting.
      */
     int size();
 
     /**
-     * Checkpoints the current store contents to the given ChannelStateWriter. Implementations
-     * should snapshot ready buffers first, then notify the registered {@link
-     * RecoveredBufferStoreCoordinator} (if any) <em>outside</em> any store-level lock to avoid
-     * deadlock with the coordinator's own synchronisation.
-     *
-     * <p>The store is bound to a single {@link InputChannelInfo} at construction time; both the
-     * snapshot and the coordinator notification use that bound channel info.
-     *
-     * @param writer the channel state writer to checkpoint to
-     * @param checkpointId the checkpoint ID
-     * @throws IOException if checkpointing fails
+     * Snapshots ready buffers into {@code writer}, then notifies the registered coordinator
+     * (outside the store lock to avoid deadlock).
      */
     void checkpoint(ChannelStateWriter writer, long checkpointId) throws IOException;
 
     /**
-     * Releases all buffers held in this store and clears all state. Before clearing local state,
-     * the registered {@link RecoveredBufferStoreCoordinator} (if any) is notified so the
-     * coordinator can drop any still-pending spill entries for this channel from disk.
+     * Releases all buffers and clears state. Notifies the coordinator (if any) so it can drop
+     * still-pending spill entries for this channel.
      */
     void releaseAll();
 
     /**
-     * Notifies the registered {@link RecoveredBufferStoreCoordinator} (if any) that the owning
-     * channel has finished or aborted the given checkpoint. The notification fires <em>outside</em>
-     * any store-level lock so the coordinator can safely acquire its own lock without deadlock.
-     *
-     * <p>Called from {@code ChannelStatePersister#stopPersisting}, which itself is invoked once on
-     * every channel both on checkpoint completion (all barriers received) and on checkpoint abort.
-     * The store does not maintain per-checkpoint state; the call is a pure passthrough so that
-     * cross-channel bookkeeping (such as a checkpoint wait-set) lives in the coordinator.
-     *
-     * @param checkpointId the ID of the checkpoint that just stopped for this channel
+     * Forwards a checkpoint-stopped notification (completion or abort) to the coordinator. The
+     * store keeps no per-checkpoint state; cross-channel bookkeeping (wait-set) lives there.
      */
     void notifyCheckpointStopped(long checkpointId);
 
-    /**
-     * Registers the {@link RecoveredBufferStoreCoordinator} that owns cross-channel bookkeeping
-     * (such as the checkpoint wait-set and disk-resident spill entries). The store invokes the
-     * coordinator from {@link #checkpoint}, {@link #notifyCheckpointStopped} and
-     * {@link #releaseAll} on lifecycle transitions. Do not call this method (or pass {@code null})
-     * when there is no coordinator.
-     *
-     * @param coordinator the coordinator to notify; replaces any previously registered coordinator
-     */
+    /** Registers the cross-channel coordinator. Pass non-null when one exists. */
     void setCoordinator(RecoveredBufferStoreCoordinator coordinator);
 
     /**
-     * Registers a callback that is invoked when a buffer is added to a previously empty ready
-     * queue. Used to notify the InputChannel that data is available for consumption.
-     *
-     * @param listener the listener to invoke; replaces any previously registered listener
+     * Listener fired when a buffer is added to a previously empty ready queue. The typical
+     * recipient is the owning InputChannel, which uses it to wake up the Task thread.
      */
     void setDataAvailableListener(DataAvailableListener listener);
 
-    /**
-     * Listener invoked when a buffer has been added to a previously empty ready queue. The typical
-     * recipient is the owning InputChannel, which uses it to wake up the Task thread.
-     */
     @FunctionalInterface
     interface DataAvailableListener {
 
-        /** Called when a buffer becomes available for consumption. */
         void onDataAvailable();
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredBufferStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredBufferStore.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.consumer;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
+import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
+import org.apache.flink.runtime.checkpoint.channel.RecoveredBufferStoreCoordinator;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+
+/**
+ * Per-channel store for recovered buffers during unaligned checkpoint recovery. Buffers can be
+ * either in-memory (ready for consumption) or on disk (pending spill entries).
+ *
+ * <h3>Locking contract</h3>
+ *
+ * <p>The store's intrinsic monitor IS the channel-private lock. Callers MUST hold {@code synchronized
+ * (store)} when invoking the consumer-side query methods ({@link #tryTake}, {@link
+ * #peekNextDataType}, {@link #isEmpty}) and the setters ({@link #setCoordinator},
+ * {@link #setDataAvailableListener}). Implementations enforce this with an internal {@code assert
+ * Thread.holdsLock(this)} that fires under {@code -ea}.
+ *
+ * <p>{@link #size()} is exempt and lock-free: it is intended for metric / gate-bookkeeping paths
+ * that already tolerate a slightly stale read. Callers that need a consistent {@code isEmpty +
+ * size} pair must wrap both calls in a single {@code synchronized (store)} block themselves.
+ *
+ * <p>The lifecycle methods {@link #checkpoint}, {@link #releaseAll} and {@link
+ * #notifyCheckpointStopped} self-manage their store-level locking and fire any coordinator
+ * callback <em>outside</em> the lock to avoid deadlock with the coordinator's own synchronisation.
+ *
+ * <p>Use {@link #EMPTY} as a sentinel when no recovered data is present (non-filtering mode, or
+ * after recovery has fully drained), rather than holding {@code null} references. The sentinel's
+ * methods are no-ops; callers still wrap them in {@code synchronized (store)} to keep the same
+ * call shape regardless of which implementation backs the channel.
+ */
+@Internal
+public interface RecoveredBufferStore {
+
+    /**
+     * Singleton no-op store used when there is no recovered data for a channel. All query methods
+     * return their neutral/empty sentinel values; all mutating methods and callback setters are
+     * no-ops.
+     */
+    RecoveredBufferStore EMPTY = new EmptyRecoveredBufferStore();
+
+    /**
+     * Takes the next buffer from the store. Returns null if no ready buffer is available.
+     *
+     * @return the next buffer, or null if no ready buffer available
+     */
+    @Nullable
+    Buffer tryTake();
+
+    /**
+     * Peeks the data type of the next ready buffer without removing it.
+     *
+     * @return the data type of the next buffer, or {@link Buffer.DataType#NONE} if empty
+     */
+    Buffer.DataType peekNextDataType();
+
+    /** Returns true if the ready buffer queue is empty and no pending spill entries exist. */
+    boolean isEmpty();
+
+    /**
+     * Returns the total number of buffers held by this store for the bound channel: ready buffers
+     * already in memory plus pending entries currently spilled to disk. Callers use this for
+     * in-use / backlog accounting, which should reflect every buffer the recovery pipeline still
+     * owes the channel regardless of where it is physically stored.
+     */
+    int size();
+
+    /**
+     * Checkpoints the current store contents to the given ChannelStateWriter. Implementations
+     * should snapshot ready buffers first, then notify the registered {@link
+     * RecoveredBufferStoreCoordinator} (if any) <em>outside</em> any store-level lock to avoid
+     * deadlock with the coordinator's own synchronisation.
+     *
+     * <p>The store is bound to a single {@link InputChannelInfo} at construction time; both the
+     * snapshot and the coordinator notification use that bound channel info.
+     *
+     * @param writer the channel state writer to checkpoint to
+     * @param checkpointId the checkpoint ID
+     * @throws IOException if checkpointing fails
+     */
+    void checkpoint(ChannelStateWriter writer, long checkpointId) throws IOException;
+
+    /**
+     * Releases all buffers held in this store and clears all state. Before clearing local state,
+     * the registered {@link RecoveredBufferStoreCoordinator} (if any) is notified so the
+     * coordinator can drop any still-pending spill entries for this channel from disk.
+     */
+    void releaseAll();
+
+    /**
+     * Notifies the registered {@link RecoveredBufferStoreCoordinator} (if any) that the owning
+     * channel has finished or aborted the given checkpoint. The notification fires <em>outside</em>
+     * any store-level lock so the coordinator can safely acquire its own lock without deadlock.
+     *
+     * <p>Called from {@code ChannelStatePersister#stopPersisting}, which itself is invoked once on
+     * every channel both on checkpoint completion (all barriers received) and on checkpoint abort.
+     * The store does not maintain per-checkpoint state; the call is a pure passthrough so that
+     * cross-channel bookkeeping (such as a checkpoint wait-set) lives in the coordinator.
+     *
+     * @param checkpointId the ID of the checkpoint that just stopped for this channel
+     */
+    void notifyCheckpointStopped(long checkpointId);
+
+    /**
+     * Registers the {@link RecoveredBufferStoreCoordinator} that owns cross-channel bookkeeping
+     * (such as the checkpoint wait-set and disk-resident spill entries). The store invokes the
+     * coordinator from {@link #checkpoint}, {@link #notifyCheckpointStopped} and
+     * {@link #releaseAll} on lifecycle transitions. Do not call this method (or pass {@code null})
+     * when there is no coordinator.
+     *
+     * @param coordinator the coordinator to notify; replaces any previously registered coordinator
+     */
+    void setCoordinator(RecoveredBufferStoreCoordinator coordinator);
+
+    /**
+     * Registers a callback that is invoked when a buffer is added to a previously empty ready
+     * queue. Used to notify the InputChannel that data is available for consumption.
+     *
+     * @param listener the listener to invoke; replaces any previously registered listener
+     */
+    void setDataAvailableListener(DataAvailableListener listener);
+
+    /**
+     * Listener invoked when a buffer has been added to a previously empty ready queue. The typical
+     * recipient is the owning InputChannel, which uses it to wake up the Task thread.
+     */
+    @FunctionalInterface
+    interface DataAvailableListener {
+
+        /** Called when a buffer becomes available for consumption. */
+        void onDataAvailable();
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredBufferStoreImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredBufferStoreImpl.java
@@ -1,0 +1,408 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.consumer;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
+import org.apache.flink.runtime.checkpoint.channel.EntryPosition;
+import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
+import org.apache.flink.runtime.checkpoint.channel.RecoveredBufferStoreCoordinator;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.util.CloseableIterator;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Per-channel store for recovered buffers. Buffers are either ready (in-memory, available for
+ * consumption) or pending (on disk, tracked by count only — the actual spill entries are owned by
+ * FilteredBufferDispatcher).
+ *
+ * <h3>Locking contract</h3>
+ *
+ * <p>The store's intrinsic monitor ({@code this}) IS the channel-private lock. The store does NOT
+ * synchronise its own methods; callers must hold {@code synchronized (store)} when invoking any
+ * method marked {@link GuardedBy @GuardedBy("this")}. Each such method runs an
+ * {@code assert Thread.holdsLock(this)} so violations surface immediately under {@code -ea}.
+ *
+ * <p>{@link #size()} is the deliberate exception: it is a lock-free best-effort read that
+ * supports metric / gate-bookkeeping paths which tolerate a slightly stale value. It MUST NOT be
+ * combined with {@link #isEmpty()} to derive a stronger invariant unless the caller holds the
+ * store lock around both reads itself.
+ *
+ * <p>Two-phase methods ({@link #addBufferAndCaptureListener}, {@link
+ * #addBufferAfterDiskAndCaptureListener}, {@link #checkpoint}, {@link #releaseAll},
+ * {@link #notifyCheckpointStopped}) self-manage their own {@code synchronized (this)} block: they
+ * commit state inside the block and then fire any captured listener / coordinator callback after
+ * the block has been exited (capture-then-fire-outside).
+ *
+ * <h3>Lock order</h3>
+ *
+ * <p>Gate's {@code inputChannelsWithData} → channel store. The capture-then-fire-outside protocol
+ * exists so the producer side can publish a buffer (taking the store lock) and only afterwards
+ * traverse the gate-side notify path (which acquires the gate lock); without it the producer would
+ * form an AB-BA deadlock with the consumer (gate → store).
+ *
+ * <h3>Thread roles</h3>
+ *
+ * <p>Public consumer methods are driven by the Task thread. Producer-side mutators ({@link
+ * #addBuffer}, {@link #addBufferAfterDisk}, {@link #incrementPending}) are called from the
+ * Recovery thread via FilteredBufferDispatcher.
+ */
+@Internal
+public class RecoveredBufferStoreImpl implements RecoveredBufferStore {
+
+    private final InputChannelInfo channelInfo;
+
+    @GuardedBy("this")
+    private final ArrayDeque<Buffer> readyBuffers = new ArrayDeque<>();
+
+    @GuardedBy("this")
+    private int pendingCount = 0;
+
+    /**
+     * Buffers that must only become consumer-visible <em>after</em> all on-disk pending entries
+     * have been drained. Used for finish/control events (currently only the per-channel
+     * {@link org.apache.flink.runtime.io.network.partition.consumer.EndOfInputChannelStateEvent})
+     * whose contract is "everything before me has been delivered". When {@link #pendingCount}
+     * drops to zero inside {@link #addBufferAndCaptureListener}, the deferred buffers are
+     * atomically promoted into {@link #readyBuffers} so the consumer sees them strictly after the
+     * last drained spill entry — a logical FIFO that does not require routing events through the
+     * spill path.
+     *
+     * <p>Not counted as part of the public {@link #size()} / {@link #isEmpty()} surface: while
+     * something is deferred, {@code pendingCount > 0} already keeps the store non-empty; the
+     * promotion to {@code readyBuffers} happens in the same critical section that drops
+     * {@code pendingCount} to zero, so the store is never observed as "empty with deferred
+     * buffers still hidden".
+     */
+    @GuardedBy("this")
+    private final ArrayDeque<Buffer> deferredBuffers = new ArrayDeque<>();
+
+    private volatile boolean released = false;
+
+    @GuardedBy("this")
+    private DataAvailableListener dataAvailableListener;
+
+    @GuardedBy("this")
+    private RecoveredBufferStoreCoordinator coordinator;
+
+    /**
+     * Creates a store bound to a single input channel. The bound {@link InputChannelInfo} is used
+     * when persisting ready buffers during checkpoint and when notifying the checkpoint listener.
+     */
+    public RecoveredBufferStoreImpl(InputChannelInfo channelInfo) {
+        this.channelInfo = checkNotNull(channelInfo);
+    }
+
+    /** Returns the input channel this store is bound to. */
+    public InputChannelInfo getChannelInfo() {
+        return channelInfo;
+    }
+
+    // ---------------------------------------------------------------------------
+    // Public interface methods (Task thread)
+    // ---------------------------------------------------------------------------
+
+    @Nullable
+    @Override
+    @GuardedBy("this")
+    public Buffer tryTake() {
+        assert Thread.holdsLock(this);
+        return readyBuffers.poll();
+    }
+
+    @Override
+    @GuardedBy("this")
+    public Buffer.DataType peekNextDataType() {
+        assert Thread.holdsLock(this);
+        Buffer peeked = readyBuffers.peek();
+        return peeked != null ? peeked.getDataType() : Buffer.DataType.NONE;
+    }
+
+    @Override
+    @GuardedBy("this")
+    public boolean isEmpty() {
+        assert Thread.holdsLock(this);
+        return readyBuffers.isEmpty() && pendingCount == 0;
+    }
+
+    /**
+     * Lock-free best-effort read used by metric and gate-bookkeeping paths that can tolerate a
+     * slightly stale value. Both reads ({@code readyBuffers.size()} and {@code pendingCount}) are
+     * single-word and the worst observable inconsistency is "size off by 1 vs. the actual state",
+     * which is exactly what every other {@code unsynchronizedGetNumberOfQueuedBuffers} caller
+     * already accepts. Callers that need a consistent {@code isEmpty + size} pair must take the
+     * store lock around both calls themselves.
+     */
+    @Override
+    public int size() {
+        return readyBuffers.size() + pendingCount;
+    }
+
+    /**
+     * Checkpoints the ready buffers to the given ChannelStateWriter. Ready buffers are retained and
+     * passed to the writer via CloseableIterator. After snapshotting, the registered {@link
+     * RecoveredBufferStoreCoordinator} is notified <em>outside</em> the store lock so the
+     * coordinator can safely acquire its own lock without risking a deadlock.
+     *
+     * <p>Pending spill entries on disk are checkpointed by the coordinator, which owns the spill
+     * entries and file readers, triggered via
+     * {@link RecoveredBufferStoreCoordinator#onChannelCheckpointStarted}.
+     */
+    @Override
+    public void checkpoint(ChannelStateWriter writer, long checkpointId) throws IOException {
+        // Step 1: snapshot ready buffers AND read the coordinator's current drain head atomically
+        // under the store lock. Both reads must be a single consistent observation: the per-channel
+        // phase-2 filter compares each spill entry's position against the captured drain head, so
+        // any entry the drain bundle adds to readyBuffers after this point must also have advanced
+        // the drain head past its position before this snapshot was taken (drain bundle commits
+        // addBuffer + drainHead update atomically under the same store lock for the entry's
+        // channel; cross-channel visibility is provided by the volatile drain head).
+        RecoveredBufferStoreCoordinator c;
+        EntryPosition startPos;
+        synchronized (this) {
+            c = coordinator;
+            startPos = c != null ? c.getCurrentDrainHead() : EntryPosition.END;
+            if (!readyBuffers.isEmpty()) {
+                // Mirror RemoteInputChannel#getInflightBuffersUnsafe: only data buffers belong
+                // in the persisted in-flight channel state. Non-data entries in readyBuffers
+                // (notably the EndOfInputChannelStateEvent that finishReadRecoveredState pushes
+                // and that the task may not yet have consumed when CDR transitions to RUNNING
+                // before stateConsumedFuture completes) are control signals — passing them to
+                // ChannelStateWriteRequest#checkBufferIsBuffer kills the writer worker thread
+                // (IllegalArgumentException), which then surfaces on every subsequent enqueue
+                // as "not running". Events stay in readyBuffers and are recycled later by the
+                // task's normal tryTake path.
+                List<Buffer> retained = new ArrayList<>(readyBuffers.size());
+                for (Buffer buffer : readyBuffers) {
+                    if (buffer.isBuffer()) {
+                        retained.add(buffer.retainBuffer());
+                    }
+                }
+                if (!retained.isEmpty()) {
+                    writer.addInputData(
+                            checkpointId,
+                            channelInfo,
+                            ChannelStateWriter.SEQUENCE_NUMBER_RESTORED,
+                            CloseableIterator.fromList(retained, Buffer::recycleBuffer));
+                }
+            }
+        }
+
+        // Step 2: notify the coordinator outside the store lock to avoid deadlock with the
+        // coordinator's own synchronisation. The captured startPos is forwarded so the coordinator
+        // can record the per-channel cutoff for phase-2 filtering.
+        if (c != null) {
+            c.onChannelCheckpointStarted(checkpointId, channelInfo, startPos);
+        }
+    }
+
+    @Override
+    public void releaseAll() {
+        // Step 1: flip the released flag and recycle ready / deferred buffers under lock; capture
+        // the coordinator reference for invocation outside the lock.
+        RecoveredBufferStoreCoordinator c;
+        synchronized (this) {
+            released = true;
+            for (Buffer buffer : readyBuffers) {
+                buffer.recycleBuffer();
+            }
+            readyBuffers.clear();
+            for (Buffer buffer : deferredBuffers) {
+                buffer.recycleBuffer();
+            }
+            deferredBuffers.clear();
+            pendingCount = 0;
+            c = coordinator;
+        }
+
+        // Step 2: notify the coordinator outside the store lock so the coordinator can safely
+        // acquire its own lock to drop disk-resident spill entries for this channel.
+        if (c != null) {
+            c.onChannelReleased(channelInfo);
+        }
+    }
+
+    @Override
+    public void notifyCheckpointStopped(long checkpointId) {
+        // Capture the coordinator reference under lock; fire the notification outside so the
+        // coordinator can safely acquire its own synchronisation without risking deadlock.
+        RecoveredBufferStoreCoordinator c;
+        synchronized (this) {
+            c = coordinator;
+        }
+        if (c != null) {
+            c.onChannelCheckpointStopped(checkpointId, channelInfo);
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Setters (interface methods)
+    // ---------------------------------------------------------------------------
+
+    @Override
+    @GuardedBy("this")
+    public void setCoordinator(RecoveredBufferStoreCoordinator coordinator) {
+        assert Thread.holdsLock(this);
+        this.coordinator = coordinator;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The notification listener fires when a buffer is added to a previously empty ready queue,
+     * waking up the Task thread waiting for data.
+     */
+    @Override
+    @GuardedBy("this")
+    public void setDataAvailableListener(DataAvailableListener listener) {
+        assert Thread.holdsLock(this);
+        this.dataAvailableListener = listener;
+    }
+
+    // ---------------------------------------------------------------------------
+    // Internal methods (Recovery thread, called by FilteredBufferDispatcher)
+    // ---------------------------------------------------------------------------
+
+    /**
+     * Adds a recovered buffer to the ready queue. If the queue was previously empty, the
+     * notification listener is invoked to wake up the Task thread.
+     *
+     * <p>The listener is invoked <em>outside</em> the store monitor: the listener path goes through
+     * {@code SingleInputGate.queueChannel}, which acquires the gate's {@code inputChannelsWithData}
+     * monitor. A task thread holding that monitor while peeking the store would otherwise form an
+     * AB-BA deadlock with this method. Lock-order matches the two-phase pattern used by
+     * {@link #checkpoint}, {@link #releaseAll} and {@link #notifyCheckpointStopped}.
+     *
+     * <p>Callers that wrap this method in their own {@code synchronized(store)} block must instead
+     * use {@link #addBufferAndCaptureListener(Buffer)} and fire the returned listener after exiting
+     * that outer block — otherwise the listener still runs while the outer lock is held and the
+     * AB-BA risk reappears.
+     */
+    public void addBuffer(Buffer buffer) {
+        DataAvailableListener listenerToFire = addBufferAndCaptureListener(buffer);
+        if (listenerToFire != null) {
+            listenerToFire.onDataAvailable();
+        }
+    }
+
+    /**
+     * Variant of {@link #addBuffer(Buffer)} that captures the data-available listener inside the
+     * store monitor and returns it instead of firing it. Callers must invoke {@code
+     * onDataAvailable()} on the returned listener (if non-null) <em>after</em> releasing any outer
+     * lock that orders before the gate's {@code inputChannelsWithData} monitor — otherwise the
+     * listener would run while that outer lock is held and re-introduce the AB-BA deadlock with
+     * the task thread (gate lock → store lock).
+     *
+     * <p>If {@link #pendingCount} is non-zero when this method is called, the buffer being added
+     * is necessarily a drained spill entry (the only producer path into a non-idle store goes
+     * through the dispatcher's drain), so {@code pendingCount} is decremented here. When that
+     * decrement reaches zero, any {@link #deferredBuffers} are promoted into {@link #readyBuffers}
+     * in the same critical section.
+     *
+     * @return the listener to fire, or {@code null} if no notification is needed (queue was already
+     *     non-empty, no listener registered, or the store has been released)
+     */
+    @Nullable
+    public DataAvailableListener addBufferAndCaptureListener(Buffer buffer) {
+        synchronized (this) {
+            if (released) {
+                buffer.recycleBuffer();
+                return null;
+            }
+            boolean wasEmpty = readyBuffers.isEmpty();
+            readyBuffers.add(buffer);
+            if (pendingCount > 0) {
+                pendingCount--;
+                if (pendingCount == 0 && !deferredBuffers.isEmpty()) {
+                    while (!deferredBuffers.isEmpty()) {
+                        readyBuffers.add(deferredBuffers.pollFirst());
+                    }
+                }
+            }
+            return wasEmpty ? dataAvailableListener : null;
+        }
+    }
+
+    /**
+     * Increments the pending spill entry count. Called when FilteredBufferDispatcher spills data to
+     * disk; the matching decrement happens implicitly inside {@link #addBufferAndCaptureListener}
+     * when the spill entry is drained back into a buffer.
+     */
+    @GuardedBy("this")
+    public void incrementPending() {
+        assert Thread.holdsLock(this);
+        pendingCount++;
+    }
+
+    /**
+     * Adds a buffer that must only become consumer-visible after all on-disk entries have been
+     * drained. If no spill entries are pending, the buffer is delivered immediately as a normal
+     * ready buffer. Otherwise it is held in {@link #deferredBuffers} and atomically promoted by
+     * {@link #addBufferAndCaptureListener(Buffer)} when the count reaches zero.
+     *
+     * <p>Used by {@code RecoveredInputChannel#finishReadRecoveredState} to publish the per-channel
+     * {@code EndOfInputChannelStateEvent} so the event always lands strictly after the last
+     * recovered data buffer for the channel — preserving the contract "all data has been read"
+     * without needing the event to traverse the dispatcher's spill path.
+     *
+     * <p>The listener is invoked <em>outside</em> the store monitor for the same lock-order
+     * reasons documented on {@link #addBuffer}.
+     *
+     * <p>Callers that wrap this method in their own {@code synchronized(store)} block must instead
+     * use {@link #addBufferAfterDiskAndCaptureListener(Buffer)} and fire the returned listener
+     * after exiting that outer block.
+     */
+    public void addBufferAfterDisk(Buffer buffer) {
+        DataAvailableListener listenerToFire = addBufferAfterDiskAndCaptureListener(buffer);
+        if (listenerToFire != null) {
+            listenerToFire.onDataAvailable();
+        }
+    }
+
+    /**
+     * Variant of {@link #addBufferAfterDisk(Buffer)} that captures the data-available listener
+     * inside the store monitor and returns it instead of firing it. Same lock-order constraints as
+     * {@link #addBufferAndCaptureListener(Buffer)} apply to the caller.
+     */
+    @Nullable
+    public DataAvailableListener addBufferAfterDiskAndCaptureListener(Buffer buffer) {
+        synchronized (this) {
+            if (released) {
+                buffer.recycleBuffer();
+                return null;
+            }
+            if (pendingCount == 0) {
+                boolean wasEmpty = readyBuffers.isEmpty();
+                readyBuffers.add(buffer);
+                return wasEmpty ? dataAvailableListener : null;
+            } else {
+                deferredBuffers.add(buffer);
+                return null;
+            }
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredBufferStoreImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredBufferStoreImpl.java
@@ -41,20 +41,20 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *
  * <h3>Locking</h3>
  *
- * <p>The store's intrinsic monitor IS the channel-private lock. Methods marked
- * {@link GuardedBy @GuardedBy("this")} require the caller to hold {@code synchronized(store)};
- * each runs {@code assert Thread.holdsLock(this)}. {@link #size()} is the deliberate exception
- * (lock-free best-effort).
+ * <p>The store's intrinsic monitor IS the channel-private lock. Methods marked {@link
+ * GuardedBy @GuardedBy("this")} require the caller to hold {@code synchronized(store)}; each runs
+ * {@code assert Thread.holdsLock(this)}. {@link #size()} is the deliberate exception (lock-free
+ * best-effort).
  *
  * <p>Two-phase methods ({@code *AndCaptureListener}, {@link #checkpoint}, {@link #releaseAll},
  * {@link #notifyCheckpointStopped}) self-manage their critical section and fire any captured
- * listener / coordinator callback after exiting the lock. This capture-then-fire-outside
- * protocol respects the lock order {@code gate.inputChannelsWithData → store}; firing inside
- * the store lock would form an AB-BA cycle with the consumer side.
+ * listener / coordinator callback after exiting the lock. This capture-then-fire-outside protocol
+ * respects the lock order {@code gate.inputChannelsWithData → store}; firing inside the store lock
+ * would form an AB-BA cycle with the consumer side.
  *
- * <p>Consumer methods run on the Task thread; producer-side mutators
- * ({@link #addBuffer}, {@link #addBufferAfterDisk}, {@link #incrementPending}) run on the
- * Recovery thread via FilteredBufferDispatcher.
+ * <p>Consumer methods run on the Task thread; producer-side mutators ({@link #addBuffer}, {@link
+ * #addBufferAfterDisk}, {@link #incrementPending}) run on the Recovery thread via
+ * FilteredBufferDispatcher.
  */
 @Internal
 public class RecoveredBufferStoreImpl implements RecoveredBufferStore {
@@ -71,9 +71,9 @@ public class RecoveredBufferStoreImpl implements RecoveredBufferStore {
      * Buffers visible to the consumer only after all on-disk entries have been drained. Used for
      * finish/control events whose contract is "everything before me has been delivered" (currently
      * {@link EndOfInputChannelStateEvent}). Atomically promoted into {@link #readyBuffers} when
-     * {@link #pendingCount} reaches zero — a logical FIFO without routing events through the
-     * spill path. Not counted in {@link #size()} / {@link #isEmpty()}: while something is
-     * deferred, {@code pendingCount > 0} already keeps the store non-empty.
+     * {@link #pendingCount} reaches zero — a logical FIFO without routing events through the spill
+     * path. Not counted in {@link #size()} / {@link #isEmpty()}: while something is deferred,
+     * {@code pendingCount > 0} already keeps the store non-empty.
      */
     @GuardedBy("this")
     private final ArrayDeque<Buffer> deferredBuffers = new ArrayDeque<>();
@@ -214,9 +214,9 @@ public class RecoveredBufferStoreImpl implements RecoveredBufferStore {
 
     /**
      * Adds a recovered buffer to the ready queue. The listener fires <em>outside</em> the store
-     * monitor (gate → store lock-order). Callers that already hold {@code synchronized(store)}
-     * must use {@link #addBufferAndCaptureListener(Buffer)} and fire the listener after releasing
-     * that outer lock to avoid AB-BA deadlock.
+     * monitor (gate → store lock-order). Callers that already hold {@code synchronized(store)} must
+     * use {@link #addBufferAndCaptureListener(Buffer)} and fire the listener after releasing that
+     * outer lock to avoid AB-BA deadlock.
      */
     public void addBuffer(Buffer buffer) {
         DataAvailableListener listenerToFire = addBufferAndCaptureListener(buffer);
@@ -268,12 +268,12 @@ public class RecoveredBufferStoreImpl implements RecoveredBufferStore {
     }
 
     /**
-     * Adds a buffer that becomes consumer-visible only after all on-disk entries have been
-     * drained: delivered as a normal ready buffer when {@code pendingCount == 0}, otherwise held
-     * in {@link #deferredBuffers} and promoted when the count reaches zero. Used by
-     * {@code RecoveredInputChannel#finishReadRecoveredState} to publish
-     * {@code EndOfInputChannelStateEvent} so it always lands after the last recovered data buffer
-     * — without routing the event through the spill path.
+     * Adds a buffer that becomes consumer-visible only after all on-disk entries have been drained:
+     * delivered as a normal ready buffer when {@code pendingCount == 0}, otherwise held in {@link
+     * #deferredBuffers} and promoted when the count reaches zero. Used by {@code
+     * RecoveredInputChannel#finishReadRecoveredState} to publish {@code
+     * EndOfInputChannelStateEvent} so it always lands after the last recovered data buffer —
+     * without routing the event through the spill path.
      */
     public void addBufferAfterDisk(Buffer buffer) {
         DataAvailableListener listenerToFire = addBufferAfterDiskAndCaptureListener(buffer);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredBufferStoreImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredBufferStoreImpl.java
@@ -18,6 +18,7 @@
 package org.apache.flink.runtime.io.network.partition.consumer;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.checkpoint.channel.EntryPosition;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
@@ -41,25 +42,45 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *
  * <h3>Locking</h3>
  *
- * <p>The store's intrinsic monitor IS the channel-private lock. Methods marked {@link
- * GuardedBy @GuardedBy("this")} require the caller to hold {@code synchronized(store)}; each runs
- * {@code assert Thread.holdsLock(this)}. {@link #size()} is the deliberate exception (lock-free
- * best-effort).
+ * <p>Two monitors guard the race-relevant paths: the owning gate's lock (returned by {@code
+ * SingleInputGate#getGateLock()}, henceforth <i>gate lock</i>) and this store's intrinsic monitor.
+ * The acquisition order is always {@code gate → store}; the same order is enforced by the consumer
+ * (task read), the producer (drain / EOICS publish) and conversion ({@code
+ * SingleInputGate#convertRecoveredInputChannels}). This is what closes the FLINK-39519
+ * stale-enqueue race: producer add+fire and conversion's listener replace + {@code channels[i]}
+ * swap are serialised through the same gate lock.
  *
- * <p>Two-phase methods ({@code *AndCaptureListener}, {@link #checkpoint}, {@link #releaseAll},
- * {@link #notifyCheckpointStopped}) self-manage their critical section and fire any captured
- * listener / coordinator callback after exiting the lock. This capture-then-fire-outside protocol
- * respects the lock order {@code gate.inputChannelsWithData → store}; firing inside the store lock
- * would form an AB-BA cycle with the consumer side.
+ * <p>Per-method contracts (each one's preconditions are restated as {@code assert}s at the entry):
  *
- * <p>Consumer methods run on the Task thread; producer-side mutators ({@link #addBuffer}, {@link
- * #addBufferAfterDisk}, {@link #incrementPending}) run on the Recovery thread via
- * FilteredBufferDispatcher.
+ * <ul>
+ *   <li><b>Producer mutators</b> ({@link #addBuffer}, {@link #addBufferAfterDisk}): caller holds
+ *       the gate lock; the store self-manages its own monitor and fires the data-available
+ *       listener inline. Firing inside the store monitor is safe because the gate lock is held by
+ *       the caller, so {@code queueChannel} re-acquires it as a recursive intrinsic-monitor entry
+ *       — no AB-BA cycle.
+ *   <li><b>Race-path readers / setter</b> ({@link #tryTake}, {@link #peekNextDataType}, {@link
+ *       #setDataAvailableListener}): {@code @GuardedBy("this")} — caller wraps the call in {@code
+ *       synchronized(store)} so compound operations such as {@code tryTake() + peekNextDataType()}
+ *       observe a consistent snapshot — and additionally holds the gate lock so the {@code gate →
+ *       store} order is explicit.
+ *   <li><b>Store-only readers / mutators</b> ({@link #isEmpty}, {@link #setCoordinator}, {@link
+ *       #incrementPending}): {@code @GuardedBy("this")} only. {@link #isEmpty} is consulted from
+ *       {@code RemoteInputChannel#onSenderBacklog} on the netty event loop where the gate lock is
+ *       not held; {@link #setCoordinator} / {@link #incrementPending} run before the recovery
+ *       flush, off the race path.
+ *   <li><b>Lifecycle / coordinator</b> ({@link #checkpoint}, {@link #releaseAll}, {@link
+ *       #notifyCheckpointStopped}): self-manage the store monitor and fire any captured
+ *       coordinator callback after exiting the lock. Independent of the producer/consumer hot
+ *       path.
+ *   <li>{@link #size()} is a deliberate lock-free best-effort read.
+ * </ul>
  */
 @Internal
 public class RecoveredBufferStoreImpl implements RecoveredBufferStore {
 
     private final InputChannelInfo channelInfo;
+
+    private final Object gateLock;
 
     @GuardedBy("this")
     private final ArrayDeque<Buffer> readyBuffers = new ArrayDeque<>();
@@ -68,12 +89,10 @@ public class RecoveredBufferStoreImpl implements RecoveredBufferStore {
     private int pendingCount = 0;
 
     /**
-     * Buffers visible to the consumer only after all on-disk entries have been drained. Used for
-     * finish/control events whose contract is "everything before me has been delivered" (currently
-     * {@link EndOfInputChannelStateEvent}). Atomically promoted into {@link #readyBuffers} when
-     * {@link #pendingCount} reaches zero — a logical FIFO without routing events through the spill
-     * path. Not counted in {@link #size()} / {@link #isEmpty()}: while something is deferred,
-     * {@code pendingCount > 0} already keeps the store non-empty.
+     * Holds buffers whose contract is "everything before me has been delivered" (e.g.
+     * {@link EndOfInputChannelStateEvent}) until {@link #pendingCount} reaches zero, then promotes
+     * them into {@link #readyBuffers}. Excluded from {@link #size()} / {@link #isEmpty()}: while
+     * something is deferred, {@code pendingCount > 0} already keeps the store non-empty.
      */
     @GuardedBy("this")
     private final ArrayDeque<Buffer> deferredBuffers = new ArrayDeque<>();
@@ -86,12 +105,24 @@ public class RecoveredBufferStoreImpl implements RecoveredBufferStore {
     @GuardedBy("this")
     private RecoveredBufferStoreCoordinator coordinator;
 
+    public RecoveredBufferStoreImpl(InputChannelInfo channelInfo, Object gateLock) {
+        this.channelInfo = checkNotNull(channelInfo);
+        this.gateLock = checkNotNull(gateLock);
+    }
+
+    /** Test-only: ties {@code gateLock} to the store itself so {@code synchronized(store)} alone satisfies both preconditions. */
+    @VisibleForTesting
     public RecoveredBufferStoreImpl(InputChannelInfo channelInfo) {
         this.channelInfo = checkNotNull(channelInfo);
+        this.gateLock = this;
     }
 
     public InputChannelInfo getChannelInfo() {
         return channelInfo;
+    }
+
+    public Object getGateLock() {
+        return gateLock;
     }
 
     @Nullable
@@ -99,6 +130,7 @@ public class RecoveredBufferStoreImpl implements RecoveredBufferStore {
     @GuardedBy("this")
     public Buffer tryTake() {
         assert Thread.holdsLock(this);
+        assert Thread.holdsLock(gateLock);
         return readyBuffers.poll();
     }
 
@@ -106,6 +138,7 @@ public class RecoveredBufferStoreImpl implements RecoveredBufferStore {
     @GuardedBy("this")
     public Buffer.DataType peekNextDataType() {
         assert Thread.holdsLock(this);
+        assert Thread.holdsLock(gateLock);
         Buffer peeked = readyBuffers.peek();
         return peeked != null ? peeked.getDataType() : Buffer.DataType.NONE;
     }
@@ -117,33 +150,21 @@ public class RecoveredBufferStoreImpl implements RecoveredBufferStore {
         return readyBuffers.isEmpty() && pendingCount == 0;
     }
 
-    /** Lock-free best-effort read; see class javadoc. */
     @Override
     public int size() {
         return readyBuffers.size() + pendingCount;
     }
 
-    /**
-     * Snapshots ready buffers to {@code writer}, then notifies the coordinator outside the store
-     * lock. Pending spill entries on disk are checkpointed by the coordinator (which owns them),
-     * triggered via {@link RecoveredBufferStoreCoordinator#onChannelCheckpointStarted}.
-     */
     @Override
     public void checkpoint(ChannelStateWriter writer, long checkpointId) throws IOException {
-        // Snapshot ready buffers AND read drainHead atomically under the store lock. The drain
-        // bundle commits addBuffer + drainHead update under the same store lock, so any entry
-        // added after this point has already advanced drainHead past its position; cross-channel
-        // visibility is provided by the volatile drainHead read.
         RecoveredBufferStoreCoordinator c;
         EntryPosition startPos;
         synchronized (this) {
             c = coordinator;
             startPos = c != null ? c.getCurrentDrainHead() : EntryPosition.END;
             if (!readyBuffers.isEmpty()) {
-                // Only data buffers belong in persisted in-flight state. Skip non-data entries
-                // (notably EndOfInputChannelStateEvent which finishReadRecoveredState pushes
-                // ahead of the task consuming it) — they would be rejected by
-                // ChannelStateWriteRequest#checkBufferIsBuffer and kill the writer thread.
+                // Skip non-data entries (notably EndOfInputChannelStateEvent): they would be
+                // rejected by ChannelStateWriteRequest#checkBufferIsBuffer and kill the writer.
                 List<Buffer> retained = new ArrayList<>(readyBuffers.size());
                 for (Buffer buffer : readyBuffers) {
                     if (buffer.isBuffer()) {
@@ -209,39 +230,17 @@ public class RecoveredBufferStoreImpl implements RecoveredBufferStore {
     @GuardedBy("this")
     public void setDataAvailableListener(DataAvailableListener listener) {
         assert Thread.holdsLock(this);
+        assert Thread.holdsLock(gateLock);
         this.dataAvailableListener = listener;
     }
 
-    /**
-     * Adds a recovered buffer to the ready queue. The listener fires <em>outside</em> the store
-     * monitor (gate → store lock-order). Callers that already hold {@code synchronized(store)} must
-     * use {@link #addBufferAndCaptureListener(Buffer)} and fire the listener after releasing that
-     * outer lock to avoid AB-BA deadlock.
-     */
     public void addBuffer(Buffer buffer) {
-        DataAvailableListener listenerToFire = addBufferAndCaptureListener(buffer);
-        if (listenerToFire != null) {
-            listenerToFire.onDataAvailable();
-        }
-    }
-
-    /**
-     * Captures the data-available listener inside the store monitor and returns it. Caller must
-     * fire it after releasing any outer lock ordered before the gate monitor.
-     *
-     * <p>When {@link #pendingCount} is non-zero, the buffer is necessarily a drained spill entry
-     * (only producer path into a non-idle store goes through dispatcher drain), so the count is
-     * decremented here; reaching zero promotes {@link #deferredBuffers} into {@link #readyBuffers}
-     * in the same critical section.
-     *
-     * @return listener to fire, or {@code null} if no notification is needed
-     */
-    @Nullable
-    public DataAvailableListener addBufferAndCaptureListener(Buffer buffer) {
+        assert Thread.holdsLock(gateLock);
+        DataAvailableListener listenerToFire;
         synchronized (this) {
             if (released) {
                 buffer.recycleBuffer();
-                return null;
+                return;
             }
             boolean wasEmpty = readyBuffers.isEmpty();
             readyBuffers.add(buffer);
@@ -253,14 +252,14 @@ public class RecoveredBufferStoreImpl implements RecoveredBufferStore {
                     }
                 }
             }
-            return wasEmpty ? dataAvailableListener : null;
+            listenerToFire = wasEmpty ? dataAvailableListener : null;
+        }
+        if (listenerToFire != null) {
+            listenerToFire.onDataAvailable();
         }
     }
 
-    /**
-     * Called when FilteredBufferDispatcher spills data; the matching decrement happens implicitly
-     * inside {@link #addBufferAndCaptureListener} when the entry is drained back into a buffer.
-     */
+    /** Counterpart of {@link #addBuffer}: increments the pending-on-disk counter for a spill. */
     @GuardedBy("this")
     public void incrementPending() {
         assert Thread.holdsLock(this);
@@ -268,36 +267,29 @@ public class RecoveredBufferStoreImpl implements RecoveredBufferStore {
     }
 
     /**
-     * Adds a buffer that becomes consumer-visible only after all on-disk entries have been drained:
-     * delivered as a normal ready buffer when {@code pendingCount == 0}, otherwise held in {@link
-     * #deferredBuffers} and promoted when the count reaches zero. Used by {@code
-     * RecoveredInputChannel#finishReadRecoveredState} to publish {@code
-     * EndOfInputChannelStateEvent} so it always lands after the last recovered data buffer —
-     * without routing the event through the spill path.
+     * Adds a buffer that becomes consumer-visible only after all on-disk entries have been drained.
+     * Used to publish {@code EndOfInputChannelStateEvent} so it always lands after the last
+     * recovered data buffer — without routing the event through the spill path.
      */
     public void addBufferAfterDisk(Buffer buffer) {
-        DataAvailableListener listenerToFire = addBufferAfterDiskAndCaptureListener(buffer);
-        if (listenerToFire != null) {
-            listenerToFire.onDataAvailable();
-        }
-    }
-
-    /** Capture-then-fire variant of {@link #addBufferAfterDisk(Buffer)}. */
-    @Nullable
-    public DataAvailableListener addBufferAfterDiskAndCaptureListener(Buffer buffer) {
+        assert Thread.holdsLock(gateLock);
+        DataAvailableListener listenerToFire;
         synchronized (this) {
             if (released) {
                 buffer.recycleBuffer();
-                return null;
+                return;
             }
             if (pendingCount == 0) {
                 boolean wasEmpty = readyBuffers.isEmpty();
                 readyBuffers.add(buffer);
-                return wasEmpty ? dataAvailableListener : null;
+                listenerToFire = wasEmpty ? dataAvailableListener : null;
             } else {
                 deferredBuffers.add(buffer);
-                return null;
+                listenerToFire = null;
             }
+        }
+        if (listenerToFire != null) {
+            listenerToFire.onDataAvailable();
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredBufferStoreImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredBufferStoreImpl.java
@@ -54,10 +54,10 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *
  * <ul>
  *   <li><b>Producer mutators</b> ({@link #addBuffer}, {@link #addBufferAfterDisk}): caller holds
- *       the gate lock; the store self-manages its own monitor and fires the data-available
- *       listener inline. Firing inside the store monitor is safe because the gate lock is held by
- *       the caller, so {@code queueChannel} re-acquires it as a recursive intrinsic-monitor entry
- *       — no AB-BA cycle.
+ *       the gate lock; the store self-manages its own monitor and fires the data-available listener
+ *       inline. Firing inside the store monitor is safe because the gate lock is held by the
+ *       caller, so {@code queueChannel} re-acquires it as a recursive intrinsic-monitor entry — no
+ *       AB-BA cycle.
  *   <li><b>Race-path readers / setter</b> ({@link #tryTake}, {@link #peekNextDataType}, {@link
  *       #setDataAvailableListener}): {@code @GuardedBy("this")} — caller wraps the call in {@code
  *       synchronized(store)} so compound operations such as {@code tryTake() + peekNextDataType()}
@@ -69,9 +69,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *       not held; {@link #setCoordinator} / {@link #incrementPending} run before the recovery
  *       flush, off the race path.
  *   <li><b>Lifecycle / coordinator</b> ({@link #checkpoint}, {@link #releaseAll}, {@link
- *       #notifyCheckpointStopped}): self-manage the store monitor and fire any captured
- *       coordinator callback after exiting the lock. Independent of the producer/consumer hot
- *       path.
+ *       #notifyCheckpointStopped}): self-manage the store monitor and fire any captured coordinator
+ *       callback after exiting the lock. Independent of the producer/consumer hot path.
  *   <li>{@link #size()} is a deliberate lock-free best-effort read.
  * </ul>
  */
@@ -89,9 +88,9 @@ public class RecoveredBufferStoreImpl implements RecoveredBufferStore {
     private int pendingCount = 0;
 
     /**
-     * Holds buffers whose contract is "everything before me has been delivered" (e.g.
-     * {@link EndOfInputChannelStateEvent}) until {@link #pendingCount} reaches zero, then promotes
-     * them into {@link #readyBuffers}. Excluded from {@link #size()} / {@link #isEmpty()}: while
+     * Holds buffers whose contract is "everything before me has been delivered" (e.g. {@link
+     * EndOfInputChannelStateEvent}) until {@link #pendingCount} reaches zero, then promotes them
+     * into {@link #readyBuffers}. Excluded from {@link #size()} / {@link #isEmpty()}: while
      * something is deferred, {@code pendingCount > 0} already keeps the store non-empty.
      */
     @GuardedBy("this")
@@ -110,7 +109,10 @@ public class RecoveredBufferStoreImpl implements RecoveredBufferStore {
         this.gateLock = checkNotNull(gateLock);
     }
 
-    /** Test-only: ties {@code gateLock} to the store itself so {@code synchronized(store)} alone satisfies both preconditions. */
+    /**
+     * Test-only: ties {@code gateLock} to the store itself so {@code synchronized(store)} alone
+     * satisfies both preconditions.
+     */
     @VisibleForTesting
     public RecoveredBufferStoreImpl(InputChannelInfo channelInfo) {
         this.channelInfo = checkNotNull(channelInfo);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredBufferStoreImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredBufferStoreImpl.java
@@ -36,39 +36,24 @@ import java.util.List;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
- * Per-channel store for recovered buffers. Buffers are either ready (in-memory, available for
- * consumption) or pending (on disk, tracked by count only — the actual spill entries are owned by
- * FilteredBufferDispatcher).
+ * Per-channel store for recovered buffers. Buffers are either ready (in-memory) or pending (on
+ * disk, tracked by count only — the actual entries are owned by FilteredBufferDispatcher).
  *
- * <h3>Locking contract</h3>
+ * <h3>Locking</h3>
  *
- * <p>The store's intrinsic monitor ({@code this}) IS the channel-private lock. The store does NOT
- * synchronise its own methods; callers must hold {@code synchronized (store)} when invoking any
- * method marked {@link GuardedBy @GuardedBy("this")}. Each such method runs an
- * {@code assert Thread.holdsLock(this)} so violations surface immediately under {@code -ea}.
+ * <p>The store's intrinsic monitor IS the channel-private lock. Methods marked
+ * {@link GuardedBy @GuardedBy("this")} require the caller to hold {@code synchronized(store)};
+ * each runs {@code assert Thread.holdsLock(this)}. {@link #size()} is the deliberate exception
+ * (lock-free best-effort).
  *
- * <p>{@link #size()} is the deliberate exception: it is a lock-free best-effort read that
- * supports metric / gate-bookkeeping paths which tolerate a slightly stale value. It MUST NOT be
- * combined with {@link #isEmpty()} to derive a stronger invariant unless the caller holds the
- * store lock around both reads itself.
+ * <p>Two-phase methods ({@code *AndCaptureListener}, {@link #checkpoint}, {@link #releaseAll},
+ * {@link #notifyCheckpointStopped}) self-manage their critical section and fire any captured
+ * listener / coordinator callback after exiting the lock. This capture-then-fire-outside
+ * protocol respects the lock order {@code gate.inputChannelsWithData → store}; firing inside
+ * the store lock would form an AB-BA cycle with the consumer side.
  *
- * <p>Two-phase methods ({@link #addBufferAndCaptureListener}, {@link
- * #addBufferAfterDiskAndCaptureListener}, {@link #checkpoint}, {@link #releaseAll},
- * {@link #notifyCheckpointStopped}) self-manage their own {@code synchronized (this)} block: they
- * commit state inside the block and then fire any captured listener / coordinator callback after
- * the block has been exited (capture-then-fire-outside).
- *
- * <h3>Lock order</h3>
- *
- * <p>Gate's {@code inputChannelsWithData} → channel store. The capture-then-fire-outside protocol
- * exists so the producer side can publish a buffer (taking the store lock) and only afterwards
- * traverse the gate-side notify path (which acquires the gate lock); without it the producer would
- * form an AB-BA deadlock with the consumer (gate → store).
- *
- * <h3>Thread roles</h3>
- *
- * <p>Public consumer methods are driven by the Task thread. Producer-side mutators ({@link
- * #addBuffer}, {@link #addBufferAfterDisk}, {@link #incrementPending}) are called from the
+ * <p>Consumer methods run on the Task thread; producer-side mutators
+ * ({@link #addBuffer}, {@link #addBufferAfterDisk}, {@link #incrementPending}) run on the
  * Recovery thread via FilteredBufferDispatcher.
  */
 @Internal
@@ -83,20 +68,12 @@ public class RecoveredBufferStoreImpl implements RecoveredBufferStore {
     private int pendingCount = 0;
 
     /**
-     * Buffers that must only become consumer-visible <em>after</em> all on-disk pending entries
-     * have been drained. Used for finish/control events (currently only the per-channel
-     * {@link org.apache.flink.runtime.io.network.partition.consumer.EndOfInputChannelStateEvent})
-     * whose contract is "everything before me has been delivered". When {@link #pendingCount}
-     * drops to zero inside {@link #addBufferAndCaptureListener}, the deferred buffers are
-     * atomically promoted into {@link #readyBuffers} so the consumer sees them strictly after the
-     * last drained spill entry — a logical FIFO that does not require routing events through the
-     * spill path.
-     *
-     * <p>Not counted as part of the public {@link #size()} / {@link #isEmpty()} surface: while
-     * something is deferred, {@code pendingCount > 0} already keeps the store non-empty; the
-     * promotion to {@code readyBuffers} happens in the same critical section that drops
-     * {@code pendingCount} to zero, so the store is never observed as "empty with deferred
-     * buffers still hidden".
+     * Buffers visible to the consumer only after all on-disk entries have been drained. Used for
+     * finish/control events whose contract is "everything before me has been delivered" (currently
+     * {@link EndOfInputChannelStateEvent}). Atomically promoted into {@link #readyBuffers} when
+     * {@link #pendingCount} reaches zero — a logical FIFO without routing events through the
+     * spill path. Not counted in {@link #size()} / {@link #isEmpty()}: while something is
+     * deferred, {@code pendingCount > 0} already keeps the store non-empty.
      */
     @GuardedBy("this")
     private final ArrayDeque<Buffer> deferredBuffers = new ArrayDeque<>();
@@ -109,22 +86,13 @@ public class RecoveredBufferStoreImpl implements RecoveredBufferStore {
     @GuardedBy("this")
     private RecoveredBufferStoreCoordinator coordinator;
 
-    /**
-     * Creates a store bound to a single input channel. The bound {@link InputChannelInfo} is used
-     * when persisting ready buffers during checkpoint and when notifying the checkpoint listener.
-     */
     public RecoveredBufferStoreImpl(InputChannelInfo channelInfo) {
         this.channelInfo = checkNotNull(channelInfo);
     }
 
-    /** Returns the input channel this store is bound to. */
     public InputChannelInfo getChannelInfo() {
         return channelInfo;
     }
-
-    // ---------------------------------------------------------------------------
-    // Public interface methods (Task thread)
-    // ---------------------------------------------------------------------------
 
     @Nullable
     @Override
@@ -149,53 +117,33 @@ public class RecoveredBufferStoreImpl implements RecoveredBufferStore {
         return readyBuffers.isEmpty() && pendingCount == 0;
     }
 
-    /**
-     * Lock-free best-effort read used by metric and gate-bookkeeping paths that can tolerate a
-     * slightly stale value. Both reads ({@code readyBuffers.size()} and {@code pendingCount}) are
-     * single-word and the worst observable inconsistency is "size off by 1 vs. the actual state",
-     * which is exactly what every other {@code unsynchronizedGetNumberOfQueuedBuffers} caller
-     * already accepts. Callers that need a consistent {@code isEmpty + size} pair must take the
-     * store lock around both calls themselves.
-     */
+    /** Lock-free best-effort read; see class javadoc. */
     @Override
     public int size() {
         return readyBuffers.size() + pendingCount;
     }
 
     /**
-     * Checkpoints the ready buffers to the given ChannelStateWriter. Ready buffers are retained and
-     * passed to the writer via CloseableIterator. After snapshotting, the registered {@link
-     * RecoveredBufferStoreCoordinator} is notified <em>outside</em> the store lock so the
-     * coordinator can safely acquire its own lock without risking a deadlock.
-     *
-     * <p>Pending spill entries on disk are checkpointed by the coordinator, which owns the spill
-     * entries and file readers, triggered via
-     * {@link RecoveredBufferStoreCoordinator#onChannelCheckpointStarted}.
+     * Snapshots ready buffers to {@code writer}, then notifies the coordinator outside the store
+     * lock. Pending spill entries on disk are checkpointed by the coordinator (which owns them),
+     * triggered via {@link RecoveredBufferStoreCoordinator#onChannelCheckpointStarted}.
      */
     @Override
     public void checkpoint(ChannelStateWriter writer, long checkpointId) throws IOException {
-        // Step 1: snapshot ready buffers AND read the coordinator's current drain head atomically
-        // under the store lock. Both reads must be a single consistent observation: the per-channel
-        // phase-2 filter compares each spill entry's position against the captured drain head, so
-        // any entry the drain bundle adds to readyBuffers after this point must also have advanced
-        // the drain head past its position before this snapshot was taken (drain bundle commits
-        // addBuffer + drainHead update atomically under the same store lock for the entry's
-        // channel; cross-channel visibility is provided by the volatile drain head).
+        // Snapshot ready buffers AND read drainHead atomically under the store lock. The drain
+        // bundle commits addBuffer + drainHead update under the same store lock, so any entry
+        // added after this point has already advanced drainHead past its position; cross-channel
+        // visibility is provided by the volatile drainHead read.
         RecoveredBufferStoreCoordinator c;
         EntryPosition startPos;
         synchronized (this) {
             c = coordinator;
             startPos = c != null ? c.getCurrentDrainHead() : EntryPosition.END;
             if (!readyBuffers.isEmpty()) {
-                // Mirror RemoteInputChannel#getInflightBuffersUnsafe: only data buffers belong
-                // in the persisted in-flight channel state. Non-data entries in readyBuffers
-                // (notably the EndOfInputChannelStateEvent that finishReadRecoveredState pushes
-                // and that the task may not yet have consumed when CDR transitions to RUNNING
-                // before stateConsumedFuture completes) are control signals — passing them to
-                // ChannelStateWriteRequest#checkBufferIsBuffer kills the writer worker thread
-                // (IllegalArgumentException), which then surfaces on every subsequent enqueue
-                // as "not running". Events stay in readyBuffers and are recycled later by the
-                // task's normal tryTake path.
+                // Only data buffers belong in persisted in-flight state. Skip non-data entries
+                // (notably EndOfInputChannelStateEvent which finishReadRecoveredState pushes
+                // ahead of the task consuming it) — they would be rejected by
+                // ChannelStateWriteRequest#checkBufferIsBuffer and kill the writer thread.
                 List<Buffer> retained = new ArrayList<>(readyBuffers.size());
                 for (Buffer buffer : readyBuffers) {
                     if (buffer.isBuffer()) {
@@ -212,9 +160,6 @@ public class RecoveredBufferStoreImpl implements RecoveredBufferStore {
             }
         }
 
-        // Step 2: notify the coordinator outside the store lock to avoid deadlock with the
-        // coordinator's own synchronisation. The captured startPos is forwarded so the coordinator
-        // can record the per-channel cutoff for phase-2 filtering.
         if (c != null) {
             c.onChannelCheckpointStarted(checkpointId, channelInfo, startPos);
         }
@@ -222,8 +167,6 @@ public class RecoveredBufferStoreImpl implements RecoveredBufferStore {
 
     @Override
     public void releaseAll() {
-        // Step 1: flip the released flag and recycle ready / deferred buffers under lock; capture
-        // the coordinator reference for invocation outside the lock.
         RecoveredBufferStoreCoordinator c;
         synchronized (this) {
             released = true;
@@ -239,8 +182,6 @@ public class RecoveredBufferStoreImpl implements RecoveredBufferStore {
             c = coordinator;
         }
 
-        // Step 2: notify the coordinator outside the store lock so the coordinator can safely
-        // acquire its own lock to drop disk-resident spill entries for this channel.
         if (c != null) {
             c.onChannelReleased(channelInfo);
         }
@@ -248,8 +189,6 @@ public class RecoveredBufferStoreImpl implements RecoveredBufferStore {
 
     @Override
     public void notifyCheckpointStopped(long checkpointId) {
-        // Capture the coordinator reference under lock; fire the notification outside so the
-        // coordinator can safely acquire its own synchronisation without risking deadlock.
         RecoveredBufferStoreCoordinator c;
         synchronized (this) {
             c = coordinator;
@@ -259,10 +198,6 @@ public class RecoveredBufferStoreImpl implements RecoveredBufferStore {
         }
     }
 
-    // ---------------------------------------------------------------------------
-    // Setters (interface methods)
-    // ---------------------------------------------------------------------------
-
     @Override
     @GuardedBy("this")
     public void setCoordinator(RecoveredBufferStoreCoordinator coordinator) {
@@ -270,12 +205,6 @@ public class RecoveredBufferStoreImpl implements RecoveredBufferStore {
         this.coordinator = coordinator;
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * <p>The notification listener fires when a buffer is added to a previously empty ready queue,
-     * waking up the Task thread waiting for data.
-     */
     @Override
     @GuardedBy("this")
     public void setDataAvailableListener(DataAvailableListener listener) {
@@ -283,24 +212,11 @@ public class RecoveredBufferStoreImpl implements RecoveredBufferStore {
         this.dataAvailableListener = listener;
     }
 
-    // ---------------------------------------------------------------------------
-    // Internal methods (Recovery thread, called by FilteredBufferDispatcher)
-    // ---------------------------------------------------------------------------
-
     /**
-     * Adds a recovered buffer to the ready queue. If the queue was previously empty, the
-     * notification listener is invoked to wake up the Task thread.
-     *
-     * <p>The listener is invoked <em>outside</em> the store monitor: the listener path goes through
-     * {@code SingleInputGate.queueChannel}, which acquires the gate's {@code inputChannelsWithData}
-     * monitor. A task thread holding that monitor while peeking the store would otherwise form an
-     * AB-BA deadlock with this method. Lock-order matches the two-phase pattern used by
-     * {@link #checkpoint}, {@link #releaseAll} and {@link #notifyCheckpointStopped}.
-     *
-     * <p>Callers that wrap this method in their own {@code synchronized(store)} block must instead
-     * use {@link #addBufferAndCaptureListener(Buffer)} and fire the returned listener after exiting
-     * that outer block — otherwise the listener still runs while the outer lock is held and the
-     * AB-BA risk reappears.
+     * Adds a recovered buffer to the ready queue. The listener fires <em>outside</em> the store
+     * monitor (gate → store lock-order). Callers that already hold {@code synchronized(store)}
+     * must use {@link #addBufferAndCaptureListener(Buffer)} and fire the listener after releasing
+     * that outer lock to avoid AB-BA deadlock.
      */
     public void addBuffer(Buffer buffer) {
         DataAvailableListener listenerToFire = addBufferAndCaptureListener(buffer);
@@ -310,21 +226,15 @@ public class RecoveredBufferStoreImpl implements RecoveredBufferStore {
     }
 
     /**
-     * Variant of {@link #addBuffer(Buffer)} that captures the data-available listener inside the
-     * store monitor and returns it instead of firing it. Callers must invoke {@code
-     * onDataAvailable()} on the returned listener (if non-null) <em>after</em> releasing any outer
-     * lock that orders before the gate's {@code inputChannelsWithData} monitor — otherwise the
-     * listener would run while that outer lock is held and re-introduce the AB-BA deadlock with
-     * the task thread (gate lock → store lock).
+     * Captures the data-available listener inside the store monitor and returns it. Caller must
+     * fire it after releasing any outer lock ordered before the gate monitor.
      *
-     * <p>If {@link #pendingCount} is non-zero when this method is called, the buffer being added
-     * is necessarily a drained spill entry (the only producer path into a non-idle store goes
-     * through the dispatcher's drain), so {@code pendingCount} is decremented here. When that
-     * decrement reaches zero, any {@link #deferredBuffers} are promoted into {@link #readyBuffers}
+     * <p>When {@link #pendingCount} is non-zero, the buffer is necessarily a drained spill entry
+     * (only producer path into a non-idle store goes through dispatcher drain), so the count is
+     * decremented here; reaching zero promotes {@link #deferredBuffers} into {@link #readyBuffers}
      * in the same critical section.
      *
-     * @return the listener to fire, or {@code null} if no notification is needed (queue was already
-     *     non-empty, no listener registered, or the store has been released)
+     * @return listener to fire, or {@code null} if no notification is needed
      */
     @Nullable
     public DataAvailableListener addBufferAndCaptureListener(Buffer buffer) {
@@ -348,9 +258,8 @@ public class RecoveredBufferStoreImpl implements RecoveredBufferStore {
     }
 
     /**
-     * Increments the pending spill entry count. Called when FilteredBufferDispatcher spills data to
-     * disk; the matching decrement happens implicitly inside {@link #addBufferAndCaptureListener}
-     * when the spill entry is drained back into a buffer.
+     * Called when FilteredBufferDispatcher spills data; the matching decrement happens implicitly
+     * inside {@link #addBufferAndCaptureListener} when the entry is drained back into a buffer.
      */
     @GuardedBy("this")
     public void incrementPending() {
@@ -359,22 +268,12 @@ public class RecoveredBufferStoreImpl implements RecoveredBufferStore {
     }
 
     /**
-     * Adds a buffer that must only become consumer-visible after all on-disk entries have been
-     * drained. If no spill entries are pending, the buffer is delivered immediately as a normal
-     * ready buffer. Otherwise it is held in {@link #deferredBuffers} and atomically promoted by
-     * {@link #addBufferAndCaptureListener(Buffer)} when the count reaches zero.
-     *
-     * <p>Used by {@code RecoveredInputChannel#finishReadRecoveredState} to publish the per-channel
-     * {@code EndOfInputChannelStateEvent} so the event always lands strictly after the last
-     * recovered data buffer for the channel — preserving the contract "all data has been read"
-     * without needing the event to traverse the dispatcher's spill path.
-     *
-     * <p>The listener is invoked <em>outside</em> the store monitor for the same lock-order
-     * reasons documented on {@link #addBuffer}.
-     *
-     * <p>Callers that wrap this method in their own {@code synchronized(store)} block must instead
-     * use {@link #addBufferAfterDiskAndCaptureListener(Buffer)} and fire the returned listener
-     * after exiting that outer block.
+     * Adds a buffer that becomes consumer-visible only after all on-disk entries have been
+     * drained: delivered as a normal ready buffer when {@code pendingCount == 0}, otherwise held
+     * in {@link #deferredBuffers} and promoted when the count reaches zero. Used by
+     * {@code RecoveredInputChannel#finishReadRecoveredState} to publish
+     * {@code EndOfInputChannelStateEvent} so it always lands after the last recovered data buffer
+     * — without routing the event through the spill path.
      */
     public void addBufferAfterDisk(Buffer buffer) {
         DataAvailableListener listenerToFire = addBufferAfterDiskAndCaptureListener(buffer);
@@ -383,11 +282,7 @@ public class RecoveredBufferStoreImpl implements RecoveredBufferStore {
         }
     }
 
-    /**
-     * Variant of {@link #addBufferAfterDisk(Buffer)} that captures the data-available listener
-     * inside the store monitor and returns it instead of firing it. Same lock-order constraints as
-     * {@link #addBufferAndCaptureListener(Buffer)} apply to the caller.
-     */
+    /** Capture-then-fire variant of {@link #addBufferAfterDisk(Buffer)}. */
     @Nullable
     public DataAvailableListener addBufferAfterDiskAndCaptureListener(Buffer buffer) {
         synchronized (this) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
@@ -106,11 +106,6 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
         }
     }
 
-    /**
-     * Returns the store for recovered buffers. Used for store transfer during channel conversion,
-     * by {@link org.apache.flink.runtime.checkpoint.channel.RecoveredChannelStateHandler} to add
-     * recovered buffers directly, and for FilteredBufferDispatcher integration during filtering.
-     */
     public RecoveredBufferStoreImpl getStore() {
         return store;
     }
@@ -121,13 +116,7 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
         this.channelStateWriter = checkNotNull(channelStateWriter);
     }
 
-    /**
-     * Returns the ChannelStateWriter assigned to this channel. Used by FilteredBufferDispatcher to
-     * obtain the writer for phase2 disk checkpoint without threading it through every call site.
-     *
-     * <p>Must be called after {@link #setChannelStateWriter} has been invoked (i.e., after channel
-     * state writer injection during task initialization).
-     */
+    /** Must be called after {@link #setChannelStateWriter}. */
     public ChannelStateWriter getChannelStateWriter() {
         return checkNotNull(channelStateWriter, "ChannelStateWriter has not been set yet");
     }
@@ -140,7 +129,6 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
                     stateConsumedFuture.isDone(), "recovered state is not fully consumed");
         }
 
-        // Pass the store reference to the physical channel for continued consumption.
         final InputChannel inputChannel = toInputChannelInternal(store);
         inputChannel.checkpointStopped(lastStoppedCheckpointId);
         return inputChannel;
@@ -152,12 +140,8 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
     }
 
     /**
-     * Creates the physical InputChannel from this recovered channel.
-     *
-     * @param recoveredStore the store containing recovered buffers that have been filtered but not
-     *     yet consumed by the Task. The store reference is passed to the physical channel for
-     *     continued consumption.
-     * @return the physical InputChannel (LocalInputChannel or RemoteInputChannel)
+     * Creates the physical InputChannel; the store reference is transferred for continued
+     * consumption.
      */
     protected abstract InputChannel toInputChannelInternal(RecoveredBufferStoreImpl recoveredStore)
             throws IOException;
@@ -175,32 +159,18 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
     }
 
     public void finishReadRecoveredState() throws IOException {
-        // Use addBufferAfterDisk so the event becomes consumer-visible only after every disk-
-        // resident spill entry for this channel has been drained. If the dispatcher never spilled
-        // (pendingCount == 0) the store delivers the event immediately as a normal ready buffer;
-        // otherwise it is held in deferredBuffers and atomically promoted into readyBuffers when
-        // the last drainPendingSpill pop hits zero. This preserves the EndOfInputChannelStateEvent
-        // contract ("everything before me has been delivered") without routing the event through
-        // the dispatcher's spill path.
+        // addBufferAfterDisk preserves the EndOfInputChannelStateEvent contract ("everything
+        // before me has been delivered"): delivered immediately when no spill, otherwise held in
+        // deferredBuffers and promoted when pendingCount hits zero.
         //
-        // Adding the event and completing the future must be atomic under the store lock,
-        // otherwise:
-        // - event first (no lock): task thread consumes EndOfInputChannelStateEvent, which
-        //   completes stateConsumedFuture. When checkpointing during recovery is disabled,
-        //   stateConsumedFuture triggers requestPartitions -> toInputChannel(), which fails
-        //   because bufferFilteringCompleteFuture is not yet done.
-        // - future first (no lock): toInputChannel() passes the store before the event is added,
+        // The event-add and future-complete must be atomic under the store lock — otherwise:
+        // - event first: task thread consumes the event, completes stateConsumedFuture, then
+        //   triggers toInputChannel() before bufferFilteringCompleteFuture is done.
+        // - future first: toInputChannel() transfers the store before the event is added,
         //   losing the EndOfInputChannelStateEvent.
-        // RecoveredBufferStoreImpl uses the same intrinsic monitor, so synchronizing on the store
-        // here makes the pair atomic.
         //
-        // The data-available listener must be fired *outside* this synchronized(store) block: the
-        // listener path goes through SingleInputGate.queueChannel which acquires the gate's
-        // inputChannelsWithData monitor, while a task thread holding that monitor calls
-        // store.peekNextDataType() / store.tryTake() under the store lock. Firing the listener
-        // while we still hold the store lock forms an AB-BA deadlock with that task thread (gate
-        // lock → store lock vs. store lock → gate lock). Capture the listener inside the store
-        // lock via addBufferAfterDiskAndCaptureListener and fire it after the lock is released.
+        // The listener fires outside the lock to avoid AB-BA with the task thread (gate → store
+        // lock vs store → gate lock).
         RecoveredBufferStore.DataAvailableListener listenerToFire;
         synchronized (store) {
             listenerToFire =
@@ -218,8 +188,7 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
     @Nullable
     private BufferAndAvailability getNextRecoveredStateBuffer() throws IOException {
         checkState(!isReleased.get(), "Trying to read from released RecoveredInputChannel");
-        // tryTake + peekNextDataType under one lock so the consumer never observes a torn view
-        // (post-take, pre-peek) where another producer slipped a buffer in between.
+        // tryTake + peekNextDataType under one lock so the consumer never observes a torn view.
         final Buffer next;
         final Buffer.DataType nextDataType;
         synchronized (store) {
@@ -262,7 +231,6 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
 
     @Override
     int getBuffersInUseCount() {
-        // size() is lock-free best-effort — see RecoveredBufferStore javadoc.
         return store.size();
     }
 
@@ -305,14 +273,10 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
     }
 
     /**
-     * Tear-down fired only after BOTH (a) drain has finished and (b) the gate slot has been
-     * replaced by the physical channel. Releases the {@link BufferManager}'s exclusive segments
-     * back to the global pool but does <em>not</em> touch the recovered store — the store
-     * reference has been transferred to the physical channel by {@link #toInputChannel} and is
-     * owned (and finally released) there. Sets {@link #isReleased} so {@link BufferManager#recycle}
-     * returns lingering segments (still in flight via buffers in the store) straight to the global
-     * pool, preventing leaks. Idempotent with {@link #releaseAllResources} via the same atomic
-     * flag, so the abort path that calls {@code releaseAllResources} stays correct.
+     * Tear-down fires only after BOTH drain has finished and the gate slot has been replaced.
+     * Does not touch the recovered store — the store reference has been transferred to the
+     * physical channel by {@link #toInputChannel}. Idempotent with {@link #releaseAllResources}
+     * via the same atomic flag.
      */
     private void releaseAfterDrain() throws IOException {
         if (isReleased.compareAndSet(false, true)) {
@@ -323,10 +287,7 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
     private volatile boolean drainDone = false;
     private volatile boolean converted = false;
 
-    /**
-     * Signalled by {@code BufferRequester#releaseExclusiveBuffers} (invoked from
-     * {@code FilteredBufferDispatcher#close} on the recovery thread once drain has finished).
-     */
+    /** Signalled when {@code FilteredBufferDispatcher#close} finishes drain. */
     public void markDrainDone() throws IOException {
         drainDone = true;
         if (converted) {
@@ -334,11 +295,7 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
         }
     }
 
-    /**
-     * Signalled by {@code SingleInputGate#convertRecoveredInputChannels} on the mailbox thread
-     * after the gate slot has been replaced by the physical channel and the old RecoveredInputChannel
-     * is no longer reachable through the gate.
-     */
+    /** Signalled after the gate slot has been replaced by the physical channel. */
     public void markConverted() throws IOException {
         converted = true;
         if (drainDone) {
@@ -348,14 +305,10 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
 
     @VisibleForTesting
     protected int getNumberOfQueuedBuffers() {
-        // size() is lock-free best-effort — see RecoveredBufferStore javadoc.
         return store.size();
     }
 
-    /**
-     * Non-blocking buffer request. Returns a buffer from the pool, or {@code null} if the pool is
-     * exhausted.
-     */
+    /** Non-blocking; returns {@code null} if the pool is exhausted. */
     @Nullable
     public Buffer requestBuffer() throws IOException {
         if (!exclusiveBuffersAssigned) {
@@ -371,9 +324,6 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
             bufferManager.requestExclusiveBuffers(networkBuffersPerChannel);
             exclusiveBuffersAssigned = true;
         }
-        // Both filtering and non-filtering modes block-wait for a Network Buffer Pool buffer. In
-        // filtering mode the pre-filter buffer is heap-allocated separately in the state handler,
-        // so this method is only called for post-filter buffers which must come from the pool.
         return bufferManager.requestBufferBlocking();
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
@@ -273,10 +273,10 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
     }
 
     /**
-     * Tear-down fires only after BOTH drain has finished and the gate slot has been replaced.
-     * Does not touch the recovered store — the store reference has been transferred to the
-     * physical channel by {@link #toInputChannel}. Idempotent with {@link #releaseAllResources}
-     * via the same atomic flag.
+     * Tear-down fires only after BOTH drain has finished and the gate slot has been replaced. Does
+     * not touch the recovered store — the store reference has been transferred to the physical
+     * channel by {@link #toInputChannel}. Idempotent with {@link #releaseAllResources} via the same
+     * atomic flag.
      */
     private void releaseAfterDrain() throws IOException {
         if (isReleased.compareAndSet(false, true)) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
@@ -19,8 +19,6 @@
 package org.apache.flink.runtime.io.network.partition.consumer;
 
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.core.memory.MemorySegment;
-import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
@@ -29,13 +27,10 @@ import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
-import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
-import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
 import org.apache.flink.runtime.io.network.logger.NetworkActionsLogger;
 import org.apache.flink.runtime.io.network.partition.ChannelStateHolder;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartitionIndexSet;
-import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
@@ -332,32 +327,29 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
         }
     }
 
+    /**
+     * Non-blocking buffer request. Returns a buffer from the pool, or {@code null} if the pool is
+     * exhausted.
+     */
+    @Nullable
+    public Buffer requestBuffer() throws IOException {
+        if (!exclusiveBuffersAssigned) {
+            bufferManager.requestExclusiveBuffers(networkBuffersPerChannel);
+            exclusiveBuffersAssigned = true;
+        }
+        return bufferManager.requestBuffer();
+    }
+
     public Buffer requestBufferBlocking() throws InterruptedException, IOException {
         // not in setup to avoid assigning buffers unnecessarily if there is no state
         if (!exclusiveBuffersAssigned) {
             bufferManager.requestExclusiveBuffers(networkBuffersPerChannel);
             exclusiveBuffersAssigned = true;
         }
-        if (!inputGate.isCheckpointingDuringRecoveryEnabled()) {
-            // When checkpoint-during-recovery is not enabled, the original blocking allocation
-            // is used as-is — no heap buffer fallback, no behavior change from the legacy path.
-            return bufferManager.requestBufferBlocking();
-        }
-        // Use heap buffer fallback to avoid deadlock during filtering recovery: the filtering
-        // thread first requests buffers to read state (pre-filter), then requests more buffers
-        // to write filtered output (post-filter). If pre-filter buffers exhaust the pool,
-        // post-filter allocation blocks, stalling the thread so pre-filter buffers can never
-        // be consumed and released — the thread deadlocks itself. Heap buffers bypass the pool
-        // so post-filter writes always proceed. Both call sites (getBuffer and filterAndRewrite)
-        // go through this method, so the fallback applies uniformly.
-        // TODO: replace heap fallback with disk spilling to bound memory usage in FLINK-38544.
-        Buffer buffer = bufferManager.requestBuffer();
-        if (buffer != null) {
-            return buffer;
-        }
-        MemorySegment memorySegment =
-                MemorySegmentFactory.allocateUnpooledSegment(MemoryManager.DEFAULT_PAGE_SIZE);
-        return new NetworkBuffer(memorySegment, FreeingBufferRecycler.INSTANCE);
+        // Both filtering and non-filtering modes block-wait for a Network Buffer Pool buffer. In
+        // filtering mode the pre-filter buffer is heap-allocated separately in the state handler,
+        // so this method is only called for post-filter buffers which must come from the pool.
+        return bufferManager.requestBufferBlocking();
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
@@ -103,9 +103,11 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
 
         bufferManager = new BufferManager(inputGate.getMemorySegmentProvider(), this, 0);
         this.networkBuffersPerChannel = networkBuffersPerChannel;
-        this.store = new RecoveredBufferStoreImpl(getChannelInfo());
-        synchronized (store) {
-            store.setDataAvailableListener(this::notifyChannelNonEmpty);
+        this.store = new RecoveredBufferStoreImpl(getChannelInfo(), inputGate.getGateLock());
+        synchronized (inputGate.getGateLock()) {
+            synchronized (store) {
+                store.setDataAvailableListener(this::notifyChannelNonEmpty);
+            }
         }
     }
 
@@ -161,31 +163,22 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
         return stateConsumedFuture;
     }
 
+    /**
+     * Publishes the {@link EndOfInputChannelStateEvent} (deferred behind any pending spill) and
+     * completes {@link #bufferFilteringCompleteFuture}. Caller must hold the gate lock; floating
+     * buffers are released separately via {@link #releaseRecoveryFloatingBuffers()}.
+     */
     public void finishReadRecoveredState() throws IOException {
-        // addBufferAfterDisk preserves the EndOfInputChannelStateEvent contract ("everything
-        // before me has been delivered"): delivered immediately when no spill, otherwise held in
-        // deferredBuffers and promoted when pendingCount hits zero.
-        //
-        // The event-add and future-complete must be atomic under the store lock — otherwise:
-        // - event first: task thread consumes the event, completes stateConsumedFuture, then
-        //   triggers toInputChannel() before bufferFilteringCompleteFuture is done.
-        // - future first: toInputChannel() transfers the store before the event is added,
-        //   losing the EndOfInputChannelStateEvent.
-        //
-        // The listener fires outside the lock to avoid AB-BA with the task thread (gate → store
-        // lock vs store → gate lock).
-        RecoveredBufferStore.DataAvailableListener listenerToFire;
-        synchronized (store) {
-            listenerToFire =
-                    store.addBufferAfterDiskAndCaptureListener(
-                            EventSerializer.toBuffer(EndOfInputChannelStateEvent.INSTANCE, false));
-            bufferFilteringCompleteFuture.complete(null);
-        }
-        if (listenerToFire != null) {
-            listenerToFire.onDataAvailable();
-        }
-        bufferManager.releaseFloatingBuffers();
+        assert Thread.holdsLock(inputGate.getGateLock());
+        store.addBufferAfterDisk(
+                EventSerializer.toBuffer(EndOfInputChannelStateEvent.INSTANCE, false));
+        bufferFilteringCompleteFuture.complete(null);
         LOG.debug("{}/{} finished recovering input.", inputGate.getOwningTaskName(), channelInfo);
+    }
+
+    /** Buffer pool release; intentionally invoked outside the gate lock. */
+    public void releaseRecoveryFloatingBuffers() throws IOException {
+        bufferManager.releaseFloatingBuffers();
     }
 
     @Nullable

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
@@ -78,6 +78,9 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
 
     private long lastStoppedCheckpointId = -1;
 
+    private volatile boolean drainDone = false;
+    private volatile boolean storeTransferred = false;
+
     RecoveredInputChannel(
             SingleInputGate inputGate,
             int channelIndex,
@@ -268,36 +271,27 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
 
     void releaseAllResources() throws IOException {
         if (isReleased.compareAndSet(false, true)) {
+            // Abort path: gate.close races requestLock with convertRecoveredInputChannels, so
+            // storeTransferred=false means conversion never ran and the store is still ours.
+            // After conversion the physical channel owns the store and releases it itself.
+            if (!storeTransferred) {
+                store.releaseAll();
+            }
             bufferManager.releaseAllBuffers(new ArrayDeque<>());
         }
     }
-
-    /**
-     * Tear-down fires only after BOTH drain has finished and the gate slot has been replaced. Does
-     * not touch the recovered store — the store reference has been transferred to the physical
-     * channel by {@link #toInputChannel}. Idempotent with {@link #releaseAllResources} via the same
-     * atomic flag.
-     */
-    private void releaseAfterDrain() throws IOException {
-        if (isReleased.compareAndSet(false, true)) {
-            bufferManager.releaseAllBuffers(new ArrayDeque<>());
-        }
-    }
-
-    private volatile boolean drainDone = false;
-    private volatile boolean converted = false;
 
     /** Signalled when {@code FilteredBufferDispatcher#close} finishes drain. */
     public void markDrainDone() throws IOException {
         drainDone = true;
-        if (converted) {
+        if (storeTransferred) {
             releaseAllResources();
         }
     }
 
     /** Signalled after the gate slot has been replaced by the physical channel. */
-    public void markConverted() throws IOException {
-        converted = true;
+    public void markStoreTransferred() throws IOException {
+        storeTransferred = true;
         if (drainDone) {
             releaseAllResources();
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
@@ -27,7 +27,6 @@ import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
-import org.apache.flink.runtime.io.network.logger.NetworkActionsLogger;
 import org.apache.flink.runtime.io.network.partition.ChannelStateHolder;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartitionIndexSet;
@@ -37,12 +36,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
-import javax.annotation.concurrent.GuardedBy;
 
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.flink.runtime.checkpoint.CheckpointFailureReason.CHECKPOINT_DECLINED_TASK_NOT_READY;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -53,7 +52,7 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
 
     private static final Logger LOG = LoggerFactory.getLogger(RecoveredInputChannel.class);
 
-    private final ArrayDeque<Buffer> receivedBuffers = new ArrayDeque<>();
+    private final RecoveredBufferStoreImpl store;
     private final CompletableFuture<?> stateConsumedFuture = new CompletableFuture<>();
     protected final BufferManager bufferManager;
 
@@ -64,8 +63,7 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
      */
     private final CompletableFuture<Void> bufferFilteringCompleteFuture = new CompletableFuture<>();
 
-    @GuardedBy("receivedBuffers")
-    private boolean isReleased;
+    private final AtomicBoolean isReleased = new AtomicBoolean(false);
 
     protected ChannelStateWriter channelStateWriter;
 
@@ -102,12 +100,36 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
 
         bufferManager = new BufferManager(inputGate.getMemorySegmentProvider(), this, 0);
         this.networkBuffersPerChannel = networkBuffersPerChannel;
+        this.store = new RecoveredBufferStoreImpl(getChannelInfo());
+        synchronized (store) {
+            store.setDataAvailableListener(this::notifyChannelNonEmpty);
+        }
+    }
+
+    /**
+     * Returns the store for recovered buffers. Used for store transfer during channel conversion,
+     * by {@link org.apache.flink.runtime.checkpoint.channel.RecoveredChannelStateHandler} to add
+     * recovered buffers directly, and for FilteredBufferDispatcher integration during filtering.
+     */
+    public RecoveredBufferStoreImpl getStore() {
+        return store;
     }
 
     @Override
     public void setChannelStateWriter(ChannelStateWriter channelStateWriter) {
         checkState(this.channelStateWriter == null, "Already initialized");
         this.channelStateWriter = checkNotNull(channelStateWriter);
+    }
+
+    /**
+     * Returns the ChannelStateWriter assigned to this channel. Used by FilteredBufferDispatcher to
+     * obtain the writer for phase2 disk checkpoint without threading it through every call site.
+     *
+     * <p>Must be called after {@link #setChannelStateWriter} has been invoked (i.e., after channel
+     * state writer injection during task initialization).
+     */
+    public ChannelStateWriter getChannelStateWriter() {
+        return checkNotNull(channelStateWriter, "ChannelStateWriter has not been set yet");
     }
 
     public final InputChannel toInputChannel() throws IOException {
@@ -118,15 +140,8 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
                     stateConsumedFuture.isDone(), "recovered state is not fully consumed");
         }
 
-        // Extract remaining buffers before conversion.
-        // These buffers have been filtered but not yet consumed by the Task.
-        final ArrayDeque<Buffer> remainingBuffers;
-        synchronized (receivedBuffers) {
-            remainingBuffers = new ArrayDeque<>(receivedBuffers);
-            receivedBuffers.clear();
-        }
-
-        final InputChannel inputChannel = toInputChannelInternal(remainingBuffers);
+        // Pass the store reference to the physical channel for continued consumption.
+        final InputChannel inputChannel = toInputChannelInternal(store);
         inputChannel.checkpointStopped(lastStoppedCheckpointId);
         return inputChannel;
     }
@@ -139,11 +154,12 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
     /**
      * Creates the physical InputChannel from this recovered channel.
      *
-     * @param remainingBuffers buffers that have been filtered but not yet consumed by the Task.
-     *     These buffers will be migrated to the new physical channel.
+     * @param recoveredStore the store containing recovered buffers that have been filtered but not
+     *     yet consumed by the Task. The store reference is passed to the physical channel for
+     *     continued consumption.
      * @return the physical InputChannel (LocalInputChannel or RemoteInputChannel)
      */
-    protected abstract InputChannel toInputChannelInternal(ArrayDeque<Buffer> remainingBuffers)
+    protected abstract InputChannel toInputChannelInternal(RecoveredBufferStoreImpl recoveredStore)
             throws IOException;
 
     /**
@@ -158,53 +174,42 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
         return stateConsumedFuture;
     }
 
-    public void onRecoveredStateBuffer(Buffer buffer) {
-        boolean recycleBuffer = true;
-        NetworkActionsLogger.traceRecover(
-                "InputChannelRecoveredStateHandler#recover",
-                buffer,
-                inputGate.getOwningTaskName(),
-                channelInfo);
-        try {
-            final boolean wasEmpty;
-            synchronized (receivedBuffers) {
-                // Similar to notifyBufferAvailable(), make sure that we never add a buffer
-                // after releaseAllResources() released all buffers from receivedBuffers.
-                if (isReleased) {
-                    wasEmpty = false;
-                } else {
-                    wasEmpty = receivedBuffers.isEmpty();
-                    receivedBuffers.add(buffer);
-                    recycleBuffer = false;
-                }
-            }
-
-            if (wasEmpty) {
-                notifyChannelNonEmpty();
-            }
-        } finally {
-            if (recycleBuffer) {
-                buffer.recycleBuffer();
-            }
-        }
-    }
-
     public void finishReadRecoveredState() throws IOException {
-        // Adding the event and completing the future must be atomic under receivedBuffers lock.
-        // Without this, either ordering has a race:
-        // - event first: task thread consumes EndOfInputChannelStateEvent, which completes
-        //   stateConsumedFuture. When checkpointing during recovery is disabled,
-        //   stateConsumedFuture triggers requestPartitions -> toInputChannel(), which
-        //   fails because bufferFilteringCompleteFuture is not yet done.
-        // - future first: toInputChannel() extracts buffers before the event is added,
+        // Use addBufferAfterDisk so the event becomes consumer-visible only after every disk-
+        // resident spill entry for this channel has been drained. If the dispatcher never spilled
+        // (pendingCount == 0) the store delivers the event immediately as a normal ready buffer;
+        // otherwise it is held in deferredBuffers and atomically promoted into readyBuffers when
+        // the last drainPendingSpill pop hits zero. This preserves the EndOfInputChannelStateEvent
+        // contract ("everything before me has been delivered") without routing the event through
+        // the dispatcher's spill path.
+        //
+        // Adding the event and completing the future must be atomic under the store lock,
+        // otherwise:
+        // - event first (no lock): task thread consumes EndOfInputChannelStateEvent, which
+        //   completes stateConsumedFuture. When checkpointing during recovery is disabled,
+        //   stateConsumedFuture triggers requestPartitions -> toInputChannel(), which fails
+        //   because bufferFilteringCompleteFuture is not yet done.
+        // - future first (no lock): toInputChannel() passes the store before the event is added,
         //   losing the EndOfInputChannelStateEvent.
-        // Both toInputChannel() and getNextRecoveredStateBuffer() synchronize on
-        // receivedBuffers, so holding the same lock here guarantees
-        // bufferFilteringCompleteFuture is always done before stateConsumedFuture.
-        synchronized (receivedBuffers) {
-            onRecoveredStateBuffer(
-                    EventSerializer.toBuffer(EndOfInputChannelStateEvent.INSTANCE, false));
+        // RecoveredBufferStoreImpl uses the same intrinsic monitor, so synchronizing on the store
+        // here makes the pair atomic.
+        //
+        // The data-available listener must be fired *outside* this synchronized(store) block: the
+        // listener path goes through SingleInputGate.queueChannel which acquires the gate's
+        // inputChannelsWithData monitor, while a task thread holding that monitor calls
+        // store.peekNextDataType() / store.tryTake() under the store lock. Firing the listener
+        // while we still hold the store lock forms an AB-BA deadlock with that task thread (gate
+        // lock → store lock vs. store lock → gate lock). Capture the listener inside the store
+        // lock via addBufferAfterDiskAndCaptureListener and fire it after the lock is released.
+        RecoveredBufferStore.DataAvailableListener listenerToFire;
+        synchronized (store) {
+            listenerToFire =
+                    store.addBufferAfterDiskAndCaptureListener(
+                            EventSerializer.toBuffer(EndOfInputChannelStateEvent.INSTANCE, false));
             bufferFilteringCompleteFuture.complete(null);
+        }
+        if (listenerToFire != null) {
+            listenerToFire.onDataAvailable();
         }
         bufferManager.releaseFloatingBuffers();
         LOG.debug("{}/{} finished recovering input.", inputGate.getOwningTaskName(), channelInfo);
@@ -212,13 +217,14 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
 
     @Nullable
     private BufferAndAvailability getNextRecoveredStateBuffer() throws IOException {
+        checkState(!isReleased.get(), "Trying to read from released RecoveredInputChannel");
+        // tryTake + peekNextDataType under one lock so the consumer never observes a torn view
+        // (post-take, pre-peek) where another producer slipped a buffer in between.
         final Buffer next;
         final Buffer.DataType nextDataType;
-
-        synchronized (receivedBuffers) {
-            checkState(!isReleased, "Trying to read from released RecoveredInputChannel");
-            next = receivedBuffers.poll();
-            nextDataType = peekDataTypeUnsafe();
+        synchronized (store) {
+            next = store.tryTake();
+            nextDataType = next != null ? store.peekNextDataType() : Buffer.DataType.NONE;
         }
 
         if (next == null) {
@@ -254,18 +260,10 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
         return Optional.ofNullable(getNextRecoveredStateBuffer());
     }
 
-    private Buffer.DataType peekDataTypeUnsafe() {
-        assert Thread.holdsLock(receivedBuffers);
-
-        final Buffer first = receivedBuffers.peek();
-        return first != null ? first.getDataType() : Buffer.DataType.NONE;
-    }
-
     @Override
     int getBuffersInUseCount() {
-        synchronized (receivedBuffers) {
-            return receivedBuffers.size();
-        }
+        // size() is lock-free best-effort — see RecoveredBufferStore javadoc.
+        return store.size();
     }
 
     @Override
@@ -297,34 +295,61 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
 
     @Override
     boolean isReleased() {
-        synchronized (receivedBuffers) {
-            return isReleased;
-        }
+        return isReleased.get();
     }
 
     void releaseAllResources() throws IOException {
-        ArrayDeque<Buffer> releasedBuffers = new ArrayDeque<>();
-        boolean shouldRelease = false;
-
-        synchronized (receivedBuffers) {
-            if (!isReleased) {
-                isReleased = true;
-                shouldRelease = true;
-                releasedBuffers.addAll(receivedBuffers);
-                receivedBuffers.clear();
-            }
+        if (isReleased.compareAndSet(false, true)) {
+            bufferManager.releaseAllBuffers(new ArrayDeque<>());
         }
+    }
 
-        if (shouldRelease) {
-            bufferManager.releaseAllBuffers(releasedBuffers);
+    /**
+     * Tear-down fired only after BOTH (a) drain has finished and (b) the gate slot has been
+     * replaced by the physical channel. Releases the {@link BufferManager}'s exclusive segments
+     * back to the global pool but does <em>not</em> touch the recovered store — the store
+     * reference has been transferred to the physical channel by {@link #toInputChannel} and is
+     * owned (and finally released) there. Sets {@link #isReleased} so {@link BufferManager#recycle}
+     * returns lingering segments (still in flight via buffers in the store) straight to the global
+     * pool, preventing leaks. Idempotent with {@link #releaseAllResources} via the same atomic
+     * flag, so the abort path that calls {@code releaseAllResources} stays correct.
+     */
+    private void releaseAfterDrain() throws IOException {
+        if (isReleased.compareAndSet(false, true)) {
+            bufferManager.releaseAllBuffers(new ArrayDeque<>());
+        }
+    }
+
+    private volatile boolean drainDone = false;
+    private volatile boolean converted = false;
+
+    /**
+     * Signalled by {@code BufferRequester#releaseExclusiveBuffers} (invoked from
+     * {@code FilteredBufferDispatcher#close} on the recovery thread once drain has finished).
+     */
+    public void markDrainDone() throws IOException {
+        drainDone = true;
+        if (converted) {
+            releaseAllResources();
+        }
+    }
+
+    /**
+     * Signalled by {@code SingleInputGate#convertRecoveredInputChannels} on the mailbox thread
+     * after the gate slot has been replaced by the physical channel and the old RecoveredInputChannel
+     * is no longer reachable through the gate.
+     */
+    public void markConverted() throws IOException {
+        converted = true;
+        if (drainDone) {
+            releaseAllResources();
         }
     }
 
     @VisibleForTesting
     protected int getNumberOfQueuedBuffers() {
-        synchronized (receivedBuffers) {
-            return receivedBuffers.size();
-        }
+        // size() is lock-free best-effort — see RecoveredBufferStore javadoc.
+        return store.size();
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -169,9 +169,10 @@ public class RemoteInputChannel extends InputChannel {
         this.connectionId = checkNotNull(connectionId);
         this.connectionManager = checkNotNull(connectionManager);
         this.bufferManager = new BufferManager(inputGate.getMemorySegmentProvider(), this, 0);
-        this.channelStatePersister = new ChannelStatePersister(stateWriter, getChannelInfo());
 
         this.recoveredStore = checkNotNull(recoveredStore);
+        this.channelStatePersister =
+                new ChannelStatePersister(stateWriter, getChannelInfo(), this.recoveredStore);
         synchronized (this.recoveredStore) {
             this.recoveredStore.setDataAvailableListener(this::notifyChannelNonEmpty);
         }
@@ -812,13 +813,13 @@ public class RemoteInputChannel extends InputChannel {
     /**
      * Spills all queued buffers on checkpoint start. If barrier has already been received (and
      * reordered), spill only the overtaken buffers.
+     *
+     * <p>The entire body runs under the store lock. {@code startPersisting} can call back into
+     * the dispatcher coordinator via {@code store.checkpoint()}; that callback is lock-free in
+     * the post-iter_6 design, so no AB-BA cycle forms with the recovery thread that may also
+     * touch this store.
      */
     public void checkpointStarted(CheckpointBarrier barrier) throws CheckpointException {
-        // Collect the inflight snapshot under the lock for consistency, then release before
-        // calling startPersisting: that reaches store.checkpoint() which fires the dispatcher
-        // coordinator (synchronized), and the dispatcher itself acquires the store lock from
-        // the recovery thread, so holding the store lock across would deadlock AB-BA.
-        final List<Buffer> inflightBuffers;
         synchronized (recoveredStore) {
             if (barrier.getId() < lastBarrierId) {
                 throw new CheckpointException(
@@ -834,16 +835,14 @@ public class RemoteInputChannel extends InputChannel {
                 // obsoleted checkpoint barrier sequence number.
                 resetLastBarrier();
             }
-            inflightBuffers = getInflightBuffersUnsafe(barrier.getId());
+            channelStatePersister.startPersisting(
+                    barrier.getId(), getInflightBuffersUnsafe(barrier.getId()));
         }
-
-        channelStatePersister.startPersisting(barrier.getId(), recoveredStore, inflightBuffers);
     }
 
     public void checkpointStopped(long checkpointId) {
-        // Outside the store lock for the same AB-BA reason as checkpointStarted.
-        channelStatePersister.stopPersisting(checkpointId, recoveredStore);
         synchronized (recoveredStore) {
+            channelStatePersister.stopPersisting(checkpointId);
             if (lastBarrierId == checkpointId) {
                 resetLastBarrier();
             }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -811,10 +811,10 @@ public class RemoteInputChannel extends InputChannel {
     }
 
     /**
-     * Spills all queued buffers on checkpoint start. If the barrier has already been received
-     * (and reordered), spill only the overtaken buffers. The entire body runs under the store
-     * lock so {@code checkpointStatus} transitions inside {@code startPersisting} cannot tear
-     * against the network thread's {@code maybePersist}.
+     * Spills all queued buffers on checkpoint start. If the barrier has already been received (and
+     * reordered), spill only the overtaken buffers. The entire body runs under the store lock so
+     * {@code checkpointStatus} transitions inside {@code startPersisting} cannot tear against the
+     * network thread's {@code maybePersist}.
      */
     public void checkpointStarted(CheckpointBarrier barrier) throws CheckpointException {
         synchronized (recoveredStore) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -89,7 +89,12 @@ public class RemoteInputChannel extends InputChannel {
     /**
      * The received buffers. Received buffers are enqueued by the network I/O thread and the queue
      * is consumed by the receiving task thread.
+     *
+     * <p>Guarded by the {@link #recoveredStore} monitor (the unified channel-private lock; see the
+     * locking contract in {@link RecoveredBufferStore}). All access — reads, mutations, iteration
+     * — must happen under {@code synchronized (recoveredStore)}.
      */
+    @GuardedBy("recoveredStore")
     private final PrioritizedDeque<SequenceBuffer> receivedBuffers = new PrioritizedDeque<>();
 
     /**
@@ -115,13 +120,27 @@ public class RemoteInputChannel extends InputChannel {
 
     private final BufferManager bufferManager;
 
-    @GuardedBy("receivedBuffers")
+    @GuardedBy("recoveredStore")
     private int lastBarrierSequenceNumber = NONE;
 
-    @GuardedBy("receivedBuffers")
+    @GuardedBy("recoveredStore")
     private long lastBarrierId = NONE;
 
     private final ChannelStatePersister channelStatePersister;
+
+    /**
+     * Store for recovered buffers. Always non-null: callers with no recovered data pass {@link
+     * RecoveredBufferStore#EMPTY}.
+     */
+    private final RecoveredBufferStore recoveredStore;
+
+    /**
+     * True iff a priority element sits at the head of {@link #receivedBuffers} and should be
+     * consumed before the recovered store. Invariant maintained under the lock:
+     * {@code hasPendingPriorityEvent <=> receivedBuffers.getNumPriorityElements() > 0}.
+     */
+    @GuardedBy("recoveredStore")
+    private boolean hasPendingPriorityEvent = false;
 
     private long totalQueueSizeInBytes;
 
@@ -139,7 +158,7 @@ public class RemoteInputChannel extends InputChannel {
             Counter numBytesIn,
             Counter numBuffersIn,
             ChannelStateWriter stateWriter,
-            ArrayDeque<Buffer> initialRecoveredBuffers) {
+            RecoveredBufferStore recoveredStore) {
 
         super(
                 inputGate,
@@ -159,27 +178,13 @@ public class RemoteInputChannel extends InputChannel {
         this.bufferManager = new BufferManager(inputGate.getMemorySegmentProvider(), this, 0);
         this.channelStatePersister = new ChannelStatePersister(stateWriter, getChannelInfo());
 
-        // Migrate recovered buffers from RecoveredInputChannel if provided.
-        // These buffers have been filtered but not yet consumed by the Task.
-        if (!initialRecoveredBuffers.isEmpty()) {
-            final int expectedCount = initialRecoveredBuffers.size();
-            // Sequence number starts at Integer.MIN_VALUE, consistent with RecoveredInputChannel.
-            int seqNum = Integer.MIN_VALUE;
-            for (Buffer buffer : initialRecoveredBuffers) {
-                // subpartitionId is set to 0 for recovered buffers. This is correct because:
-                // 1) For single-subpartition channels, the only valid subpartition is 0.
-                // 2) For multi-subpartition channels (consumedSubpartitionIndexSet.size() > 1),
-                //    RecoveryMetadata events embedded in the recovered buffer sequence track
-                //    the actual subpartition context for proper routing.
-                SequenceBuffer sequenceBuffer = new SequenceBuffer(buffer, seqNum++, 0);
-                receivedBuffers.add(sequenceBuffer);
-                totalQueueSizeInBytes += buffer.getSize();
-            }
-            checkState(
-                    receivedBuffers.size() == expectedCount,
-                    "Buffer migration failed: expected %s buffers but got %s",
-                    expectedCount,
-                    receivedBuffers.size());
+        // Callers with no recovered data pass RecoveredBufferStore.EMPTY; unconditional assignment
+        // avoids null guards throughout the class and eliminates the buggy isEmpty() guard that
+        // would discard the store reference while FilteredBufferDispatcher still has pending
+        // writes.
+        this.recoveredStore = checkNotNull(recoveredStore);
+        synchronized (this.recoveredStore) {
+            this.recoveredStore.setDataAvailableListener(this::notifyChannelNonEmpty);
         }
     }
 
@@ -263,8 +268,8 @@ public class RemoteInputChannel extends InputChannel {
 
     @Override
     protected int peekNextBufferSubpartitionIdInternal() throws IOException {
-        synchronized (receivedBuffers) {
-            checkReadability();
+        synchronized (recoveredStore) {
+            checkPartitionRequestQueueInitialized();
 
             final SequenceBuffer next = receivedBuffers.peek();
 
@@ -278,24 +283,62 @@ public class RemoteInputChannel extends InputChannel {
 
     @Override
     public Optional<BufferAndAvailability> getNextBuffer() throws IOException {
-        final SequenceBuffer next;
+        // Single-lock decision: classify the state and pick the next buffer in one critical
+        // section so "is recovery done", "is there a priority event", "what is the next
+        // data type" cannot be torn against the underlying queues. Splitting the decision
+        // across multiple synchronized blocks would let producers slip data into
+        // receivedBuffers (or drain the store) between segments and surface a stale
+        // moreAvailable that hides queued buffers from the gate.
+        final Buffer recoveredBuffer;
+        final SequenceBuffer fromReceivedBuffers;
         final DataType nextDataType;
 
-        synchronized (receivedBuffers) {
-            checkReadability();
-
-            next = receivedBuffers.poll();
-
-            if (next != null) {
-                totalQueueSizeInBytes -= next.buffer.getSize();
+        synchronized (recoveredStore) {
+            if (!recoveredStore.isEmpty()) {
+                if (hasPendingPriorityEvent) {
+                    fromReceivedBuffers = pollPendingPriorityEvent();
+                    if (fromReceivedBuffers == null) {
+                        // Defensive: invariant should keep the flag aligned with
+                        // receivedBuffers.getNumPriorityElements() > 0; if it is not,
+                        // mirror the pre-refactor behavior and yield without consuming
+                        // from the recovered store.
+                        return Optional.empty();
+                    }
+                    nextDataType = peekNextDataType();
+                    recoveredBuffer = null;
+                } else {
+                    recoveredBuffer = recoveredStore.tryTake();
+                    if (recoveredBuffer == null) {
+                        // readyBuffers empty but pendingCount > 0: the drain listener
+                        // will wake us when the next buffer lands in readyBuffers.
+                        return Optional.empty();
+                    }
+                    nextDataType = peekNextDataType();
+                    fromReceivedBuffers = null;
+                }
+            } else {
+                checkPartitionRequestQueueInitialized();
+                fromReceivedBuffers = receivedBuffers.poll();
+                if (fromReceivedBuffers != null) {
+                    totalQueueSizeInBytes -= fromReceivedBuffers.buffer.getSize();
+                    if (receivedBuffers.getNumPriorityElements() == 0) {
+                        hasPendingPriorityEvent = false;
+                    }
+                }
+                nextDataType = peekNextDataType();
+                recoveredBuffer = null;
             }
-            nextDataType =
-                    receivedBuffers.peek() != null
-                            ? receivedBuffers.peek().buffer.getDataType()
-                            : DataType.NONE;
         }
 
-        if (next == null) {
+        if (recoveredBuffer != null) {
+            numBytesIn.inc(recoveredBuffer.getSize());
+            numBuffersIn.inc();
+            return Optional.of(
+                    new BufferAndAvailability(
+                            recoveredBuffer, nextDataType, 0, Integer.MIN_VALUE));
+        }
+
+        if (fromReceivedBuffers == null) {
             if (isReleased.get()) {
                 throw new CancelTaskException(
                         "Queried for a buffer after channel has been released.");
@@ -305,15 +348,73 @@ public class RemoteInputChannel extends InputChannel {
 
         NetworkActionsLogger.traceInput(
                 "RemoteInputChannel#getNextBuffer",
-                next.buffer,
+                fromReceivedBuffers.buffer,
                 inputGate.getOwningTaskName(),
                 channelInfo,
                 channelStatePersister,
-                next.sequenceNumber);
-        numBytesIn.inc(next.buffer.getSize());
+                fromReceivedBuffers.sequenceNumber);
+        numBytesIn.inc(fromReceivedBuffers.buffer.getSize());
         numBuffersIn.inc();
         return Optional.of(
-                new BufferAndAvailability(next.buffer, nextDataType, 0, next.sequenceNumber));
+                new BufferAndAvailability(
+                        fromReceivedBuffers.buffer,
+                        nextDataType,
+                        0,
+                        fromReceivedBuffers.sequenceNumber));
+    }
+
+    /**
+     * Returns the data type of the next buffer the consumer will see across the layered
+     * sources ({@link #recoveredStore} first, then {@link #receivedBuffers}), respecting the
+     * priority-bypass rule. Returns {@link DataType#NONE} when neither source has a visible
+     * head; this includes the case where the recovered store has only on-disk pending entries
+     * (the drain listener will fire once they land in readyBuffers).
+     *
+     * <p>Caller MUST hold the {@link #recoveredStore} monitor.
+     */
+    @GuardedBy("recoveredStore")
+    private DataType peekNextDataType() {
+        assert Thread.holdsLock(recoveredStore);
+        if (hasPendingPriorityEvent) {
+            // Priority head bypasses the FIFO recovery-first rule.
+            SequenceBuffer peeked = receivedBuffers.peek();
+            return peeked != null ? peeked.buffer.getDataType() : DataType.NONE;
+        }
+        if (!recoveredStore.isEmpty()) {
+            // readyBuffers head if any; NONE while only pendingCount > 0 — the drain
+            // listener will wake the consumer when readyBuffers becomes non-empty.
+            return recoveredStore.peekNextDataType();
+        }
+        SequenceBuffer peeked = receivedBuffers.peek();
+        return peeked != null ? peeked.buffer.getDataType() : DataType.NONE;
+    }
+
+    /**
+     * Pulls the priority head of {@link #receivedBuffers} (skipping {@link #recoveredStore})
+     * and updates {@link #hasPendingPriorityEvent} when the last priority is drained.
+     * Returns {@code null} when no priority element is pending. Caller MUST hold the
+     * {@link #recoveredStore} monitor.
+     */
+    @GuardedBy("recoveredStore")
+    @Nullable
+    private SequenceBuffer pollPendingPriorityEvent() throws IOException {
+        assert Thread.holdsLock(recoveredStore);
+        if (!hasPendingPriorityEvent) {
+            return null;
+        }
+        checkPartitionRequestQueueInitialized();
+
+        SequenceBuffer next = receivedBuffers.poll();
+        checkState(
+                next != null && next.buffer.getDataType().hasPriority(),
+                "Expected priority event, but got %s",
+                next == null ? "null" : next.buffer.getDataType());
+        totalQueueSizeInBytes -= next.buffer.getSize();
+
+        if (receivedBuffers.getNumPriorityElements() == 0) {
+            hasPendingPriorityEvent = false;
+        }
+        return next;
     }
 
     // ------------------------------------------------------------------------
@@ -344,8 +445,12 @@ public class RemoteInputChannel extends InputChannel {
     void releaseAllResources() throws IOException {
         if (isReleased.compareAndSet(false, true)) {
 
+            // Release recovered store (EMPTY.releaseAll() is a no-op, so no null check needed).
+            recoveredStore.releaseAll();
+
             final ArrayDeque<Buffer> releasedBuffers;
-            synchronized (receivedBuffers) {
+            synchronized (recoveredStore) {
+                hasPendingPriorityEvent = false;
                 releasedBuffers =
                         receivedBuffers.stream()
                                 .map(sb -> sb.buffer)
@@ -366,7 +471,13 @@ public class RemoteInputChannel extends InputChannel {
 
     @Override
     int getBuffersInUseCount() {
-        return getNumberOfQueuedBuffers()
+        // recoveredStore.size() and receivedBuffers.size() share the same monitor; collect both
+        // under the store lock so the result is a single consistent snapshot.
+        int channelBacklog;
+        synchronized (recoveredStore) {
+            channelBacklog = recoveredStore.size() + receivedBuffers.size();
+        }
+        return channelBacklog
                 + Math.max(0, bufferManager.getNumberOfRequiredBuffers() - initialCredit);
     }
 
@@ -430,7 +541,10 @@ public class RemoteInputChannel extends InputChannel {
 
     @VisibleForTesting
     public Buffer getNextReceivedBuffer() {
-        final SequenceBuffer sequenceBuffer = receivedBuffers.poll();
+        final SequenceBuffer sequenceBuffer;
+        synchronized (recoveredStore) {
+            sequenceBuffer = receivedBuffers.poll();
+        }
         return sequenceBuffer != null ? sequenceBuffer.buffer : null;
     }
 
@@ -521,14 +635,14 @@ public class RemoteInputChannel extends InputChannel {
      * @return Buffers queued for processing.
      */
     public int getNumberOfQueuedBuffers() {
-        synchronized (receivedBuffers) {
+        synchronized (recoveredStore) {
             return receivedBuffers.size();
         }
     }
 
     @Override
     public int unsynchronizedGetNumberOfQueuedBuffers() {
-        return Math.max(0, receivedBuffers.size());
+        return recoveredStore.size() + Math.max(0, receivedBuffers.size());
     }
 
     @Override
@@ -577,9 +691,20 @@ public class RemoteInputChannel extends InputChannel {
      * is less than backlog + initialCredit, it will request floating buffers from the buffer
      * manager, and then notify unannounced credits to the producer.
      *
+     * <p>While the recovered store is non-empty, this is a no-op: credit is gated and the upstream
+     * is not allowed to send new data (see {@link #notifyBufferAvailable}).
+     *
      * @param backlog The number of unsent buffers in the producer's sub partition.
      */
     public void onSenderBacklog(int backlog) throws IOException {
+        final boolean stillRecovering;
+        synchronized (recoveredStore) {
+            stillRecovering = !recoveredStore.isEmpty();
+        }
+        if (stillRecovering) {
+            // Credit gated during recovery; ignore backlog signals from upstream.
+            return;
+        }
         notifyBufferAvailable(bufferManager.requestFloatingBuffers(backlog + initialCredit));
     }
 
@@ -604,7 +729,7 @@ public class RemoteInputChannel extends InputChannel {
 
             final boolean wasEmpty;
             boolean firstPriorityEvent = false;
-            synchronized (receivedBuffers) {
+            synchronized (recoveredStore) {
                 NetworkActionsLogger.traceInput(
                         "RemoteInputChannel#onBuffer",
                         buffer,
@@ -633,6 +758,9 @@ public class RemoteInputChannel extends InputChannel {
                     if (dataType.requiresAnnouncement()) {
                         firstPriorityEvent = addPriorityBuffer(announce(sequenceBuffer));
                     }
+                }
+                if (firstPriorityEvent) {
+                    hasPendingPriorityEvent = true;
                 }
                 totalQueueSizeInBytes += buffer.getSize();
                 final OptionalLong barrierId =
@@ -710,9 +838,22 @@ public class RemoteInputChannel extends InputChannel {
     /**
      * Spills all queued buffers on checkpoint start. If barrier has already been received (and
      * reordered), spill only the overtaken buffers.
+     *
+     * <p>The recoveredStore is passed to the centralized {@link
+     * ChannelStatePersister#startPersisting} so that ready-buffer snapshot and
+     * FilteredBufferDispatcher callback are handled in one place. Network inflight buffers from
+     * {@code receivedBuffers} are collected here (Remote-specific) and passed as {@code
+     * knownBuffers}.
      */
     public void checkpointStarted(CheckpointBarrier barrier) throws CheckpointException {
-        synchronized (receivedBuffers) {
+        // Collect the inflight snapshot under the store lock so receivedBuffers iteration and
+        // barrier-id state are consistent. Then release the store lock before calling
+        // startPersisting — startPersisting reaches into store.checkpoint() which fires the
+        // dispatcher coordinator callback (a synchronized method on the dispatcher); the dispatcher
+        // also acquires the store lock from the recovery thread (write/flushCache → incrementPending),
+        // so holding the store lock across the dispatcher acquire would form an AB-BA deadlock.
+        final List<Buffer> inflightBuffers;
+        synchronized (recoveredStore) {
             if (barrier.getId() < lastBarrierId) {
                 throw new CheckpointException(
                         String.format(
@@ -723,20 +864,22 @@ public class RemoteInputChannel extends InputChannel {
                 // checkpoint is possible
             } else if (barrier.getId() > lastBarrierId) {
                 // This channel has received some obsolete barrier, older compared to the
-                // checkpointId
-                // which we are processing right now, and we should ignore that obsoleted checkpoint
-                // barrier sequence number.
+                // checkpointId which we are processing right now, and we should ignore that
+                // obsoleted checkpoint barrier sequence number.
                 resetLastBarrier();
             }
-
-            channelStatePersister.startPersisting(
-                    barrier.getId(), getInflightBuffersUnsafe(barrier.getId()));
+            inflightBuffers = getInflightBuffersUnsafe(barrier.getId());
         }
+
+        channelStatePersister.startPersisting(barrier.getId(), recoveredStore, inflightBuffers);
     }
 
     public void checkpointStopped(long checkpointId) {
-        synchronized (receivedBuffers) {
-            channelStatePersister.stopPersisting(checkpointId);
+        // stopPersisting is invoked outside the store lock for the same lock-order reason as
+        // checkpointStarted: it eventually calls into the dispatcher coordinator (notifyCheckpointStopped)
+        // and the dispatcher's synchronized methods can acquire the store lock from the recovery side.
+        channelStatePersister.stopPersisting(checkpointId, recoveredStore);
+        synchronized (recoveredStore) {
             if (lastBarrierId == checkpointId) {
                 resetLastBarrier();
             }
@@ -745,7 +888,7 @@ public class RemoteInputChannel extends InputChannel {
 
     @VisibleForTesting
     List<Buffer> getInflightBuffers(long checkpointId) {
-        synchronized (receivedBuffers) {
+        synchronized (recoveredStore) {
             return getInflightBuffersUnsafe(checkpointId);
         }
     }
@@ -753,7 +896,7 @@ public class RemoteInputChannel extends InputChannel {
     @Override
     public void convertToPriorityEvent(int sequenceNumber) throws IOException {
         boolean firstPriorityEvent;
-        synchronized (receivedBuffers) {
+        synchronized (recoveredStore) {
             checkState(channelStatePersister.hasBarrierReceived());
             int numPriorityElementsBeforeRemoval = receivedBuffers.getNumPriorityElements();
             SequenceBuffer toPrioritize =
@@ -782,6 +925,9 @@ public class RemoteInputChannel extends InputChannel {
                     addPriorityBuffer(
                             toPrioritize); // note that only position of the element is changed
             // converting the event itself would require switching the controller sooner
+            if (firstPriorityEvent) {
+                hasPendingPriorityEvent = true;
+            }
         }
         if (firstPriorityEvent) {
             notifyPriorityEventForce(); // forcibly notify about the priority event
@@ -799,7 +945,7 @@ public class RemoteInputChannel extends InputChannel {
      * events.
      */
     private List<Buffer> getInflightBuffersUnsafe(long checkpointId) {
-        assert Thread.holdsLock(receivedBuffers);
+        assert Thread.holdsLock(recoveredStore);
 
         checkState(checkpointId == lastBarrierId || lastBarrierId == NONE);
 
@@ -879,7 +1025,7 @@ public class RemoteInputChannel extends InputChannel {
     public void onEmptyBuffer(int sequenceNumber, int backlog) throws IOException {
         boolean success = false;
 
-        synchronized (receivedBuffers) {
+        synchronized (recoveredStore) {
             if (!isReleased.get()) {
                 if (expectedSequenceNumber == sequenceNumber) {
                     expectedSequenceNumber++;
@@ -901,20 +1047,6 @@ public class RemoteInputChannel extends InputChannel {
 
     public void onError(Throwable cause) {
         setError(cause);
-    }
-
-    /**
-     * When receivedBuffers contains migrated buffers from RecoveredInputChannel, they can be read
-     * before requestSubpartitions(). In that case only check for errors. Once migrated buffers are
-     * drained, require full client initialization check.
-     */
-    private void checkReadability() throws IOException {
-        assert Thread.holdsLock(receivedBuffers);
-        if (receivedBuffers.isEmpty()) {
-            checkPartitionRequestQueueInitialized();
-        } else {
-            checkError();
-        }
     }
 
     private void checkPartitionRequestQueueInitialized() throws IOException {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -811,13 +811,10 @@ public class RemoteInputChannel extends InputChannel {
     }
 
     /**
-     * Spills all queued buffers on checkpoint start. If barrier has already been received (and
-     * reordered), spill only the overtaken buffers.
-     *
-     * <p>The entire body runs under the store lock. {@code startPersisting} can call back into
-     * the dispatcher coordinator via {@code store.checkpoint()}; that callback is lock-free in
-     * the post-iter_6 design, so no AB-BA cycle forms with the recovery thread that may also
-     * touch this store.
+     * Spills all queued buffers on checkpoint start. If the barrier has already been received
+     * (and reordered), spill only the overtaken buffers. The entire body runs under the store
+     * lock so {@code checkpointStatus} transitions inside {@code startPersisting} cannot tear
+     * against the network thread's {@code maybePersist}.
      */
     public void checkpointStarted(CheckpointBarrier barrier) throws CheckpointException {
         synchronized (recoveredStore) {
@@ -826,13 +823,10 @@ public class RemoteInputChannel extends InputChannel {
                         String.format(
                                 "Sequence number for checkpoint %d is not known (it was likely been overwritten by a newer checkpoint %d)",
                                 barrier.getId(), lastBarrierId),
-                        CheckpointFailureReason
-                                .CHECKPOINT_SUBSUMED); // currently, at most one active unaligned
-                // checkpoint is possible
+                        CheckpointFailureReason.CHECKPOINT_SUBSUMED);
             } else if (barrier.getId() > lastBarrierId) {
-                // This channel has received some obsolete barrier, older compared to the
-                // checkpointId which we are processing right now, and we should ignore that
-                // obsoleted checkpoint barrier sequence number.
+                // Older barrier already in flight — drop its sequence number; the newer
+                // checkpoint we just received takes over.
                 resetLastBarrier();
             }
             channelStatePersister.startPersisting(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -128,9 +128,9 @@ public class RemoteInputChannel extends InputChannel {
     private final RecoveredBufferStore recoveredStore;
 
     /**
-     * Invariant under lock:
-     * {@code hasPendingPriorityEvent <=> receivedBuffers.getNumPriorityElements() > 0}. A
-     * priority element bypasses the FIFO recovery-first rule.
+     * Invariant under lock: {@code hasPendingPriorityEvent <=>
+     * receivedBuffers.getNumPriorityElements() > 0}. A priority element bypasses the FIFO
+     * recovery-first rule.
      */
     @GuardedBy("recoveredStore")
     private boolean hasPendingPriorityEvent = false;
@@ -318,8 +318,7 @@ public class RemoteInputChannel extends InputChannel {
             numBytesIn.inc(recoveredBuffer.getSize());
             numBuffersIn.inc();
             return Optional.of(
-                    new BufferAndAvailability(
-                            recoveredBuffer, nextDataType, 0, Integer.MIN_VALUE));
+                    new BufferAndAvailability(recoveredBuffer, nextDataType, 0, Integer.MIN_VALUE));
         }
 
         if (fromReceivedBuffers == null) {
@@ -348,9 +347,8 @@ public class RemoteInputChannel extends InputChannel {
     }
 
     /**
-     * Data type of the next buffer the consumer will see across {@link #recoveredStore} and
-     * {@link #receivedBuffers}, respecting the priority bypass. Caller MUST hold
-     * {@code recoveredStore}.
+     * Data type of the next buffer the consumer will see across {@link #recoveredStore} and {@link
+     * #receivedBuffers}, respecting the priority bypass. Caller MUST hold {@code recoveredStore}.
      */
     @GuardedBy("recoveredStore")
     private DataType peekNextDataType() {
@@ -668,8 +666,8 @@ public class RemoteInputChannel extends InputChannel {
      * is less than backlog + initialCredit, it will request floating buffers from the buffer
      * manager, and then notify unannounced credits to the producer.
      *
-     * <p>No-op while the recovered store is non-empty: credit is gated during recovery so
-     * upstream cannot send new data.
+     * <p>No-op while the recovered store is non-empty: credit is gated during recovery so upstream
+     * cannot send new data.
      *
      * @param backlog The number of unsent buffers in the producer's sub partition.
      */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -87,12 +87,8 @@ public class RemoteInputChannel extends InputChannel {
     private final ConnectionManager connectionManager;
 
     /**
-     * The received buffers. Received buffers are enqueued by the network I/O thread and the queue
-     * is consumed by the receiving task thread.
-     *
-     * <p>Guarded by the {@link #recoveredStore} monitor (the unified channel-private lock; see the
-     * locking contract in {@link RecoveredBufferStore}). All access — reads, mutations, iteration
-     * — must happen under {@code synchronized (recoveredStore)}.
+     * Buffers enqueued by the network I/O thread and consumed by the task thread. Guarded by the
+     * {@link #recoveredStore} monitor (the unified channel-private lock).
      */
     @GuardedBy("recoveredStore")
     private final PrioritizedDeque<SequenceBuffer> receivedBuffers = new PrioritizedDeque<>();
@@ -128,16 +124,13 @@ public class RemoteInputChannel extends InputChannel {
 
     private final ChannelStatePersister channelStatePersister;
 
-    /**
-     * Store for recovered buffers. Always non-null: callers with no recovered data pass {@link
-     * RecoveredBufferStore#EMPTY}.
-     */
+    /** Always non-null: callers with no recovered data pass {@link RecoveredBufferStore#EMPTY}. */
     private final RecoveredBufferStore recoveredStore;
 
     /**
-     * True iff a priority element sits at the head of {@link #receivedBuffers} and should be
-     * consumed before the recovered store. Invariant maintained under the lock:
-     * {@code hasPendingPriorityEvent <=> receivedBuffers.getNumPriorityElements() > 0}.
+     * Invariant under lock:
+     * {@code hasPendingPriorityEvent <=> receivedBuffers.getNumPriorityElements() > 0}. A
+     * priority element bypasses the FIFO recovery-first rule.
      */
     @GuardedBy("recoveredStore")
     private boolean hasPendingPriorityEvent = false;
@@ -178,10 +171,6 @@ public class RemoteInputChannel extends InputChannel {
         this.bufferManager = new BufferManager(inputGate.getMemorySegmentProvider(), this, 0);
         this.channelStatePersister = new ChannelStatePersister(stateWriter, getChannelInfo());
 
-        // Callers with no recovered data pass RecoveredBufferStore.EMPTY; unconditional assignment
-        // avoids null guards throughout the class and eliminates the buggy isEmpty() guard that
-        // would discard the store reference while FilteredBufferDispatcher still has pending
-        // writes.
         this.recoveredStore = checkNotNull(recoveredStore);
         synchronized (this.recoveredStore) {
             this.recoveredStore.setDataAvailableListener(this::notifyChannelNonEmpty);
@@ -283,12 +272,10 @@ public class RemoteInputChannel extends InputChannel {
 
     @Override
     public Optional<BufferAndAvailability> getNextBuffer() throws IOException {
-        // Single-lock decision: classify the state and pick the next buffer in one critical
-        // section so "is recovery done", "is there a priority event", "what is the next
-        // data type" cannot be torn against the underlying queues. Splitting the decision
-        // across multiple synchronized blocks would let producers slip data into
-        // receivedBuffers (or drain the store) between segments and surface a stale
-        // moreAvailable that hides queued buffers from the gate.
+        // Single critical section so "is recovery done", "is there a priority event", "what is
+        // the next data type" cannot be torn against the underlying queues. Splitting would let
+        // producers slip data into receivedBuffers (or drain the store) between segments and
+        // surface a stale moreAvailable that hides queued buffers from the gate.
         final Buffer recoveredBuffer;
         final SequenceBuffer fromReceivedBuffers;
         final DataType nextDataType;
@@ -298,10 +285,8 @@ public class RemoteInputChannel extends InputChannel {
                 if (hasPendingPriorityEvent) {
                     fromReceivedBuffers = pollPendingPriorityEvent();
                     if (fromReceivedBuffers == null) {
-                        // Defensive: invariant should keep the flag aligned with
-                        // receivedBuffers.getNumPriorityElements() > 0; if it is not,
-                        // mirror the pre-refactor behavior and yield without consuming
-                        // from the recovered store.
+                        // Invariant should keep the flag aligned with priority count; defensive
+                        // yield mirrors pre-refactor behavior.
                         return Optional.empty();
                     }
                     nextDataType = peekNextDataType();
@@ -309,8 +294,7 @@ public class RemoteInputChannel extends InputChannel {
                 } else {
                     recoveredBuffer = recoveredStore.tryTake();
                     if (recoveredBuffer == null) {
-                        // readyBuffers empty but pendingCount > 0: the drain listener
-                        // will wake us when the next buffer lands in readyBuffers.
+                        // readyBuffers empty but pendingCount > 0: drain listener wakes us.
                         return Optional.empty();
                     }
                     nextDataType = peekNextDataType();
@@ -364,25 +348,20 @@ public class RemoteInputChannel extends InputChannel {
     }
 
     /**
-     * Returns the data type of the next buffer the consumer will see across the layered
-     * sources ({@link #recoveredStore} first, then {@link #receivedBuffers}), respecting the
-     * priority-bypass rule. Returns {@link DataType#NONE} when neither source has a visible
-     * head; this includes the case where the recovered store has only on-disk pending entries
-     * (the drain listener will fire once they land in readyBuffers).
-     *
-     * <p>Caller MUST hold the {@link #recoveredStore} monitor.
+     * Data type of the next buffer the consumer will see across {@link #recoveredStore} and
+     * {@link #receivedBuffers}, respecting the priority bypass. Caller MUST hold
+     * {@code recoveredStore}.
      */
     @GuardedBy("recoveredStore")
     private DataType peekNextDataType() {
         assert Thread.holdsLock(recoveredStore);
         if (hasPendingPriorityEvent) {
-            // Priority head bypasses the FIFO recovery-first rule.
             SequenceBuffer peeked = receivedBuffers.peek();
             return peeked != null ? peeked.buffer.getDataType() : DataType.NONE;
         }
         if (!recoveredStore.isEmpty()) {
-            // readyBuffers head if any; NONE while only pendingCount > 0 — the drain
-            // listener will wake the consumer when readyBuffers becomes non-empty.
+            // NONE while only pendingCount > 0; drain listener wakes the consumer when
+            // readyBuffers becomes non-empty.
             return recoveredStore.peekNextDataType();
         }
         SequenceBuffer peeked = receivedBuffers.peek();
@@ -390,10 +369,9 @@ public class RemoteInputChannel extends InputChannel {
     }
 
     /**
-     * Pulls the priority head of {@link #receivedBuffers} (skipping {@link #recoveredStore})
-     * and updates {@link #hasPendingPriorityEvent} when the last priority is drained.
-     * Returns {@code null} when no priority element is pending. Caller MUST hold the
-     * {@link #recoveredStore} monitor.
+     * Polls the priority head of {@link #receivedBuffers}, skipping {@link #recoveredStore} and
+     * clearing {@link #hasPendingPriorityEvent} when the last priority drains. Caller MUST hold
+     * {@code recoveredStore}.
      */
     @GuardedBy("recoveredStore")
     @Nullable
@@ -445,7 +423,7 @@ public class RemoteInputChannel extends InputChannel {
     void releaseAllResources() throws IOException {
         if (isReleased.compareAndSet(false, true)) {
 
-            // Release recovered store (EMPTY.releaseAll() is a no-op, so no null check needed).
+            // EMPTY.releaseAll() is a no-op, so no null check needed.
             recoveredStore.releaseAll();
 
             final ArrayDeque<Buffer> releasedBuffers;
@@ -471,8 +449,7 @@ public class RemoteInputChannel extends InputChannel {
 
     @Override
     int getBuffersInUseCount() {
-        // recoveredStore.size() and receivedBuffers.size() share the same monitor; collect both
-        // under the store lock so the result is a single consistent snapshot.
+        // Single snapshot under the shared monitor.
         int channelBacklog;
         synchronized (recoveredStore) {
             channelBacklog = recoveredStore.size() + receivedBuffers.size();
@@ -691,8 +668,8 @@ public class RemoteInputChannel extends InputChannel {
      * is less than backlog + initialCredit, it will request floating buffers from the buffer
      * manager, and then notify unannounced credits to the producer.
      *
-     * <p>While the recovered store is non-empty, this is a no-op: credit is gated and the upstream
-     * is not allowed to send new data (see {@link #notifyBufferAvailable}).
+     * <p>No-op while the recovered store is non-empty: credit is gated during recovery so
+     * upstream cannot send new data.
      *
      * @param backlog The number of unsent buffers in the producer's sub partition.
      */
@@ -702,7 +679,6 @@ public class RemoteInputChannel extends InputChannel {
             stillRecovering = !recoveredStore.isEmpty();
         }
         if (stillRecovering) {
-            // Credit gated during recovery; ignore backlog signals from upstream.
             return;
         }
         notifyBufferAvailable(bufferManager.requestFloatingBuffers(backlog + initialCredit));
@@ -838,20 +814,12 @@ public class RemoteInputChannel extends InputChannel {
     /**
      * Spills all queued buffers on checkpoint start. If barrier has already been received (and
      * reordered), spill only the overtaken buffers.
-     *
-     * <p>The recoveredStore is passed to the centralized {@link
-     * ChannelStatePersister#startPersisting} so that ready-buffer snapshot and
-     * FilteredBufferDispatcher callback are handled in one place. Network inflight buffers from
-     * {@code receivedBuffers} are collected here (Remote-specific) and passed as {@code
-     * knownBuffers}.
      */
     public void checkpointStarted(CheckpointBarrier barrier) throws CheckpointException {
-        // Collect the inflight snapshot under the store lock so receivedBuffers iteration and
-        // barrier-id state are consistent. Then release the store lock before calling
-        // startPersisting — startPersisting reaches into store.checkpoint() which fires the
-        // dispatcher coordinator callback (a synchronized method on the dispatcher); the dispatcher
-        // also acquires the store lock from the recovery thread (write/flushCache → incrementPending),
-        // so holding the store lock across the dispatcher acquire would form an AB-BA deadlock.
+        // Collect the inflight snapshot under the lock for consistency, then release before
+        // calling startPersisting: that reaches store.checkpoint() which fires the dispatcher
+        // coordinator (synchronized), and the dispatcher itself acquires the store lock from
+        // the recovery thread, so holding the store lock across would deadlock AB-BA.
         final List<Buffer> inflightBuffers;
         synchronized (recoveredStore) {
             if (barrier.getId() < lastBarrierId) {
@@ -875,9 +843,7 @@ public class RemoteInputChannel extends InputChannel {
     }
 
     public void checkpointStopped(long checkpointId) {
-        // stopPersisting is invoked outside the store lock for the same lock-order reason as
-        // checkpointStarted: it eventually calls into the dispatcher coordinator (notifyCheckpointStopped)
-        // and the dispatcher's synchronized methods can acquire the store lock from the recovery side.
+        // Outside the store lock for the same AB-BA reason as checkpointStarted.
         channelStatePersister.stopPersisting(checkpointId, recoveredStore);
         synchronized (recoveredStore) {
             if (lastBarrierId == checkpointId) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteRecoveredInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteRecoveredInputChannel.java
@@ -20,13 +20,11 @@ package org.apache.flink.runtime.io.network.partition.consumer;
 
 import org.apache.flink.runtime.io.network.ConnectionID;
 import org.apache.flink.runtime.io.network.ConnectionManager;
-import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.metrics.InputChannelMetrics;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartitionIndexSet;
 
 import java.io.IOException;
-import java.util.ArrayDeque;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -68,7 +66,7 @@ public class RemoteRecoveredInputChannel extends RecoveredInputChannel {
     }
 
     @Override
-    protected InputChannel toInputChannelInternal(ArrayDeque<Buffer> remainingBuffers)
+    protected InputChannel toInputChannelInternal(RecoveredBufferStoreImpl recoveredStore)
             throws IOException {
         RemoteInputChannel remoteInputChannel =
                 new RemoteInputChannel(
@@ -85,7 +83,7 @@ public class RemoteRecoveredInputChannel extends RecoveredInputChannel {
                         numBytesIn,
                         numBuffersIn,
                         channelStateWriter,
-                        remainingBuffers);
+                        recoveredStore);
         remoteInputChannel.setup();
         return remoteInputChannel;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -407,29 +407,21 @@ public class SingleInputGate extends IndexedInputGate {
                     continue;
                 }
                 try {
-                    // Phase 1: Convert channel outside the lock so toInputChannel() can acquire
-                    // the store lock internally without violating the store-then-gate lock order
-                    // observed by store.addBuffer() / notifyChannelNonEmpty().
+                    // Convert outside the lock so toInputChannel() can take the store lock
+                    // internally without violating the store-then-gate order.
                     //
                     // Do NOT call inputChannel.releaseAllResources() here: the recovered store
-                    // reference has just been transferred to the physical channel for continued
-                    // consumption, and the BufferManager's exclusive segments are still being
-                    // consumed by the dispatcher's drainPendingSpill (which is concurrent with
-                    // this conversion). Releasing either now silently wipes recovered data and
-                    // the failure surfaces downstream as EOFException / record-count mismatch.
-                    // Both are released later — the store by the physical channel's own
-                    // releaseAllResources, the BufferManager by BufferRequester#releaseExclusiveBuffers
-                    // invoked from FilteredBufferDispatcherImpl#close after drain finishes.
+                    // has just been transferred to the physical channel and the BufferManager's
+                    // exclusive segments are still being consumed by the concurrent
+                    // drainPendingSpill. Both are released later — store by the physical
+                    // channel's releaseAllResources, BufferManager by
+                    // BufferRequester#releaseExclusiveBuffers from FilteredBufferDispatcher#close.
                     InputChannel realInputChannel =
                             ((RecoveredInputChannel) inputChannel).toInputChannel();
 
-                    // Phase 2: Atomically update data structures under the lock. Reading
-                    // {@code buffersInUseCount} INSIDE the gate lock closes a TOCTOU window:
-                    // a concurrent producer could otherwise add a buffer to the channel between a
-                    // lock-free read above and the {@code inputChannelsWithData.add} below, which
-                    // — combined with notifyChannelNonEmpty already running under the same gate
-                    // lock — would either skip enqueuing the channel (count read == 0) or enqueue
-                    // it twice (count read > 0 plus the listener-driven add).
+                    // Read buffersInUseCount INSIDE the gate lock to close a TOCTOU window with
+                    // a concurrent producer add → enqueue would either be skipped (count == 0)
+                    // or doubled (count > 0 plus the listener-driven add).
                     synchronized (inputChannelsWithData) {
                         int buffersInUseCount = realInputChannel.getBuffersInUseCount();
 
@@ -448,9 +440,8 @@ public class SingleInputGate extends IndexedInputGate {
                             enqueuedInputChannelsWithData.set(realInputChannel.getChannelIndex());
                         }
                     }
-                    // Gate slot is now wired to the physical channel; nothing on the gate side
-                    // can reach the old RecoveredInputChannel anymore. Signal the rendezvous so
-                    // BufferManager teardown fires once drain has also completed (whichever order).
+                    // Signal the drainDone+converted rendezvous; BufferManager teardown fires
+                    // once drain also completes.
                     ((RecoveredInputChannel) inputChannel).markConverted();
                 } catch (Throwable t) {
                     inputChannel.setError(t);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -162,8 +162,8 @@ public class SingleInputGate extends IndexedInputGate {
     private final PrioritizedDeque<InputChannel> inputChannelsWithData = new PrioritizedDeque<>();
 
     /**
-     * Returns this gate's intrinsic monitor — see {@link RecoveredBufferStoreImpl} for the
-     * {@code gate → store} contract that uses it.
+     * Returns this gate's intrinsic monitor — see {@link RecoveredBufferStoreImpl} for the {@code
+     * gate → store} contract that uses it.
      */
     @Internal
     public Object getGateLock() {
@@ -424,7 +424,8 @@ public class SingleInputGate extends IndexedInputGate {
                     //
                     // The recovered store and its BufferManager are released later (the physical
                     // channel takes ownership of the store; BufferManager segments are returned
-                    // by BufferRequester#releaseExclusiveBuffers from FilteredBufferDispatcher#close).
+                    // by BufferRequester#releaseExclusiveBuffers from
+                    // FilteredBufferDispatcher#close).
                     synchronized (inputChannelsWithData) {
                         InputChannel realInputChannel =
                                 ((RecoveredInputChannel) inputChannel).toInputChannel();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.partition.consumer;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.memory.MemorySegment;
@@ -159,6 +160,15 @@ public class SingleInputGate extends IndexedInputGate {
 
     /** Channels, which notified this input gate about available data. */
     private final PrioritizedDeque<InputChannel> inputChannelsWithData = new PrioritizedDeque<>();
+
+    /**
+     * Returns this gate's intrinsic monitor — see {@link RecoveredBufferStoreImpl} for the
+     * {@code gate → store} contract that uses it.
+     */
+    @Internal
+    public Object getGateLock() {
+        return inputChannelsWithData;
+    }
 
     /**
      * Field guaranteeing uniqueness for inputChannelsWithData queue. Both of those fields should be
@@ -407,22 +417,18 @@ public class SingleInputGate extends IndexedInputGate {
                     continue;
                 }
                 try {
-                    // Convert outside the lock so toInputChannel() can take the store lock
-                    // internally without violating the store-then-gate order.
+                    // toInputChannel + channels[i] swap must be atomic against producer add+fire
+                    // — see RecoveredBufferStoreImpl class javadoc. markStoreTransferred is fired
+                    // outside the gate lock so the (drainDone + storeTransferred) rendezvous's
+                    // BufferManager teardown stays off the gate lock's dependency graph.
                     //
-                    // Do NOT call inputChannel.releaseAllResources() here: the recovered store
-                    // has just been transferred to the physical channel and the BufferManager's
-                    // exclusive segments are still being consumed by the concurrent
-                    // drainPendingSpill. Both are released later — store by the physical
-                    // channel's releaseAllResources, BufferManager by
-                    // BufferRequester#releaseExclusiveBuffers from FilteredBufferDispatcher#close.
-                    InputChannel realInputChannel =
-                            ((RecoveredInputChannel) inputChannel).toInputChannel();
-
-                    // Read buffersInUseCount INSIDE the gate lock to close a TOCTOU window with
-                    // a concurrent producer add → enqueue would either be skipped (count == 0)
-                    // or doubled (count > 0 plus the listener-driven add).
+                    // The recovered store and its BufferManager are released later (the physical
+                    // channel takes ownership of the store; BufferManager segments are returned
+                    // by BufferRequester#releaseExclusiveBuffers from FilteredBufferDispatcher#close).
                     synchronized (inputChannelsWithData) {
+                        InputChannel realInputChannel =
+                                ((RecoveredInputChannel) inputChannel).toInputChannel();
+
                         int buffersInUseCount = realInputChannel.getBuffersInUseCount();
 
                         if (inputChannelsWithData.contains(inputChannel)) {
@@ -440,8 +446,6 @@ public class SingleInputGate extends IndexedInputGate {
                             enqueuedInputChannelsWithData.set(realInputChannel.getChannelIndex());
                         }
                     }
-                    // Signal the drainDone+converted rendezvous; BufferManager teardown fires
-                    // once drain also completes.
                     ((RecoveredInputChannel) inputChannel).markStoreTransferred();
                 } catch (Throwable t) {
                     inputChannel.setError(t);
@@ -473,10 +477,20 @@ public class SingleInputGate extends IndexedInputGate {
 
     @Override
     public void finishReadRecoveredState() throws IOException {
-        for (final InputChannel channel : channels) {
-            if (channel instanceof RecoveredInputChannel) {
-                ((RecoveredInputChannel) channel).finishReadRecoveredState();
+        // Pass 1 under the gate lock: EOICS publish + future completion. Pass 2 lock-free:
+        // floating-buffer release stays off the gate lock's dependency graph.
+        List<RecoveredInputChannel> recovered = new ArrayList<>();
+        synchronized (inputChannelsWithData) {
+            for (final InputChannel channel : channels) {
+                if (channel instanceof RecoveredInputChannel) {
+                    RecoveredInputChannel rc = (RecoveredInputChannel) channel;
+                    rc.finishReadRecoveredState();
+                    recovered.add(rc);
+                }
             }
+        }
+        for (RecoveredInputChannel rc : recovered) {
+            rc.releaseRecoveryFloatingBuffers();
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -442,7 +442,7 @@ public class SingleInputGate extends IndexedInputGate {
                     }
                     // Signal the drainDone+converted rendezvous; BufferManager teardown fires
                     // once drain also completes.
-                    ((RecoveredInputChannel) inputChannel).markConverted();
+                    ((RecoveredInputChannel) inputChannel).markStoreTransferred();
                 } catch (Throwable t) {
                     inputChannel.setError(t);
                     return;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -407,18 +407,32 @@ public class SingleInputGate extends IndexedInputGate {
                     continue;
                 }
                 try {
-                    // Phase 1: Convert channel and release resources outside the lock.
-                    // These calls may acquire the receivedBuffers lock internally, so they
-                    // run outside inputChannelsWithData lock to maintain a consistent lock
-                    // order with onRecoveredStateBuffer() which acquires receivedBuffers
-                    // first and then inputChannelsWithData.
+                    // Phase 1: Convert channel outside the lock so toInputChannel() can acquire
+                    // the store lock internally without violating the store-then-gate lock order
+                    // observed by store.addBuffer() / notifyChannelNonEmpty().
+                    //
+                    // Do NOT call inputChannel.releaseAllResources() here: the recovered store
+                    // reference has just been transferred to the physical channel for continued
+                    // consumption, and the BufferManager's exclusive segments are still being
+                    // consumed by the dispatcher's drainPendingSpill (which is concurrent with
+                    // this conversion). Releasing either now silently wipes recovered data and
+                    // the failure surfaces downstream as EOFException / record-count mismatch.
+                    // Both are released later — the store by the physical channel's own
+                    // releaseAllResources, the BufferManager by BufferRequester#releaseExclusiveBuffers
+                    // invoked from FilteredBufferDispatcherImpl#close after drain finishes.
                     InputChannel realInputChannel =
                             ((RecoveredInputChannel) inputChannel).toInputChannel();
-                    inputChannel.releaseAllResources();
-                    int buffersInUseCount = realInputChannel.getBuffersInUseCount();
 
-                    // Phase 2: Atomically update data structures under the lock.
+                    // Phase 2: Atomically update data structures under the lock. Reading
+                    // {@code buffersInUseCount} INSIDE the gate lock closes a TOCTOU window:
+                    // a concurrent producer could otherwise add a buffer to the channel between a
+                    // lock-free read above and the {@code inputChannelsWithData.add} below, which
+                    // — combined with notifyChannelNonEmpty already running under the same gate
+                    // lock — would either skip enqueuing the channel (count read == 0) or enqueue
+                    // it twice (count read > 0 plus the listener-driven add).
                     synchronized (inputChannelsWithData) {
+                        int buffersInUseCount = realInputChannel.getBuffersInUseCount();
+
                         if (inputChannelsWithData.contains(inputChannel)) {
                             inputChannelsWithData.getAndRemove(ch -> ch == inputChannel);
                         }
@@ -434,9 +448,22 @@ public class SingleInputGate extends IndexedInputGate {
                             enqueuedInputChannelsWithData.set(realInputChannel.getChannelIndex());
                         }
                     }
+                    // Gate slot is now wired to the physical channel; nothing on the gate side
+                    // can reach the old RecoveredInputChannel anymore. Signal the rendezvous so
+                    // BufferManager teardown fires once drain has also completed (whichever order).
+                    ((RecoveredInputChannel) inputChannel).markConverted();
                 } catch (Throwable t) {
                     inputChannel.setError(t);
                     return;
+                }
+            }
+        }
+
+        try (GateNotificationHelper notification =
+                new GateNotificationHelper(this, inputChannelsWithData)) {
+            synchronized (inputChannelsWithData) {
+                if (!inputChannelsWithData.isEmpty()) {
+                    notification.notifyDataAvailable();
                 }
             }
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnknownInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnknownInputChannel.java
@@ -35,7 +35,6 @@ import org.apache.flink.util.Preconditions;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
-import java.util.ArrayDeque;
 import java.util.Optional;
 
 import static org.apache.flink.runtime.checkpoint.CheckpointFailureReason.CHECKPOINT_DECLINED_TASK_NOT_READY;
@@ -185,7 +184,7 @@ class UnknownInputChannel extends InputChannel implements ChannelStateHolder {
                 metrics.getNumBytesInRemoteCounter(),
                 metrics.getNumBuffersInRemoteCounter(),
                 channelStateWriter == null ? ChannelStateWriter.NO_OP : channelStateWriter,
-                new ArrayDeque<>());
+                RecoveredBufferStore.EMPTY);
     }
 
     public LocalInputChannel toLocalInputChannel(ResultPartitionID resultPartitionID) {
@@ -201,7 +200,7 @@ class UnknownInputChannel extends InputChannel implements ChannelStateHolder {
                 metrics.getNumBytesInLocalCounter(),
                 metrics.getNumBuffersInLocalCounter(),
                 channelStateWriter == null ? ChannelStateWriter.NO_OP : channelStateWriter,
-                new ArrayDeque<>());
+                RecoveredBufferStore.EMPTY);
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateCheckpointWriterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateCheckpointWriterTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.filesystem.FsCheckpointStreamFactory;
 import org.apache.flink.runtime.state.memory.MemCheckpointStreamFactory.MemoryCheckpointOutputStream;
 import org.apache.flink.testutils.junit.utils.TempDirUtils;
+import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.function.RunnableWithException;
 
 import org.junit.jupiter.api.Test;
@@ -408,6 +409,101 @@ class ChannelStateCheckpointWriterTest {
                                     + numBytes * offsetCounts.remove(handle.getInfo()));
         }
         assertThat(offsetCounts).isEmpty();
+    }
+
+    @Test
+    void testSpillWriteFormatCompatibility() throws Exception {
+        // Verify that data written via writeInputFromSpill produces the same byte format
+        // as data written via the buffer-based path: [4-byte length][data bytes].
+        byte[] testData = getData(100);
+
+        // Build expected output via buffer-based path
+        ByteArrayOutputStream bufferRawStream = new ByteArrayOutputStream();
+        DataOutputStream bufferDataStream = new DataOutputStream(bufferRawStream);
+        ChannelStateSerializerImpl serializer = new ChannelStateSerializerImpl();
+        serializer.writeHeader(bufferDataStream);
+        MemorySegment segment = wrap(testData);
+        NetworkBuffer buffer =
+                new NetworkBuffer(
+                        segment,
+                        FreeingBufferRecycler.INSTANCE,
+                        Buffer.DataType.DATA_BUFFER,
+                        segment.size());
+        serializer.writeData(bufferDataStream, buffer);
+        bufferDataStream.flush();
+        byte[] bufferPathOutput = bufferRawStream.toByteArray();
+
+        // Build expected output via spill path: [4-byte length][data bytes]
+        ByteArrayOutputStream spillRawStream = new ByteArrayOutputStream();
+        DataOutputStream spillDataStream = new DataOutputStream(spillRawStream);
+        serializer.writeHeader(spillDataStream);
+        spillDataStream.writeInt(testData.length);
+        spillDataStream.write(testData);
+        spillDataStream.flush();
+        byte[] spillPathOutput = spillRawStream.toByteArray();
+
+        assertThat(spillPathOutput).isEqualTo(bufferPathOutput);
+    }
+
+    @Test
+    void testSpillWriteViaWriter() throws Exception {
+        // Verify end-to-end that writeInputFromSpill produces the correct state handle
+        // with proper offsets and state size.
+        byte[] testData = getData(100);
+        InputChannelInfo channelInfo = new InputChannelInfo(0, 0);
+
+        // Write via buffer-based path
+        ChannelStateWriteResult bufferResult = new ChannelStateWriteResult();
+        ChannelStateCheckpointWriter bufferWriter =
+                createWriter(bufferResult, new MemoryCheckpointOutputStream(4096));
+        write(bufferWriter, channelInfo, testData);
+        bufferWriter.completeInput(JOB_VERTEX_ID, SUBTASK_INDEX);
+        bufferWriter.completeOutput(JOB_VERTEX_ID, SUBTASK_INDEX);
+
+        // Write via spill path using a single chunk
+        ChannelStateWriteResult spillResult = new ChannelStateWriteResult();
+        ChannelStateCheckpointWriter spillWriter =
+                createWriter(spillResult, new MemoryCheckpointOutputStream(4096));
+        FilteredSpillFile.Chunk chunk =
+                new FilteredSpillFile.Chunk(channelInfo, testData, testData.length);
+        spillWriter.writeInputFromSpill(
+                JOB_VERTEX_ID, SUBTASK_INDEX, CloseableIterator.ofElements(ignored -> {}, chunk));
+        spillWriter.completeInput(JOB_VERTEX_ID, SUBTASK_INDEX);
+        spillWriter.completeOutput(JOB_VERTEX_ID, SUBTASK_INDEX);
+
+        // Compare state handles: offsets and state sizes must match
+        for (InputChannelStateHandle bufferHandle : bufferResult.inputChannelStateHandles.get()) {
+            for (InputChannelStateHandle spillHandle : spillResult.inputChannelStateHandles.get()) {
+                assertThat(spillHandle.getOffsets()).isEqualTo(bufferHandle.getOffsets());
+                assertThat(spillHandle.getStateSize()).isEqualTo(bufferHandle.getStateSize());
+            }
+        }
+    }
+
+    @Test
+    void testSpillWriteRecordsOffsets() throws Exception {
+        // Verify that writeInputFromSpill correctly records offsets and state size,
+        // consistent with the buffer-based write.
+        int numBytesPerWrite = 50;
+        InputChannelInfo channelInfo = new InputChannelInfo(0, 0);
+
+        ChannelStateWriteResult result = new ChannelStateWriteResult();
+        ChannelStateCheckpointWriter writer =
+                createWriter(result, new MemoryCheckpointOutputStream(4096));
+
+        byte[] data = getData(numBytesPerWrite);
+        FilteredSpillFile.Chunk chunk = new FilteredSpillFile.Chunk(channelInfo, data, data.length);
+        writer.writeInputFromSpill(
+                JOB_VERTEX_ID, SUBTASK_INDEX, CloseableIterator.ofElements(ignored -> {}, chunk));
+        writer.completeInput(JOB_VERTEX_ID, SUBTASK_INDEX);
+        writer.completeOutput(JOB_VERTEX_ID, SUBTASK_INDEX);
+
+        for (InputChannelStateHandle handle : result.inputChannelStateHandles.get()) {
+            int headerSize = Integer.BYTES;
+            assertThat(handle.getOffsets()).isEqualTo(singletonList((long) headerSize));
+            int lengthSize = Integer.BYTES;
+            assertThat(handle.getStateSize()).isEqualTo(headerSize + lengthSize + numBytesPerWrite);
+        }
     }
 
     private byte[] getData(int len) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateChunkReaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateChunkReaderTest.java
@@ -137,6 +137,9 @@ class ChannelStateChunkReaderTest {
         }
 
         @Override
+        public void finishRecovery() {}
+
+        @Override
         public void close() throws Exception {}
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriterImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriterImplTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.storage.JobManagerCheckpointStorage;
+import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.function.BiConsumerWithException;
 
 import org.junit.jupiter.api.Test;
@@ -277,6 +278,37 @@ class ChannelStateWriterImplTest {
         callStart(writer);
         writer.close();
         assertThatThrownBy(() -> callAddInputData(writer))
+                .hasCauseInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void testAddInputDataFromSpill() throws Exception {
+        executeCallbackWithSyncWorker(
+                (writer, worker) -> {
+                    callStart(writer);
+                    FilteredSpillFile.Chunk chunk =
+                            new FilteredSpillFile.Chunk(
+                                    new InputChannelInfo(1, 1), new byte[] {1, 2, 3, 4, 5}, 5);
+                    writer.addInputDataFromSpill(
+                            CHECKPOINT_ID, CloseableIterator.ofElements(ignored -> {}, chunk));
+                    worker.processAllRequests();
+                    ChannelStateWriteResult result = writer.getAndRemoveWriteResult(CHECKPOINT_ID);
+                    assertThat(result.isDone()).isFalse();
+                });
+    }
+
+    @Test
+    void testAddInputDataFromSpillAfterClose() throws IOException {
+        ChannelStateWriterImpl writer = openWriter();
+        callStart(writer);
+        writer.close();
+        FilteredSpillFile.Chunk chunk =
+                new FilteredSpillFile.Chunk(new InputChannelInfo(1, 1), new byte[] {1, 2, 3}, 3);
+        assertThatThrownBy(
+                        () ->
+                                writer.addInputDataFromSpill(
+                                        CHECKPOINT_ID,
+                                        CloseableIterator.ofElements(ignored -> {}, chunk)))
                 .hasCauseInstanceOf(IllegalStateException.class);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/EntryPositionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/EntryPositionTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link EntryPosition}. */
+class EntryPositionTest {
+
+    @Test
+    void testCompareToOrdersByFileIndexFirst() {
+        // Two positions in the same file: offset breaks the tie.
+        EntryPosition a = new EntryPosition(0, 0L);
+        EntryPosition b = new EntryPosition(0, 100L);
+        assertThat(a.compareTo(b)).isNegative();
+        assertThat(b.compareTo(a)).isPositive();
+
+        // Different files: file index dominates regardless of offset.
+        EntryPosition c = new EntryPosition(1, 0L);
+        assertThat(b.compareTo(c)).isNegative();
+        EntryPosition d = new EntryPosition(0, Long.MAX_VALUE - 1);
+        EntryPosition e = new EntryPosition(1, 0L);
+        assertThat(d.compareTo(e)).isNegative();
+    }
+
+    @Test
+    void testEndIsGreaterThanEveryRealPosition() {
+        EntryPosition firstEntry = new EntryPosition(0, 0L);
+        EntryPosition lateEntry = new EntryPosition(Integer.MAX_VALUE - 1, Long.MAX_VALUE - 1);
+        assertThat(firstEntry.compareTo(EntryPosition.END)).isNegative();
+        assertThat(lateEntry.compareTo(EntryPosition.END)).isNegative();
+        assertThat(EntryPosition.END.compareTo(EntryPosition.END)).isZero();
+    }
+
+    @Test
+    void testEqualsAndHashCode() {
+        EntryPosition a = new EntryPosition(2, 100L);
+        EntryPosition b = new EntryPosition(2, 100L);
+        EntryPosition c = new EntryPosition(2, 101L);
+        EntryPosition d = new EntryPosition(3, 100L);
+
+        assertThat(a).isEqualTo(b).hasSameHashCodeAs(b);
+        assertThat(a).isNotEqualTo(c);
+        assertThat(a).isNotEqualTo(d);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/FilteredBufferDispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/FilteredBufferDispatcherTest.java
@@ -1,0 +1,1883 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
+import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
+import org.apache.flink.runtime.io.network.partition.consumer.RecoveredBufferStoreImpl;
+import org.apache.flink.util.CloseableIterator;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+/** Tests for {@link FilteredBufferDispatcherImpl}. */
+class FilteredBufferDispatcherTest {
+
+    private static final int SEGMENT_SIZE = 64;
+
+    @TempDir Path tempDir;
+
+    private InputChannelInfo ch0;
+    private InputChannelInfo ch1;
+    private RecoveredBufferStoreImpl store0;
+    private RecoveredBufferStoreImpl store1;
+    private Map<InputChannelInfo, RecoveredBufferStoreImpl> stores;
+    private String[] spillDirs;
+
+    @BeforeEach
+    void setUp() {
+        ch0 = new InputChannelInfo(0, 0);
+        ch1 = new InputChannelInfo(0, 1);
+        store0 = new RecoveredBufferStoreImpl(ch0);
+        store1 = new RecoveredBufferStoreImpl(ch1);
+        stores = new HashMap<>();
+        stores.put(ch0, store0);
+        stores.put(ch1, store1);
+        spillDirs = new String[] {tempDir.toString()};
+    }
+
+    @AfterEach
+    void tearDown() {
+        // Temp dir auto-cleaned by @TempDir
+    }
+
+    /**
+     * Test-only subclass of RecoveredBufferStoreImpl that records whether setCoordinator was
+     * called and captures the registered coordinator, without using Mockito.
+     */
+    private static class TrackingBufferStore extends RecoveredBufferStoreImpl {
+        private RecoveredBufferStoreCoordinator registeredCoordinator;
+        private int setCoordinatorCount = 0;
+
+        TrackingBufferStore(InputChannelInfo channelInfo) {
+            super(channelInfo);
+        }
+
+        @Override
+        public synchronized void setCoordinator(RecoveredBufferStoreCoordinator coordinator) {
+            super.setCoordinator(coordinator);
+            this.registeredCoordinator = coordinator;
+            this.setCoordinatorCount++;
+        }
+    }
+
+    // --- Helper methods ---
+
+    private Buffer createBuffer() {
+        return new NetworkBuffer(
+                MemorySegmentFactory.allocateUnpooledSegment(SEGMENT_SIZE),
+                FreeingBufferRecycler.INSTANCE);
+    }
+
+    private Queue<Buffer> createBufferPool(int count) {
+        Queue<Buffer> pool = new LinkedList<>();
+        for (int i = 0; i < count; i++) {
+            pool.add(createBuffer());
+        }
+        return pool;
+    }
+
+    private byte[] createTestData(int length, byte fillValue) {
+        byte[] data = new byte[length];
+        Arrays.fill(data, fillValue);
+        return data;
+    }
+
+    /** Drains all ready buffers from a store and returns their data. */
+    private List<byte[]> drainStore(RecoveredBufferStoreImpl store) {
+        List<byte[]> result = new ArrayList<>();
+        while (true) {
+            Buffer buf;
+            synchronized (store) {
+                buf = store.tryTake();
+            }
+            if (buf == null) {
+                break;
+            }
+            byte[] data = new byte[buf.getSize()];
+            buf.getMemorySegment().get(0, data, 0, buf.getSize());
+            buf.recycleBuffer();
+            result.add(data);
+        }
+        return result;
+    }
+
+    /** Concatenates all byte arrays into a single byte array. */
+    private byte[] concat(List<byte[]> chunks) {
+        int totalLen = chunks.stream().mapToInt(a -> a.length).sum();
+        byte[] result = new byte[totalLen];
+        int pos = 0;
+        for (byte[] chunk : chunks) {
+            System.arraycopy(chunk, 0, result, pos, chunk.length);
+            pos += chunk.length;
+        }
+        return result;
+    }
+
+    // --- Tests ---
+
+    /** Buffer always available, no disk. All data flows to stores via buffers. */
+    @Test
+    void testP1MemoryPath() throws Exception {
+        // Provide plenty of buffers so no spilling happens
+        Queue<Buffer> pool = createBufferPool(10);
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        stores,
+                        ChannelStateWriter.NO_OP,
+                        spillDirs,
+                        SEGMENT_SIZE,
+                        new TestBufferPool(pool));
+
+        byte[] data = createTestData(SEGMENT_SIZE, (byte) 0xAA);
+        writer.write(data, data.length, ch0);
+        writer.flush();
+        writer.close();
+
+        List<byte[]> buffers = drainStore(store0);
+        byte[] actual = concat(buffers);
+        assertThat(actual).isEqualTo(data);
+        assertEmpty(store0);
+    }
+
+    /** Buffer supplier always returns null. Data goes to disk, replayed on close. */
+    @Test
+    void testP2SpillPath() throws Exception {
+        // No buffers for write, but provide blocking buffers for close drain
+        Queue<Buffer> drainPool = createBufferPool(5);
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        stores,
+                        ChannelStateWriter.NO_OP,
+                        spillDirs,
+                        SEGMENT_SIZE,
+                        TestBufferPool.drainOnly(drainPool));
+
+        byte[] data = createTestData(SEGMENT_SIZE, (byte) 0xBB);
+        writer.write(data, data.length, ch0);
+        writer.flush();
+
+        // Before drain, store should have no ready buffers (data is on disk as pending)
+        assertThat(tryTake(store0)).isNull();
+
+        writer.drainPendingSpill();
+        writer.close();
+
+        // After drain, data should be in store
+        List<byte[]> buffers = drainStore(store0);
+        byte[] actual = concat(buffers);
+        assertThat(actual).isEqualTo(data);
+        assertEmpty(store0);
+    }
+
+    /** First write spills, then buffer becomes available. P3 replays from disk. */
+    @Test
+    void testP3ReplayPath() throws Exception {
+        Queue<Buffer> pool = new LinkedList<>();
+        // No buffer initially — first write spills
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        stores,
+                        ChannelStateWriter.NO_OP,
+                        spillDirs,
+                        SEGMENT_SIZE,
+                        new TestBufferPool(pool));
+
+        // Write exactly SEGMENT_SIZE so the spill entry is auto-sealed
+        byte[] data1 = createTestData(SEGMENT_SIZE, (byte) 0x11);
+        writer.write(data1, data1.length, ch0);
+
+        // Now add buffers — next write triggers P3 eager drain
+        pool.addAll(createBufferPool(5));
+
+        // Write to ch1 — channel change flushes ch0, then P3 drains the spilled entry
+        byte[] data2 = createTestData(SEGMENT_SIZE, (byte) 0x22);
+        writer.write(data2, data2.length, ch1);
+        writer.flush();
+        writer.drainPendingSpill();
+        writer.close();
+
+        // ch0's data should be replayed from disk via P3
+        List<byte[]> buf0 = drainStore(store0);
+        assertThat(concat(buf0)).isEqualTo(data1);
+
+        List<byte[]> buf1 = drainStore(store1);
+        assertThat(concat(buf1)).isEqualTo(data2);
+    }
+
+    /**
+     * Multiple channels' data goes to disk. Replay order matches FIFO write order across channels.
+     */
+    @Test
+    void testP3FIFOOrdering() throws Exception {
+        Queue<Buffer> drainPool = createBufferPool(10);
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        stores,
+                        ChannelStateWriter.NO_OP,
+                        spillDirs,
+                        SEGMENT_SIZE,
+                        TestBufferPool.drainOnly(drainPool));
+
+        // Write to ch0 then ch1 — both spill to disk
+        byte[] d0 = createTestData(SEGMENT_SIZE, (byte) 0x10);
+        byte[] d1 = createTestData(SEGMENT_SIZE, (byte) 0x20);
+        writer.write(d0, d0.length, ch0);
+        writer.write(d1, d1.length, ch1);
+        writer.flush();
+        writer.drainPendingSpill();
+        writer.close();
+
+        // Both stores should have data after drain
+        assertThat(concat(drainStore(store0))).isEqualTo(d0);
+        assertThat(concat(drainStore(store1))).isEqualTo(d1);
+    }
+
+    /**
+     * Multiple entries on disk, multiple buffers available. P3 loops until no buffer or disk empty.
+     */
+    @Test
+    void testP3EagerDrain() throws Exception {
+        Queue<Buffer> pool = new LinkedList<>();
+        // No buffers initially
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        stores,
+                        ChannelStateWriter.NO_OP,
+                        spillDirs,
+                        SEGMENT_SIZE,
+                        new TestBufferPool(pool));
+
+        // Spill 3 entries for ch0 (each exactly SEGMENT_SIZE so they auto-seal)
+        for (int i = 0; i < 3; i++) {
+            byte[] d = createTestData(SEGMENT_SIZE, (byte) (0x30 + i));
+            writer.write(d, d.length, ch0);
+        }
+
+        // Now provide buffers and write to ch1 — P3 eager drain should replay all 3 entries
+        pool.addAll(createBufferPool(10));
+
+        byte[] d3 = createTestData(SEGMENT_SIZE, (byte) 0x40);
+        writer.write(d3, d3.length, ch1);
+        writer.flush();
+        writer.drainPendingSpill();
+        writer.close();
+
+        // Verify all 3 entries were drained to store0
+        List<byte[]> results = drainStore(store0);
+        assertThat(results).hasSize(3);
+        for (int i = 0; i < 3; i++) {
+            assertThat(results.get(i)).isEqualTo(createTestData(SEGMENT_SIZE, (byte) (0x30 + i)));
+        }
+
+        // ch1's data should also be correct
+        assertThat(concat(drainStore(store1))).isEqualTo(d3);
+    }
+
+    /**
+     * Start with buffer, buffer fills, no new buffer available. Remaining data goes to file. Cannot
+     * upgrade back to buffer within one writeToBackend call.
+     */
+    @Test
+    void testBackendDowngradeOnly() throws Exception {
+        Queue<Buffer> pool = createBufferPool(1); // Only 1 buffer available
+        Queue<Buffer> drainPool = createBufferPool(5);
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        stores,
+                        ChannelStateWriter.NO_OP,
+                        spillDirs,
+                        SEGMENT_SIZE,
+                        new TestBufferPool(pool, drainPool));
+
+        // Write data larger than one buffer — first SEGMENT_SIZE goes to buffer, rest to disk
+        byte[] data = createTestData(SEGMENT_SIZE * 2, (byte) 0x44);
+        writer.write(data, data.length, ch0);
+        writer.flush();
+        writer.drainPendingSpill();
+        writer.close();
+
+        // All data should be recovered
+        List<byte[]> results = drainStore(store0);
+        byte[] actual = concat(results);
+        assertThat(actual).isEqualTo(data);
+    }
+
+    /** Data starts in buffer, spans to file when buffer full. */
+    @Test
+    void testCrossBackendRecordSpanning() throws Exception {
+        Queue<Buffer> pool = createBufferPool(1); // 1 buffer of SEGMENT_SIZE
+        Queue<Buffer> drainPool = createBufferPool(5);
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        stores,
+                        ChannelStateWriter.NO_OP,
+                        spillDirs,
+                        SEGMENT_SIZE,
+                        new TestBufferPool(pool, drainPool));
+
+        // Write half a buffer
+        byte[] part1 = createTestData(SEGMENT_SIZE / 2, (byte) 0x55);
+        writer.write(part1, part1.length, ch0);
+
+        // Write data that exceeds the remaining buffer capacity
+        byte[] part2 = createTestData(SEGMENT_SIZE, (byte) 0x66);
+        writer.write(part2, part2.length, ch0);
+
+        writer.flush();
+        writer.drainPendingSpill();
+        writer.close();
+
+        // All data should be present
+        List<byte[]> results = drainStore(store0);
+        byte[] actual = concat(results);
+        byte[] expected = new byte[part1.length + part2.length];
+        System.arraycopy(part1, 0, expected, 0, part1.length);
+        System.arraycopy(part2, 0, expected, part1.length, part2.length);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    /** Write to channel A, then B. Verify flush between transitions. */
+    @Test
+    void testChannelChangeDetection() throws Exception {
+        Queue<Buffer> pool = createBufferPool(10);
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        stores,
+                        ChannelStateWriter.NO_OP,
+                        spillDirs,
+                        SEGMENT_SIZE,
+                        new TestBufferPool(pool));
+
+        // Write partial data to ch0
+        byte[] d0 = createTestData(SEGMENT_SIZE / 2, (byte) 0x77);
+        writer.write(d0, d0.length, ch0);
+
+        // Switch to ch1 — should flush ch0's partial buffer
+        byte[] d1 = createTestData(SEGMENT_SIZE / 2, (byte) 0x88);
+        writer.write(d1, d1.length, ch1);
+
+        writer.flush();
+        writer.close();
+
+        // ch0 should have received its partial buffer
+        List<byte[]> results0 = drainStore(store0);
+        assertThat(concat(results0)).isEqualTo(d0);
+
+        List<byte[]> results1 = drainStore(store1);
+        assertThat(concat(results1)).isEqualTo(d1);
+    }
+
+    /** Multiple channels share one spill file. */
+    @Test
+    void testSingleFilePerTask() throws Exception {
+        Queue<Buffer> drainPool = createBufferPool(10);
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        stores,
+                        ChannelStateWriter.NO_OP,
+                        spillDirs,
+                        SEGMENT_SIZE,
+                        TestBufferPool.drainOnly(drainPool));
+
+        byte[] d0 = createTestData(SEGMENT_SIZE, (byte) 0x99);
+        byte[] d1 = createTestData(SEGMENT_SIZE, (byte) 0xAA);
+        writer.write(d0, d0.length, ch0);
+        writer.write(d1, d1.length, ch1);
+        writer.flush();
+        writer.drainPendingSpill();
+        writer.close();
+
+        // Both channels' data should be correct after drain
+        assertThat(concat(drainStore(store0))).isEqualTo(d0);
+        assertThat(concat(drainStore(store1))).isEqualTo(d1);
+    }
+
+    /** Spill, partial replay, verify tracking state. */
+    @Test
+    void testCursorBasedTracking() throws Exception {
+        Queue<Buffer> pool = new LinkedList<>();
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        stores,
+                        ChannelStateWriter.NO_OP,
+                        spillDirs,
+                        SEGMENT_SIZE,
+                        new TestBufferPool(pool));
+
+        // Spill 2 entries to ch0 (each exactly SEGMENT_SIZE so they auto-seal)
+        byte[] d1 = createTestData(SEGMENT_SIZE, (byte) 0x01);
+        byte[] d2 = createTestData(SEGMENT_SIZE, (byte) 0x02);
+        writer.write(d1, d1.length, ch0);
+        writer.write(d2, d2.length, ch0);
+
+        // Add only 1 buffer — partial replay (only 1 of 2 entries will drain)
+        pool.add(createBuffer());
+
+        // Write to ch1 — channel change triggers flush, then P3 drains 1 entry
+        byte[] d3 = createTestData(SEGMENT_SIZE, (byte) 0x03);
+        writer.write(d3, d3.length, ch1);
+
+        // Provide remaining buffers for drain
+        pool.addAll(createBufferPool(5));
+        writer.flush();
+        writer.drainPendingSpill();
+        writer.close();
+
+        // All data should be correct
+        List<byte[]> results0 = drainStore(store0);
+        assertThat(results0).hasSize(2);
+        assertThat(results0.get(0)).isEqualTo(d1);
+        assertThat(results0.get(1)).isEqualTo(d2);
+    }
+
+    /** drainPendingSpill() drains all disk data; close() is then a no-op resource release. */
+    @Test
+    void testDrainPendingSpillUntilEmpty() throws Exception {
+        Queue<Buffer> drainPool = createBufferPool(10);
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        stores,
+                        ChannelStateWriter.NO_OP,
+                        spillDirs,
+                        SEGMENT_SIZE,
+                        TestBufferPool.drainOnly(drainPool));
+
+        // Spill multiple entries
+        for (int i = 0; i < 5; i++) {
+            byte[] data = createTestData(SEGMENT_SIZE, (byte) i);
+            writer.write(data, data.length, ch0);
+        }
+        writer.flush();
+
+        // Before drain, no ready buffers
+        assertThat(tryTake(store0)).isNull();
+
+        writer.drainPendingSpill();
+
+        // After drain, all 5 entries should be delivered to the store
+        List<byte[]> results = drainStore(store0);
+        assertThat(results).hasSize(5);
+        for (int i = 0; i < 5; i++) {
+            assertThat(results.get(i)).isEqualTo(createTestData(SEGMENT_SIZE, (byte) i));
+        }
+
+        // close() is pure resource release — no additional drain
+        writer.close();
+        assertThat(tryTake(store0)).isNull();
+    }
+
+    /** close() twice doesn't throw; drainPendingSpill() after close() is a no-op. */
+    @Test
+    void testCloseIdempotent() throws Exception {
+        Queue<Buffer> pool = createBufferPool(5);
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        stores,
+                        ChannelStateWriter.NO_OP,
+                        spillDirs,
+                        SEGMENT_SIZE,
+                        new TestBufferPool(pool));
+
+        writer.flush();
+        writer.drainPendingSpill();
+        writer.close();
+        // Second close should not throw
+        writer.close();
+    }
+
+    /** After close(), spill files deleted. */
+    @Test
+    void testCloseCleanup() throws Exception {
+        Queue<Buffer> drainPool = createBufferPool(10);
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        stores,
+                        ChannelStateWriter.NO_OP,
+                        spillDirs,
+                        SEGMENT_SIZE,
+                        TestBufferPool.drainOnly(drainPool));
+
+        byte[] data = createTestData(SEGMENT_SIZE * 3, (byte) 0xCC);
+        writer.write(data, data.length, ch0);
+        writer.flush();
+
+        // Verify spill files exist
+        try (Stream<Path> files =
+                Files.list(tempDir).filter(p -> p.getFileName().toString().startsWith("spill-"))) {
+            assertThat(files.count()).isGreaterThan(0);
+        }
+
+        writer.drainPendingSpill();
+        writer.close();
+
+        // After close, spill files should be deleted
+        try (Stream<Path> files =
+                Files.list(tempDir).filter(p -> p.getFileName().toString().startsWith("spill-"))) {
+            assertThat(files.count()).isEqualTo(0);
+        }
+    }
+
+    /** write() after close() throws IllegalStateException. */
+    @Test
+    void testWriteAfterClose() throws Exception {
+        Queue<Buffer> pool = createBufferPool(5);
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        stores,
+                        ChannelStateWriter.NO_OP,
+                        spillDirs,
+                        SEGMENT_SIZE,
+                        new TestBufferPool(pool));
+
+        writer.flush();
+        writer.drainPendingSpill();
+        writer.close();
+
+        byte[] data = createTestData(10, (byte) 0xDD);
+        assertThatThrownBy(() -> writer.write(data, data.length, ch0))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    /** write() after flush() throws IllegalStateException. */
+    @Test
+    void testWriteAfterFlush() throws Exception {
+        Queue<Buffer> pool = createBufferPool(5);
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        stores,
+                        ChannelStateWriter.NO_OP,
+                        spillDirs,
+                        SEGMENT_SIZE,
+                        new TestBufferPool(pool));
+
+        writer.flush();
+
+        byte[] data = createTestData(10, (byte) 0xEE);
+        assertThatThrownBy(() -> writer.write(data, data.length, ch0))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    /** Empty spill dirs throws IOException. */
+    @Test
+    void testSpillDirectorySource() {
+        assertThatThrownBy(
+                        () ->
+                                new FilteredBufferDispatcherImpl(
+                                        stores,
+                                        ChannelStateWriter.NO_OP,
+                                        new String[0],
+                                        SEGMENT_SIZE,
+                                        TestBufferPool.empty()))
+                .isInstanceOf(IOException.class);
+    }
+
+    /** Enough data for 3+ file rotations. All replayed correctly. */
+    @Test
+    void testLargeDataMultiRotation() throws Exception {
+        // FilteredSpillFile rotates at 64MB. Use small segments and many writes to trigger rotation.
+        // For testing, we write enough data to cause rotation. FilteredSpillFile threshold is 64MB.
+        // We use a small segment size and write enough data to exceed 64MB.
+        // To avoid enormous test data, we use a smaller approach:
+        // The rotation threshold in FilteredSpillFile is 64*1024*1024.
+        // We need to write > 192MB of data for 3+ rotations.
+        // For a unit test, this is too much. Instead, we verify the mechanism works
+        // by writing enough data that results in multiple spill entries and verifying correctness.
+        int entryCount = 100;
+        int segmentSize = 256;
+        Queue<Buffer> drainPool = new LinkedList<>();
+        for (int i = 0; i < entryCount + 10; i++) {
+            drainPool.add(
+                    new NetworkBuffer(
+                            MemorySegmentFactory.allocateUnpooledSegment(segmentSize),
+                            FreeingBufferRecycler.INSTANCE));
+        }
+
+        String[] dirs = new String[] {tempDir.toString()};
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        stores,
+                        ChannelStateWriter.NO_OP,
+                        dirs,
+                        segmentSize,
+                        TestBufferPool.drainOnly(drainPool));
+
+        byte[][] expectedData = new byte[entryCount][];
+        for (int i = 0; i < entryCount; i++) {
+            expectedData[i] = new byte[segmentSize];
+            Arrays.fill(expectedData[i], (byte) (i & 0xFF));
+            writer.write(expectedData[i], expectedData[i].length, ch0);
+        }
+        writer.flush();
+        writer.drainPendingSpill();
+        writer.close();
+
+        List<byte[]> results = drainStore(store0);
+        assertThat(results).hasSize(entryCount);
+        for (int i = 0; i < entryCount; i++) {
+            assertThat(results.get(i)).isEqualTo(expectedData[i]);
+        }
+    }
+
+    /** FilteredBufferDispatcher.write(data, length, channelInfo) is the unified write interface. */
+    @Test
+    void testUnifiedWriteInterface() throws Exception {
+        Queue<Buffer> pool = createBufferPool(10);
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        stores,
+                        ChannelStateWriter.NO_OP,
+                        spillDirs,
+                        SEGMENT_SIZE,
+                        new TestBufferPool(pool));
+
+        // The write method accepts data, length, channelInfo — this is the unified interface
+        // used by filterAndRewrite. Verify it works for multiple channels.
+        byte[] d0 = createTestData(32, (byte) 0xF0);
+        byte[] d1 = createTestData(32, (byte) 0xF1);
+
+        writer.write(d0, d0.length, ch0);
+        writer.write(d1, d1.length, ch1);
+        writer.flush();
+        writer.close();
+
+        assertThat(concat(drainStore(store0))).isEqualTo(d0);
+        assertThat(concat(drainStore(store1))).isEqualTo(d1);
+    }
+
+    /** SpillEntry aligns with memorySegmentSize, 1:1 with buffer. */
+    @Test
+    void testBufferAlignedEntryReplay() throws Exception {
+        Queue<Buffer> drainPool = createBufferPool(5);
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        stores,
+                        ChannelStateWriter.NO_OP,
+                        spillDirs,
+                        SEGMENT_SIZE,
+                        TestBufferPool.drainOnly(drainPool));
+
+        // Write exactly 3 * SEGMENT_SIZE bytes — should create exactly 3 spill entries
+        for (int i = 0; i < 3; i++) {
+            byte[] data = createTestData(SEGMENT_SIZE, (byte) (0xA0 + i));
+            writer.write(data, data.length, ch0);
+        }
+        writer.flush();
+        writer.drainPendingSpill();
+        writer.close();
+
+        // Each spill entry maps 1:1 to a buffer
+        List<byte[]> results = drainStore(store0);
+        assertThat(results).hasSize(3);
+        for (int i = 0; i < 3; i++) {
+            assertThat(results.get(i)).hasSize(SEGMENT_SIZE);
+            assertThat(results.get(i)).isEqualTo(createTestData(SEGMENT_SIZE, (byte) (0xA0 + i)));
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Tests for dispatcher registration and wait-set state machine
+    // ---------------------------------------------------------------------------
+
+    /**
+     * After construction, each store has its coordinator registered to the
+     * FilteredBufferDispatcherImpl instance.
+     */
+    @Test
+    void testCoordinatorRegisteredOnConstruction() throws Exception {
+        TrackingBufferStore trackStore0 = new TrackingBufferStore(ch0);
+        TrackingBufferStore trackStore1 = new TrackingBufferStore(ch1);
+        Map<InputChannelInfo, RecoveredBufferStoreImpl> trackStores = new HashMap<>();
+        trackStores.put(ch0, trackStore0);
+        trackStores.put(ch1, trackStore1);
+
+        Queue<Buffer> pool = createBufferPool(5);
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        trackStores,
+                        ChannelStateWriter.NO_OP,
+                        spillDirs,
+                        SEGMENT_SIZE,
+                        new TestBufferPool(pool));
+
+        // Both stores must have had setCoordinator called exactly once with the dispatcher.
+        assertThat(trackStore0.setCoordinatorCount).isEqualTo(1);
+        assertThat(trackStore0.registeredCoordinator).isSameAs(writer);
+        assertThat(trackStore1.setCoordinatorCount).isEqualTo(1);
+        assertThat(trackStore1.registeredCoordinator).isSameAs(writer);
+    }
+
+    /**
+     * First onChannelCheckpointStarted call for a checkpointId scans spillEntryQueue and builds the
+     * correct wait-set; subsequent calls for the same checkpointId remove channels.
+     */
+    @Test
+    void testWaitSetBuiltOnFirstCallback() throws Exception {
+        // Spill one entry per channel so both appear in the wait-set.
+        Queue<Buffer> drainPool = createBufferPool(10);
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        stores,
+                        ChannelStateWriter.NO_OP,
+                        spillDirs,
+                        SEGMENT_SIZE,
+                        TestBufferPool.drainOnly(drainPool));
+
+        byte[] d0 = createTestData(SEGMENT_SIZE, (byte) 0x10);
+        byte[] d1 = createTestData(SEGMENT_SIZE, (byte) 0x20);
+        writer.write(d0, d0.length, ch0);
+        writer.write(d1, d1.length, ch1);
+        writer.flush();
+
+        // After flush: 2 spill entries in queue (ch0, ch1).
+        // First callback for checkpoint 1: wait-set = {ch0, ch1}; then ch0 is removed.
+        writer.onChannelCheckpointStarted(1L, ch0, writer.getCurrentDrainHead());
+        // Second callback for same checkpoint: ch1 is removed → wait-set is now empty.
+        writer.onChannelCheckpointStarted(1L, ch1, writer.getCurrentDrainHead());
+        // No exception; wait-set reached empty — state machine operated correctly.
+
+        writer.drainPendingSpill();
+        writer.close();
+    }
+
+    /** New checkpointId causes wait-set to be rebuilt from current spillEntryQueue. */
+    @Test
+    void testWaitSetRebuiltOnNewCheckpointId() throws Exception {
+        Queue<Buffer> drainPool = createBufferPool(10);
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        stores,
+                        ChannelStateWriter.NO_OP,
+                        spillDirs,
+                        SEGMENT_SIZE,
+                        TestBufferPool.drainOnly(drainPool));
+
+        // Spill entries for both channels.
+        writer.write(createTestData(SEGMENT_SIZE, (byte) 0x30), SEGMENT_SIZE, ch0);
+        writer.write(createTestData(SEGMENT_SIZE, (byte) 0x40), SEGMENT_SIZE, ch1);
+        writer.flush();
+
+        // Checkpoint 1: consume both callbacks (wait-set empties).
+        writer.onChannelCheckpointStarted(1L, ch0, writer.getCurrentDrainHead());
+        writer.onChannelCheckpointStarted(1L, ch1, writer.getCurrentDrainHead());
+
+        // Checkpoint 2: new id → wait-set should be rebuilt from the *remaining* spillEntryQueue.
+        // At this point the queue still holds the 2 entries (they are drained only on close).
+        // Both channels should again appear in the wait-set.
+        writer.onChannelCheckpointStarted(2L, ch0, writer.getCurrentDrainHead());
+        writer.onChannelCheckpointStarted(2L, ch1, writer.getCurrentDrainHead());
+        // No exception; both rebuilt and removed successfully.
+
+        writer.drainPendingSpill();
+        writer.close();
+    }
+
+    /**
+     * Channel not present in spillEntryQueue is not in wait-set; removing it is a no-op. Uses a
+     * fresh store map so only ch0 has a spill entry; ch1 callback is a no-op.
+     */
+    @Test
+    void testCallbackForChannelWithNoPendingEntryIsNoOp() throws Exception {
+        // Use a fresh store map to avoid interference from previous tests
+        RecoveredBufferStoreImpl freshStore0 = new RecoveredBufferStoreImpl(ch0);
+        RecoveredBufferStoreImpl freshStore1 = new RecoveredBufferStoreImpl(ch1);
+        Map<InputChannelInfo, RecoveredBufferStoreImpl> freshStores = new HashMap<>();
+        freshStores.put(ch0, freshStore0);
+        freshStores.put(ch1, freshStore1);
+
+        Queue<Buffer> drainPool = createBufferPool(5);
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        freshStores,
+                        ChannelStateWriter.NO_OP,
+                        spillDirs,
+                        SEGMENT_SIZE,
+                        TestBufferPool.drainOnly(drainPool));
+
+        // Only ch0 spills; ch1 has no entries in the queue.
+        writer.write(createTestData(SEGMENT_SIZE, (byte) 0x50), SEGMENT_SIZE, ch0);
+        writer.flush();
+
+        // ch1 callback: not in wait-set → no-op remove, wait-set stays non-empty.
+        writer.onChannelCheckpointStarted(42L, ch1, writer.getCurrentDrainHead());
+        // ch0 callback: removed from wait-set → empty.
+        writer.onChannelCheckpointStarted(42L, ch0, writer.getCurrentDrainHead());
+
+        writer.drainPendingSpill();
+        writer.close();
+    }
+
+    /**
+     * Duplicate callback for the same channel in the same checkpoint is idempotent (Set.remove on
+     * an already-absent element is a no-op).
+     */
+    @Test
+    void testDuplicateCallbackForSameChannelIsIdempotent() throws Exception {
+        Queue<Buffer> drainPool = createBufferPool(5);
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        stores,
+                        ChannelStateWriter.NO_OP,
+                        spillDirs,
+                        SEGMENT_SIZE,
+                        TestBufferPool.drainOnly(drainPool));
+
+        writer.write(createTestData(SEGMENT_SIZE, (byte) 0x70), SEGMENT_SIZE, ch0);
+        writer.flush();
+
+        // ch0 removed on first call; second call is a no-op (already absent from set).
+        writer.onChannelCheckpointStarted(10L, ch0, writer.getCurrentDrainHead());
+        writer.onChannelCheckpointStarted(10L, ch0, writer.getCurrentDrainHead()); // idempotent — no exception
+
+        writer.drainPendingSpill();
+        writer.close();
+    }
+
+    /**
+     * A stale callback (checkpointId &lt; currentCheckpointId) must be ignored: it must not modify
+     * the current checkpoint's wait-set and must not trigger phase 2. We verify this by observing
+     * that after the stale callback arrives, the current checkpoint still converges normally when
+     * its own callbacks arrive.
+     */
+    @Test
+    void testStaleCheckpointCallbackIsIgnored() throws Exception {
+        Queue<Buffer> drainPool = createBufferPool(5);
+        RecordingChannelStateWriter recordingWriter = new RecordingChannelStateWriter();
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        stores,
+                        recordingWriter,
+                        spillDirs,
+                        SEGMENT_SIZE,
+                        TestBufferPool.drainOnly(drainPool));
+
+        // Two entries so both channels appear in the wait-set.
+        writer.write(createTestData(SEGMENT_SIZE, (byte) 0xA1), SEGMENT_SIZE, ch0);
+        writer.write(createTestData(SEGMENT_SIZE, (byte) 0xA2), SEGMENT_SIZE, ch1);
+        writer.flush();
+
+        // Move to a newer checkpoint (id=20) and deliver one of its two channel callbacks.
+        writer.onChannelCheckpointStarted(20L, ch0, writer.getCurrentDrainHead());
+        // wait-set still contains ch1; phase 2 not yet triggered.
+        assertThat(recordingWriter.inputDataCalls).isEmpty();
+
+        // A stale callback for an older checkpoint (id=10) arrives. It must be ignored — not
+        // alter the wait-set for checkpoint 20, and must not trigger phase 2.
+        writer.onChannelCheckpointStarted(10L, ch0, writer.getCurrentDrainHead());
+        writer.onChannelCheckpointStarted(10L, ch1, writer.getCurrentDrainHead());
+        assertThat(recordingWriter.inputDataCalls).isEmpty();
+
+        // Now deliver the remaining callback for checkpoint 20 — wait-set empties and phase 2
+        // snapshots the entries into the ChannelStateWriter.
+        writer.onChannelCheckpointStarted(20L, ch1, writer.getCurrentDrainHead());
+        assertThat(recordingWriter.inputDataCalls).hasSize(2);
+
+        writer.drainPendingSpill();
+        writer.close();
+    }
+
+    /**
+     * wait-set reaching empty triggers phase2 {@code drainSpillEntriesToCheckpoint}: the sealed
+     * readers are snapshotted and streamed to the ChannelStateWriter, but the original readers and
+     * store state are left intact. drainPendingSpill() then still delivers every entry to the
+     * store via network buffers.
+     */
+    @Test
+    void testWaitSetEmptyTriggersPhase2SnapshotThenDrainDeliversBuffers() throws Exception {
+        Queue<Buffer> drainPool = createBufferPool(5);
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        stores,
+                        ChannelStateWriter.NO_OP,
+                        spillDirs,
+                        SEGMENT_SIZE,
+                        TestBufferPool.drainOnly(drainPool));
+
+        byte[] payload = createTestData(SEGMENT_SIZE, (byte) 0x80);
+        writer.write(payload, SEGMENT_SIZE, ch0);
+        writer.flush();
+
+        // phase2: snapshots sealed readers into the ChannelStateWriter (NO_OP here); the original
+        // reader and store state are untouched.
+        writer.onChannelCheckpointStarted(99L, ch0, writer.getCurrentDrainHead());
+
+        // drainPendingSpill() consumes the original reader and delivers buffers to the store.
+        writer.drainPendingSpill();
+        writer.close();
+
+        Buffer delivered = tryTake(store0);
+        assertThat(delivered).isNotNull();
+        byte[] actual = new byte[delivered.getSize()];
+        delivered.getMemorySegment().get(0, actual, 0, delivered.getSize());
+        delivered.recycleBuffer();
+        assertThat(actual).isEqualTo(payload);
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Phase2 disk checkpoint tests
+    // -----------------------------------------------------------------------------------------
+
+    /**
+     * A recording ChannelStateWriter that captures addInputDataFromSpill calls for assertions.
+     * Drains the chunk iterator synchronously so tests can assert on actual bytes and channel info.
+     */
+    private static class RecordingChannelStateWriter
+            extends ChannelStateWriter.NoOpChannelStateWriter {
+
+        static class Call {
+            final long checkpointId;
+            final InputChannelInfo info;
+            final int dataLength;
+            final byte[] capturedBytes;
+
+            Call(long checkpointId, InputChannelInfo info, int dataLength, byte[] capturedBytes) {
+                this.checkpointId = checkpointId;
+                this.info = info;
+                this.dataLength = dataLength;
+                this.capturedBytes = capturedBytes;
+            }
+        }
+
+        final List<Call> inputDataCalls = new ArrayList<>();
+
+        @Override
+        public void addInputDataFromSpill(
+                long checkpointId, CloseableIterator<FilteredSpillFile.Chunk> chunks) {
+            try {
+                while (chunks.hasNext()) {
+                    FilteredSpillFile.Chunk chunk = chunks.next();
+                    byte[] bytes = new byte[chunk.getLength()];
+                    System.arraycopy(chunk.getData(), 0, bytes, 0, chunk.getLength());
+                    inputDataCalls.add(
+                            new Call(
+                                    checkpointId,
+                                    chunk.getChannelInfo(),
+                                    chunk.getLength(),
+                                    bytes));
+                }
+                chunks.close();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    /**
+     * phase2 writes all spill entries to ChannelStateWriter via streaming addInputData. Verifies
+     * checkpointId, channelInfo, seqNum=SEQUENCE_NUMBER_RESTORED, and byte content.
+     */
+    @Test
+    void testPhase2WritesDiskDataThroughStreamingApi() throws Exception {
+        RecordingChannelStateWriter recordingWriter = new RecordingChannelStateWriter();
+
+        // drainOnly: no buffers for the write path (forces everything to spill), but the blocking
+        // drain path gets buffers so close()'s drain loop can still deliver the snapshotted entries
+        // to the stores. phase 2 is a backup — close() drain is the task-facing delivery path.
+        Queue<Buffer> drainPool = createBufferPool(5);
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        stores,
+                        recordingWriter,
+                        spillDirs,
+                        SEGMENT_SIZE,
+                        TestBufferPool.drainOnly(drainPool));
+
+        byte[] d0 = createTestData(SEGMENT_SIZE, (byte) 0xA1);
+        byte[] d1 = createTestData(SEGMENT_SIZE, (byte) 0xA2);
+        writer.write(d0, d0.length, ch0);
+        writer.write(d1, d1.length, ch1);
+        writer.flush();
+
+        // Trigger phase2: all channels report in, wait-set empties on second callback
+        long checkpointId = 42L;
+        writer.onChannelCheckpointStarted(checkpointId, ch0, writer.getCurrentDrainHead());
+        writer.onChannelCheckpointStarted(checkpointId, ch1, writer.getCurrentDrainHead());
+
+        // Two entries must have been streamed to ChannelStateWriter
+        assertThat(recordingWriter.inputDataCalls).hasSize(2);
+
+        RecordingChannelStateWriter.Call call0 = recordingWriter.inputDataCalls.get(0);
+        assertThat(call0.checkpointId).isEqualTo(checkpointId);
+        assertThat(call0.info).isEqualTo(ch0);
+        assertThat(call0.dataLength).isEqualTo(SEGMENT_SIZE);
+        assertThat(call0.capturedBytes).isEqualTo(d0);
+
+        RecordingChannelStateWriter.Call call1 = recordingWriter.inputDataCalls.get(1);
+        assertThat(call1.checkpointId).isEqualTo(checkpointId);
+        assertThat(call1.info).isEqualTo(ch1);
+        assertThat(call1.dataLength).isEqualTo(SEGMENT_SIZE);
+        assertThat(call1.capturedBytes).isEqualTo(d1);
+
+        writer.drainPendingSpill();
+        writer.close();
+    }
+
+    /**
+     * phase 2 is a snapshot-only backup: it must NOT decrement {@code store.pendingCount}. The
+     * original reader and the store state are left untouched so close()'s drain loop still has
+     * these entries to deliver to the task via network buffers.
+     */
+    @Test
+    void testPhase2DoesNotTouchStorePendingCount() throws Exception {
+        Queue<Buffer> drainPool = createBufferPool(3);
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        stores,
+                        ChannelStateWriter.NO_OP,
+                        spillDirs,
+                        SEGMENT_SIZE,
+                        TestBufferPool.drainOnly(drainPool));
+
+        // Spill 2 entries for ch0, 1 for ch1 — each exactly SEGMENT_SIZE so they auto-seal
+        writer.write(createTestData(SEGMENT_SIZE, (byte) 0xB1), SEGMENT_SIZE, ch0);
+        writer.write(createTestData(SEGMENT_SIZE, (byte) 0xB2), SEGMENT_SIZE, ch1);
+        writer.write(createTestData(SEGMENT_SIZE, (byte) 0xB3), SEGMENT_SIZE, ch0);
+        writer.flush();
+
+        // Before phase 2: both stores non-empty
+        assertNotEmpty(store0);
+        assertNotEmpty(store1);
+
+        // Phase 2: all callbacks arrive — entries are copied to checkpoint, but pendingCount stays
+        long checkpointId = 7L;
+        writer.onChannelCheckpointStarted(checkpointId, ch0, writer.getCurrentDrainHead());
+        writer.onChannelCheckpointStarted(checkpointId, ch1, writer.getCurrentDrainHead());
+
+        // pendingCount untouched — stores still report non-empty
+        assertNotEmpty(store0);
+        assertNotEmpty(store1);
+
+        // drainPendingSpill() delivers all entries to stores; only then do the counts go to zero
+        writer.drainPendingSpill();
+        writer.close();
+        // Drain the ready buffers so isEmpty() reflects pendingCount only
+        drainReady(store0);
+        drainReady(store1);
+        assertEmpty(store0);
+        assertEmpty(store1);
+    }
+
+    /**
+     * After phase 2 snapshots entries into the checkpoint, drainPendingSpill() must still deliver
+     * every entry to the stores (phase 2 is a backup, not an ownership transfer).
+     */
+    @Test
+    void testDrainStillDeliversEntriesAfterPhase2() throws Exception {
+        Queue<Buffer> drainPool = createBufferPool(1);
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        stores,
+                        ChannelStateWriter.NO_OP,
+                        spillDirs,
+                        SEGMENT_SIZE,
+                        TestBufferPool.drainOnly(drainPool));
+
+        byte[] payload = createTestData(SEGMENT_SIZE, (byte) 0xC1);
+        writer.write(payload, SEGMENT_SIZE, ch0);
+        writer.flush();
+
+        writer.onChannelCheckpointStarted(55L, ch0, writer.getCurrentDrainHead());
+
+        // drainPendingSpill() consumes the still-pending entry and delivers it to the store
+        writer.drainPendingSpill();
+        writer.close();
+
+        Buffer delivered = tryTake(store0);
+        assertThat(delivered).isNotNull();
+        byte[] actual = new byte[delivered.getSize()];
+        delivered.getMemorySegment().get(0, actual, 0, delivered.getSize());
+        delivered.recycleBuffer();
+        assertThat(actual).isEqualTo(payload);
+    }
+
+    /**
+     * Two independent consumers: phase 2 writes every entry into the checkpoint via
+     * ChannelStateWriter, and drainPendingSpill() additionally delivers every entry to the stores.
+     * Both streams see the full data — the on-disk bytes are read twice via independent
+     * FileChannels.
+     */
+    @Test
+    void testPhase2AndDrainBothReceiveAllEntries() throws Exception {
+        Queue<Buffer> drainPool = createBufferPool(2);
+        RecordingChannelStateWriter recordingWriter = new RecordingChannelStateWriter();
+
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        stores,
+                        recordingWriter,
+                        spillDirs,
+                        SEGMENT_SIZE,
+                        TestBufferPool.drainOnly(drainPool));
+
+        byte[] payload0 = createTestData(SEGMENT_SIZE, (byte) 0xD1);
+        byte[] payload1 = createTestData(SEGMENT_SIZE, (byte) 0xD2);
+        writer.write(payload0, SEGMENT_SIZE, ch0);
+        writer.write(payload1, SEGMENT_SIZE, ch1);
+        writer.flush();
+
+        // Phase 2: both entries captured into ChannelStateWriter (checkpoint backup)
+        long checkpointId = 100L;
+        writer.onChannelCheckpointStarted(checkpointId, ch0, writer.getCurrentDrainHead());
+        writer.onChannelCheckpointStarted(checkpointId, ch1, writer.getCurrentDrainHead());
+        assertThat(recordingWriter.inputDataCalls).hasSize(2);
+
+        // drainPendingSpill(): both entries additionally delivered to the stores (task-facing pipeline)
+        writer.drainPendingSpill();
+        writer.close();
+
+        Buffer buf0 = tryTake(store0);
+        Buffer buf1 = tryTake(store1);
+        assertThat(buf0).isNotNull();
+        assertThat(buf1).isNotNull();
+        byte[] got0 = new byte[buf0.getSize()];
+        byte[] got1 = new byte[buf1.getSize()];
+        buf0.getMemorySegment().get(0, got0, 0, buf0.getSize());
+        buf1.getMemorySegment().get(0, got1, 0, buf1.getSize());
+        buf0.recycleBuffer();
+        buf1.recycleBuffer();
+        assertThat(got0).isEqualTo(payload0);
+        assertThat(got1).isEqualTo(payload1);
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Release listener tests: releaseAll() on a store must also drop the channel's disk entries.
+    // -----------------------------------------------------------------------------------------
+
+    /**
+     * After a store is released, its pending disk entries must be dropped from every Reader so the
+     * dispatcher's subsequent close() drain does not try to deliver bytes for the gone channel.
+     */
+    @Test
+    void testReleaseAllRemovesChannelDiskEntriesEagerly() throws Exception {
+        Queue<Buffer> drainPool = createBufferPool(5);
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        stores,
+                        ChannelStateWriter.NO_OP,
+                        spillDirs,
+                        SEGMENT_SIZE,
+                        TestBufferPool.drainOnly(drainPool));
+
+        byte[] d0 = createTestData(SEGMENT_SIZE, (byte) 0x51);
+        byte[] d1 = createTestData(SEGMENT_SIZE, (byte) 0x52);
+        writer.write(d0, d0.length, ch0);
+        writer.write(d1, d1.length, ch1);
+        writer.flush();
+
+        // Release store0 before draining — this should propagate to the dispatcher, which drops
+        // all ch0 entries from the Readers.
+        store0.releaseAll();
+
+        writer.drainPendingSpill();
+        writer.close();
+
+        // store1 still receives its data; store0 must stay empty since ch0 entries were dropped.
+        assertThat(tryTake(store0)).isNull();
+        assertThat(concat(drainStore(store1))).isEqualTo(d1);
+    }
+
+    /**
+     * When a channel is released while an in-flight checkpoint wait-set still contains it, the
+     * dispatcher must remove it from the wait-set so the wait-set can still converge to empty and
+     * phase-2 drain is not blocked.
+     */
+    @Test
+    void testReleaseAllConvergesInFlightCheckpointWaitSet() throws Exception {
+        Queue<Buffer> drainPool = createBufferPool(5);
+        RecordingChannelStateWriter recordingWriter = new RecordingChannelStateWriter();
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        stores,
+                        recordingWriter,
+                        spillDirs,
+                        SEGMENT_SIZE,
+                        TestBufferPool.drainOnly(drainPool));
+
+        writer.write(createTestData(SEGMENT_SIZE, (byte) 0x61), SEGMENT_SIZE, ch0);
+        writer.write(createTestData(SEGMENT_SIZE, (byte) 0x62), SEGMENT_SIZE, ch1);
+        writer.flush();
+
+        // ch0 reports in. Wait-set still contains ch1 so phase 2 must not have fired yet.
+        writer.onChannelCheckpointStarted(30L, ch0, writer.getCurrentDrainHead());
+        assertThat(recordingWriter.inputDataCalls).isEmpty();
+
+        // ch1 is released before its checkpoint callback ever arrives. The dispatcher removes it
+        // from the wait-set, which now empties and triggers phase 2.
+        store1.releaseAll();
+
+        // Only ch0's entry made it into the checkpoint backup; ch1's entries were dropped on
+        // release.
+        assertThat(recordingWriter.inputDataCalls).hasSize(1);
+        assertThat(recordingWriter.inputDataCalls.get(0).info).isEqualTo(ch0);
+
+        writer.drainPendingSpill();
+        writer.close();
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // onChannelCheckpointStopped tests
+    // -----------------------------------------------------------------------------------------
+
+    /**
+     * After a checkpoint is aborted (i.e. all stores called notifyCheckpointStopped), a
+     * subsequent channel release must NOT trigger a phase-2 drain into the stopped checkpoint —
+     * the writer for that id is gone and any drain would either be wasted work or rely on the
+     * writer's isDone() guard to silently swallow the data.
+     */
+    @Test
+    void testReleaseAfterStoppedCheckpointDoesNotDrainStoppedCheckpoint() throws Exception {
+        Queue<Buffer> drainPool = createBufferPool(5);
+        RecordingChannelStateWriter recordingWriter = new RecordingChannelStateWriter();
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        stores,
+                        recordingWriter,
+                        spillDirs,
+                        SEGMENT_SIZE,
+                        TestBufferPool.drainOnly(drainPool));
+
+        writer.write(createTestData(SEGMENT_SIZE, (byte) 0x71), SEGMENT_SIZE, ch0);
+        writer.write(createTestData(SEGMENT_SIZE, (byte) 0x72), SEGMENT_SIZE, ch1);
+        writer.flush();
+
+        // Checkpoint 50 starts on ch0; wait-set still contains ch1.
+        writer.onChannelCheckpointStarted(50L, ch0, writer.getCurrentDrainHead());
+        assertThat(recordingWriter.inputDataCalls).isEmpty();
+
+        // The task aborts checkpoint 50 — every channel's persister fires notifyCheckpointStopped.
+        store0.notifyCheckpointStopped(50L);
+        store1.notifyCheckpointStopped(50L);
+
+        // Now ch1 is released. Without the stopped-checkpoint short-circuit, the wait-set would
+        // empty and the dispatcher would drain to checkpoint 50; with the fix, no drain fires.
+        store1.releaseAll();
+
+        assertThat(recordingWriter.inputDataCalls).isEmpty();
+
+        writer.drainPendingSpill();
+        writer.close();
+    }
+
+    /**
+     * A late {@code onChannelCheckpointStarted} for a checkpoint that has already been stopped
+     * must be ignored as stale, even if a new checkpoint has not yet started.
+     */
+    @Test
+    void testLateCheckpointStartedAfterStoppedIsIgnored() throws Exception {
+        Queue<Buffer> drainPool = createBufferPool(5);
+        RecordingChannelStateWriter recordingWriter = new RecordingChannelStateWriter();
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        stores,
+                        recordingWriter,
+                        spillDirs,
+                        SEGMENT_SIZE,
+                        TestBufferPool.drainOnly(drainPool));
+
+        writer.write(createTestData(SEGMENT_SIZE, (byte) 0x81), SEGMENT_SIZE, ch0);
+        writer.flush();
+
+        // Stop checkpoint 60 before anyone reports in.
+        store0.notifyCheckpointStopped(60L);
+        store1.notifyCheckpointStopped(60L);
+
+        // A late onChannelCheckpointStarted(60, ...) shows up. It must be short-circuited.
+        writer.onChannelCheckpointStarted(60L, ch0, writer.getCurrentDrainHead());
+        writer.onChannelCheckpointStarted(60L, ch1, writer.getCurrentDrainHead());
+
+        assertThat(recordingWriter.inputDataCalls).isEmpty();
+
+        writer.drainPendingSpill();
+        writer.close();
+    }
+
+    /**
+     * A new checkpoint started AFTER a stop notification must still progress normally — the
+     * stopped-id short-circuit only skips the exact stopped id, not all subsequent checkpoints.
+     */
+    @Test
+    void testCheckpointAfterStoppedStillProgresses() throws Exception {
+        Queue<Buffer> drainPool = createBufferPool(5);
+        RecordingChannelStateWriter recordingWriter = new RecordingChannelStateWriter();
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        stores,
+                        recordingWriter,
+                        spillDirs,
+                        SEGMENT_SIZE,
+                        TestBufferPool.drainOnly(drainPool));
+
+        writer.write(createTestData(SEGMENT_SIZE, (byte) 0x91), SEGMENT_SIZE, ch0);
+        writer.write(createTestData(SEGMENT_SIZE, (byte) 0x92), SEGMENT_SIZE, ch1);
+        writer.flush();
+
+        // Abort checkpoint 70.
+        store0.notifyCheckpointStopped(70L);
+        store1.notifyCheckpointStopped(70L);
+
+        // Checkpoint 71 begins; both channels report in and phase-2 fires for 71.
+        writer.onChannelCheckpointStarted(71L, ch0, writer.getCurrentDrainHead());
+        writer.onChannelCheckpointStarted(71L, ch1, writer.getCurrentDrainHead());
+
+        assertThat(recordingWriter.inputDataCalls).hasSize(2);
+        assertThat(recordingWriter.inputDataCalls.get(0).checkpointId).isEqualTo(71L);
+        assertThat(recordingWriter.inputDataCalls.get(1).checkpointId).isEqualTo(71L);
+
+        writer.drainPendingSpill();
+        writer.close();
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // AT-CABT / AT-INTR / AT-LOCK: close/drain contract regression tests
+    // -----------------------------------------------------------------------------------------
+
+    /**
+     * A BufferRequester whose blocking path parks indefinitely until interrupted. Used to verify
+     * that callers that should NOT invoke requestBufferBlocking (e.g. close()) are not blocked.
+     */
+    private static final class BlockingForeverBufferRequester implements BufferRequester {
+
+        /** Signals that a blocking request is in flight. */
+        final CountDownLatch blockingStarted = new CountDownLatch(1);
+
+        /** Unblocks the blocking requester when a real buffer should be delivered. */
+        final SynchronousQueue<Buffer> releaseQueue = new SynchronousQueue<>();
+
+        @Override
+        public Buffer requestBuffer(InputChannelInfo channelInfo) {
+            return null; // write path always spills
+        }
+
+        @Override
+        public Buffer requestBufferBlocking(InputChannelInfo channelInfo)
+                throws InterruptedException {
+            blockingStarted.countDown();
+            // Park until a buffer arrives through releaseQueue or the thread is interrupted.
+            return releaseQueue.take();
+        }
+
+        @Override
+        public void releaseExclusiveBuffers() {
+            // No-op: this test fixture has no per-channel buffer manager to tear down.
+        }
+    }
+
+    /**
+     * AT-CABT: abort path — skip drainPendingSpill, call close() directly. close() must return
+     * promptly (it must not invoke requestBufferBlocking) and delete all spill files.
+     */
+    @Test
+    void testCloseWithoutDrainReleasesResources() throws Exception {
+        // requestBufferBlocking parks indefinitely — if close() mistakenly calls it the test hangs.
+        BlockingForeverBufferRequester requester = new BlockingForeverBufferRequester();
+
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        stores,
+                        ChannelStateWriter.NO_OP,
+                        spillDirs,
+                        SEGMENT_SIZE,
+                        requester);
+
+        byte[] data = createTestData(SEGMENT_SIZE, (byte) 0xAB);
+        writer.write(data, data.length, ch0);
+        writer.flush();
+
+        // Verify spill file exists before close.
+        try (Stream<Path> files =
+                Files.list(tempDir).filter(p -> p.getFileName().toString().startsWith("spill-"))) {
+            assertThat(files.count()).isGreaterThan(0);
+        }
+
+        // close() skips drainPendingSpill entirely: must complete within 5 s (not block on buffer).
+        assertTimeoutPreemptively(
+                Duration.ofSeconds(5),
+                () -> assertDoesNotThrow(writer::close),
+                "close() blocked — it incorrectly called requestBufferBlocking");
+
+        // Spill files must be deleted on close.
+        try (Stream<Path> files =
+                Files.list(tempDir).filter(p -> p.getFileName().toString().startsWith("spill-"))) {
+            assertThat(files.count()).isEqualTo(0);
+        }
+
+        // The written bytes were intentionally dropped (abort semantics). Store must remain empty.
+        assertThat(tryTake(store0)).isNull();
+    }
+
+    /**
+     * AT-INTR: drainPendingSpill() is interruptible. When the drain thread blocks on
+     * requestBufferBlocking and the thread is interrupted, drainPendingSpill() must propagate
+     * InterruptedException. A subsequent close() must still release resources.
+     */
+    @Test
+    void testDrainPendingSpillInterruptible() throws Exception {
+        BlockingForeverBufferRequester requester = new BlockingForeverBufferRequester();
+
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        stores,
+                        ChannelStateWriter.NO_OP,
+                        spillDirs,
+                        SEGMENT_SIZE,
+                        requester);
+
+        byte[] data = createTestData(SEGMENT_SIZE, (byte) 0xBC);
+        writer.write(data, data.length, ch0);
+        writer.flush();
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Future<Exception> drainFuture =
+                executor.submit(
+                        () -> {
+                            try {
+                                writer.drainPendingSpill();
+                                return null; // unexpected: should have thrown
+                            } catch (InterruptedException e) {
+                                // restore flag for good measure
+                                Thread.currentThread().interrupt();
+                                return e;
+                            } catch (Exception e) {
+                                return e;
+                            }
+                        });
+
+        // Wait until drainPendingSpill() is actually blocked.
+        assertThat(requester.blockingStarted.await(5, TimeUnit.SECONDS))
+                .as("drain thread did not enter blocking state in time")
+                .isTrue();
+
+        // Interrupt the drain thread.
+        executor.shutdownNow();
+
+        Exception thrown = drainFuture.get(5, TimeUnit.SECONDS);
+        assertThat(thrown)
+                .as("drainPendingSpill() must throw InterruptedException on interrupt")
+                .isInstanceOf(InterruptedException.class);
+
+        // Even after an interrupted drain, close() must release resources without throwing.
+        assertTimeoutPreemptively(
+                Duration.ofSeconds(5),
+                () -> assertDoesNotThrow(writer::close),
+                "close() blocked after interrupted drain");
+
+        // Spill files must be cleaned up.
+        try (Stream<Path> files =
+                Files.list(tempDir).filter(p -> p.getFileName().toString().startsWith("spill-"))) {
+            assertThat(files.count()).isEqualTo(0);
+        }
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Phase-2 per-channel startPos filtering (drain race fix)
+    // -----------------------------------------------------------------------------------------
+
+    /**
+     * Phase 2 must respect each channel's recorded {@code startPos}: entries with position strictly
+     * less than the channel's startPos are skipped (their channel's Step 1 already captured them
+     * via readyBuffers), while entries at or beyond startPos are emitted to the channel state. Two
+     * channels with different startPos values let us verify the filter is applied per-channel and
+     * not globally.
+     */
+    @Test
+    void testPhase2FilterByPerChannelStartPos() throws Exception {
+        RecordingChannelStateWriter recordingWriter = new RecordingChannelStateWriter();
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        stores,
+                        recordingWriter,
+                        spillDirs,
+                        SEGMENT_SIZE,
+                        TestBufferPool.drainOnly(createBufferPool(0)));
+
+        // Layout in the spill file: ch0 entries at offsets 0 and 2*SEGMENT_SIZE, ch1 entry at
+        // offset SEGMENT_SIZE. Total 3 entries, FIFO order.
+        byte[] d0a = createTestData(SEGMENT_SIZE, (byte) 0x10);
+        byte[] d1 = createTestData(SEGMENT_SIZE, (byte) 0x20);
+        byte[] d0b = createTestData(SEGMENT_SIZE, (byte) 0x11);
+        writer.write(d0a, SEGMENT_SIZE, ch0);
+        writer.write(d1, SEGMENT_SIZE, ch1);
+        writer.write(d0b, SEGMENT_SIZE, ch0);
+        writer.flush();
+
+        // ch0's barrier passed before any drain — its startPos is the head of the file (include
+        // every ch0 entry). ch1's barrier passed after the first ch0 entry was logically drained —
+        // its startPos points at the third entry (file 0, offset 2*SEGMENT_SIZE), so its single
+        // entry at offset SEGMENT_SIZE must be skipped (covered by Step 1 ready snapshot).
+        EntryPosition ch0StartPos = new EntryPosition(0, 0);
+        EntryPosition ch1StartPos = new EntryPosition(0, 2L * SEGMENT_SIZE);
+        writer.onChannelCheckpointStarted(7L, ch0, ch0StartPos);
+        writer.onChannelCheckpointStarted(7L, ch1, ch1StartPos);
+
+        writer.close();
+
+        // ch0 receives both of its entries; ch1 receives nothing in phase 2.
+        List<byte[]> ch0Bytes =
+                recordingWriter.inputDataCalls.stream()
+                        .filter(c -> c.info.equals(ch0))
+                        .map(c -> c.capturedBytes)
+                        .collect(java.util.stream.Collectors.toList());
+        List<byte[]> ch1Bytes =
+                recordingWriter.inputDataCalls.stream()
+                        .filter(c -> c.info.equals(ch1))
+                        .map(c -> c.capturedBytes)
+                        .collect(java.util.stream.Collectors.toList());
+        assertThat(ch0Bytes).hasSize(2);
+        assertThat(ch0Bytes.get(0)).isEqualTo(d0a);
+        assertThat(ch0Bytes.get(1)).isEqualTo(d0b);
+        assertThat(ch1Bytes).isEmpty();
+    }
+
+    /**
+     * The phase-2 snapshot is captured at the <em>first</em> {@code onChannelCheckpointStarted}
+     * call, not at wait-set convergence. This guards the original race: between the first and last
+     * trigger, drainPendingSpill could pop entries off the original Reader; the pinned snapshot
+     * preserves the pre-drain view so phase-2 sees every entry that was on disk when the first
+     * channel passed its barrier.
+     *
+     * <p>Scenario: write three entries for two channels, fire ch0's trigger to capture the
+     * snapshot, drain everything (which empties the original Reader's deque), then fire ch1's
+     * trigger to converge the wait-set. Phase 2 must still report all three entries because the
+     * snapshot was taken before drain ran.
+     */
+    @Test
+    void testPhase2SnapshotPinnedAtFirstTrigger() throws Exception {
+        RecordingChannelStateWriter recordingWriter = new RecordingChannelStateWriter();
+        Queue<Buffer> drainPool = createBufferPool(5);
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        stores,
+                        recordingWriter,
+                        spillDirs,
+                        SEGMENT_SIZE,
+                        TestBufferPool.drainOnly(drainPool));
+
+        byte[] d0 = createTestData(SEGMENT_SIZE, (byte) 0xC0);
+        byte[] d1 = createTestData(SEGMENT_SIZE, (byte) 0xC1);
+        byte[] d2 = createTestData(SEGMENT_SIZE, (byte) 0xC2);
+        writer.write(d0, SEGMENT_SIZE, ch0);
+        writer.write(d1, SEGMENT_SIZE, ch1);
+        writer.write(d2, SEGMENT_SIZE, ch0);
+        writer.flush();
+
+        // First trigger arrives BEFORE drain. The snapshot pins the full disk view here.
+        EntryPosition initialDrainHead = writer.getCurrentDrainHead();
+        writer.onChannelCheckpointStarted(11L, ch0, initialDrainHead);
+
+        // drainPendingSpill empties the ORIGINAL Reader. Phase 2 must read from the pinned
+        // snapshot, not the post-drain Reader, otherwise we lose every entry.
+        writer.drainPendingSpill();
+
+        // Now ch1's trigger converges the wait-set, firing phase-2.
+        writer.onChannelCheckpointStarted(11L, ch1, initialDrainHead);
+        writer.close();
+
+        // All three entries must show up in phase-2 with their original channel info.
+        List<RecordingChannelStateWriter.Call> calls = recordingWriter.inputDataCalls;
+        assertThat(calls).hasSize(3);
+        assertThat(calls.get(0).info).isEqualTo(ch0);
+        assertThat(calls.get(0).capturedBytes).isEqualTo(d0);
+        assertThat(calls.get(1).info).isEqualTo(ch1);
+        assertThat(calls.get(1).capturedBytes).isEqualTo(d1);
+        assertThat(calls.get(2).info).isEqualTo(ch0);
+        assertThat(calls.get(2).capturedBytes).isEqualTo(d2);
+    }
+
+    /**
+     * {@code onChannelCheckpointStopped} must close pinned snapshot Readers and clear the in-
+     * progress checkpoint state, otherwise every aborted checkpoint leaks one {@code FileChannel}
+     * per spill file and a stale per-channel startPos map can poison the next checkpoint's filter.
+     * Following an abort, a fresh checkpoint must produce a complete phase-2 from a brand-new
+     * snapshot.
+     */
+    @Test
+    void testCheckpointStoppedReleasesSnapshotsAndStateForNextCheckpoint() throws Exception {
+        RecordingChannelStateWriter recordingWriter = new RecordingChannelStateWriter();
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        stores,
+                        recordingWriter,
+                        spillDirs,
+                        SEGMENT_SIZE,
+                        TestBufferPool.drainOnly(createBufferPool(0)));
+
+        byte[] d0 = createTestData(SEGMENT_SIZE, (byte) 0xD0);
+        byte[] d1 = createTestData(SEGMENT_SIZE, (byte) 0xD1);
+        writer.write(d0, SEGMENT_SIZE, ch0);
+        writer.write(d1, SEGMENT_SIZE, ch1);
+        writer.flush();
+
+        // Start checkpoint 5; only ch0 reports in, then both channels stop the checkpoint
+        // (e.g. abort path) before ch1 reports.
+        writer.onChannelCheckpointStarted(5L, ch0, writer.getCurrentDrainHead());
+        writer.onChannelCheckpointStopped(5L, ch0);
+        writer.onChannelCheckpointStopped(5L, ch1);
+        // Phase 2 for ckpt 5 was never submitted because the wait-set never converged before stop.
+        assertThat(recordingWriter.inputDataCalls).isEmpty();
+
+        // A subsequent checkpoint 6 starts cleanly and converges normally — must include both
+        // entries despite the dangling state from the aborted checkpoint 5.
+        EntryPosition startPos = writer.getCurrentDrainHead();
+        writer.onChannelCheckpointStarted(6L, ch0, startPos);
+        writer.onChannelCheckpointStarted(6L, ch1, startPos);
+        writer.close();
+
+        assertThat(recordingWriter.inputDataCalls).hasSize(2);
+        assertThat(recordingWriter.inputDataCalls.get(0).checkpointId).isEqualTo(6L);
+        assertThat(recordingWriter.inputDataCalls.get(1).checkpointId).isEqualTo(6L);
+    }
+
+    /**
+     * The {@code drainHead} field must advance only after each drain bundle's {@code addBuffer},
+     * so an external observer reading {@code getCurrentDrainHead()} can rely on the invariant
+     * "drainHead crossed e ⇒ e is in store.readyBuffers". This test exercises the public
+     * observable: at flush() drainHead points at the first entry; after each drain bundle commits,
+     * drainHead advances to the next entry; after the last entry drainHead reaches END.
+     */
+    @Test
+    void testDrainHeadAdvancesAfterEachAddBuffer() throws Exception {
+        Queue<Buffer> drainPool = createBufferPool(5);
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        stores,
+                        ChannelStateWriter.NO_OP,
+                        spillDirs,
+                        SEGMENT_SIZE,
+                        TestBufferPool.drainOnly(drainPool));
+
+        byte[] d0 = createTestData(SEGMENT_SIZE, (byte) 0xE0);
+        byte[] d1 = createTestData(SEGMENT_SIZE, (byte) 0xE1);
+        writer.write(d0, SEGMENT_SIZE, ch0);
+        writer.write(d1, SEGMENT_SIZE, ch1);
+        writer.flush();
+
+        // After flush, drainHead points at the first entry of file 0.
+        EntryPosition headAfterFlush = writer.getCurrentDrainHead();
+        assertThat(headAfterFlush.getFileIndex()).isEqualTo(0);
+        assertThat(headAfterFlush.getOffset()).isEqualTo(0L);
+
+        writer.drainPendingSpill();
+
+        // After drain consumes everything, drainHead reaches the END sentinel.
+        assertThat(writer.getCurrentDrainHead()).isEqualTo(EntryPosition.END);
+
+        writer.close();
+    }
+
+    /**
+     * Before the {@link #drainPendingSpill()} bundle was made atomic, a phase-2 snapshot taken in
+     * the gap between {@code reader.skipNextEntry()} (entry gone from disk-side bookkeeping) and
+     * {@code store.addBuffer()} (entry not yet in the channel's readyBuffers) would lose the
+     * entry: Step 1 captures no buffer, phase-2 sees no entry. This test exercises the invariant
+     * by injecting an {@code onChannelCheckpointStarted} call between two drain bundles and
+     * asserting that every spilled entry appears either in the channel's readyBuffers (Step 1) or
+     * in phase-2 capture — never neither.
+     */
+    @Test
+    void testNoEntryLostBetweenDrainAndCheckpointTrigger() throws Exception {
+        RecordingChannelStateWriter recordingWriter = new RecordingChannelStateWriter();
+        Queue<Buffer> drainPool = createBufferPool(5);
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        stores,
+                        recordingWriter,
+                        spillDirs,
+                        SEGMENT_SIZE,
+                        TestBufferPool.drainOnly(drainPool));
+
+        byte[] d0a = createTestData(SEGMENT_SIZE, (byte) 0x60);
+        byte[] d0b = createTestData(SEGMENT_SIZE, (byte) 0x61);
+        byte[] d0c = createTestData(SEGMENT_SIZE, (byte) 0x62);
+        byte[] d1 = createTestData(SEGMENT_SIZE, (byte) 0x70);
+        writer.write(d0a, SEGMENT_SIZE, ch0);
+        writer.write(d1, SEGMENT_SIZE, ch1);
+        writer.write(d0b, SEGMENT_SIZE, ch0);
+        writer.write(d0c, SEGMENT_SIZE, ch0);
+        writer.flush();
+
+        // ch0's barrier arrives BEFORE drain runs — every ch0 entry is "in flight" for ckpt 9.
+        EntryPosition ch0StartPos = writer.getCurrentDrainHead();
+        writer.onChannelCheckpointStarted(9L, ch0, ch0StartPos);
+
+        // Drain runs to completion: entries are popped from the original reader and addBuffered
+        // to their stores. The phase-2 snapshot was pinned before drain so it still owns the full
+        // disk view; per-channel filtering decides whether each snapshot entry is emitted.
+        writer.drainPendingSpill();
+
+        // ch1 reports in AFTER drain — its startPos is END (everything already drained for ch1's
+        // perspective). Phase-2 must skip every ch1 snapshot entry (Step 1 captured them via
+        // store readyBuffers) and emit the full ch0 set.
+        EntryPosition ch1StartPos = writer.getCurrentDrainHead();
+        writer.onChannelCheckpointStarted(9L, ch1, ch1StartPos);
+        writer.close();
+
+        // Aggregate every ch0 byte the dispatcher told the world about: phase-2 emits + buffers
+        // the store actually received via drain. The set must equal the original three ch0 writes
+        // — no entry can fall through both paths.
+        List<byte[]> phase2Ch0 =
+                recordingWriter.inputDataCalls.stream()
+                        .filter(c -> c.info.equals(ch0))
+                        .map(c -> c.capturedBytes)
+                        .collect(java.util.stream.Collectors.toList());
+        List<byte[]> readyCh0 = drainStore(store0);
+        // ch0 trigger fired before drain → every ch0 spill entry has p_e >= startPos_ch0,
+        // so phase 2 emits all three. Drain afterwards still adds them to readyBuffers, but the
+        // race fix only guarantees coverage (no loss); a buffer being delivered post-trigger is
+        // expected and Task will consume it as ckpt N+1's input.
+        assertThat(phase2Ch0).hasSize(3);
+        assertThat(phase2Ch0).containsExactly(d0a, d0b, d0c);
+        // For ch1: ch1's barrier was after drain, so its single entry is captured by Step 1
+        // (readyBuffers) and skipped in phase 2.
+        List<byte[]> phase2Ch1 =
+                recordingWriter.inputDataCalls.stream()
+                        .filter(c -> c.info.equals(ch1))
+                        .map(c -> c.capturedBytes)
+                        .collect(java.util.stream.Collectors.toList());
+        List<byte[]> readyCh1 = drainStore(store1);
+        assertThat(phase2Ch1).isEmpty();
+        assertThat(readyCh1).hasSize(1);
+        assertThat(readyCh1.get(0)).isEqualTo(d1);
+        // Sanity: the ready set for ch0 contains every original byte too (drain delivered them
+        // post-trigger), but the test's correctness hinges on the phase-2 set being complete.
+        assertThat(readyCh0).hasSize(3);
+    }
+
+    /**
+     * AT-LOCK: FLINK-39519 deadlock regression. drainPendingSpill() must NOT hold the dispatcher
+     * monitor while blocking on requestBufferBlocking. Concurrent onChannelCheckpointStopped (which
+     * acquires the dispatcher monitor) must complete promptly while drain is blocked.
+     *
+     * <p>Before the close/drain split, drainSpillThroughBuffers() ran inside a synchronized block,
+     * so onChannelCheckpointStopped would deadlock waiting for the monitor held by drain. This test
+     * reproduces that scenario and asserts the callback completes in time.
+     */
+    @Test
+    void testDrainPendingSpillReleasesMonitorForCheckpointStopped() throws Exception {
+        BlockingForeverBufferRequester requester = new BlockingForeverBufferRequester();
+
+        FilteredBufferDispatcherImpl writer =
+                new FilteredBufferDispatcherImpl(
+                        stores,
+                        ChannelStateWriter.NO_OP,
+                        spillDirs,
+                        SEGMENT_SIZE,
+                        requester);
+
+        // Set up checkpoint wait-set state so onChannelCheckpointStopped follows the full path.
+        // notifyCheckpointStopped on the stores will call writer.onChannelCheckpointStopped.
+        long checkpointId = 42L;
+
+        byte[] data = createTestData(SEGMENT_SIZE, (byte) 0xCD);
+        writer.write(data, data.length, ch0);
+        writer.flush();
+
+        // Build the wait-set for checkpoint 42 by having ch0 report in.
+        writer.onChannelCheckpointStarted(checkpointId, ch0, writer.getCurrentDrainHead());
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Future<?> drainFuture =
+                executor.submit(
+                        () -> {
+                            try {
+                                writer.drainPendingSpill();
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                            } catch (Exception ignored) {
+                            }
+                        });
+
+        // Wait until drainPendingSpill() is blocked inside requestBufferBlocking.
+        assertThat(requester.blockingStarted.await(5, TimeUnit.SECONDS))
+                .as("drain thread did not enter blocking state in time")
+                .isTrue();
+
+        // onChannelCheckpointStopped acquires the dispatcher monitor. If drain held the monitor
+        // this call would deadlock; it must return within 1 s.
+        assertTimeoutPreemptively(
+                Duration.ofSeconds(1),
+                () -> {
+                    store0.notifyCheckpointStopped(checkpointId);
+                    store1.notifyCheckpointStopped(checkpointId);
+                },
+                "onChannelCheckpointStopped deadlocked — drainPendingSpill held the dispatcher monitor");
+
+        // Interrupt the drain thread so the test exits cleanly.
+        executor.shutdownNow();
+        drainFuture.get(5, TimeUnit.SECONDS);
+
+        writer.close();
+    }
+
+    // -- helpers --
+
+    private static void assertEmpty(RecoveredBufferStoreImpl store) {
+        synchronized (store) {
+            assertThat(store.isEmpty()).isTrue();
+        }
+    }
+
+    private static void assertNotEmpty(RecoveredBufferStoreImpl store) {
+        synchronized (store) {
+            assertThat(store.isEmpty()).isFalse();
+        }
+    }
+
+    private static Buffer tryTake(RecoveredBufferStoreImpl store) {
+        synchronized (store) {
+            return store.tryTake();
+        }
+    }
+
+    private static void drainReady(RecoveredBufferStoreImpl store) {
+        synchronized (store) {
+            Buffer b;
+            while ((b = store.tryTake()) != null) {
+                b.recycleBuffer();
+            }
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/FilteredBufferDispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/FilteredBufferDispatcherTest.java
@@ -863,7 +863,7 @@ class FilteredBufferDispatcherTest {
     }
 
     /**
-     * wait-set reaching empty triggers phase2 {@code drainSpillEntriesToCheckpoint}: the sealed
+     * wait-set reaching empty triggers phase2 {@code drainSpillEntriesToCheckpoint}: the frozen
      * readers are snapshotted and streamed to the ChannelStateWriter, but the original readers and
      * store state are left intact. drainPendingSpill() then still delivers every entry to the store
      * via network buffers.
@@ -883,7 +883,7 @@ class FilteredBufferDispatcherTest {
         writer.write(payload, SEGMENT_SIZE, ch0);
         writer.flush();
 
-        // phase2: snapshots sealed readers into the ChannelStateWriter (NO_OP here); the original
+        // phase2: snapshots frozen readers into the ChannelStateWriter (NO_OP here); the original
         // reader and store state are untouched.
         writer.onChannelCheckpointStarted(99L, ch0, writer.getCurrentDrainHead());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/FilteredBufferDispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/FilteredBufferDispatcherTest.java
@@ -51,7 +51,6 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 /** Tests for {@link FilteredBufferDispatcherImpl}. */
@@ -81,14 +80,9 @@ class FilteredBufferDispatcherTest {
     }
 
     @AfterEach
-    void tearDown() {
-        // Temp dir auto-cleaned by @TempDir
-    }
+    void tearDown() {}
 
-    /**
-     * Test-only subclass of RecoveredBufferStoreImpl that records whether setCoordinator was
-     * called and captures the registered coordinator, without using Mockito.
-     */
+    /** Records setCoordinator calls without Mockito. */
     private static class TrackingBufferStore extends RecoveredBufferStoreImpl {
         private RecoveredBufferStoreCoordinator registeredCoordinator;
         private int setCoordinatorCount = 0;
@@ -104,8 +98,6 @@ class FilteredBufferDispatcherTest {
             this.setCoordinatorCount++;
         }
     }
-
-    // --- Helper methods ---
 
     private Buffer createBuffer() {
         return new NetworkBuffer(
@@ -127,7 +119,6 @@ class FilteredBufferDispatcherTest {
         return data;
     }
 
-    /** Drains all ready buffers from a store and returns their data. */
     private List<byte[]> drainStore(RecoveredBufferStoreImpl store) {
         List<byte[]> result = new ArrayList<>();
         while (true) {
@@ -146,7 +137,6 @@ class FilteredBufferDispatcherTest {
         return result;
     }
 
-    /** Concatenates all byte arrays into a single byte array. */
     private byte[] concat(List<byte[]> chunks) {
         int totalLen = chunks.stream().mapToInt(a -> a.length).sum();
         byte[] result = new byte[totalLen];
@@ -158,12 +148,9 @@ class FilteredBufferDispatcherTest {
         return result;
     }
 
-    // --- Tests ---
-
     /** Buffer always available, no disk. All data flows to stores via buffers. */
     @Test
     void testP1MemoryPath() throws Exception {
-        // Provide plenty of buffers so no spilling happens
         Queue<Buffer> pool = createBufferPool(10);
         FilteredBufferDispatcherImpl writer =
                 new FilteredBufferDispatcherImpl(
@@ -187,7 +174,6 @@ class FilteredBufferDispatcherTest {
     /** Buffer supplier always returns null. Data goes to disk, replayed on close. */
     @Test
     void testP2SpillPath() throws Exception {
-        // No buffers for write, but provide blocking buffers for close drain
         Queue<Buffer> drainPool = createBufferPool(5);
         FilteredBufferDispatcherImpl writer =
                 new FilteredBufferDispatcherImpl(
@@ -201,13 +187,11 @@ class FilteredBufferDispatcherTest {
         writer.write(data, data.length, ch0);
         writer.flush();
 
-        // Before drain, store should have no ready buffers (data is on disk as pending)
         assertThat(tryTake(store0)).isNull();
 
         writer.drainPendingSpill();
         writer.close();
 
-        // After drain, data should be in store
         List<byte[]> buffers = drainStore(store0);
         byte[] actual = concat(buffers);
         assertThat(actual).isEqualTo(data);
@@ -218,7 +202,6 @@ class FilteredBufferDispatcherTest {
     @Test
     void testP3ReplayPath() throws Exception {
         Queue<Buffer> pool = new LinkedList<>();
-        // No buffer initially — first write spills
         FilteredBufferDispatcherImpl writer =
                 new FilteredBufferDispatcherImpl(
                         stores,
@@ -227,21 +210,18 @@ class FilteredBufferDispatcherTest {
                         SEGMENT_SIZE,
                         new TestBufferPool(pool));
 
-        // Write exactly SEGMENT_SIZE so the spill entry is auto-sealed
         byte[] data1 = createTestData(SEGMENT_SIZE, (byte) 0x11);
         writer.write(data1, data1.length, ch0);
 
-        // Now add buffers — next write triggers P3 eager drain
+        // Buffers added — next write triggers P3 eager drain.
         pool.addAll(createBufferPool(5));
 
-        // Write to ch1 — channel change flushes ch0, then P3 drains the spilled entry
         byte[] data2 = createTestData(SEGMENT_SIZE, (byte) 0x22);
         writer.write(data2, data2.length, ch1);
         writer.flush();
         writer.drainPendingSpill();
         writer.close();
 
-        // ch0's data should be replayed from disk via P3
         List<byte[]> buf0 = drainStore(store0);
         assertThat(concat(buf0)).isEqualTo(data1);
 
@@ -263,7 +243,6 @@ class FilteredBufferDispatcherTest {
                         SEGMENT_SIZE,
                         TestBufferPool.drainOnly(drainPool));
 
-        // Write to ch0 then ch1 — both spill to disk
         byte[] d0 = createTestData(SEGMENT_SIZE, (byte) 0x10);
         byte[] d1 = createTestData(SEGMENT_SIZE, (byte) 0x20);
         writer.write(d0, d0.length, ch0);
@@ -272,7 +251,6 @@ class FilteredBufferDispatcherTest {
         writer.drainPendingSpill();
         writer.close();
 
-        // Both stores should have data after drain
         assertThat(concat(drainStore(store0))).isEqualTo(d0);
         assertThat(concat(drainStore(store1))).isEqualTo(d1);
     }
@@ -283,7 +261,6 @@ class FilteredBufferDispatcherTest {
     @Test
     void testP3EagerDrain() throws Exception {
         Queue<Buffer> pool = new LinkedList<>();
-        // No buffers initially
         FilteredBufferDispatcherImpl writer =
                 new FilteredBufferDispatcherImpl(
                         stores,
@@ -292,13 +269,11 @@ class FilteredBufferDispatcherTest {
                         SEGMENT_SIZE,
                         new TestBufferPool(pool));
 
-        // Spill 3 entries for ch0 (each exactly SEGMENT_SIZE so they auto-seal)
         for (int i = 0; i < 3; i++) {
             byte[] d = createTestData(SEGMENT_SIZE, (byte) (0x30 + i));
             writer.write(d, d.length, ch0);
         }
 
-        // Now provide buffers and write to ch1 — P3 eager drain should replay all 3 entries
         pool.addAll(createBufferPool(10));
 
         byte[] d3 = createTestData(SEGMENT_SIZE, (byte) 0x40);
@@ -307,14 +282,12 @@ class FilteredBufferDispatcherTest {
         writer.drainPendingSpill();
         writer.close();
 
-        // Verify all 3 entries were drained to store0
         List<byte[]> results = drainStore(store0);
         assertThat(results).hasSize(3);
         for (int i = 0; i < 3; i++) {
             assertThat(results.get(i)).isEqualTo(createTestData(SEGMENT_SIZE, (byte) (0x30 + i)));
         }
 
-        // ch1's data should also be correct
         assertThat(concat(drainStore(store1))).isEqualTo(d3);
     }
 
@@ -324,7 +297,7 @@ class FilteredBufferDispatcherTest {
      */
     @Test
     void testBackendDowngradeOnly() throws Exception {
-        Queue<Buffer> pool = createBufferPool(1); // Only 1 buffer available
+        Queue<Buffer> pool = createBufferPool(1);
         Queue<Buffer> drainPool = createBufferPool(5);
         FilteredBufferDispatcherImpl writer =
                 new FilteredBufferDispatcherImpl(
@@ -334,14 +307,13 @@ class FilteredBufferDispatcherTest {
                         SEGMENT_SIZE,
                         new TestBufferPool(pool, drainPool));
 
-        // Write data larger than one buffer — first SEGMENT_SIZE goes to buffer, rest to disk
+        // First SEGMENT_SIZE goes to buffer, rest to disk.
         byte[] data = createTestData(SEGMENT_SIZE * 2, (byte) 0x44);
         writer.write(data, data.length, ch0);
         writer.flush();
         writer.drainPendingSpill();
         writer.close();
 
-        // All data should be recovered
         List<byte[]> results = drainStore(store0);
         byte[] actual = concat(results);
         assertThat(actual).isEqualTo(data);
@@ -350,7 +322,7 @@ class FilteredBufferDispatcherTest {
     /** Data starts in buffer, spans to file when buffer full. */
     @Test
     void testCrossBackendRecordSpanning() throws Exception {
-        Queue<Buffer> pool = createBufferPool(1); // 1 buffer of SEGMENT_SIZE
+        Queue<Buffer> pool = createBufferPool(1);
         Queue<Buffer> drainPool = createBufferPool(5);
         FilteredBufferDispatcherImpl writer =
                 new FilteredBufferDispatcherImpl(
@@ -360,11 +332,9 @@ class FilteredBufferDispatcherTest {
                         SEGMENT_SIZE,
                         new TestBufferPool(pool, drainPool));
 
-        // Write half a buffer
         byte[] part1 = createTestData(SEGMENT_SIZE / 2, (byte) 0x55);
         writer.write(part1, part1.length, ch0);
 
-        // Write data that exceeds the remaining buffer capacity
         byte[] part2 = createTestData(SEGMENT_SIZE, (byte) 0x66);
         writer.write(part2, part2.length, ch0);
 
@@ -372,7 +342,6 @@ class FilteredBufferDispatcherTest {
         writer.drainPendingSpill();
         writer.close();
 
-        // All data should be present
         List<byte[]> results = drainStore(store0);
         byte[] actual = concat(results);
         byte[] expected = new byte[part1.length + part2.length];
@@ -393,18 +362,16 @@ class FilteredBufferDispatcherTest {
                         SEGMENT_SIZE,
                         new TestBufferPool(pool));
 
-        // Write partial data to ch0
         byte[] d0 = createTestData(SEGMENT_SIZE / 2, (byte) 0x77);
         writer.write(d0, d0.length, ch0);
 
-        // Switch to ch1 — should flush ch0's partial buffer
+        // Channel switch should flush ch0's partial buffer.
         byte[] d1 = createTestData(SEGMENT_SIZE / 2, (byte) 0x88);
         writer.write(d1, d1.length, ch1);
 
         writer.flush();
         writer.close();
 
-        // ch0 should have received its partial buffer
         List<byte[]> results0 = drainStore(store0);
         assertThat(concat(results0)).isEqualTo(d0);
 
@@ -432,7 +399,6 @@ class FilteredBufferDispatcherTest {
         writer.drainPendingSpill();
         writer.close();
 
-        // Both channels' data should be correct after drain
         assertThat(concat(drainStore(store0))).isEqualTo(d0);
         assertThat(concat(drainStore(store1))).isEqualTo(d1);
     }
@@ -449,26 +415,22 @@ class FilteredBufferDispatcherTest {
                         SEGMENT_SIZE,
                         new TestBufferPool(pool));
 
-        // Spill 2 entries to ch0 (each exactly SEGMENT_SIZE so they auto-seal)
         byte[] d1 = createTestData(SEGMENT_SIZE, (byte) 0x01);
         byte[] d2 = createTestData(SEGMENT_SIZE, (byte) 0x02);
         writer.write(d1, d1.length, ch0);
         writer.write(d2, d2.length, ch0);
 
-        // Add only 1 buffer — partial replay (only 1 of 2 entries will drain)
+        // Only 1 buffer — partial replay: only 1 of 2 entries drains.
         pool.add(createBuffer());
 
-        // Write to ch1 — channel change triggers flush, then P3 drains 1 entry
         byte[] d3 = createTestData(SEGMENT_SIZE, (byte) 0x03);
         writer.write(d3, d3.length, ch1);
 
-        // Provide remaining buffers for drain
         pool.addAll(createBufferPool(5));
         writer.flush();
         writer.drainPendingSpill();
         writer.close();
 
-        // All data should be correct
         List<byte[]> results0 = drainStore(store0);
         assertThat(results0).hasSize(2);
         assertThat(results0.get(0)).isEqualTo(d1);
@@ -487,26 +449,22 @@ class FilteredBufferDispatcherTest {
                         SEGMENT_SIZE,
                         TestBufferPool.drainOnly(drainPool));
 
-        // Spill multiple entries
         for (int i = 0; i < 5; i++) {
             byte[] data = createTestData(SEGMENT_SIZE, (byte) i);
             writer.write(data, data.length, ch0);
         }
         writer.flush();
 
-        // Before drain, no ready buffers
         assertThat(tryTake(store0)).isNull();
 
         writer.drainPendingSpill();
 
-        // After drain, all 5 entries should be delivered to the store
         List<byte[]> results = drainStore(store0);
         assertThat(results).hasSize(5);
         for (int i = 0; i < 5; i++) {
             assertThat(results.get(i)).isEqualTo(createTestData(SEGMENT_SIZE, (byte) i));
         }
 
-        // close() is pure resource release — no additional drain
         writer.close();
         assertThat(tryTake(store0)).isNull();
     }
@@ -526,7 +484,6 @@ class FilteredBufferDispatcherTest {
         writer.flush();
         writer.drainPendingSpill();
         writer.close();
-        // Second close should not throw
         writer.close();
     }
 
@@ -546,7 +503,6 @@ class FilteredBufferDispatcherTest {
         writer.write(data, data.length, ch0);
         writer.flush();
 
-        // Verify spill files exist
         try (Stream<Path> files =
                 Files.list(tempDir).filter(p -> p.getFileName().toString().startsWith("spill-"))) {
             assertThat(files.count()).isGreaterThan(0);
@@ -555,7 +511,6 @@ class FilteredBufferDispatcherTest {
         writer.drainPendingSpill();
         writer.close();
 
-        // After close, spill files should be deleted
         try (Stream<Path> files =
                 Files.list(tempDir).filter(p -> p.getFileName().toString().startsWith("spill-"))) {
             assertThat(files.count()).isEqualTo(0);
@@ -616,17 +571,11 @@ class FilteredBufferDispatcherTest {
                 .isInstanceOf(IOException.class);
     }
 
-    /** Enough data for 3+ file rotations. All replayed correctly. */
+    /** Enough data for many spill entries. All replayed correctly. */
     @Test
     void testLargeDataMultiRotation() throws Exception {
-        // FilteredSpillFile rotates at 64MB. Use small segments and many writes to trigger rotation.
-        // For testing, we write enough data to cause rotation. FilteredSpillFile threshold is 64MB.
-        // We use a small segment size and write enough data to exceed 64MB.
-        // To avoid enormous test data, we use a smaller approach:
-        // The rotation threshold in FilteredSpillFile is 64*1024*1024.
-        // We need to write > 192MB of data for 3+ rotations.
-        // For a unit test, this is too much. Instead, we verify the mechanism works
-        // by writing enough data that results in multiple spill entries and verifying correctness.
+        // FilteredSpillFile rotates at 64MB; truly testing rotation needs >192MB which is too
+        // much for a unit test. Verify the mechanism with many entries instead.
         int entryCount = 100;
         int segmentSize = 256;
         Queue<Buffer> drainPool = new LinkedList<>();
@@ -675,8 +624,6 @@ class FilteredBufferDispatcherTest {
                         SEGMENT_SIZE,
                         new TestBufferPool(pool));
 
-        // The write method accepts data, length, channelInfo — this is the unified interface
-        // used by filterAndRewrite. Verify it works for multiple channels.
         byte[] d0 = createTestData(32, (byte) 0xF0);
         byte[] d1 = createTestData(32, (byte) 0xF1);
 
@@ -701,7 +648,7 @@ class FilteredBufferDispatcherTest {
                         SEGMENT_SIZE,
                         TestBufferPool.drainOnly(drainPool));
 
-        // Write exactly 3 * SEGMENT_SIZE bytes — should create exactly 3 spill entries
+        // 3 * SEGMENT_SIZE bytes → exactly 3 spill entries, 1:1 with buffers.
         for (int i = 0; i < 3; i++) {
             byte[] data = createTestData(SEGMENT_SIZE, (byte) (0xA0 + i));
             writer.write(data, data.length, ch0);
@@ -710,7 +657,6 @@ class FilteredBufferDispatcherTest {
         writer.drainPendingSpill();
         writer.close();
 
-        // Each spill entry maps 1:1 to a buffer
         List<byte[]> results = drainStore(store0);
         assertThat(results).hasSize(3);
         for (int i = 0; i < 3; i++) {
@@ -718,10 +664,6 @@ class FilteredBufferDispatcherTest {
             assertThat(results.get(i)).isEqualTo(createTestData(SEGMENT_SIZE, (byte) (0xA0 + i)));
         }
     }
-
-    // ---------------------------------------------------------------------------
-    // Tests for dispatcher registration and wait-set state machine
-    // ---------------------------------------------------------------------------
 
     /**
      * After construction, each store has its coordinator registered to the
@@ -744,7 +686,6 @@ class FilteredBufferDispatcherTest {
                         SEGMENT_SIZE,
                         new TestBufferPool(pool));
 
-        // Both stores must have had setCoordinator called exactly once with the dispatcher.
         assertThat(trackStore0.setCoordinatorCount).isEqualTo(1);
         assertThat(trackStore0.registeredCoordinator).isSameAs(writer);
         assertThat(trackStore1.setCoordinatorCount).isEqualTo(1);
@@ -871,7 +812,8 @@ class FilteredBufferDispatcherTest {
 
         // ch0 removed on first call; second call is a no-op (already absent from set).
         writer.onChannelCheckpointStarted(10L, ch0, writer.getCurrentDrainHead());
-        writer.onChannelCheckpointStarted(10L, ch0, writer.getCurrentDrainHead()); // idempotent — no exception
+        writer.onChannelCheckpointStarted(
+                10L, ch0, writer.getCurrentDrainHead()); // idempotent — no exception
 
         writer.drainPendingSpill();
         writer.close();
@@ -923,8 +865,8 @@ class FilteredBufferDispatcherTest {
     /**
      * wait-set reaching empty triggers phase2 {@code drainSpillEntriesToCheckpoint}: the sealed
      * readers are snapshotted and streamed to the ChannelStateWriter, but the original readers and
-     * store state are left intact. drainPendingSpill() then still delivers every entry to the
-     * store via network buffers.
+     * store state are left intact. drainPendingSpill() then still delivers every entry to the store
+     * via network buffers.
      */
     @Test
     void testWaitSetEmptyTriggersPhase2SnapshotThenDrainDeliversBuffers() throws Exception {
@@ -957,13 +899,9 @@ class FilteredBufferDispatcherTest {
         assertThat(actual).isEqualTo(payload);
     }
 
-    // -----------------------------------------------------------------------------------------
-    // Phase2 disk checkpoint tests
-    // -----------------------------------------------------------------------------------------
-
     /**
-     * A recording ChannelStateWriter that captures addInputDataFromSpill calls for assertions.
-     * Drains the chunk iterator synchronously so tests can assert on actual bytes and channel info.
+     * Captures addInputDataFromSpill calls for assertions; drains the chunk iterator synchronously
+     * so tests can assert on actual bytes and channel info.
      */
     private static class RecordingChannelStateWriter
             extends ChannelStateWriter.NoOpChannelStateWriter {
@@ -1165,7 +1103,8 @@ class FilteredBufferDispatcherTest {
         writer.onChannelCheckpointStarted(checkpointId, ch1, writer.getCurrentDrainHead());
         assertThat(recordingWriter.inputDataCalls).hasSize(2);
 
-        // drainPendingSpill(): both entries additionally delivered to the stores (task-facing pipeline)
+        // drainPendingSpill(): both entries additionally delivered to the stores (task-facing
+        // pipeline)
         writer.drainPendingSpill();
         writer.close();
 
@@ -1182,10 +1121,6 @@ class FilteredBufferDispatcherTest {
         assertThat(got0).isEqualTo(payload0);
         assertThat(got1).isEqualTo(payload1);
     }
-
-    // -----------------------------------------------------------------------------------------
-    // Release listener tests: releaseAll() on a store must also drop the channel's disk entries.
-    // -----------------------------------------------------------------------------------------
 
     /**
      * After a store is released, its pending disk entries must be dropped from every Reader so the
@@ -1258,15 +1193,11 @@ class FilteredBufferDispatcherTest {
         writer.close();
     }
 
-    // -----------------------------------------------------------------------------------------
-    // onChannelCheckpointStopped tests
-    // -----------------------------------------------------------------------------------------
-
     /**
-     * After a checkpoint is aborted (i.e. all stores called notifyCheckpointStopped), a
-     * subsequent channel release must NOT trigger a phase-2 drain into the stopped checkpoint —
-     * the writer for that id is gone and any drain would either be wasted work or rely on the
-     * writer's isDone() guard to silently swallow the data.
+     * After a checkpoint is aborted (i.e. all stores called notifyCheckpointStopped), a subsequent
+     * channel release must NOT trigger a phase-2 drain into the stopped checkpoint — the writer for
+     * that id is gone and any drain would either be wasted work or rely on the writer's isDone()
+     * guard to silently swallow the data.
      */
     @Test
     void testReleaseAfterStoppedCheckpointDoesNotDrainStoppedCheckpoint() throws Exception {
@@ -1303,8 +1234,8 @@ class FilteredBufferDispatcherTest {
     }
 
     /**
-     * A late {@code onChannelCheckpointStarted} for a checkpoint that has already been stopped
-     * must be ignored as stale, even if a new checkpoint has not yet started.
+     * A late {@code onChannelCheckpointStarted} for a checkpoint that has already been stopped must
+     * be ignored as stale, even if a new checkpoint has not yet started.
      */
     @Test
     void testLateCheckpointStartedAfterStoppedIsIgnored() throws Exception {
@@ -1371,10 +1302,6 @@ class FilteredBufferDispatcherTest {
         writer.close();
     }
 
-    // -----------------------------------------------------------------------------------------
-    // AT-CABT / AT-INTR / AT-LOCK: close/drain contract regression tests
-    // -----------------------------------------------------------------------------------------
-
     /**
      * A BufferRequester whose blocking path parks indefinitely until interrupted. Used to verify
      * that callers that should NOT invoke requestBufferBlocking (e.g. close()) are not blocked.
@@ -1417,11 +1344,7 @@ class FilteredBufferDispatcherTest {
 
         FilteredBufferDispatcherImpl writer =
                 new FilteredBufferDispatcherImpl(
-                        stores,
-                        ChannelStateWriter.NO_OP,
-                        spillDirs,
-                        SEGMENT_SIZE,
-                        requester);
+                        stores, ChannelStateWriter.NO_OP, spillDirs, SEGMENT_SIZE, requester);
 
         byte[] data = createTestData(SEGMENT_SIZE, (byte) 0xAB);
         writer.write(data, data.length, ch0);
@@ -1460,11 +1383,7 @@ class FilteredBufferDispatcherTest {
 
         FilteredBufferDispatcherImpl writer =
                 new FilteredBufferDispatcherImpl(
-                        stores,
-                        ChannelStateWriter.NO_OP,
-                        spillDirs,
-                        SEGMENT_SIZE,
-                        requester);
+                        stores, ChannelStateWriter.NO_OP, spillDirs, SEGMENT_SIZE, requester);
 
         byte[] data = createTestData(SEGMENT_SIZE, (byte) 0xBC);
         writer.write(data, data.length, ch0);
@@ -1511,10 +1430,6 @@ class FilteredBufferDispatcherTest {
             assertThat(files.count()).isEqualTo(0);
         }
     }
-
-    // -----------------------------------------------------------------------------------------
-    // Phase-2 per-channel startPos filtering (drain race fix)
-    // -----------------------------------------------------------------------------------------
 
     /**
      * Phase 2 must respect each channel's recorded {@code startPos}: entries with position strictly
@@ -1672,8 +1587,8 @@ class FilteredBufferDispatcherTest {
     }
 
     /**
-     * The {@code drainHead} field must advance only after each drain bundle's {@code addBuffer},
-     * so an external observer reading {@code getCurrentDrainHead()} can rely on the invariant
+     * The {@code drainHead} field must advance only after each drain bundle's {@code addBuffer}, so
+     * an external observer reading {@code getCurrentDrainHead()} can rely on the invariant
      * "drainHead crossed e ⇒ e is in store.readyBuffers". This test exercises the public
      * observable: at flush() drainHead points at the first entry; after each drain bundle commits,
      * drainHead advances to the next entry; after the last entry drainHead reaches END.
@@ -1711,11 +1626,11 @@ class FilteredBufferDispatcherTest {
     /**
      * Before the {@link #drainPendingSpill()} bundle was made atomic, a phase-2 snapshot taken in
      * the gap between {@code reader.skipNextEntry()} (entry gone from disk-side bookkeeping) and
-     * {@code store.addBuffer()} (entry not yet in the channel's readyBuffers) would lose the
-     * entry: Step 1 captures no buffer, phase-2 sees no entry. This test exercises the invariant
-     * by injecting an {@code onChannelCheckpointStarted} call between two drain bundles and
-     * asserting that every spilled entry appears either in the channel's readyBuffers (Step 1) or
-     * in phase-2 capture — never neither.
+     * {@code store.addBuffer()} (entry not yet in the channel's readyBuffers) would lose the entry:
+     * Step 1 captures no buffer, phase-2 sees no entry. This test exercises the invariant by
+     * injecting an {@code onChannelCheckpointStarted} call between two drain bundles and asserting
+     * that every spilled entry appears either in the channel's readyBuffers (Step 1) or in phase-2
+     * capture — never neither.
      */
     @Test
     void testNoEntryLostBetweenDrainAndCheckpointTrigger() throws Exception {
@@ -1801,11 +1716,7 @@ class FilteredBufferDispatcherTest {
 
         FilteredBufferDispatcherImpl writer =
                 new FilteredBufferDispatcherImpl(
-                        stores,
-                        ChannelStateWriter.NO_OP,
-                        spillDirs,
-                        SEGMENT_SIZE,
-                        requester);
+                        stores, ChannelStateWriter.NO_OP, spillDirs, SEGMENT_SIZE, requester);
 
         // Set up checkpoint wait-set state so onChannelCheckpointStopped follows the full path.
         // notifyCheckpointStopped on the stores will call writer.onChannelCheckpointStopped.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/FilteredSpillFileTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/FilteredSpillFileTest.java
@@ -1,0 +1,356 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.apache.flink.runtime.memory.MemoryManager;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link FilteredSpillFile}, {@link FilteredSpillFile.Reader}, and {@link
+ * FilteredSpillFile.Chunk}.
+ */
+class FilteredSpillFileTest {
+
+    @TempDir private Path temporaryFolder;
+
+    private static final int MEMORY_SEGMENT_SIZE = MemoryManager.DEFAULT_PAGE_SIZE;
+
+    private static final InputChannelInfo CHANNEL_0 = new InputChannelInfo(0, 0);
+    private static final InputChannelInfo CHANNEL_1 = new InputChannelInfo(0, 1);
+
+    /** Write a single entry and read it back via readNext; verify bytes match. */
+    @Test
+    void testSingleEntryRoundTrip() throws Exception {
+        String[] spillDirs = {temporaryFolder.toString()};
+        Random random = new Random(42);
+        byte[] data = new byte[1024];
+        random.nextBytes(data);
+
+        try (FilteredSpillFile writer =
+                new FilteredSpillFile(spillDirs, MEMORY_SEGMENT_SIZE)) {
+            writer.writeEntry(data, data.length, CHANNEL_0);
+            writer.finish();
+
+            FilteredSpillFile.Reader reader = writer.getReaders().get(0);
+            assertThat(reader.hasEntries()).isTrue();
+            FilteredSpillFile.Chunk chunk = reader.readNext();
+            assertThat(chunk).isNotNull();
+            assertThat(chunk.getChannelInfo()).isEqualTo(CHANNEL_0);
+            assertThat(chunk.getLength()).isEqualTo(data.length);
+            assertThat(chunk.getData()).startsWith(data);
+            assertThat(reader.hasEntries()).isFalse();
+        }
+    }
+
+    /** Write multiple entries across channels; verify readNext returns them in order. */
+    @Test
+    void testMultipleEntriesInOrder() throws Exception {
+        String[] spillDirs = {temporaryFolder.toString()};
+        byte[] d0 = new byte[] {1, 2, 3, 4};
+        byte[] d1 = new byte[] {5, 6, 7, 8};
+
+        try (FilteredSpillFile writer =
+                new FilteredSpillFile(spillDirs, MEMORY_SEGMENT_SIZE)) {
+            writer.writeEntry(d0, d0.length, CHANNEL_0);
+            writer.writeEntry(d1, d1.length, CHANNEL_1);
+            writer.finish();
+
+            FilteredSpillFile.Reader reader = writer.getReaders().get(0);
+            FilteredSpillFile.Chunk c0 = reader.readNext();
+            assertThat(c0.getChannelInfo()).isEqualTo(CHANNEL_0);
+            assertThat(c0.getLength()).isEqualTo(d0.length);
+            byte[] actual0 = new byte[d0.length];
+            System.arraycopy(c0.getData(), 0, actual0, 0, d0.length);
+            assertThat(actual0).isEqualTo(d0);
+
+            FilteredSpillFile.Chunk c1 = reader.readNext();
+            assertThat(c1.getChannelInfo()).isEqualTo(CHANNEL_1);
+            assertThat(c1.getLength()).isEqualTo(d1.length);
+            byte[] actual1 = new byte[d1.length];
+            System.arraycopy(c1.getData(), 0, actual1, 0, d1.length);
+            assertThat(actual1).isEqualTo(d1);
+
+            assertThat(reader.readNext()).isNull();
+        }
+    }
+
+    /**
+     * Write more than 64MB to trigger file rotation; verify multiple Readers are created and data
+     * is correct across files.
+     */
+    @Test
+    void testFileRotation() throws Exception {
+        Path dir1 = Files.createDirectory(temporaryFolder.resolve("dir1"));
+        Path dir2 = Files.createDirectory(temporaryFolder.resolve("dir2"));
+        String[] spillDirs = {dir1.toString(), dir2.toString()};
+
+        // 64MB / DEFAULT_PAGE_SIZE + extra to force at least one rotation
+        int numEntries = (int) (64L * 1024 * 1024 / MEMORY_SEGMENT_SIZE) + 10;
+        byte[][] chunks = new byte[numEntries][MEMORY_SEGMENT_SIZE];
+        Random random = new Random(42);
+        for (byte[] chunk : chunks) {
+            random.nextBytes(chunk);
+        }
+
+        try (FilteredSpillFile writer =
+                new FilteredSpillFile(spillDirs, MEMORY_SEGMENT_SIZE)) {
+            for (int i = 0; i < numEntries; i++) {
+                writer.writeEntry(chunks[i], MEMORY_SEGMENT_SIZE, CHANNEL_0);
+            }
+            writer.finish();
+
+            assertThat(writer.getReaders().size()).isGreaterThan(1);
+
+            int idx = 0;
+            for (FilteredSpillFile.Reader reader : writer.getReaders()) {
+                while (reader.hasEntries()) {
+                    FilteredSpillFile.Chunk chunk = reader.readNext();
+                    byte[] actual = new byte[chunk.getLength()];
+                    System.arraycopy(chunk.getData(), 0, actual, 0, chunk.getLength());
+                    assertThat(actual).isEqualTo(chunks[idx++]);
+                }
+            }
+            assertThat(idx).isEqualTo(numEntries);
+        }
+    }
+
+    /** Writer.close() finishes and releases resources; writeEntry after close throws. */
+    @Test
+    void testCloseReleasesResources() throws Exception {
+        String[] spillDirs = {temporaryFolder.toString()};
+        FilteredSpillFile writer =
+                new FilteredSpillFile(spillDirs, MEMORY_SEGMENT_SIZE);
+        writer.writeEntry(new byte[] {1, 2, 3}, 3, CHANNEL_0);
+        writer.close();
+
+        assertThatThrownBy(() -> writer.writeEntry(new byte[] {4}, 1, CHANNEL_0))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    /** Truncated file causes readNext to throw IOException. */
+    @Test
+    void testTruncatedFileThrows() throws Exception {
+        String[] spillDirs = {temporaryFolder.toString()};
+        byte[] data = new byte[1024];
+        new Random(42).nextBytes(data);
+
+        try (FilteredSpillFile writer =
+                new FilteredSpillFile(spillDirs, MEMORY_SEGMENT_SIZE)) {
+            writer.writeEntry(data, data.length, CHANNEL_0);
+            writer.finish();
+
+            // Truncate the spill file to half
+            Path filePath = writer.getReaders().get(0).filePath;
+            try (RandomAccessFile raf = new RandomAccessFile(filePath.toFile(), "rw")) {
+                raf.setLength(data.length / 2);
+            }
+
+            assertThatThrownBy(() -> writer.getReaders().get(0).readNext())
+                    .isInstanceOf(IOException.class);
+        }
+    }
+
+    /** snapshot() creates an independent Reader with the same entries; pre-sealed. */
+    @Test
+    void testSnapshot() throws Exception {
+        String[] spillDirs = {temporaryFolder.toString()};
+        byte[] data = new byte[256];
+        for (int i = 0; i < data.length; i++) {
+            data[i] = (byte) i;
+        }
+
+        try (FilteredSpillFile writer =
+                new FilteredSpillFile(spillDirs, MEMORY_SEGMENT_SIZE)) {
+            writer.writeEntry(data, data.length, CHANNEL_0);
+            writer.finish();
+
+            FilteredSpillFile.Reader original = writer.getReaders().get(0);
+            assertThat(original.isSealed()).isTrue();
+
+            FilteredSpillFile.Reader snap = original.snapshot();
+            try {
+                assertThat(snap.isSealed()).isTrue();
+                assertThat(snap.hasEntries()).isTrue();
+
+                FilteredSpillFile.Chunk chunk = snap.readNext();
+                assertThat(chunk.getLength()).isEqualTo(data.length);
+                byte[] actual = new byte[data.length];
+                System.arraycopy(chunk.getData(), 0, actual, 0, data.length);
+                assertThat(actual).isEqualTo(data);
+
+                // Original still has entries (snapshot is independent)
+                assertThat(original.hasEntries()).isTrue();
+            } finally {
+                snap.close();
+            }
+        }
+    }
+
+    /** addEntry after seal throws IllegalStateException. */
+    @Test
+    void testAddEntryAfterSealThrows() throws Exception {
+        String[] spillDirs = {temporaryFolder.toString()};
+        try (FilteredSpillFile writer =
+                new FilteredSpillFile(spillDirs, MEMORY_SEGMENT_SIZE)) {
+            writer.writeEntry(new byte[] {1}, 1, CHANNEL_0);
+            writer.finish();
+            // Reader is sealed by finish(); addEntry via a new writeEntry after finish should throw
+            assertThatThrownBy(() -> writer.writeEntry(new byte[] {2}, 1, CHANNEL_0))
+                    .isInstanceOf(IllegalStateException.class);
+        }
+    }
+
+    /** peekNextChannel returns the channel of the next entry without consuming it. */
+    @Test
+    void testPeekNextChannel() throws Exception {
+        String[] spillDirs = {temporaryFolder.toString()};
+        try (FilteredSpillFile writer =
+                new FilteredSpillFile(spillDirs, MEMORY_SEGMENT_SIZE)) {
+            writer.writeEntry(new byte[] {1, 2}, 2, CHANNEL_0);
+            writer.writeEntry(new byte[] {3, 4}, 2, CHANNEL_1);
+            writer.finish();
+
+            FilteredSpillFile.Reader reader = writer.getReaders().get(0);
+            assertThat(reader.peekNextChannel()).isEqualTo(CHANNEL_0);
+            reader.readNext();
+            assertThat(reader.peekNextChannel()).isEqualTo(CHANNEL_1);
+            reader.readNext();
+            assertThat(reader.peekNextChannel()).isNull();
+        }
+    }
+
+    /** getPendingChannels returns all channels with pending entries. */
+    @Test
+    void testGetPendingChannels() throws Exception {
+        String[] spillDirs = {temporaryFolder.toString()};
+        try (FilteredSpillFile writer =
+                new FilteredSpillFile(spillDirs, MEMORY_SEGMENT_SIZE)) {
+            writer.writeEntry(new byte[] {1}, 1, CHANNEL_0);
+            writer.writeEntry(new byte[] {2}, 1, CHANNEL_1);
+            writer.finish();
+
+            FilteredSpillFile.Reader reader = writer.getReaders().get(0);
+            assertThat(reader.getPendingChannels()).containsExactlyInAnyOrder(CHANNEL_0, CHANNEL_1);
+
+            reader.readNext(); // consume CHANNEL_0
+            assertThat(reader.getPendingChannels()).containsExactly(CHANNEL_1);
+
+            reader.readNext(); // consume CHANNEL_1
+            assertThat(reader.getPendingChannels()).isEmpty();
+        }
+    }
+
+    /** isIdle() returns true before any writeEntry call, false after. */
+    @Test
+    void testIsIdle() throws Exception {
+        String[] spillDirs = {temporaryFolder.toString()};
+        try (FilteredSpillFile writer =
+                new FilteredSpillFile(spillDirs, MEMORY_SEGMENT_SIZE)) {
+            assertThat(writer.isIdle()).isTrue();
+            writer.writeEntry(new byte[] {1}, 1, CHANNEL_0);
+            assertThat(writer.isIdle()).isFalse();
+        }
+    }
+
+    /**
+     * isIdle() flips dynamically with the reader entry count: empty at start, non-idle after any
+     * write, stays non-idle while entries remain even if some are partially drained, idle again
+     * only after all entries have been consumed. Must behave consistently across multiple
+     * write / drain rounds.
+     */
+    @Test
+    void testIsIdleFlipsAcrossWriteDrainRounds() throws Exception {
+        String[] spillDirs = {temporaryFolder.toString()};
+        try (FilteredSpillFile writer =
+                new FilteredSpillFile(spillDirs, MEMORY_SEGMENT_SIZE)) {
+            // Initially idle
+            assertThat(writer.isIdle()).isTrue();
+
+            // --- Round 1: write 3 entries ---
+            writer.writeEntry(new byte[] {1}, 1, CHANNEL_0);
+            writer.writeEntry(new byte[] {2}, 1, CHANNEL_1);
+            writer.writeEntry(new byte[] {3}, 1, CHANNEL_0);
+            assertThat(writer.isIdle()).isFalse();
+
+            FilteredSpillFile.Reader reader = writer.getReaders().get(0);
+
+            // Partial consume (1 of 3) — still not idle
+            reader.readNext();
+            assertThat(writer.isIdle()).isFalse();
+
+            // Another partial consume (2 of 3) — still not idle
+            reader.readNext();
+            assertThat(writer.isIdle()).isFalse();
+
+            // Consume last one — now idle
+            reader.readNext();
+            assertThat(reader.hasEntries()).isFalse();
+            assertThat(writer.isIdle()).isTrue();
+
+            // --- Round 2: write 2 more entries ---
+            writer.writeEntry(new byte[] {4}, 1, CHANNEL_1);
+            writer.writeEntry(new byte[] {5}, 1, CHANNEL_0);
+            assertThat(writer.isIdle()).isFalse();
+
+            // Partial consume (1 of 2) — still not idle
+            reader.readNext();
+            assertThat(writer.isIdle()).isFalse();
+
+            // Consume remainder — idle again
+            reader.readNext();
+            assertThat(reader.hasEntries()).isFalse();
+            assertThat(writer.isIdle()).isTrue();
+        }
+    }
+
+    /** close() deletes all spill files on disk. */
+    @Test
+    void testCloseDeletesAllFiles() throws Exception {
+        String[] spillDirs = {temporaryFolder.toString()};
+        FilteredSpillFile writer =
+                new FilteredSpillFile(spillDirs, MEMORY_SEGMENT_SIZE);
+        writer.writeEntry(new byte[64], 64, CHANNEL_0);
+        List<Path> filePaths = new ArrayList<>();
+        for (FilteredSpillFile.Reader r : writer.getReaders()) {
+            filePaths.add(r.filePath);
+        }
+        for (Path p : filePaths) {
+            assertThat(Files.exists(p)).isTrue();
+        }
+
+        writer.close();
+
+        for (Path p : filePaths) {
+            assertThat(Files.exists(p)).isFalse();
+        }
+    }
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/FilteredSpillFileTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/FilteredSpillFileTest.java
@@ -173,7 +173,7 @@ class FilteredSpillFileTest {
         }
     }
 
-    /** snapshot() creates an independent Reader with the same entries; pre-sealed. */
+    /** snapshot() creates an independent Reader with the same entries; pre-frozen. */
     @Test
     void testSnapshot() throws Exception {
         String[] spillDirs = {temporaryFolder.toString()};
@@ -187,11 +187,11 @@ class FilteredSpillFileTest {
             writer.finish();
 
             FilteredSpillFile.Reader original = writer.getReaders().get(0);
-            assertThat(original.isSealed()).isTrue();
+            assertThat(original.isFrozen()).isTrue();
 
             FilteredSpillFile.Reader snap = original.snapshot();
             try {
-                assertThat(snap.isSealed()).isTrue();
+                assertThat(snap.isFrozen()).isTrue();
                 assertThat(snap.hasEntries()).isTrue();
 
                 FilteredSpillFile.Chunk chunk = snap.readNext();
@@ -208,14 +208,14 @@ class FilteredSpillFileTest {
         }
     }
 
-    /** addEntry after seal throws IllegalStateException. */
+    /** addEntry after freeze throws IllegalStateException. */
     @Test
-    void testAddEntryAfterSealThrows() throws Exception {
+    void testAddEntryAfterFreezeThrows() throws Exception {
         String[] spillDirs = {temporaryFolder.toString()};
         try (FilteredSpillFile writer = new FilteredSpillFile(spillDirs, MEMORY_SEGMENT_SIZE)) {
             writer.writeEntry(new byte[] {1}, 1, CHANNEL_0);
             writer.finish();
-            // Reader is sealed by finish(); addEntry via a new writeEntry after finish should throw
+            // Reader is frozen by finish(); addEntry via a new writeEntry after finish should throw
             assertThatThrownBy(() -> writer.writeEntry(new byte[] {2}, 1, CHANNEL_0))
                     .isInstanceOf(IllegalStateException.class);
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/FilteredSpillFileTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/FilteredSpillFileTest.java
@@ -54,8 +54,7 @@ class FilteredSpillFileTest {
         byte[] data = new byte[1024];
         random.nextBytes(data);
 
-        try (FilteredSpillFile writer =
-                new FilteredSpillFile(spillDirs, MEMORY_SEGMENT_SIZE)) {
+        try (FilteredSpillFile writer = new FilteredSpillFile(spillDirs, MEMORY_SEGMENT_SIZE)) {
             writer.writeEntry(data, data.length, CHANNEL_0);
             writer.finish();
 
@@ -77,8 +76,7 @@ class FilteredSpillFileTest {
         byte[] d0 = new byte[] {1, 2, 3, 4};
         byte[] d1 = new byte[] {5, 6, 7, 8};
 
-        try (FilteredSpillFile writer =
-                new FilteredSpillFile(spillDirs, MEMORY_SEGMENT_SIZE)) {
+        try (FilteredSpillFile writer = new FilteredSpillFile(spillDirs, MEMORY_SEGMENT_SIZE)) {
             writer.writeEntry(d0, d0.length, CHANNEL_0);
             writer.writeEntry(d1, d1.length, CHANNEL_1);
             writer.finish();
@@ -120,8 +118,7 @@ class FilteredSpillFileTest {
             random.nextBytes(chunk);
         }
 
-        try (FilteredSpillFile writer =
-                new FilteredSpillFile(spillDirs, MEMORY_SEGMENT_SIZE)) {
+        try (FilteredSpillFile writer = new FilteredSpillFile(spillDirs, MEMORY_SEGMENT_SIZE)) {
             for (int i = 0; i < numEntries; i++) {
                 writer.writeEntry(chunks[i], MEMORY_SEGMENT_SIZE, CHANNEL_0);
             }
@@ -146,8 +143,7 @@ class FilteredSpillFileTest {
     @Test
     void testCloseReleasesResources() throws Exception {
         String[] spillDirs = {temporaryFolder.toString()};
-        FilteredSpillFile writer =
-                new FilteredSpillFile(spillDirs, MEMORY_SEGMENT_SIZE);
+        FilteredSpillFile writer = new FilteredSpillFile(spillDirs, MEMORY_SEGMENT_SIZE);
         writer.writeEntry(new byte[] {1, 2, 3}, 3, CHANNEL_0);
         writer.close();
 
@@ -162,8 +158,7 @@ class FilteredSpillFileTest {
         byte[] data = new byte[1024];
         new Random(42).nextBytes(data);
 
-        try (FilteredSpillFile writer =
-                new FilteredSpillFile(spillDirs, MEMORY_SEGMENT_SIZE)) {
+        try (FilteredSpillFile writer = new FilteredSpillFile(spillDirs, MEMORY_SEGMENT_SIZE)) {
             writer.writeEntry(data, data.length, CHANNEL_0);
             writer.finish();
 
@@ -187,8 +182,7 @@ class FilteredSpillFileTest {
             data[i] = (byte) i;
         }
 
-        try (FilteredSpillFile writer =
-                new FilteredSpillFile(spillDirs, MEMORY_SEGMENT_SIZE)) {
+        try (FilteredSpillFile writer = new FilteredSpillFile(spillDirs, MEMORY_SEGMENT_SIZE)) {
             writer.writeEntry(data, data.length, CHANNEL_0);
             writer.finish();
 
@@ -218,8 +212,7 @@ class FilteredSpillFileTest {
     @Test
     void testAddEntryAfterSealThrows() throws Exception {
         String[] spillDirs = {temporaryFolder.toString()};
-        try (FilteredSpillFile writer =
-                new FilteredSpillFile(spillDirs, MEMORY_SEGMENT_SIZE)) {
+        try (FilteredSpillFile writer = new FilteredSpillFile(spillDirs, MEMORY_SEGMENT_SIZE)) {
             writer.writeEntry(new byte[] {1}, 1, CHANNEL_0);
             writer.finish();
             // Reader is sealed by finish(); addEntry via a new writeEntry after finish should throw
@@ -232,8 +225,7 @@ class FilteredSpillFileTest {
     @Test
     void testPeekNextChannel() throws Exception {
         String[] spillDirs = {temporaryFolder.toString()};
-        try (FilteredSpillFile writer =
-                new FilteredSpillFile(spillDirs, MEMORY_SEGMENT_SIZE)) {
+        try (FilteredSpillFile writer = new FilteredSpillFile(spillDirs, MEMORY_SEGMENT_SIZE)) {
             writer.writeEntry(new byte[] {1, 2}, 2, CHANNEL_0);
             writer.writeEntry(new byte[] {3, 4}, 2, CHANNEL_1);
             writer.finish();
@@ -251,8 +243,7 @@ class FilteredSpillFileTest {
     @Test
     void testGetPendingChannels() throws Exception {
         String[] spillDirs = {temporaryFolder.toString()};
-        try (FilteredSpillFile writer =
-                new FilteredSpillFile(spillDirs, MEMORY_SEGMENT_SIZE)) {
+        try (FilteredSpillFile writer = new FilteredSpillFile(spillDirs, MEMORY_SEGMENT_SIZE)) {
             writer.writeEntry(new byte[] {1}, 1, CHANNEL_0);
             writer.writeEntry(new byte[] {2}, 1, CHANNEL_1);
             writer.finish();
@@ -272,8 +263,7 @@ class FilteredSpillFileTest {
     @Test
     void testIsIdle() throws Exception {
         String[] spillDirs = {temporaryFolder.toString()};
-        try (FilteredSpillFile writer =
-                new FilteredSpillFile(spillDirs, MEMORY_SEGMENT_SIZE)) {
+        try (FilteredSpillFile writer = new FilteredSpillFile(spillDirs, MEMORY_SEGMENT_SIZE)) {
             assertThat(writer.isIdle()).isTrue();
             writer.writeEntry(new byte[] {1}, 1, CHANNEL_0);
             assertThat(writer.isIdle()).isFalse();
@@ -283,18 +273,15 @@ class FilteredSpillFileTest {
     /**
      * isIdle() flips dynamically with the reader entry count: empty at start, non-idle after any
      * write, stays non-idle while entries remain even if some are partially drained, idle again
-     * only after all entries have been consumed. Must behave consistently across multiple
-     * write / drain rounds.
+     * only after all entries have been consumed. Must behave consistently across multiple write /
+     * drain rounds.
      */
     @Test
     void testIsIdleFlipsAcrossWriteDrainRounds() throws Exception {
         String[] spillDirs = {temporaryFolder.toString()};
-        try (FilteredSpillFile writer =
-                new FilteredSpillFile(spillDirs, MEMORY_SEGMENT_SIZE)) {
-            // Initially idle
+        try (FilteredSpillFile writer = new FilteredSpillFile(spillDirs, MEMORY_SEGMENT_SIZE)) {
             assertThat(writer.isIdle()).isTrue();
 
-            // --- Round 1: write 3 entries ---
             writer.writeEntry(new byte[] {1}, 1, CHANNEL_0);
             writer.writeEntry(new byte[] {2}, 1, CHANNEL_1);
             writer.writeEntry(new byte[] {3}, 1, CHANNEL_0);
@@ -302,29 +289,23 @@ class FilteredSpillFileTest {
 
             FilteredSpillFile.Reader reader = writer.getReaders().get(0);
 
-            // Partial consume (1 of 3) — still not idle
             reader.readNext();
             assertThat(writer.isIdle()).isFalse();
 
-            // Another partial consume (2 of 3) — still not idle
             reader.readNext();
             assertThat(writer.isIdle()).isFalse();
 
-            // Consume last one — now idle
             reader.readNext();
             assertThat(reader.hasEntries()).isFalse();
             assertThat(writer.isIdle()).isTrue();
 
-            // --- Round 2: write 2 more entries ---
             writer.writeEntry(new byte[] {4}, 1, CHANNEL_1);
             writer.writeEntry(new byte[] {5}, 1, CHANNEL_0);
             assertThat(writer.isIdle()).isFalse();
 
-            // Partial consume (1 of 2) — still not idle
             reader.readNext();
             assertThat(writer.isIdle()).isFalse();
 
-            // Consume remainder — idle again
             reader.readNext();
             assertThat(reader.hasEntries()).isFalse();
             assertThat(writer.isIdle()).isTrue();
@@ -335,8 +316,7 @@ class FilteredSpillFileTest {
     @Test
     void testCloseDeletesAllFiles() throws Exception {
         String[] spillDirs = {temporaryFolder.toString()};
-        FilteredSpillFile writer =
-                new FilteredSpillFile(spillDirs, MEMORY_SEGMENT_SIZE);
+        FilteredSpillFile writer = new FilteredSpillFile(spillDirs, MEMORY_SEGMENT_SIZE);
         writer.writeEntry(new byte[64], 64, CHANNEL_0);
         List<Path> filePaths = new ArrayList<>();
         for (FilteredSpillFile.Reader r : writer.getReaders()) {
@@ -352,5 +332,4 @@ class FilteredSpillFileTest {
             assertThat(Files.exists(p)).isFalse();
         }
     }
-
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/GateFilterHandlerBufferOwnershipTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/GateFilterHandlerBufferOwnershipTest.java
@@ -148,10 +148,6 @@ class GateFilterHandlerBufferOwnershipTest {
         assertThat(sourceBuffer.isRecycled()).isTrue();
     }
 
-    // -------------------------------------------------------------------------------------------
-    // Helper methods
-    // -------------------------------------------------------------------------------------------
-
     private ChannelStateFilteringHandler.GateFilterHandler<Long> createHandler(
             RecordFilter<Long> filter) {
         RecordDeserializer<DeserializationDelegate<StreamElement>> deserializer =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/GateFilterHandlerBufferOwnershipTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/GateFilterHandlerBufferOwnershipTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.io.network.api.serialization.SpillingAdaptiveSpa
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
 import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
+import org.apache.flink.runtime.io.network.partition.consumer.RecoveredBufferStoreImpl;
 import org.apache.flink.runtime.plugable.DeserializationDelegate;
 import org.apache.flink.streaming.runtime.io.recovery.RecordFilter;
 import org.apache.flink.streaming.runtime.io.recovery.VirtualChannel;
@@ -35,12 +36,12 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamElementSerializer;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -53,6 +54,9 @@ class GateFilterHandlerBufferOwnershipTest {
 
     private static final int BUFFER_SIZE = 1024;
     private static final SubtaskConnectionDescriptor KEY = new SubtaskConnectionDescriptor(0, 0);
+    private static final InputChannelInfo TARGET_CHANNEL = new InputChannelInfo(0, 0);
+
+    @TempDir private Path temporaryFolder;
 
     @Test
     void testSourceBufferRecycledOnSuccess() throws Exception {
@@ -60,13 +64,14 @@ class GateFilterHandlerBufferOwnershipTest {
                 createHandler(RecordFilter.acceptAll());
 
         Buffer sourceBuffer = createBufferWithRecords(1L, 2L);
-        List<Buffer> result = handler.filterAndRewrite(0, 0, sourceBuffer, this::createEmptyBuffer);
+        FilteredBufferDispatcher outputWriter = createTestOutputWriter();
+        handler.filterAndRewrite(0, 0, sourceBuffer, outputWriter, TARGET_CHANNEL);
 
         // sourceBuffer should be recycled by the deserializer after consumption
         assertThat(sourceBuffer.isRecycled()).isTrue();
 
-        // Clean up result buffers
-        result.forEach(Buffer::recycleBuffer);
+        outputWriter.flush();
+        outputWriter.close();
     }
 
     @Test
@@ -75,79 +80,44 @@ class GateFilterHandlerBufferOwnershipTest {
         ChannelStateFilteringHandler.GateFilterHandler<Long> handler = createHandler(rejectAll);
 
         Buffer sourceBuffer = createBufferWithRecords(1L, 2L);
-        List<Buffer> result = handler.filterAndRewrite(0, 0, sourceBuffer, this::createEmptyBuffer);
+        FilteredBufferDispatcher outputWriter = createTestOutputWriter();
+        handler.filterAndRewrite(0, 0, sourceBuffer, outputWriter, TARGET_CHANNEL);
 
-        assertThat(result).isEmpty();
         // sourceBuffer should still be recycled even though no output was produced
         assertThat(sourceBuffer.isRecycled()).isTrue();
+
+        outputWriter.flush();
+        outputWriter.close();
     }
 
     @Test
-    void testSourceBufferRecycledOnInvalidVirtualChannel() {
+    void testSourceBufferRecycledOnInvalidVirtualChannel() throws Exception {
         // Create handler with KEY=(0,0) but call with (1,1) to trigger IllegalStateException
         ChannelStateFilteringHandler.GateFilterHandler<Long> handler =
                 createHandler(RecordFilter.acceptAll());
 
         Buffer sourceBuffer = createBufferWithRecords(1L);
+        FilteredBufferDispatcher outputWriter = createTestOutputWriter();
 
         assertThatThrownBy(
-                        () -> handler.filterAndRewrite(1, 1, sourceBuffer, this::createEmptyBuffer))
+                        () ->
+                                handler.filterAndRewrite(
+                                        1, 1, sourceBuffer, outputWriter, TARGET_CHANNEL))
                 .isInstanceOf(IllegalStateException.class);
 
         // sourceBuffer must be recycled even when lookup fails before setNextBuffer
         assertThat(sourceBuffer.isRecycled()).isTrue();
-    }
 
-    @Test
-    void testResultBuffersAndCurrentBufferRecycledOnSerializationError() throws Exception {
-        // Use a small buffer so that records span multiple buffers. The supplier fails on the
-        // second request, after the first output buffer has been filled and added to resultBuffers.
-        AtomicInteger bufferRequestCount = new AtomicInteger(0);
-        ChannelStateFilteringHandler.BufferSupplier failingSupplier =
-                () -> {
-                    if (bufferRequestCount.incrementAndGet() > 1) {
-                        throw new IOException("Simulated buffer allocation failure");
-                    }
-                    return createEmptyBuffer(13);
-                };
-
-        ChannelStateFilteringHandler.GateFilterHandler<Long> handler =
-                createHandler(RecordFilter.acceptAll());
-
-        Buffer sourceBuffer = createBufferWithRecords(1L, 2L, 3L, 4L, 5L);
-
-        // The exception should propagate; no buffer leak (no IllegalReferenceCountException
-        // from double-recycle).
-        assertThatThrownBy(() -> handler.filterAndRewrite(0, 0, sourceBuffer, failingSupplier))
-                .isInstanceOf(IOException.class)
-                .hasMessage("Simulated buffer allocation failure");
-
-        // sourceBuffer ownership was transferred to the deserializer via setNextBuffer().
-        // The deserializer may still hold it if it hasn't fully consumed the buffer before the
-        // error. Calling clear() triggers the cleanup chain:
-        // GateFilterHandler#clear() -> VirtualChannel#clear() -> deserializer.clear()
-        handler.clear();
-        assertThat(sourceBuffer.isRecycled()).isTrue();
+        outputWriter.close();
     }
 
     /**
-     * Tests the production cleanup path: when filterAndRewrite throws mid-processing, the
-     * deserializer may still hold sourceBuffer. In production, ChannelStateFilteringHandler is used
-     * in a try-with-resources block (see {@code SequentialChannelStateReaderImpl#readInputData}),
-     * so its close() is guaranteed to be called, which triggers clear() on all GateFilterHandlers
-     * and their deserializers. This test simulates that exact pattern.
+     * Tests that the production cleanup path works: when ChannelStateFilteringHandler is used in a
+     * try-with-resources block, its close() clears all GateFilterHandlers and their deserializers,
+     * ensuring buffers held by the deserializer are recycled.
      */
     @Test
     void testCloseRecyclesDeserializerHeldBufferAfterError() throws Exception {
-        AtomicInteger bufferRequestCount = new AtomicInteger(0);
-        ChannelStateFilteringHandler.BufferSupplier failingSupplier =
-                () -> {
-                    if (bufferRequestCount.incrementAndGet() > 1) {
-                        throw new IOException("Simulated buffer allocation failure");
-                    }
-                    return createEmptyBuffer(13);
-                };
-
         ChannelStateFilteringHandler.GateFilterHandler<Long> gateHandler =
                 createHandler(RecordFilter.acceptAll());
         // Wrap in ChannelStateFilteringHandler, the production-level owner
@@ -155,18 +125,22 @@ class GateFilterHandlerBufferOwnershipTest {
                 new ChannelStateFilteringHandler(
                         new ChannelStateFilteringHandler.GateFilterHandler<?>[] {gateHandler});
 
+        // Create a large buffer that will require multiple writes
         Buffer sourceBuffer = createBufferWithRecords(1L, 2L, 3L, 4L, 5L);
+
+        // Create a dispatcher that throws on the second write call
+        FilteredBufferDispatcher failingWriter = new FailingOutputWriter();
 
         // Simulate the production try-with-resources pattern
         assertThatThrownBy(
                         () -> {
                             try (ChannelStateFilteringHandler ignored = filteringHandler) {
                                 filteringHandler.filterAndRewrite(
-                                        0, 0, 0, sourceBuffer, failingSupplier);
+                                        0, 0, 0, sourceBuffer, failingWriter, TARGET_CHANNEL);
                             }
                         })
                 .isInstanceOf(IOException.class)
-                .hasMessage("Simulated buffer allocation failure");
+                .hasMessage("Simulated write failure");
 
         // After close(), the entire cleanup chain has fired:
         // ChannelStateFilteringHandler.close() -> GateFilterHandler.clear()
@@ -191,6 +165,35 @@ class GateFilterHandlerBufferOwnershipTest {
         StreamElementSerializer<Long> serializer =
                 new StreamElementSerializer<>(LongSerializer.INSTANCE);
         return new ChannelStateFilteringHandler.GateFilterHandler<>(channels, serializer);
+    }
+
+    private FilteredBufferDispatcher createTestOutputWriter() throws IOException {
+        RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(TARGET_CHANNEL);
+        Map<InputChannelInfo, RecoveredBufferStoreImpl> storesByChannel = new HashMap<>();
+        storesByChannel.put(TARGET_CHANNEL, store);
+
+        String[] spillDirs = new String[] {temporaryFolder.toString()};
+        BufferRequester newBufferPerRequest =
+                new BufferRequester() {
+                    @Override
+                    public Buffer requestBuffer(InputChannelInfo channelInfo) {
+                        return createEmptyBuffer();
+                    }
+
+                    @Override
+                    public Buffer requestBufferBlocking(InputChannelInfo channelInfo) {
+                        return createEmptyBuffer();
+                    }
+
+                    @Override
+                    public void releaseExclusiveBuffers() {}
+                };
+        return new FilteredBufferDispatcherImpl(
+                storesByChannel,
+                ChannelStateWriter.NO_OP,
+                spillDirs,
+                BUFFER_SIZE,
+                newBufferPerRequest);
     }
 
     private Buffer createBufferWithRecords(Long... values) {
@@ -220,11 +223,33 @@ class GateFilterHandlerBufferOwnershipTest {
     }
 
     private Buffer createEmptyBuffer() {
-        return createEmptyBuffer(BUFFER_SIZE);
+        MemorySegment segment = MemorySegmentFactory.allocateUnpooledSegment(BUFFER_SIZE);
+        return new NetworkBuffer(segment, FreeingBufferRecycler.INSTANCE);
     }
 
-    private Buffer createEmptyBuffer(int size) {
-        MemorySegment segment = MemorySegmentFactory.allocateUnpooledSegment(size);
-        return new NetworkBuffer(segment, FreeingBufferRecycler.INSTANCE);
+    /**
+     * A dispatcher that fails on the second write call. Used to test cleanup paths when
+     * filterAndRewrite encounters an error during serialization output.
+     */
+    private static class FailingOutputWriter implements FilteredBufferDispatcher {
+        private int writeCount = 0;
+
+        @Override
+        public void write(byte[] data, int length, InputChannelInfo channelInfo)
+                throws IOException {
+            writeCount++;
+            if (writeCount > 1) {
+                throw new IOException("Simulated write failure");
+            }
+        }
+
+        @Override
+        public void flush() {}
+
+        @Override
+        public void drainPendingSpill() {}
+
+        @Override
+        public void close() {}
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/GateFilterHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/GateFilterHandlerTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.io.network.api.serialization.SpillingAdaptiveSpa
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
 import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
+import org.apache.flink.runtime.io.network.partition.consumer.RecoveredBufferStoreImpl;
 import org.apache.flink.runtime.plugable.DeserializationDelegate;
 import org.apache.flink.runtime.plugable.NonReusingDeserializationDelegate;
 import org.apache.flink.streaming.runtime.io.recovery.RecordFilter;
@@ -36,8 +37,10 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamElementSerializer;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -50,17 +53,24 @@ class GateFilterHandlerTest {
 
     private static final int BUFFER_SIZE = 1024;
     private static final SubtaskConnectionDescriptor KEY = new SubtaskConnectionDescriptor(0, 0);
+    private static final InputChannelInfo TARGET_CHANNEL = new InputChannelInfo(0, 0);
+
+    @TempDir private Path temporaryFolder;
 
     @Test
     void testAllRecordsPassFilter() throws Exception {
         ChannelStateFilteringHandler.GateFilterHandler<Long> handler =
                 createHandler(RecordFilter.acceptAll());
 
-        Buffer sourceBuffer = createBufferWithRecords(1L, 2L, 3L);
-        List<Buffer> result = handler.filterAndRewrite(0, 0, sourceBuffer, this::createEmptyBuffer);
+        RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(TARGET_CHANNEL);
+        FilteredBufferDispatcher outputWriter = createTestOutputWriter(store);
 
-        // deserializeBuffers consumes (recycles) each buffer via the deserializer
-        List<Long> values = deserializeBuffers(result);
+        Buffer sourceBuffer = createBufferWithRecords(1L, 2L, 3L);
+        handler.filterAndRewrite(0, 0, sourceBuffer, outputWriter, TARGET_CHANNEL);
+        outputWriter.flush();
+        outputWriter.close();
+
+        List<Long> values = drainAndDeserialize(store);
         assertThat(values).containsExactly(1L, 2L, 3L);
     }
 
@@ -69,10 +79,16 @@ class GateFilterHandlerTest {
         RecordFilter<Long> rejectAll = record -> false;
         ChannelStateFilteringHandler.GateFilterHandler<Long> handler = createHandler(rejectAll);
 
-        Buffer sourceBuffer = createBufferWithRecords(1L, 2L, 3L);
-        List<Buffer> result = handler.filterAndRewrite(0, 0, sourceBuffer, this::createEmptyBuffer);
+        RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(TARGET_CHANNEL);
+        FilteredBufferDispatcher outputWriter = createTestOutputWriter(store);
 
-        assertThat(result).isEmpty();
+        Buffer sourceBuffer = createBufferWithRecords(1L, 2L, 3L);
+        handler.filterAndRewrite(0, 0, sourceBuffer, outputWriter, TARGET_CHANNEL);
+        outputWriter.flush();
+        outputWriter.close();
+
+        List<Long> values = drainAndDeserialize(store);
+        assertThat(values).isEmpty();
     }
 
     @Test
@@ -80,30 +96,16 @@ class GateFilterHandlerTest {
         RecordFilter<Long> keepEven = record -> record.getValue() % 2 == 0;
         ChannelStateFilteringHandler.GateFilterHandler<Long> handler = createHandler(keepEven);
 
+        RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(TARGET_CHANNEL);
+        FilteredBufferDispatcher outputWriter = createTestOutputWriter(store);
+
         Buffer sourceBuffer = createBufferWithRecords(1L, 2L, 3L, 4L, 5L);
-        List<Buffer> result = handler.filterAndRewrite(0, 0, sourceBuffer, this::createEmptyBuffer);
+        handler.filterAndRewrite(0, 0, sourceBuffer, outputWriter, TARGET_CHANNEL);
+        outputWriter.flush();
+        outputWriter.close();
 
-        List<Long> values = deserializeBuffers(result);
+        List<Long> values = drainAndDeserialize(store);
         assertThat(values).containsExactly(2L, 4L);
-    }
-
-    @Test
-    void testSmallOutputBufferProducesMultipleBuffers() throws Exception {
-        // Use a very small output buffer size so records must span multiple buffers
-        int smallBufferSize = 8;
-        ChannelStateFilteringHandler.GateFilterHandler<Long> handler =
-                createHandler(RecordFilter.acceptAll());
-
-        Buffer sourceBuffer = createBufferWithRecords(1L, 2L, 3L);
-        List<Buffer> result =
-                handler.filterAndRewrite(
-                        0, 0, sourceBuffer, () -> createEmptyBuffer(smallBufferSize));
-
-        // Each Long record needs 4 bytes length + ~9 bytes data > 8-byte buffer
-        assertThat(result.size()).isGreaterThan(1);
-
-        List<Long> values = deserializeBuffers(result);
-        assertThat(values).containsExactly(1L, 2L, 3L);
     }
 
     @Test
@@ -111,12 +113,18 @@ class GateFilterHandlerTest {
         ChannelStateFilteringHandler.GateFilterHandler<Long> handler =
                 createHandler(RecordFilter.acceptAll());
 
+        RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(TARGET_CHANNEL);
+        FilteredBufferDispatcher outputWriter = createTestOutputWriter(store);
+
         Buffer emptyBuffer = createEmptyBuffer();
         emptyBuffer.setSize(0);
 
-        List<Buffer> result = handler.filterAndRewrite(0, 0, emptyBuffer, this::createEmptyBuffer);
+        handler.filterAndRewrite(0, 0, emptyBuffer, outputWriter, TARGET_CHANNEL);
+        outputWriter.flush();
+        outputWriter.close();
 
-        assertThat(result).isEmpty();
+        List<Long> values = drainAndDeserialize(store);
+        assertThat(values).isEmpty();
     }
 
     // -------------------------------------------------------------------------------------------
@@ -138,6 +146,35 @@ class GateFilterHandlerTest {
         return new ChannelStateFilteringHandler.GateFilterHandler<>(channels, serializer);
     }
 
+    private FilteredBufferDispatcher createTestOutputWriter(RecoveredBufferStoreImpl store)
+            throws IOException {
+        Map<InputChannelInfo, RecoveredBufferStoreImpl> storesByChannel = new HashMap<>();
+        storesByChannel.put(TARGET_CHANNEL, store);
+
+        String[] spillDirs = new String[] {temporaryFolder.toString()};
+        BufferRequester newBufferPerRequest =
+                new BufferRequester() {
+                    @Override
+                    public Buffer requestBuffer(InputChannelInfo channelInfo) {
+                        return createEmptyBuffer();
+                    }
+
+                    @Override
+                    public Buffer requestBufferBlocking(InputChannelInfo channelInfo) {
+                        return createEmptyBuffer();
+                    }
+
+                    @Override
+                    public void releaseExclusiveBuffers() {}
+                };
+        return new FilteredBufferDispatcherImpl(
+                storesByChannel,
+                ChannelStateWriter.NO_OP,
+                spillDirs,
+                BUFFER_SIZE,
+                newBufferPerRequest);
+    }
+
     private Buffer createBufferWithRecords(Long... values) throws IOException {
         StreamElementSerializer<Long> serializer =
                 new StreamElementSerializer<>(LongSerializer.INSTANCE);
@@ -150,14 +187,11 @@ class GateFilterHandlerTest {
         DataOutputSerializer output = new DataOutputSerializer(BUFFER_SIZE);
 
         for (Long value : values) {
-            // Serialize using the same length-prefixed format as Flink
             DataOutputSerializer recordOutput = new DataOutputSerializer(64);
             serializer.serialize(new StreamRecord<>(value), recordOutput);
             int recordLength = recordOutput.length();
 
-            // Write 4-byte big-endian length prefix
             output.writeInt(recordLength);
-            // Write record bytes
             output.write(recordOutput.getSharedBuffer(), 0, recordLength);
         }
 
@@ -179,7 +213,8 @@ class GateFilterHandlerTest {
         return new NetworkBuffer(segment, FreeingBufferRecycler.INSTANCE);
     }
 
-    private List<Long> deserializeBuffers(List<Buffer> buffers) throws IOException {
+    /** Drains all buffers from the store and deserializes Long values. */
+    private List<Long> drainAndDeserialize(RecoveredBufferStoreImpl store) throws IOException {
         StreamElementSerializer<Long> serializer =
                 new StreamElementSerializer<>(LongSerializer.INSTANCE);
         SpillingAdaptiveSpanningRecordDeserializer<DeserializationDelegate<StreamElement>>
@@ -190,7 +225,8 @@ class GateFilterHandlerTest {
                 new NonReusingDeserializationDelegate<>(serializer);
 
         List<Long> values = new ArrayList<>();
-        for (Buffer buffer : buffers) {
+        Buffer buffer;
+        while ((buffer = takeUnderLock(store)) != null) {
             deserializer.setNextBuffer(buffer);
             while (true) {
                 RecordDeserializer.DeserializationResult result =
@@ -209,5 +245,11 @@ class GateFilterHandlerTest {
             }
         }
         return values;
+    }
+
+    private static Buffer takeUnderLock(RecoveredBufferStoreImpl store) {
+        synchronized (store) {
+            return store.tryTake();
+        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/GateFilterHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/GateFilterHandlerTest.java
@@ -127,10 +127,6 @@ class GateFilterHandlerTest {
         assertThat(values).isEmpty();
     }
 
-    // -------------------------------------------------------------------------------------------
-    // Helper methods
-    // -------------------------------------------------------------------------------------------
-
     private ChannelStateFilteringHandler.GateFilterHandler<Long> createHandler(
             RecordFilter<Long> filter) {
         RecordDeserializer<DeserializationDelegate<StreamElement>> deserializer =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/InputChannelRecoveredStateHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/InputChannelRecoveredStateHandlerTest.java
@@ -306,9 +306,9 @@ class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandler
      * AT-FRCV (input half): finishRecovery() triggers finishReadRecoveredState() on every gate
      * exactly once; close() must NOT invoke it again (close is pure resource release).
      *
-     * <p>The internal {@code recoveryFinished} idempotency guard is verified via reflection.
-     * We also verify that the pre-filter segment — allocated during recovery — is freed by close()
-     * and not by finishRecovery(), confirming the clean separation of lifecycle concerns.
+     * <p>The internal {@code recoveryFinished} idempotency guard is verified via reflection. We
+     * also verify that the pre-filter segment — allocated during recovery — is freed by close() and
+     * not by finishRecovery(), confirming the clean separation of lifecycle concerns.
      */
     @Test
     void testFinishRecoveryTriggersConversion() throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/InputChannelRecoveredStateHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/InputChannelRecoveredStateHandlerTest.java
@@ -83,7 +83,8 @@ class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandler
                                             .MappingType.IDENTITY)
                         }),
                 null,
-                MemoryManager.DEFAULT_PAGE_SIZE);
+                MemoryManager.DEFAULT_PAGE_SIZE,
+                null);
     }
 
     private InputChannelRecoveredStateHandler buildMultiChannelHandler() {
@@ -111,7 +112,8 @@ class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandler
                                             .MappingType.RESCALING)
                         }),
                 null,
-                MemoryManager.DEFAULT_PAGE_SIZE);
+                MemoryManager.DEFAULT_PAGE_SIZE,
+                null);
     }
 
     /** Builds a handler in filtering mode (non-null filtering handler, no-op stub). */
@@ -136,7 +138,8 @@ class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandler
                                             .MappingType.IDENTITY)
                         }),
                 stubFilteringHandler,
-                MemoryManager.DEFAULT_PAGE_SIZE);
+                MemoryManager.DEFAULT_PAGE_SIZE,
+                null);
     }
 
     @Test
@@ -297,5 +300,58 @@ class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandler
 
         assertThat(segment.isFreed()).isTrue();
         assertThat(filteringHandler.getPreFilterSegmentForTesting()).isNull();
+    }
+
+    /**
+     * AT-FRCV (input half): finishRecovery() triggers finishReadRecoveredState() on every gate
+     * exactly once; close() must NOT invoke it again (close is pure resource release).
+     *
+     * <p>The internal {@code recoveryFinished} idempotency guard is verified via reflection.
+     * We also verify that the pre-filter segment — allocated during recovery — is freed by close()
+     * and not by finishRecovery(), confirming the clean separation of lifecycle concerns.
+     */
+    @Test
+    void testFinishRecoveryTriggersConversion() throws Exception {
+        InputChannelRecoveredStateHandler filteringHandler =
+                buildFilteringInputChannelStateHandler();
+
+        // Allocate and recycle a pre-filter buffer so preFilterSegment is live before close().
+        RecoveredChannelStateHandler.BufferWithContext<Buffer> buf =
+                filteringHandler.getBuffer(channelInfo);
+        buf.context.recycleBuffer();
+        MemorySegment segmentBeforeFinish = filteringHandler.getPreFilterSegmentForTesting();
+        assertThat(segmentBeforeFinish).isNotNull();
+
+        // Before finishRecovery(): recoveryFinished == false.
+        assertThat(getRecoveryFinishedFlag(filteringHandler)).isFalse();
+
+        // finishRecovery() must complete without error and flip the guard.
+        filteringHandler.finishRecovery();
+        assertThat(getRecoveryFinishedFlag(filteringHandler)).isTrue();
+
+        // Idempotency: second call keeps the guard at true and does not re-invoke the gate loop.
+        filteringHandler.finishRecovery();
+        assertThat(getRecoveryFinishedFlag(filteringHandler)).isTrue();
+
+        // close() is pure resource release: segment freed, guard unchanged (still true).
+        filteringHandler.close();
+        assertThat(getRecoveryFinishedFlag(filteringHandler))
+                .as("close() must not alter the recoveryFinished flag")
+                .isTrue();
+        assertThat(filteringHandler.getPreFilterSegmentForTesting())
+                .as("close() must null-out the preFilterSegment reference")
+                .isNull();
+        assertThat(segmentBeforeFinish.isFreed())
+                .as("close() must free the preFilterSegment")
+                .isTrue();
+    }
+
+    /** Reads the private {@code recoveryFinished} field via reflection. */
+    private static boolean getRecoveryFinishedFlag(InputChannelRecoveredStateHandler handler)
+            throws Exception {
+        java.lang.reflect.Field field =
+                InputChannelRecoveredStateHandler.class.getDeclaredField("recoveryFinished");
+        field.setAccessible(true);
+        return (boolean) field.get(handler);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/MockChannelStateWriter.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/MockChannelStateWriter.java
@@ -75,6 +75,16 @@ public class MockChannelStateWriter implements ChannelStateWriter {
     }
 
     @Override
+    public void addInputDataFromSpill(
+            long checkpointId, CloseableIterator<FilteredSpillFile.Chunk> chunks) {
+        try {
+            chunks.close();
+        } catch (Exception e) {
+            rethrow(e);
+        }
+    }
+
+    @Override
     public void addOutputData(
             long checkpointId, ResultSubpartitionInfo info, int startSeqNum, Buffer... data) {
         checkCheckpointId(checkpointId);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ResultSubpartitionRecoveredStateHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ResultSubpartitionRecoveredStateHandlerTest.java
@@ -106,4 +106,47 @@ class ResultSubpartitionRecoveredStateHandlerTest extends RecoveredChannelStateH
         assertThat(networkBufferPool.getNumberOfAvailableMemorySegments())
                 .isEqualTo(preAllocatedSegments);
     }
+
+    /**
+     * AT-FRCV (output half): finishRecovery() invokes finishReadRecoveredState(
+     * notifyAndBlockOnCompletion) on each CheckpointedResultPartition exactly once; close() must
+     * NOT invoke it again (close is a no-op resource release for the output handler).
+     *
+     * <p>Verification strategy: the {@code recoveryFinished} idempotency guard on the handler is
+     * inspected via reflection. We verify it flips from false to true on the first finishRecovery()
+     * call, stays true on the second (idempotent), and remains true after close() — confirming
+     * that close() does not re-enter the finishReadRecoveredState logic.
+     */
+    @Test
+    void testFinishRecoveryTriggersFinishReadRecoveredState() throws Exception {
+        // Before finishRecovery(): recoveryFinished == false.
+        assertThat(getRecoveryFinishedFlag(rstHandler)).isFalse();
+
+        // finishRecovery() must flip the guard.
+        rstHandler.finishRecovery();
+        assertThat(getRecoveryFinishedFlag(rstHandler))
+                .as("finishRecovery() must set recoveryFinished to true")
+                .isTrue();
+
+        // Idempotency: second call keeps the guard at true, does not re-invoke partition loop.
+        rstHandler.finishRecovery();
+        assertThat(getRecoveryFinishedFlag(rstHandler))
+                .as("second finishRecovery() must leave recoveryFinished as true")
+                .isTrue();
+
+        // close() is a no-op for the output handler: guard must not change.
+        rstHandler.close();
+        assertThat(getRecoveryFinishedFlag(rstHandler))
+                .as("close() must NOT alter the recoveryFinished flag")
+                .isTrue();
+    }
+
+    /** Reads the private {@code recoveryFinished} field via reflection. */
+    private static boolean getRecoveryFinishedFlag(ResultSubpartitionRecoveredStateHandler handler)
+            throws Exception {
+        java.lang.reflect.Field field =
+                ResultSubpartitionRecoveredStateHandler.class.getDeclaredField("recoveryFinished");
+        field.setAccessible(true);
+        return (boolean) field.get(handler);
+    }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ResultSubpartitionRecoveredStateHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ResultSubpartitionRecoveredStateHandlerTest.java
@@ -114,8 +114,8 @@ class ResultSubpartitionRecoveredStateHandlerTest extends RecoveredChannelStateH
      *
      * <p>Verification strategy: the {@code recoveryFinished} idempotency guard on the handler is
      * inspected via reflection. We verify it flips from false to true on the first finishRecovery()
-     * call, stays true on the second (idempotent), and remains true after close() — confirming
-     * that close() does not re-enter the finishReadRecoveredState logic.
+     * call, stays true on the second (idempotent), and remains true after close() — confirming that
+     * close() does not re-enter the finishReadRecoveredState logic.
      */
     @Test
     void testFinishRecoveryTriggersFinishReadRecoveredState() throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/TestBufferPool.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/TestBufferPool.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+
+import javax.annotation.Nullable;
+
+import java.util.LinkedList;
+import java.util.Queue;
+
+/**
+ * Test-only {@link BufferRequester} backed by two queues: one drawn by the non-blocking fast path
+ * (P1 / P3) and one drawn by the blocking close() drain. Tests provide concrete queues and control
+ * which buffers are available on each path.
+ */
+final class TestBufferPool implements BufferRequester {
+
+    private final Queue<Buffer> writePool;
+    private final Queue<Buffer> drainPool;
+
+    /** Uses the same queue for both paths. */
+    TestBufferPool(Queue<Buffer> pool) {
+        this(pool, pool);
+    }
+
+    /** Uses separate queues for the non-blocking and blocking paths. */
+    TestBufferPool(Queue<Buffer> writePool, Queue<Buffer> drainPool) {
+        this.writePool = writePool;
+        this.drainPool = drainPool;
+    }
+
+    /** Shorthand for a requester that only supplies buffers to the blocking drain path. */
+    static TestBufferPool drainOnly(Queue<Buffer> drainPool) {
+        return new TestBufferPool(new LinkedList<>(), drainPool);
+    }
+
+    /** Shorthand for a requester whose queues are both empty (no buffer available at all). */
+    static TestBufferPool empty() {
+        return new TestBufferPool(new LinkedList<>(), new LinkedList<>());
+    }
+
+    @Override
+    @Nullable
+    public Buffer requestBuffer(InputChannelInfo channelInfo) {
+        return writePool.poll();
+    }
+
+    @Override
+    @Nullable
+    public Buffer requestBufferBlocking(InputChannelInfo channelInfo) {
+        return drainPool.poll();
+    }
+
+    @Override
+    public void releaseExclusiveBuffers() {
+        // No-op: tests pre-supply queues; nothing to return to a global pool.
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandlerTest.java
@@ -46,6 +46,7 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartitionIndexSet;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannelBuilder;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannelID;
+import org.apache.flink.runtime.io.network.partition.consumer.RecoveredBufferStore;
 import org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannel;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateBuilder;
@@ -68,7 +69,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.util.ArrayDeque;
 import java.util.stream.Stream;
 
 import static org.apache.flink.runtime.io.network.netty.PartitionRequestQueueTest.blockChannel;
@@ -953,7 +953,7 @@ class CreditBasedPartitionRequestClientHandlerTest {
                     new SimpleCounter(),
                     new SimpleCounter(),
                     ChannelStateWriter.NO_OP,
-                    new ArrayDeque<>());
+                    RecoveredBufferStore.EMPTY);
             this.expectedMessage = expectedMessage;
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestRegistrationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestRegistrationTest.java
@@ -35,6 +35,7 @@ import org.apache.flink.runtime.io.network.partition.ResultSubpartitionView;
 import org.apache.flink.runtime.io.network.partition.TestingResultPartition;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannelBuilder;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannelID;
+import org.apache.flink.runtime.io.network.partition.consumer.RecoveredBufferStore;
 import org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannel;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateBuilder;
 import org.apache.flink.runtime.io.network.util.TestPooledBufferProvider;
@@ -44,7 +45,6 @@ import org.apache.flink.shaded.netty4.io.netty.channel.Channel;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayDeque;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -250,7 +250,7 @@ class PartitionRequestRegistrationTest {
                     new SimpleCounter(),
                     new SimpleCounter(),
                     ChannelStateWriter.NO_OP,
-                    new ArrayDeque<>());
+                    RecoveredBufferStore.EMPTY);
             this.latch = latch;
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersisterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersisterTest.java
@@ -43,8 +43,8 @@ class ChannelStatePersisterTest {
 
     /**
      * Build a persister bound to a fresh {@link RecoveredBufferStore#EMPTY} so the test holds the
-     * same store monitor that the persister asserts on. Tests that need a non-empty store pass
-     * one explicitly to {@link #newPersister(ChannelStateWriter, InputChannelInfo,
+     * same store monitor that the persister asserts on. Tests that need a non-empty store pass one
+     * explicitly to {@link #newPersister(ChannelStateWriter, InputChannelInfo,
      * RecoveredBufferStore)}.
      */
     private static ChannelStatePersister newPersister(
@@ -172,7 +172,9 @@ class ChannelStatePersisterTest {
                 checkpointId, CheckpointOptions.unaligned(CheckpointType.CHECKPOINT, getDefault()));
 
         RecoveredBufferStoreImpl nonEmptyStore = new RecoveredBufferStoreImpl(channelInfo);
-        synchronized (nonEmptyStore) { nonEmptyStore.addBuffer(buildSomeBuffer()); }
+        synchronized (nonEmptyStore) {
+            nonEmptyStore.addBuffer(buildSomeBuffer());
+        }
         ChannelStatePersister persister =
                 newPersister(channelStateWriter, channelInfo, nonEmptyStore);
         assertThatThrownBy(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersisterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersisterTest.java
@@ -53,7 +53,8 @@ class ChannelStatePersisterTest {
                 checkpointId, CheckpointOptions.unaligned(CheckpointType.CHECKPOINT, getDefault()));
 
         persister.checkForBarrier(barrier(checkpointId));
-        persister.startPersisting(checkpointId, Arrays.asList(buildSomeBuffer()));
+        persister.startPersisting(
+                checkpointId, RecoveredBufferStore.EMPTY, Arrays.asList(buildSomeBuffer()));
         assertThat(channelStateWriter.getAddedInput().get(channelInfo)).hasSize(1);
 
         persister.maybePersist(buildSomeBuffer());
@@ -63,7 +64,7 @@ class ChannelStatePersisterTest {
         // now task thread is picking up the barrier and aborts the 1st:
         persister.checkForBarrier(barrier(checkpointId + 1));
         persister.maybePersist(buildSomeBuffer());
-        persister.stopPersisting(checkpointId);
+        persister.stopPersisting(checkpointId, RecoveredBufferStore.EMPTY);
         persister.maybePersist(buildSomeBuffer());
         assertThat(channelStateWriter.getAddedInput().get(channelInfo)).hasSize(1);
 
@@ -75,8 +76,8 @@ class ChannelStatePersisterTest {
         ChannelStatePersister persister =
                 new ChannelStatePersister(ChannelStateWriter.NO_OP, new InputChannelInfo(0, 0));
 
-        persister.startPersisting(1L, Collections.emptyList());
-        persister.startPersisting(2L, Collections.emptyList());
+        persister.startPersisting(1L, RecoveredBufferStore.EMPTY, Collections.emptyList());
+        persister.startPersisting(2L, RecoveredBufferStore.EMPTY, Collections.emptyList());
 
         assertThat(persister.checkForBarrier(barrier(1L))).isNotPresent();
 
@@ -110,21 +111,50 @@ class ChannelStatePersisterTest {
         long lateCheckpointId = 1L;
         long checkpointId = 2L;
         if (startCheckpointOnLateBarrier) {
-            persister.startPersisting(lateCheckpointId, Collections.emptyList());
+            persister.startPersisting(
+                    lateCheckpointId, RecoveredBufferStore.EMPTY, Collections.emptyList());
         }
         if (cancelCheckpointBeforeLateBarrier) {
-            persister.stopPersisting(lateCheckpointId);
+            persister.stopPersisting(lateCheckpointId, RecoveredBufferStore.EMPTY);
         }
         persister.checkForBarrier(barrier(lateCheckpointId));
         channelStateWriter.start(
                 checkpointId, CheckpointOptions.unaligned(CheckpointType.CHECKPOINT, getDefault()));
-        persister.startPersisting(checkpointId, Arrays.asList(buildSomeBuffer()));
+        persister.startPersisting(
+                checkpointId, RecoveredBufferStore.EMPTY, Arrays.asList(buildSomeBuffer()));
         persister.maybePersist(buildSomeBuffer());
         persister.checkForBarrier(barrier(checkpointId));
         persister.maybePersist(buildSomeBuffer());
 
         assertThat(persister.hasBarrierReceived()).isTrue();
         assertThat(channelStateWriter.getAddedInput().get(channelInfo)).hasSize(2);
+    }
+
+    @Test
+    void testStartPersistingRejectsNonEmptyStoreAndNonEmptyKnownBuffers() throws Exception {
+        // Invariant: store non-empty and knownBuffers non-empty must not coexist. This is
+        // guaranteed by UNALIGNED_RECOVER_OUTPUT_ON_DOWNSTREAM=true (upstream does not replay
+        // output state) combined with RemoteInputChannel#getNextBuffer draining the store before
+        // polling receivedBuffers. Violating this means one of those assumptions broke.
+        RecordingChannelStateWriter channelStateWriter = new RecordingChannelStateWriter();
+        InputChannelInfo channelInfo = new InputChannelInfo(0, 0);
+        ChannelStatePersister persister =
+                new ChannelStatePersister(channelStateWriter, channelInfo);
+
+        long checkpointId = 1L;
+        channelStateWriter.start(
+                checkpointId, CheckpointOptions.unaligned(CheckpointType.CHECKPOINT, getDefault()));
+
+        RecoveredBufferStoreImpl nonEmptyStore = new RecoveredBufferStoreImpl(channelInfo);
+        nonEmptyStore.addBuffer(buildSomeBuffer());
+        assertThatThrownBy(
+                        () ->
+                                persister.startPersisting(
+                                        checkpointId,
+                                        nonEmptyStore,
+                                        Arrays.asList(buildSomeBuffer())))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Invariant violated");
     }
 
     @Test
@@ -137,7 +167,11 @@ class ChannelStatePersisterTest {
 
         persister.checkForBarrier(barrier(checkpointId));
         assertThatThrownBy(
-                        () -> persister.startPersisting(lateCheckpointId, Collections.emptyList()))
+                        () ->
+                                persister.startPersisting(
+                                        lateCheckpointId,
+                                        RecoveredBufferStore.EMPTY,
+                                        Collections.emptyList()))
                 .isInstanceOf(CheckpointException.class);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersisterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersisterTest.java
@@ -172,7 +172,7 @@ class ChannelStatePersisterTest {
                 checkpointId, CheckpointOptions.unaligned(CheckpointType.CHECKPOINT, getDefault()));
 
         RecoveredBufferStoreImpl nonEmptyStore = new RecoveredBufferStoreImpl(channelInfo);
-        nonEmptyStore.addBuffer(buildSomeBuffer());
+        synchronized (nonEmptyStore) { nonEmptyStore.addBuffer(buildSomeBuffer()); }
         ChannelStatePersister persister =
                 newPersister(channelStateWriter, channelInfo, nonEmptyStore);
         assertThatThrownBy(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersisterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersisterTest.java
@@ -41,47 +41,73 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /** {@link ChannelStatePersister} test. */
 class ChannelStatePersisterTest {
 
+    /**
+     * Build a persister bound to a fresh {@link RecoveredBufferStore#EMPTY} so the test holds the
+     * same store monitor that the persister asserts on. Tests that need a non-empty store pass
+     * one explicitly to {@link #newPersister(ChannelStateWriter, InputChannelInfo,
+     * RecoveredBufferStore)}.
+     */
+    private static ChannelStatePersister newPersister(
+            ChannelStateWriter writer, InputChannelInfo channelInfo) {
+        return newPersister(writer, channelInfo, RecoveredBufferStore.EMPTY);
+    }
+
+    private static ChannelStatePersister newPersister(
+            ChannelStateWriter writer, InputChannelInfo channelInfo, RecoveredBufferStore store) {
+        return new ChannelStatePersister(writer, channelInfo, store);
+    }
+
     @Test
     void testNewBarrierNotOverwrittenByStopPersisting() throws Exception {
         RecordingChannelStateWriter channelStateWriter = new RecordingChannelStateWriter();
         InputChannelInfo channelInfo = new InputChannelInfo(0, 0);
-        ChannelStatePersister persister =
-                new ChannelStatePersister(channelStateWriter, channelInfo);
+        RecoveredBufferStore store = RecoveredBufferStore.EMPTY;
+        ChannelStatePersister persister = newPersister(channelStateWriter, channelInfo, store);
 
         long checkpointId = 1L;
         channelStateWriter.start(
                 checkpointId, CheckpointOptions.unaligned(CheckpointType.CHECKPOINT, getDefault()));
 
-        persister.checkForBarrier(barrier(checkpointId));
-        persister.startPersisting(
-                checkpointId, RecoveredBufferStore.EMPTY, Arrays.asList(buildSomeBuffer()));
+        synchronized (store) {
+            persister.checkForBarrier(barrier(checkpointId));
+            persister.startPersisting(checkpointId, Arrays.asList(buildSomeBuffer()));
+        }
         assertThat(channelStateWriter.getAddedInput().get(channelInfo)).hasSize(1);
 
-        persister.maybePersist(buildSomeBuffer());
+        synchronized (store) {
+            persister.maybePersist(buildSomeBuffer());
+        }
         assertThat(channelStateWriter.getAddedInput().get(channelInfo)).hasSize(1);
 
         // meanwhile, checkpoint coordinator timed out the 1st checkpoint and started the 2nd
         // now task thread is picking up the barrier and aborts the 1st:
-        persister.checkForBarrier(barrier(checkpointId + 1));
-        persister.maybePersist(buildSomeBuffer());
-        persister.stopPersisting(checkpointId, RecoveredBufferStore.EMPTY);
-        persister.maybePersist(buildSomeBuffer());
+        synchronized (store) {
+            persister.checkForBarrier(barrier(checkpointId + 1));
+            persister.maybePersist(buildSomeBuffer());
+            persister.stopPersisting(checkpointId);
+            persister.maybePersist(buildSomeBuffer());
+        }
         assertThat(channelStateWriter.getAddedInput().get(channelInfo)).hasSize(1);
 
-        assertThat(persister.hasBarrierReceived()).isTrue();
+        synchronized (store) {
+            assertThat(persister.hasBarrierReceived()).isTrue();
+        }
     }
 
     @Test
     void testNewBarrierNotOverwrittenByCheckForBarrier() throws Exception {
+        RecoveredBufferStore store = RecoveredBufferStore.EMPTY;
         ChannelStatePersister persister =
-                new ChannelStatePersister(ChannelStateWriter.NO_OP, new InputChannelInfo(0, 0));
+                newPersister(ChannelStateWriter.NO_OP, new InputChannelInfo(0, 0), store);
 
-        persister.startPersisting(1L, RecoveredBufferStore.EMPTY, Collections.emptyList());
-        persister.startPersisting(2L, RecoveredBufferStore.EMPTY, Collections.emptyList());
+        synchronized (store) {
+            persister.startPersisting(1L, Collections.emptyList());
+            persister.startPersisting(2L, Collections.emptyList());
 
-        assertThat(persister.checkForBarrier(barrier(1L))).isNotPresent();
+            assertThat(persister.checkForBarrier(barrier(1L))).isNotPresent();
 
-        assertThat(persister.hasBarrierReceived()).isFalse();
+            assertThat(persister.hasBarrierReceived()).isFalse();
+        }
     }
 
     @Test
@@ -104,29 +130,31 @@ class ChannelStatePersisterTest {
             throws Exception {
         RecordingChannelStateWriter channelStateWriter = new RecordingChannelStateWriter();
         InputChannelInfo channelInfo = new InputChannelInfo(0, 0);
+        RecoveredBufferStore store = RecoveredBufferStore.EMPTY;
 
-        ChannelStatePersister persister =
-                new ChannelStatePersister(channelStateWriter, channelInfo);
+        ChannelStatePersister persister = newPersister(channelStateWriter, channelInfo, store);
 
         long lateCheckpointId = 1L;
         long checkpointId = 2L;
-        if (startCheckpointOnLateBarrier) {
-            persister.startPersisting(
-                    lateCheckpointId, RecoveredBufferStore.EMPTY, Collections.emptyList());
+        synchronized (store) {
+            if (startCheckpointOnLateBarrier) {
+                persister.startPersisting(lateCheckpointId, Collections.emptyList());
+            }
+            if (cancelCheckpointBeforeLateBarrier) {
+                persister.stopPersisting(lateCheckpointId);
+            }
+            persister.checkForBarrier(barrier(lateCheckpointId));
         }
-        if (cancelCheckpointBeforeLateBarrier) {
-            persister.stopPersisting(lateCheckpointId, RecoveredBufferStore.EMPTY);
-        }
-        persister.checkForBarrier(barrier(lateCheckpointId));
         channelStateWriter.start(
                 checkpointId, CheckpointOptions.unaligned(CheckpointType.CHECKPOINT, getDefault()));
-        persister.startPersisting(
-                checkpointId, RecoveredBufferStore.EMPTY, Arrays.asList(buildSomeBuffer()));
-        persister.maybePersist(buildSomeBuffer());
-        persister.checkForBarrier(barrier(checkpointId));
-        persister.maybePersist(buildSomeBuffer());
+        synchronized (store) {
+            persister.startPersisting(checkpointId, Arrays.asList(buildSomeBuffer()));
+            persister.maybePersist(buildSomeBuffer());
+            persister.checkForBarrier(barrier(checkpointId));
+            persister.maybePersist(buildSomeBuffer());
 
-        assertThat(persister.hasBarrierReceived()).isTrue();
+            assertThat(persister.hasBarrierReceived()).isTrue();
+        }
         assertThat(channelStateWriter.getAddedInput().get(channelInfo)).hasSize(2);
     }
 
@@ -138,8 +166,6 @@ class ChannelStatePersisterTest {
         // polling receivedBuffers. Violating this means one of those assumptions broke.
         RecordingChannelStateWriter channelStateWriter = new RecordingChannelStateWriter();
         InputChannelInfo channelInfo = new InputChannelInfo(0, 0);
-        ChannelStatePersister persister =
-                new ChannelStatePersister(channelStateWriter, channelInfo);
 
         long checkpointId = 1L;
         channelStateWriter.start(
@@ -147,31 +173,38 @@ class ChannelStatePersisterTest {
 
         RecoveredBufferStoreImpl nonEmptyStore = new RecoveredBufferStoreImpl(channelInfo);
         nonEmptyStore.addBuffer(buildSomeBuffer());
+        ChannelStatePersister persister =
+                newPersister(channelStateWriter, channelInfo, nonEmptyStore);
         assertThatThrownBy(
-                        () ->
+                        () -> {
+                            synchronized (nonEmptyStore) {
                                 persister.startPersisting(
-                                        checkpointId,
-                                        nonEmptyStore,
-                                        Arrays.asList(buildSomeBuffer())))
+                                        checkpointId, Arrays.asList(buildSomeBuffer()));
+                            }
+                        })
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Invariant violated");
     }
 
     @Test
     void testLateBarrierTriggeringCheckpoint() throws Exception {
+        RecoveredBufferStore store = RecoveredBufferStore.EMPTY;
         ChannelStatePersister persister =
-                new ChannelStatePersister(ChannelStateWriter.NO_OP, new InputChannelInfo(0, 0));
+                newPersister(ChannelStateWriter.NO_OP, new InputChannelInfo(0, 0), store);
 
         long lateCheckpointId = 1L;
         long checkpointId = 2L;
 
-        persister.checkForBarrier(barrier(checkpointId));
+        synchronized (store) {
+            persister.checkForBarrier(barrier(checkpointId));
+        }
         assertThatThrownBy(
-                        () ->
+                        () -> {
+                            synchronized (store) {
                                 persister.startPersisting(
-                                        lateCheckpointId,
-                                        RecoveredBufferStore.EMPTY,
-                                        Collections.emptyList()))
+                                        lateCheckpointId, Collections.emptyList());
+                            }
+                        })
                 .isInstanceOf(CheckpointException.class);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannelBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannelBuilder.java
@@ -34,7 +34,6 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartitionIndexSet;
 
 import java.net.InetSocketAddress;
-import java.util.ArrayDeque;
 
 import static org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateTest.TestingResultPartitionManager;
 
@@ -166,7 +165,7 @@ public class InputChannelBuilder {
                 metrics.getNumBytesInLocalCounter(),
                 metrics.getNumBuffersInLocalCounter(),
                 stateWriter,
-                new ArrayDeque<>());
+                RecoveredBufferStore.EMPTY);
     }
 
     public RemoteInputChannel buildRemoteChannel(SingleInputGate inputGate) {
@@ -184,7 +183,7 @@ public class InputChannelBuilder {
                 metrics.getNumBytesInRemoteCounter(),
                 metrics.getNumBuffersInRemoteCounter(),
                 stateWriter,
-                new ArrayDeque<>());
+                RecoveredBufferStore.EMPTY);
     }
 
     public LocalRecoveredInputChannel buildLocalRecoveredChannel(SingleInputGate inputGate) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
@@ -680,9 +680,15 @@ class LocalInputChannelTest {
 
         // Create 3 recovered buffers in a store
         RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(new InputChannelInfo(0, 0));
-        synchronized (store) { store.addBuffer(TestBufferFactory.createBuffer(32)); }
-        synchronized (store) { store.addBuffer(TestBufferFactory.createBuffer(32)); }
-        synchronized (store) { store.addBuffer(TestBufferFactory.createBuffer(32)); }
+        synchronized (store) {
+            store.addBuffer(TestBufferFactory.createBuffer(32));
+        }
+        synchronized (store) {
+            store.addBuffer(TestBufferFactory.createBuffer(32));
+        }
+        synchronized (store) {
+            store.addBuffer(TestBufferFactory.createBuffer(32));
+        }
 
         final LocalInputChannel localChannel =
                 new LocalInputChannel(
@@ -719,8 +725,12 @@ class LocalInputChannelTest {
         SingleInputGate inputGate = createSingleInputGate(1);
 
         RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(new InputChannelInfo(0, 0));
-        synchronized (store) { store.addBuffer(TestBufferFactory.createBuffer(10)); }
-        synchronized (store) { store.addBuffer(TestBufferFactory.createBuffer(20)); }
+        synchronized (store) {
+            store.addBuffer(TestBufferFactory.createBuffer(10));
+        }
+        synchronized (store) {
+            store.addBuffer(TestBufferFactory.createBuffer(20));
+        }
 
         LocalInputChannel channel =
                 new LocalInputChannel(
@@ -756,9 +766,15 @@ class LocalInputChannelTest {
         SingleInputGate inputGate = new SingleInputGateBuilder().build();
 
         RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(new InputChannelInfo(0, 0));
-        synchronized (store) { store.addBuffer(TestBufferFactory.createBuffer(10)); }
-        synchronized (store) { store.addBuffer(TestBufferFactory.createBuffer(20)); }
-        synchronized (store) { store.addBuffer(TestBufferFactory.createBuffer(30)); }
+        synchronized (store) {
+            store.addBuffer(TestBufferFactory.createBuffer(10));
+        }
+        synchronized (store) {
+            store.addBuffer(TestBufferFactory.createBuffer(20));
+        }
+        synchronized (store) {
+            store.addBuffer(TestBufferFactory.createBuffer(30));
+        }
 
         RecordingChannelStateWriter stateWriter = new RecordingChannelStateWriter();
 
@@ -800,9 +816,15 @@ class LocalInputChannelTest {
         SingleInputGate inputGate = new SingleInputGateBuilder().build();
 
         RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(new InputChannelInfo(0, 0));
-        synchronized (store) { store.addBuffer(TestBufferFactory.createBuffer(10)); }
-        synchronized (store) { store.addBuffer(TestBufferFactory.createBuffer(20)); }
-        synchronized (store) { store.addBuffer(TestBufferFactory.createBuffer(30)); }
+        synchronized (store) {
+            store.addBuffer(TestBufferFactory.createBuffer(10));
+        }
+        synchronized (store) {
+            store.addBuffer(TestBufferFactory.createBuffer(20));
+        }
+        synchronized (store) {
+            store.addBuffer(TestBufferFactory.createBuffer(30));
+        }
 
         RecordingChannelStateWriter stateWriter = new RecordingChannelStateWriter();
 
@@ -869,7 +891,9 @@ class LocalInputChannelTest {
         SingleInputGate inputGate = new SingleInputGateBuilder().build();
 
         RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(new InputChannelInfo(0, 0));
-        synchronized (store) { store.addBuffer(TestBufferFactory.createBuffer(10)); }
+        synchronized (store) {
+            store.addBuffer(TestBufferFactory.createBuffer(10));
+        }
 
         LocalInputChannel channel =
                 new LocalInputChannel(
@@ -1076,7 +1100,9 @@ class LocalInputChannelTest {
 
         RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(new InputChannelInfo(0, 0));
         for (int size : recoveredBufferSizes) {
-            synchronized (store) { store.addBuffer(TestBufferFactory.createBuffer(size)); }
+            synchronized (store) {
+                store.addBuffer(TestBufferFactory.createBuffer(size));
+            }
         }
 
         LocalInputChannel channel =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
@@ -680,9 +680,9 @@ class LocalInputChannelTest {
 
         // Create 3 recovered buffers in a store
         RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(new InputChannelInfo(0, 0));
-        store.addBuffer(TestBufferFactory.createBuffer(32));
-        store.addBuffer(TestBufferFactory.createBuffer(32));
-        store.addBuffer(TestBufferFactory.createBuffer(32));
+        synchronized (store) { store.addBuffer(TestBufferFactory.createBuffer(32)); }
+        synchronized (store) { store.addBuffer(TestBufferFactory.createBuffer(32)); }
+        synchronized (store) { store.addBuffer(TestBufferFactory.createBuffer(32)); }
 
         final LocalInputChannel localChannel =
                 new LocalInputChannel(
@@ -719,8 +719,8 @@ class LocalInputChannelTest {
         SingleInputGate inputGate = createSingleInputGate(1);
 
         RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(new InputChannelInfo(0, 0));
-        store.addBuffer(TestBufferFactory.createBuffer(10));
-        store.addBuffer(TestBufferFactory.createBuffer(20));
+        synchronized (store) { store.addBuffer(TestBufferFactory.createBuffer(10)); }
+        synchronized (store) { store.addBuffer(TestBufferFactory.createBuffer(20)); }
 
         LocalInputChannel channel =
                 new LocalInputChannel(
@@ -756,9 +756,9 @@ class LocalInputChannelTest {
         SingleInputGate inputGate = new SingleInputGateBuilder().build();
 
         RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(new InputChannelInfo(0, 0));
-        store.addBuffer(TestBufferFactory.createBuffer(10));
-        store.addBuffer(TestBufferFactory.createBuffer(20));
-        store.addBuffer(TestBufferFactory.createBuffer(30));
+        synchronized (store) { store.addBuffer(TestBufferFactory.createBuffer(10)); }
+        synchronized (store) { store.addBuffer(TestBufferFactory.createBuffer(20)); }
+        synchronized (store) { store.addBuffer(TestBufferFactory.createBuffer(30)); }
 
         RecordingChannelStateWriter stateWriter = new RecordingChannelStateWriter();
 
@@ -800,9 +800,9 @@ class LocalInputChannelTest {
         SingleInputGate inputGate = new SingleInputGateBuilder().build();
 
         RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(new InputChannelInfo(0, 0));
-        store.addBuffer(TestBufferFactory.createBuffer(10));
-        store.addBuffer(TestBufferFactory.createBuffer(20));
-        store.addBuffer(TestBufferFactory.createBuffer(30));
+        synchronized (store) { store.addBuffer(TestBufferFactory.createBuffer(10)); }
+        synchronized (store) { store.addBuffer(TestBufferFactory.createBuffer(20)); }
+        synchronized (store) { store.addBuffer(TestBufferFactory.createBuffer(30)); }
 
         RecordingChannelStateWriter stateWriter = new RecordingChannelStateWriter();
 
@@ -869,7 +869,7 @@ class LocalInputChannelTest {
         SingleInputGate inputGate = new SingleInputGateBuilder().build();
 
         RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(new InputChannelInfo(0, 0));
-        store.addBuffer(TestBufferFactory.createBuffer(10));
+        synchronized (store) { store.addBuffer(TestBufferFactory.createBuffer(10)); }
 
         LocalInputChannel channel =
                 new LocalInputChannel(
@@ -1076,7 +1076,7 @@ class LocalInputChannelTest {
 
         RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(new InputChannelInfo(0, 0));
         for (int size : recoveredBufferSizes) {
-            store.addBuffer(TestBufferFactory.createBuffer(size));
+            synchronized (store) { store.addBuffer(TestBufferFactory.createBuffer(size)); }
         }
 
         LocalInputChannel channel =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
+import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.checkpoint.channel.RecordingChannelStateWriter;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.io.disk.NoOpFileChannelManager;
@@ -61,7 +62,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
-import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -678,11 +678,11 @@ class LocalInputChannelTest {
                 new TestingResultPartitionManager(subpartitionView);
         final SingleInputGate inputGate = createSingleInputGate(1);
 
-        // Create 3 recovered buffers
-        ArrayDeque<Buffer> recoveredBuffers = new ArrayDeque<>();
-        recoveredBuffers.add(TestBufferFactory.createBuffer(32));
-        recoveredBuffers.add(TestBufferFactory.createBuffer(32));
-        recoveredBuffers.add(TestBufferFactory.createBuffer(32));
+        // Create 3 recovered buffers in a store
+        RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(new InputChannelInfo(0, 0));
+        store.addBuffer(TestBufferFactory.createBuffer(32));
+        store.addBuffer(TestBufferFactory.createBuffer(32));
+        store.addBuffer(TestBufferFactory.createBuffer(32));
 
         final LocalInputChannel localChannel =
                 new LocalInputChannel(
@@ -697,7 +697,7 @@ class LocalInputChannelTest {
                         new SimpleCounter(),
                         new SimpleCounter(),
                         ChannelStateWriter.NO_OP,
-                        recoveredBuffers);
+                        store);
 
         inputGate.setInputChannels(localChannel);
 
@@ -714,13 +714,13 @@ class LocalInputChannelTest {
     }
 
     @Test
-    void testGetNextBufferWithMigratedRecoveredBuffers() throws Exception {
-        // given: LocalInputChannel with recovered buffers migrated from RecoveredInputChannel
+    void testGetNextBufferWithRecoveredStore() throws Exception {
+        // given: LocalInputChannel with recovered buffers in a store
         SingleInputGate inputGate = createSingleInputGate(1);
 
-        ArrayDeque<Buffer> recoveredBuffers = new ArrayDeque<>();
-        recoveredBuffers.add(TestBufferFactory.createBuffer(10));
-        recoveredBuffers.add(TestBufferFactory.createBuffer(20));
+        RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(new InputChannelInfo(0, 0));
+        store.addBuffer(TestBufferFactory.createBuffer(10));
+        store.addBuffer(TestBufferFactory.createBuffer(20));
 
         LocalInputChannel channel =
                 new LocalInputChannel(
@@ -735,7 +735,7 @@ class LocalInputChannelTest {
                         new SimpleCounter(),
                         new SimpleCounter(),
                         ChannelStateWriter.NO_OP,
-                        recoveredBuffers);
+                        store);
 
         inputGate.setInputChannels(channel);
 
@@ -752,13 +752,13 @@ class LocalInputChannelTest {
 
     @Test
     void testCheckpointStartedPersistsRecoveredBuffers() throws Exception {
-        // given: Local input channel with recovered buffers
+        // given: Local input channel with recovered buffers in a store
         SingleInputGate inputGate = new SingleInputGateBuilder().build();
 
-        ArrayDeque<Buffer> recoveredBuffers = new ArrayDeque<>();
-        recoveredBuffers.add(TestBufferFactory.createBuffer(10));
-        recoveredBuffers.add(TestBufferFactory.createBuffer(20));
-        recoveredBuffers.add(TestBufferFactory.createBuffer(30));
+        RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(new InputChannelInfo(0, 0));
+        store.addBuffer(TestBufferFactory.createBuffer(10));
+        store.addBuffer(TestBufferFactory.createBuffer(20));
+        store.addBuffer(TestBufferFactory.createBuffer(30));
 
         RecordingChannelStateWriter stateWriter = new RecordingChannelStateWriter();
 
@@ -775,7 +775,7 @@ class LocalInputChannelTest {
                         new SimpleCounter(),
                         new SimpleCounter(),
                         stateWriter,
-                        recoveredBuffers);
+                        store);
 
         inputGate.setInputChannels(channel);
 
@@ -787,6 +787,50 @@ class LocalInputChannelTest {
         channel.checkpointStarted(barrier);
 
         // then: All 3 recovered buffers should be persisted as inflight data
+        List<Buffer> persistedBuffers = stateWriter.getAddedInput().get(channel.getChannelInfo());
+        assertThat(persistedBuffers).isNotNull().hasSize(3);
+        assertThat(persistedBuffers.stream().mapToInt(Buffer::getSize).toArray())
+                .containsExactly(10, 20, 30);
+    }
+
+    // Verify that checkpoint delegates to RecoveredBufferStore when present
+    @Test
+    void testCheckpointWithRecoveredStore() throws Exception {
+        // given: LocalInputChannel with a RecoveredBufferStore containing buffers
+        SingleInputGate inputGate = new SingleInputGateBuilder().build();
+
+        RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(new InputChannelInfo(0, 0));
+        store.addBuffer(TestBufferFactory.createBuffer(10));
+        store.addBuffer(TestBufferFactory.createBuffer(20));
+        store.addBuffer(TestBufferFactory.createBuffer(30));
+
+        RecordingChannelStateWriter stateWriter = new RecordingChannelStateWriter();
+
+        LocalInputChannel channel =
+                new LocalInputChannel(
+                        inputGate,
+                        0,
+                        new ResultPartitionID(),
+                        new ResultSubpartitionIndexSet(0),
+                        new ResultPartitionManager(),
+                        new TaskEventDispatcher(),
+                        0,
+                        0,
+                        new SimpleCounter(),
+                        new SimpleCounter(),
+                        stateWriter,
+                        store);
+
+        inputGate.setInputChannels(channel);
+
+        // when: Checkpoint is started
+        CheckpointOptions options =
+                CheckpointOptions.unaligned(CheckpointType.CHECKPOINT, getDefault());
+        stateWriter.start(1L, options);
+        CheckpointBarrier barrier = new CheckpointBarrier(1L, 0L, options);
+        channel.checkpointStarted(barrier);
+
+        // then: All 3 recovered buffers should be persisted via store.checkpoint()
         List<Buffer> persistedBuffers = stateWriter.getAddedInput().get(channel.getChannelInfo());
         assertThat(persistedBuffers).isNotNull().hasSize(3);
         assertThat(persistedBuffers.stream().mapToInt(Buffer::getSize).toArray())
@@ -824,8 +868,8 @@ class LocalInputChannelTest {
         // given: Local input channel with recovered buffers but NO subpartition view initialized
         SingleInputGate inputGate = new SingleInputGateBuilder().build();
 
-        ArrayDeque<Buffer> recoveredBuffers = new ArrayDeque<>();
-        recoveredBuffers.add(TestBufferFactory.createBuffer(10));
+        RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(new InputChannelInfo(0, 0));
+        store.addBuffer(TestBufferFactory.createBuffer(10));
 
         LocalInputChannel channel =
                 new LocalInputChannel(
@@ -840,7 +884,7 @@ class LocalInputChannelTest {
                         new SimpleCounter(),
                         new SimpleCounter(),
                         ChannelStateWriter.NO_OP,
-                        recoveredBuffers);
+                        store);
 
         inputGate.setInputChannels(channel);
         // Do NOT call channel.requestSubpartitions() — subpartitionView stays null
@@ -943,6 +987,74 @@ class LocalInputChannelTest {
         assertThat(next.get().buffer().getSize()).isEqualTo(10);
     }
 
+    @Test
+    void testEmptyRecoveredStoreHasNoBuffers() throws Exception {
+        // Callers with no recovered data pass RecoveredBufferStore.EMPTY explicitly.
+        // EMPTY.isEmpty() == true so getBuffersInUseCount() should count 0 from the store.
+        // EMPTY.releaseAll() is a no-op, so releaseAllResources() must not throw.
+        SingleInputGate inputGate = new SingleInputGateBuilder().build();
+        LocalInputChannel channel =
+                new LocalInputChannel(
+                        inputGate,
+                        0,
+                        new ResultPartitionID(),
+                        new ResultSubpartitionIndexSet(0),
+                        new ResultPartitionManager(),
+                        new TaskEventDispatcher(),
+                        0,
+                        0,
+                        new SimpleCounter(),
+                        new SimpleCounter(),
+                        ChannelStateWriter.NO_OP,
+                        RecoveredBufferStore.EMPTY);
+
+        inputGate.setInputChannels(channel);
+
+        // The EMPTY store contributes 0 to the queued buffer count.
+        assertThat(channel.getBuffersInUseCount()).isEqualTo(0);
+        // releaseAllResources() must not throw (EMPTY.releaseAll() is a no-op).
+        channel.releaseAllResources();
+    }
+
+    @Test
+    void testCheckpointStartedPassesEmptyKnownBuffers() throws Exception {
+        // LocalInputChannel has no network inflight buffers; it always passes emptyList to
+        // startPersisting so that toBeConsumedBuffers are NOT snapshotted (they are ordinary
+        // FullyFilledBuffer splits, not channel state).
+        SingleInputGate inputGate = new SingleInputGateBuilder().build();
+        RecordingChannelStateWriter stateWriter = new RecordingChannelStateWriter();
+
+        LocalInputChannel channel =
+                new LocalInputChannel(
+                        inputGate,
+                        0,
+                        new ResultPartitionID(),
+                        new ResultSubpartitionIndexSet(0),
+                        new ResultPartitionManager(),
+                        new TaskEventDispatcher(),
+                        0,
+                        0,
+                        new SimpleCounter(),
+                        new SimpleCounter(),
+                        stateWriter,
+                        RecoveredBufferStore.EMPTY);
+
+        inputGate.setInputChannels(channel);
+
+        CheckpointOptions options =
+                CheckpointOptions.unaligned(CheckpointType.CHECKPOINT, getDefault());
+        stateWriter.start(1L, options);
+        CheckpointBarrier barrier = new CheckpointBarrier(1L, 0L, options);
+
+        // checkpointStarted must not throw and should produce no persisted inflight data
+        // (knownBuffers is always emptyList for Local).
+        channel.checkpointStarted(barrier);
+
+        List<Buffer> persisted = stateWriter.getAddedInput().get(channel.getChannelInfo());
+        // No inflight buffers persisted (store is EMPTY, knownBuffers is emptyList).
+        assertThat(persisted).isNullOrEmpty();
+    }
+
     /**
      * Creates a LocalInputChannel with recovered buffers and a live subpartition, ready for
      * priority event tests. The channel has already called requestSubpartitions().
@@ -962,9 +1074,9 @@ class LocalInputChannelTest {
         TestingResultPartitionManager partitionManager =
                 new TestingResultPartitionManager(subpartitionView);
 
-        ArrayDeque<Buffer> recoveredBuffers = new ArrayDeque<>();
+        RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(new InputChannelInfo(0, 0));
         for (int size : recoveredBufferSizes) {
-            recoveredBuffers.add(TestBufferFactory.createBuffer(size));
+            store.addBuffer(TestBufferFactory.createBuffer(size));
         }
 
         LocalInputChannel channel =
@@ -980,7 +1092,7 @@ class LocalInputChannelTest {
                         new SimpleCounter(),
                         new SimpleCounter(),
                         stateWriter,
-                        recoveredBuffers);
+                        store);
 
         inputGate.setInputChannels(channel);
         channel.requestSubpartitions();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredBufferStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredBufferStoreTest.java
@@ -1,0 +1,798 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.consumer;
+
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.runtime.checkpoint.channel.EntryPosition;
+import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
+import org.apache.flink.runtime.checkpoint.channel.RecordingChannelStateWriter;
+import org.apache.flink.runtime.checkpoint.channel.RecoveredBufferStoreCoordinator;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
+import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link RecoveredBufferStoreImpl}. */
+class RecoveredBufferStoreTest {
+
+    private static final InputChannelInfo DEFAULT_CHANNEL_INFO = new InputChannelInfo(0, 0);
+
+    /** Create store, addBuffer, tryTake. Verify the lifecycle of the store. */
+    @Test
+    void testStoreLifecycle() {
+        RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(DEFAULT_CHANNEL_INFO);
+
+        // Initially empty — query methods require holding the store monitor (locking contract).
+        synchronized (store) {
+            assertThat(store.isEmpty()).isTrue();
+            assertThat(store.size()).isEqualTo(0);
+            assertThat(store.peekNextDataType()).isEqualTo(Buffer.DataType.NONE);
+        }
+
+        // Add a buffer
+        NetworkBuffer buffer1 = createBuffer(new byte[] {1, 2, 3, 4});
+        store.addBuffer(buffer1);
+
+        Buffer taken;
+        synchronized (store) {
+            assertThat(store.isEmpty()).isFalse();
+            assertThat(store.size()).isEqualTo(1);
+            assertThat(store.peekNextDataType()).isEqualTo(Buffer.DataType.DATA_BUFFER);
+
+            // Take the buffer
+            taken = store.tryTake();
+            assertThat(taken).isNotNull();
+            assertThat(store.isEmpty()).isTrue();
+            assertThat(store.size()).isEqualTo(0);
+        }
+        taken.recycleBuffer();
+
+        synchronized (store) {
+            // tryTake on empty returns null
+            assertThat(store.tryTake()).isNull();
+        }
+    }
+
+    /**
+     * Checkpoint with ready buffers. Ready buffers should be retained and passed to the
+     * ChannelStateWriter.
+     */
+    @Test
+    void testCheckpointWithReadyBuffers() throws Exception {
+        RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(DEFAULT_CHANNEL_INFO);
+
+        byte[] data = new byte[] {10, 20, 30, 40};
+        NetworkBuffer buffer = createBuffer(data);
+        store.addBuffer(buffer);
+
+        RecordingChannelStateWriter writer = new RecordingChannelStateWriter();
+        long checkpointId = 1L;
+        writer.start(checkpointId, null);
+
+        store.checkpoint(writer, checkpointId);
+
+        // Verify the buffer was recorded by the writer
+        assertThat(writer.getAddedInput().get(DEFAULT_CHANNEL_INFO)).hasSize(1);
+
+        // The original buffer should still be in the store (retained, not consumed)
+        synchronized (store) {
+            assertThat(store.size()).isEqualTo(1);
+        }
+
+        // Clean up: recycle the buffer recorded by writer
+        writer.getAddedInput().get(DEFAULT_CHANNEL_INFO).forEach(Buffer::recycleBuffer);
+        store.releaseAll();
+    }
+
+    /** Concurrent access from two threads. One thread adds buffers and the other takes them. */
+    @Test
+    void testConcurrentCheckpointAndReplay() throws Exception {
+        RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(DEFAULT_CHANNEL_INFO);
+        int numBuffers = 100;
+        CyclicBarrier barrier = new CyclicBarrier(2);
+        AtomicReference<Throwable> error = new AtomicReference<>();
+
+        // Producer thread: adds buffers
+        Thread producer =
+                new Thread(
+                        () -> {
+                            try {
+                                barrier.await();
+                                for (int i = 0; i < numBuffers; i++) {
+                                    NetworkBuffer buf = createBuffer(new byte[] {(byte) i});
+                                    store.addBuffer(buf);
+                                }
+                            } catch (Throwable t) {
+                                error.set(t);
+                            }
+                        });
+
+        // Consumer thread: takes buffers
+        CountDownLatch consumedAll = new CountDownLatch(1);
+        Thread consumer =
+                new Thread(
+                        () -> {
+                            try {
+                                barrier.await();
+                                int consumed = 0;
+                                while (consumed < numBuffers) {
+                                    Buffer buf;
+                                    synchronized (store) {
+                                        buf = store.tryTake();
+                                    }
+                                    if (buf != null) {
+                                        buf.recycleBuffer();
+                                        consumed++;
+                                    }
+                                }
+                                consumedAll.countDown();
+                            } catch (Throwable t) {
+                                error.set(t);
+                            }
+                        });
+
+        producer.start();
+        consumer.start();
+        producer.join(10_000);
+        consumer.join(10_000);
+
+        assertThat(error.get()).isNull();
+        synchronized (store) {
+            assertThat(store.isEmpty()).isTrue();
+        }
+    }
+
+    /**
+     * Simulate store transfer by adding buffers, then taking them in another "context" (simulating
+     * conversion). Continue consuming after conversion.
+     */
+    @Test
+    void testConsumptionAfterConversion() {
+        RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(DEFAULT_CHANNEL_INFO);
+
+        // Add buffers in "recovery" phase
+        NetworkBuffer buf1 = createBuffer(new byte[] {1, 2});
+        NetworkBuffer buf2 = createBuffer(new byte[] {3, 4});
+        NetworkBuffer buf3 = createBuffer(new byte[] {5, 6});
+        store.addBuffer(buf1);
+        store.addBuffer(buf2);
+        store.addBuffer(buf3);
+
+        // Simulate partial consumption before conversion
+        Buffer taken1;
+        synchronized (store) {
+            taken1 = store.tryTake();
+        }
+        assertThat(taken1).isNotNull();
+        taken1.recycleBuffer();
+
+        // After conversion, continue consuming remaining buffers
+        Buffer taken2;
+        Buffer taken3;
+        synchronized (store) {
+            taken2 = store.tryTake();
+            assertThat(taken2).isNotNull();
+            taken3 = store.tryTake();
+            assertThat(taken3).isNotNull();
+        }
+        taken2.recycleBuffer();
+        taken3.recycleBuffer();
+
+        synchronized (store) {
+            assertThat(store.isEmpty()).isTrue();
+            assertThat(store.tryTake()).isNull();
+        }
+    }
+
+    /** Verify releaseAll recycles all buffers and clears state. */
+    @Test
+    void testReleaseAll() {
+        RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(DEFAULT_CHANNEL_INFO);
+
+        NetworkBuffer buf1 = createBuffer(new byte[] {1});
+        NetworkBuffer buf2 = createBuffer(new byte[] {2});
+        store.addBuffer(buf1);
+        store.addBuffer(buf2);
+
+        store.releaseAll();
+
+        assertThat(buf1.isRecycled()).isTrue();
+        assertThat(buf2.isRecycled()).isTrue();
+        synchronized (store) {
+            assertThat(store.isEmpty()).isTrue();
+            assertThat(store.size()).isEqualTo(0);
+        }
+    }
+
+    /** Verify releaseAll notifies the registered coordinator with the bound channel info. */
+    @Test
+    void testReleaseAllNotifiesCoordinator() {
+        InputChannelInfo channelInfo = new InputChannelInfo(3, 7);
+        RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(channelInfo);
+
+        RecordingCoordinator coordinator = new RecordingCoordinator();
+        synchronized (store) {
+            store.setCoordinator(coordinator);
+        }
+
+        // Add some in-memory and on-disk bookkeeping to make the release meaningful.
+        store.addBuffer(createBuffer(new byte[] {1}));
+        synchronized (store) {
+            store.incrementPending();
+        }
+
+        store.releaseAll();
+
+        assertThat(coordinator.released).containsExactly(channelInfo);
+        synchronized (store) {
+            assertThat(store.isEmpty()).isTrue();
+            assertThat(store.size()).isEqualTo(0);
+        }
+    }
+
+    /**
+     * Verify the data-available listener is invoked OUTSIDE the store monitor.
+     *
+     * <p>If the listener fires while the store monitor is held, the listener's downstream lock
+     * acquisition (e.g. {@code SingleInputGate.queueChannel} taking the gate's
+     * {@code inputChannelsWithData} monitor) can deadlock against a task thread that already holds
+     * that monitor and is trying to acquire the store monitor (via {@code peekNextDataType}). This
+     * is the AB-BA deadlock pattern observed in JVM-level deadlock reports. The contract aligns
+     * with {@link RecoveredBufferStoreImpl#checkpoint} / {@link RecoveredBufferStoreImpl#releaseAll}
+     * / {@link RecoveredBufferStoreImpl#notifyCheckpointStopped}, all of which fire callbacks
+     * outside the store lock.
+     */
+    @Test
+    void testDataAvailableListenerFiresOutsideStoreMonitor() {
+        RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(DEFAULT_CHANNEL_INFO);
+        boolean[] storeMonitorHeldDuringCallback = {false};
+        synchronized (store) {
+            store.setDataAvailableListener(
+                    () -> storeMonitorHeldDuringCallback[0] = Thread.holdsLock(store));
+        }
+
+        store.addBuffer(createBuffer(new byte[] {1}));
+
+        assertThat(storeMonitorHeldDuringCallback[0])
+                .as("dataAvailableListener must be invoked outside the store monitor")
+                .isFalse();
+
+        store.releaseAll();
+    }
+
+    /**
+     * Reproduces the AB-BA deadlock pattern between {@link RecoveredBufferStoreImpl#addBuffer} and
+     * a task thread that holds a downstream gate-side lock while reaching into the store.
+     *
+     * <p>Thread A (task): holds {@code gateLock}, then tries to acquire the store monitor via a
+     * synchronized store method (mirrors {@link RecoveredBufferStoreImpl#peekNextDataType}). Thread
+     * B (recovery): calls {@code addBuffer}, which under the broken contract fires the listener
+     * while holding the store monitor; the listener tries to acquire {@code gateLock}, mirroring
+     * {@code SingleInputGate.queueChannel}.
+     *
+     * <p>If {@code addBuffer} invokes the listener inside the synchronized block, this test
+     * deadlocks. The fixed contract fires the listener outside the lock, so the test completes
+     * within the timeout.
+     */
+    @Test
+    void testAddBufferDoesNotDeadlockWithGateSideLock() throws Exception {
+        RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(DEFAULT_CHANNEL_INFO);
+        Object gateLock = new Object();
+        CountDownLatch taskHoldsGateLock = new CountDownLatch(1);
+        CountDownLatch recoveryStartedAddBuffer = new CountDownLatch(1);
+        AtomicReference<Throwable> error = new AtomicReference<>();
+
+        // Listener mirrors SingleInputGate.queueChannel: must take gateLock to enqueue.
+        synchronized (store) {
+            store.setDataAvailableListener(
+                    () -> {
+                        synchronized (gateLock) {
+                            // touch shared state under the gate lock to mirror real notify path
+                        }
+                    });
+        }
+
+        // Thread A (task): take gateLock first, then call into the store. This emulates
+        // SingleInputGate holding inputChannelsWithData while reading peekNextDataType.
+        Thread taskThread =
+                new Thread(
+                        () -> {
+                            try {
+                                synchronized (gateLock) {
+                                    taskHoldsGateLock.countDown();
+                                    // Wait until the recovery thread has entered addBuffer and (in
+                                    // the broken contract) is holding the store monitor while
+                                    // trying to grab gateLock.
+                                    recoveryStartedAddBuffer.await();
+                                    // Sleep a touch so the recovery thread is parked on gateLock
+                                    // before we go grab the store monitor; without this, the test
+                                    // could pass even with the broken contract because both
+                                    // threads might serialise.
+                                    Thread.sleep(50);
+                                    // Now reach into the store under gateLock — this mirrors
+                                    // peekNextDataType / size and would block on the store monitor
+                                    // if addBuffer is still inside synchronized.
+                                    synchronized (store) {
+                                        store.peekNextDataType();
+                                    }
+                                }
+                            } catch (Throwable t) {
+                                error.set(t);
+                            }
+                        },
+                        "test-task-thread");
+
+        // Thread B (recovery): wait until the task thread holds gateLock, then call addBuffer,
+        // which will trigger the listener that wants gateLock.
+        Thread recoveryThread =
+                new Thread(
+                        () -> {
+                            try {
+                                taskHoldsGateLock.await();
+                                recoveryStartedAddBuffer.countDown();
+                                store.addBuffer(createBuffer(new byte[] {1}));
+                            } catch (Throwable t) {
+                                error.set(t);
+                            }
+                        },
+                        "test-recovery-thread");
+
+        taskThread.start();
+        recoveryThread.start();
+
+        // Generous timeout: deadlock would otherwise hang the test forever.
+        taskThread.join(10_000);
+        recoveryThread.join(10_000);
+
+        assertThat(taskThread.isAlive())
+                .as("task thread is still alive — likely deadlocked on store monitor")
+                .isFalse();
+        assertThat(recoveryThread.isAlive())
+                .as("recovery thread is still alive — likely deadlocked on gate lock")
+                .isFalse();
+        assertThat(error.get()).isNull();
+
+        store.releaseAll();
+    }
+
+    /** Verify data-available listener fires when buffer is added to empty store. */
+    @Test
+    void testDataAvailableListener() {
+        RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(DEFAULT_CHANNEL_INFO);
+        int[] callbackCount = {0};
+        synchronized (store) {
+            store.setDataAvailableListener(() -> callbackCount[0]++);
+        }
+
+        // Add first buffer: should trigger listener (store was empty)
+        store.addBuffer(createBuffer(new byte[] {1}));
+        assertThat(callbackCount[0]).isEqualTo(1);
+
+        // Add second buffer: should NOT trigger listener (store was not empty)
+        store.addBuffer(createBuffer(new byte[] {2}));
+        assertThat(callbackCount[0]).isEqualTo(1);
+
+        // Drain both buffers
+        synchronized (store) {
+            store.tryTake().recycleBuffer();
+            store.tryTake().recycleBuffer();
+        }
+
+        // Add buffer again to empty store: should trigger listener
+        store.addBuffer(createBuffer(new byte[] {3}));
+        assertThat(callbackCount[0]).isEqualTo(2);
+
+        store.releaseAll();
+    }
+
+    /** Verify pending spill entry count tracking. */
+    @Test
+    void testPendingCount() {
+        RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(DEFAULT_CHANNEL_INFO);
+
+        synchronized (store) {
+            store.incrementPending();
+
+            // Store not empty when pending entries exist
+            assertThat(store.isEmpty()).isFalse();
+            // size() reports ready + pending so the channel-level backlog reflects on-disk data too
+            assertThat(store.size()).isEqualTo(1);
+        }
+
+        // Drain the pending entry by handing back a buffer; addBuffer folds in the matching
+        // pending decrement.
+        store.addBuffer(createBuffer(new byte[] {1}));
+        synchronized (store) {
+            // pending consumed, buffer became ready — still size 1 but now in readyBuffers
+            assertThat(store.size()).isEqualTo(1);
+            store.tryTake().recycleBuffer();
+            assertThat(store.isEmpty()).isTrue();
+            assertThat(store.size()).isEqualTo(0);
+        }
+    }
+
+    /** Verify size() aggregates ready buffers and pending on-disk entries. */
+    @Test
+    void testSizeAggregatesReadyAndPending() {
+        RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(DEFAULT_CHANNEL_INFO);
+
+        store.addBuffer(createBuffer(new byte[] {1}));
+        synchronized (store) {
+            store.incrementPending();
+            store.incrementPending();
+
+            assertThat(store.size()).isEqualTo(3);
+
+            store.tryTake().recycleBuffer();
+            assertThat(store.size()).isEqualTo(2);
+        }
+
+        // Drain both pending entries by handing back buffers; each addBuffer consumes one pending.
+        store.addBuffer(createBuffer(new byte[] {2}));
+        store.addBuffer(createBuffer(new byte[] {3}));
+        synchronized (store) {
+            assertThat(store.size()).isEqualTo(2);
+        }
+
+        store.releaseAll();
+    }
+
+    // ---------------------------------------------------------------------------
+    // Tests for coordinator notification on checkpoint
+    // ---------------------------------------------------------------------------
+
+    /**
+     * Verify that the coordinator registered via setCoordinator receives
+     * onChannelCheckpointStarted during checkpoint() after snapshotting ready buffers, with the
+     * correct checkpointId and channelInfo.
+     */
+    @Test
+    void testCheckpointNotifiesCoordinatorAfterSnapshot() throws Exception {
+        InputChannelInfo channelInfo = new InputChannelInfo(0, 0);
+        RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(channelInfo);
+
+        RecordingCoordinator coordinator = new RecordingCoordinator();
+        synchronized (store) {
+            store.setCoordinator(coordinator);
+        }
+
+        store.addBuffer(createBuffer(new byte[] {1, 2}));
+
+        RecordingChannelStateWriter writer = new RecordingChannelStateWriter();
+        long checkpointId = 42L;
+        writer.start(checkpointId, null);
+
+        store.checkpoint(writer, checkpointId);
+
+        // Coordinator must have been notified exactly once with correct args
+        assertThat(coordinator.checkpointIds).containsExactly(42L);
+        assertThat(coordinator.checkpointChannels).containsExactly(channelInfo);
+
+        // Writer received the ready buffer before notification fired (snapshot happened first)
+        assertThat(writer.getAddedInput().get(channelInfo)).hasSize(1);
+
+        writer.getAddedInput().get(channelInfo).forEach(Buffer::recycleBuffer);
+        store.releaseAll();
+    }
+
+    /**
+     * Verify checkpoint() without any ready buffers still notifies the coordinator.
+     */
+    @Test
+    void testCheckpointNotifiesCoordinatorEvenWhenNoReadyBuffers() throws Exception {
+        InputChannelInfo channelInfo = new InputChannelInfo(1, 2);
+        RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(channelInfo);
+
+        RecordingCoordinator coordinator = new RecordingCoordinator();
+        synchronized (store) {
+            store.setCoordinator(coordinator);
+        }
+
+        RecordingChannelStateWriter writer = new RecordingChannelStateWriter();
+        writer.start(1L, null);
+        store.checkpoint(writer, 1L);
+
+        assertThat(coordinator.checkpointIds).containsExactly(1L);
+    }
+
+    /** Verify no notification is fired if setCoordinator was never called. */
+    @Test
+    void testCheckpointWithNoCoordinatorSetDoesNotThrow() throws Exception {
+        RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(DEFAULT_CHANNEL_INFO);
+        store.addBuffer(createBuffer(new byte[] {1}));
+
+        RecordingChannelStateWriter writer = new RecordingChannelStateWriter();
+        writer.start(1L, null);
+        // Should not throw even without a coordinator registered
+        store.checkpoint(writer, 1L);
+
+        writer.getAddedInput().get(DEFAULT_CHANNEL_INFO).forEach(Buffer::recycleBuffer);
+        store.releaseAll();
+    }
+
+    /**
+     * Verify notifyCheckpointStopped forwards the call to the registered coordinator with the
+     * bound channel info.
+     */
+    @Test
+    void testNotifyCheckpointStoppedNotifiesCoordinator() {
+        InputChannelInfo channelInfo = new InputChannelInfo(2, 5);
+        RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(channelInfo);
+
+        RecordingCoordinator coordinator = new RecordingCoordinator();
+        synchronized (store) {
+            store.setCoordinator(coordinator);
+        }
+
+        store.notifyCheckpointStopped(11L);
+        store.notifyCheckpointStopped(12L);
+
+        assertThat(coordinator.stoppedCheckpointIds).containsExactly(11L, 12L);
+        assertThat(coordinator.stoppedChannels).containsExactly(channelInfo, channelInfo);
+    }
+
+    /** Verify notifyCheckpointStopped is a safe no-op when no coordinator is registered. */
+    @Test
+    void testNotifyCheckpointStoppedWithoutCoordinatorIsNoOp() {
+        RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(DEFAULT_CHANNEL_INFO);
+        // Should not throw without a coordinator registered
+        store.notifyCheckpointStopped(7L);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Tests for setDataAvailableListener via interface
+    // ---------------------------------------------------------------------------
+
+    /**
+     * Verify setDataAvailableListener can be called through the RecoveredBufferStore interface
+     * without instanceof casts.
+     */
+    @Test
+    void testSetDataAvailableListenerViaInterface() {
+        RecoveredBufferStore store = new RecoveredBufferStoreImpl(DEFAULT_CHANNEL_INFO);
+        int[] callCount = {0};
+        // Must compile and run without instanceof check
+        synchronized (store) {
+            store.setDataAvailableListener(() -> callCount[0]++);
+        }
+
+        ((RecoveredBufferStoreImpl) store).addBuffer(createBuffer(new byte[] {1}));
+        assertThat(callCount[0]).isEqualTo(1);
+
+        store.releaseAll();
+    }
+
+    // ---------------------------------------------------------------------------
+    // Tests for RecoveredBufferStore.EMPTY singleton
+    // ---------------------------------------------------------------------------
+
+    /** Verify all methods of EMPTY return expected no-op / sentinel values. */
+    @Test
+    void testEmptySingletonBehavior() throws Exception {
+        RecoveredBufferStore empty = RecoveredBufferStore.EMPTY;
+
+        assertThat(empty.tryTake()).isNull();
+        assertThat(empty.peekNextDataType()).isEqualTo(Buffer.DataType.NONE);
+        assertThat(empty.isEmpty()).isTrue();
+        assertThat(empty.size()).isEqualTo(0);
+    }
+
+    /** Verify checkpoint() on EMPTY is a no-op and does not write any channel state. */
+    @Test
+    void testEmptySingletonCheckpointIsNoOp() throws Exception {
+        RecoveredBufferStore empty = RecoveredBufferStore.EMPTY;
+
+        RecordingChannelStateWriter writer = new RecordingChannelStateWriter();
+        writer.start(1L, null);
+        empty.checkpoint(writer, 1L);
+
+        // No data must have been written
+        assertThat(writer.getAddedInput().isEmpty()).isTrue();
+    }
+
+    /** Verify releaseAll() on EMPTY does not throw. */
+    @Test
+    void testEmptySingletonReleaseAllIsNoOp() {
+        RecoveredBufferStore.EMPTY.releaseAll();
+    }
+
+    /** Verify notifyCheckpointStopped() on EMPTY does not throw. */
+    @Test
+    void testEmptySingletonNotifyCheckpointStoppedIsNoOp() {
+        RecoveredBufferStore.EMPTY.notifyCheckpointStopped(99L);
+    }
+
+    /** Verify all setters on EMPTY are no-ops (accept and discard without throwing). */
+    @Test
+    void testEmptySingletonSettersAreNoOp() {
+        RecoveredBufferStore empty = RecoveredBufferStore.EMPTY;
+
+        empty.setCoordinator(new RecordingCoordinator());
+        empty.setDataAvailableListener(() -> {});
+        // No exception == pass
+    }
+
+    // ---------------------------------------------------------------------------
+    // Locking-contract regression tests
+    // ---------------------------------------------------------------------------
+
+    /**
+     * Calling a {@code @GuardedBy("this")} method without holding the store monitor must trip the
+     * {@code assert Thread.holdsLock(this)} guard under {@code -ea}. This locks the contract in:
+     * future refactors that accidentally drop the synchronized wrapper at a call site will fail
+     * loudly in tests instead of silently producing torn reads.
+     */
+    @Test
+    void testGuardedMethodsAssertHoldsLock() {
+        // The AssertionError surfaces only with assertions enabled; flink test JVMs run with -ea
+        // by default. Skip the test cleanly if for some reason this JVM was started without -ea
+        // so the suite does not turn red on a JVM configuration issue.
+        if (!RecoveredBufferStoreTest.class.desiredAssertionStatus()) {
+            return;
+        }
+
+        RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(DEFAULT_CHANNEL_INFO);
+        try {
+            assertThat(catchAssertion(() -> store.tryTake())).isTrue();
+            assertThat(catchAssertion(() -> store.peekNextDataType())).isTrue();
+            assertThat(catchAssertion(() -> store.isEmpty())).isTrue();
+            assertThat(catchAssertion(() -> store.incrementPending())).isTrue();
+            assertThat(catchAssertion(() -> store.setCoordinator(new RecordingCoordinator())))
+                    .isTrue();
+            assertThat(catchAssertion(() -> store.setDataAvailableListener(() -> {}))).isTrue();
+            // size() is the deliberate exception — lock-free for metric / gate-bookkeeping paths.
+            // Calling it without holding the monitor must NOT trip the assertion guard.
+            assertThat(catchAssertion(() -> store.size())).isFalse();
+        } finally {
+            store.releaseAll();
+        }
+    }
+
+    /**
+     * Concurrent drain test: when the producer keeps appending and the consumer keeps polling,
+     * each {@code tryTake + peekNextDataType} pair observed by the consumer must be self-
+     * consistent — if {@code peekNextDataType()} returns {@code NONE} after a successful tryTake
+     * it must mean the next tryTake on the same thread also returns null (modulo any further
+     * producer activity that happened strictly after the peek), and if it returns a non-NONE type
+     * the next tryTake must return a buffer with that type. The test guards against future
+     * regressions where someone splits the take/peek pair across two store-lock acquisitions.
+     */
+    @Test
+    void testTryTakePeekPairAtomicUnderConcurrency() throws Exception {
+        RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(DEFAULT_CHANNEL_INFO);
+        int numBuffers = 500;
+        CyclicBarrier startBarrier = new CyclicBarrier(2);
+        AtomicReference<Throwable> error = new AtomicReference<>();
+
+        Thread producer =
+                new Thread(
+                        () -> {
+                            try {
+                                startBarrier.await();
+                                for (int i = 0; i < numBuffers; i++) {
+                                    store.addBuffer(createBuffer(new byte[] {(byte) i}));
+                                }
+                            } catch (Throwable t) {
+                                error.set(t);
+                            }
+                        },
+                        "atomic-pair-producer");
+
+        Thread consumer =
+                new Thread(
+                        () -> {
+                            try {
+                                startBarrier.await();
+                                int consumed = 0;
+                                while (consumed < numBuffers) {
+                                    Buffer taken;
+                                    Buffer.DataType peekedType;
+                                    synchronized (store) {
+                                        taken = store.tryTake();
+                                        peekedType = store.peekNextDataType();
+                                    }
+                                    if (taken == null) {
+                                        // peeked type with no taken buffer must be NONE
+                                        assertThat(peekedType).isEqualTo(Buffer.DataType.NONE);
+                                        continue;
+                                    }
+                                    taken.recycleBuffer();
+                                    consumed++;
+                                }
+                            } catch (Throwable t) {
+                                error.set(t);
+                            }
+                        },
+                        "atomic-pair-consumer");
+
+        producer.start();
+        consumer.start();
+        producer.join(10_000);
+        consumer.join(10_000);
+
+        assertThat(error.get()).isNull();
+        synchronized (store) {
+            assertThat(store.isEmpty()).isTrue();
+        }
+    }
+
+    private static boolean catchAssertion(Runnable r) {
+        try {
+            r.run();
+            return false;
+        } catch (AssertionError ae) {
+            return true;
+        }
+    }
+
+    /**
+     * Test-only coordinator that records all coordinator notifications: started, stopped, and
+     * released.
+     */
+    private static class RecordingCoordinator implements RecoveredBufferStoreCoordinator {
+        final List<Long> checkpointIds = new ArrayList<>();
+        final List<InputChannelInfo> checkpointChannels = new ArrayList<>();
+        final List<EntryPosition> checkpointStartPositions = new ArrayList<>();
+        final List<Long> stoppedCheckpointIds = new ArrayList<>();
+        final List<InputChannelInfo> stoppedChannels = new ArrayList<>();
+        final List<InputChannelInfo> released = new ArrayList<>();
+        volatile EntryPosition currentDrainHead = EntryPosition.END;
+
+        @Override
+        public EntryPosition getCurrentDrainHead() {
+            return currentDrainHead;
+        }
+
+        @Override
+        public void onChannelCheckpointStarted(
+                long checkpointId, InputChannelInfo channelInfo, EntryPosition startPos) {
+            checkpointIds.add(checkpointId);
+            checkpointChannels.add(channelInfo);
+            checkpointStartPositions.add(startPos);
+        }
+
+        @Override
+        public void onChannelCheckpointStopped(long checkpointId, InputChannelInfo channelInfo) {
+            stoppedCheckpointIds.add(checkpointId);
+            stoppedChannels.add(channelInfo);
+        }
+
+        @Override
+        public void onChannelReleased(InputChannelInfo channelInfo) {
+            released.add(channelInfo);
+        }
+    }
+
+    private static NetworkBuffer createBuffer(byte[] data) {
+        org.apache.flink.core.memory.MemorySegment segment =
+                MemorySegmentFactory.allocateUnpooledSegment(data.length);
+        segment.put(0, data, 0, data.length);
+        NetworkBuffer buffer = new NetworkBuffer(segment, FreeingBufferRecycler.INSTANCE);
+        buffer.setSize(data.length);
+        return buffer;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredBufferStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredBufferStoreTest.java
@@ -54,7 +54,7 @@ class RecoveredBufferStoreTest {
         }
 
         NetworkBuffer buffer1 = createBuffer(new byte[] {1, 2, 3, 4});
-        store.addBuffer(buffer1);
+        synchronized (store) { store.addBuffer(buffer1); }
 
         Buffer taken;
         synchronized (store) {
@@ -84,7 +84,7 @@ class RecoveredBufferStoreTest {
 
         byte[] data = new byte[] {10, 20, 30, 40};
         NetworkBuffer buffer = createBuffer(data);
-        store.addBuffer(buffer);
+        synchronized (store) { store.addBuffer(buffer); }
 
         RecordingChannelStateWriter writer = new RecordingChannelStateWriter();
         long checkpointId = 1L;
@@ -120,7 +120,7 @@ class RecoveredBufferStoreTest {
                                 barrier.await();
                                 for (int i = 0; i < numBuffers; i++) {
                                     NetworkBuffer buf = createBuffer(new byte[] {(byte) i});
-                                    store.addBuffer(buf);
+                                    synchronized (store) { store.addBuffer(buf); }
                                 }
                             } catch (Throwable t) {
                                 error.set(t);
@@ -174,9 +174,9 @@ class RecoveredBufferStoreTest {
         NetworkBuffer buf1 = createBuffer(new byte[] {1, 2});
         NetworkBuffer buf2 = createBuffer(new byte[] {3, 4});
         NetworkBuffer buf3 = createBuffer(new byte[] {5, 6});
-        store.addBuffer(buf1);
-        store.addBuffer(buf2);
-        store.addBuffer(buf3);
+        synchronized (store) { store.addBuffer(buf1); }
+        synchronized (store) { store.addBuffer(buf2); }
+        synchronized (store) { store.addBuffer(buf3); }
 
         // Simulate partial consumption before conversion
         Buffer taken1;
@@ -211,8 +211,8 @@ class RecoveredBufferStoreTest {
 
         NetworkBuffer buf1 = createBuffer(new byte[] {1});
         NetworkBuffer buf2 = createBuffer(new byte[] {2});
-        store.addBuffer(buf1);
-        store.addBuffer(buf2);
+        synchronized (store) { store.addBuffer(buf1); }
+        synchronized (store) { store.addBuffer(buf2); }
 
         store.releaseAll();
 
@@ -236,7 +236,7 @@ class RecoveredBufferStoreTest {
         }
 
         // Add some in-memory and on-disk bookkeeping to make the release meaningful.
-        store.addBuffer(createBuffer(new byte[] {1}));
+        synchronized (store) { store.addBuffer(createBuffer(new byte[] {1})); }
         synchronized (store) {
             store.incrementPending();
         }
@@ -250,131 +250,6 @@ class RecoveredBufferStoreTest {
         }
     }
 
-    /**
-     * Verify the data-available listener is invoked OUTSIDE the store monitor.
-     *
-     * <p>If the listener fires while the store monitor is held, the listener's downstream lock
-     * acquisition (e.g. {@code SingleInputGate.queueChannel} taking the gate's {@code
-     * inputChannelsWithData} monitor) can deadlock against a task thread that already holds that
-     * monitor and is trying to acquire the store monitor (via {@code peekNextDataType}). This is
-     * the AB-BA deadlock pattern observed in JVM-level deadlock reports. The contract aligns with
-     * {@link RecoveredBufferStoreImpl#checkpoint} / {@link RecoveredBufferStoreImpl#releaseAll} /
-     * {@link RecoveredBufferStoreImpl#notifyCheckpointStopped}, all of which fire callbacks outside
-     * the store lock.
-     */
-    @Test
-    void testDataAvailableListenerFiresOutsideStoreMonitor() {
-        RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(DEFAULT_CHANNEL_INFO);
-        boolean[] storeMonitorHeldDuringCallback = {false};
-        synchronized (store) {
-            store.setDataAvailableListener(
-                    () -> storeMonitorHeldDuringCallback[0] = Thread.holdsLock(store));
-        }
-
-        store.addBuffer(createBuffer(new byte[] {1}));
-
-        assertThat(storeMonitorHeldDuringCallback[0])
-                .as("dataAvailableListener must be invoked outside the store monitor")
-                .isFalse();
-
-        store.releaseAll();
-    }
-
-    /**
-     * Reproduces the AB-BA deadlock pattern between {@link RecoveredBufferStoreImpl#addBuffer} and
-     * a task thread that holds a downstream gate-side lock while reaching into the store.
-     *
-     * <p>Thread A (task): holds {@code gateLock}, then tries to acquire the store monitor via a
-     * synchronized store method (mirrors {@link RecoveredBufferStoreImpl#peekNextDataType}). Thread
-     * B (recovery): calls {@code addBuffer}, which under the broken contract fires the listener
-     * while holding the store monitor; the listener tries to acquire {@code gateLock}, mirroring
-     * {@code SingleInputGate.queueChannel}.
-     *
-     * <p>If {@code addBuffer} invokes the listener inside the synchronized block, this test
-     * deadlocks. The fixed contract fires the listener outside the lock, so the test completes
-     * within the timeout.
-     */
-    @Test
-    void testAddBufferDoesNotDeadlockWithGateSideLock() throws Exception {
-        RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(DEFAULT_CHANNEL_INFO);
-        Object gateLock = new Object();
-        CountDownLatch taskHoldsGateLock = new CountDownLatch(1);
-        CountDownLatch recoveryStartedAddBuffer = new CountDownLatch(1);
-        AtomicReference<Throwable> error = new AtomicReference<>();
-
-        // Listener mirrors SingleInputGate.queueChannel: must take gateLock to enqueue.
-        synchronized (store) {
-            store.setDataAvailableListener(
-                    () -> {
-                        synchronized (gateLock) {
-                            // touch shared state under the gate lock to mirror real notify path
-                        }
-                    });
-        }
-
-        // Thread A (task): take gateLock first, then call into the store. This emulates
-        // SingleInputGate holding inputChannelsWithData while reading peekNextDataType.
-        Thread taskThread =
-                new Thread(
-                        () -> {
-                            try {
-                                synchronized (gateLock) {
-                                    taskHoldsGateLock.countDown();
-                                    // Wait until the recovery thread has entered addBuffer and (in
-                                    // the broken contract) is holding the store monitor while
-                                    // trying to grab gateLock.
-                                    recoveryStartedAddBuffer.await();
-                                    // Sleep a touch so the recovery thread is parked on gateLock
-                                    // before we go grab the store monitor; without this, the test
-                                    // could pass even with the broken contract because both
-                                    // threads might serialise.
-                                    Thread.sleep(50);
-                                    // Now reach into the store under gateLock — this mirrors
-                                    // peekNextDataType / size and would block on the store monitor
-                                    // if addBuffer is still inside synchronized.
-                                    synchronized (store) {
-                                        store.peekNextDataType();
-                                    }
-                                }
-                            } catch (Throwable t) {
-                                error.set(t);
-                            }
-                        },
-                        "test-task-thread");
-
-        // Thread B (recovery): wait until the task thread holds gateLock, then call addBuffer,
-        // which will trigger the listener that wants gateLock.
-        Thread recoveryThread =
-                new Thread(
-                        () -> {
-                            try {
-                                taskHoldsGateLock.await();
-                                recoveryStartedAddBuffer.countDown();
-                                store.addBuffer(createBuffer(new byte[] {1}));
-                            } catch (Throwable t) {
-                                error.set(t);
-                            }
-                        },
-                        "test-recovery-thread");
-
-        taskThread.start();
-        recoveryThread.start();
-
-        // Generous timeout: deadlock would otherwise hang the test forever.
-        taskThread.join(10_000);
-        recoveryThread.join(10_000);
-
-        assertThat(taskThread.isAlive())
-                .as("task thread is still alive — likely deadlocked on store monitor")
-                .isFalse();
-        assertThat(recoveryThread.isAlive())
-                .as("recovery thread is still alive — likely deadlocked on gate lock")
-                .isFalse();
-        assertThat(error.get()).isNull();
-
-        store.releaseAll();
-    }
-
     /** Verify data-available listener fires when buffer is added to empty store. */
     @Test
     void testDataAvailableListener() {
@@ -385,11 +260,11 @@ class RecoveredBufferStoreTest {
         }
 
         // Add first buffer: should trigger listener (store was empty)
-        store.addBuffer(createBuffer(new byte[] {1}));
+        synchronized (store) { store.addBuffer(createBuffer(new byte[] {1})); }
         assertThat(callbackCount[0]).isEqualTo(1);
 
         // Add second buffer: should NOT trigger listener (store was not empty)
-        store.addBuffer(createBuffer(new byte[] {2}));
+        synchronized (store) { store.addBuffer(createBuffer(new byte[] {2})); }
         assertThat(callbackCount[0]).isEqualTo(1);
 
         // Drain both buffers
@@ -399,7 +274,7 @@ class RecoveredBufferStoreTest {
         }
 
         // Add buffer again to empty store: should trigger listener
-        store.addBuffer(createBuffer(new byte[] {3}));
+        synchronized (store) { store.addBuffer(createBuffer(new byte[] {3})); }
         assertThat(callbackCount[0]).isEqualTo(2);
 
         store.releaseAll();
@@ -421,7 +296,7 @@ class RecoveredBufferStoreTest {
 
         // Drain the pending entry by handing back a buffer; addBuffer folds in the matching
         // pending decrement.
-        store.addBuffer(createBuffer(new byte[] {1}));
+        synchronized (store) { store.addBuffer(createBuffer(new byte[] {1})); }
         synchronized (store) {
             // pending consumed, buffer became ready — still size 1 but now in readyBuffers
             assertThat(store.size()).isEqualTo(1);
@@ -436,7 +311,7 @@ class RecoveredBufferStoreTest {
     void testSizeAggregatesReadyAndPending() {
         RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(DEFAULT_CHANNEL_INFO);
 
-        store.addBuffer(createBuffer(new byte[] {1}));
+        synchronized (store) { store.addBuffer(createBuffer(new byte[] {1})); }
         synchronized (store) {
             store.incrementPending();
             store.incrementPending();
@@ -448,8 +323,8 @@ class RecoveredBufferStoreTest {
         }
 
         // Drain both pending entries by handing back buffers; each addBuffer consumes one pending.
-        store.addBuffer(createBuffer(new byte[] {2}));
-        store.addBuffer(createBuffer(new byte[] {3}));
+        synchronized (store) { store.addBuffer(createBuffer(new byte[] {2})); }
+        synchronized (store) { store.addBuffer(createBuffer(new byte[] {3})); }
         synchronized (store) {
             assertThat(store.size()).isEqualTo(2);
         }
@@ -472,7 +347,7 @@ class RecoveredBufferStoreTest {
             store.setCoordinator(coordinator);
         }
 
-        store.addBuffer(createBuffer(new byte[] {1, 2}));
+        synchronized (store) { store.addBuffer(createBuffer(new byte[] {1, 2})); }
 
         RecordingChannelStateWriter writer = new RecordingChannelStateWriter();
         long checkpointId = 42L;
@@ -513,7 +388,7 @@ class RecoveredBufferStoreTest {
     @Test
     void testCheckpointWithNoCoordinatorSetDoesNotThrow() throws Exception {
         RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(DEFAULT_CHANNEL_INFO);
-        store.addBuffer(createBuffer(new byte[] {1}));
+        synchronized (store) { store.addBuffer(createBuffer(new byte[] {1})); }
 
         RecordingChannelStateWriter writer = new RecordingChannelStateWriter();
         writer.start(1L, null);
@@ -566,7 +441,9 @@ class RecoveredBufferStoreTest {
             store.setDataAvailableListener(() -> callCount[0]++);
         }
 
-        ((RecoveredBufferStoreImpl) store).addBuffer(createBuffer(new byte[] {1}));
+        synchronized (store) {
+            ((RecoveredBufferStoreImpl) store).addBuffer(createBuffer(new byte[] {1}));
+        }
         assertThat(callCount[0]).isEqualTo(1);
 
         store.releaseAll();
@@ -672,7 +549,7 @@ class RecoveredBufferStoreTest {
                             try {
                                 startBarrier.await();
                                 for (int i = 0; i < numBuffers; i++) {
-                                    store.addBuffer(createBuffer(new byte[] {(byte) i}));
+                                    synchronized (store) { store.addBuffer(createBuffer(new byte[] {(byte) i})); }
                                 }
                             } catch (Throwable t) {
                                 error.set(t);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredBufferStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredBufferStoreTest.java
@@ -54,7 +54,9 @@ class RecoveredBufferStoreTest {
         }
 
         NetworkBuffer buffer1 = createBuffer(new byte[] {1, 2, 3, 4});
-        synchronized (store) { store.addBuffer(buffer1); }
+        synchronized (store) {
+            store.addBuffer(buffer1);
+        }
 
         Buffer taken;
         synchronized (store) {
@@ -84,7 +86,9 @@ class RecoveredBufferStoreTest {
 
         byte[] data = new byte[] {10, 20, 30, 40};
         NetworkBuffer buffer = createBuffer(data);
-        synchronized (store) { store.addBuffer(buffer); }
+        synchronized (store) {
+            store.addBuffer(buffer);
+        }
 
         RecordingChannelStateWriter writer = new RecordingChannelStateWriter();
         long checkpointId = 1L;
@@ -120,7 +124,9 @@ class RecoveredBufferStoreTest {
                                 barrier.await();
                                 for (int i = 0; i < numBuffers; i++) {
                                     NetworkBuffer buf = createBuffer(new byte[] {(byte) i});
-                                    synchronized (store) { store.addBuffer(buf); }
+                                    synchronized (store) {
+                                        store.addBuffer(buf);
+                                    }
                                 }
                             } catch (Throwable t) {
                                 error.set(t);
@@ -174,9 +180,15 @@ class RecoveredBufferStoreTest {
         NetworkBuffer buf1 = createBuffer(new byte[] {1, 2});
         NetworkBuffer buf2 = createBuffer(new byte[] {3, 4});
         NetworkBuffer buf3 = createBuffer(new byte[] {5, 6});
-        synchronized (store) { store.addBuffer(buf1); }
-        synchronized (store) { store.addBuffer(buf2); }
-        synchronized (store) { store.addBuffer(buf3); }
+        synchronized (store) {
+            store.addBuffer(buf1);
+        }
+        synchronized (store) {
+            store.addBuffer(buf2);
+        }
+        synchronized (store) {
+            store.addBuffer(buf3);
+        }
 
         // Simulate partial consumption before conversion
         Buffer taken1;
@@ -211,8 +223,12 @@ class RecoveredBufferStoreTest {
 
         NetworkBuffer buf1 = createBuffer(new byte[] {1});
         NetworkBuffer buf2 = createBuffer(new byte[] {2});
-        synchronized (store) { store.addBuffer(buf1); }
-        synchronized (store) { store.addBuffer(buf2); }
+        synchronized (store) {
+            store.addBuffer(buf1);
+        }
+        synchronized (store) {
+            store.addBuffer(buf2);
+        }
 
         store.releaseAll();
 
@@ -236,7 +252,9 @@ class RecoveredBufferStoreTest {
         }
 
         // Add some in-memory and on-disk bookkeeping to make the release meaningful.
-        synchronized (store) { store.addBuffer(createBuffer(new byte[] {1})); }
+        synchronized (store) {
+            store.addBuffer(createBuffer(new byte[] {1}));
+        }
         synchronized (store) {
             store.incrementPending();
         }
@@ -260,11 +278,15 @@ class RecoveredBufferStoreTest {
         }
 
         // Add first buffer: should trigger listener (store was empty)
-        synchronized (store) { store.addBuffer(createBuffer(new byte[] {1})); }
+        synchronized (store) {
+            store.addBuffer(createBuffer(new byte[] {1}));
+        }
         assertThat(callbackCount[0]).isEqualTo(1);
 
         // Add second buffer: should NOT trigger listener (store was not empty)
-        synchronized (store) { store.addBuffer(createBuffer(new byte[] {2})); }
+        synchronized (store) {
+            store.addBuffer(createBuffer(new byte[] {2}));
+        }
         assertThat(callbackCount[0]).isEqualTo(1);
 
         // Drain both buffers
@@ -274,7 +296,9 @@ class RecoveredBufferStoreTest {
         }
 
         // Add buffer again to empty store: should trigger listener
-        synchronized (store) { store.addBuffer(createBuffer(new byte[] {3})); }
+        synchronized (store) {
+            store.addBuffer(createBuffer(new byte[] {3}));
+        }
         assertThat(callbackCount[0]).isEqualTo(2);
 
         store.releaseAll();
@@ -296,7 +320,9 @@ class RecoveredBufferStoreTest {
 
         // Drain the pending entry by handing back a buffer; addBuffer folds in the matching
         // pending decrement.
-        synchronized (store) { store.addBuffer(createBuffer(new byte[] {1})); }
+        synchronized (store) {
+            store.addBuffer(createBuffer(new byte[] {1}));
+        }
         synchronized (store) {
             // pending consumed, buffer became ready — still size 1 but now in readyBuffers
             assertThat(store.size()).isEqualTo(1);
@@ -311,7 +337,9 @@ class RecoveredBufferStoreTest {
     void testSizeAggregatesReadyAndPending() {
         RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(DEFAULT_CHANNEL_INFO);
 
-        synchronized (store) { store.addBuffer(createBuffer(new byte[] {1})); }
+        synchronized (store) {
+            store.addBuffer(createBuffer(new byte[] {1}));
+        }
         synchronized (store) {
             store.incrementPending();
             store.incrementPending();
@@ -323,8 +351,12 @@ class RecoveredBufferStoreTest {
         }
 
         // Drain both pending entries by handing back buffers; each addBuffer consumes one pending.
-        synchronized (store) { store.addBuffer(createBuffer(new byte[] {2})); }
-        synchronized (store) { store.addBuffer(createBuffer(new byte[] {3})); }
+        synchronized (store) {
+            store.addBuffer(createBuffer(new byte[] {2}));
+        }
+        synchronized (store) {
+            store.addBuffer(createBuffer(new byte[] {3}));
+        }
         synchronized (store) {
             assertThat(store.size()).isEqualTo(2);
         }
@@ -347,7 +379,9 @@ class RecoveredBufferStoreTest {
             store.setCoordinator(coordinator);
         }
 
-        synchronized (store) { store.addBuffer(createBuffer(new byte[] {1, 2})); }
+        synchronized (store) {
+            store.addBuffer(createBuffer(new byte[] {1, 2}));
+        }
 
         RecordingChannelStateWriter writer = new RecordingChannelStateWriter();
         long checkpointId = 42L;
@@ -388,7 +422,9 @@ class RecoveredBufferStoreTest {
     @Test
     void testCheckpointWithNoCoordinatorSetDoesNotThrow() throws Exception {
         RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(DEFAULT_CHANNEL_INFO);
-        synchronized (store) { store.addBuffer(createBuffer(new byte[] {1})); }
+        synchronized (store) {
+            store.addBuffer(createBuffer(new byte[] {1}));
+        }
 
         RecordingChannelStateWriter writer = new RecordingChannelStateWriter();
         writer.start(1L, null);
@@ -549,7 +585,9 @@ class RecoveredBufferStoreTest {
                             try {
                                 startBarrier.await();
                                 for (int i = 0; i < numBuffers; i++) {
-                                    synchronized (store) { store.addBuffer(createBuffer(new byte[] {(byte) i})); }
+                                    synchronized (store) {
+                                        store.addBuffer(createBuffer(new byte[] {(byte) i}));
+                                    }
                                 }
                             } catch (Throwable t) {
                                 error.set(t);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredBufferStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredBufferStoreTest.java
@@ -41,19 +41,18 @@ class RecoveredBufferStoreTest {
 
     private static final InputChannelInfo DEFAULT_CHANNEL_INFO = new InputChannelInfo(0, 0);
 
-    /** Create store, addBuffer, tryTake. Verify the lifecycle of the store. */
+    /** addBuffer / tryTake lifecycle. */
     @Test
     void testStoreLifecycle() {
         RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(DEFAULT_CHANNEL_INFO);
 
-        // Initially empty — query methods require holding the store monitor (locking contract).
+        // Query methods require holding the store monitor (locking contract).
         synchronized (store) {
             assertThat(store.isEmpty()).isTrue();
             assertThat(store.size()).isEqualTo(0);
             assertThat(store.peekNextDataType()).isEqualTo(Buffer.DataType.NONE);
         }
 
-        // Add a buffer
         NetworkBuffer buffer1 = createBuffer(new byte[] {1, 2, 3, 4});
         store.addBuffer(buffer1);
 
@@ -63,7 +62,6 @@ class RecoveredBufferStoreTest {
             assertThat(store.size()).isEqualTo(1);
             assertThat(store.peekNextDataType()).isEqualTo(Buffer.DataType.DATA_BUFFER);
 
-            // Take the buffer
             taken = store.tryTake();
             assertThat(taken).isNotNull();
             assertThat(store.isEmpty()).isTrue();
@@ -72,7 +70,6 @@ class RecoveredBufferStoreTest {
         taken.recycleBuffer();
 
         synchronized (store) {
-            // tryTake on empty returns null
             assertThat(store.tryTake()).isNull();
         }
     }
@@ -95,7 +92,6 @@ class RecoveredBufferStoreTest {
 
         store.checkpoint(writer, checkpointId);
 
-        // Verify the buffer was recorded by the writer
         assertThat(writer.getAddedInput().get(DEFAULT_CHANNEL_INFO)).hasSize(1);
 
         // The original buffer should still be in the store (retained, not consumed)
@@ -258,13 +254,13 @@ class RecoveredBufferStoreTest {
      * Verify the data-available listener is invoked OUTSIDE the store monitor.
      *
      * <p>If the listener fires while the store monitor is held, the listener's downstream lock
-     * acquisition (e.g. {@code SingleInputGate.queueChannel} taking the gate's
-     * {@code inputChannelsWithData} monitor) can deadlock against a task thread that already holds
-     * that monitor and is trying to acquire the store monitor (via {@code peekNextDataType}). This
-     * is the AB-BA deadlock pattern observed in JVM-level deadlock reports. The contract aligns
-     * with {@link RecoveredBufferStoreImpl#checkpoint} / {@link RecoveredBufferStoreImpl#releaseAll}
-     * / {@link RecoveredBufferStoreImpl#notifyCheckpointStopped}, all of which fire callbacks
-     * outside the store lock.
+     * acquisition (e.g. {@code SingleInputGate.queueChannel} taking the gate's {@code
+     * inputChannelsWithData} monitor) can deadlock against a task thread that already holds that
+     * monitor and is trying to acquire the store monitor (via {@code peekNextDataType}). This is
+     * the AB-BA deadlock pattern observed in JVM-level deadlock reports. The contract aligns with
+     * {@link RecoveredBufferStoreImpl#checkpoint} / {@link RecoveredBufferStoreImpl#releaseAll} /
+     * {@link RecoveredBufferStoreImpl#notifyCheckpointStopped}, all of which fire callbacks outside
+     * the store lock.
      */
     @Test
     void testDataAvailableListenerFiresOutsideStoreMonitor() {
@@ -461,14 +457,10 @@ class RecoveredBufferStoreTest {
         store.releaseAll();
     }
 
-    // ---------------------------------------------------------------------------
-    // Tests for coordinator notification on checkpoint
-    // ---------------------------------------------------------------------------
-
     /**
-     * Verify that the coordinator registered via setCoordinator receives
-     * onChannelCheckpointStarted during checkpoint() after snapshotting ready buffers, with the
-     * correct checkpointId and channelInfo.
+     * Verify that the coordinator registered via setCoordinator receives onChannelCheckpointStarted
+     * during checkpoint() after snapshotting ready buffers, with the correct checkpointId and
+     * channelInfo.
      */
     @Test
     void testCheckpointNotifiesCoordinatorAfterSnapshot() throws Exception {
@@ -499,9 +491,7 @@ class RecoveredBufferStoreTest {
         store.releaseAll();
     }
 
-    /**
-     * Verify checkpoint() without any ready buffers still notifies the coordinator.
-     */
+    /** Verify checkpoint() without any ready buffers still notifies the coordinator. */
     @Test
     void testCheckpointNotifiesCoordinatorEvenWhenNoReadyBuffers() throws Exception {
         InputChannelInfo channelInfo = new InputChannelInfo(1, 2);
@@ -535,8 +525,8 @@ class RecoveredBufferStoreTest {
     }
 
     /**
-     * Verify notifyCheckpointStopped forwards the call to the registered coordinator with the
-     * bound channel info.
+     * Verify notifyCheckpointStopped forwards the call to the registered coordinator with the bound
+     * channel info.
      */
     @Test
     void testNotifyCheckpointStoppedNotifiesCoordinator() {
@@ -563,10 +553,6 @@ class RecoveredBufferStoreTest {
         store.notifyCheckpointStopped(7L);
     }
 
-    // ---------------------------------------------------------------------------
-    // Tests for setDataAvailableListener via interface
-    // ---------------------------------------------------------------------------
-
     /**
      * Verify setDataAvailableListener can be called through the RecoveredBufferStore interface
      * without instanceof casts.
@@ -585,10 +571,6 @@ class RecoveredBufferStoreTest {
 
         store.releaseAll();
     }
-
-    // ---------------------------------------------------------------------------
-    // Tests for RecoveredBufferStore.EMPTY singleton
-    // ---------------------------------------------------------------------------
 
     /** Verify all methods of EMPTY return expected no-op / sentinel values. */
     @Test
@@ -636,10 +618,6 @@ class RecoveredBufferStoreTest {
         // No exception == pass
     }
 
-    // ---------------------------------------------------------------------------
-    // Locking-contract regression tests
-    // ---------------------------------------------------------------------------
-
     /**
      * Calling a {@code @GuardedBy("this")} method without holding the store monitor must trip the
      * {@code assert Thread.holdsLock(this)} guard under {@code -ea}. This locks the contract in:
@@ -673,13 +651,13 @@ class RecoveredBufferStoreTest {
     }
 
     /**
-     * Concurrent drain test: when the producer keeps appending and the consumer keeps polling,
-     * each {@code tryTake + peekNextDataType} pair observed by the consumer must be self-
-     * consistent — if {@code peekNextDataType()} returns {@code NONE} after a successful tryTake
-     * it must mean the next tryTake on the same thread also returns null (modulo any further
-     * producer activity that happened strictly after the peek), and if it returns a non-NONE type
-     * the next tryTake must return a buffer with that type. The test guards against future
-     * regressions where someone splits the take/peek pair across two store-lock acquisitions.
+     * Concurrent drain test: when the producer keeps appending and the consumer keeps polling, each
+     * {@code tryTake + peekNextDataType} pair observed by the consumer must be self- consistent —
+     * if {@code peekNextDataType()} returns {@code NONE} after a successful tryTake it must mean
+     * the next tryTake on the same thread also returns null (modulo any further producer activity
+     * that happened strictly after the peek), and if it returns a non-NONE type the next tryTake
+     * must return a buffer with that type. The test guards against future regressions where someone
+     * splits the take/peek pair across two store-lock acquisitions.
      */
     @Test
     void testTryTakePeekPairAtomicUnderConcurrency() throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannelTest.java
@@ -21,15 +21,23 @@ package org.apache.flink.runtime.io.network.partition.consumer;
 import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointType;
+import org.apache.flink.runtime.io.network.NettyShuffleEnvironment;
+import org.apache.flink.runtime.io.network.NettyShuffleEnvironmentBuilder;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartitionIndexSet;
+import org.apache.flink.runtime.memory.MemoryManager;
 
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.runtime.checkpoint.CheckpointOptions.unaligned;
 import static org.apache.flink.runtime.state.CheckpointStorageLocationReference.getDefault;
@@ -148,6 +156,83 @@ class RecoveredInputChannelTest {
             // getNextBuffer() returns empty when it encounters the event internally.
             assertThat(channel.getNextBuffer()).isNotPresent();
             assertThat(channel.getStateConsumedFuture()).isDone();
+        }
+    }
+
+    @Test
+    void testRequestBufferNonBlockingAndBlockingHasNoHeapFallback() throws Exception {
+        int numBuffers = 3;
+        NettyShuffleEnvironment environment =
+                new NettyShuffleEnvironmentBuilder()
+                        .setNumNetworkBuffers(numBuffers)
+                        .setBufferSize(MemoryManager.DEFAULT_PAGE_SIZE)
+                        .build();
+        try {
+            SingleInputGate filteringGate =
+                    new SingleInputGateBuilder()
+                            .setChannelFactory(InputChannelBuilder::buildLocalRecoveredChannel)
+                            .setupBufferPoolFactory(environment)
+                            .setCheckpointingDuringRecoveryEnabled(true)
+                            .build();
+            filteringGate.setup();
+
+            RecoveredInputChannel channel = (RecoveredInputChannel) filteringGate.getChannel(0);
+
+            // requestBuffer() is non-blocking: drain exclusive buffers, then null is returned.
+            List<Buffer> allBuffers = new ArrayList<>();
+            while (true) {
+                Buffer b = channel.requestBuffer();
+                if (b == null) {
+                    break;
+                }
+                allBuffers.add(b);
+            }
+            assertThat(channel.requestBuffer()).isNull();
+
+            // Also drain the gate's floating buffer pool so requestBufferBlocking() has nothing
+            // left and is forced to block.
+            BufferPool bufferPool = filteringGate.getBufferPool();
+            while (true) {
+                Buffer b = bufferPool.requestBuffer();
+                if (b == null) {
+                    break;
+                }
+                allBuffers.add(b);
+            }
+
+            // requestBufferBlocking() must block (not fall back to heap) when the pool is empty.
+            CompletableFuture<Buffer> blockingFuture = new CompletableFuture<>();
+            Thread blockingThread =
+                    new Thread(
+                            () -> {
+                                try {
+                                    blockingFuture.complete(channel.requestBufferBlocking());
+                                } catch (Exception e) {
+                                    blockingFuture.completeExceptionally(e);
+                                }
+                            });
+            blockingThread.start();
+
+            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+            while (blockingThread.getState() != Thread.State.WAITING
+                    && System.nanoTime() < deadline) {
+                Thread.onSpinWait();
+            }
+            assertThat(blockingFuture.isDone()).isFalse();
+
+            // Recycle one buffer; blocking thread then gets a pool buffer.
+            allBuffers.remove(0).recycleBuffer();
+            Buffer poolBuffer = blockingFuture.get(5, TimeUnit.SECONDS);
+            assertThat(poolBuffer).isNotNull();
+            poolBuffer.recycleBuffer();
+
+            for (Buffer b : allBuffers) {
+                b.recycleBuffer();
+            }
+            blockingThread.join(5000);
+            filteringGate.close();
+        } finally {
+            environment.close();
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannelTest.java
@@ -88,7 +88,9 @@ class RecoveredInputChannelTest {
                 .hasMessageContaining("buffer filtering is not complete");
 
         // After finishReadRecoveredState(), bufferFilteringCompleteFuture should be done
-        channel.finishReadRecoveredState();
+        synchronized (channel.inputGate.getGateLock()) {
+            channel.finishReadRecoveredState();
+        }
         assertThat(channel.getBufferFilteringCompleteFuture()).isDone();
         assertThat(channel.getStateConsumedFuture()).isNotDone();
 
@@ -110,7 +112,9 @@ class RecoveredInputChannelTest {
 
         // After finishReadRecoveredState(), bufferFilteringCompleteFuture is done
         // but stateConsumedFuture is not
-        channel.finishReadRecoveredState();
+        synchronized (channel.inputGate.getGateLock()) {
+            channel.finishReadRecoveredState();
+        }
         assertThat(channel.getBufferFilteringCompleteFuture()).isDone();
         assertThat(channel.getStateConsumedFuture()).isNotDone();
 
@@ -120,7 +124,9 @@ class RecoveredInputChannelTest {
                 .hasMessageContaining("recovered state is not fully consumed");
 
         // Consume the EndOfInputChannelStateEvent to complete stateConsumedFuture
-        assertThat(channel.getNextBuffer()).isNotPresent();
+        synchronized (channel.inputGate.getGateLock()) {
+            assertThat(channel.getNextBuffer()).isNotPresent();
+        }
         assertThat(channel.getStateConsumedFuture()).isDone();
 
         // Now conversion should succeed
@@ -134,7 +140,9 @@ class RecoveredInputChannelTest {
         for (boolean configEnabled : new boolean[] {true, false}) {
             RecoveredInputChannel channel = buildChannel(configEnabled);
             assertThat(channel.getBufferFilteringCompleteFuture()).isNotDone();
-            channel.finishReadRecoveredState();
+            synchronized (channel.inputGate.getGateLock()) {
+                channel.finishReadRecoveredState();
+            }
             assertThat(channel.getBufferFilteringCompleteFuture()).isDone();
         }
     }
@@ -148,12 +156,16 @@ class RecoveredInputChannelTest {
 
             assertThat(channel.getStateConsumedFuture()).isNotDone();
 
-            channel.finishReadRecoveredState();
+            synchronized (channel.inputGate.getGateLock()) {
+                channel.finishReadRecoveredState();
+            }
             assertThat(channel.getStateConsumedFuture()).isNotDone();
 
             // Consuming the EndOfInputChannelStateEvent should complete the future.
             // getNextBuffer() returns empty when it encounters the event internally.
-            assertThat(channel.getNextBuffer()).isNotPresent();
+            synchronized (channel.inputGate.getGateLock()) {
+                assertThat(channel.getNextBuffer()).isNotPresent();
+            }
             assertThat(channel.getStateConsumedFuture()).isDone();
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannelTest.java
@@ -33,7 +33,6 @@ import org.apache.flink.runtime.memory.MemoryManager;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -254,7 +253,8 @@ class RecoveredInputChannelTest {
                     new SimpleCounter(),
                     10) {
                 @Override
-                protected InputChannel toInputChannelInternal(ArrayDeque<Buffer> remainingBuffers) {
+                protected InputChannel toInputChannelInternal(
+                        RecoveredBufferStoreImpl recoveredStore) {
                     throw new AssertionError("channel conversion succeeded");
                 }
             };
@@ -295,7 +295,7 @@ class RecoveredInputChannelTest {
         }
 
         @Override
-        protected InputChannel toInputChannelInternal(ArrayDeque<Buffer> remainingBuffers) {
+        protected InputChannel toInputChannelInternal(RecoveredBufferStoreImpl recoveredStore) {
             return new TestInputChannel(inputGate, 0);
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
@@ -2204,8 +2204,12 @@ class RemoteInputChannelTest {
         SingleInputGate inputGate = createSingleInputGate(1);
 
         RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(new InputChannelInfo(0, 0));
-        synchronized (store) { store.addBuffer(TestBufferFactory.createBuffer(10)); }
-        synchronized (store) { store.addBuffer(TestBufferFactory.createBuffer(20)); }
+        synchronized (store) {
+            store.addBuffer(TestBufferFactory.createBuffer(10));
+        }
+        synchronized (store) {
+            store.addBuffer(TestBufferFactory.createBuffer(20));
+        }
 
         ConnectionID connectionId =
                 new ConnectionID(
@@ -2255,8 +2259,12 @@ class RemoteInputChannelTest {
         SingleInputGate inputGate = createSingleInputGate(1);
 
         RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(new InputChannelInfo(0, 0));
-        synchronized (store) { store.addBuffer(TestBufferFactory.createBuffer(10)); }
-        synchronized (store) { store.addBuffer(TestBufferFactory.createBuffer(20)); }
+        synchronized (store) {
+            store.addBuffer(TestBufferFactory.createBuffer(10));
+        }
+        synchronized (store) {
+            store.addBuffer(TestBufferFactory.createBuffer(20));
+        }
 
         ConnectionID connectionId =
                 new ConnectionID(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
@@ -2244,8 +2244,7 @@ class RemoteInputChannelTest {
     }
 
     @Test
-    void testNextDataTypeReflectsReceivedBuffersWhenRecoveredStoreExhausted()
-            throws Exception {
+    void testNextDataTypeReflectsReceivedBuffersWhenRecoveredStoreExhausted() throws Exception {
         // When the very last tryTake empties the recovered store but receivedBuffers
         // already has a buffer queued by onBuffer (this happens in production when the
         // channel was already in inputChannelsWithData with the bit set, so the

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
@@ -163,6 +163,95 @@ class RemoteInputChannelTest {
     }
 
     @Test
+    void testPriorityFlagSetUnderLockOnPriorityEnqueue() throws Exception {
+        // Producer-side invariant: when onBuffer enqueues a priority element under the
+        // receivedBuffers lock, hasPendingPriorityEvent is also set true *inside* that same
+        // synchronized block. Externally observable consequence: the flag is already true the
+        // moment onBuffer returns to its caller (network thread), with no window in which the
+        // priority element is queued but the flag is still false.
+        SingleInputGate inputGate = createSingleInputGate(1);
+        RemoteInputChannel inputChannel = createRemoteInputChannel(inputGate);
+        inputGate.setInputChannels(inputChannel);
+        inputChannel.requestSubpartitions();
+
+        Buffer priority =
+                toBuffer(
+                        new CheckpointBarrier(
+                                CHECKPOINT_ID,
+                                System.currentTimeMillis(),
+                                CheckpointOptions.unaligned(CHECKPOINT, getDefault())),
+                        true);
+        inputChannel.onBuffer(priority, 0, -1, 0);
+
+        assertThat(getHasPendingPriorityEvent(inputChannel)).isTrue();
+
+        inputChannel.releaseAllResources();
+    }
+
+    @Test
+    void testNormalPathPollClearsPriorityFlagInvariant() throws Exception {
+        // Consumer-side invariant: if a normal-path getNextBuffer drains the last priority
+        // element via PrioritizedDeque.poll() (which can happen when a stale `false` read of
+        // the flag routes the consumer through the normal path), the same synchronized block
+        // resets the flag so a subsequent producer flag write cannot leave the channel in a
+        // `flag=true && numPriorityElements==0` state.
+        //
+        // We simulate the "stale read sent the consumer down the normal path" outcome by
+        // manually clearing the flag (post-onBuffer) before calling getNextBuffer, so the
+        // consumer's `if (hasPendingPriorityEvent)` check sees false and falls through to the
+        // normal poll. The point under test is what getNextBuffer does under its receivedBuffers
+        // lock, not the upstream stale-read window itself.
+        SingleInputGate inputGate = createSingleInputGate(1);
+        RemoteInputChannel inputChannel = createRemoteInputChannel(inputGate);
+        inputGate.setInputChannels(inputChannel);
+        inputChannel.requestSubpartitions();
+
+        Buffer priority =
+                toBuffer(
+                        new CheckpointBarrier(
+                                CHECKPOINT_ID,
+                                System.currentTimeMillis(),
+                                CheckpointOptions.unaligned(CHECKPOINT, getDefault())),
+                        true);
+        inputChannel.onBuffer(priority, 0, -1, 0);
+        // Force the consumer into the normal path even though a priority element is queued.
+        setHasPendingPriorityEvent(inputChannel, false);
+
+        Optional<BufferAndAvailability> first = inputChannel.getNextBuffer();
+        assertThat(first).isPresent();
+        assertThat(first.get().buffer().getDataType().hasPriority()).isTrue();
+        assertThat(getHasPendingPriorityEvent(inputChannel)).isFalse();
+
+        // Subsequent DATA must not trip the priority invariant: with the flag correctly cleared
+        // by the previous normal-path poll, the consumer takes the normal path again.
+        Buffer dataBuffer = createBuffer(TestBufferFactory.BUFFER_SIZE);
+        inputChannel.onBuffer(dataBuffer, 1, -1, 0);
+
+        Optional<BufferAndAvailability> second = inputChannel.getNextBuffer();
+        assertThat(second).isPresent();
+        assertThat(second.get().buffer().getDataType()).isEqualTo(DataType.DATA_BUFFER);
+        assertThat(getHasPendingPriorityEvent(inputChannel)).isFalse();
+
+        inputChannel.releaseAllResources();
+    }
+
+    private static void setHasPendingPriorityEvent(RemoteInputChannel channel, boolean value)
+            throws ReflectiveOperationException {
+        java.lang.reflect.Field f =
+                RemoteInputChannel.class.getDeclaredField("hasPendingPriorityEvent");
+        f.setAccessible(true);
+        f.setBoolean(channel, value);
+    }
+
+    private static boolean getHasPendingPriorityEvent(RemoteInputChannel channel)
+            throws ReflectiveOperationException {
+        java.lang.reflect.Field f =
+                RemoteInputChannel.class.getDeclaredField("hasPendingPriorityEvent");
+        f.setAccessible(true);
+        return f.getBoolean(channel);
+    }
+
+    @Test
     void testExceptionOnReordering() throws Exception {
         // Setup
         final SingleInputGate inputGate = createSingleInputGate(1);
@@ -2075,13 +2164,48 @@ class RemoteInputChannelTest {
     }
 
     @Test
-    void testGetNextBufferWithMigratedRecoveredBuffers() throws Exception {
-        // given: RemoteInputChannel with recovered buffers migrated from RecoveredInputChannel
+    void testNullRecoveredStoreDefaultsToEmpty() throws Exception {
+        // When no recovered data is passed (null), the constructor must substitute EMPTY.
+        // releaseAllResources() must not throw (EMPTY.releaseAll() is a no-op).
+        SingleInputGate inputGate = createSingleInputGate(1);
+        ConnectionID connectionId =
+                new ConnectionID(
+                        org.apache.flink.runtime.clusterframework.types.ResourceID.generate(),
+                        new java.net.InetSocketAddress("localhost", 0),
+                        0);
+        RemoteInputChannel channel =
+                new RemoteInputChannel(
+                        inputGate,
+                        0,
+                        new ResultPartitionID(),
+                        new ResultSubpartitionIndexSet(0),
+                        connectionId,
+                        InputChannelTestUtils.mockConnectionManagerWithPartitionRequestClient(
+                                mock(PartitionRequestClient.class)),
+                        0,
+                        0,
+                        0,
+                        2 /* initialCredit */,
+                        new SimpleCounter(),
+                        new SimpleCounter(),
+                        ChannelStateWriter.NO_OP,
+                        RecoveredBufferStore.EMPTY);
+
+        inputGate.setInputChannels(channel);
+
+        assertThat(channel.getInitialCredit()).isEqualTo(2);
+        // releaseAllResources() must not throw (EMPTY.releaseAll() is a no-op).
+        channel.releaseAllResources();
+    }
+
+    @Test
+    void testGetNextBufferWithRecoveredStore() throws Exception {
+        // given: RemoteInputChannel with recovered buffers in a store
         SingleInputGate inputGate = createSingleInputGate(1);
 
-        ArrayDeque<Buffer> recoveredBuffers = new ArrayDeque<>();
-        recoveredBuffers.add(TestBufferFactory.createBuffer(10));
-        recoveredBuffers.add(TestBufferFactory.createBuffer(20));
+        RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(new InputChannelInfo(0, 0));
+        store.addBuffer(TestBufferFactory.createBuffer(10));
+        store.addBuffer(TestBufferFactory.createBuffer(20));
 
         ConnectionID connectionId =
                 new ConnectionID(
@@ -2104,7 +2228,7 @@ class RemoteInputChannelTest {
                         new SimpleCounter(),
                         new SimpleCounter(),
                         ChannelStateWriter.NO_OP,
-                        recoveredBuffers);
+                        store);
 
         inputGate.setInputChannels(channel);
 
@@ -2117,6 +2241,78 @@ class RemoteInputChannelTest {
         Optional<BufferAndAvailability> second = channel.getNextBuffer();
         assertThat(second).isPresent();
         assertThat(second.get().buffer().getSize()).isEqualTo(20);
+    }
+
+    @Test
+    void testNextDataTypeReflectsReceivedBuffersWhenRecoveredStoreExhausted()
+            throws Exception {
+        // When the very last tryTake empties the recovered store but receivedBuffers
+        // already has a buffer queued by onBuffer (this happens in production when the
+        // channel was already in inputChannelsWithData with the bit set, so the
+        // notifyChannelNonEmpty triggered by onBuffer is short-circuited by
+        // alreadyEnqueued), getNextBuffer must surface the receivedBuffers head as the
+        // next data type so moreAvailable() == true and the gate keeps the channel
+        // enqueued. Otherwise the queued buffer becomes invisible to the gate.
+        SingleInputGate inputGate = createSingleInputGate(1);
+
+        RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(new InputChannelInfo(0, 0));
+        store.addBuffer(TestBufferFactory.createBuffer(10));
+        store.addBuffer(TestBufferFactory.createBuffer(20));
+
+        ConnectionID connectionId =
+                new ConnectionID(
+                        org.apache.flink.runtime.clusterframework.types.ResourceID.generate(),
+                        new java.net.InetSocketAddress("localhost", 0),
+                        0);
+        RemoteInputChannel channel =
+                new RemoteInputChannel(
+                        inputGate,
+                        0,
+                        new ResultPartitionID(),
+                        new ResultSubpartitionIndexSet(0),
+                        connectionId,
+                        InputChannelTestUtils.mockConnectionManagerWithPartitionRequestClient(
+                                mock(PartitionRequestClient.class)),
+                        0,
+                        0,
+                        0,
+                        2,
+                        new SimpleCounter(),
+                        new SimpleCounter(),
+                        ChannelStateWriter.NO_OP,
+                        store);
+
+        inputGate.setInputChannels(channel);
+        channel.requestSubpartitions();
+
+        // First take: store still has one more, moreAvailable=true (purely from store).
+        Optional<BufferAndAvailability> first = channel.getNextBuffer();
+        assertThat(first).isPresent();
+        assertThat(first.get().moreAvailable()).isTrue();
+        first.get().buffer().recycleBuffer();
+
+        // Producer-side message arrives via the network thread and lands in
+        // receivedBuffers. The data type is irrelevant for this assertion (production
+        // hits this with RECOVERY_COMPLETION but any non-priority buffer reproduces it).
+        Buffer received = TestBufferFactory.createBuffer(30);
+        channel.onBuffer(received, 0, 0, 0);
+
+        // Last take from the recovered store. Without the fix the next-data-type peek
+        // only consults the recovered store and returns NONE — the gate then sees
+        // moreAvailable=false and never re-enqueues the channel.
+        Optional<BufferAndAvailability> second = channel.getNextBuffer();
+        assertThat(second).isPresent();
+        assertThat(second.get().moreAvailable())
+                .as(
+                        "moreAvailable must reflect receivedBuffers when the recovered store is exhausted")
+                .isTrue();
+        second.get().buffer().recycleBuffer();
+
+        // Sanity: the buffer queued via onBuffer is still consumable from the post-recovery path.
+        Optional<BufferAndAvailability> third = channel.getNextBuffer();
+        assertThat(third).isPresent();
+        assertThat(third.get().buffer().getSize()).isEqualTo(30);
+        third.get().buffer().recycleBuffer();
     }
 
     private static final class TestBufferPool extends NoOpBufferPool {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
@@ -2204,8 +2204,8 @@ class RemoteInputChannelTest {
         SingleInputGate inputGate = createSingleInputGate(1);
 
         RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(new InputChannelInfo(0, 0));
-        store.addBuffer(TestBufferFactory.createBuffer(10));
-        store.addBuffer(TestBufferFactory.createBuffer(20));
+        synchronized (store) { store.addBuffer(TestBufferFactory.createBuffer(10)); }
+        synchronized (store) { store.addBuffer(TestBufferFactory.createBuffer(20)); }
 
         ConnectionID connectionId =
                 new ConnectionID(
@@ -2255,8 +2255,8 @@ class RemoteInputChannelTest {
         SingleInputGate inputGate = createSingleInputGate(1);
 
         RecoveredBufferStoreImpl store = new RecoveredBufferStoreImpl(new InputChannelInfo(0, 0));
-        store.addBuffer(TestBufferFactory.createBuffer(10));
-        store.addBuffer(TestBufferFactory.createBuffer(20));
+        synchronized (store) { store.addBuffer(TestBufferFactory.createBuffer(10)); }
+        synchronized (store) { store.addBuffer(TestBufferFactory.createBuffer(20)); }
 
         ConnectionID connectionId =
                 new ConnectionID(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGateTest.java
@@ -325,9 +325,7 @@ class UnionInputGateTest extends InputGateTestBase {
                 new SimpleCounter(),
                 10) {
             @Override
-            protected InputChannel toInputChannelInternal(
-                    java.util.ArrayDeque<org.apache.flink.runtime.io.network.buffer.Buffer>
-                            remainingBuffers) {
+            protected InputChannel toInputChannelInternal(RecoveredBufferStoreImpl recoveredStore) {
                 throw new UnsupportedOperationException();
             }
         };

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGateTest.java
@@ -300,12 +300,16 @@ class UnionInputGateTest extends InputGateTestBase {
         assertThat(union.getStateConsumedFuture()).isNotDone();
 
         // Complete buffer filtering on first gate only
-        channel1.finishReadRecoveredState();
+        synchronized (ig1.getGateLock()) {
+            channel1.finishReadRecoveredState();
+        }
         assertThat(ig1.getBufferFilteringCompleteFuture()).isDone();
         assertThat(union.getBufferFilteringCompleteFuture()).isNotDone();
 
         // Complete buffer filtering on second gate
-        channel2.finishReadRecoveredState();
+        synchronized (ig2.getGateLock()) {
+            channel2.finishReadRecoveredState();
+        }
         assertThat(ig2.getBufferFilteringCompleteFuture()).isDone();
         assertThat(union.getBufferFilteringCompleteFuture()).isDone();
 

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/SingleInputGateBenchmarkFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/SingleInputGateBenchmarkFactory.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartitionIndexSet;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannel;
 import org.apache.flink.runtime.io.network.partition.consumer.LocalInputChannel;
+import org.apache.flink.runtime.io.network.partition.consumer.RecoveredBufferStore;
 import org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannel;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateFactory;
@@ -37,7 +38,6 @@ import org.apache.flink.runtime.shuffle.NettyShuffleDescriptor;
 import org.apache.flink.runtime.taskmanager.NettyShuffleEnvironmentConfiguration;
 
 import java.io.IOException;
-import java.util.ArrayDeque;
 
 /**
  * A benchmark-specific input gate factory which overrides the respective methods of creating {@link
@@ -130,7 +130,7 @@ public class SingleInputGateBenchmarkFactory extends SingleInputGateFactory {
                     metrics.getNumBytesInLocalCounter(),
                     metrics.getNumBuffersInLocalCounter(),
                     ChannelStateWriter.NO_OP,
-                    new ArrayDeque<>());
+                    RecoveredBufferStore.EMPTY);
         }
 
         @Override
@@ -186,7 +186,7 @@ public class SingleInputGateBenchmarkFactory extends SingleInputGateFactory {
                     metrics.getNumBytesInRemoteCounter(),
                     metrics.getNumBuffersInRemoteCounter(),
                     ChannelStateWriter.NO_OP,
-                    new ArrayDeque<>());
+                    RecoveredBufferStore.EMPTY);
         }
 
         @Override


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
