### PR TITLE
[FLINK-39604][table] Show state and PTF capabilities in DESCRIBE FUNCTION EXTENDED

### DIFF
--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/utils/DescribeFunctionTestAgg.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/utils/DescribeFunctionTestAgg.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.client.cli.utils;
+
+import org.apache.flink.table.annotation.StateHint;
+import org.apache.flink.table.functions.AggregateFunction;
+
+/**
+ * Minimal {@link AggregateFunction} used by {@code function.q} to exercise {@code DESCRIBE FUNCTION
+ * EXTENDED} on a function whose accumulator surfaces as a {@code state:} row. The body is a no-op
+ * since only the introspection output is asserted.
+ */
+public class DescribeFunctionTestAgg extends AggregateFunction<Long, DescribeFunctionTestAgg.Acc> {
+
+    /** Accumulator type for the aggregate. */
+    public static class Acc {
+        public Long sum;
+        public Long count;
+    }
+
+    @Override
+    public Acc createAccumulator() {
+        return new Acc();
+    }
+
+    public void accumulate(@StateHint(ttl = "2 d") Acc acc, Long value) {}
+
+    @Override
+    public Long getValue(Acc accumulator) {
+        return 0L;
+    }
+}

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/utils/DescribeFunctionTestMinimalPtf.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/utils/DescribeFunctionTestMinimalPtf.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.client.cli.utils;
+
+import org.apache.flink.table.annotation.ArgumentHint;
+import org.apache.flink.table.annotation.ArgumentTrait;
+import org.apache.flink.table.functions.ProcessTableFunction;
+import org.apache.flink.types.Row;
+
+/**
+ * Minimal Process Table Function used by {@code function.q} to exercise the {@code false} side of
+ * the per-PTF capability flags in {@code DESCRIBE FUNCTION EXTENDED}: no {@link
+ * org.apache.flink.table.annotation.StateHint StateHint} (no {@code state:} row), does not
+ * implement {@link org.apache.flink.table.functions.ChangelogFunction ChangelogFunction} ({@code is
+ * changelog function = false}), and declares no {@code onTimer} ({@code uses timers = false}).
+ */
+public class DescribeFunctionTestMinimalPtf extends ProcessTableFunction<Long> {
+
+    public void eval(@ArgumentHint(ArgumentTrait.SET_SEMANTIC_TABLE) Row input) {}
+}

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/utils/DescribeFunctionTestPtf.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/utils/DescribeFunctionTestPtf.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.client.cli.utils;
+
+import org.apache.flink.table.annotation.ArgumentHint;
+import org.apache.flink.table.annotation.ArgumentTrait;
+import org.apache.flink.table.annotation.DataTypeHint;
+import org.apache.flink.table.annotation.StateHint;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.functions.ChangelogFunction;
+import org.apache.flink.table.functions.ProcessTableFunction;
+import org.apache.flink.types.Row;
+
+/**
+ * Process Table Function used by {@code function.q} to exercise {@code DESCRIBE FUNCTION EXTENDED}.
+ *
+ * <p>Carries: a state entry with TTL (via {@link StateHint}), a table arg with multiple traits (via
+ * {@link ArgumentHint}), an {@code onTimer} method, and an implementation of {@link
+ * ChangelogFunction} so that the {@code emits updates} and {@code uses timers} flags both light up.
+ * The bodies are no-ops since only the introspection output is asserted.
+ */
+public class DescribeFunctionTestPtf extends ProcessTableFunction<Long>
+        implements ChangelogFunction {
+
+    public void eval(
+            @StateHint(type = @DataTypeHint("ROW<count BIGINT>"), ttl = "1 d") Row state,
+            @ArgumentHint({ArgumentTrait.SET_SEMANTIC_TABLE, ArgumentTrait.OPTIONAL_PARTITION_BY})
+                    Row input) {}
+
+    public void onTimer(Row state) {}
+
+    @Override
+    public ChangelogMode getChangelogMode(ChangelogContext changelogContext) {
+        return ChangelogMode.insertOnly();
+    }
+}

--- a/flink-table/flink-sql-client/src/test/resources/sql/function.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/function.q
@@ -502,3 +502,79 @@ describe function extended temp_upperudf;
 +---------------------------+-------------------------------+
 7 rows in set
 !ok
