### PR TITLE
[FLINK-39585][runtime] Log execution graph creation failures at ERROR Level

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/CreatingExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/CreatingExecutionGraph.java
@@ -95,7 +95,7 @@ public class CreatingExecutionGraph extends StateWithoutExecutionGraph {
             @Nullable Throwable throwable) {
         if (throwable != null) {
             getLogger()
-                    .info(
+                    .error(
                             "Failed to go from {} to {} because the ExecutionGraph creation failed.",
                             CreatingExecutionGraph.class.getSimpleName(),
                             Executing.class.getSimpleName(),


### PR DESCRIPTION
## What is the purpose of the change

Promotes the single failure log in `CreatingExecutionGraph#handleExecutionGraphCreation` from INFO to ERROR. A non-null throwable here means the AdaptiveScheduler couldn't build/restore the ExecutionGraph and the job is immediately transitioned to FAILED. Therefore, ERROR is the appropriate severity for that root-cause line.

## Brief change log

*   `CreatingExecutionGraph.java`: change the throwable-branch log call from `info(...)` to `error(...)`.

## Verifying this change

This change is a trivial logging-severity adjustment without any test coverage.

## Documentation

*   Does this pull request introduce a new feature? no
*   If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

*   [ ] Yes (please specify the tool below)