### PR TITLE
[FLINK-34620] Fix stack overflow in recursive protobuf message handling in `flink-protobuf`

### DIFF
--- a/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/deserialize/PbCodegenBytesDeserializer.java
+++ b/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/deserialize/PbCodegenBytesDeserializer.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.protobuf.deserialize;
+
+import org.apache.flink.formats.protobuf.PbCodegenException;
+import org.apache.flink.formats.protobuf.util.PbCodegenAppender;
+
+import com.google.protobuf.Descriptors.FieldDescriptor;
+
+/**
+ * Deserializer that converts a protobuf message to its raw binary bytes. Used when a recursive
+ * message type is detected and represented as BYTES in the Flink schema, preserving the data for
+ * optional later unpacking via a UDF.
+ */
+public class PbCodegenBytesDeserializer implements PbCodegenDeserializer {
+    private final FieldDescriptor fd;
+
+    public PbCodegenBytesDeserializer(FieldDescriptor fd) {
+        this.fd = fd;
+    }
+
+    @Override
+    public String codegen(String resultVar, String pbObjectCode, int indent)
+            throws PbCodegenException {
+        PbCodegenAppender appender = new PbCodegenAppender(indent);
+        appender.appendLine(resultVar + " = " + pbObjectCode + ".toByteArray()");
+        return appender.code();
+    }
+}

--- a/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/deserialize/PbCodegenDeserializeFactory.java
+++ b/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/deserialize/PbCodegenDeserializeFactory.java
@@ -23,16 +23,25 @@ import org.apache.flink.formats.protobuf.PbFormatContext;
 import org.apache.flink.formats.protobuf.util.PbFormatUtils;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.RowType;
 
 import com.google.protobuf.Descriptors;
