### PR TITLE
[FLINK-39619][docs] Add release notes for Flink 2.3

### DIFF
--- a/docs/content/release-notes/flink-2.3.md
+++ b/docs/content/release-notes/flink-2.3.md
@@ -113,6 +113,17 @@ with the DataStream API:
 - **`ORDER BY` on table arguments**: `MyPtf(input => TABLE t PARTITION BY k ORDER BY ts)` lets a
   PTF receive partitioned rows in deterministic temporal order.
 
+#### Fix for MiniBatchGroupAggFunction silently dropping records
+
+##### [FLINK-35661](https://issues.apache.org/jira/browse/FLINK-35661)
+
+When mini-batch aggregation is enabled and the planner falls back to a `ONE_PHASE` aggregation
+strategy (for example, because a UDAF does not implement `merge`), `MiniBatchGroupAggFunction`
+could silently drop records and produce incorrect aggregation results. The bug occurred when a
+key's bundle contained only retraction messages with no existing state for that key — the
+function would `return` from `finishBundle` instead of skipping the key, dropping all remaining
+keys in the bundle. Flink 2.3 fixes this so the remaining keys are processed correctly.
+
 ### Connectors
 
 #### Flink Native S3 FileSystem
@@ -185,6 +196,30 @@ and `jobType` fields so the UI can render adaptive-scheduler-specific informatio
 
 See the [Elastic Scaling documentation](https://nightlies.apache.org/flink/flink-docs-release-2.3/docs/deployment/elastic_scaling/)
 for details.
+
+#### Watermark alignment improvements for backlog processing
+
+##### [FLINK-37399](https://issues.apache.org/jira/browse/FLINK-37399)
+
+Prior to Flink 2.3, watermark alignment due to the announcement delays was inadvertently
+limiting how quickly a job could process a backlog. For example with max allowed drift
+configured to 30s and watermark alignment updated every ~1s, prior to Flink 2.3 watermark
+alignment was de facto capping the backlog processing speed to:
+
+> 30 "event time" seconds per each 1 "real world" second
+
+In Flink 2.3 the watermark alignment was redesigned to solve those announcement delays by an
+introduction of the watermark alignment buffer. By default this buffer has size of 3 and it
+delays the application of the watermark alignment algorithm by 3 update intervals. This means
+in Flink 2.3+ by default watermark alignment will be pausing sources a couple of seconds later
+than it used to, potentially slightly increasing state size of windowed and temporal operators.
+However this should be negligible for all practical use cases. Nevertheless, size of this
+buffer can be configured using:
+
+- `pipeline.watermark-alignment.buffer-size`
+
+Setting its value to zero restores the old behaviour from Flink 2.2. For more information
+please refer to the documentation of this config option.
 
 #### Checkpointing during recovery
 

--- a/docs/content/release-notes/flink-2.3.md
+++ b/docs/content/release-notes/flink-2.3.md
@@ -27,12 +27,334 @@ These release notes discuss important aspects, such as configuration, behavior o
 that changed between Flink 2.2 and Flink 2.3. Please read these notes carefully if you are
 planning to upgrade your Flink version to 2.3.
 
+### Table SQL / API
 
-### Core
+#### FROM_CHANGELOG and TO_CHANGELOG built-in PTFs
+
+##### [FLINK-39261](https://issues.apache.org/jira/browse/FLINK-39261), [FLINK-39419](https://issues.apache.org/jira/browse/FLINK-39419) (FLIP-564)
+
+Flink 2.3 introduces two new built-in Process Table Functions for converting between append-only
+streams that encode change operations and dynamic tables with full changelog semantics:
+
+- `FROM_CHANGELOG` converts an append-only stream that carries an operation column (and optional
+  before/after row descriptors) into a dynamic table. A configurable `op_mapping` makes it
+  straightforward to plug in custom CDC formats, and `invalid_op_handling` (`FAIL`/`LOG`/`SKIP`)
+  controls how rows with unmapped operation codes are treated.
+- `TO_CHANGELOG` is the inverse: it materializes a dynamic table back into an append-only
+  changelog stream. This is the first SQL-level operator that lets users convert upsert/retract
+  streams into append-only form, which is useful for archival, audit and writing to append-only
+  sinks. `produces_full_deletes` controls whether `-D` records carry the full row.
+
+Both PTFs support `PARTITION BY` for parallel execution and `uid` for query evolution, and they
+expose a `state_ttl` parameter for state retention.
+
+#### CREATE/ALTER for MATERIALIZED TABLE aligned with TABLE
+
+##### [FLINK-39303](https://issues.apache.org/jira/browse/FLINK-39303) (FLIP-550)
+
+The DDL surface of `MATERIALIZED TABLE` is brought to parity with regular tables. `CREATE
+MATERIALIZED TABLE` now accepts an explicit column list (including watermarks and primary keys)
+in front of the defining `AS` query. `ALTER MATERIALIZED TABLE` gains `ADD`, `MODIFY` and `DROP`
+operations on metadata and computed columns, plus `RENAME TO`, allowing materialized tables to
+evolve through the same workflow already used for regular Flink tables.
+
+#### Granular control over data reprocessing during materialized table evolution
+
+##### [FLINK-39460](https://issues.apache.org/jira/browse/FLINK-39460) (FLIP-557)
+
+When a materialized table's defining query is changed, Flink would previously always reprocess
+historical data from the beginning. Flink 2.3 introduces an optional `START_MODE` clause on
+`CREATE [OR ALTER]` and `ALTER MATERIALIZED TABLE`, letting users start the refresh pipeline
+`FROM_BEGINNING`, `FROM_NOW[(interval)]`, `FROM_TIMESTAMP(timestamp)`, or resume from previous
+offsets when available (`RESUME_OR_FROM_BEGINNING`/`RESUME_OR_FROM_NOW`/`RESUME_OR_FROM_TIMESTAMP`).
+The default remains `FROM_BEGINNING` for backward compatibility.
+
+#### ARTIFACT keyword in CREATE FUNCTION
+
+##### [FLINK-39462](https://issues.apache.org/jira/browse/FLINK-39462) (FLIP-559)
+
+The `USING` clause of `CREATE FUNCTION` accepts a new `ARTIFACT` keyword as an alternative to
+`JAR`. `ARTIFACT` is intentionally generic so that future ecosystem assets (Python wheels, etc.)
+can be referenced through the same syntax. Both keywords are interchangeable and may even be
+mixed within a single statement; existing `USING JAR` syntax continues to work unchanged.
+
+```sql
+CREATE FUNCTION my_func AS 'com.example.MyUdf'
+  USING ARTIFACT 's3://bucket/path/my-udf.jar';
+```
+
+#### SinkUpsertMaterializer improvements and changelog disorder handling
+
+##### [FLINK-39461](https://issues.apache.org/jira/browse/FLINK-39461) (FLIP-558)
+
+Flink 2.3 reworks how `SinkUpsertMaterializer` handles the case where a query's upsert key
+differs from the sink's primary key. Previously this required maintaining the full history of
+records and could blow up state. Two changes address this:
+
+- A new `ON CONFLICT` clause with `DO NOTHING`, `DO ERROR` and `DO DEDUPLICATE` strategies makes
+  the behavior on key conflict explicit. By default, planning now fails when the upsert and
+  primary keys differ, requiring the user to choose a conflict strategy.
+- Watermark-based record compaction is introduced to fix internal changelog disorder. The
+  trigger and frequency of compaction are controlled by:
+  - `table.exec.sink.upserts.compaction-mode` (default: `WATERMARK`) — `WATERMARK` or
+    `CHECKPOINT`.
+  - `table.exec.sink.upserts.compaction-interval` — optional fallback interval for emitting
+    watermarks when none arrive naturally.
+
+#### Process Table Function enhancements
+
+##### [FLINK-39256](https://issues.apache.org/jira/browse/FLINK-39256), [FLINK-39392](https://issues.apache.org/jira/browse/FLINK-39392), [FLINK-39436](https://issues.apache.org/jira/browse/FLINK-39436), [FLINK-39437](https://issues.apache.org/jira/browse/FLINK-39437), [FLINK-37599](https://issues.apache.org/jira/browse/FLINK-37599) (FLIP-565)
+
+Process Table Functions (PTFs), introduced in Flink 2.1, gain several capabilities aligning them
+with the DataStream API:
+
+- **Late data handling**: late records are no longer silently dropped; PTFs can react to them.
+- **`ORDER BY` on table arguments**: `MyPtf(input => TABLE t PARTITION BY k ORDER BY ts)` lets a
+  PTF receive partitioned rows in deterministic temporal order.
+- **`ValueView`**: a new lazy single-value state primitive (`value()`, `update()`, `isEmpty()`,
+  `clear()`) joins the existing `MapView` and `ListView` for working with single-element state
+  efficiently.
+- **Broadcast state**: PTFs support broadcast state through the new
+  `@ArgumentHint(ArgumentTrait.BROADCAST_SEMANTIC_TABLE)` and `@StateHint(StateKind.BROADCAST)`
+  annotations, plus `@ArgumentHint(ArgumentTrait.NOTIFY_STATEFUL_SETS)` for re-evaluating keys
+  when broadcast state changes.
+- **Conditional traits and `on_time` column expansion**: planner can use traits that depend on
+  argument values, and `on_time` columns participate in `SELECT *` expansion.
+- **Interruptible timers**: long timer-driven work yields to checkpoints and other timers.
+
+#### Metadata filter push-down for table sources
+
+##### [FLINK-39421](https://issues.apache.org/jira/browse/FLINK-39421)
+
+Filters that apply only to metadata columns (for example, Kafka headers, partition or offset)
+can now be pushed down into the source. This reduces the amount of data read from external
+systems for queries that filter primarily on metadata.
+
+#### New built-in functions and string utilities
+
+##### [FLINK-39601](https://issues.apache.org/jira/browse/FLINK-39601), [FLINK-39602](https://issues.apache.org/jira/browse/FLINK-39602)
+
+Flink 2.3 adds the built-in functions `IS_VALID_UTF8` and `MAKE_VALID_UTF8` for validating and
+sanitizing string data, along with corresponding `StringData.fromUtf8Bytes` connector APIs.
+
+#### Other SQL improvements
+
+- [FLINK-39253](https://issues.apache.org/jira/browse/FLINK-39253): The `ROW` function now
+  preserves field names from `AS` aliases.
+- [FLINK-39424](https://issues.apache.org/jira/browse/FLINK-39424): `LIKE` correctly supports
+  the default escape character.
+- [FLINK-39293](https://issues.apache.org/jira/browse/FLINK-39293): `MATCH_RECOGNIZE` no longer
+  fails with `SqlParserException` when used inside views.
+- [FLINK-39504](https://issues.apache.org/jira/browse/FLINK-39504): Special characters in
+  `VARIANT` `ITEM` calls are handled correctly.
+- [FLINK-39420](https://issues.apache.org/jira/browse/FLINK-39420): Temporal joins are rejected
+  in batch mode with a clear error message instead of producing incorrect results.
+- [FLINK-39458](https://issues.apache.org/jira/browse/FLINK-39458): Table type converters and
+  serializers were moved into a new `flink-table-type-utils` module to enable reuse outside the
+  table planner.
+- [FLINK-39606](https://issues.apache.org/jira/browse/FLINK-39606): `SHOW CREATE MATERIALIZED
+  TABLE` exposes flags to control whether `FRESHNESS`/`REFRESH MODE` clauses are included.
+
+### Connectors
+
+#### Flink Native S3 FileSystem
+
+##### [FLINK-39465](https://issues.apache.org/jira/browse/FLINK-39465) (FLIP-555)
+
+Flink 2.3 introduces a new native S3 file system plugin (`flink-s3-fs-native`) implemented
+directly on top of the AWS SDK v2, removing the Hadoop and Presto dependencies of the previous
+S3 connectors. The unified plugin provides both `FileSystem` and `RecoverableWriter`
+implementations (so streaming sinks retain exactly-once semantics), uses non-blocking I/O, and
+natively supports modern AWS auth patterns such as IAM Roles for Service Accounts.
+
+The plugin registers the standard `s3://` URI scheme and is deployed via the regular plugins
+directory. Configuration uses a new `s3.*` namespace (e.g. `s3.region`, `s3.endpoint`,
+`s3.path-style-access`, `s3.access-key`, `s3.secret-key`, `s3.upload.min.part.size`,
+`s3.upload.max.concurrent.uploads`, `s3.bulk-copy.enabled`, `s3.async.enabled`,
+`s3.read.buffer.size`, `s3.entropy.key`, plus SSE-KMS and chunked-encoding/checksum-validation
+controls).
+
+See the [Native S3 FileSystem documentation](https://nightlies.apache.org/flink/flink-docs-release-2.3/docs/deployment/filesystems/s3/)
+for setup details.
+
+### Runtime
+
+#### Adaptive Partition Selection for StreamPartitioner
+
+##### [FLINK-39466](https://issues.apache.org/jira/browse/FLINK-39466) (FLIP-339)
+
+`StreamPartitioner` gains an adaptive, load-aware partition-selection mode that routes records
+to the least-loaded downstream channel. This mitigates backpressure caused by skewed downstream
+processing and, in benchmarks, delivers up to ~3x throughput improvement under such conditions.
+The feature is opt-in via two new options:
+
+- `taskmanager.network.adaptive-partitioner.enabled` (default: `false`)
+- `taskmanager.network.adaptive-partitioner.max-traverse-size` (default: `4`) — number of
+  channels examined when selecting the idlest target.
+
+#### AdaptiveScheduler rescale history and Web UI
+
+##### [FLINK-39467](https://issues.apache.org/jira/browse/FLINK-39467), [FLINK-39468](https://issues.apache.org/jira/browse/FLINK-39468), [FLINK-38893](https://issues.apache.org/jira/browse/FLINK-38893), [FLINK-38896](https://issues.apache.org/jira/browse/FLINK-38896), [FLINK-38898](https://issues.apache.org/jira/browse/FLINK-38898), [FLINK-38900](https://issues.apache.org/jira/browse/FLINK-38900), [FLINK-38902](https://issues.apache.org/jira/browse/FLINK-38902) (FLIP-487, FLIP-495)
+
+Streaming jobs running with the adaptive scheduler now record a history of rescale events,
+including job-vertex parallelisms, slot allocations, scheduler-state transitions and
+termination reasons. Events are kept in memory and on disk following the existing
+`ExecutionGraphInfoStore` pattern.
+
+A new "Rescales" tab in the Web UI exposes this information through subpages for overview,
+history, summary and per-event details. The same data is available through new REST endpoints:
+
+- `/jobs/:jobid/rescales/overview`
+- `/jobs/:jobid/rescales/history`
+- `/jobs/:jobid/rescales/details/:rescaleuuid`
+- `/jobs/:jobid/rescales/summary`
+
+The existing `/jobs/overview` endpoint is extended with `schedulerType` and `jobType` fields so
+the UI can render adaptive-scheduler-specific information.
+
+The feature is controlled by a new option:
+
+- `web.adaptive-scheduler.rescale-history.size` (default: `0`) — maximum number of rescale
+  records retained per job. Setting `0` disables the feature.
+
+See the [Elastic Scaling documentation](https://nightlies.apache.org/flink/flink-docs-release-2.3/docs/deployment/elastic_scaling/)
+for details.
+
+#### Checkpointing during recovery
+
+##### [FLINK-39469](https://issues.apache.org/jira/browse/FLINK-39469), [FLINK-38541](https://issues.apache.org/jira/browse/FLINK-38541) (FLIP-547)
+
+Recovering from large unaligned checkpoints can stall a job for a long time, blocking upstream
+systems and increasing the cost of subsequent failures. Flink 2.3 enables checkpointing during
+the recovery phase: filtered records are re-organized into new buffers, output buffers are
+restored on the downstream task, and the task lifecycle allows the checkpoint coordinator to
+trigger checkpoints earlier. Two opt-in options are introduced:
+
+- `execution.checkpointing.unaligned.recover-output-on-downstream.enabled` (default: `false`)
+- `execution.checkpointing.unaligned.during-recovery.enabled` (default: `false`; requires the
+  option above to be enabled).
+
+#### Application Management
+
+##### [FLINK-39470](https://issues.apache.org/jira/browse/FLINK-39470), [FLINK-39264](https://issues.apache.org/jira/browse/FLINK-39264) (FLIP-549)
+
+Flink 2.3 introduces a first-class **application** concept that sits above jobs and unifies the
+behavior of user code across deployment modes. The cluster-job model is replaced by a
+cluster-application-job hierarchy, with two backing implementations
+(`PackagedProgramApplication` and `SingleJobApplication`). Application archives are organized
+by cluster and application IDs.
+
+New REST APIs:
+
+- `GET /applications/overview` — list applications.
+- `GET /applications/:applicationid` — application details.
+- `POST /applications/:applicationid/cancel` — cancel an application.
+- `POST /jars/:jarid/run-application` — submit an application asynchronously.
+
+New configuration options:
+
+- `execution.terminate-application-on-any-job-terminated-exceptionally` (default: `true`).
+- `cluster.id` (default: all-zero UUID).
+- `historyserver.archive.clean-expired-applications` (default: `false`).
+- `historyserver.archive.retained-applications` (default: `-1`).
+
+The Web UI gains an Applications tab and a redesigned home page; jobs link back to the
+application that owns them. See the
+[Application Lifecycle documentation](https://nightlies.apache.org/flink/flink-docs-release-2.3/docs/internals/application_lifecycle/)
+for details.
+
+#### Application Capability Enhancement
+
+##### [FLINK-39473](https://issues.apache.org/jira/browse/FLINK-39473) (FLIP-560)
+
+Building on FLIP-549, FLIP-560 hardens the application layer for high availability and improves
+error visibility:
+
+- Job-name-based matching enables correct recovery of multi-job applications after a JobManager
+  failure; job recovery is deferred until the user `main` method reaches the corresponding
+  submission point.
+- Applications can execute zero or multiple jobs (with some limitations for streaming jobs and
+  certain APIs).
+- A new `ApplicationStore` and `ApplicationResultStore` persist application metadata and
+  cleanup state across HA recovery.
+- Application-level exceptions (errors thrown by user `main` code, not just job execution) are
+  exposed through a new REST endpoint and Web UI subpage.
+
+New REST APIs:
+
+- `GET /applications/:applicationid/exceptions`
+- `GET /applications/:applicationid/jobmanager/config`
+
+New configuration options:
+
+- `application-result-store.storage-path`
+- `application-result-store.delete-on-commit` (default: `true`)
+
+The application page in the Web UI now shows start/end times and duration, a cancel action,
+log links, and a new exceptions subpage.
+
+#### Robust OTel gRPC metric exporter
+
+##### [FLINK-39471](https://issues.apache.org/jira/browse/FLINK-39471), [FLINK-39127](https://issues.apache.org/jira/browse/FLINK-39127) (FLIP-553)
+
+Large Flink jobs can produce metric payloads that exceed the size limits of common OTel gRPC
+backends, causing data loss. Flink 2.3 adds three opt-in robustness features to the OTel
+exporter (all backward compatible):
+
+- `metrics.reporter.otel.exporter.compression` — `gzip` or `none` (default).
+- `metrics.reporter.otel.batch.size` — split a single export into multiple gRPC calls; default
+  `0` (disabled).
+- `metrics.reporter.otel.transform.attribute-value-length-limits.<attribute_name>` — per-attribute
+  truncation; `*` applies a global default.
+
+#### Watermark alignment improvements
+
+##### [FLINK-39474](https://issues.apache.org/jira/browse/FLINK-39474) ([FLINK-37399](https://issues.apache.org/jira/browse/FLINK-37399))
+
+Watermark alignment now makes better use of source resources, avoiding unnecessary stalls when
+one source partition is far ahead of others.
+
+#### MiniBatchGroupAggFunction correctness fix
+
+##### [FLINK-39475](https://issues.apache.org/jira/browse/FLINK-39475) ([FLINK-35661](https://issues.apache.org/jira/browse/FLINK-35661))
+
+A correctness bug in `MiniBatchGroupAggFunction` that could produce incorrect aggregation
+results in certain mini-batch scenarios has been fixed. Users running streaming aggregations
+with mini-batch enabled are encouraged to upgrade.
+
+### Python
+
+#### Python Table API: fromChangelog / toChangelog / descriptor
+
+##### [FLINK-39479](https://issues.apache.org/jira/browse/FLINK-39479), [FLINK-39442](https://issues.apache.org/jira/browse/FLINK-39442)
+
+The Python Table API gains parity with the Java Table API for the new changelog PTFs introduced
+in this release. `fromChangelog()`, `toChangelog()` and `descriptor()` are now available from
+PyFlink, allowing Python users to express the same changelog conversions as Java/SQL users.
+
+### Documentation
+
+#### Documentation restructure
+
+##### [FLINK-39476](https://issues.apache.org/jira/browse/FLINK-39476) (FLIP-561)
+
+The Flink documentation has been reorganized to make navigation easier. Highlights:
+
+- Flink SQL gets a dedicated top-level section, separated from the Table API.
+- Relational streaming concepts (changelogs, dynamic tables, state, etc.) are promoted to a
+  top-level Concepts section.
+- Python documentation is integrated into the relevant API sections instead of living in a
+  standalone area.
+- Contributor-facing content has been relocated outside the main user-facing docs.
+
+Existing URLs continue to work via redirects. The top-level structure is documented on the
+[docs landing page](https://nightlies.apache.org/flink/flink-docs-release-2.3/).
+
+### Core / Security
 
 #### Set security.ssl.algorithms default value to modern cipher suite
 
-### [FLINK-39022](https://issues.apache.org/jira/browse/FLINK-39022)
+##### [FLINK-39022](https://issues.apache.org/jira/browse/FLINK-39022)
 
 A JDK update (affecting JDK 11.0.30+, 17.0.18+, 21.0.10+, and 24+) disabled `TLS_RSA_*` cipher suites.
 This was done to support forward-secrecy (RFC 9325) and comply with the IETF Draft on *Deprecating Obsolete Key Exchange Methods in TLS*.
@@ -41,5 +363,27 @@ To support these and future JDK versions, the default value for the Flink config
 
 `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384`
 
-This default provides strong security and wide compatibility. You can customize the cipher suites using the `security.ssl.algorithms` configuration option if your environment has different requirements. 
+This default provides strong security and wide compatibility. You can customize the cipher suites using the `security.ssl.algorithms` configuration option if your environment has different requirements.
 If these cipher suites are not supported on your setup, you will see that Flink processes will not be able to connect to each other.
+
+#### Sensitive key redaction extended
+
+##### [FLINK-39561](https://issues.apache.org/jira/browse/FLINK-39561)
+
+The set of configuration keys whose values are redacted from logs and the Web UI has been
+extended to cover additional access-key patterns. Users can also contribute their own
+additional patterns through configuration.
+
+### Dependency upgrades
+
+- [FLINK-39580](https://issues.apache.org/jira/browse/FLINK-39580): Bump Flink-controlled Java
+  dependencies (log4j, jackson, assertj, netty).
+- [FLINK-39542](https://issues.apache.org/jira/browse/FLINK-39542): Upgrade Avro to 1.11.5.
+- [FLINK-39528](https://issues.apache.org/jira/browse/FLINK-39528): Update `apache-arrow` to
+  19.0.0.
+- [FLINK-39598](https://issues.apache.org/jira/browse/FLINK-39598),
+  [FLINK-31070](https://issues.apache.org/jira/browse/FLINK-31070): Bump `jline` to 3.30.12.
+- [FLINK-39534](https://issues.apache.org/jira/browse/FLINK-39534): Bump `pemja` to 0.5.7.
+- [FLINK-39427](https://issues.apache.org/jira/browse/FLINK-39427): Use Apache Parent POM 35.
+- [FLINK-39483](https://issues.apache.org/jira/browse/FLINK-39483): Bump dependency-check Maven
+  plugin to 12.2.1.

--- a/docs/content/release-notes/flink-2.3.md
+++ b/docs/content/release-notes/flink-2.3.md
@@ -33,20 +33,23 @@ planning to upgrade your Flink version to 2.3.
 
 ##### [FLINK-39258](https://issues.apache.org/jira/browse/FLINK-39258) (FLIP-564)
 
-Flink 2.3 introduces two new built-in Process Table Functions for converting between append-only
-streams that encode change operations and dynamic tables with full changelog semantics:
+The DataStream API has long offered `toChangelogStream()` and `fromChangelogStream()` for working
+with changelog streams; Flink 2.3 brings equivalent functionality to SQL via two new built-in
+Process Table Functions:
 
 - `FROM_CHANGELOG` converts an append-only stream that carries an operation column (and optional
   before/after row descriptors) into a dynamic table. A configurable `op_mapping` makes it
-  straightforward to plug in custom CDC formats, and `invalid_op_handling` (`FAIL`/`LOG`/`SKIP`)
-  controls how rows with unmapped operation codes are treated.
+  straightforward to plug in custom CDC formats (e.g. Debezium-style `c`/`u`/`d` codes), and
+  `invalid_op_handling` (`FAIL`/`LOG`/`SKIP`) controls how rows with unmapped operation codes
+  are treated.
 - `TO_CHANGELOG` is the inverse: it materializes a dynamic table back into an append-only
-  changelog stream. This is the first SQL-level operator that lets users convert upsert/retract
-  streams into append-only form, which is useful for archival, audit and writing to append-only
-  sinks. `produces_full_deletes` controls whether `-D` records carry the full row.
+  changelog stream. This is the first SQL-level operator that lets users convert
+  retract/upsert streams into append form, which is useful for archival, audit and writing to
+  append-only sinks. `produces_full_deletes` controls whether `-D` records carry the full row.
 
-Both PTFs support `PARTITION BY` for parallel execution and `uid` for query evolution, and they
-expose a `state_ttl` parameter for state retention.
+The two PTFs are designed to be symmetric, so `FROM_CHANGELOG(TO_CHANGELOG(table))` round-trips
+correctly. Both support `PARTITION BY` for parallel execution and `uid` for query evolution, and
+they expose a `state_ttl` parameter for state retention.
 
 #### CREATE/ALTER for MATERIALIZED TABLE aligned with TABLE
 
@@ -147,9 +150,13 @@ for setup details.
 
 ##### [FLINK-31655](https://issues.apache.org/jira/browse/FLINK-31655) (FLIP-339)
 
-`StreamPartitioner` gains an adaptive, load-aware partition-selection mode that routes records
-to the least-loaded downstream channel. This mitigates backpressure caused by skewed downstream
-processing and, in benchmarks, delivers up to ~3x throughput improvement under such conditions.
+When upstream and downstream parallelism differ, Flink uses `RebalancePartitioner`, which selects
+target channels round-robin. For jobs that interact with external RPC services (Redis, HBase,
+LLM serving, etc.) round-robin selection causes severe backpressure as soon as a single
+downstream subtask slows down — the partitioner keeps feeding it new data even though it is
+already overloaded. Flink 2.3 adds an adaptive, load-aware partition-selection mode for
+`StreamPartitioner` that routes records to the least-loaded downstream channel instead. In
+benchmarks, this delivers up to ~3x throughput improvement under skewed downstream processing.
 The feature is opt-in via two new options:
 
 - `taskmanager.network.adaptive-partitioner.enabled` (default: `false`)
@@ -192,11 +199,14 @@ for details.
 
 ##### [FLINK-35761](https://issues.apache.org/jira/browse/FLINK-35761) (FLIP-547)
 
-Recovering from large unaligned checkpoints can stall a job for a long time, blocking upstream
-systems and increasing the cost of subsequent failures. Flink 2.3 enables checkpointing during
-the recovery phase: filtered records are re-organized into new buffers, output buffers are
-restored on the downstream task, and the task lifecycle allows the checkpoint coordinator to
-trigger checkpoints earlier. Two opt-in options are introduced:
+When restoring from an unaligned checkpoint, a task previously stayed in `INITIALIZING` until
+*all* recovered input buffers had been processed before transitioning to `RUNNING`. For
+high-parallelism jobs with large numbers of in-flight buffers, this could leave the task unable
+to checkpoint for tens of minutes (30+ minutes in real cases), so any subsequent failure had to
+restart from the original checkpoint. Flink 2.3 fixes this by transitioning to `RUNNING` as
+soon as all input buffers have been added to `RecoveredInputChannel` and by allowing the
+recovered input channels to be snapshotted, so a new unaligned checkpoint can be taken during
+recovery. Two opt-in options are introduced:
 
 - `execution.checkpointing.unaligned.recover-output-on-downstream.enabled` (default: `false`)
 - `execution.checkpointing.unaligned.during-recovery.enabled` (default: `false`; requires the
@@ -265,9 +275,13 @@ log links, and a new exceptions subpage.
 
 ##### [FLINK-38603](https://issues.apache.org/jira/browse/FLINK-38603) (FLIP-553)
 
-Large Flink jobs can produce metric payloads that exceed the size limits of common OTel gRPC
-backends, causing data loss. Flink 2.3 adds three opt-in robustness features to the OTel
-exporter (all backward compatible):
+Jobs with large numbers of tasks and operators can produce metric payloads big enough for the
+OTel gRPC backend to reject them, causing exported metric data to be dropped in production. The
+existing exporter had three concrete limitations: gzip compression was not exposed in Flink
+configuration, all data points went out in a single gRPC call without pagination, and metric
+attributes such as `task_name` could grow to contain hundreds of operator names and bloat the
+payload further. Flink 2.3 adds three opt-in robustness features to address these (all backward
+compatible):
 
 - `metrics.reporter.otel.exporter.compression` — `gzip` or `none` (default).
 - `metrics.reporter.otel.batch.size` — split a single export into multiple gRPC calls; default

--- a/docs/content/release-notes/flink-2.3.md
+++ b/docs/content/release-notes/flink-2.3.md
@@ -37,19 +37,17 @@ The DataStream API has long offered `toChangelogStream()` and `fromChangelogStre
 with changelog streams; Flink 2.3 brings equivalent functionality to SQL via two new built-in
 Process Table Functions:
 
-- `FROM_CHANGELOG` converts an append-only stream that carries an operation column (and optional
-  before/after row descriptors) into a dynamic table. A configurable `op_mapping` makes it
-  straightforward to plug in custom CDC formats (e.g. Debezium-style `c`/`u`/`d` codes), and
-  `invalid_op_handling` (`FAIL`/`LOG`/`SKIP`) controls how rows with unmapped operation codes
-  are treated.
+- `FROM_CHANGELOG` converts an append-only stream that carries an operation column into a dynamic
+  table. A configurable `op_mapping` makes it straightforward to plug in custom CDC formats and
+  controls how rows with unmapped operation codes are treated.
 - `TO_CHANGELOG` is the inverse: it materializes a dynamic table back into an append-only
-  changelog stream. This is the first SQL-level operator that lets users convert
-  retract/upsert streams into append form, which is useful for archival, audit and writing to
-  append-only sinks. `produces_full_deletes` controls whether `-D` records carry the full row.
+  changelog stream. This is the first SQL-level operator that lets users convert retract or
+  upsert streams into append form — useful for archival, audit, writing to append-only sinks,
+  and working around pipelines that require an append-only table.
 
-The two PTFs are designed to be symmetric, so `FROM_CHANGELOG(TO_CHANGELOG(table))` round-trips
-correctly. Both support `PARTITION BY` for parallel execution and `uid` for query evolution, and
-they expose a `state_ttl` parameter for state retention.
+The 2.3 release covers limited basic use cases for both. Future versions will extend both
+functions with `PARTITION BY`, `invalid_op_handling`, `produces_full_deletes` and more to make
+both features powerful and extensive. See [FLIP-564](https://cwiki.apache.org/confluence/display/FLINK/FLIP-564%3A+Support+FROM_CHANGELOG+and+TO_CHANGELOG+built-in+PTFs).
 
 #### CREATE/ALTER for MATERIALIZED TABLE aligned with TABLE
 
@@ -114,13 +112,6 @@ with the DataStream API:
 - **Late data handling**: late records are no longer silently dropped; PTFs can react to them.
 - **`ORDER BY` on table arguments**: `MyPtf(input => TABLE t PARTITION BY k ORDER BY ts)` lets a
   PTF receive partitioned rows in deterministic temporal order.
-- **`ValueView`**: a new lazy single-value state primitive (`value()`, `update()`, `isEmpty()`,
-  `clear()`) joins the existing `MapView` and `ListView` for working with single-element state
-  efficiently.
-- **Broadcast state**: PTFs support broadcast state through the new
-  `@ArgumentHint(ArgumentTrait.BROADCAST_SEMANTIC_TABLE)` and `@StateHint(StateKind.BROADCAST)`
-  annotations, plus `@ArgumentHint(ArgumentTrait.NOTIFY_STATEFUL_SETS)` for re-evaluating keys
-  when broadcast state changes.
 
 ### Connectors
 
@@ -199,18 +190,23 @@ for details.
 
 ##### [FLINK-35761](https://issues.apache.org/jira/browse/FLINK-35761) (FLIP-547)
 
-When restoring from an unaligned checkpoint, a task previously stayed in `INITIALIZING` until
-*all* recovered input buffers had been processed before transitioning to `RUNNING`. For
-high-parallelism jobs with large numbers of in-flight buffers, this could leave the task unable
-to checkpoint for tens of minutes (30+ minutes in real cases), so any subsequent failure had to
-restart from the original checkpoint. Flink 2.3 fixes this by transitioning to `RUNNING` as
-soon as all input buffers have been added to `RecoveredInputChannel` and by allowing the
-recovered input channels to be snapshotted, so a new unaligned checkpoint can be taken during
-recovery. Two opt-in options are introduced:
+Flink now supports triggering checkpoints while a job is still recovering from unaligned
+checkpoints. Previously, a checkpoint could only be triggered after all restored channel state
+had been fully consumed; when the in-flight state was large, this meant no new checkpoint could
+complete for hours, and any restart or rescaling during that window forced the job to redo the
+entire recovery from the original checkpoint.
+
+With this feature enabled, jobs can checkpoint early during recovery, preserving work across
+subsequent restarts and scaling events. Exactly-once semantics are unchanged.
+
+The feature is disabled by default and can be enabled via two new options:
 
 - `execution.checkpointing.unaligned.recover-output-on-downstream.enabled` (default: `false`)
-- `execution.checkpointing.unaligned.during-recovery.enabled` (default: `false`; requires the
-  option above to be enabled).
+- `execution.checkpointing.unaligned.during-recovery.enabled` (default: `false`, requires the
+  option above to be enabled)
+
+Enabling both is recommended for jobs with large unaligned checkpoint state or frequent
+rescaling.
 
 #### Application Management
 
@@ -245,31 +241,13 @@ for details.
 
 ##### [FLINK-38972](https://issues.apache.org/jira/browse/FLINK-38972) (FLIP-560)
 
-Building on FLIP-549, FLIP-560 hardens the application layer for high availability and improves
-error visibility:
-
-- Job-name-based matching enables correct recovery of multi-job applications after a JobManager
-  failure; job recovery is deferred until the user `main` method reaches the corresponding
-  submission point.
-- Applications can execute zero or multiple jobs (with some limitations for streaming jobs and
-  certain APIs).
-- A new `ApplicationStore` and `ApplicationResultStore` persist application metadata and
-  cleanup state across HA recovery.
-- Application-level exceptions (errors thrown by user `main` code, not just job execution) are
-  exposed through a new REST endpoint and Web UI subpage.
-
-New REST APIs:
-
-- `GET /applications/:applicationid/exceptions`
-- `GET /applications/:applicationid/jobmanager/config`
-
-New configuration options:
-
-- `application-result-store.storage-path`
-- `application-result-store.delete-on-commit` (default: `true`)
-
-The application page in the Web UI now shows start/end times and duration, a cancel action,
-log links, and a new exceptions subpage.
+Building on the application management framework introduced in FLIP-549, Flink 2.3.0 further
+enhances application capabilities via FLIP-560. High-availability (HA) recovery is strengthened
+by improving the handling of applications and their constituent jobs, including the automatic
+re-execution of incomplete applications in session mode. Furthermore, Flink now supports
+multiple batch jobs within a single application, using job names to ensure correct matching
+during HA recovery. Finally, application-level failure exceptions and JobManager configurations
+are now exposed through the REST API to facilitate troubleshooting.
 
 #### Robust OTel gRPC metric exporter
 
@@ -277,17 +255,13 @@ log links, and a new exceptions subpage.
 
 Jobs with large numbers of tasks and operators can produce metric payloads big enough for the
 OTel gRPC backend to reject them, causing exported metric data to be dropped in production. The
-existing exporter had three concrete limitations: gzip compression was not exposed in Flink
-configuration, all data points went out in a single gRPC call without pagination, and metric
-attributes such as `task_name` could grow to contain hundreds of operator names and bloat the
-payload further. Flink 2.3 adds three opt-in robustness features to address these (all backward
-compatible):
+existing exporter had two concrete limitations: gzip compression was not exposed in Flink
+configuration, and all data points went out in a single gRPC call without pagination. Flink 2.3
+adds two opt-in robustness features to address these (all backward compatible):
 
 - `metrics.reporter.otel.exporter.compression` — `gzip` or `none` (default).
 - `metrics.reporter.otel.batch.size` — split a single export into multiple gRPC calls; default
   `0` (disabled).
-- `metrics.reporter.otel.transform.attribute-value-length-limits.<attribute_name>` — per-attribute
-  truncation; `*` applies a global default.
 
 ### Documentation
 

--- a/docs/content/release-notes/flink-2.3.md
+++ b/docs/content/release-notes/flink-2.3.md
@@ -31,7 +31,7 @@ planning to upgrade your Flink version to 2.3.
 
 #### FROM_CHANGELOG and TO_CHANGELOG built-in PTFs
 
-##### [FLINK-39261](https://issues.apache.org/jira/browse/FLINK-39261), [FLINK-39419](https://issues.apache.org/jira/browse/FLINK-39419) (FLIP-564)
+##### [FLINK-39258](https://issues.apache.org/jira/browse/FLINK-39258) (FLIP-564)
 
 Flink 2.3 introduces two new built-in Process Table Functions for converting between append-only
 streams that encode change operations and dynamic tables with full changelog semantics:
@@ -50,7 +50,7 @@ expose a `state_ttl` parameter for state retention.
 
 #### CREATE/ALTER for MATERIALIZED TABLE aligned with TABLE
 
-##### [FLINK-39303](https://issues.apache.org/jira/browse/FLINK-39303) (FLIP-550)
+##### [FLINK-38673](https://issues.apache.org/jira/browse/FLINK-38673) (FLIP-550)
 
 The DDL surface of `MATERIALIZED TABLE` is brought to parity with regular tables. `CREATE
 MATERIALIZED TABLE` now accepts an explicit column list (including watermarks and primary keys)
@@ -60,7 +60,7 @@ evolve through the same workflow already used for regular Flink tables.
 
 #### Granular control over data reprocessing during materialized table evolution
 
-##### [FLINK-39460](https://issues.apache.org/jira/browse/FLINK-39460) (FLIP-557)
+##### [FLINK-39301](https://issues.apache.org/jira/browse/FLINK-39301) (FLIP-557)
 
 When a materialized table's defining query is changed, Flink would previously always reprocess
 historical data from the beginning. Flink 2.3 introduces an optional `START_MODE` clause on
@@ -71,7 +71,7 @@ The default remains `FROM_BEGINNING` for backward compatibility.
 
 #### ARTIFACT keyword in CREATE FUNCTION
 
-##### [FLINK-39462](https://issues.apache.org/jira/browse/FLINK-39462) (FLIP-559)
+##### [FLINK-39081](https://issues.apache.org/jira/browse/FLINK-39081) (FLIP-559)
 
 The `USING` clause of `CREATE FUNCTION` accepts a new `ARTIFACT` keyword as an alternative to
 `JAR`. `ARTIFACT` is intentionally generic so that future ecosystem assets (Python wheels, etc.)
@@ -85,7 +85,7 @@ CREATE FUNCTION my_func AS 'com.example.MyUdf'
 
 #### SinkUpsertMaterializer improvements and changelog disorder handling
 
-##### [FLINK-39461](https://issues.apache.org/jira/browse/FLINK-39461) (FLIP-558)
+##### [FLINK-38926](https://issues.apache.org/jira/browse/FLINK-38926) (FLIP-558)
 
 Flink 2.3 reworks how `SinkUpsertMaterializer` handles the case where a query's upsert key
 differs from the sink's primary key. Previously this required maintaining the full history of
@@ -103,7 +103,7 @@ records and could blow up state. Two changes address this:
 
 #### Process Table Function enhancements
 
-##### [FLINK-39256](https://issues.apache.org/jira/browse/FLINK-39256), [FLINK-39392](https://issues.apache.org/jira/browse/FLINK-39392), [FLINK-39436](https://issues.apache.org/jira/browse/FLINK-39436), [FLINK-39437](https://issues.apache.org/jira/browse/FLINK-39437), [FLINK-37599](https://issues.apache.org/jira/browse/FLINK-37599) (FLIP-565)
+##### [FLINK-39254](https://issues.apache.org/jira/browse/FLINK-39254) (FLIP-565)
 
 Process Table Functions (PTFs), introduced in Flink 2.1, gain several capabilities aligning them
 with the DataStream API:
@@ -118,48 +118,12 @@ with the DataStream API:
   `@ArgumentHint(ArgumentTrait.BROADCAST_SEMANTIC_TABLE)` and `@StateHint(StateKind.BROADCAST)`
   annotations, plus `@ArgumentHint(ArgumentTrait.NOTIFY_STATEFUL_SETS)` for re-evaluating keys
   when broadcast state changes.
-- **Conditional traits and `on_time` column expansion**: planner can use traits that depend on
-  argument values, and `on_time` columns participate in `SELECT *` expansion.
-- **Interruptible timers**: long timer-driven work yields to checkpoints and other timers.
-
-#### Metadata filter push-down for table sources
-
-##### [FLINK-39421](https://issues.apache.org/jira/browse/FLINK-39421)
-
-Filters that apply only to metadata columns (for example, Kafka headers, partition or offset)
-can now be pushed down into the source. This reduces the amount of data read from external
-systems for queries that filter primarily on metadata.
-
-#### New built-in functions and string utilities
-
-##### [FLINK-39601](https://issues.apache.org/jira/browse/FLINK-39601), [FLINK-39602](https://issues.apache.org/jira/browse/FLINK-39602)
-
-Flink 2.3 adds the built-in functions `IS_VALID_UTF8` and `MAKE_VALID_UTF8` for validating and
-sanitizing string data, along with corresponding `StringData.fromUtf8Bytes` connector APIs.
-
-#### Other SQL improvements
-
-- [FLINK-39253](https://issues.apache.org/jira/browse/FLINK-39253): The `ROW` function now
-  preserves field names from `AS` aliases.
-- [FLINK-39424](https://issues.apache.org/jira/browse/FLINK-39424): `LIKE` correctly supports
-  the default escape character.
-- [FLINK-39293](https://issues.apache.org/jira/browse/FLINK-39293): `MATCH_RECOGNIZE` no longer
-  fails with `SqlParserException` when used inside views.
-- [FLINK-39504](https://issues.apache.org/jira/browse/FLINK-39504): Special characters in
-  `VARIANT` `ITEM` calls are handled correctly.
-- [FLINK-39420](https://issues.apache.org/jira/browse/FLINK-39420): Temporal joins are rejected
-  in batch mode with a clear error message instead of producing incorrect results.
-- [FLINK-39458](https://issues.apache.org/jira/browse/FLINK-39458): Table type converters and
-  serializers were moved into a new `flink-table-type-utils` module to enable reuse outside the
-  table planner.
-- [FLINK-39606](https://issues.apache.org/jira/browse/FLINK-39606): `SHOW CREATE MATERIALIZED
-  TABLE` exposes flags to control whether `FRESHNESS`/`REFRESH MODE` clauses are included.
 
 ### Connectors
 
 #### Flink Native S3 FileSystem
 
-##### [FLINK-39465](https://issues.apache.org/jira/browse/FLINK-39465) (FLIP-555)
+##### [FLINK-38592](https://issues.apache.org/jira/browse/FLINK-38592) (FLIP-555)
 
 Flink 2.3 introduces a new native S3 file system plugin (`flink-s3-fs-native`) implemented
 directly on top of the AWS SDK v2, removing the Hadoop and Presto dependencies of the previous
@@ -181,7 +145,7 @@ for setup details.
 
 #### Adaptive Partition Selection for StreamPartitioner
 
-##### [FLINK-39466](https://issues.apache.org/jira/browse/FLINK-39466) (FLIP-339)
+##### [FLINK-31655](https://issues.apache.org/jira/browse/FLINK-31655) (FLIP-339)
 
 `StreamPartitioner` gains an adaptive, load-aware partition-selection mode that routes records
 to the least-loaded downstream channel. This mitigates backpressure caused by skewed downstream
@@ -192,37 +156,41 @@ The feature is opt-in via two new options:
 - `taskmanager.network.adaptive-partitioner.max-traverse-size` (default: `4`) — number of
   channels examined when selecting the idlest target.
 
-#### AdaptiveScheduler rescale history and Web UI
+#### AdaptiveScheduler rescale history
 
-##### [FLINK-39467](https://issues.apache.org/jira/browse/FLINK-39467), [FLINK-39468](https://issues.apache.org/jira/browse/FLINK-39468), [FLINK-38893](https://issues.apache.org/jira/browse/FLINK-38893), [FLINK-38896](https://issues.apache.org/jira/browse/FLINK-38896), [FLINK-38898](https://issues.apache.org/jira/browse/FLINK-38898), [FLINK-38900](https://issues.apache.org/jira/browse/FLINK-38900), [FLINK-38902](https://issues.apache.org/jira/browse/FLINK-38902) (FLIP-487, FLIP-495)
+##### [FLINK-38333](https://issues.apache.org/jira/browse/FLINK-38333) (FLIP-495)
 
 Streaming jobs running with the adaptive scheduler now record a history of rescale events,
-including job-vertex parallelisms, slot allocations, scheduler-state transitions and
-termination reasons. Events are kept in memory and on disk following the existing
-`ExecutionGraphInfoStore` pattern.
-
-A new "Rescales" tab in the Web UI exposes this information through subpages for overview,
-history, summary and per-event details. The same data is available through new REST endpoints:
+including job-vertex parallelisms, slot allocations, scheduler-state transitions and termination
+reasons. Events are kept in memory and on disk following the existing `ExecutionGraphInfoStore`
+pattern. The same data is available through new REST endpoints:
 
 - `/jobs/:jobid/rescales/overview`
 - `/jobs/:jobid/rescales/history`
 - `/jobs/:jobid/rescales/details/:rescaleuuid`
 - `/jobs/:jobid/rescales/summary`
 
-The existing `/jobs/overview` endpoint is extended with `schedulerType` and `jobType` fields so
-the UI can render adaptive-scheduler-specific information.
-
-The feature is controlled by a new option:
+The feature is controlled by:
 
 - `web.adaptive-scheduler.rescale-history.size` (default: `0`) — maximum number of rescale
   records retained per job. Setting `0` disables the feature.
+
+#### Web UI for AdaptiveScheduler rescale history
+
+##### [FLINK-22258](https://issues.apache.org/jira/browse/FLINK-22258) (FLIP-487)
+
+Building on FLIP-495, the Flink Web UI gains a new "Rescales" tab for streaming jobs running
+with the adaptive scheduler. Subpages expose rescale counts, the latest events, a historical
+timeline, duration statistics with percentiles, per-event details, and the adaptive scheduler
+configuration in effect. The existing `/jobs/overview` endpoint is extended with `schedulerType`
+and `jobType` fields so the UI can render adaptive-scheduler-specific information.
 
 See the [Elastic Scaling documentation](https://nightlies.apache.org/flink/flink-docs-release-2.3/docs/deployment/elastic_scaling/)
 for details.
 
 #### Checkpointing during recovery
 
-##### [FLINK-39469](https://issues.apache.org/jira/browse/FLINK-39469), [FLINK-38541](https://issues.apache.org/jira/browse/FLINK-38541) (FLIP-547)
+##### [FLINK-35761](https://issues.apache.org/jira/browse/FLINK-35761) (FLIP-547)
 
 Recovering from large unaligned checkpoints can stall a job for a long time, blocking upstream
 systems and increasing the cost of subsequent failures. Flink 2.3 enables checkpointing during
@@ -236,7 +204,7 @@ trigger checkpoints earlier. Two opt-in options are introduced:
 
 #### Application Management
 
-##### [FLINK-39470](https://issues.apache.org/jira/browse/FLINK-39470), [FLINK-39264](https://issues.apache.org/jira/browse/FLINK-39264) (FLIP-549)
+##### [FLINK-38755](https://issues.apache.org/jira/browse/FLINK-38755) (FLIP-549)
 
 Flink 2.3 introduces a first-class **application** concept that sits above jobs and unifies the
 behavior of user code across deployment modes. The cluster-job model is replaced by a
@@ -265,7 +233,7 @@ for details.
 
 #### Application Capability Enhancement
 
-##### [FLINK-39473](https://issues.apache.org/jira/browse/FLINK-39473) (FLIP-560)
+##### [FLINK-38972](https://issues.apache.org/jira/browse/FLINK-38972) (FLIP-560)
 
 Building on FLIP-549, FLIP-560 hardens the application layer for high availability and improves
 error visibility:
@@ -295,7 +263,7 @@ log links, and a new exceptions subpage.
 
 #### Robust OTel gRPC metric exporter
 
-##### [FLINK-39471](https://issues.apache.org/jira/browse/FLINK-39471), [FLINK-39127](https://issues.apache.org/jira/browse/FLINK-39127) (FLIP-553)
+##### [FLINK-38603](https://issues.apache.org/jira/browse/FLINK-38603) (FLIP-553)
 
 Large Flink jobs can produce metric payloads that exceed the size limits of common OTel gRPC
 backends, causing data loss. Flink 2.3 adds three opt-in robustness features to the OTel
@@ -307,36 +275,11 @@ exporter (all backward compatible):
 - `metrics.reporter.otel.transform.attribute-value-length-limits.<attribute_name>` — per-attribute
   truncation; `*` applies a global default.
 
-#### Watermark alignment improvements
-
-##### [FLINK-39474](https://issues.apache.org/jira/browse/FLINK-39474) ([FLINK-37399](https://issues.apache.org/jira/browse/FLINK-37399))
-
-Watermark alignment now makes better use of source resources, avoiding unnecessary stalls when
-one source partition is far ahead of others.
-
-#### MiniBatchGroupAggFunction correctness fix
-
-##### [FLINK-39475](https://issues.apache.org/jira/browse/FLINK-39475) ([FLINK-35661](https://issues.apache.org/jira/browse/FLINK-35661))
-
-A correctness bug in `MiniBatchGroupAggFunction` that could produce incorrect aggregation
-results in certain mini-batch scenarios has been fixed. Users running streaming aggregations
-with mini-batch enabled are encouraged to upgrade.
-
-### Python
-
-#### Python Table API: fromChangelog / toChangelog / descriptor
-
-##### [FLINK-39479](https://issues.apache.org/jira/browse/FLINK-39479), [FLINK-39442](https://issues.apache.org/jira/browse/FLINK-39442)
-
-The Python Table API gains parity with the Java Table API for the new changelog PTFs introduced
-in this release. `fromChangelog()`, `toChangelog()` and `descriptor()` are now available from
-PyFlink, allowing Python users to express the same changelog conversions as Java/SQL users.
-
 ### Documentation
 
 #### Documentation restructure
 
-##### [FLINK-39476](https://issues.apache.org/jira/browse/FLINK-39476) (FLIP-561)
+##### [FLINK-38945](https://issues.apache.org/jira/browse/FLINK-38945) (FLIP-561)
 
 The Flink documentation has been reorganized to make navigation easier. Highlights:
 
@@ -349,41 +292,3 @@ The Flink documentation has been reorganized to make navigation easier. Highligh
 
 Existing URLs continue to work via redirects. The top-level structure is documented on the
 [docs landing page](https://nightlies.apache.org/flink/flink-docs-release-2.3/).
-
-### Core / Security
-
-#### Set security.ssl.algorithms default value to modern cipher suite
-
-##### [FLINK-39022](https://issues.apache.org/jira/browse/FLINK-39022)
-
-A JDK update (affecting JDK 11.0.30+, 17.0.18+, 21.0.10+, and 24+) disabled `TLS_RSA_*` cipher suites.
-This was done to support forward-secrecy (RFC 9325) and comply with the IETF Draft on *Deprecating Obsolete Key Exchange Methods in TLS*.
-
-To support these and future JDK versions, the default value for the Flink configuration option `security.ssl.algorithms` has been changed to a modern, widely available cipher suite:
-
-`TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384`
-
-This default provides strong security and wide compatibility. You can customize the cipher suites using the `security.ssl.algorithms` configuration option if your environment has different requirements.
-If these cipher suites are not supported on your setup, you will see that Flink processes will not be able to connect to each other.
-
-#### Sensitive key redaction extended
-
-##### [FLINK-39561](https://issues.apache.org/jira/browse/FLINK-39561)
-
-The set of configuration keys whose values are redacted from logs and the Web UI has been
-extended to cover additional access-key patterns. Users can also contribute their own
-additional patterns through configuration.
-
-### Dependency upgrades
-
-- [FLINK-39580](https://issues.apache.org/jira/browse/FLINK-39580): Bump Flink-controlled Java
-  dependencies (log4j, jackson, assertj, netty).
-- [FLINK-39542](https://issues.apache.org/jira/browse/FLINK-39542): Upgrade Avro to 1.11.5.
-- [FLINK-39528](https://issues.apache.org/jira/browse/FLINK-39528): Update `apache-arrow` to
-  19.0.0.
-- [FLINK-39598](https://issues.apache.org/jira/browse/FLINK-39598),
-  [FLINK-31070](https://issues.apache.org/jira/browse/FLINK-31070): Bump `jline` to 3.30.12.
-- [FLINK-39534](https://issues.apache.org/jira/browse/FLINK-39534): Bump `pemja` to 0.5.7.
-- [FLINK-39427](https://issues.apache.org/jira/browse/FLINK-39427): Use Apache Parent POM 35.
-- [FLINK-39483](https://issues.apache.org/jira/browse/FLINK-39483): Bump dependency-check Maven
-  plugin to 12.2.1.


### PR DESCRIPTION
## What is the purpose of the change

Adds the release notes for the upcoming Flink 2.3 release, modeled on the format of the
[2.2 release notes](https://nightlies.apache.org/flink/flink-docs-release-2.2/release-notes/flink-2.2/).
Contents are derived from the FLIP wiki pages for the FLIPs included in 2.3 (FLIP-339, FLIP-487,
FLIP-495, FLIP-547, FLIP-549, FLIP-550, FLIP-553, FLIP-555, FLIP-557, FLIP-558, FLIP-559,
FLIP-560, FLIP-561, FLIP-564, FLIP-565), with motivation/impact details pulled from each FLIP's
umbrella JIRA where present.

JIRA: [FLINK-39619](https://issues.apache.org/jira/browse/FLINK-39619)

## Brief change log

Section coverage in `docs/content/release-notes/flink-2.3.md`:

- Table SQL / API: FROM_CHANGELOG/TO_CHANGELOG PTFs (FLIP-564), CREATE/ALTER MATERIALIZED TABLE parity (FLIP-550), START_MODE for materialized table evolution (FLIP-557), ARTIFACT keyword (FLIP-559), SinkUpsertMaterializer / ON CONFLICT (FLIP-558), Process Table Function enhancements (FLIP-565).
- Connectors: Native S3 FileSystem (FLIP-555).
- Runtime: Adaptive Partition Selection (FLIP-339), AdaptiveScheduler rescale history (FLIP-495) + Web UI (FLIP-487), checkpointing during recovery (FLIP-547), Application Management (FLIP-549), Application Capability Enhancement (FLIP-560), robust OTel gRPC exporter (FLIP-553).
- Documentation: docs restructure (FLIP-561).

## Verifying this change

This change is a docs-only addition; no code paths are exercised.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? docs (release notes only)