+
+# ==========================================================================
+# test describe function on a process table function (PTF)
+# ==========================================================================
+
+create temporary system function my_ptf as 'org.apache.flink.table.client.cli.utils.DescribeFunctionTestPtf';
+[INFO] Execute statement succeeded.
+!info
+
+describe function extended my_ptf;
++---------------------------+---------------------------------------------------------------------+
+|                 info name |                                                          info value |
++---------------------------+---------------------------------------------------------------------+
+|        is system function |                                                                true |
+|              is temporary |                                                                true |
+|                      kind |                                                       PROCESS_TABLE |
+|              requirements |                                                                  [] |
+|          is deterministic |                                                                true |
+| supports constant folding |                                                                true |
+|                 signature | my_ptf(input => {TABLE, SET SEMANTIC TABLE, OPTIONAL PARTITION BY}) |
+|              state: state |                                 type=ROW<`count` BIGINT>, ttl=PT24H |
+|  accepts system arguments |                                                                true |
+|     is changelog function |                                                                true |
+|               uses timers |                                                                true |
++---------------------------+---------------------------------------------------------------------+
+11 rows in set
+!ok
+
+# A minimal PTF demonstrates the "false" side of all three capability flags:
+# no @StateHint, no ChangelogFunction implementation, no onTimer method.
+create temporary system function my_minimal_ptf as 'org.apache.flink.table.client.cli.utils.DescribeFunctionTestMinimalPtf';
+[INFO] Execute statement succeeded.
+!info
+
+describe function extended my_minimal_ptf;
++---------------------------+------------------------------------------------------+
+|                 info name |                                           info value |
++---------------------------+------------------------------------------------------+
+|        is system function |                                                 true |
+|              is temporary |                                                 true |
+|                      kind |                                        PROCESS_TABLE |
+|              requirements |                                                   [] |
+|          is deterministic |                                                 true |
+| supports constant folding |                                                 true |
+|                 signature | my_minimal_ptf(input => {TABLE, SET SEMANTIC TABLE}) |
+|  accepts system arguments |                                                 true |
+|     is changelog function |                                                false |
+|               uses timers |                                                false |
++---------------------------+------------------------------------------------------+
+10 rows in set
+!ok
+
+# ==========================================================================
+# test describe function on a user-defined aggregate function (accumulator
+# surfaces via the same state:* row mechanism as PTFs)
+# ==========================================================================
+
+create temporary system function my_agg as 'org.apache.flink.table.client.cli.utils.DescribeFunctionTestAgg';
+[INFO] Execute statement succeeded.
+!info
+
+describe function extended my_agg;
++---------------------------+---------------------------------------------------------------------------------------------------------------------------------+
+|                 info name |                                                                                                                      info value |
++---------------------------+---------------------------------------------------------------------------------------------------------------------------------+
+|        is system function |                                                                                                                            true |
+|              is temporary |                                                                                                                            true |
+|                      kind |                                                                                                                       AGGREGATE |
+|              requirements |                                                                                                                              [] |
+|          is deterministic |                                                                                                                            true |
+| supports constant folding |                                                                                                                            true |
+|                 signature |                                                                                                         my_agg(value => BIGINT) |
+|                state: acc | type=STRUCTURED<'org.apache.flink.table.client.cli.utils.DescribeFunctionTestAgg$Acc', `count` BIGINT, `sum` BIGINT>, ttl=PT48H |
++---------------------------+---------------------------------------------------------------------------------------------------------------------------------+
+8 rows in set
+!ok

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/DescribeFunctionOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/DescribeFunctionOperation.java
@@ -25,9 +25,19 @@ import org.apache.flink.table.api.internal.TableResultInternal;
 import org.apache.flink.table.catalog.CatalogFunction;
 import org.apache.flink.table.catalog.ContextResolvedFunction;
 import org.apache.flink.table.catalog.UnresolvedIdentifier;
+import org.apache.flink.table.functions.ChangelogFunction;
 import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.functions.FunctionKind;
+import org.apache.flink.table.functions.UserDefinedFunctionHelper;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.extraction.ExtractionUtils;
+import org.apache.flink.table.types.inference.StateTypeStrategy;
+import org.apache.flink.table.types.inference.TypeInference;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -50,6 +60,8 @@ import static org.apache.flink.table.types.inference.TypeInferenceUtil.generateS
  */
 @Internal
 public class DescribeFunctionOperation implements Operation, ExecutableOperation {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DescribeFunctionOperation.class);
 
     private final UnresolvedIdentifier sqlIdentifier;
     private final boolean isExtended;
@@ -114,19 +126,84 @@ public class DescribeFunctionOperation implements Operation, ExecutableOperation
                     Arrays.asList(
                             "supports constant folding",
                             String.valueOf(definition.supportsConstantFolding())));