+import com.google.protobuf.Descriptors.FieldDescriptor.JavaType;
 
 /** Codegen factory class which return {@link PbCodegenDeserializer} of different data type. */
 public class PbCodegenDeserializeFactory {
     public static PbCodegenDeserializer getPbCodegenDes(
             Descriptors.FieldDescriptor fd, LogicalType type, PbFormatContext formatContext)
             throws PbCodegenException {
+        // Check for recursive message type represented as raw bytes:
+        // the proto field is a MESSAGE but the logical type has been resolved to VARBINARY
+        // by PbToRowTypeUtil's cycle detection.
+        if (fd.getJavaType() == JavaType.MESSAGE
+                && type.getTypeRoot() == LogicalTypeRoot.VARBINARY) {
+            return new PbCodegenBytesDeserializer(fd);
+        }
         // We do not use FieldDescriptor to check because there's no way to get
         // element field descriptor of array type.
         if (type instanceof RowType) {

--- a/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/util/PbSchemaValidationUtils.java
+++ b/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/util/PbSchemaValidationUtils.java
@@ -100,7 +100,11 @@ public class PbSchemaValidationUtils {
                 // simple type
                 validateSimpleType(fd, logicalType.getTypeRoot());
             } else {
-                // message type
+                // message type - may be RowType (normal) or VarBinaryType (recursive, as bytes)
+                if (logicalType.getTypeRoot() == LogicalTypeRoot.VARBINARY) {
+                    // Recursive message type represented as raw bytes - valid mapping
+                    return;
+                }
                 if (!(logicalType instanceof RowType)) {
                     throw new ValidationException(
                             "Unexpected LogicalType: " + logicalType + ". It should be RowType");
@@ -131,6 +135,10 @@ public class PbSchemaValidationUtils {
                 if (fd.getJavaType() == JavaType.MESSAGE) {
                     // array message type
                     LogicalType elementType = arrayType.getElementType();
+                    if (elementType.getTypeRoot() == LogicalTypeRoot.VARBINARY) {
+                        // Recursive message type as raw bytes - valid
+                        return;
+                    }
                     if (!(elementType instanceof RowType)) {
                         throw new ValidationException(
                                 "Unexpected logicalType: "

--- a/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/util/PbToRowTypeUtil.java
+++ b/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/util/PbToRowTypeUtil.java
@@ -36,6 +36,9 @@ import com.google.protobuf.Descriptors;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor.JavaType;
 
+import java.util.HashSet;
+import java.util.Set;
+
 /** Generate Row type information according to pb descriptors. */
 public class PbToRowTypeUtil {
     public static RowType generateRowType(Descriptors.Descriptor root) {
@@ -43,20 +46,43 @@ public class PbToRowTypeUtil {
     }
 
     public static RowType generateRowType(Descriptors.Descriptor root, boolean enumAsInt) {
+        // Track message types currently being resolved in the ancestor chain to detect
+        // recursive references (e.g., A -> B -> A). Without this, recursive proto
+        // definitions cause infinite recursion and StackOverflowError.
+        Set<String> ancestors = new HashSet<>();
+        return generateRowTypeInternal(root, enumAsInt, ancestors);
+    }
+
+    /**
+     * @param ancestors message type full names currently being resolved in the call stack. Used to
+     *     detect cycles: if a field's message type is already in this set, it's a recursive
+     *     reference and gets emitted as BYTES instead of recursing infinitely.
+     */
+    private static RowType generateRowTypeInternal(
+            Descriptors.Descriptor root, boolean enumAsInt, Set<String> ancestors) {
         int size = root.getFields().size();
         LogicalType[] types = new LogicalType[size];
         String[] rowFieldNames = new String[size];
 
-        for (int i = 0; i < size; i++) {
-            FieldDescriptor field = root.getFields().get(i);
-            rowFieldNames[i] = field.getName();
-            types[i] = generateFieldTypeInformation(field, enumAsInt);
+        // Mark this type as "being resolved" before processing its fields
+        String fullName = root.getFullName();
+        ancestors.add(fullName);
+
+        try {
+            for (int i = 0; i < size; i++) {
+                FieldDescriptor field = root.getFields().get(i);
+                rowFieldNames[i] = field.getName();
+                types[i] = generateFieldTypeInformation(field, enumAsInt, ancestors);
+            }
+        } finally {
+            // Unmark when we're done - sibling branches shouldn't see this type as an ancestor
+            ancestors.remove(fullName);
         }
         return RowType.of(types, rowFieldNames);
     }
 
     private static LogicalType generateFieldTypeInformation(
-            FieldDescriptor field, boolean enumAsInt) {
+            FieldDescriptor field, boolean enumAsInt, Set<String> ancestors) {
         JavaType fieldType = field.getJavaType();
         LogicalType type;
         if (fieldType.equals(JavaType.MESSAGE)) {
@@ -66,16 +92,36 @@ public class PbToRowTypeUtil {
                                 generateFieldTypeInformation(
                                         field.getMessageType()
                                                 .findFieldByName(PbConstant.PB_MAP_KEY_NAME),
-                                        enumAsInt),
+                                        enumAsInt,
+                                        ancestors),
                                 generateFieldTypeInformation(
                                         field.getMessageType()
                                                 .findFieldByName(PbConstant.PB_MAP_VALUE_NAME),
-                                        enumAsInt));
+                                        enumAsInt,
+                                        ancestors));
                 return mapType;
-            } else if (field.isRepeated()) {
-                return new ArrayType(generateRowType(field.getMessageType()));
+            }
+
+            // Cycle detection: if this field's message type is already being resolved
+            // in the ancestor chain, we have a recursive proto definition
+            // (e.g., Node -> Child -> Node). Columnar schemas cannot represent
+            // infinite recursion, so we emit the field as raw BYTES. The protobuf
+            // binary is preserved and can be deserialized on demand if consumers
+            // need the recursive data.
+            String msgFullName = field.getMessageType().getFullName();
+            if (ancestors.contains(msgFullName)) {
+                LogicalType bytesType = new VarBinaryType(Integer.MAX_VALUE);
+                if (field.isRepeated()) {
+                    return new ArrayType(bytesType);
+                }
+                return bytesType;
+            }
+
+            if (field.isRepeated()) {
+                return new ArrayType(
+                        generateRowTypeInternal(field.getMessageType(), enumAsInt, ancestors));
             } else {
-                return generateRowType(field.getMessageType());
+                return generateRowTypeInternal(field.getMessageType(), enumAsInt, ancestors);
             }
         } else {
             if (fieldType.equals(JavaType.STRING)) {

--- a/flink-formats/flink-protobuf/src/test/java/org/apache/flink/formats/protobuf/RecursiveMessageProtoToRowTest.java
+++ b/flink-formats/flink-protobuf/src/test/java/org/apache/flink/formats/protobuf/RecursiveMessageProtoToRowTest.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.protobuf;
+
+import org.apache.flink.formats.protobuf.deserialize.PbRowDataDeserializationSchema;
+import org.apache.flink.formats.protobuf.testproto.RecursiveMessageProto2Test;
+import org.apache.flink.formats.protobuf.testproto.RecursiveMessageTest;
+import org.apache.flink.formats.protobuf.util.PbFormatUtils;
+import org.apache.flink.formats.protobuf.util.PbToRowTypeUtil;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.RowType;
+
+import com.google.protobuf.Descriptors;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/** Test handling of recursive protobuf message types. */
+public class RecursiveMessageProtoToRowTest {
+
+    private static final String PROTO3_CLASS =
+            "org.apache.flink.formats.protobuf.testproto.RecursiveMessageTest";
+    private static final String PROTO2_CLASS =
+            "org.apache.flink.formats.protobuf.testproto.RecursiveMessageProto2Test";
+
+    /** Deserializes proto bytes through the full Flink codegen pipeline. */
+    private RowData deserialize(String className, boolean readDefaultValues, byte[] data)
+            throws Exception {
+        RowType rowType = PbToRowTypeUtil.generateRowType(PbFormatUtils.getDescriptor(className));
+        PbFormatConfig config = new PbFormatConfig(className, false, readDefaultValues, "");
+        PbRowDataDeserializationSchema schema =
+                new PbRowDataDeserializationSchema(rowType, InternalTypeInfo.of(rowType), config);
+        schema.open(null);
+        return schema.deserialize(data);
+    }
+
+    // --- schema generation ---
+
+    @Test
+    public void testCycleDetectionProducesBytes() {
+        Descriptors.Descriptor descriptor = RecursiveMessageTest.getDescriptor();
+        RowType rowType = PbToRowTypeUtil.generateRowType(descriptor);
+
+        assertEquals(3, rowType.getFieldCount());
+        assertEquals("id", rowType.getFieldNames().get(0));
+        assertEquals("name", rowType.getFieldNames().get(1));
+        assertEquals("parent", rowType.getFieldNames().get(2));
+        assertEquals(
+                "Recursive field should be VARBINARY",
+                LogicalTypeRoot.VARBINARY,
+                rowType.getTypeAt(2).getTypeRoot());
+    }
+
+    // --- proto3 deserialization ---
+
+    @Test
+    public void testProto3NestedDataPreservedAsBytes() throws Exception {
+        RecursiveMessageTest grandparent =
+                RecursiveMessageTest.newBuilder().setId(1).setName("grandparent").build();
+        RecursiveMessageTest parent =
+                RecursiveMessageTest.newBuilder()
+                        .setId(2)
+                        .setName("parent")
+                        .setParent(grandparent)
+                        .build();
+        RecursiveMessageTest message =
+                RecursiveMessageTest.newBuilder()
+                        .setId(3)
+                        .setName("child")
+                        .setParent(parent)
+                        .build();
+
+        RowData row = deserialize(PROTO3_CLASS, false, message.toByteArray());
+        assertNotNull(row);
+        assertEquals(3, row.getInt(0));
+        assertEquals("child", row.getString(1).toString());
+
+        // Parse the bytes back - should contain full parent including grandparent
+        byte[] parentBytes = row.getBinary(2);
+        RecursiveMessageTest parsedParent = RecursiveMessageTest.parseFrom(parentBytes);
+        assertEquals(2, parsedParent.getId());
+        assertEquals("parent", parsedParent.getName());
+        assertTrue(parsedParent.hasParent());
+        assertEquals(1, parsedParent.getParent().getId());
+        assertEquals("grandparent", parsedParent.getParent().getName());
+    }
+
+    @Test
+    public void testProto3UnsetFieldReadsDefaultBytes() throws Exception {
+        // In proto3, the recursive field is treated as a primitive type (VARBINARY)
+        // by the codegen, so it always reads default values regardless of the
+        // readDefaultValues config. Both true and false produce the same result:
+        // empty bytes from .toByteArray() on the default message instance.
+        RecursiveMessageTest message =
+                RecursiveMessageTest.newBuilder().setId(1).setName("leaf").build();
+
+        for (boolean readDefaults : new boolean[] {true, false}) {
+            RowData row = deserialize(PROTO3_CLASS, readDefaults, message.toByteArray());
+            assertNotNull(row);
+            assertEquals(1, row.getInt(0));
+            assertEquals("leaf", row.getString(1).toString());
+            byte[] parentBytes = row.getBinary(2);
+            assertNotNull("readDefaultValues=" + readDefaults, parentBytes);
+            RecursiveMessageTest parsed = RecursiveMessageTest.parseFrom(parentBytes);
+            assertEquals(0, parsed.getId());
+            assertEquals("", parsed.getName());
+        }
+    }
+
+    // --- proto2 deserialization ---
+
+    @Test
+    public void testProto2SetFieldPreservedAsBytes() throws Exception {
+        RecursiveMessageProto2Test parent =
+                RecursiveMessageProto2Test.newBuilder().setId(1).setName("parent").build();
+        RecursiveMessageProto2Test message =
+                RecursiveMessageProto2Test.newBuilder()
+                        .setId(2)
+                        .setName("child")
+                        .setParent(parent)
+                        .build();
+
+        RowData row = deserialize(PROTO2_CLASS, false, message.toByteArray());
+        assertNotNull(row);
+        assertEquals(2, row.getInt(0));
+        assertEquals("child", row.getString(1).toString());
+
+        byte[] parentBytes = row.getBinary(2);
+        assertNotNull(parentBytes);
+        RecursiveMessageProto2Test parsed = RecursiveMessageProto2Test.parseFrom(parentBytes);
+        assertEquals(1, parsed.getId());
+        assertEquals("parent", parsed.getName());
+    }
+
+    @Test
+    public void testProto2UnsetFieldIsNull() throws Exception {
+        // Proto2 has explicit field presence. With readDefaultValues=false,
+        // hasParent() returns false so the field is null.
+        RecursiveMessageProto2Test message =
+                RecursiveMessageProto2Test.newBuilder().setId(1).setName("leaf").build();
+
+        RowData row = deserialize(PROTO2_CLASS, false, message.toByteArray());
+        assertNotNull(row);
+        assertEquals(1, row.getInt(0));
+        assertEquals("leaf", row.getString(1).toString());
+        assertTrue("Proto2 unset recursive field should be null", row.isNullAt(2));
+    }
+
+    @Test
+    public void testProto2UnsetFieldWithReadDefaultValues() throws Exception {
+        // With readDefaultValues=true, proto2 returns the default instance as bytes
+        // instead of null.
+        RecursiveMessageProto2Test message =
+                RecursiveMessageProto2Test.newBuilder().setId(1).setName("leaf").build();
+
+        RowData row = deserialize(PROTO2_CLASS, true, message.toByteArray());
+        assertNotNull(row);
+        assertEquals(1, row.getInt(0));
+        assertEquals("leaf", row.getString(1).toString());
+        byte[] parentBytes = row.getBinary(2);
+        assertNotNull(parentBytes);
+        RecursiveMessageProto2Test parsed = RecursiveMessageProto2Test.parseFrom(parentBytes);
+        assertEquals(0, parsed.getId());
+        assertEquals("", parsed.getName());
+    }
+}

--- a/flink-formats/flink-protobuf/src/test/proto/test_recursive_message.proto
+++ b/flink-formats/flink-protobuf/src/test/proto/test_recursive_message.proto
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+package org.apache.flink.formats.protobuf.proto;
+option java_package = "org.apache.flink.formats.protobuf.testproto";
+option java_multiple_files = true;
+
+message RecursiveMessageTest {
+  int32 id = 1;
+  string name = 2;
+  RecursiveMessageTest parent = 3;
+}

--- a/flink-formats/flink-protobuf/src/test/proto/test_recursive_message_proto2.proto
+++ b/flink-formats/flink-protobuf/src/test/proto/test_recursive_message_proto2.proto
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto2";
+package org.apache.flink.formats.protobuf.proto;
+option java_package = "org.apache.flink.formats.protobuf.testproto";
+option java_multiple_files = true;
+
+message RecursiveMessageProto2Test {
+  optional int32 id = 1;
+  optional string name = 2;
+  optional RecursiveMessageProto2Test parent = 3;
+}


### PR DESCRIPTION
## What is the purpose of the change

Protobuf allows recursive message definitions (e.g., `message Node { Node child = 1; }`). When Flink's protobuf format encounters such a schema, `PbToRowTypeUtil.generateRowType` recurses infinitely and crashes with `StackOverflowError`. This makes it impossible to use the protobuf format with any proto schema that contains recursive references.

This change adds cycle detection to `PbToRowTypeUtil`. When a message type is encountered that is already being resolved in the current ancestor chain, the recursive field is emitted as `VARBINARY` (raw protobuf bytes) instead of recursing. The protobuf binary data is preserved and can be deserialized on demand by consumers if needed.

## Brief change log

- `PbToRowTypeUtil` tracks ancestor message types during schema generation and emits `VARBINARY` for fields that would cause infinite recursion
- `PbCodegenBytesDeserializer` generates code to serialize recursive message fields to their raw protobuf bytes via `.toByteArray()`
- `PbCodegenDeserializeFactory` routes MESSAGE fields mapped to `VARBINARY` to the new bytes deserializer
- `PbSchemaValidationUtils` accepts `VARBINARY` as a valid mapping for MESSAGE fields at recursive boundaries

## Verifying this change

**Note: This change has been reviewed and deployed internally at Shopify on production Flink jobs with no regressions since March 13, 2026.**

This change added tests and can be verified as follows:

- Added `RecursiveMessageProtoToRowTest` with 6 tests covering:
  - Schema generation produces `VARBINARY` for recursive fields instead of crashing
  - Nested data is preserved as parseable protobuf bytes through the full deserialization pipeline
  - Proto3 unset recursive fields produce empty bytes (default instance) regardless of `readDefaultValues` setting
  - Proto2 unset recursive fields are null with `readDefaultValues=false` (explicit field presence)
  - Proto2 unset recursive fields produce empty bytes with `readDefaultValues=true`
  - Proto2 set recursive fields are preserved as bytes
- Added `test_recursive_message.proto` (proto3) and `test_recursive_message_proto2.proto` (proto2) test protos with self-referencing message definitions
- All `flink-protobuf` tests pass with no regressions

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **yes** - adds handling for a new case in protobuf deserialization (recursive messages)
  - The runtime per-record code paths (performance sensitive): **no** - cycle detection runs at planning time only, not per-record
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Generated-by: Claude Code
