### PR TITLE
[FLINK-39590] connection catalog manager changes

### DIFF
--- a/flink-python/pyflink/table/tests/test_catalog_completeness.py
+++ b/flink-python/pyflink/table/tests/test_catalog_completeness.py
@@ -45,7 +45,13 @@ class CatalogAPICompletenessTests(PythonAPICompletenessTestCase, PyFlinkTestCase
             'getFactory',
             'getTableFactory',
             'getFunctionDefinitionFactory',
-            'listPartitionsByFilter'}
+            'listPartitionsByFilter',
+            'getConnection',
+            'dropConnection',
+            'connectionExists',
+            'listConnections',
+            'createConnection',
+            'alterConnection'}
 
 
 class CatalogDatabaseAPICompletenessTests(PythonAPICompletenessTestCase, PyFlinkTestCase):

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -85,6 +85,7 @@ import org.apache.flink.table.expressions.TableReferenceExpression;
 import org.apache.flink.table.expressions.utils.ApiExpressionDefaultVisitor;
 import org.apache.flink.table.factories.ApiFactoryUtil;
 import org.apache.flink.table.factories.CatalogStoreFactory;
+import org.apache.flink.table.factories.DefaultConnectionFactory;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.factories.PlannerFactoryUtil;
 import org.apache.flink.table.factories.TableFactoryUtil;
@@ -122,6 +123,7 @@ import org.apache.flink.table.resource.ResourceType;
 import org.apache.flink.table.resource.ResourceUri;
 import org.apache.flink.table.secret.SecretStore;
 import org.apache.flink.table.secret.SecretStoreFactory;
+import org.apache.flink.table.secret.WritableSecretStore;
 import org.apache.flink.table.types.AbstractDataType;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.utils.DataTypeUtils;
@@ -275,6 +277,11 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
         final ResourceManager resourceManager =
                 new ResourceManager(settings.getConfiguration(), userClassLoader);
         final ModuleManager moduleManager = new ModuleManager();
+        final WritableSecretStore writableSecretStore =
+                secretStore instanceof WritableSecretStore
+                        ? (WritableSecretStore) secretStore
+                        : null;
+
         final CatalogManager catalogManager =
                 CatalogManager.newBuilder()
                         .classLoader(userClassLoader)
@@ -297,6 +304,8 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
                         .sqlFactory(
                                 settings.getSqlFactory()
                                         .orElseGet(() -> DefaultSqlFactory.INSTANCE))
+                        .connectionFactory(new DefaultConnectionFactory())
+                        .writableSecretStore(writableSecretStore)
                         .build();
 
         final FunctionCatalog functionCatalog =

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -85,7 +85,6 @@ import org.apache.flink.table.expressions.TableReferenceExpression;
 import org.apache.flink.table.expressions.utils.ApiExpressionDefaultVisitor;
 import org.apache.flink.table.factories.ApiFactoryUtil;
 import org.apache.flink.table.factories.CatalogStoreFactory;
-import org.apache.flink.table.factories.DefaultConnectionFactory;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.factories.PlannerFactoryUtil;
 import org.apache.flink.table.factories.TableFactoryUtil;
@@ -304,7 +303,6 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
                         .sqlFactory(
                                 settings.getSqlFactory()
                                         .orElseGet(() -> DefaultSqlFactory.INSTANCE))
-                        .connectionFactory(new DefaultConnectionFactory())
                         .writableSecretStore(writableSecretStore)
                         .build();
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -43,14 +43,17 @@ import org.apache.flink.table.catalog.exceptions.ModelNotExistException;
 import org.apache.flink.table.catalog.exceptions.PartitionNotExistException;
 import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.TableNotExistException;
+import org.apache.flink.table.catalog.listener.AlterConnectionEvent;
 import org.apache.flink.table.catalog.listener.AlterDatabaseEvent;
 import org.apache.flink.table.catalog.listener.AlterModelEvent;
 import org.apache.flink.table.catalog.listener.AlterTableEvent;
 import org.apache.flink.table.catalog.listener.CatalogContext;
 import org.apache.flink.table.catalog.listener.CatalogModificationListener;
+import org.apache.flink.table.catalog.listener.CreateConnectionEvent;
 import org.apache.flink.table.catalog.listener.CreateDatabaseEvent;
 import org.apache.flink.table.catalog.listener.CreateModelEvent;
 import org.apache.flink.table.catalog.listener.CreateTableEvent;
+import org.apache.flink.table.catalog.listener.DropConnectionEvent;
 import org.apache.flink.table.catalog.listener.DropDatabaseEvent;
 import org.apache.flink.table.catalog.listener.DropModelEvent;
 import org.apache.flink.table.catalog.listener.DropTableEvent;
@@ -63,7 +66,9 @@ import org.apache.flink.table.factories.ConnectionFactory;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.QueryOperation;
+import org.apache.flink.table.secret.GenericInMemorySecretStore;
 import org.apache.flink.table.secret.WritableSecretStore;
+import org.apache.flink.table.secret.exceptions.SecretException;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.StringUtils;
 
@@ -102,6 +107,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 @Internal
 public final class CatalogManager implements CatalogRegistry, AutoCloseable {
+
     private static final Logger LOG = LoggerFactory.getLogger(CatalogManager.class);
 
     // A map between names and catalogs.
@@ -118,6 +124,11 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
     // Those connections take precedence over corresponding permanent connections, thus they shadow
     // connections coming from catalogs.
     private final Map<ObjectIdentifier, CatalogConnection> temporaryConnections;
+
+    // Backing store for secrets of temporary connections. Lifetime is tied to this
+    // CatalogManager — temporary connections are session-scoped, so their secrets should not
+    // be persisted in the configured (potentially persistent) writableSecretStore.
+    private final WritableSecretStore temporarySecretStore;
 
     // The name of the current catalog and database
     private @Nullable String currentCatalogName;
@@ -167,6 +178,7 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
         temporaryTables = new HashMap<>();
         temporaryModels = new HashMap<>();
         temporaryConnections = new HashMap<>();
+        temporarySecretStore = new GenericInMemorySecretStore();
 
         // right now the default catalog is always the built-in one
         builtInCatalogName = defaultCatalogName;
@@ -1842,8 +1854,9 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
         if (catalog.isPresent()) {
             try {
                 return Optional.of(catalog.get().getConnection(objectIdentifier.toObjectPath()));
-            } catch (Exception e) {
-                // Connection does not exist
+            } catch (ConnectionNotExistException | UnsupportedOperationException e) {
+                // ConnectionNotExistException: connection does not exist in this catalog.
+                // UnsupportedOperationException: catalog does not support connections.
                 return Optional.empty();
             }
         } else {
@@ -1906,14 +1919,46 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
             throw new ValidationException(
                     "ConnectionFactory and WritableSecretStore must be configured to create connections.");
         }
+        if (getConnection(objectIdentifier).isPresent()) {
+            if (ignoreIfExists) {
+                return;
+            }
+            throw new ValidationException(
+                    String.format(
+                            "Connection with identifier '%s' already exists.",
+                            objectIdentifier.asSummaryString()));
+        }
         final CatalogConnection catalogConnection =
                 connectionFactory.createConnection(connection, writableSecretStore);
-        execute(
-                (catalog, path) ->
-                        catalog.createConnection(path, catalogConnection, ignoreIfExists),
-                objectIdentifier,
-                ignoreIfExists,
-                "CreateConnection");
+        boolean persisted = false;
+        try {
+            execute(
+                    (catalog, path) -> {
+                        catalog.createConnection(path, catalogConnection, ignoreIfExists);
+                        catalogModificationListeners.forEach(
+                                listener ->
+                                        listener.onEvent(
+                                                CreateConnectionEvent.createEvent(
+                                                        CatalogContext.createContext(
+                                                                objectIdentifier.getCatalogName(),
+                                                                catalog),
+                                                        objectIdentifier,
+                                                        catalogConnection,
+                                                        ignoreIfExists,
+                                                        false)));
+                    },
+                    objectIdentifier,
+                    ignoreIfExists,
+                    "CreateConnection");
+            persisted = true;
+        } finally {
+            if (!persisted) {
+                tryDeleteSecrets(
+                        catalogConnection,
+                        writableSecretStore,
+                        "rollback createConnection " + objectIdentifier);
+            }
+        }
     }
 
     /**
@@ -1927,27 +1972,33 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
             SensitiveConnection connection,
             ObjectIdentifier objectIdentifier,
             boolean ignoreIfExists) {
-        if (connectionFactory == null || writableSecretStore == null) {
+        if (connectionFactory == null) {
             throw new ValidationException(
-                    "ConnectionFactory and WritableSecretStore must be configured to create connections.");
+                    "ConnectionFactory must be configured to create connections.");
         }
+        if (temporaryConnections.containsKey(objectIdentifier)) {
+            if (ignoreIfExists) {
+                return;
+            }
+            throw new ValidationException(
+                    String.format("Temporary connection '%s' already exists", objectIdentifier));
+        }
+        // Temporary connections are session-scoped; store secrets in an in-memory store rather
+        // than the configured (potentially persistent) writableSecretStore.
         final CatalogConnection catalogConnection =
-                connectionFactory.createConnection(connection, writableSecretStore);
-        temporaryConnections.compute(
-                objectIdentifier,
-                (k, v) -> {
-                    if (v != null) {
-                        if (!ignoreIfExists) {
-                            throw new ValidationException(
-                                    String.format(
-                                            "Temporary connection '%s' already exists",
-                                            objectIdentifier));
-                        }
-                        return v;
-                    } else {
-                        return catalogConnection;
-                    }
-                });
+                connectionFactory.createConnection(connection, temporarySecretStore);
+        temporaryConnections.put(objectIdentifier, catalogConnection);
+        Catalog catalog = getCatalog(objectIdentifier.getCatalogName()).orElse(null);
+        catalogModificationListeners.forEach(
+                listener ->
+                        listener.onEvent(
+                                CreateConnectionEvent.createEvent(
+                                        CatalogContext.createContext(
+                                                objectIdentifier.getCatalogName(), catalog),
+                                        objectIdentifier,
+                                        catalogConnection,
+                                        ignoreIfExists,
+                                        true)));
     }
 
     /**
@@ -1966,15 +2017,48 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
             throw new ValidationException(
                     "ConnectionFactory and WritableSecretStore must be configured to alter connections.");
         }
-        execute(
-                (catalog, path) -> {
-                    final CatalogConnection catalogConnection =
-                            connectionFactory.createConnection(newConnection, writableSecretStore);
-                    catalog.alterConnection(path, catalogConnection, ignoreIfNotExists);
-                },
-                objectIdentifier,
-                ignoreIfNotExists,
-                "AlterConnection");
+        Optional<CatalogConnection> existingOpt = getConnection(objectIdentifier);
+        if (!existingOpt.isPresent()) {
+            if (ignoreIfNotExists) {
+                return;
+            }
+            throw new ValidationException(
+                    String.format(
+                            "Connection with identifier '%s' does not exist.",
+                            objectIdentifier.asSummaryString()));
+        }
+        final CatalogConnection existing = existingOpt.get();
+        final CatalogConnection newCatalogConnection =
+                connectionFactory.createConnection(newConnection, writableSecretStore);
+        boolean persisted = false;
+        try {
+            execute(
+                    (catalog, path) -> {
+                        catalog.alterConnection(path, newCatalogConnection, ignoreIfNotExists);
+                        catalogModificationListeners.forEach(
+                                listener ->
+                                        listener.onEvent(
+                                                AlterConnectionEvent.createEvent(
+                                                        CatalogContext.createContext(
+                                                                objectIdentifier.getCatalogName(),
+                                                                catalog),
+                                                        objectIdentifier,
+                                                        newCatalogConnection,
+                                                        ignoreIfNotExists)));
+                    },
+                    objectIdentifier,
+                    ignoreIfNotExists,
+                    "AlterConnection");
+            persisted = true;
+        } finally {
+            // On success: drop the OLD secret. On failure: drop the freshly-stored NEW secret.
+            tryDeleteSecrets(
+                    persisted ? existing : newCatalogConnection,
+                    writableSecretStore,
+                    persisted
+                            ? "post-alter cleanup of old secret for " + objectIdentifier
+                            : "rollback alterConnection " + objectIdentifier);
+        }
     }
 
     /**
@@ -1985,11 +2069,39 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
      *     does not exist.
      */
     public void dropConnection(ObjectIdentifier objectIdentifier, boolean ignoreIfNotExists) {
+        Optional<CatalogConnection> existingOpt = getConnection(objectIdentifier);
+        if (!existingOpt.isPresent()) {
+            if (ignoreIfNotExists) {
+                return;
+            }
+            throw new ValidationException(
+                    String.format(
+                            "Connection with identifier '%s' does not exist.",
+                            objectIdentifier.asSummaryString()));
+        }
+        final CatalogConnection existing = existingOpt.get();
         execute(
-                (catalog, path) -> catalog.dropConnection(path, ignoreIfNotExists),
+                (catalog, path) -> {
+                    catalog.dropConnection(path, ignoreIfNotExists);
+                    catalogModificationListeners.forEach(
+                            listener ->
+                                    listener.onEvent(
+                                            DropConnectionEvent.createEvent(
+                                                    CatalogContext.createContext(
+                                                            objectIdentifier.getCatalogName(),
+                                                            catalog),
+                                                    objectIdentifier,
+                                                    existing,
+                                                    ignoreIfNotExists,
+                                                    false)));
+                },
                 objectIdentifier,
                 ignoreIfNotExists,
                 "DropConnection");
+        if (connectionFactory != null && writableSecretStore != null) {
+            tryDeleteSecrets(
+                    existing, writableSecretStore, "post-drop cleanup for " + objectIdentifier);
+        }
     }
 
     /**
@@ -2004,11 +2116,45 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
         CatalogConnection connection = temporaryConnections.get(objectIdentifier);
         if (connection != null) {
             temporaryConnections.remove(objectIdentifier);
+            Catalog catalog = getCatalog(objectIdentifier.getCatalogName()).orElse(null);
+            catalogModificationListeners.forEach(
+                    listener ->
+                            listener.onEvent(
+                                    DropConnectionEvent.createEvent(
+                                            CatalogContext.createContext(
+                                                    objectIdentifier.getCatalogName(), catalog),
+                                            objectIdentifier,
+                                            connection,
+                                            ignoreIfNotExists,
+                                            true)));
+            if (connectionFactory != null) {
+                tryDeleteSecrets(
+                        connection,
+                        temporarySecretStore,
+                        "post-drop cleanup of temporary " + objectIdentifier);
+            }
         } else if (!ignoreIfNotExists) {
             throw new ValidationException(
                     String.format(
                             "Temporary connection with identifier '%s' does not exist.",
                             objectIdentifier.asSummaryString()));
+        }
+    }
+
+    /**
+     * Best-effort cleanup of a connection's secrets. The catalog state has already been mutated (or
+     * failed); a cleanup failure should not mask the user-visible result. Logs the failure (which
+     * may indicate an orphaned secret in the underlying store) and swallows the exception.
+     */
+    private void tryDeleteSecrets(
+            CatalogConnection connection, WritableSecretStore store, String context) {
+        try {
+            connectionFactory.deleteSecrets(connection, store);
+        } catch (SecretException e) {
+            LOG.warn(
+                    "Failed to delete connection secrets during {}; the catalog state is correct, but the secret may be orphaned in the secret store.",
+                    context,
+                    e);
         }
     }
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -64,6 +64,7 @@ import org.apache.flink.table.expressions.DefaultSqlFactory;
 import org.apache.flink.table.expressions.SqlFactory;
 import org.apache.flink.table.expressions.resolver.ExpressionResolver.ExpressionResolverBuilder;
 import org.apache.flink.table.factories.ConnectionFactory;
