### PR TITLE
[FLINK-37121][docs] Fix syntax and examples in create table statement doc

### DIFF
--- a/docs/content.zh/docs/sql/reference/ddl/create.md
+++ b/docs/content.zh/docs/sql/reference/ddl/create.md
@@ -156,7 +156,7 @@ Flink SQL> INSERT INTO RubberOrders SELECT product, amount FROM Orders WHERE pro
 ##  CREATE TABLE
 
 ```text
-CREATE TABLE [IF NOT EXISTS] [catalog_name.][db_name.]table_name
+CREATE [TEMPORARY] TABLE [IF NOT EXISTS] [catalog_name.][db_name.]table_name
   (
     { <physical_column_definition> | <metadata_column_definition> | <computed_column_definition> }[ , ...n]
     [ <watermark_definition> ]
@@ -204,6 +204,12 @@ CREATE TABLE [IF NOT EXISTS] [catalog_name.][db_name.]table_name
 ```
 
 根据指定的表名创建一个表，如果同名表已经在 catalog 中存在了，则无法注册。
+
+**TEMPORARY**
+
+临时表通常保存于内存中并且仅在创建它们的 Flink 会话持续期间存在。
+
+更多信息请查看 [Temporary vs Permanent tables]({{< ref "docs/dev/table/common" >}}#temporary-vs-permanent-tables).
 
 ### Columns
 
@@ -295,7 +301,7 @@ CREATE TABLE MyTable (
   `timestamp` BIGINT METADATA,       -- part of the query-to-sink schema
   `offset` BIGINT METADATA VIRTUAL,  -- not part of the query-to-sink schema
   `user_id` BIGINT,
-  `name` STRING,
+  `name` STRING
 ) WITH (
   'connector' = 'kafka'
   ...
@@ -608,7 +614,7 @@ CREATE TABLE my_ctas_table (
     desc STRING,
     quantity DOUBLE,   
     cost AS price * quantity,
-    WATERMARK FOR order_time AS order_time - INTERVAL '5' SECOND,
+    WATERMARK FOR order_time AS order_time - INTERVAL '5' SECOND
 ) WITH (
     'connector' = 'kafka',
     ...

--- a/docs/content/docs/sql/reference/ddl/create.md
+++ b/docs/content/docs/sql/reference/ddl/create.md
@@ -150,7 +150,7 @@ Flink SQL> INSERT INTO RubberOrders SELECT product, amount FROM Orders WHERE pro
 The following grammar gives an overview about the available syntax:
 
 ```text
-CREATE TABLE [IF NOT EXISTS] [catalog_name.][db_name.]table_name
+CREATE [TEMPORARY] TABLE [IF NOT EXISTS] [catalog_name.][db_name.]table_name
   (
     { <physical_column_definition> | <metadata_column_definition> | <computed_column_definition> }[ , ...n]
     [ <watermark_definition> ]
@@ -199,6 +199,13 @@ CREATE TABLE [IF NOT EXISTS] [catalog_name.][db_name.]table_name
 
 The statement above creates a table with the given name. If a table with the same name already exists
 in the catalog, an exception is thrown.
+
+**TEMPORARY**
+
+Temporary tables are always stored in memory and only exist for the duration of
+the Flink session they are created within.
+
+Check out more details at [Temporary vs Permanent tables]({{< ref "docs/dev/table/common" >}}#temporary-vs-permanent-tables).
 
 ### Columns
 
@@ -290,7 +297,7 @@ CREATE TABLE MyTable (
   `timestamp` BIGINT METADATA,       -- part of the query-to-sink schema
   `offset` BIGINT METADATA VIRTUAL,  -- not part of the query-to-sink schema
   `user_id` BIGINT,
-  `name` STRING,
+  `name` STRING
 ) WITH (
   'connector' = 'kafka'
   ...
@@ -597,7 +604,7 @@ CREATE TABLE my_ctas_table (
     desc STRING,
     quantity DOUBLE,   
     cost AS price * quantity,
-    WATERMARK FOR order_time AS order_time - INTERVAL '5' SECOND,
+    WATERMARK FOR order_time AS order_time - INTERVAL '5' SECOND
 ) WITH (
     'connector' = 'kafka',
     ...


### PR DESCRIPTION
## Brief change log                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                           
- Add the optional `TEMPORARY` keyword to the `CREATE TABLE` grammar header                                                                                                                                                                                                              
- Add a `**TEMPORARY**` description block linking to the *Temporary vs Permanent tables* section                                                                                                                                                                                                                                                
- Remove a trailing comma after `` `name` STRING `` in the metadata-columns example                                                                                                                                                                                                                                                                                
- Remove a trailing comma after `INTERVAL '5' SECOND` in the CTAS example                                                                                                                                                                                                                
- Apply the same changes to the Chinese version                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                           
## Verifying this change                                                                                                                                                                                                                                                              
This change is a trivial rework / code cleanup without any test coverage.                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                           
## Does this pull request potentially affect one of the following parts:                                                                                                                                                                                                                                                                                    
- Dependencies (does it add or upgrade a dependency): no                                                                                                                                                                                                                               
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no                                                                                                                                                                                                    
- The serializers: no                                                                                                                                                                                                                                                                  
- The runtime per-record code paths (performance sensitive): no                                                                                                                                                                                                                        
- Anything that affects deployment or recovery: no                                                                                                                                                                                                                                     
- The S3 file system connector: no                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                           
## Documentation                                                                                                                                                                                                                                                                     
- Does this pull request introduce a new feature? no                                                                                                                                                                                                                                   
- If yes, how is the feature documented? not applicable                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                           
---                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                           
##### Was generative AI tooling used to co-author this PR?                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                           
  - [ ] Yes (please specify the tool below)