### PR TITLE
[BP-2.3][hotfix] Add log4j-layout-template-json to NOTICE

### DIFF
--- a/tools/releasing/NOTICE-binary_PREAMBLE.txt
+++ b/tools/releasing/NOTICE-binary_PREAMBLE.txt
@@ -12,6 +12,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.logging.log4j:log4j-core:2.25.3
 - org.apache.logging.log4j:log4j-slf4j-impl:2.25.3
 - org.apache.logging.log4j:log4j-1.2-api:2.25.3
+- org.apache.logging.log4j:log4j-layout-template-json:2.25.3
 
 This project bundles the following dependencies under the BSD license.
 See bundled license files for details.


### PR DESCRIPTION
backport of https://github.com/apache/flink/pull/28081

also taking into account that in 2.3 there is version 2.25.3
https://github.com/apache/flink/blob/84cd7548d1dddcd9dfecd4e49f287fc8554ae57c/pom.xml#L137