+import org.apache.flink.table.factories.DefaultConnectionFactory;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.QueryOperation;

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.catalog;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.api.CatalogNotExistException;
 import org.apache.flink.table.api.EnvironmentSettings;
@@ -197,16 +198,14 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
 
     /**
      * Discovers the {@link ConnectionFactory} for the given connection options via SPI, using the
-     * {@code type} option as the factory identifier (see FLIP-529). Falls back to {@link
-     * DefaultConnectionFactory} when the {@code type} option is absent or empty.
+     * {@link FactoryUtil#CONNECTION_TYPE} option as the factory identifier. Falls back to {@link
+     * DefaultConnectionFactory} via the option's default value when {@code type} is absent.
      *
      * @param options the options of the connection being created / altered / dropped
      * @return the discovered factory
      */
     private ConnectionFactory discoverConnectionFactory(Map<String, String> options) {
-        final String type = options.get(ConnectionFactory.CONNECTION_TYPE_KEY);
-        final String identifier =
-                (type == null || type.isEmpty()) ? DefaultConnectionFactory.IDENTIFIER : type;
+        final String identifier = Configuration.fromMap(options).get(FactoryUtil.CONNECTION_TYPE);
         return FactoryUtil.discoverFactory(userClassLoader, ConnectionFactory.class, identifier);
     }
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -1889,12 +1889,13 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
         } catch (DatabaseNotExistException e) {
             throw new ValidationException(
                     String.format(
-                            "Database %s does not exist in catalog %s.", databaseName, catalogName),
+                            "Database '%s' does not exist in catalog '%s'.",
+                            databaseName, catalogName),
                     e);
         } catch (CatalogException e) {
             throw new TableException(
                     String.format(
-                            "Failed to list connections in catalog %s and database %s.",
+                            "Failed to list connections in catalog '%s' and database '%s'.",
                             catalogName, databaseName),
                     e);
         }
@@ -1981,7 +1982,7 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
                 return;
             }
             throw new ValidationException(
-                    String.format("Temporary connection '%s' already exists", objectIdentifier));
+                    String.format("Temporary connection '%s' already exists.", objectIdentifier));
         }
         // Temporary connections are session-scoped; store secrets in an in-memory store rather
         // than the configured (potentially persistent) writableSecretStore.

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -63,7 +63,6 @@ import org.apache.flink.table.expressions.DefaultSqlFactory;
 import org.apache.flink.table.expressions.SqlFactory;
 import org.apache.flink.table.expressions.resolver.ExpressionResolver.ExpressionResolverBuilder;
 import org.apache.flink.table.factories.ConnectionFactory;
-import org.apache.flink.table.factories.DefaultConnectionFactory;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.QueryOperation;

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -33,6 +33,8 @@ import org.apache.flink.table.catalog.CatalogBaseTable.TableKind;
 import org.apache.flink.table.catalog.CatalogMaterializedTable.RefreshMode;
 import org.apache.flink.table.catalog.StartMode.StartModeKind;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
+import org.apache.flink.table.catalog.exceptions.ConnectionAlreadyExistException;
+import org.apache.flink.table.catalog.exceptions.ConnectionNotExistException;
 import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotEmptyException;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
@@ -57,9 +59,11 @@ import org.apache.flink.table.delegation.Planner;
 import org.apache.flink.table.expressions.DefaultSqlFactory;
 import org.apache.flink.table.expressions.SqlFactory;
 import org.apache.flink.table.expressions.resolver.ExpressionResolver.ExpressionResolverBuilder;
+import org.apache.flink.table.factories.ConnectionFactory;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.QueryOperation;
+import org.apache.flink.table.secret.WritableSecretStore;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.StringUtils;
 
@@ -111,6 +115,10 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
     // models coming from catalogs.
     private final Map<ObjectIdentifier, CatalogModel> temporaryModels;
 
+    // Those connections take precedence over corresponding permanent connections, thus they shadow
+    // connections coming from catalogs.
+    private final Map<ObjectIdentifier, CatalogConnection> temporaryConnections;
+
     // The name of the current catalog and database
     private @Nullable String currentCatalogName;
 
@@ -132,6 +140,10 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
 
     private final MaterializedTableEnricher materializedTableEnricher;
 
+    @Nullable private final ConnectionFactory connectionFactory;
+
+    @Nullable private final WritableSecretStore writableSecretStore;
+
     private CatalogManager(
             String defaultCatalogName,
             Catalog defaultCatalog,
@@ -139,7 +151,9 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
             List<CatalogModificationListener> catalogModificationListeners,
             CatalogStoreHolder catalogStoreHolder,
             SqlFactory sqlFactory,
-            MaterializedTableEnricher materializedTableEnricher) {
+            MaterializedTableEnricher materializedTableEnricher,
+            @Nullable ConnectionFactory connectionFactory,
+            @Nullable WritableSecretStore writableSecretStore) {
         checkArgument(
                 !StringUtils.isNullOrWhitespaceOnly(defaultCatalogName),
                 "Default catalog name cannot be null or empty");
@@ -152,6 +166,7 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
 
         temporaryTables = new HashMap<>();
         temporaryModels = new HashMap<>();
+        temporaryConnections = new HashMap<>();
 
         // right now the default catalog is always the built-in one
         builtInCatalogName = defaultCatalogName;
@@ -164,6 +179,8 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
         this.sqlFactory = sqlFactory;
         this.materializedTableEnricher =
                 checkNotNull(materializedTableEnricher, "MaterializedTableEnricher cannot be null");
+        this.connectionFactory = connectionFactory;
+        this.writableSecretStore = writableSecretStore;
     }
 
     @VisibleForTesting
@@ -202,6 +219,10 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
         private SqlFactory sqlFactory = DefaultSqlFactory.INSTANCE;
 
         private MaterializedTableEnricher materializedTableEnricher;
+
+        private @Nullable ConnectionFactory connectionFactory;
+
+        private @Nullable WritableSecretStore writableSecretStore;
 
         public Builder classLoader(ClassLoader classLoader) {
             this.classLoader = classLoader;
@@ -251,6 +272,16 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
             return this;
         }
 
+        public Builder connectionFactory(@Nullable ConnectionFactory connectionFactory) {
+            this.connectionFactory = connectionFactory;
+            return this;
+        }
+
+        public Builder writableSecretStore(@Nullable WritableSecretStore writableSecretStore) {
+            this.writableSecretStore = writableSecretStore;
+            return this;
+        }
+
         public CatalogManager build() {
             checkNotNull(classLoader, "Class loader cannot be null");
             checkNotNull(config, "Config cannot be null");
@@ -271,7 +302,9 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
                     sqlFactory,
                     materializedTableEnricher != null
                             ? materializedTableEnricher
-                            : createDefaultMaterializedTableEnricher());
+                            : createDefaultMaterializedTableEnricher(),
+                    connectionFactory,
+                    writableSecretStore);
         }
 
         private MaterializedTableEnricher createDefaultMaterializedTableEnricher() {
@@ -1791,6 +1824,194 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
         return ResolvedCatalogModel.of(model, resolvedInputSchema, resolvedOutputSchema);
     }
 
+    // ------ connections ------
+
+    /**
+     * Get a connection from the catalog with the given object identifier.
+     *
+     * @param objectIdentifier The fully qualified path of the connection.
+     * @return The requested connection wrapped in Optional.
+     */
+    public Optional<CatalogConnection> getConnection(ObjectIdentifier objectIdentifier) {
+        CatalogConnection temporaryConnection = temporaryConnections.get(objectIdentifier);
+        if (temporaryConnection != null) {
+            return Optional.of(temporaryConnection);
+        }
+
+        Optional<Catalog> catalog = getCatalog(objectIdentifier.getCatalogName());
+        if (catalog.isPresent()) {
+            try {
+                return Optional.of(catalog.get().getConnection(objectIdentifier.toObjectPath()));
+            } catch (Exception e) {
+                // Connection does not exist
+                return Optional.empty();
+            }
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * List all connections in the given catalog and database.
+     *
+     * @param catalogName The name of the catalog.
+     * @param databaseName The name of the database.
+     * @return A set of connection names.
+     */
+    public Set<String> listConnections(String catalogName, String databaseName) {
+        Catalog catalog = getCatalogOrError(catalogName);
+        try {
+            Set<String> connections = new HashSet<>(catalog.listConnections(databaseName));
+
+            // Add temporary connections for this catalog and database
+            temporaryConnections.keySet().stream()
+                    .filter(
+                            identifier ->
+                                    identifier.getCatalogName().equals(catalogName)
+                                            && identifier.getDatabaseName().equals(databaseName))
+                    .map(ObjectIdentifier::getObjectName)
+                    .forEach(connections::add);
+
+            return connections;
+        } catch (DatabaseNotExistException e) {
+            throw new ValidationException(
+                    String.format(
+                            "Database %s does not exist in catalog %s.", databaseName, catalogName),
+                    e);
+        } catch (CatalogException e) {
+            throw new TableException(
+                    String.format(
+                            "Failed to list connections in catalog %s and database %s.",
+                            catalogName, databaseName),
+                    e);
+        }
+    }
+
+    /**
+     * Create a permanent connection in the given fully qualified path.
+     *
+     * <p>If a {@link ConnectionFactory} and {@link WritableSecretStore} are configured, sensitive
+     * fields are extracted from the connection and stored in the secret store before persisting the
+     * non-sensitive {@link CatalogConnection} to the catalog.
+     *
+     * @param connection The connection with all options including sensitive fields.
+     * @param objectIdentifier The fully qualified path where to create the connection.
+     * @param ignoreIfExists If false exception will be thrown if the connection already exists.
+     */
+    public void createConnection(
+            SensitiveConnection connection,
+            ObjectIdentifier objectIdentifier,
+            boolean ignoreIfExists) {
+        if (connectionFactory == null || writableSecretStore == null) {
+            throw new ValidationException(
+                    "ConnectionFactory and WritableSecretStore must be configured to create connections.");
+        }
+        final CatalogConnection catalogConnection =
+                connectionFactory.createConnection(connection, writableSecretStore);
+        execute(
+                (catalog, path) ->
+                        catalog.createConnection(path, catalogConnection, ignoreIfExists),
+                objectIdentifier,
+                ignoreIfExists,
+                "CreateConnection");
+    }
+
+    /**
+     * Create a temporary connection in the given fully qualified path.
+     *
+     * @param connection The connection with all options including sensitive fields.
+     * @param objectIdentifier The fully qualified path where to create the connection.
+     * @param ignoreIfExists If false exception will be thrown if the connection already exists.
+     */
+    public void createTemporaryConnection(
+            SensitiveConnection connection,
+            ObjectIdentifier objectIdentifier,
+            boolean ignoreIfExists) {
+        if (connectionFactory == null || writableSecretStore == null) {
+            throw new ValidationException(
+                    "ConnectionFactory and WritableSecretStore must be configured to create connections.");
+        }
+        final CatalogConnection catalogConnection =
+                connectionFactory.createConnection(connection, writableSecretStore);
+        temporaryConnections.compute(
+                objectIdentifier,
+                (k, v) -> {
+                    if (v != null) {
+                        if (!ignoreIfExists) {
+                            throw new ValidationException(
+                                    String.format(
+                                            "Temporary connection '%s' already exists",
+                                            objectIdentifier));
+                        }
+                        return v;
+                    } else {
+                        return catalogConnection;
+                    }
+                });
+    }
+
+    /**
+     * Alter a connection in the given fully qualified path.
+     *
+     * @param newConnection The new connection containing changes.
+     * @param objectIdentifier The fully qualified path where to alter the connection.
+     * @param ignoreIfNotExists If false exception will be thrown if the connection to be altered
+     *     does not exist.
+     */
+    public void alterConnection(
+            SensitiveConnection newConnection,
+            ObjectIdentifier objectIdentifier,
+            boolean ignoreIfNotExists) {
+        if (connectionFactory == null || writableSecretStore == null) {
+            throw new ValidationException(
+                    "ConnectionFactory and WritableSecretStore must be configured to alter connections.");
+        }
+        execute(
+                (catalog, path) -> {
+                    final CatalogConnection catalogConnection =
+                            connectionFactory.createConnection(newConnection, writableSecretStore);
+                    catalog.alterConnection(path, catalogConnection, ignoreIfNotExists);
+                },
+                objectIdentifier,
+                ignoreIfNotExists,
+                "AlterConnection");
+    }
+
+    /**
+     * Drop a permanent connection from the given fully qualified path.
+     *
+     * @param objectIdentifier The fully qualified path of the connection to be dropped.
+     * @param ignoreIfNotExists If false exception will be thrown if the connection to be dropped
+     *     does not exist.
+     */
+    public void dropConnection(ObjectIdentifier objectIdentifier, boolean ignoreIfNotExists) {
+        execute(
+                (catalog, path) -> catalog.dropConnection(path, ignoreIfNotExists),
+                objectIdentifier,
+                ignoreIfNotExists,
+                "DropConnection");
+    }
+
+    /**
+     * Drop a temporary connection from the given fully qualified path.
+     *
+     * @param objectIdentifier The fully qualified path of the connection to be dropped.
+     * @param ignoreIfNotExists If false exception will be thrown if the connection to be dropped
+     *     does not exist.
+     */
+    public void dropTemporaryConnection(
+            ObjectIdentifier objectIdentifier, boolean ignoreIfNotExists) {
+        CatalogConnection connection = temporaryConnections.get(objectIdentifier);
+        if (connection != null) {
+            temporaryConnections.remove(objectIdentifier);
+        } else if (!ignoreIfNotExists) {
+            throw new ValidationException(
+                    String.format(
+                            "Temporary connection with identifier '%s' does not exist.",
+                            objectIdentifier.asSummaryString()));
+        }
+    }
+
     /**
      * A command that modifies given {@link Catalog} in an {@link ObjectPath}. This unifies error
      * handling across different commands.
@@ -1813,6 +2034,8 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
                     | TableNotExistException
                     | ModelNotExistException
                     | ModelAlreadyExistException
+                    | ConnectionNotExistException
+                    | ConnectionAlreadyExistException
                     | DatabaseNotExistException e) {
                 throw new ValidationException(getErrorMessage(objectIdentifier, commandName), e);
             } catch (Exception e) {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -63,6 +63,7 @@ import org.apache.flink.table.expressions.DefaultSqlFactory;
 import org.apache.flink.table.expressions.SqlFactory;
 import org.apache.flink.table.expressions.resolver.ExpressionResolver.ExpressionResolverBuilder;
 import org.apache.flink.table.factories.ConnectionFactory;
+import org.apache.flink.table.factories.DefaultConnectionFactory;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.QueryOperation;
@@ -151,7 +152,7 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
 
     private final MaterializedTableEnricher materializedTableEnricher;
 
-    @Nullable private final ConnectionFactory connectionFactory;
+    private final ClassLoader userClassLoader;
 
     @Nullable private final WritableSecretStore writableSecretStore;
 
@@ -163,7 +164,7 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
             CatalogStoreHolder catalogStoreHolder,
             SqlFactory sqlFactory,
             MaterializedTableEnricher materializedTableEnricher,
-            @Nullable ConnectionFactory connectionFactory,
+            ClassLoader userClassLoader,
             @Nullable WritableSecretStore writableSecretStore) {
         checkArgument(
                 !StringUtils.isNullOrWhitespaceOnly(defaultCatalogName),
@@ -191,8 +192,23 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
         this.sqlFactory = sqlFactory;
         this.materializedTableEnricher =
                 checkNotNull(materializedTableEnricher, "MaterializedTableEnricher cannot be null");
-        this.connectionFactory = connectionFactory;
+        this.userClassLoader = checkNotNull(userClassLoader, "User class loader cannot be null");
         this.writableSecretStore = writableSecretStore;
+    }
+
+    /**
+     * Discovers the {@link ConnectionFactory} for the given connection options via SPI, using the
+     * {@code type} option as the factory identifier (see FLIP-529). Falls back to {@link
+     * DefaultConnectionFactory} when the {@code type} option is absent or empty.
+     *
+     * @param options the options of the connection being created / altered / dropped
+     * @return the discovered factory
+     */
+    private ConnectionFactory discoverConnectionFactory(Map<String, String> options) {
+        final String type = options.get(ConnectionFactory.CONNECTION_TYPE_KEY);
+        final String identifier =
+                (type == null || type.isEmpty()) ? DefaultConnectionFactory.IDENTIFIER : type;
+        return FactoryUtil.discoverFactory(userClassLoader, ConnectionFactory.class, identifier);
     }
 
     @VisibleForTesting
@@ -231,8 +247,6 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
         private SqlFactory sqlFactory = DefaultSqlFactory.INSTANCE;
 
         private MaterializedTableEnricher materializedTableEnricher;
-
-        private @Nullable ConnectionFactory connectionFactory;
 
         private @Nullable WritableSecretStore writableSecretStore;
 
@@ -284,11 +298,6 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
             return this;
         }
 
-        public Builder connectionFactory(@Nullable ConnectionFactory connectionFactory) {
-            this.connectionFactory = connectionFactory;
-            return this;
-        }
-
         public Builder writableSecretStore(@Nullable WritableSecretStore writableSecretStore) {
             this.writableSecretStore = writableSecretStore;
             return this;
@@ -315,7 +324,7 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
                     materializedTableEnricher != null
                             ? materializedTableEnricher
                             : createDefaultMaterializedTableEnricher(),
-                    connectionFactory,
+                    classLoader,
                     writableSecretStore);
         }
 