+            final TypeInference typeInference =
+                    definition.getTypeInference(ctx.getCatalogManager().getDataTypeFactory());
             rows.add(
                     Arrays.asList(
                             "signature",
-                            generateSignature(
-                                    definition.getTypeInference(
-                                            ctx.getCatalogManager().getDataTypeFactory()),
-                                    function.toString(),
-                                    definition)));
+                            generateSignature(typeInference, function.toString(), definition)));
+            rows.addAll(buildPtfMetadataRows(definition, typeInference));
         }
 
         return buildTableResult(
                 new String[] {"info name", "info value"},
                 new DataType[] {DataTypes.STRING(), DataTypes.STRING()},
                 rows.stream().map(List::toArray).toArray(Object[][]::new));
+    }
+
+    /**
+     * Builds supplemental info rows from the given {@link FunctionDefinition} and {@link
+     * TypeInference}: a {@code state: <name>} row per state entry (with type and TTL) and, for
+     * PROCESS_TABLE functions, three capability rows: {@code accepts system arguments} (whether the
+     * framework auto-injects {@code uid} / {@code on_time}), {@code is changelog function} (whether
+     * the function implements {@link ChangelogFunction}), and {@code uses timers} (whether the
+     * function declares an {@code onTimer} method). Returns an empty list when none apply.
+     */
+    private static List<List<Object>> buildPtfMetadataRows(
+            FunctionDefinition definition, TypeInference typeInference) {
+        final List<List<Object>> rows = new ArrayList<>();
+        typeInference
+                .getStateTypeStrategies()
+                .forEach(
+                        (name, strategy) ->
+                                rows.add(
+                                        Arrays.asList(
+                                                "state: " + name, formatStateEntry(strategy))));
+        if (definition.getKind() == FunctionKind.PROCESS_TABLE) {
+            rows.add(
+                    Arrays.asList(
+                            "accepts system arguments",
+                            String.valueOf(!typeInference.disableSystemArguments())));
+            rows.add(
+                    Arrays.asList(
+                            "is changelog function",
+                            String.valueOf(definition instanceof ChangelogFunction)));
+            rows.add(
+                    Arrays.asList(
+                            "uses timers",
+                            String.valueOf(
+                                    !ExtractionUtils.collectMethods(
+                                                    definition.getClass(),
+                                                    UserDefinedFunctionHelper
+                                                            .PROCESS_TABLE_ON_TIMER)
+                                            .isEmpty())));
+        }
+        return rows;
+    }
+
+    private static String formatStateEntry(StateTypeStrategy strategy) {
+        // We have no CallContext at DESCRIBE time. Many strategies (including TTL lookups in
+        // DefaultStateTypeStrategy) ignore the context, but inferType forwards it to the wrapped
+        // TypeStrategy which may dereference it. Catch and degrade to <unknown> rather than
+        // failing the entire DESCRIBE for one strategy that needs a real CallContext. Log at
+        // DEBUG so the cause is diagnosable when a user reports an unexpected <unknown>.
+        String typeStr;
+        try {
+            typeStr = strategy.inferType(null).map(Object::toString).orElse("<unknown>");
+        } catch (Exception e) {
+            LOG.debug(
+                    "Could not infer state type for DESCRIBE FUNCTION; rendering as <unknown>.", e);
+            typeStr = "<unknown>";
+        }
+        final Optional<Duration> ttl;
+        try {
+            ttl = strategy.getTimeToLive(null);
+        } catch (Exception e) {
+            LOG.debug(
+                    "Could not resolve state TTL for DESCRIBE FUNCTION; rendering as <unknown>.",
+                    e);
+            return "type=" + typeStr + ", ttl=<unknown>";
+        }
+        return "type=" + typeStr + ", ttl=" + ttl.map(Duration::toString).orElse("<default>");
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/DescribeFunctionOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/DescribeFunctionOperation.java
@@ -181,29 +181,33 @@ public class DescribeFunctionOperation implements Operation, ExecutableOperation
         return rows;
     }
 
