### PR TITLE
[hotfix][docs] Correct registerOnTime reference in PTF documentation

### DIFF
--- a/docs/content.zh/docs/dev/table/functions/ptfs.md
+++ b/docs/content.zh/docs/dev/table/functions/ptfs.md
@@ -1006,7 +1006,7 @@ class TimerFunction extends ProcessTableFunction<String> {
     TimeContext<Instant> timeCtx = ctx.timeContext(Instant.class);
       if (memory.seen == null) {
         memory.seen = input.getField(0).toString();
-        timeCtx.registerOnTimer("timeout", timeCtx.time().plusSeconds(60));
+        timeCtx.registerOnTime("timeout", timeCtx.time().plusSeconds(60));
       } else {
         collect("Second event arrived for: " + memory.seen);
         ctx.clearAll();

--- a/docs/content/docs/dev/table/functions/ptfs.md
+++ b/docs/content/docs/dev/table/functions/ptfs.md
@@ -1007,7 +1007,7 @@ class TimerFunction extends ProcessTableFunction<String> {
     TimeContext<Instant> timeCtx = ctx.timeContext(Instant.class);
       if (memory.seen == null) {
         memory.seen = input.getField(0).toString();
-        timeCtx.registerOnTimer("timeout", timeCtx.time().plusSeconds(60));
+        timeCtx.registerOnTime("timeout", timeCtx.time().plusSeconds(60));
       } else {
         collect("Second event arrived for: " + memory.seen);
         ctx.clearAll();

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/ProcessTableFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/ProcessTableFunction.java
@@ -390,7 +390,7 @@ import java.time.LocalDateTime;
  *     TimeContext<Instant> timeCtx = ctx.timeContext(Instant.class);
  *     if (memory.seen == null) {
  *       memory.seen = input.getField(0).toString();
- *       timeCtx.registerOnTimer("timeout", timeCtx.time().plusSeconds(60));
+ *       timeCtx.registerOnTime("timeout", timeCtx.time().plusSeconds(60));
  *     } else {
  *       collect("Second event arrived for: " + memory.seen);
  *       ctx.clearAll();


### PR DESCRIPTION
## What is the purpose of the change

The PTF documentation contains an incorrect reference to `timeCtx.registerOnTimer`, this should be `registerOnTime`.

## Brief change log

- Corrected registerOnTime reference in PTF documentation

## Verifying this change

This change is a trivial rework