### PR TITLE
[hotfix][docs] Fix incorrect HashMapStateBackend recommendations

### DIFF
--- a/docs/content.zh/docs/ops/state/state_backends.md
+++ b/docs/content.zh/docs/ops/state/state_backends.md
@@ -58,8 +58,8 @@ Flink 内置了以下这些开箱即用的 state backends ：
 
 HashMapStateBackend 的适用场景：
 
-  - 有较大 state，较长 window 和较大 key/value 状态的 Job。
-  - 所有的高可用场景。
+  - 状态可以完全放入 TaskManager JVM 堆内存的 Job，需要快速的、基于内存的状态访问。
+  - 对延迟敏感、希望避免每次状态访问都进行序列化/反序列化开销的 Job。
 
 建议同时将 [managed memory]({{< ref "docs/deployment/memory/mem_setup_tm" >}}#managed-memory) 设为0，以保证将最大限度的内存分配给 JVM 上的用户代码。
 

--- a/docs/content.zh/docs/ops/state/state_backends.md
+++ b/docs/content.zh/docs/ops/state/state_backends.md
@@ -56,9 +56,14 @@ Flink 内置了以下这些开箱即用的 state backends ：
 
 在 *HashMapStateBackend* 内部，数据以 Java 对象的形式存储在堆中。 Key/value 形式的状态和窗口算子会持有一个 hash table，其中存储着状态值、触发器。
 
+HashMapStateBackend 的局限：
+
+  - 状态大小受限于 TaskManager 上可用的 JVM 堆内存。从 checkpoint 或 savepoint 恢复时，每个 TaskManager 必须有足够的堆内存来容纳其分配到的状态。
+  - 仅支持全量快照，不支持增量 checkpoint。每次 checkpoint 都会捕获完整的状态，随着状态规模增长，checkpoint 时长和恢复时间也会随之延长。
+
 HashMapStateBackend 的适用场景：
 
-  - 状态可以完全放入 TaskManager JVM 堆内存的 Job，需要快速的、基于内存的状态访问。
+  - 状态可以完全放入 TaskManager JVM 堆内存的 Job，需要快速、基于内存的状态访问。
   - 对延迟敏感、希望避免每次状态访问都进行序列化/反序列化开销的 Job。
 
 建议同时将 [managed memory]({{< ref "docs/deployment/memory/mem_setup_tm" >}}#managed-memory) 设为0，以保证将最大限度的内存分配给 JVM 上的用户代码。

--- a/docs/content/docs/ops/state/state_backends.md
+++ b/docs/content/docs/ops/state/state_backends.md
@@ -55,8 +55,8 @@ that store the values, triggers, etc.
 
 The HashMapStateBackend is encouraged for:
 
-  - Jobs with large state, long windows, large key/value states.
-  - All high-availability setups.
+  - Jobs whose state fits comfortably in the JVM heap of the TaskManagers, where fast, in-memory state access is the priority.
+  - Jobs with low-latency requirements that benefit from avoiding (de-)serialization on every state access.
 
 It is also recommended to set [managed memory]({{< ref "docs/deployment/memory/mem_setup_tm" >}}#managed-memory) to zero.
 This will ensure that the maximum amount of memory is allocated for user code on the JVM.

--- a/docs/content/docs/ops/state/state_backends.md
+++ b/docs/content/docs/ops/state/state_backends.md
@@ -53,6 +53,11 @@ If nothing else is configured, the system will use the HashMapStateBackend.
 The *HashMapStateBackend* holds data internally as objects on the Java heap. Key/value state and window operators hold hash tables
 that store the values, triggers, etc.
 
+Limitations of the HashMapStateBackend:
+
+  - State size is bounded by the JVM heap available on the TaskManagers. Restoring a checkpoint or savepoint requires that each TaskManager has enough heap to hold its share of the state.
+  - Only full snapshots are supported as incremental checkpoints are not available. Every checkpoint captures the complete state, which can lengthen checkpoint duration and recovery time as state grows.
+
 The HashMapStateBackend is encouraged for:
 
   - Jobs whose state fits comfortably in the JVM heap of the TaskManagers, where fast, in-memory state access is the priority.

--- a/docs/content/docs/ops/state/state_backends.md
+++ b/docs/content/docs/ops/state/state_backends.md
@@ -56,7 +56,7 @@ that store the values, triggers, etc.
 The HashMapStateBackend is encouraged for:
 
   - Jobs whose state fits comfortably in the JVM heap of the TaskManagers, where fast, in-memory state access is the priority.
-  - Jobs with low-latency requirements that benefit from avoiding (de-)serialization on every state access.
+  - Jobs with low-latency requirements that benefit from avoiding de-/serialization on every state access.
 
 It is also recommended to set [managed memory]({{< ref "docs/deployment/memory/mem_setup_tm" >}}#managed-memory) to zero.
 This will ensure that the maximum amount of memory is allocated for user code on the JVM.


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull request fixes incorrect recommendations in the State Backends documentation. The "encouraged for" bullets under the `HashMapStateBackend` section were copy-pasted from the `EmbeddedRocksDBStateBackend` section and incorrectly recommended the heap-based backend for "jobs with large state, long windows, large key/value states" and "all high-availability setups", which is the opposite of HashMapStateBackend's actual sweet spot. The fix replaces them with bullets that reflect HashMapStateBackend's real strengths (in-memory access for state that fits on the JVM heap, avoiding (de-)serialization on every state access). Both the English and Chinese versions of the page are updated to stay in sync.


## Brief change log

  - Replaced the misleading bullets under "The HashMapStateBackend is encouraged for:" in `docs/content/docs/ops/state/state_backends.md`.
  - Mirrored the same fix in the Chinese translation at `docs/content.zh/docs/ops/state/state_backends.md`.

## Verifying this change

This change is a trivial documentation fix without any test coverage. It can be verified by rendering the docs locally (`docs/build_docs.sh`) and inspecting the "The HashMapStateBackend" section on both the English and Chinese pages.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [X] Yes (please specify the tool below)

Generated-by: [Github Copilot]