+    /**
+     * Formats a single state entry as {@code type=<type>, ttl=<ttl>}.
+     *
+     * <p>No {@code CallContext} is available at DESCRIBE time. Many strategies (including TTL
+     * lookups in {@code DefaultStateTypeStrategy}) ignore the context, but {@code inferType}
+     * forwards it to the wrapped {@code TypeStrategy}, which may dereference it. Any failure is
+     * caught and degraded to {@code <unknown>} rather than failing the entire DESCRIBE for one
+     * strategy that needs a real {@code CallContext}. The cause is logged at DEBUG so an unexpected
+     * {@code <unknown>} is diagnosable.
+     */
     private static String formatStateEntry(StateTypeStrategy strategy) {
-        // We have no CallContext at DESCRIBE time. Many strategies (including TTL lookups in
-        // DefaultStateTypeStrategy) ignore the context, but inferType forwards it to the wrapped
-        // TypeStrategy which may dereference it. Catch and degrade to <unknown> rather than
-        // failing the entire DESCRIBE for one strategy that needs a real CallContext. Log at
-        // DEBUG so the cause is diagnosable when a user reports an unexpected <unknown>.
-        String typeStr;
+        final StringBuilder entry = new StringBuilder("type=");
         try {
-            typeStr = strategy.inferType(null).map(Object::toString).orElse("<unknown>");
+            entry.append(strategy.inferType(null).map(Object::toString).orElse("<unknown>"));
         } catch (Exception e) {
             LOG.debug(
                     "Could not infer state type for DESCRIBE FUNCTION; rendering as <unknown>.", e);
-            typeStr = "<unknown>";
+            entry.append("<unknown>");
         }
-        final Optional<Duration> ttl;
+        entry.append(", ttl=");
         try {
-            ttl = strategy.getTimeToLive(null);
+            entry.append(strategy.getTimeToLive(null).map(Duration::toString).orElse("<default>"));
         } catch (Exception e) {
             LOG.debug(
-                    "Could not resolve state TTL for DESCRIBE FUNCTION; rendering as <unknown>.",
-                    e);
-            return "type=" + typeStr + ", ttl=<unknown>";
+                    "Could not resolve state TTL for DESCRIBE FUNCTION; rendering as <unknown>.", e);
+            entry.append("<unknown>");
         }
