### PR TITLE
[hotfix][docs] Bump externalized connector docs refs to latest minor releases

### DIFF
--- a/docs/setup_docs.sh
+++ b/docs/setup_docs.sh
@@ -54,10 +54,10 @@ if [ "$SKIP_INTEGRATE_CONNECTOR_DOCS" = false ]; then
   integrate_connector_docs elasticsearch v4.0
   integrate_connector_docs aws v6.0
   integrate_connector_docs cassandra v3.2
-  integrate_connector_docs pulsar v4.0
+  integrate_connector_docs pulsar v4.1
   integrate_connector_docs jdbc v4.0
   integrate_connector_docs rabbitmq v3.0
-  integrate_connector_docs gcp-pubsub v3.0
+  integrate_connector_docs gcp-pubsub v3.1
   integrate_connector_docs mongodb v2.0
   integrate_connector_docs opensearch v1.2
   integrate_connector_docs kafka v4.0

--- a/docs/setup_docs.sh
+++ b/docs/setup_docs.sh
@@ -55,7 +55,7 @@ if [ "$SKIP_INTEGRATE_CONNECTOR_DOCS" = false ]; then
   integrate_connector_docs aws v6.0
   integrate_connector_docs cassandra v3.2
   integrate_connector_docs pulsar v4.0
-  integrate_connector_docs jdbc v3.1
+  integrate_connector_docs jdbc v4.0
   integrate_connector_docs rabbitmq v3.0
   integrate_connector_docs gcp-pubsub v3.0
   integrate_connector_docs mongodb v2.0


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Several externalized connectors had published new minor releases that were not yet picked up by `docs/setup_docs.sh`, so the rendered pages on the Flink master docs site (`https://nightlies.apache.org/flink/flink-docs-master/docs/connectors/datastream/...`) were lagging behind the upstream connector documentation. This pull request refreshes the connector docs refs to track each connector's latest released minor branch, consistent with how the rest of the script is already pinned (Kafka `v4.0`, Elasticsearch `v4.0`, HBase `v4.0`, AWS `v6.0`, ...).

## Brief change log

`docs/setup_docs.sh`:

  - `flink-connector-jdbc`:       `v3.1` → `v4.0` (latest released: `v4.0.0`)
  - `flink-connector-pulsar`:     `v4.0` → `v4.1` (latest released: `v4.1.0`)
  - `flink-connector-gcp-pubsub`: `v3.0` → `v3.1` (latest released: `v3.1.0`)

The remaining connectors (`elasticsearch`, `aws`, `cassandra`, `rabbitmq`, `mongodb`, `opensearch`, `kafka`, `hbase`, `prometheus`, `hive`) were verified to already track their latest released minor branch and are left untouched.

## Verifying this change

This change is a trivial documentation-tooling fix without any test coverage.

It was manually verified by:
  - Listing the upstream branches and tags of every `apache/flink-connector-*` repo, confirming that the three bumped refs each correspond to an existing release branch with a published GA tag, and that the remaining ten connectors already track their latest minor branch.
  - Wiping the connector cache (`rm -rf docs/themes/connectors docs/tmp`) and re-running `docs/setup_docs.sh`, confirming each bumped connector's docs are now sourced from the new branch.
  - Rendering the docs locally and inspecting the JDBC, Pulsar, and GCP Pub/Sub DataStream pages, which now match the upstream contents of `v4.0`, `v4.1`, and `v3.1` respectively.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
