### PR TITLE
[FLINK-39606][table] Add includeFreshness/includeRefreshMode flags to buildShowCreateMaterializedTableRow

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/ShowCreateUtil.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/ShowCreateUtil.java
@@ -131,6 +131,27 @@ public class ShowCreateUtil {
             boolean createOrAlter,
             ZoneId timeZoneId,
             SqlFactory sqlFactory) {
+        return buildShowCreateMaterializedTableRow(
+                table,
+                tableIdentifier,
+                isTemporary,
+                createOrAlter,
+                timeZoneId,
+                sqlFactory,
+                true,
+                true);
+    }
+
+    /** Show create materialized table statement only for materialized tables. */
+    public static String buildShowCreateMaterializedTableRow(
+            ResolvedCatalogMaterializedTable table,
+            ObjectIdentifier tableIdentifier,
+            boolean isTemporary,
+            boolean createOrAlter,
+            ZoneId timeZoneId,
+            SqlFactory sqlFactory,
+            boolean includeFreshness,
+            boolean includeRefreshMode) {
         validateTableKind(table, tableIdentifier, TableKind.MATERIALIZED_TABLE);
         StringBuilder sb =
                 new StringBuilder()
@@ -156,10 +177,12 @@ public class ShowCreateUtil {
         extractFormattedOptions(table.getOptions(), PRINT_INDENT)
                 .ifPresent(v -> sb.append("WITH (\n").append(v).append("\n)\n"));
         sb.append(extractStartMode(table, timeZoneId)).append("\n");
-        sb.append(extractFreshness(table))
-                .append("\n")
-                .append(extractRefreshMode(table))
-                .append("\n");
+        if (includeFreshness) {
+            sb.append(extractFreshness(table)).append("\n");
+        }
+        if (includeRefreshMode) {
+            sb.append(extractRefreshMode(table)).append("\n");
+        }
         sb.append("AS ").append(table.getExpandedQuery()).append('\n');
         return sb.toString();
     }

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/api/internal/ShowCreateUtilTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/api/internal/ShowCreateUtilTest.java
@@ -47,6 +47,7 @@ import org.apache.flink.table.expressions.DefaultSqlFactory;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.time.Instant;
@@ -144,6 +145,50 @@ class ShowCreateUtilTest {
                 setFixedTimestamp(createMaterializedTableString, fixedTimestamp);
         final String normalizedExpected = setFixedTimestamp(expected, fixedTimestamp);
         assertThat(normalizedMTString).isEqualTo(normalizedExpected);
+    }
+
+    @ParameterizedTest(name = "includeFreshness={0}, includeRefreshMode={1}")
+    @CsvSource({"true, true", "true, false", "false, true", "false, false"})
+    void showCreateMaterializedTableWithFlags(
+            final boolean includeFreshness, final boolean includeRefreshMode) {
+        final ResolvedCatalogMaterializedTable materializedTable =
+                createResolvedMaterialized(
+                        ONE_COLUMN_SCHEMA,
+                        null,
+                        List.of(),
+                        null,
+                        StartMode.of(StartModeKind.FROM_BEGINNING),
+                        IntervalFreshness.ofMinute(2),
+                        RefreshMode.CONTINUOUS,
+                        "SELECT 1",
+                        "SELECT 1");
+        final String result =
+                ShowCreateUtil.buildShowCreateMaterializedTableRow(
+                        materializedTable,
+                        MATERIALIZED_TABLE_IDENTIFIER,
+                        false,
+                        false,
+                        ZoneOffset.UTC,
+                        DefaultSqlFactory.INSTANCE,
+                        includeFreshness,
+                        includeRefreshMode);
+
+        final StringBuilder expected =
+                new StringBuilder()
+                        .append(
+                                "CREATE MATERIALIZED TABLE `catalogName`.`dbName`.`materializedTableName` (\n")
+                        .append("  `id` INT\n")
+                        .append(")\n")
+                        .append("START_MODE = FROM_BEGINNING\n");
+        if (includeFreshness) {
+            expected.append("FRESHNESS = INTERVAL '2' MINUTE\n");
+        }
+        if (includeRefreshMode) {
+            expected.append("REFRESH_MODE = CONTINUOUS\n");
+        }
+        expected.append("AS SELECT 1\n");
+
+        assertThat(result).isEqualTo(expected.toString());
     }
 
     @ParameterizedTest(name = "{index}: {1}")


### PR DESCRIPTION
## What is the purpose of the change

This PR adds an overload of `ShowCreateUtil.buildShowCreateMaterializedTableRow` that accepts two flags, `includeFreshness` and `includeRefreshMode`, controlling whether the `FRESHNESS` and `REFRESH_MODE` clauses appear in the rendered `SHOW CREATE MATERIALIZED TABLE` output.

The existing 6-arg overload delegates to the new 8-arg overload with `true, true`, so all current callers are unaffected. Deployments that fix freshness or refresh mode at the platform level can now suppress these clauses from `SHOW CREATE` output without post-processing the result with regexes.

## Brief change log

- Added 8-arg overload `buildShowCreateMaterializedTableRow(table, identifier, isTemporary, createOrAlter, timeZoneId, sqlFactory, includeFreshness, includeRefreshMode)` in `ShowCreateUtil`.
- Existing 6-arg public overload now delegates to the new one with `includeFreshness=true, includeRefreshMode=true`.
- The 8-arg path conditionally emits the `FRESHNESS` and `REFRESH_MODE` lines based on the flags.

## Verifying this change

This change is already covered by existing tests, such as the cases in `ShowCreateUtilTest` that exercise materialized table rendering. Those tests go through the 6-arg overload, which now routes to the new 8-arg overload with `true, true`, so they assert the unchanged output.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no (`ShowCreateUtil` is `@Internal`)
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)