-        return "type=" + typeStr + ", ttl=" + ttl.map(Duration::toString).orElse("<default>");
+        return entry.toString();
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/StateTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/StateTypeStrategy.java
@@ -43,6 +43,12 @@ public interface StateTypeStrategy extends TypeStrategy {
      * <p>Returning {@code Optional.empty()} will fall back to default behavior. Returning a value
      * equal or greater than 0 means setting a custom TTL for this state entry and ignoring the
      * global defaults.
+     *
+     * <p>Note: {@code DESCRIBE FUNCTION EXTENDED} may invoke this method with a {@code null} {@link
+     * CallContext} to surface the TTL at definition time. Implementations that derive the TTL from
+     * call-time information should handle {@code null} defensively (e.g. return {@code
+     * Optional.empty()}); throwing will cause {@code DESCRIBE} to render the TTL as {@code
+     * <unknown>}.
      */
     Optional<Duration> getTimeToLive(CallContext callContext);
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeStrategy.java
@@ -34,6 +34,14 @@ import java.util.Optional;
 @PublicEvolving
 public interface TypeStrategy {
 
-    /** Infers a type from the given function call. */
+    /**
+     * Infers a type from the given function call.
+     *
+     * <p>Note: {@code DESCRIBE FUNCTION EXTENDED} may invoke this method via {@link
+     * StateTypeStrategy} with a {@code null} {@link CallContext} to surface a state entry's type at
+     * definition time. Implementations that derive the result type from call-time information
+     * should handle {@code null} defensively (e.g. return {@code Optional.empty()}); throwing will
+     * cause {@code DESCRIBE} to render the type as {@code <unknown>}.
+     */
     Optional<DataType> inferType(CallContext callContext);
 }


### PR DESCRIPTION
## What is the purpose of the change

Extend `DESCRIBE FUNCTION EXTENDED` to surface function metadata that previously had no introspection path from SQL: state entries (with type and TTL) and three PTF capability flags.

JIRA: [FLINK-39604](https://issues.apache.org/jira/browse/FLINK-39604)

`DESCRIBE FUNCTION` shipped under FLINK-35822 before the PTF infrastructure (FLIP-440 / FLINK-36705) and has not been touched since. The `EXTENDED` form already calls `FunctionDefinition#getTypeInference(...)` to render the `signature` row, but it ignores `getStateTypeStrategies()`, `disableSystemArguments()`, the `ChangelogFunction` interface, and the presence of an `onTimer` method — all class-level facts the user can't otherwise see.

Per-argument trait info was considered but rejected because it is already encoded in the `signature` row (e.g. `f(input => {TABLE, SET SEMANTIC TABLE, OPTIONAL PARTITION BY})`).

## Brief change log

- `DescribeFunctionOperation`: new private `buildPtfMetadataRows(FunctionDefinition, TypeInference)` helper appends:
  - `state: <name>` rows (type + TTL, best-effort via `inferType(null)` / `getTimeToLive(null)`) — applies to PTFs *and* aggregate functions (the accumulator surfaces as `state: acc`).
  - When `kind == PROCESS_TABLE`:
    - `accepts system arguments` — `!disableSystemArguments()` (whether `uid` / `on_time` are auto-injected).
    - `is changelog function` — `definition instanceof ChangelogFunction` (whether the PTF *implements* the interface that lets it emit `+U`/`-U`/`-D`).
    - `uses timers` — reuses `ExtractionUtils.collectMethods(cls, UserDefinedFunctionHelper.PROCESS_TABLE_ON_TIMER)`, the same lookup the planner uses.
- `DescribeFunctionTestPtf`, `DescribeFunctionTestMinimalPtf`, `DescribeFunctionTestAgg` (new): three small test fixtures in `flink-sql-client/src/test/java/.../cli/utils/`, reachable on the test classpath via FQN. Together they cover both `true` and `false` for each of the three capability flags, plus state entries on both a PTF and an aggregate.
- `function.q` golden: three new blocks register `my_ptf`, `my_minimal_ptf`, and `my_agg` and assert their `DESCRIBE FUNCTION EXTENDED` output. Existing `temp_upperudf` / `SUM` blocks unchanged.

## Output schema

Unchanged: still `(info name, info value)`. Additional rows appended only when applicable. No new SQL syntax.

### Example (PTF, all capabilities present)

```
+---------------------------+---------------------------------------------------------------------+
|                 info name |                                                          info value |
+---------------------------+---------------------------------------------------------------------+
| ...                       | ...                                                                 |
|                 signature | my_ptf(input => {TABLE, SET SEMANTIC TABLE, OPTIONAL PARTITION BY}) |
|              state: state |                                 type=ROW<\`count\` BIGINT>, ttl=PT24H |
|  accepts system arguments |                                                                true |
|     is changelog function |                                                                true |
|               uses timers |                                                                true |
+---------------------------+---------------------------------------------------------------------+
```

### Example (Minimal PTF, no capabilities)

```
| ...                       | ...                                                  |
|                 signature | my_minimal_ptf(input => {TABLE, SET SEMANTIC TABLE}) |
|  accepts system arguments |                                                 true |
|     is changelog function |                                                false |
|               uses timers |                                                false |
```

### Example (Aggregate)

```
| ...        | ...                                                                                         |
| signature  | my_agg(value => BIGINT)                                                                     |
| state: acc | type=STRUCTURED<'...DescribeFunctionTestAgg\$Acc', \`count\` BIGINT, \`sum\` BIGINT>, ttl=PT48H |
```

For non-PTF / non-stateful functions (most scalar UDFs, SUM, etc.) the output is unchanged from today.

## Verifying this change

- `flink-table-api-java`: `./mvnw test -pl flink-table/flink-table-api-java` — all tests pass.
- `flink-sql-client`: `./mvnw test -pl flink-table/flink-sql-client -Dtest=CliClientITCase` — all 14 tests pass with the three new function blocks in `function.q`.

## Does this pull request potentially affect one of the following parts?

- Dependencies (does it add or upgrade a dependency): **no**
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no** (the helper is private and the class is `@Internal`)
- The serializers: **no**
- The runtime per-record code paths (performance sensitive): **no**
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
- The S3 file system connector: **no**

## Documentation

- Does this pull request introduce a new feature? **no** (extension of existing `DESCRIBE FUNCTION EXTENDED`)
- If yes, how is the feature documented? **N/A**

## Out of scope (deliberately)

- Per-argument rows — redundant with the `signature` row, which already encodes name, type, and traits via `f(arg => TYPE {TRAITS})`.
- New SQL syntax (e.g. `DESCRIBE FUNCTION ... SHOW STATE`) — would require a FLIP.
- Adding columns to the result schema — output remains `(info name, info value)`.
- Resolved changelog mode — `ChangelogFunction#getChangelogMode(ChangelogContext)` and `ChangelogModeStrategy#inferChangelogMode(...)` both require call-time context, so only the static `instanceof` boolean is exposed here. The label `is changelog function` (rather than `emits updates`) reflects that this is a class-level check, not a runtime fact.
- Time / late-record / ordering behavior — all per-call.