@@ -1904,9 +1913,10 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
     /**
      * Create a permanent connection in the given fully qualified path.
      *
-     * <p>If a {@link ConnectionFactory} and {@link WritableSecretStore} are configured, sensitive
-     * fields are extracted from the connection and stored in the secret store before persisting the
-     * non-sensitive {@link CatalogConnection} to the catalog.
+     * <p>The {@link ConnectionFactory} is discovered from the connection's {@code type} option (see
+     * FLIP-529). If a {@link WritableSecretStore} is configured, sensitive fields are extracted
+     * from the connection and stored in the secret store before persisting the non-sensitive {@link
+     * CatalogConnection} to the catalog.
      *
      * @param connection The connection with all options including sensitive fields.
      * @param objectIdentifier The fully qualified path where to create the connection.
@@ -1916,9 +1926,9 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
             SensitiveConnection connection,
             ObjectIdentifier objectIdentifier,
             boolean ignoreIfExists) {
-        if (connectionFactory == null || writableSecretStore == null) {
+        if (writableSecretStore == null) {
             throw new ValidationException(
-                    "ConnectionFactory and WritableSecretStore must be configured to create connections.");
+                    "WritableSecretStore must be configured to create connections.");
         }
         if (getConnection(objectIdentifier).isPresent()) {
             if (ignoreIfExists) {
@@ -1929,6 +1939,8 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
                             "Connection with identifier '%s' already exists.",
                             objectIdentifier.asSummaryString()));
         }
+        final ConnectionFactory connectionFactory =
+                discoverConnectionFactory(connection.getOptions());
         final CatalogConnection catalogConnection =
                 connectionFactory.createConnection(connection, writableSecretStore);
         boolean persisted = false;
@@ -1973,10 +1985,6 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
             SensitiveConnection connection,
             ObjectIdentifier objectIdentifier,
             boolean ignoreIfExists) {
-        if (connectionFactory == null) {
-            throw new ValidationException(
-                    "ConnectionFactory must be configured to create connections.");
-        }
         if (temporaryConnections.containsKey(objectIdentifier)) {
             if (ignoreIfExists) {
                 return;
@@ -1986,6 +1994,8 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
         }
         // Temporary connections are session-scoped; store secrets in an in-memory store rather
         // than the configured (potentially persistent) writableSecretStore.
+        final ConnectionFactory connectionFactory =
+                discoverConnectionFactory(connection.getOptions());
         final CatalogConnection catalogConnection =
                 connectionFactory.createConnection(connection, temporarySecretStore);
         temporaryConnections.put(objectIdentifier, catalogConnection);
@@ -2014,9 +2024,9 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
             SensitiveConnection newConnection,
             ObjectIdentifier objectIdentifier,
             boolean ignoreIfNotExists) {
-        if (connectionFactory == null || writableSecretStore == null) {
+        if (writableSecretStore == null) {
             throw new ValidationException(
-                    "ConnectionFactory and WritableSecretStore must be configured to alter connections.");
+                    "WritableSecretStore must be configured to alter connections.");
         }
         Optional<CatalogConnection> existingOpt = getConnection(objectIdentifier);
         if (!existingOpt.isPresent()) {
@@ -2029,6 +2039,8 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
                             objectIdentifier.asSummaryString()));
         }
         final CatalogConnection existing = existingOpt.get();
+        final ConnectionFactory connectionFactory =
+                discoverConnectionFactory(newConnection.getOptions());
         final CatalogConnection newCatalogConnection =
                 connectionFactory.createConnection(newConnection, writableSecretStore);
         boolean persisted = false;
@@ -2099,7 +2111,7 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
                 objectIdentifier,
                 ignoreIfNotExists,
                 "DropConnection");
-        if (connectionFactory != null && writableSecretStore != null) {
+        if (writableSecretStore != null) {
             tryDeleteSecrets(
                     existing, writableSecretStore, "post-drop cleanup for " + objectIdentifier);
         }
@@ -2128,12 +2140,10 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
                                             connection,
                                             ignoreIfNotExists,
                                             true)));
-            if (connectionFactory != null) {
-                tryDeleteSecrets(
-                        connection,
-                        temporarySecretStore,
-                        "post-drop cleanup of temporary " + objectIdentifier);
-            }
+            tryDeleteSecrets(
+                    connection,
+                    temporarySecretStore,
+                    "post-drop cleanup of temporary " + objectIdentifier);
         } else if (!ignoreIfNotExists) {
             throw new ValidationException(
                     String.format(
@@ -2150,8 +2160,8 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
     private void tryDeleteSecrets(
             CatalogConnection connection, WritableSecretStore store, String context) {
         try {
-            connectionFactory.deleteSecrets(connection, store);
-        } catch (SecretException e) {
+            discoverConnectionFactory(connection.getOptions()).deleteSecrets(connection, store);
+        } catch (SecretException | ValidationException e) {
             LOG.warn(
                     "Failed to delete connection secrets during {}; the catalog state is correct, but the secret may be orphaned in the secret store.",
                     context,

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
@@ -20,6 +20,8 @@ package org.apache.flink.table.catalog;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
+import org.apache.flink.table.catalog.exceptions.ConnectionAlreadyExistException;
+import org.apache.flink.table.catalog.exceptions.ConnectionNotExistException;
 import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotEmptyException;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
@@ -59,6 +61,7 @@ public class GenericInMemoryCatalog extends AbstractCatalog {
     private final Map<String, CatalogDatabase> databases;
     private final Map<ObjectPath, CatalogBaseTable> tables;
     private final Map<ObjectPath, CatalogModel> models;
+    private final Map<ObjectPath, CatalogConnection> connections;
     private final Map<ObjectPath, CatalogFunction> functions;
     private final Map<ObjectPath, Map<CatalogPartitionSpec, CatalogPartition>> partitions;
 
@@ -79,6 +82,7 @@ public class GenericInMemoryCatalog extends AbstractCatalog {
         this.databases.put(defaultDatabase, new CatalogDatabaseImpl(new HashMap<>(), null));
         this.tables = new LinkedHashMap<>();
         this.models = new LinkedHashMap<>();
+        this.connections = new LinkedHashMap<>();
         this.functions = new LinkedHashMap<>();
         this.partitions = new LinkedHashMap<>();
         this.tableStats = new LinkedHashMap<>();
@@ -451,6 +455,78 @@ public class GenericInMemoryCatalog extends AbstractCatalog {
     public boolean modelExists(ObjectPath modelPath) {
         checkNotNull(modelPath);
         return databaseExists(modelPath.getDatabaseName()) && models.containsKey(modelPath);
+    }
+
+    // ------ connections ------
+
+    @Override
+    public void createConnection(
+            ObjectPath connectionPath, CatalogConnection connection, boolean ignoreIfExists)
+            throws ConnectionAlreadyExistException, DatabaseNotExistException {
+        checkNotNull(connectionPath);
+        checkNotNull(connection);
+        if (!databaseExists(connectionPath.getDatabaseName())) {
+            throw new DatabaseNotExistException(getName(), connectionPath.getDatabaseName());
+        }
+        if (connectionExists(connectionPath)) {
+            if (!ignoreIfExists) {
+                throw new ConnectionAlreadyExistException(getName(), connectionPath);
+            }
+        } else {
+            connections.put(connectionPath, connection.copy());
+        }
+    }
+
+    @Override
+    public void alterConnection(
+            ObjectPath connectionPath, CatalogConnection newConnection, boolean ignoreIfNotExists)
+            throws ConnectionNotExistException {
+        checkNotNull(connectionPath);
+
+        CatalogConnection existingConnection = connections.get(connectionPath);
+        if (existingConnection == null || newConnection == null) {
+            if (ignoreIfNotExists) {
+                return;
+            }
+            throw new ConnectionNotExistException(getName(), connectionPath);
+        }
+
+        connections.put(connectionPath, newConnection.copy());
+    }
+
+    @Override
+    public void dropConnection(ObjectPath connectionPath, boolean ignoreIfNotExists)
+            throws ConnectionNotExistException {
+        checkNotNull(connectionPath);
+        if (connectionExists(connectionPath)) {
+            connections.remove(connectionPath);
+        } else if (!ignoreIfNotExists) {
+            throw new ConnectionNotExistException(getName(), connectionPath);
+        }
+    }
+
+    @Override
+    public List<String> listConnections(String databaseName) throws DatabaseNotExistException {
+        return listObjectsUnderDatabase(connections, databaseName, k -> true);
+    }
+
+    @Override
+    public CatalogConnection getConnection(ObjectPath connectionPath)
+            throws ConnectionNotExistException {
+        checkNotNull(connectionPath);
+
+        if (!connectionExists(connectionPath)) {
+            throw new ConnectionNotExistException(getName(), connectionPath);
+        } else {
+            return connections.get(connectionPath).copy();
+        }
+    }
+
+    @Override
+    public boolean connectionExists(ObjectPath connectionPath) {
+        checkNotNull(connectionPath);
+        return databaseExists(connectionPath.getDatabaseName())
+                && connections.containsKey(connectionPath);
     }
 
     // ------ functions ------

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
@@ -482,9 +482,9 @@ public class GenericInMemoryCatalog extends AbstractCatalog {
             ObjectPath connectionPath, CatalogConnection newConnection, boolean ignoreIfNotExists)
             throws ConnectionNotExistException {
         checkNotNull(connectionPath);
+        checkNotNull(newConnection);
 
-        CatalogConnection existingConnection = connections.get(connectionPath);
-        if (existingConnection == null || newConnection == null) {
+        if (!connectionExists(connectionPath)) {
             if (ignoreIfNotExists) {
                 return;
             }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/listener/AlterConnectionEvent.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/listener/AlterConnectionEvent.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.listener;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.catalog.CatalogConnection;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+
+/** When a connection is altered, a {@link AlterConnectionEvent} event will be created and fired. */
+@PublicEvolving
+public interface AlterConnectionEvent extends ConnectionModificationEvent {
+    ObjectIdentifier identifier();
+
+    CatalogConnection newConnection();
+
+    boolean ignoreIfNotExists();
+
+    static AlterConnectionEvent createEvent(
+            final CatalogContext context,
+            final ObjectIdentifier identifier,
+            final CatalogConnection newConnection,
+            final boolean ignoreIfNotExists) {
+        return new AlterConnectionEvent() {
+            @Override
+            public CatalogConnection newConnection() {
+                return newConnection;
+            }
+
+            @Override
+            public boolean ignoreIfNotExists() {
+                return ignoreIfNotExists;
+            }
+
+            @Override
+            public ObjectIdentifier identifier() {
+                return identifier;
+            }
+
+            @Override
+            public CatalogConnection connection() {
+                throw new IllegalStateException(
+                        "There is no connection in AlterConnectionEvent, use identifier() instead.");
+            }
+
+            @Override
+            public boolean isTemporary() {
+                return false;
+            }
+
+            @Override
+            public CatalogContext context() {
+                return context;
+            }
+        };
+    }
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/listener/ConnectionModificationEvent.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/listener/ConnectionModificationEvent.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.listener;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.catalog.CatalogConnection;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+
+/** Basic event for connection modification such as create, alter and drop. */
+@PublicEvolving
+public interface ConnectionModificationEvent extends CatalogModificationEvent {
+
+    ObjectIdentifier identifier();
+
+    CatalogConnection connection();
+
+    boolean isTemporary();
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/listener/CreateConnectionEvent.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/listener/CreateConnectionEvent.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.listener;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.catalog.CatalogConnection;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+
+/**
+ * When a connection is created, a {@link CreateConnectionEvent} event will be created and fired.
+ */
+@PublicEvolving
+public interface CreateConnectionEvent extends ConnectionModificationEvent {
+    ObjectIdentifier identifier();
+
+    CatalogConnection connection();
+
+    boolean ignoreIfExists();
+
+    boolean isTemporary();
+
+    static CreateConnectionEvent createEvent(
+            final CatalogContext context,
+            final ObjectIdentifier identifier,
+            final CatalogConnection connection,
+            final boolean ignoreIfExists,
+            final boolean isTemporary) {
+        return new CreateConnectionEvent() {
+            @Override
+            public boolean ignoreIfExists() {
+                return ignoreIfExists;
+            }
+
+            @Override
+            public ObjectIdentifier identifier() {
+                return identifier;
+            }
+
+            @Override
+            public CatalogConnection connection() {
+                return connection;
+            }
+
+            @Override
+            public CatalogContext context() {
+                return context;
+            }
+
+            @Override
+            public boolean isTemporary() {
+                return isTemporary;
+            }
+        };
+    }
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/listener/DropConnectionEvent.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/listener/DropConnectionEvent.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.listener;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.catalog.CatalogConnection;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+
+import javax.annotation.Nullable;
+
+/** When a connection is dropped, a {@link DropConnectionEvent} event will be created and fired. */
+@PublicEvolving
+public interface DropConnectionEvent extends ConnectionModificationEvent {
+    ObjectIdentifier identifier();
+
+    boolean ignoreIfNotExists();
+
+    boolean isTemporary();
+
+    CatalogConnection connection();
+
+    static DropConnectionEvent createEvent(
+            final CatalogContext context,
+            final ObjectIdentifier identifier,
+            @Nullable final CatalogConnection connection,
+            final boolean ignoreIfNotExists,
+            final boolean isTemporary) {
+        return new DropConnectionEvent() {
+            @Override
+            public boolean ignoreIfNotExists() {
+                return ignoreIfNotExists;
+            }
+
+            @Override
+            public ObjectIdentifier identifier() {
+                return identifier;
+            }
+
+            @Override
+            @Nullable
+            public CatalogConnection connection() {
+                return connection;
+            }
+
+            @Override
+            public CatalogContext context() {
+                return context;
+            }
+
+            @Override
+            public boolean isTemporary() {
+                return isTemporary;
+            }
+        };
+    }
+}

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogManagerTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogManagerTest.java
@@ -22,17 +22,23 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
+import org.apache.flink.table.catalog.listener.AlterConnectionEvent;
 import org.apache.flink.table.catalog.listener.AlterDatabaseEvent;
 import org.apache.flink.table.catalog.listener.AlterModelEvent;
 import org.apache.flink.table.catalog.listener.AlterTableEvent;
 import org.apache.flink.table.catalog.listener.CatalogModificationEvent;
 import org.apache.flink.table.catalog.listener.CatalogModificationListener;
+import org.apache.flink.table.catalog.listener.CreateConnectionEvent;
 import org.apache.flink.table.catalog.listener.CreateDatabaseEvent;
 import org.apache.flink.table.catalog.listener.CreateModelEvent;
 import org.apache.flink.table.catalog.listener.CreateTableEvent;
+import org.apache.flink.table.catalog.listener.DropConnectionEvent;
 import org.apache.flink.table.catalog.listener.DropDatabaseEvent;
 import org.apache.flink.table.catalog.listener.DropModelEvent;
 import org.apache.flink.table.catalog.listener.DropTableEvent;
+import org.apache.flink.table.factories.DefaultConnectionFactory;
+import org.apache.flink.table.secret.GenericInMemorySecretStore;
+import org.apache.flink.table.secret.WritableSecretStore;
 import org.apache.flink.table.utils.CatalogManagerMocks;
 import org.apache.flink.table.utils.ExpressionResolverMocks;
 import org.apache.flink.table.utils.ParserMock;
@@ -365,6 +371,127 @@ class CatalogManagerTest {
         assertThat(dropTemporaryEvent.identifier().getObjectName()).isEqualTo("model2");
     }
 
+    @Test
+    public void testConnectionModificationListener() throws Exception {
+        CompletableFuture<CreateConnectionEvent> createFuture = new CompletableFuture<>();
+        CompletableFuture<CreateConnectionEvent> createTemporaryFuture = new CompletableFuture<>();
+        CompletableFuture<AlterConnectionEvent> alterFuture = new CompletableFuture<>();
+        CompletableFuture<DropConnectionEvent> dropFuture = new CompletableFuture<>();
+        CompletableFuture<DropConnectionEvent> dropTemporaryFuture = new CompletableFuture<>();
+        WritableSecretStore secretStore = new GenericInMemorySecretStore();
+        CatalogManager catalogManager =
+                CatalogManagerMocks.preparedCatalogManager()
+                        .defaultCatalog("default", new GenericInMemoryCatalog("default"))
+                        .classLoader(CatalogManagerTest.class.getClassLoader())
+                        .config(new Configuration())
+                        .catalogModificationListeners(
+                                Collections.singletonList(
+                                        new TestingConnectionModificationListener(
+                                                createFuture,
+                                                createTemporaryFuture,
+                                                alterFuture,
+                                                dropFuture,
+                                                dropTemporaryFuture)))
+                        .catalogStoreHolder(
+                                CatalogStoreHolder.newBuilder()
+                                        .classloader(CatalogManagerTest.class.getClassLoader())
+                                        .catalogStore(new GenericInMemoryCatalogStore())
+                                        .config(new Configuration())
+                                        .build())
+                        .connectionFactory(new DefaultConnectionFactory())
+                        .writableSecretStore(secretStore)
+                        .build();
+
+        catalogManager.initSchemaResolver(
+                true, ExpressionResolverMocks.dummyResolver(), new ParserMock());
+
+        HashMap<String, String> options =
+                new HashMap<String, String>() {
+                    {
+                        put("type", "kafka");
+                        put("bootstrap.servers", "localhost:9092");
+                        put("password", "secret-pw");
+                    }
+                };
+
+        // Create a connection
+        catalogManager.createConnection(
+                SensitiveConnection.of(options, null),
+                ObjectIdentifier.of(
+                        catalogManager.getCurrentCatalog(),
+                        catalogManager.getCurrentDatabase(),
+                        "conn1"),
+                true);
+        CreateConnectionEvent createConnectionEvent = createFuture.get(10, TimeUnit.SECONDS);
+        assertThat(createConnectionEvent.identifier().getObjectName()).isEqualTo("conn1");
+        assertThat(createConnectionEvent.ignoreIfExists()).isTrue();
+        assertThat(createConnectionEvent.isTemporary()).isFalse();
+        // Sensitive field should be stripped from the persisted CatalogConnection
+        assertThat(createConnectionEvent.connection().getOptions()).doesNotContainKey("password");
+
+        // Create a temporary connection
+        catalogManager.createTemporaryConnection(
+                SensitiveConnection.of(options, null),
+                ObjectIdentifier.of(
+                        catalogManager.getCurrentCatalog(),
+                        catalogManager.getCurrentDatabase(),
+                        "conn2"),
+                false);
+        CreateConnectionEvent createTemporaryEvent =
+                createTemporaryFuture.get(10, TimeUnit.SECONDS);
+        assertThat(createTemporaryEvent.isTemporary()).isTrue();
+        assertThat(createTemporaryEvent.identifier().getObjectName()).isEqualTo("conn2");
+        assertThat(createTemporaryEvent.ignoreIfExists()).isFalse();
+
+        // Alter a connection
+        HashMap<String, String> alteredOptions =
+                new HashMap<String, String>() {
+                    {
+                        put("type", "kafka");
+                        put("bootstrap.servers", "remote:9092");
+                        put("password", "rotated-pw");
+                    }
+                };
+        catalogManager.alterConnection(
+                SensitiveConnection.of(alteredOptions, "conn1 comment"),
+                ObjectIdentifier.of(
+                        catalogManager.getCurrentCatalog(),
+                        catalogManager.getCurrentDatabase(),
+                        "conn1"),
+                false);
+        AlterConnectionEvent alterEvent = alterFuture.get(10, TimeUnit.SECONDS);
+        assertThat(alterEvent.identifier().getObjectName()).isEqualTo("conn1");
+        assertThat(alterEvent.newConnection().getComment()).isEqualTo("conn1 comment");
+        assertThat(alterEvent.newConnection().getOptions().get("bootstrap.servers"))
+                .isEqualTo("remote:9092");
+        assertThat(alterEvent.newConnection().getOptions()).doesNotContainKey("password");
+        assertThat(alterEvent.ignoreIfNotExists()).isFalse();
+
+        // Drop a connection
+        ObjectIdentifier oi =
+                ObjectIdentifier.of(
+                        catalogManager.getCurrentCatalog(),
+                        catalogManager.getCurrentDatabase(),
+                        "conn1");
+        catalogManager.dropConnection(oi, true);
+        DropConnectionEvent dropEvent = dropFuture.get(10, TimeUnit.SECONDS);
+        assertThat(dropEvent.ignoreIfNotExists()).isTrue();
+        assertThat(dropEvent.identifier().getObjectName()).isEqualTo("conn1");
+        assertThat(dropEvent.isTemporary()).isFalse();
+
+        // Drop a temporary connection
+        catalogManager.dropTemporaryConnection(
+                ObjectIdentifier.of(
+                        catalogManager.getCurrentCatalog(),
+                        catalogManager.getCurrentDatabase(),
+                        "conn2"),
+                false);
+        DropConnectionEvent dropTemporaryEvent = dropTemporaryFuture.get(10, TimeUnit.SECONDS);
+        assertThat(dropTemporaryEvent.isTemporary()).isTrue();
+        assertThat(dropTemporaryEvent.ignoreIfNotExists()).isFalse();
+        assertThat(dropTemporaryEvent.identifier().getObjectName()).isEqualTo("conn2");
+    }
+
     private CatalogManager createCatalogManager(@Nullable CatalogModificationListener listener) {
         CatalogManager.Builder builder =
                 CatalogManager.newBuilder()
@@ -450,6 +577,49 @@ class CatalogManagerTest {
                     dropTemporaryFuture.complete((DropTableEvent) event);
                 } else {
                     dropFuture.complete((DropTableEvent) event);
+                }
+            } else {
+                throw new UnsupportedOperationException();
+            }
+        }
+    }
+
+    /** Testing connection modification listener. */
+    static class TestingConnectionModificationListener implements CatalogModificationListener {
+        private final CompletableFuture<CreateConnectionEvent> createFuture;
+        private final CompletableFuture<CreateConnectionEvent> createTemporaryFuture;
+        private final CompletableFuture<AlterConnectionEvent> alterFuture;
+        private final CompletableFuture<DropConnectionEvent> dropFuture;
+        private final CompletableFuture<DropConnectionEvent> dropTemporaryFuture;
+
+        TestingConnectionModificationListener(
+                CompletableFuture<CreateConnectionEvent> createFuture,
+                CompletableFuture<CreateConnectionEvent> createTemporaryFuture,
+                CompletableFuture<AlterConnectionEvent> alterFuture,
+                CompletableFuture<DropConnectionEvent> dropFuture,
+                CompletableFuture<DropConnectionEvent> dropTemporaryFuture) {
+            this.createFuture = createFuture;
+            this.createTemporaryFuture = createTemporaryFuture;
+            this.alterFuture = alterFuture;
+            this.dropFuture = dropFuture;
+            this.dropTemporaryFuture = dropTemporaryFuture;
+        }
+
+        @Override
+        public void onEvent(CatalogModificationEvent event) {
+            if (event instanceof CreateConnectionEvent) {
+                if (((CreateConnectionEvent) event).isTemporary()) {
+                    createTemporaryFuture.complete((CreateConnectionEvent) event);
+                } else {
+                    createFuture.complete((CreateConnectionEvent) event);
+                }
+            } else if (event instanceof AlterConnectionEvent) {
+                alterFuture.complete((AlterConnectionEvent) event);
+            } else if (event instanceof DropConnectionEvent) {
+                if (((DropConnectionEvent) event).isTemporary()) {
+                    dropTemporaryFuture.complete((DropConnectionEvent) event);
+                } else {
+                    dropFuture.complete((DropConnectionEvent) event);
                 }
             } else {
                 throw new UnsupportedOperationException();

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogManagerTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogManagerTest.java
@@ -36,7 +36,6 @@ import org.apache.flink.table.catalog.listener.DropConnectionEvent;
 import org.apache.flink.table.catalog.listener.DropDatabaseEvent;
 import org.apache.flink.table.catalog.listener.DropModelEvent;
 import org.apache.flink.table.catalog.listener.DropTableEvent;
-import org.apache.flink.table.factories.DefaultConnectionFactory;
 import org.apache.flink.table.secret.GenericInMemorySecretStore;
 import org.apache.flink.table.secret.WritableSecretStore;
 import org.apache.flink.table.utils.CatalogManagerMocks;
@@ -398,7 +397,6 @@ class CatalogManagerTest {
                                         .catalogStore(new GenericInMemoryCatalogStore())
                                         .config(new Configuration())
                                         .build())
-                        .connectionFactory(new DefaultConnectionFactory())
                         .writableSecretStore(secretStore)
                         .build();
 
@@ -408,7 +406,7 @@ class CatalogManagerTest {
         HashMap<String, String> options =
                 new HashMap<String, String>() {
                     {
-                        put("type", "kafka");
+                        put("type", "default");
                         put("bootstrap.servers", "localhost:9092");
                         put("password", "secret-pw");
                     }
@@ -447,7 +445,7 @@ class CatalogManagerTest {
         HashMap<String, String> alteredOptions =
                 new HashMap<String, String>() {
                     {
-                        put("type", "kafka");
+                        put("type", "default");
                         put("bootstrap.servers", "remote:9092");
                         put("password", "rotated-pw");
                     }
@@ -490,6 +488,60 @@ class CatalogManagerTest {
         assertThat(dropTemporaryEvent.isTemporary()).isTrue();
         assertThat(dropTemporaryEvent.ignoreIfNotExists()).isFalse();
         assertThat(dropTemporaryEvent.identifier().getObjectName()).isEqualTo("conn2");
+    }
+
+    @Test
+    public void testCreateConnectionWithoutTypeFallsBackToDefaultFactory() throws Exception {
+        CompletableFuture<CreateConnectionEvent> createFuture = new CompletableFuture<>();
+        WritableSecretStore secretStore = new GenericInMemorySecretStore();
+        CatalogManager catalogManager =
+                CatalogManagerMocks.preparedCatalogManager()
+                        .defaultCatalog("default", new GenericInMemoryCatalog("default"))
+                        .classLoader(CatalogManagerTest.class.getClassLoader())
+                        .config(new Configuration())
+                        .catalogModificationListeners(
+                                Collections.singletonList(
+                                        new TestingConnectionModificationListener(
+                                                createFuture,
+                                                new CompletableFuture<>(),
+                                                new CompletableFuture<>(),
+                                                new CompletableFuture<>(),
+                                                new CompletableFuture<>())))
+                        .catalogStoreHolder(
+                                CatalogStoreHolder.newBuilder()
+                                        .classloader(CatalogManagerTest.class.getClassLoader())
+                                        .catalogStore(new GenericInMemoryCatalogStore())
+                                        .config(new Configuration())
+                                        .build())
+                        .writableSecretStore(secretStore)
+                        .build();
+
+        catalogManager.initSchemaResolver(
+                true, ExpressionResolverMocks.dummyResolver(), new ParserMock());
+
+        // Omit the 'type' option entirely; discovery should fall back to DefaultConnectionFactory.
+        HashMap<String, String> options =
+                new HashMap<String, String>() {
+                    {
+                        put("bootstrap.servers", "localhost:9092");
+                        put("password", "secret-pw");
+                    }
+                };
+
+        catalogManager.createConnection(
+                SensitiveConnection.of(options, null),
+                ObjectIdentifier.of(
+                        catalogManager.getCurrentCatalog(),
+                        catalogManager.getCurrentDatabase(),
+                        "conn-no-type"),
+                false);
+
+        CreateConnectionEvent event = createFuture.get(10, TimeUnit.SECONDS);
+        assertThat(event.identifier().getObjectName()).isEqualTo("conn-no-type");
+        // Sensitive field stripped — proves DefaultConnectionFactory ran via the fallback path.
+        assertThat(event.connection().getOptions()).doesNotContainKey("password");
+        assertThat(event.connection().getOptions())
+                .containsEntry("bootstrap.servers", "localhost:9092");
     }
 
     private CatalogManager createCatalogManager(@Nullable CatalogModificationListener listener) {

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
@@ -256,6 +256,11 @@ class GenericInMemoryCatalogTest extends CatalogTestBase {
     }
 
     @Override
+    protected boolean supportsConnections() {
+        return true;
+    }
+
+    @Override
     protected CatalogFunction createPythonFunction() {
         return new CatalogFunctionImpl("test.func1", FunctionLanguage.PYTHON);
     }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
@@ -959,7 +959,9 @@ public interface Catalog {
      */
     default CatalogConnection getConnection(ObjectPath connectionPath)
             throws ConnectionNotExistException, CatalogException {
-        throw new ConnectionNotExistException(null, connectionPath);
+        throw new UnsupportedOperationException(
+                String.format(
+                        "getConnection(ObjectPath) is not implemented for %s.", this.getClass()));
     }
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
@@ -20,6 +20,8 @@ package org.apache.flink.table.catalog;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
+import org.apache.flink.table.catalog.exceptions.ConnectionAlreadyExistException;
+import org.apache.flink.table.catalog.exceptions.ConnectionNotExistException;
 import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotEmptyException;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
@@ -931,5 +933,101 @@ public interface Catalog {
             boolean ignoreIfNotExists)
             throws ModelNotExistException, CatalogException {
         alterModel(modelPath, newModel, ignoreIfNotExists);
+    }
+
+    // ------ connections ------
+
+    /**
+     * Get names of all connections under this database. An empty list is returned if none exists.
+     *
+     * @return a list of the names of all connections in this database
+     * @throws DatabaseNotExistException if the database does not exist
+     * @throws CatalogException in case of any runtime exception
+     */
+    default List<String> listConnections(String databaseName)
+            throws DatabaseNotExistException, CatalogException {
+        return Collections.emptyList();
+    }
+
+    /**
+     * Returns a {@link CatalogConnection} identified by the given {@link ObjectPath}.
+     *
+     * @param connectionPath Path of the connection
+     * @return The requested connection
+     * @throws ConnectionNotExistException if the target does not exist
+     * @throws CatalogException in case of any runtime exception
+     */
+    default CatalogConnection getConnection(ObjectPath connectionPath)
+            throws ConnectionNotExistException, CatalogException {
+        throw new ConnectionNotExistException(null, connectionPath);
+    }
+
+    /**
+     * Check if a connection exists in this catalog.
+     *
+     * @param connectionPath Path of the connection
+     * @return true if the given connection exists in the catalog false otherwise
+     * @throws CatalogException in case of any runtime exception
+     */
+    default boolean connectionExists(ObjectPath connectionPath) throws CatalogException {
+        return false;
+    }
+
+    /**
+     * Creates a new connection.
+     *
+     * @param connectionPath path of the connection to be created
+     * @param connection the CatalogConnection definition
+     * @param ignoreIfExists flag to specify behavior when a connection already exists at the given
+     *     path: if set to false, it throws a ConnectionAlreadyExistException, if set to true, do
+     *     nothing.
+     * @throws ConnectionAlreadyExistException if connection already exists and ignoreIfExists is
+     *     false
+     * @throws DatabaseNotExistException if the database in connectionPath doesn't exist
+     * @throws CatalogException in case of any runtime exception
+     */
+    default void createConnection(
+            ObjectPath connectionPath, CatalogConnection connection, boolean ignoreIfExists)
+            throws ConnectionAlreadyExistException, DatabaseNotExistException, CatalogException {
+        throw new UnsupportedOperationException(
+                String.format(
+                        "createConnection(ObjectPath, CatalogConnection, boolean) is not implemented for %s.",
+                        this.getClass()));
+    }
+
+    /**
+     * Modifies an existing connection.
+     *
+     * @param connectionPath path of the connection to be modified
+     * @param newConnection the new connection definition
+     * @param ignoreIfNotExists flag to specify behavior when the connection does not exist: if set
+     *     to false, throw an exception, if set to true, do nothing.
+     * @throws ConnectionNotExistException if the connection does not exist
+     * @throws CatalogException in case of any runtime exception
+     */
+    default void alterConnection(
+            ObjectPath connectionPath, CatalogConnection newConnection, boolean ignoreIfNotExists)
+            throws ConnectionNotExistException, CatalogException {
+        throw new UnsupportedOperationException(
+                String.format(
+                        "alterConnection(ObjectPath, CatalogConnection, boolean) is not implemented for %s.",
+                        this.getClass()));
+    }
+
+    /**
+     * Drop a connection.
+     *
+     * @param connectionPath Path of the connection to be dropped
+     * @param ignoreIfNotExists Flag to specify behavior when the connection does not exist: if set
+     *     to false, throw an exception, if set to true, do nothing.
+     * @throws ConnectionNotExistException if the connection does not exist
+     * @throws CatalogException in case of any runtime exception
+     */
+    default void dropConnection(ObjectPath connectionPath, boolean ignoreIfNotExists)
+            throws ConnectionNotExistException, CatalogException {
+        throw new UnsupportedOperationException(
+                String.format(
+                        "dropConnection(ObjectPath, boolean) is not implemented for %s.",
+                        this.getClass()));
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/DefaultConnectionFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/DefaultConnectionFactory.java
@@ -16,13 +16,12 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.factories;
+package org.apache.flink.table.catalog;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.table.api.ValidationException;
-import org.apache.flink.table.catalog.CatalogConnection;
-import org.apache.flink.table.catalog.SensitiveConnection;
+import org.apache.flink.table.factories.ConnectionFactory;
 import org.apache.flink.table.secret.ReadableSecretStore;
 import org.apache.flink.table.secret.WritableSecretStore;
 import org.apache.flink.table.secret.exceptions.SecretException;
@@ -48,10 +47,7 @@ import java.util.stream.Collectors;
  * <p>During {@link #resolveConnection}, the secret reference is used to retrieve the sensitive
  * fields from the {@link ReadableSecretStore} and merge them back into the options.
  *
- * <p>The following field names are treated as sensitive by default: {@code password}, {@code
- * secret}, {@code fs.azure.account.key}, {@code apikey}, {@code api-key}, {@code auth-params},
- * {@code service-key}, {@code token}, {@code basic-auth}, {@code jaas.config}, {@code
- * http-headers}.
+ * <p>See {@link #SENSITIVE_FIELD_NAMES} for the default whitelist of sensitive field names.
  */
 @Internal
 public class DefaultConnectionFactory implements ConnectionFactory {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/DefaultConnectionFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/DefaultConnectionFactory.java
@@ -54,7 +54,8 @@ public class DefaultConnectionFactory implements ConnectionFactory {
 
     /**
      * Factory identifier used to discover this factory via SPI. Also used as the fallback when a
-     * connection does not specify a {@link ConnectionFactory#CONNECTION_TYPE_KEY} option.
+     * connection does not specify a {@link
+     * org.apache.flink.table.factories.FactoryUtil#CONNECTION_TYPE} option.
      */
     public static final String IDENTIFIER = "default";
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/exceptions/ConnectionAlreadyExistException.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/exceptions/ConnectionAlreadyExistException.java
@@ -25,7 +25,7 @@ import org.apache.flink.table.catalog.ObjectPath;
 @PublicEvolving
 public class ConnectionAlreadyExistException extends Exception {
 
-    private static final String MSG = "Connection %s already exists in Catalog %s.";
+    private static final String MSG = "Connection '%s' already exists in catalog '%s'.";
 
     public ConnectionAlreadyExistException(String catalogName, ObjectPath connectionPath) {
         this(catalogName, connectionPath, null);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/exceptions/ConnectionAlreadyExistException.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/exceptions/ConnectionAlreadyExistException.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.exceptions;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.catalog.ObjectPath;
+
+/** Exception for trying to create a connection that already exists. */
+@PublicEvolving
+public class ConnectionAlreadyExistException extends Exception {
+
+    private static final String MSG = "Connection %s already exists in Catalog %s.";
+
+    public ConnectionAlreadyExistException(String catalogName, ObjectPath connectionPath) {
+        this(catalogName, connectionPath, null);
+    }
+
+    public ConnectionAlreadyExistException(
+            String catalogName, ObjectPath connectionPath, Throwable cause) {
+        super(String.format(MSG, connectionPath.getFullName(), catalogName), cause);
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/exceptions/ConnectionNotExistException.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/exceptions/ConnectionNotExistException.java
@@ -25,8 +25,8 @@ import org.apache.flink.table.catalog.ObjectPath;
 @PublicEvolving
 public class ConnectionNotExistException extends Exception {
 
-    private static final String MSG = "Connection '`%s`.`%s`.`%s`' does not exist.";
-    private static final String MSG_WITHOUT_CATALOG = "Connection '`%s`.`%s`' does not exist.";
+    private static final String MSG = "Connection '%s' does not exist in catalog '%s'.";
+    private static final String MSG_WITHOUT_CATALOG = "Connection '%s' does not exist.";
 
     public ConnectionNotExistException(String catalogName, ObjectPath connectionPath) {
         this(catalogName, connectionPath, null);
@@ -39,15 +39,8 @@ public class ConnectionNotExistException extends Exception {
 
     private static String formatMsg(String catalogName, ObjectPath connectionPath) {
         if (catalogName != null) {
-            return String.format(
-                    MSG,
-                    catalogName,
-                    connectionPath.getDatabaseName(),
-                    connectionPath.getObjectName());
+            return String.format(MSG, connectionPath.getFullName(), catalogName);
         }
-        return String.format(
-                MSG_WITHOUT_CATALOG,
-                connectionPath.getDatabaseName(),
-                connectionPath.getObjectName());
+        return String.format(MSG_WITHOUT_CATALOG, connectionPath.getFullName());
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/exceptions/ConnectionNotExistException.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/exceptions/ConnectionNotExistException.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.exceptions;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.catalog.ObjectPath;
+
+/** Exception for trying to operate on a connection that doesn't exist. */
+@PublicEvolving
+public class ConnectionNotExistException extends Exception {
+
+    private static final String MSG = "Connection '`%s`.`%s`.`%s`' does not exist.";
+    private static final String MSG_WITHOUT_CATALOG = "Connection '`%s`.`%s`' does not exist.";
+
+    public ConnectionNotExistException(String catalogName, ObjectPath connectionPath) {
+        this(catalogName, connectionPath, null);
+    }
+
+    public ConnectionNotExistException(
+            String catalogName, ObjectPath connectionPath, Throwable cause) {
+        super(formatMsg(catalogName, connectionPath), cause);
+    }
+
+    private static String formatMsg(String catalogName, ObjectPath connectionPath) {
+        if (catalogName != null) {
+            return String.format(
+                    MSG,
+                    catalogName,
+                    connectionPath.getDatabaseName(),
+                    connectionPath.getObjectName());
+        }
+        return String.format(
+                MSG_WITHOUT_CATALOG,
+                connectionPath.getDatabaseName(),
+                connectionPath.getObjectName());
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/ConnectionFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/ConnectionFactory.java
@@ -39,7 +39,7 @@ import org.apache.flink.table.secret.exceptions.SecretException;
  *       {@link ReadableSecretStore} and returning a complete {@link SensitiveConnection}.
  * </ul>
  *
- * @see org.apache.flink.table.factories.DefaultConnectionFactory
+ * @see org.apache.flink.table.catalog.DefaultConnectionFactory
  */
 @PublicEvolving
 public interface ConnectionFactory extends Factory {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/ConnectionFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/ConnectionFactory.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.factories;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.catalog.CatalogConnection;
+import org.apache.flink.table.catalog.SensitiveConnection;
+import org.apache.flink.table.secret.ReadableSecretStore;
+import org.apache.flink.table.secret.WritableSecretStore;
+
+/**
+ * Factory for creating and resolving connections, handling the encryption and decryption of
+ * sensitive connection fields.
+ *
+ * <p>A {@code ConnectionFactory} is responsible for:
+ *
+ * <ul>
+ *   <li>Extracting sensitive fields from a {@link SensitiveConnection} and storing them in a {@link
+ *       WritableSecretStore}, returning a {@link CatalogConnection} that is safe to persist in a
+ *       catalog.
+ *   <li>Resolving a {@link CatalogConnection} from a catalog by retrieving its secrets from a
+ *       {@link ReadableSecretStore} and returning a complete {@link SensitiveConnection}.
+ * </ul>
+ *
+ * @see org.apache.flink.table.factories.DefaultConnectionFactory
+ */
+@PublicEvolving
+public interface ConnectionFactory extends Factory {
+
+    /**
+     * Creates a {@link CatalogConnection} from a {@link SensitiveConnection} by extracting
+     * sensitive fields and storing them in the provided {@link WritableSecretStore}.
+     *
+     * <p>The returned {@link CatalogConnection} contains only non-sensitive options plus a secret
+     * reference that can be used to retrieve the sensitive fields later via {@link
+     * #resolveConnection(CatalogConnection, ReadableSecretStore)}.
+     *
+     * @param connection the connection with all options including sensitive fields
+     * @param secretStore the secret store where sensitive fields will be stored
+     * @return a catalog-safe connection with sensitive fields replaced by a secret reference
+     */
+    CatalogConnection createConnection(
+            SensitiveConnection connection, WritableSecretStore secretStore);
+
+    /**
+     * Resolves a {@link CatalogConnection} into a {@link SensitiveConnection} by retrieving secrets
+     * from the provided {@link ReadableSecretStore}.
+     *
+     * @param connection the catalog connection containing non-sensitive options and a secret
+     *     reference
+     * @param secretStore the secret store from which sensitive fields are retrieved
+     * @return the complete connection with all options including sensitive fields
+     */
+    SensitiveConnection resolveConnection(
+            CatalogConnection connection, ReadableSecretStore secretStore);
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/ConnectionFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/ConnectionFactory.java
@@ -45,6 +45,14 @@ import org.apache.flink.table.secret.exceptions.SecretException;
 public interface ConnectionFactory extends Factory {
 
     /**
+     * The option key that identifies the connection type in a {@link SensitiveConnection}'s or
+     * {@link CatalogConnection}'s options. The value of this option is matched against the {@link
+     * #factoryIdentifier()} of registered {@code ConnectionFactory} implementations to discover the
+     * factory that handles a given connection (see FLIP-529).
+     */
+    String CONNECTION_TYPE_KEY = "type";
+
+    /**
      * Creates a {@link CatalogConnection} from a {@link SensitiveConnection} by extracting
      * sensitive fields and storing them in the provided {@link WritableSecretStore}.
      *

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/ConnectionFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/ConnectionFactory.java
@@ -39,7 +39,7 @@ import org.apache.flink.table.secret.exceptions.SecretException;
  *       {@link ReadableSecretStore} and returning a complete {@link SensitiveConnection}.
  * </ul>
  *
- * @see org.apache.flink.table.catalog.DefaultConnectionFactory
+ * @see DefaultConnectionFactory
  */
 @PublicEvolving
 public interface ConnectionFactory extends Factory {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/ConnectionFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/ConnectionFactory.java
@@ -23,6 +23,7 @@ import org.apache.flink.table.catalog.CatalogConnection;
 import org.apache.flink.table.catalog.SensitiveConnection;
 import org.apache.flink.table.secret.ReadableSecretStore;
 import org.apache.flink.table.secret.WritableSecretStore;
+import org.apache.flink.table.secret.exceptions.SecretException;
 
 /**
  * Factory for creating and resolving connections, handling the encryption and decryption of
@@ -54,9 +55,10 @@ public interface ConnectionFactory extends Factory {
      * @param connection the connection with all options including sensitive fields
      * @param secretStore the secret store where sensitive fields will be stored
      * @return a catalog-safe connection with sensitive fields replaced by a secret reference
+     * @throws SecretException if storing the secret fails (e.g. underlying-store error)
      */
     CatalogConnection createConnection(
-            SensitiveConnection connection, WritableSecretStore secretStore);
+            SensitiveConnection connection, WritableSecretStore secretStore) throws SecretException;
 
     /**
      * Resolves a {@link CatalogConnection} into a {@link SensitiveConnection} by retrieving secrets
@@ -66,7 +68,26 @@ public interface ConnectionFactory extends Factory {
      *     reference
      * @param secretStore the secret store from which sensitive fields are retrieved
      * @return the complete connection with all options including sensitive fields
+     * @throws SecretException if retrieving the secret fails (e.g. underlying-store error)
      */
     SensitiveConnection resolveConnection(
-            CatalogConnection connection, ReadableSecretStore secretStore);
+            CatalogConnection connection, ReadableSecretStore secretStore) throws SecretException;
+
+    /**
+     * Deletes any secrets associated with the given {@link CatalogConnection} from the provided
+     * {@link WritableSecretStore}.
+     *
+     * <p>Implementations should locate the secret reference embedded in the connection (created by
+     * {@link #createConnection(SensitiveConnection, WritableSecretStore)}) and remove the
+     * corresponding entry from the secret store. This is intended to be called when a connection is
+     * dropped or replaced (e.g. on alter), to avoid orphaned secrets.
+     *
+     * <p>The default implementation is a no-op for factories that do not externalize secrets.
+     *
+     * @param connection the catalog connection whose backing secrets should be removed
+     * @param secretStore the secret store from which secrets should be deleted
+     * @throws SecretException if removing the secret fails (e.g. underlying-store error)
+     */
+    default void deleteSecrets(CatalogConnection connection, WritableSecretStore secretStore)
+            throws SecretException {}
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/ConnectionFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/ConnectionFactory.java
@@ -45,14 +45,6 @@ import org.apache.flink.table.secret.exceptions.SecretException;
 public interface ConnectionFactory extends Factory {
 
     /**
-     * The option key that identifies the connection type in a {@link SensitiveConnection}'s or
-     * {@link CatalogConnection}'s options. The value of this option is matched against the {@link
-     * #factoryIdentifier()} of registered {@code ConnectionFactory} implementations to discover the
-     * factory that handles a given connection (see FLIP-529).
-     */
-    String CONNECTION_TYPE_KEY = "type";
-
-    /**
      * Creates a {@link CatalogConnection} from a {@link SensitiveConnection} by extracting
      * sensitive fields and storing them in the provided {@link WritableSecretStore}.
      *

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/DefaultConnectionFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/DefaultConnectionFactory.java
@@ -61,8 +61,13 @@ public class DefaultConnectionFactory implements ConnectionFactory {
      * surrounding double underscores make collision with user-supplied option names unlikely; user
      * options containing this key will be rejected at create-time.
      */
-    public static final String SECRET_REFERENCE_KEY = "__flink.encrypted_secret_key__";
+    static final String SECRET_REFERENCE_KEY = "__flink.encrypted-secret-key__";
 
+    /**
+     * Default whitelist of option keys treated as sensitive. Seeded from {@link
+     * org.apache.flink.configuration.GlobalConfiguration#SENSITIVE_KEYS}; the list is intentionally
+     * small to start and can be expanded over time as new sensitive options are introduced.
+     */
     private static final Set<String> SENSITIVE_FIELD_NAMES =
             Collections.unmodifiableSet(
                     new HashSet<>(

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/DefaultConnectionFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/DefaultConnectionFactory.java
@@ -57,6 +57,12 @@ import java.util.stream.Collectors;
 public class DefaultConnectionFactory implements ConnectionFactory {
 
     /**
+     * Factory identifier used to discover this factory via SPI. Also used as the fallback when a
+     * connection does not specify a {@link ConnectionFactory#CONNECTION_TYPE_KEY} option.
+     */
+    public static final String IDENTIFIER = "default";
+
+    /**
      * Reserved option key used to store the reference to secrets in the secret store. The
      * surrounding double underscores make collision with user-supplied option names unlikely; user
      * options containing this key will be rejected at create-time.
@@ -86,7 +92,7 @@ public class DefaultConnectionFactory implements ConnectionFactory {
 
     @Override
     public String factoryIdentifier() {
-        return "default";
+        return IDENTIFIER;
     }
 
     @Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/DefaultConnectionFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/DefaultConnectionFactory.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.factories;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.CatalogConnection;
+import org.apache.flink.table.catalog.SensitiveConnection;
+import org.apache.flink.table.secret.ReadableSecretStore;
+import org.apache.flink.table.secret.WritableSecretStore;
+import org.apache.flink.table.secret.exceptions.SecretNotFoundException;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Default implementation of {@link ConnectionFactory} that identifies sensitive fields by a
+ * predefined whitelist of field names.
+ *
+ * <p>During {@link #createConnection}, sensitive fields are extracted from the connection options
+ * and stored as a single secret in the {@link WritableSecretStore}. A reference key ({@value
+ * #SECRET_REFERENCE_KEY}) pointing to the stored secret is added to the returned {@link
+ * CatalogConnection}.
+ *
+ * <p>During {@link #resolveConnection}, the secret reference is used to retrieve the sensitive
+ * fields from the {@link ReadableSecretStore} and merge them back into the options.
+ *
+ * <p>The following field names are treated as sensitive by default: {@code password}, {@code
+ * secret}, {@code fs.azure.account.key}, {@code apikey}, {@code api-key}, {@code auth-params},
+ * {@code service-key}, {@code token}, {@code basic-auth}, {@code jaas.config}, {@code
+ * http-headers}.
+ */
+@Internal
+public class DefaultConnectionFactory implements ConnectionFactory {
+
+    /** Option key used to store the reference to secrets in the secret store. */
+    public static final String SECRET_REFERENCE_KEY = "encrypted_secret_key";
+
+    private static final Set<String> SENSITIVE_FIELD_NAMES =
+            Collections.unmodifiableSet(
+                    new HashSet<>(
+                            Arrays.asList(
+                                    "password",
+                                    "secret",
+                                    "fs.azure.account.key",
+                                    "apikey",
+                                    "api-key",
+                                    "auth-params",
+                                    "service-key",
+                                    "token",
+                                    "basic-auth",
+                                    "jaas.config",
+                                    "http-headers")));
+
+    @Override
+    public String factoryIdentifier() {
+        return "default";
+    }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public CatalogConnection createConnection(
+            SensitiveConnection connection, WritableSecretStore secretStore) {
+        Map<String, String> allOptions = connection.getOptions();
+
+        Map<String, String> sensitiveOptions =
+                allOptions.entrySet().stream()
+                        .filter(e -> SENSITIVE_FIELD_NAMES.contains(e.getKey()))
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        Map<String, String> nonSensitiveOptions =
+                allOptions.entrySet().stream()
+                        .filter(e -> !SENSITIVE_FIELD_NAMES.contains(e.getKey()))
+                        .collect(
+                                Collectors.toMap(
+                                        Map.Entry::getKey,
+                                        Map.Entry::getValue,
+                                        (a, b) -> a,
+                                        HashMap::new));
+
+        if (!sensitiveOptions.isEmpty()) {
+            String secretId = secretStore.storeSecret(sensitiveOptions);
+            nonSensitiveOptions.put(SECRET_REFERENCE_KEY, secretId);
+        }
+
+        return CatalogConnection.of(nonSensitiveOptions, connection.getComment());
+    }
+
+    @Override
+    public SensitiveConnection resolveConnection(
+            CatalogConnection connection, ReadableSecretStore secretStore) {
+        Map<String, String> options = new HashMap<>(connection.getOptions());
+
+        String secretId = options.remove(SECRET_REFERENCE_KEY);
+        if (secretId != null) {
+            try {
+                Map<String, String> secrets = secretStore.getSecret(secretId);
+                options.putAll(secrets);
+            } catch (SecretNotFoundException e) {
+                throw new ValidationException(
+                        String.format(
+                                "Failed to resolve connection secrets. Secret with ID '%s' not found.",
+                                secretId),
+                        e);
+            }
+        }
+
+        return SensitiveConnection.of(options, connection.getComment());
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/DefaultConnectionFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/DefaultConnectionFactory.java
@@ -16,12 +16,13 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.catalog;
+package org.apache.flink.table.factories;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.table.api.ValidationException;
-import org.apache.flink.table.factories.ConnectionFactory;
+import org.apache.flink.table.catalog.CatalogConnection;
+import org.apache.flink.table.catalog.SensitiveConnection;
 import org.apache.flink.table.secret.ReadableSecretStore;
 import org.apache.flink.table.secret.WritableSecretStore;
 import org.apache.flink.table.secret.exceptions.SecretException;
@@ -54,8 +55,7 @@ public class DefaultConnectionFactory implements ConnectionFactory {
 
     /**
      * Factory identifier used to discover this factory via SPI. Also used as the fallback when a
-     * connection does not specify a {@link
-     * org.apache.flink.table.factories.FactoryUtil#CONNECTION_TYPE} option.
+     * connection does not specify a {@link FactoryUtil#CONNECTION_TYPE} option.
      */
     public static final String IDENTIFIER = "default";
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/DefaultConnectionFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/DefaultConnectionFactory.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.catalog.CatalogConnection;
 import org.apache.flink.table.catalog.SensitiveConnection;
 import org.apache.flink.table.secret.ReadableSecretStore;
 import org.apache.flink.table.secret.WritableSecretStore;
+import org.apache.flink.table.secret.exceptions.SecretException;
 import org.apache.flink.table.secret.exceptions.SecretNotFoundException;
 
 import java.util.Arrays;
@@ -55,8 +56,12 @@ import java.util.stream.Collectors;
 @Internal
 public class DefaultConnectionFactory implements ConnectionFactory {
 
-    /** Option key used to store the reference to secrets in the secret store. */
-    public static final String SECRET_REFERENCE_KEY = "encrypted_secret_key";
+    /**
+     * Reserved option key used to store the reference to secrets in the secret store. The
+     * surrounding double underscores make collision with user-supplied option names unlikely; user
+     * options containing this key will be rejected at create-time.
+     */
+    public static final String SECRET_REFERENCE_KEY = "__flink.encrypted_secret_key__";
 
     private static final Set<String> SENSITIVE_FIELD_NAMES =
             Collections.unmodifiableSet(
@@ -94,6 +99,13 @@ public class DefaultConnectionFactory implements ConnectionFactory {
             SensitiveConnection connection, WritableSecretStore secretStore) {
         Map<String, String> allOptions = connection.getOptions();
 
+        if (allOptions.containsKey(SECRET_REFERENCE_KEY)) {
+            throw new ValidationException(
+                    String.format(
+                            "Connection option '%s' is reserved and cannot be set by users.",
+                            SECRET_REFERENCE_KEY));
+        }
+
         Map<String, String> sensitiveOptions =
                 allOptions.entrySet().stream()
                         .filter(e -> SENSITIVE_FIELD_NAMES.contains(e.getKey()))
@@ -110,7 +122,14 @@ public class DefaultConnectionFactory implements ConnectionFactory {
                                         HashMap::new));
 
         if (!sensitiveOptions.isEmpty()) {
-            String secretId = secretStore.storeSecret(sensitiveOptions);
+            final String secretId;
+            try {
+                secretId = secretStore.storeSecret(sensitiveOptions);
+            } catch (SecretException e) {
+                throw e;
+            } catch (RuntimeException e) {
+                throw new SecretException("Failed to store connection secret.", e);
+            }
             nonSensitiveOptions.put(SECRET_REFERENCE_KEY, secretId);
         }
 
@@ -133,9 +152,32 @@ public class DefaultConnectionFactory implements ConnectionFactory {
                                 "Failed to resolve connection secrets. Secret with ID '%s' not found.",
                                 secretId),
                         e);
+            } catch (SecretException e) {
+                throw e;
+            } catch (RuntimeException e) {
+                throw new SecretException(
+                        String.format(
+                                "Failed to retrieve connection secret with ID '%s'.", secretId),
+                        e);
             }
         }
 
         return SensitiveConnection.of(options, connection.getComment());
+    }
+
+    @Override
+    public void deleteSecrets(CatalogConnection connection, WritableSecretStore secretStore) {
+        String secretId = connection.getOptions().get(SECRET_REFERENCE_KEY);
+        if (secretId != null) {
+            try {
+                secretStore.removeSecret(secretId);
+            } catch (SecretException e) {
+                throw e;
+            } catch (RuntimeException e) {
+                throw new SecretException(
+                        String.format("Failed to remove connection secret with ID '%s'.", secretId),
+                        e);
+            }
+        }
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
@@ -33,6 +33,7 @@ import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CommonCatalogOptions;
+import org.apache.flink.table.catalog.DefaultConnectionFactory;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ResolvedCatalogModel;
 import org.apache.flink.table.catalog.ResolvedCatalogTable;
@@ -106,6 +107,14 @@ public final class FactoryUtil {
                     .withDescription(
                             "Uniquely identifies the provider of a model that is used for model inference."
                                     + " Its value is used during model provider discovery.");
+
+    public static final ConfigOption<String> CONNECTION_TYPE =
+            ConfigOptions.key("type")
+                    .stringType()
+                    .defaultValue(DefaultConnectionFactory.IDENTIFIER)
+                    .withDescription(
+                            "Identifies the type of a connection. Its value is used during"
+                                    + " ConnectionFactory discovery.");
 
     public static final ConfigOption<String> FORMAT =
             ConfigOptions.key("format")

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
@@ -33,7 +33,6 @@ import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CommonCatalogOptions;
-import org.apache.flink.table.catalog.DefaultConnectionFactory;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ResolvedCatalogModel;
 import org.apache.flink.table.catalog.ResolvedCatalogTable;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/secret/ReadableSecretStore.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/secret/ReadableSecretStore.java
@@ -44,6 +44,5 @@ public interface ReadableSecretStore extends SecretStore {
      * @throws SecretException if the operation fails due to underlying-store errors (network,
      *     permission, etc.)
      */
-    Map<String, String> getSecret(String secretId)
-            throws SecretNotFoundException, SecretException;
+    Map<String, String> getSecret(String secretId) throws SecretNotFoundException, SecretException;
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/secret/ReadableSecretStore.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/secret/ReadableSecretStore.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.secret;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.secret.exceptions.SecretException;
 import org.apache.flink.table.secret.exceptions.SecretNotFoundException;
 
 import java.util.Map;
@@ -40,6 +41,9 @@ public interface ReadableSecretStore extends SecretStore {
      * @param secretId the unique identifier of the secret to retrieve
      * @return a map containing the secret data as key-value pairs
      * @throws SecretNotFoundException if the secret with the given identifier does not exist
+     * @throws SecretException if the operation fails due to underlying-store errors (network,
+     *     permission, etc.)
      */
-    Map<String, String> getSecret(String secretId) throws SecretNotFoundException;
+    Map<String, String> getSecret(String secretId)
+            throws SecretNotFoundException, SecretException;
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/secret/WritableSecretStore.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/secret/WritableSecretStore.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.secret;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.secret.exceptions.SecretException;
 import org.apache.flink.table.secret.exceptions.SecretNotFoundException;
 
 import java.util.Map;
@@ -40,15 +41,19 @@ public interface WritableSecretStore extends SecretStore {
      *
      * @param secretData a map containing the secret data as key-value pairs to be stored
      * @return a unique identifier for the stored secret
+     * @throws SecretException if the operation fails due to underlying-store errors (network,
+     *     permission, quota, etc.)
      */
-    String storeSecret(Map<String, String> secretData);
+    String storeSecret(Map<String, String> secretData) throws SecretException;
 
     /**
      * Removes a secret from the secret store.
      *
      * @param secretId the unique identifier of the secret to remove
+     * @throws SecretException if the operation fails due to underlying-store errors (network,
+     *     permission, etc.)
      */
-    void removeSecret(String secretId);
+    void removeSecret(String secretId) throws SecretException;
 
     /**
      * Atomically updates an existing secret with new data.
@@ -58,7 +63,9 @@ public interface WritableSecretStore extends SecretStore {
      * @param secretId the unique identifier of the secret to update
      * @param newSecretData a map containing the new secret data as key-value pairs
      * @throws SecretNotFoundException if the secret with the given identifier does not exist
+     * @throws SecretException if the operation fails due to underlying-store errors (network,
+     *     permission, etc.)
      */
     void updateSecret(String secretId, Map<String, String> newSecretData)
-            throws SecretNotFoundException;
+            throws SecretNotFoundException, SecretException;
 }

--- a/flink-table/flink-table-common/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink-table/flink-table-common/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -14,4 +14,4 @@
 # limitations under the License.
 
 org.apache.flink.table.module.CoreModuleFactory
-org.apache.flink.table.factories.DefaultConnectionFactory
+org.apache.flink.table.catalog.DefaultConnectionFactory

--- a/flink-table/flink-table-common/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink-table/flink-table-common/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -14,3 +14,4 @@
 # limitations under the License.
 
 org.apache.flink.table.module.CoreModuleFactory
+org.apache.flink.table.factories.DefaultConnectionFactory

--- a/flink-table/flink-table-common/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink-table/flink-table-common/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -14,4 +14,4 @@
 # limitations under the License.
 
 org.apache.flink.table.module.CoreModuleFactory
-org.apache.flink.table.catalog.DefaultConnectionFactory
+org.apache.flink.table.factories.DefaultConnectionFactory

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTest.java
@@ -518,7 +518,9 @@ public abstract class CatalogTest {
                         () -> catalog.createConnection(connectionPath1, createConnection(), false))
                 .isInstanceOf(ConnectionAlreadyExistException.class)
                 .hasMessage(
-                        "Connection db1.c1 already exists in Catalog " + TEST_CATALOG_NAME + ".");
+                        "Connection 'db1.c1' already exists in catalog '"
+                                + TEST_CATALOG_NAME
+                                + "'.");
     }
 
     @Test
@@ -567,7 +569,7 @@ public abstract class CatalogTest {
         catalog.createDatabase(db1, createDb(), false);
         assertThatThrownBy(() -> catalog.getConnection(connectionPath1))
                 .isInstanceOf(ConnectionNotExistException.class)
-                .hasMessage("Connection '`test-catalog`.`db1`.`c1`' does not exist.");
+                .hasMessage("Connection 'db1.c1' does not exist in catalog 'test-catalog'.");
     }
 
     @Test
@@ -581,7 +583,7 @@ public abstract class CatalogTest {
         catalog.dropConnection(connectionPath1, false);
         assertThatThrownBy(() -> catalog.getConnection(connectionPath1))
                 .isInstanceOf(ConnectionNotExistException.class)
-                .hasMessage("Connection '`test-catalog`.`db1`.`c1`' does not exist.");
+                .hasMessage("Connection 'db1.c1' does not exist in catalog 'test-catalog'.");
     }
 
     @Test
@@ -629,7 +631,7 @@ public abstract class CatalogTest {
                         "new connection");
         assertThatThrownBy(() -> catalog.alterConnection(connectionPath1, newConnection, false))
                 .isInstanceOf(ConnectionNotExistException.class)
-                .hasMessage("Connection '`test-catalog`.`db1`.`c1`' does not exist.");
+                .hasMessage("Connection 'db1.c1' does not exist in catalog 'test-catalog'.");
     }
 
     @Test
@@ -658,7 +660,7 @@ public abstract class CatalogTest {
         catalog.createDatabase(db1, createDb(), false);
         assertThatThrownBy(() -> catalog.dropConnection(connectionPath1, false))
                 .isInstanceOf(ConnectionNotExistException.class)
-                .hasMessage("Connection '`test-catalog`.`db1`.`c1`' does not exist.");
+                .hasMessage("Connection 'db1.c1' does not exist in catalog 'test-catalog'.");
     }
 
     @Test

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTest.java
@@ -21,6 +21,8 @@ package org.apache.flink.table.catalog;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
+import org.apache.flink.table.catalog.exceptions.ConnectionAlreadyExistException;
+import org.apache.flink.table.catalog.exceptions.ConnectionNotExistException;
 import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotEmptyException;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
@@ -68,12 +70,16 @@ public abstract class CatalogTest {
     protected final String t3 = "t3";
     protected final String m1 = "m1";
     protected final String m2 = "m2";
+    protected final String c1 = "c1";
+    protected final String c2 = "c2";
     protected final ObjectPath path1 = new ObjectPath(db1, t1);
     protected final ObjectPath path2 = new ObjectPath(db2, t2);
     protected final ObjectPath path3 = new ObjectPath(db1, t2);
     protected final ObjectPath path4 = new ObjectPath(db1, t3);
     protected final ObjectPath modelPath1 = new ObjectPath(db1, m1);
     protected final ObjectPath modelPath2 = new ObjectPath(db1, m2);
+    protected final ObjectPath connectionPath1 = new ObjectPath(db1, c1);
+    protected final ObjectPath connectionPath2 = new ObjectPath(db1, c2);
     protected final ObjectPath nonExistDbPath = ObjectPath.fromString("non.exist");
     protected final ObjectPath nonExistObjectPath = ObjectPath.fromString("db1.nonexist");
 
@@ -106,6 +112,14 @@ public abstract class CatalogTest {
             }
             if (catalog.modelExists(modelPath2)) {
                 catalog.dropModel(modelPath2, true);
+            }
+        }
+        if (supportsConnections()) {
+            if (catalog.connectionExists(connectionPath1)) {
+                catalog.dropConnection(connectionPath1, true);
+            }
+            if (catalog.connectionExists(connectionPath2)) {
+                catalog.dropConnection(connectionPath2, true);
             }
         }
 
@@ -461,6 +475,199 @@ public abstract class CatalogTest {
         catalog.createDatabase(db1, createDb(), false);
         // Nothing happens since ignoreIfNotExists is true
         catalog.dropModel(modelPath1, true);
+    }
+
+    // ------ connections ------
+    @Test
+    public void testCreateConnection() throws Exception {
+        if (!supportsConnections()) {
+            return;
+        }
+        catalog.createDatabase(db1, createDb(), false);
+        CatalogConnection connection = createConnection();
+        catalog.createConnection(connectionPath1, connection, false);
+
+        List<String> connections = catalog.listConnections(db1);
+        assertThat(connections).isEqualTo(Collections.singletonList(c1));
+    }
+
+    @Test
+    public void testCreateConnection_DatabaseNotExistException() {
+        if (!supportsConnections()) {
+            return;
+        }
+        assertThat(catalog.databaseExists(db1)).isFalse();
+
+        assertThatThrownBy(
+                        () ->
+                                catalog.createConnection(
+                                        nonExistObjectPath, createConnection(), false))
+                .isInstanceOf(DatabaseNotExistException.class)
+                .hasMessage("Database db1 does not exist in Catalog " + TEST_CATALOG_NAME + ".");
+    }
+
+    @Test
+    public void testCreateConnection_ConnectionAlreadyExistException() throws Exception {
+        if (!supportsConnections()) {
+            return;
+        }
+        catalog.createDatabase(db1, createDb(), false);
+        catalog.createConnection(connectionPath1, createConnection(), false);
+
+        assertThatThrownBy(
+                        () -> catalog.createConnection(connectionPath1, createConnection(), false))
+                .isInstanceOf(ConnectionAlreadyExistException.class)
+                .hasMessage(
+                        "Connection db1.c1 already exists in Catalog " + TEST_CATALOG_NAME + ".");
+    }
+
+    @Test
+    public void testCreateConnection_ConnectionAlreadyExist_ignored() throws Exception {
+        if (!supportsConnections()) {
+            return;
+        }
+        catalog.createDatabase(db1, createDb(), false);
+
+        CatalogConnection connection = createConnection();
+        catalog.createConnection(connectionPath1, connection, false);
+        catalog.createConnection(connectionPath1, connection, true);
+
+        List<String> connections = catalog.listConnections(db1);
+        assertThat(connections).isEqualTo(Collections.singletonList(c1));
+    }
+
+    @Test
+    public void testListConnections() throws Exception {
+        if (!supportsConnections()) {
+            return;
+        }
+        catalog.createDatabase(db1, createDb(), false);
+
+        catalog.createConnection(connectionPath1, createConnection(), false);
+        catalog.createConnection(connectionPath2, createConnection(), false);
+
+        assertThat(catalog.listConnections(db1)).isEqualTo(Arrays.asList(c1, c2));
+    }
+
+    @Test
+    public void testGetConnection() throws Exception {
+        if (!supportsConnections()) {
+            return;
+        }
+        catalog.createDatabase(db1, createDb(), false);
+        catalog.createConnection(connectionPath1, createConnection(), false);
+        assertThat(catalog.getConnection(connectionPath1)).isNotNull();
+    }
+
+    @Test
+    public void testGetConnection_ConnectionNotExistException() throws Exception {
+        if (!supportsConnections()) {
+            return;
+        }
+        catalog.createDatabase(db1, createDb(), false);
+        assertThatThrownBy(() -> catalog.getConnection(connectionPath1))
+                .isInstanceOf(ConnectionNotExistException.class)
+                .hasMessage("Connection '`test-catalog`.`db1`.`c1`' does not exist.");
+    }
+
+    @Test
+    public void testDropConnection() throws Exception {
+        if (!supportsConnections()) {
+            return;
+        }
+        catalog.createDatabase(db1, createDb(), false);
+        catalog.createConnection(connectionPath1, createConnection(), false);
+        assertThat(catalog.getConnection(connectionPath1)).isNotNull();
+        catalog.dropConnection(connectionPath1, false);
+        assertThatThrownBy(() -> catalog.getConnection(connectionPath1))
+                .isInstanceOf(ConnectionNotExistException.class)
+                .hasMessage("Connection '`test-catalog`.`db1`.`c1`' does not exist.");
+    }
+
+    @Test
+    public void testAlterConnection() throws Exception {
+        if (!supportsConnections()) {
+            return;
+        }
+        catalog.createDatabase(db1, createDb(), false);
+        catalog.createConnection(connectionPath1, createConnection(), false);
+        assertThat(catalog.getConnection(connectionPath1)).isNotNull();
+        CatalogConnection newConnection =
+                CatalogConnection.of(
+                        new HashMap<String, String>() {
+                            {
+                                put("type", "kafka");
+                                put("bootstrap.servers", "remote:9092");
+                                put("group.id", "my-group");
+                            }
+                        },
+                        "updated connection");
+        catalog.alterConnection(connectionPath1, newConnection, false);
+        assertThat(catalog.getConnection(connectionPath1).getComment())
+                .isEqualTo("updated connection");
+        Map<String, String> expectedOptions = new HashMap<>();
+        expectedOptions.put("type", "kafka");
+        expectedOptions.put("bootstrap.servers", "remote:9092");
+        expectedOptions.put("group.id", "my-group");
+        assertThat(catalog.getConnection(connectionPath1).getOptions()).isEqualTo(expectedOptions);
+    }
+
+    @Test
+    public void testAlterConnection_ConnectionNotExistException() throws Exception {
+        if (!supportsConnections()) {
+            return;
+        }
+        catalog.createDatabase(db1, createDb(), false);
+        CatalogConnection newConnection =
+                CatalogConnection.of(
+                        new HashMap<String, String>() {
+                            {
+                                put("type", "kafka");
+                                put("bootstrap.servers", "remote:9092");
+                            }
+                        },
+                        "new connection");
+        assertThatThrownBy(() -> catalog.alterConnection(connectionPath1, newConnection, false))
+                .isInstanceOf(ConnectionNotExistException.class)
+                .hasMessage("Connection '`test-catalog`.`db1`.`c1`' does not exist.");
+    }
+
+    @Test
+    public void testAlterMissingConnectionIgnoreIfNotExist() throws Exception {
+        if (!supportsConnections()) {
+            return;
+        }
+        catalog.createDatabase(db1, createDb(), false);
+        CatalogConnection newConnection =
+                CatalogConnection.of(
+                        new HashMap<String, String>() {
+                            {
+                                put("type", "kafka");
+                                put("bootstrap.servers", "remote:9092");
+                            }
+                        },
+                        "new connection");
+        catalog.alterConnection(connectionPath1, newConnection, true);
+    }
+
+    @Test
+    public void testDropMissingConnectionNotExistException() throws Exception {
+        if (!supportsConnections()) {
+            return;
+        }
+        catalog.createDatabase(db1, createDb(), false);
+        assertThatThrownBy(() -> catalog.dropConnection(connectionPath1, false))
+                .isInstanceOf(ConnectionNotExistException.class)
+                .hasMessage("Connection '`test-catalog`.`db1`.`c1`' does not exist.");
+    }
+
+    @Test
+    public void testDropMissingConnectionIgnoreIfNotExist() throws Exception {
+        if (!supportsConnections()) {
+            return;
+        }
+        catalog.createDatabase(db1, createDb(), false);
+        catalog.dropConnection(connectionPath1, true);
     }
 
     // ------ tables ------
@@ -1613,6 +1820,19 @@ public abstract class CatalogTest {
     public abstract CatalogPartition createPartition();
 
     protected abstract boolean supportsModels();
+
+    protected abstract boolean supportsConnections();
+
+    protected CatalogConnection createConnection() {
+        return CatalogConnection.of(
+                new HashMap<String, String>() {
+                    {
+                        put("type", "kafka");
+                        put("bootstrap.servers", "localhost:9092");
+                    }
+                },
+                null);
+    }
 
     protected ResolvedSchema createSchema() {
         return new ResolvedSchema(

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/DefaultConnectionFactoryTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/DefaultConnectionFactoryTest.java
@@ -16,11 +16,9 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.factories;
+package org.apache.flink.table.catalog;
 
 import org.apache.flink.table.api.ValidationException;
-import org.apache.flink.table.catalog.CatalogConnection;
-import org.apache.flink.table.catalog.SensitiveConnection;
 import org.apache.flink.table.secret.ReadableSecretStore;
 import org.apache.flink.table.secret.WritableSecretStore;
 import org.apache.flink.table.secret.exceptions.SecretException;

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/DefaultConnectionFactoryTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/DefaultConnectionFactoryTest.java
@@ -1,0 +1,392 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.factories;
+
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.CatalogConnection;
+import org.apache.flink.table.catalog.SensitiveConnection;
+import org.apache.flink.table.secret.ReadableSecretStore;
+import org.apache.flink.table.secret.WritableSecretStore;
+import org.apache.flink.table.secret.exceptions.SecretException;
+import org.apache.flink.table.secret.exceptions.SecretNotFoundException;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link DefaultConnectionFactory}. */
+class DefaultConnectionFactoryTest {
+
+    private final DefaultConnectionFactory factory = new DefaultConnectionFactory();
+
+    // ---------------------------------------------------------------------------------------------
+    // createConnection
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    void createConnectionWithoutSensitiveOptionsDoesNotCallSecretStore() {
+        Map<String, String> options = new LinkedHashMap<>();
+        options.put("host", "localhost");
+        options.put("port", "9092");
+
+        RecordingSecretStore secretStore = new RecordingSecretStore();
+        CatalogConnection result =
+                factory.createConnection(
+                        SensitiveConnection.of(options, "my-comment"), secretStore);
+
+        assertThat(secretStore.stored).isEmpty();
+        assertThat(result.getOptions())
+                .containsExactlyInAnyOrderEntriesOf(options)
+                .doesNotContainKey(DefaultConnectionFactory.SECRET_REFERENCE_KEY);
+        assertThat(result.getComment()).isEqualTo("my-comment");
+    }
+
+    @Test
+    void createConnectionWithSensitiveOptionsStoresOnlySensitiveOptions() {
+        Map<String, String> options = new LinkedHashMap<>();
+        options.put("host", "localhost");
+        options.put("password", "p@ss");
+        options.put("api-key", "abc");
+        options.put("token", "tok");
+
+        RecordingSecretStore secretStore = new RecordingSecretStore();
+        CatalogConnection result =
+                factory.createConnection(SensitiveConnection.of(options, null), secretStore);
+
+        // secretStore.storeSecret called exactly once with only the sensitive subset
+        assertThat(secretStore.stored).hasSize(1);
+        Map<String, String> storedSecret = secretStore.stored.values().iterator().next();
+        assertThat(storedSecret)
+                .containsOnlyKeys("password", "api-key", "token")
+                .containsEntry("password", "p@ss")
+                .containsEntry("api-key", "abc")
+                .containsEntry("token", "tok");
+
+        // Returned connection retains only non-sensitive options plus a secret reference
+        String secretId = secretStore.stored.keySet().iterator().next();
+        assertThat(result.getOptions())
+                .containsOnlyKeys("host", DefaultConnectionFactory.SECRET_REFERENCE_KEY)
+                .containsEntry("host", "localhost")
+                .containsEntry(DefaultConnectionFactory.SECRET_REFERENCE_KEY, secretId);
+    }
+
+    @Test
+    void createConnectionRecognizesAllSensitiveFieldNames() {
+        // Covers the default sensitive whitelist; failure here flags an accidental change to
+        // the whitelist.
+        List<String> sensitiveKeys =
+                Arrays.asList(
+                        "password",
+                        "secret",
+                        "fs.azure.account.key",
+                        "apikey",
+                        "api-key",
+                        "auth-params",
+                        "service-key",
+                        "token",
+                        "basic-auth",
+                        "jaas.config",
+                        "http-headers");
+
+        Map<String, String> options = new LinkedHashMap<>();
+        for (String key : sensitiveKeys) {
+            options.put(key, "value-of-" + key);
+        }
+
+        RecordingSecretStore secretStore = new RecordingSecretStore();
+        CatalogConnection result =
+                factory.createConnection(SensitiveConnection.of(options, null), secretStore);
+
+        assertThat(secretStore.stored).hasSize(1);
+        Map<String, String> storedSecret = secretStore.stored.values().iterator().next();
+        assertThat(storedSecret).containsExactlyInAnyOrderEntriesOf(options);
+        assertThat(result.getOptions())
+                .containsOnlyKeys(DefaultConnectionFactory.SECRET_REFERENCE_KEY);
+    }
+
+    @Test
+    void createConnectionRejectsUserSuppliedReservedKey() {
+        Map<String, String> options =
+                Collections.singletonMap(
+                        DefaultConnectionFactory.SECRET_REFERENCE_KEY, "user-injected");
+
+        RecordingSecretStore secretStore = new RecordingSecretStore();
+        assertThatThrownBy(
+                        () ->
+                                factory.createConnection(
+                                        SensitiveConnection.of(options, null), secretStore))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining(DefaultConnectionFactory.SECRET_REFERENCE_KEY)
+                .hasMessageContaining("reserved");
+        assertThat(secretStore.stored).isEmpty();
+    }
+
+    @Test
+    void createConnectionPropagatesSecretException() {
+        Map<String, String> options = Collections.singletonMap("password", "p@ss");
+        SecretException original = new SecretException("downstream failure");
+
+        RecordingSecretStore secretStore =
+                new RecordingSecretStore() {
+                    @Override
+                    public String storeSecret(Map<String, String> secretData) {
+                        throw original;
+                    }
+                };
+
+        assertThatThrownBy(
+                        () ->
+                                factory.createConnection(
+                                        SensitiveConnection.of(options, null), secretStore))
+                .isSameAs(original);
+    }
+
+    @Test
+    void createConnectionWrapsRuntimeExceptionFromStore() {
+        Map<String, String> options = Collections.singletonMap("password", "p@ss");
+
+        RecordingSecretStore secretStore =
+                new RecordingSecretStore() {
+                    @Override
+                    public String storeSecret(Map<String, String> secretData) {
+                        throw new IllegalStateException("kaboom");
+                    }
+                };
+
+        assertThatThrownBy(
+                        () ->
+                                factory.createConnection(
+                                        SensitiveConnection.of(options, null), secretStore))
+                .isInstanceOf(SecretException.class)
+                .hasMessageContaining("Failed to store connection secret")
+                .hasCauseInstanceOf(IllegalStateException.class);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // resolveConnection
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    void resolveConnectionWithoutSecretReferenceReturnsOptionsUnchanged() {
+        Map<String, String> options = new LinkedHashMap<>();
+        options.put("host", "localhost");
+        options.put("port", "9092");
+
+        RecordingSecretStore secretStore = new RecordingSecretStore();
+        SensitiveConnection resolved =
+                factory.resolveConnection(
+                        CatalogConnection.of(options, "the-comment"), secretStore);
+
+        assertThat(secretStore.retrieved).isEmpty();
+        assertThat(resolved.getOptions()).containsExactlyInAnyOrderEntriesOf(options);
+        assertThat(resolved.getComment()).isEqualTo("the-comment");
+    }
+
+    @Test
+    void resolveConnectionMergesSecretsBackIntoOptions() {
+        RecordingSecretStore secretStore = new RecordingSecretStore();
+        Map<String, String> secrets = new HashMap<>();
+        secrets.put("password", "p@ss");
+        secrets.put("token", "tok");
+        String secretId = secretStore.storeSecret(secrets);
+
+        Map<String, String> catalogOptions = new LinkedHashMap<>();
+        catalogOptions.put("host", "localhost");
+        catalogOptions.put(DefaultConnectionFactory.SECRET_REFERENCE_KEY, secretId);
+
+        SensitiveConnection resolved =
+                factory.resolveConnection(CatalogConnection.of(catalogOptions, null), secretStore);
+
+        assertThat(secretStore.retrieved).containsExactly(secretId);
+        assertThat(resolved.getOptions())
+                .containsOnlyKeys("host", "password", "token")
+                .containsEntry("host", "localhost")
+                .containsEntry("password", "p@ss")
+                .containsEntry("token", "tok")
+                .doesNotContainKey(DefaultConnectionFactory.SECRET_REFERENCE_KEY);
+    }
+
+    @Test
+    void resolveConnectionTranslatesSecretNotFoundToValidationException() {
+        // Empty stored map → fake's getSecret will throw SecretNotFoundException by default.
+        RecordingSecretStore secretStore = new RecordingSecretStore();
+
+        Map<String, String> catalogOptions =
+                Collections.singletonMap(DefaultConnectionFactory.SECRET_REFERENCE_KEY, "missing");
+
+        assertThatThrownBy(
+                        () ->
+                                factory.resolveConnection(
+                                        CatalogConnection.of(catalogOptions, null), secretStore))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("'missing'")
+                .hasCauseInstanceOf(SecretNotFoundException.class);
+    }
+
+    @Test
+    void resolveConnectionWrapsRuntimeExceptionFromStore() {
+        RecordingSecretStore secretStore =
+                new RecordingSecretStore() {
+                    @Override
+                    public Map<String, String> getSecret(String secretId) {
+                        throw new IllegalStateException("transport down");
+                    }
+                };
+
+        Map<String, String> catalogOptions =
+                Collections.singletonMap(DefaultConnectionFactory.SECRET_REFERENCE_KEY, "abc");
+
+        assertThatThrownBy(
+                        () ->
+                                factory.resolveConnection(
+                                        CatalogConnection.of(catalogOptions, null), secretStore))
+                .isInstanceOf(SecretException.class)
+                .hasMessageContaining("'abc'")
+                .hasCauseInstanceOf(IllegalStateException.class);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // deleteSecrets
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    void deleteSecretsWithoutReferenceIsNoOp() {
+        Map<String, String> catalogOptions = Collections.singletonMap("host", "localhost");
+
+        RecordingSecretStore secretStore = new RecordingSecretStore();
+        factory.deleteSecrets(CatalogConnection.of(catalogOptions, null), secretStore);
+
+        assertThat(secretStore.removed).isEmpty();
+    }
+
+    @Test
+    void deleteSecretsRemovesByReference() {
+        RecordingSecretStore secretStore = new RecordingSecretStore();
+        String secretId = secretStore.storeSecret(Collections.singletonMap("password", "p@ss"));
+
+        Map<String, String> catalogOptions = new LinkedHashMap<>();
+        catalogOptions.put("host", "localhost");
+        catalogOptions.put(DefaultConnectionFactory.SECRET_REFERENCE_KEY, secretId);
+
+        factory.deleteSecrets(CatalogConnection.of(catalogOptions, null), secretStore);
+
+        assertThat(secretStore.removed).containsExactly(secretId);
+        assertThat(secretStore.stored).doesNotContainKey(secretId);
+    }
+
+    @Test
+    void deleteSecretsWrapsRuntimeExceptionFromStore() {
+        RecordingSecretStore secretStore =
+                new RecordingSecretStore() {
+                    @Override
+                    public void removeSecret(String secretId) {
+                        throw new IllegalStateException("transport down");
+                    }
+                };
+
+        Map<String, String> catalogOptions =
+                Collections.singletonMap(DefaultConnectionFactory.SECRET_REFERENCE_KEY, "abc");
+
+        assertThatThrownBy(
+                        () ->
+                                factory.deleteSecrets(
+                                        CatalogConnection.of(catalogOptions, null), secretStore))
+                .isInstanceOf(SecretException.class)
+                .hasMessageContaining("'abc'")
+                .hasCauseInstanceOf(IllegalStateException.class);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // round-trip
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    void createAndResolveRoundTripPreservesOptionsAndComment() {
+        Map<String, String> options = new LinkedHashMap<>();
+        options.put("host", "localhost");
+        options.put("port", "9092");
+        options.put("password", "p@ss");
+        options.put("token", "tok");
+
+        RecordingSecretStore secretStore = new RecordingSecretStore();
+        CatalogConnection persisted =
+                factory.createConnection(
+                        SensitiveConnection.of(options, "round-trip"), secretStore);
+        SensitiveConnection resolved = factory.resolveConnection(persisted, secretStore);
+
+        assertThat(resolved.getOptions()).containsExactlyInAnyOrderEntriesOf(options);
+        assertThat(resolved.getComment()).isEqualTo("round-trip");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Fake secret store that records all interactions; tests use the maps directly to verify how
+     * {@link DefaultConnectionFactory} invokes the store.
+     */
+    private static class RecordingSecretStore implements WritableSecretStore, ReadableSecretStore {
+
+        final Map<String, Map<String, String>> stored = new LinkedHashMap<>();
+        final List<String> retrieved = new java.util.ArrayList<>();
+        final List<String> removed = new java.util.ArrayList<>();
+
+        @Override
+        public String storeSecret(Map<String, String> secretData) {
+            String id = UUID.randomUUID().toString();
+            stored.put(id, new LinkedHashMap<>(secretData));
+            return id;
+        }
+
+        @Override
+        public void removeSecret(String secretId) {
+            removed.add(secretId);
+            stored.remove(secretId);
+        }
+
+        @Override
+        public void updateSecret(String secretId, Map<String, String> newSecretData)
+                throws SecretNotFoundException {
+            if (!stored.containsKey(secretId)) {
+                throw new SecretNotFoundException("Secret '" + secretId + "' not found.");
+            }
+            stored.put(secretId, new LinkedHashMap<>(newSecretData));
+        }
+
+        @Override
+        public Map<String, String> getSecret(String secretId) throws SecretNotFoundException {
+            retrieved.add(secretId);
+            Map<String, String> result = stored.get(secretId);
+            if (result == null) {
+                throw new SecretNotFoundException("Secret '" + secretId + "' not found.");
+            }
+            return result;
+        }
+    }
+}

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/DefaultConnectionFactoryTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/DefaultConnectionFactoryTest.java
@@ -16,9 +16,11 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.catalog;
+package org.apache.flink.table.factories;
 
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.CatalogConnection;
+import org.apache.flink.table.catalog.SensitiveConnection;
 import org.apache.flink.table.secret.ReadableSecretStore;
 import org.apache.flink.table.secret.WritableSecretStore;
 import org.apache.flink.table.secret.exceptions.SecretException;


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds first-class support for **catalog connections** in the Table API. A `Connection` is a new top-level catalog object (alongside tables, views, functions, and models) that captures the configuration for accessing an external system, so that downstream features can reuse a centrally managed connection definition rather than embedding connection properties in every table DDL.

This change introduces the connection lifecycle on the catalog stack — interface methods, in-memory implementation, plumbing through `CatalogManager` and `TableEnvironmentImpl`, listener events, exception types, and a connection factory — without altering existing catalog object behavior.

## Brief change log

  - Added connection CRUD APIs (`listConnections`, `getConnection`, `connectionExists`, `createConnection`, `dropConnection`, `alterConnection`) to `Catalog` as `default` methods, preserving binary/source compatibility for existing implementations.
  - Implemented connection storage in `GenericInMemoryCatalog`.
  - Plumbed connection management (including temporary connections) through `CatalogManager` with overloads for `ObjectIdentifier`-based lookup, listing, and create/alter/drop.
  - Wired `CatalogManager` to expose a `ConnectionFactory` and routed connection access from `TableEnvironmentImpl`.
  - Added catalog listener events: `CreateConnectionEvent`, `AlterConnectionEvent`, `DropConnectionEvent`, all extending a new `ConnectionModificationEvent`.
  - Added new exception types: `ConnectionNotExistException`, `ConnectionAlreadyExistException`.
  - Added `ConnectionFactory` SPI and `DefaultConnectionFactory` implementation.

## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

This change added tests and can be verified as follows:

  - Added `CatalogTest` (abstract test base, ~220 lines) covering `listConnections`, `getConnection`, `connectionExists`, `createConnection` (incl. `ifNotExists` semantics and `ConnectionAlreadyExistException`), `dropConnection` (incl. `ifNotExists` semantics and `ConnectionNotExistException`), and `alterConnection`.
  - `GenericInMemoryCatalogTest` extends `CatalogTest` and exercises the new methods against the in-memory implementation (123 tests passing locally).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **yes** — `Catalog` is `@PublicEvolving`. New methods are `default`, so existing implementations remain source- and binary-compatible.
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **yes**
  - If yes, how is the feature documented? **JavaDocs** on the new `Catalog` methods, listener events, exception types, and the `ConnectionFactory` SPI.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [x] Yes (please specify the tool below)
Claude
<!--
Generated-by: [Tool Name and Version]
-->
