### PR TITLE
[hotfix][build] Bump netty to 4.2.13.Final (CVEs)

### DIFF
--- a/flink-filesystems/flink-s3-fs-native/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-native/src/main/resources/META-INF/NOTICE
@@ -41,20 +41,20 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.httpcomponents:httpclient:4.5.13
 - org.apache.httpcomponents:httpcore:4.4.14
 - commons-logging:commons-logging:1.1.3
-- io.netty:netty-buffer:4.2.12.Final
-- io.netty:netty-codec:4.2.12.Final
-- io.netty:netty-codec-base:4.2.12.Final
-- io.netty:netty-codec-compression:4.2.12.Final
-- io.netty:netty-codec-http:4.2.12.Final
-- io.netty:netty-codec-http2:4.2.12.Final
-- io.netty:netty-codec-marshalling:4.2.12.Final
-- io.netty:netty-codec-protobuf:4.2.12.Final
-- io.netty:netty-common:4.2.12.Final
-- io.netty:netty-handler:4.2.12.Final
-- io.netty:netty-resolver:4.2.12.Final
-- io.netty:netty-transport:4.2.12.Final
-- io.netty:netty-transport-classes-epoll:4.2.12.Final
-- io.netty:netty-transport-native-unix-common:4.2.12.Final
+- io.netty:netty-buffer:4.2.13.Final
+- io.netty:netty-codec:4.2.13.Final
+- io.netty:netty-codec-base:4.2.13.Final
+- io.netty:netty-codec-compression:4.2.13.Final
+- io.netty:netty-codec-http:4.2.13.Final
+- io.netty:netty-codec-http2:4.2.13.Final
+- io.netty:netty-codec-marshalling:4.2.13.Final
+- io.netty:netty-codec-protobuf:4.2.13.Final
+- io.netty:netty-common:4.2.13.Final
+- io.netty:netty-handler:4.2.13.Final
+- io.netty:netty-resolver:4.2.13.Final
+- io.netty:netty-transport:4.2.13.Final
+- io.netty:netty-transport-classes-epoll:4.2.13.Final
+- io.netty:netty-transport-native-unix-common:4.2.13.Final
 
 This project bundles the following dependencies under the MIT License (https://opensource.org/licenses/MIT)
 

--- a/flink-python/src/main/resources/META-INF/NOTICE
+++ b/flink-python/src/main/resources/META-INF/NOTICE
@@ -58,8 +58,8 @@ The bundled Apache Beam dependencies bundle the following dependencies under the
 - io.grpc:grpc-protobuf:1.59.1
 - io.grpc:grpc-stub:1.59.1
 - io.grpc:grpc-testing:1.59.1
-- io.netty:netty-buffer:4.2.12.Final
-- io.netty:netty-common:4.2.12.Final
+- io.netty:netty-buffer:4.2.13.Final
+- io.netty:netty-common:4.2.13.Final
 - io.opencensus:opencensus-api:0.31.0
 - io.opencensus:opencensus-contrib-grpc-metrics:0.31.0
 - io.perfmark:perfmark-api:0.26.0

--- a/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/NOTICE
+++ b/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/NOTICE
@@ -16,13 +16,13 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.pekko:pekko-protobuf-v3_2.12:1.4.0
 - org.apache.pekko:pekko-slf4j_2.12:1.4.0
 - org.apache.pekko:pekko-stream_2.12:1.4.0
-- io.netty:netty-buffer:4.2.12.Final
-- io.netty:netty-transport-native-unix-common:4.2.12.Final
-- io.netty:netty-common:4.2.12.Final
-- io.netty:netty-codec-base:4.2.12.Final
-- io.netty:netty-handler:4.2.12.Final
-- io.netty:netty-resolver:4.2.12.Final
-- io.netty:netty-transport:4.2.12.Final
+- io.netty:netty-buffer:4.2.13.Final
+- io.netty:netty-transport-native-unix-common:4.2.13.Final
+- io.netty:netty-common:4.2.13.Final
+- io.netty:netty-codec-base:4.2.13.Final
+- io.netty:netty-handler:4.2.13.Final
+- io.netty:netty-resolver:4.2.13.Final
+- io.netty:netty-transport:4.2.13.Final
 
 
 The following dependencies all share the same BSD license which you find under licenses/LICENSE.scala.

--- a/pom.xml
+++ b/pom.xml
@@ -914,7 +914,7 @@ under the License.
 			<dependency>
 				<groupId>io.netty</groupId>
 				<artifactId>netty-bom</artifactId>
-				<version>4.2.12.Final</version>
+				<version>4.2.13.Final</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>


### PR DESCRIPTION
## What is the purpose of the change

Bump `io.netty:netty-bom` from `4.2.12.Final` to `4.2.13.Final` to pick up CVE fixes for the Netty modules Flink actually uses (non-shaded scope).

## Brief change log

- `pom.xml`: bump `netty-bom` 4.2.12.Final → 4.2.13.Final
- Update matching `META-INF/NOTICE` entries in `flink-rpc-akka`, `flink-python`, and `flink-s3-fs-native` so `NoticeFileChecker` passes

## CVEs addressed

Of the CVEs fixed in 4.2.13.Final, these apply to modules Flink imports:

| CVE | Module |
|---|---|
| CVE-2026-41417 | netty-codec-http |
| CVE-2026-42580 | netty-codec-http |
| CVE-2026-42581 | netty-codec-http |
| CVE-2026-42584 | netty-codec-http |
| CVE-2026-42585 | netty-codec-http |
| CVE-2026-42587 | netty-codec-http (http2 N/A) |
| CVE-2026-42583 | netty-codec / netty-codec-compression |
| CVE-2026-42577 | netty-transport-native-epoll |

CVEs in `netty-codec-redis`, `netty-codec-dns`, `netty-codec-mqtt`, `netty-codec-http2`, `netty-codec-http3`, and `netty-handler-proxy` do not apply — those modules are not used by Flink.

## Scope

Non-shaded only, mirroring the prior PR #28072 / FLINK-39580 split. The runtime networking path that flows through `flink-shaded-netty` requires a separate sync in that repo and is not addressed here.

## Verifying this change

This change is a dependency version bump and is already covered by tests.

- The build, unit tests, integration tests pass.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **yes**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no (NOTICE-only update)

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

## AI Disclosure

- [x] I confirm that AI agents (e.g. Cursor, Claude code, Github Copilot) were used in the process of creating this PR. Tool: Claude Code.