### PR TITLE
[FLINK-39614][table] Support TO_CHANGELOG: retract stream -> retract with set semantics

### DIFF
--- a/docs/content/docs/sql/reference/queries/changelog.md
+++ b/docs/content/docs/sql/reference/queries/changelog.md
@@ -268,6 +268,25 @@ SELECT * FROM TO_CHANGELOG(
 -- UPDATE_BEFORE is dropped (not in the mapping)
 ```
 
+#### Partitioning by a key
+
+```sql
+-- Input table 'my_aggregation' with columns (name, id, cnt)
+-- Default output schema:           [op, name, id, cnt]
+-- Output schema with PARTITION BY: [id, op, name, cnt]
+
+SELECT * FROM TO_CHANGELOG(
+  input => TABLE my_aggregation PARTITION BY id
+)
+```
+When `PARTITION BY` is provided, **the output schema changes**. The partition key columns are moved to the front by the engine, and the function emits the remaining input columns. The order becomes:
+
+```
+[partition_keys, op_column, non_partition_input_columns]
+```
+
+Prefer row semantics, when possible. `PARTITION BY` is only necessary when downstream operators are keyed on that column and you want to co-locate rows for the same key in the same parallel operator instance.
+
 #### Table API
 
 ```java

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ChangelogTypeStrategyUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ChangelogTypeStrategyUtils.java
@@ -22,9 +22,10 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.functions.TableSemantics;
 import org.apache.flink.table.types.DataType;
 
+import java.util.Arrays;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 /** Shared helpers for changelog-style PTFs ({@code TO_CHANGELOG}, {@code FROM_CHANGELOG}). */
@@ -36,9 +37,7 @@ public final class ChangelogTypeStrategyUtils {
      * partition key columns (the PTF framework prepends them when the input has set semantics).
      */
     public static int[] computeOutputIndices(final TableSemantics tableSemantics) {
-        final int inputFieldCount = DataType.getFieldNames(tableSemantics.dataType()).size();
-        final Set<Integer> excluded = collectPartitionKeyIndices(tableSemantics);
-        return filterIndices(inputFieldCount, excluded);
+        return computeOutputIndices(tableSemantics, -1);
     }
 
     /**
@@ -47,25 +46,25 @@ public final class ChangelogTypeStrategyUtils {
      */
     public static int[] computeOutputIndices(
             final TableSemantics tableSemantics, final String opColumnName) {
-        final List<String> inputFieldNames = DataType.getFieldNames(tableSemantics.dataType());
+        final int opIndex = DataType.getFieldNames(tableSemantics.dataType()).indexOf(opColumnName);
+        return computeOutputIndices(tableSemantics, opIndex);
+    }
+
+    private static int[] computeOutputIndices(
+            final TableSemantics tableSemantics, final int extraExcludedIndex) {
         final Set<Integer> excluded = collectPartitionKeyIndices(tableSemantics);
-        final int opIndex = inputFieldNames.indexOf(opColumnName);
-        if (opIndex >= 0) {
-            excluded.add(opIndex);
+        if (extraExcludedIndex >= 0) {
+            excluded.add(extraExcludedIndex);
         }
-        return filterIndices(inputFieldNames.size(), excluded);
+        final int inputFieldCount = DataType.getFieldCount(tableSemantics.dataType());
+        return IntStream.range(0, inputFieldCount).filter(i -> !excluded.contains(i)).toArray();
     }
 
     private static Set<Integer> collectPartitionKeyIndices(final TableSemantics tableSemantics) {
-        final Set<Integer> indices = new HashSet<>();
-        for (final int idx : tableSemantics.partitionByColumns()) {
-            indices.add(idx);
-        }
-        return indices;
-    }
-
-    private static int[] filterIndices(final int total, final Set<Integer> excluded) {
-        return IntStream.range(0, total).filter(i -> !excluded.contains(i)).toArray();
+        return new HashSet<>(
+                Arrays.stream(tableSemantics.partitionByColumns())
+                        .boxed()
+                        .collect(Collectors.toSet()));
     }
 
     private ChangelogTypeStrategyUtils() {}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ChangelogTypeStrategyUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ChangelogTypeStrategyUtils.java
@@ -23,8 +23,6 @@ import org.apache.flink.table.api.DataTypes.Field;
 import org.apache.flink.table.functions.TableSemantics;
 import org.apache.flink.table.types.DataType;
 
-import javax.annotation.Nullable;
-
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -35,26 +33,42 @@ import java.util.stream.IntStream;
 public final class ChangelogTypeStrategyUtils {
 
     /**
-     * Returns the input column indices that pass through to the function's output, excluding: -
-     * Partition keys, if present (the PTF framework prepends them when the input has set semantics)
-     * - The operation column {@code opColumnName} when non-null and present.
+     * Returns the input column indices that pass through to the function's output, excluding the
+     * partition key columns (the PTF framework prepends them when the input has set semantics).
+     */
+    public static int[] computeOutputIndices(final TableSemantics tableSemantics) {
+        final int inputFieldCount = DataType.getFields(tableSemantics.dataType()).size();
+        final Set<Integer> excluded = collectPartitionKeyIndices(tableSemantics);
+        return filterIndices(inputFieldCount, excluded);
+    }
+
+    /**
+     * Returns the input column indices that pass through to the function's output, excluding the
+     * partition key columns and the operation column matching {@code opColumnName}.
      */
     public static int[] computeOutputIndices(
-            final TableSemantics tableSemantics, final @Nullable String opColumnName) {
+            final TableSemantics tableSemantics, final String opColumnName) {
         final List<Field> inputFields = DataType.getFields(tableSemantics.dataType());
-        final Set<Integer> excluded = new HashSet<>();
-        for (final int idx : tableSemantics.partitionByColumns()) {
-            excluded.add(idx);
-        }
-        if (opColumnName != null) {
-            for (int i = 0; i < inputFields.size(); i++) {
-                if (inputFields.get(i).getName().equals(opColumnName)) {
-                    excluded.add(i);
-                    break;
-                }
+        final Set<Integer> excluded = collectPartitionKeyIndices(tableSemantics);
+        for (int i = 0; i < inputFields.size(); i++) {
+            if (inputFields.get(i).getName().equals(opColumnName)) {
+                excluded.add(i);
+                break;
             }
         }
-        return IntStream.range(0, inputFields.size()).filter(i -> !excluded.contains(i)).toArray();
+        return filterIndices(inputFields.size(), excluded);
+    }
+
+    private static Set<Integer> collectPartitionKeyIndices(final TableSemantics tableSemantics) {
+        final Set<Integer> indices = new HashSet<>();
+        for (final int idx : tableSemantics.partitionByColumns()) {
+            indices.add(idx);
+        }
+        return indices;
+    }
+
+    private static int[] filterIndices(final int total, final Set<Integer> excluded) {
+        return IntStream.range(0, total).filter(i -> !excluded.contains(i)).toArray();
     }
 
     private ChangelogTypeStrategyUtils() {}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ChangelogTypeStrategyUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ChangelogTypeStrategyUtils.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.types.inference.strategies;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.table.api.DataTypes.Field;
 import org.apache.flink.table.functions.TableSemantics;
 import org.apache.flink.table.types.DataType;
 
@@ -37,7 +36,7 @@ public final class ChangelogTypeStrategyUtils {
      * partition key columns (the PTF framework prepends them when the input has set semantics).
      */
     public static int[] computeOutputIndices(final TableSemantics tableSemantics) {
-        final int inputFieldCount = DataType.getFields(tableSemantics.dataType()).size();
+        final int inputFieldCount = DataType.getFieldNames(tableSemantics.dataType()).size();
         final Set<Integer> excluded = collectPartitionKeyIndices(tableSemantics);
         return filterIndices(inputFieldCount, excluded);
     }
@@ -48,15 +47,13 @@ public final class ChangelogTypeStrategyUtils {
      */
     public static int[] computeOutputIndices(
             final TableSemantics tableSemantics, final String opColumnName) {
-        final List<Field> inputFields = DataType.getFields(tableSemantics.dataType());
+        final List<String> inputFieldNames = DataType.getFieldNames(tableSemantics.dataType());
         final Set<Integer> excluded = collectPartitionKeyIndices(tableSemantics);
-        for (int i = 0; i < inputFields.size(); i++) {
-            if (inputFields.get(i).getName().equals(opColumnName)) {
-                excluded.add(i);
-                break;
-            }
+        final int opIndex = inputFieldNames.indexOf(opColumnName);
+        if (opIndex >= 0) {
+            excluded.add(opIndex);
         }
-        return filterIndices(inputFields.size(), excluded);
+        return filterIndices(inputFieldNames.size(), excluded);
     }
 
     private static Set<Integer> collectPartitionKeyIndices(final TableSemantics tableSemantics) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ChangelogTypeStrategyUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ChangelogTypeStrategyUtils.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference.strategies;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.DataTypes.Field;
+import org.apache.flink.table.functions.TableSemantics;
+import org.apache.flink.table.types.DataType;
+
+import javax.annotation.Nullable;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.IntStream;
+
+/** Shared helpers for changelog-style PTFs ({@code TO_CHANGELOG}, {@code FROM_CHANGELOG}). */
+@Internal
+public final class ChangelogTypeStrategyUtils {
+
+    /**
+     * Returns the input column indices that pass through to the function's output, excluding: -
+     * Partition keys, if present (the PTF framework prepends them when the input has set semantics)
+     * - The operation column {@code opColumnName} when non-null and present.
+     */
+    public static int[] computeOutputIndices(
+            final TableSemantics tableSemantics, final @Nullable String opColumnName) {
+        final List<Field> inputFields = DataType.getFields(tableSemantics.dataType());
+        final Set<Integer> excluded = new HashSet<>();
+        for (final int idx : tableSemantics.partitionByColumns()) {
+            excluded.add(idx);
+        }
+        if (opColumnName != null) {
+            for (int i = 0; i < inputFields.size(); i++) {
+                if (inputFields.get(i).getName().equals(opColumnName)) {
+                    excluded.add(i);
+                    break;
+                }
+            }
+        }
+        return IntStream.range(0, inputFields.size()).filter(i -> !excluded.contains(i)).toArray();
+    }
+
+    private ChangelogTypeStrategyUtils() {}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ToChangelogTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ToChangelogTypeStrategy.java
@@ -97,10 +97,8 @@ public final class ToChangelogTypeStrategy {
 
                 final String opColumnName = resolveOpColumnName(callContext);
                 final List<Field> inputFields = DataType.getFields(semantics.dataType());
-                // Excludes partition keys when set semantics; the framework prepends them so
-                // including them again here would duplicate the columns.
                 final int[] outputIndices =
-                        ChangelogTypeStrategyUtils.computeOutputIndices(semantics, null);
+                        ChangelogTypeStrategyUtils.computeOutputIndices(semantics);
 
                 final List<Field> outputFields = new ArrayList<>();
                 outputFields.add(DataTypes.FIELD(opColumnName, DataTypes.STRING()));

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ToChangelogTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ToChangelogTypeStrategy.java
@@ -35,6 +35,7 @@ import org.apache.flink.table.types.inference.TypeStrategy;
 import org.apache.flink.types.ColumnList;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -96,10 +97,14 @@ public final class ToChangelogTypeStrategy {
 
                 final String opColumnName = resolveOpColumnName(callContext);
                 final List<Field> inputFields = DataType.getFields(semantics.dataType());
+                // Excludes partition keys when set semantics; the framework prepends them so
+                // including them again here would duplicate the columns.
+                final int[] outputIndices =
+                        ChangelogTypeStrategyUtils.computeOutputIndices(semantics, null);
 
                 final List<Field> outputFields = new ArrayList<>();
                 outputFields.add(DataTypes.FIELD(opColumnName, DataTypes.STRING()));
-                outputFields.addAll(inputFields);
+                Arrays.stream(outputIndices).mapToObj(inputFields::get).forEach(outputFields::add);
 
                 return Optional.of(DataTypes.ROW(outputFields).notNull());
             };

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ToChangelogSemanticTests.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ToChangelogSemanticTests.java
@@ -39,9 +39,10 @@ public class ToChangelogSemanticTests extends SemanticTestBase {
     @Override
     public List<TableTestProgram> programs() {
         return List.of(
-                ToChangelogTestPrograms.INSERT_ONLY_INPUT,
-                ToChangelogTestPrograms.UPDATING_INPUT,
-                ToChangelogTestPrograms.UPSERT_INPUT,
+                ToChangelogTestPrograms.INSERT,
+                ToChangelogTestPrograms.RETRACT,
+                ToChangelogTestPrograms.UPSERT,
+                ToChangelogTestPrograms.RETRACT_PARTITION_BY,
                 ToChangelogTestPrograms.CUSTOM_OP_MAPPING,
                 ToChangelogTestPrograms.CUSTOM_OP_NAME,
                 ToChangelogTestPrograms.TABLE_API_DEFAULT,

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ToChangelogTestPrograms.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ToChangelogTestPrograms.java
@@ -42,7 +42,7 @@ public class ToChangelogTestPrograms {
     // SQL tests
     // --------------------------------------------------------------------------------------------
 
-    public static final TableTestProgram INSERT_ONLY_INPUT =
+    public static final TableTestProgram INSERT =
             TableTestProgram.of("to-changelog-insert-only", "insert-only input produces op=INSERT")
                     .setupTableSource(
                             SourceTestStep.newBuilder("t")
@@ -60,7 +60,7 @@ public class ToChangelogTestPrograms {
                     .runSql("INSERT INTO sink SELECT * FROM TO_CHANGELOG(input => TABLE t)")
                     .build();
 
-    public static final TableTestProgram UPDATING_INPUT =
+    public static final TableTestProgram RETRACT =
             TableTestProgram.of(
                             "to-changelog-updating-input",
                             "retract input produces all op codes including UPDATE_BEFORE")
@@ -121,7 +121,38 @@ public class ToChangelogTestPrograms {
                     .runSql("INSERT INTO sink SELECT * FROM TO_CHANGELOG(input => TABLE t)")
                     .build();
 
-    public static final TableTestProgram UPSERT_INPUT =
+    /** Partitions by a non-leading column ({@code id}, the middle column of three). */
+    public static final TableTestProgram RETRACT_PARTITION_BY =
+            TableTestProgram.of(
+                            "to-changelog-retract-partition-by-middle-column",
+                            "PARTITION BY a non-leading column drops it from the function output "
+                                    + "without disturbing the order of the remaining columns")
+                    .setupTableSource(
+                            SourceTestStep.newBuilder("t")
+                                    .addSchema(
+                                            "name STRING PRIMARY KEY NOT ENFORCED",
+                                            "id STRING",
+                                            "score BIGINT")
+                                    .addMode(ChangelogMode.all())
+                                    .producedValues(
+                                            Row.ofKind(RowKind.INSERT, "Alice", "EU", 10L),
+                                            Row.ofKind(RowKind.UPDATE_BEFORE, "Alice", "EU", 10L),
+                                            Row.ofKind(RowKind.UPDATE_AFTER, "Alice", "EU", 30L))
+                                    .build())
+                    .setupTableSink(
+                            SinkTestStep.newBuilder("sink")
+                                    .addSchema(
+                                            "id STRING", "op STRING", "name STRING", "score BIGINT")
+                                    .consumedValues(
+                                            "+I[EU, INSERT, Alice, 10]",
+                                            "+I[EU, UPDATE_BEFORE, Alice, 10]",
+                                            "+I[EU, UPDATE_AFTER, Alice, 30]")
+                                    .build())
+                    .runSql(
+                            "INSERT INTO sink SELECT * FROM TO_CHANGELOG(input => TABLE t PARTITION BY id)")
+                    .build();
+
+    public static final TableTestProgram UPSERT =
             TableTestProgram.of(
                             "to-changelog-upsert-input",
                             "upsert input gets ChangelogNormalize for UPDATE_BEFORE and full deletes")

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ToChangelogTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ToChangelogTest.java
@@ -77,7 +77,7 @@ public class ToChangelogTest extends TableTestBase {
     }
 
     @Test
-    void testInsertOnlySource() {
+    void testInsertSource() {
         util.tableEnv()
                 .executeSql(
                         "CREATE TABLE insert_only_source ("
@@ -89,7 +89,7 @@ public class ToChangelogTest extends TableTestBase {
     }
 
     @Test
-    void testSetSemanticsWithPartitionBy() {
+    void testRetractPartitionBy() {
         util.tableEnv()
                 .executeSql(
                         "CREATE TABLE retract_source ("

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/ToChangelogTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/ToChangelogTest.xml
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <Root>
-  <TestCase name="testInsertOnlySource">
+  <TestCase name="testInsertSource">
     <Resource name="sql">
       <![CDATA[SELECT * FROM TO_CHANGELOG(input => TABLE insert_only_source)]]>
     </Resource>
@@ -32,6 +32,26 @@ LogicalProject(op=[$0], id=[$1], name=[$2])
       <![CDATA[
 ProcessTableFunction(invocation=[TO_CHANGELOG(TABLE(#0), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT())], uid=[null], select=[op,id,name], rowType=[RecordType(VARCHAR(2147483647) op, INTEGER id, VARCHAR(2147483647) name)], changelogMode=[I])
 +- TableSourceScan(table=[[default_catalog, default_database, insert_only_source]], fields=[id, name], changelogMode=[I])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testRetractPartitionBy">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM TO_CHANGELOG(input => TABLE retract_source PARTITION BY id)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], op=[$1], name=[$2])
++- LogicalTableFunctionScan(invocation=[TO_CHANGELOG(TABLE(#0) PARTITION BY($0), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT())], rowType=[RecordType(INTEGER id, VARCHAR(2147483647) op, VARCHAR(2147483647) name)])
+   +- LogicalProject(id=[$0], name=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, retract_source]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+ProcessTableFunction(invocation=[TO_CHANGELOG(TABLE(#0) PARTITION BY($0), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT())], uid=[TO_CHANGELOG], select=[id,op,name], rowType=[RecordType(INTEGER id, VARCHAR(2147483647) op, VARCHAR(2147483647) name)], changelogMode=[I])
++- Exchange(distribution=[hash[id]], changelogMode=[I,UB,UA,D])
+   +- TableSourceScan(table=[[default_catalog, default_database, retract_source]], fields=[id, name], changelogMode=[I,UB,UA,D])
 ]]>
     </Resource>
   </TestCase>
@@ -51,26 +71,6 @@ LogicalProject(op=[$0], id=[$1], name=[$2])
       <![CDATA[
 ProcessTableFunction(invocation=[TO_CHANGELOG(TABLE(#0), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT())], uid=[null], select=[op,id,name], rowType=[RecordType(VARCHAR(2147483647) op, INTEGER id, VARCHAR(2147483647) name)], changelogMode=[I])
 +- TableSourceScan(table=[[default_catalog, default_database, retract_source]], fields=[id, name], changelogMode=[I,UB,UA,D])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testSetSemanticsWithPartitionBy">
-    <Resource name="sql">
-      <![CDATA[SELECT * FROM TO_CHANGELOG(input => TABLE retract_source PARTITION BY id)]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalProject(id=[$0], op=[$1], id0=[$2], name=[$3])
-+- LogicalTableFunctionScan(invocation=[TO_CHANGELOG(TABLE(#0) PARTITION BY($0), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT())], rowType=[RecordType(INTEGER id, VARCHAR(2147483647) op, INTEGER id0, VARCHAR(2147483647) name)])
-   +- LogicalProject(id=[$0], name=[$1])
-      +- LogicalTableScan(table=[[default_catalog, default_database, retract_source]])
-]]>
-    </Resource>
-    <Resource name="optimized rel plan">
-      <![CDATA[
-ProcessTableFunction(invocation=[TO_CHANGELOG(TABLE(#0) PARTITION BY($0), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT())], uid=[TO_CHANGELOG], select=[id,op,id0,name], rowType=[RecordType(INTEGER id, VARCHAR(2147483647) op, INTEGER id0, VARCHAR(2147483647) name)], changelogMode=[I])
-+- Exchange(distribution=[hash[id]], changelogMode=[I,UB,UA,D])
-   +- TableSourceScan(table=[[default_catalog, default_database, retract_source]], fields=[id, name], changelogMode=[I,UB,UA,D])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/ptf/ToChangelogFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/ptf/ToChangelogFunction.java
@@ -71,18 +71,13 @@ public class ToChangelogFunction extends BuiltInProcessTableFunction<RowData> {
     public ToChangelogFunction(final SpecializedContext context) {
         super(BuiltInFunctionDefinitions.TO_CHANGELOG, context);
         final CallContext callContext = context.getCallContext();
+        // Table argument is guaranteed by the type strategy's validation phase.
+        final TableSemantics tableSemantics = callContext.getTableSemantics(0).get();
 
         final Map<String, String> opMapping =
                 callContext.getArgumentValue(2, Map.class).orElse(null);
         this.rawOpMap = buildOpMap(opMapping);
-
-        // Drop partition keys when set semantics: the framework prepends them automatically.
-        // For row semantics, partitionByColumns is empty and this is a no-op identity projection.
-        final TableSemantics tableSemantics =
-                callContext
-                        .getTableSemantics(0)
-                        .orElseThrow(() -> new IllegalStateException("Table argument expected."));
-        this.outputIndices = ChangelogTypeStrategyUtils.computeOutputIndices(tableSemantics, null);
+        this.outputIndices = ChangelogTypeStrategyUtils.computeOutputIndices(tableSemantics);
     }
 
     @Override

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/ptf/ToChangelogFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/ptf/ToChangelogFunction.java
@@ -24,10 +24,13 @@ import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.utils.JoinedRowData;
+import org.apache.flink.table.data.utils.ProjectedRowData;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.FunctionContext;
 import org.apache.flink.table.functions.SpecializedFunction.SpecializedContext;
+import org.apache.flink.table.functions.TableSemantics;
 import org.apache.flink.table.types.inference.CallContext;
+import org.apache.flink.table.types.inference.strategies.ChangelogTypeStrategyUtils;
 import org.apache.flink.types.ColumnList;
 import org.apache.flink.types.RowKind;
 
@@ -57,10 +60,12 @@ public class ToChangelogFunction extends BuiltInProcessTableFunction<RowData> {
                     RowKind.DELETE, "DELETE");
 
     private final Map<RowKind, String> rawOpMap;
+    private final int[] outputIndices;
 
     private transient Map<RowKind, StringData> opMap;
     private transient GenericRowData opRow;
     private transient JoinedRowData output;
+    private transient ProjectedRowData projectedOutput;
 
     @SuppressWarnings("unchecked")
     public ToChangelogFunction(final SpecializedContext context) {
@@ -70,6 +75,14 @@ public class ToChangelogFunction extends BuiltInProcessTableFunction<RowData> {
         final Map<String, String> opMapping =
                 callContext.getArgumentValue(2, Map.class).orElse(null);
         this.rawOpMap = buildOpMap(opMapping);
+
+        // Drop partition keys when set semantics: the framework prepends them automatically.
+        // For row semantics, partitionByColumns is empty and this is a no-op identity projection.
+        final TableSemantics tableSemantics =
+                callContext
+                        .getTableSemantics(0)
+                        .orElseThrow(() -> new IllegalStateException("Table argument expected."));
+        this.outputIndices = ChangelogTypeStrategyUtils.computeOutputIndices(tableSemantics, null);
     }
 
     @Override
@@ -79,6 +92,7 @@ public class ToChangelogFunction extends BuiltInProcessTableFunction<RowData> {
         rawOpMap.forEach((kind, code) -> opMap.put(kind, StringData.fromString(code)));
         opRow = new GenericRowData(1);
         output = new JoinedRowData();
+        projectedOutput = ProjectedRowData.from(outputIndices);
     }
 
     /**
@@ -110,6 +124,6 @@ public class ToChangelogFunction extends BuiltInProcessTableFunction<RowData> {
         }
 
         opRow.setField(0, opCode);
-        collect(output.replace(opRow, input));
+        collect(output.replace(opRow, projectedOutput.replaceRow(input)));
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

TO_CHANGELOG was locked to row semantics; PARTITION BY silently duplicated the partition key in the output. This PR honors the conditional SET_SEMANTIC_TABLE trait declared in FLINK-39392 so the framework prepends the partition key and the function emits the rest.

## Brief change log

- Added ChangelogTypeStrategyUtils.computeOutputIndices helper. Note: shared with FROM_CHANGELOG once FLINK-39537 lands.
- Wired ToChangelogTypeStrategy and ToChangelogFunction to drop partition keys from the declared and emitted schema.
- Added two semantic test programs covering leading and middle-column partition keys; updated the existing plan test golden XML.

## Verifying this change

- ToChangelogSemanticTests
- ToChangelogTest

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? n/a

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

2.1.117 (Claude Code)