### PR TITLE
[hotfix][docs] Fix inaccurate description of slot sharing benefit

### DIFF
--- a/docs/content.zh/docs/concepts/flink-architecture.md
+++ b/docs/content.zh/docs/concepts/flink-architecture.md
@@ -87,7 +87,7 @@ _JobManager_ 具有许多与协调 Flink 应用程序的分布式执行有关的
 
 默认情况下，Flink 允许 subtask 共享 slot，即便它们是不同的 task 的 subtask，只要是来自于同一作业即可。结果就是一个 slot 可以持有整个作业管道。允许 *slot 共享*有两个主要优点：
 
-  - Flink 集群所需的 task slot 和作业中使用的最大并行度恰好一样。无需计算程序总共包含多少个 task（具有不同并行度）。
+  - 一个 Flink 作业所需的 task slot 和该作业中使用的最大并行度恰好一样。无需计算程序总共包含多少个 task（具有不同并行度）。
 
   - 容易获得更好的资源利用。如果没有 slot 共享，非密集 subtask（*source/map()*）将阻塞和密集型 subtask（*window*） 一样多的资源。通过 slot 共享，我们示例中的基本并行度从 2 增加到 6，可以充分利用分配的资源，同时确保繁重的 subtask 在 TaskManager 之间公平分配。
 

--- a/docs/content/docs/concepts/flink-architecture.md
+++ b/docs/content/docs/concepts/flink-architecture.md
@@ -143,7 +143,7 @@ different tasks, so long as they are from the same job. The result is that one
 slot may hold an entire pipeline of the job. Allowing this *slot sharing* has
 two main benefits:
 
-  - A Flink cluster needs exactly as many task slots as the highest parallelism
+  - A Flink job needs exactly as many task slots as the highest parallelism
     used in the job.  No need to calculate how many tasks (with varying
     parallelism) a program contains in total.
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes an inaccurate statement in the Flink Architecture documentation. In the "Task Slots and Resources" section, the description of the Slot Sharing benefit reads "A Flink **cluster** needs exactly as many task slots as the highest parallelism used in the job." The use of "cluster" implicitly assumes that a cluster runs only a single job, which is incorrect in Session mode where multiple jobs share the same cluster and its task slots. The fix replaces "cluster" with "job" to make the statement accurate regardless of deployment mode (Session, Application, or Per-Job). Both the English and Chinese versions of the page are updated to stay in sync.


## Brief change log

- Replaced "A Flink cluster needs exactly as many task slots as the highest parallelism used in the job." with "A Flink job needs exactly as many task slots as the highest parallelism used in the job." in `docs/content/docs/concepts/flink-architecture.md`.
- Mirrored the same fix in the Chinese translation at `docs/content.zh/docs/concepts/flink-architecture.md`.


## Verifying this change

This change is a trivial documentation fix without any test coverage. It can be verified by rendering the docs locally (`docs/build_docs.sh`) and inspecting the "Task Slots and Resources" section on both the English and Chinese pages.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable