### PR TITLE
[FLINK-39632][table] Add fromChangelog() / toChangelog() convenience methods to PartitionedTable

### DIFF
--- a/docs/content/docs/sql/reference/queries/changelog.md
+++ b/docs/content/docs/sql/reference/queries/changelog.md
@@ -139,7 +139,7 @@ SELECT * FROM FROM_CHANGELOG(
 )
 ```
 
-When `PARTITION BY` is provided, **the output schema changes**. The partition key columns are moved to the front by the engine, and the function emits the remaining input columns (excluding the op column). The order becomes:
+When `PARTITION BY` is provided, **the output schema changes**. The partition key columns are moved to the front by the engine, and the function emits the remaining input columns (excluding the op column). The output schema becomes:
 
 ```
 [partition_keys, non_partition_input_columns_excluding_op]
@@ -230,7 +230,7 @@ When `op_mapping` is omitted, all four change operations are mapped to their sta
 
 ### Output Schema
 
-The output columns are ordered as:
+The output schema is:
 
 ```
 [op_column, all_input_columns]
@@ -305,7 +305,7 @@ SELECT * FROM TO_CHANGELOG(
   input => TABLE my_aggregation PARTITION BY id
 )
 ```
-When `PARTITION BY` is provided, **the output schema changes**. The partition key columns are moved to the front by the engine, and the function emits the remaining input columns. The order becomes:
+When `PARTITION BY` is provided, **the output schema changes**. The partition key columns are moved to the front by the engine, and the function emits the remaining input columns. The output schema becomes:
 
 ```
 [partition_keys, op_column, non_partition_input_columns]

--- a/docs/content/docs/sql/reference/queries/changelog.md
+++ b/docs/content/docs/sql/reference/queries/changelog.md
@@ -187,6 +187,10 @@ Table result = cdcStream.fromChangelog(
         "ua", "UPDATE_AFTER",
         "d", "DELETE").asArgument("op_mapping")
 );
+
+// Set semantics: co-locate rows with the same key in the same parallel operator instance.
+// Equivalent to PARTITION BY in SQL. The partition keys are prepended to the output columns.
+Table result = cdcStream.partitionBy($("id")).fromChangelog();
 ```
 
 ## TO_CHANGELOG
@@ -326,6 +330,10 @@ Table result = myTable.toChangelog(
     descriptor("deleted").asArgument("op"),
     map("INSERT, UPDATE_AFTER", "false", "DELETE", "true").asArgument("op_mapping")
 );
+
+// Set semantics: co-locate rows with the same key in the same parallel operator instance.
+// Equivalent to PARTITION BY in SQL. The partition keys are prepended to the output columns.
+Table result = myTable.partitionBy($("id")).toChangelog();
 ```
 
 {{< top >}}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/PartitionedTable.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/PartitionedTable.java
@@ -207,7 +207,7 @@ public interface PartitionedTable {
      * }</pre>
      *
      * @param arguments optional named arguments for {@code op} and {@code op_mapping}
-     * @return an append-only {@link Table} ordered as {@code [partition_keys, op,
+     * @return an append-only {@link Table} with output schema {@code [partition_keys, op,
      *     non_partition_input_columns]}
      * @see Table#toChangelog(Expression...)
      */
@@ -256,7 +256,7 @@ public interface PartitionedTable {
      *
      * @param arguments optional named arguments for {@code op}, {@code op_mapping}, and {@code
      *     error_handling}
-     * @return a dynamic {@link Table} ordered as {@code [partition_keys,
+     * @return a dynamic {@link Table} with output schema {@code [partition_keys,
      *     non_partition_non_op_input_columns]}
      * @see Table#fromChangelog(Expression...)
      */

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/PartitionedTable.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/PartitionedTable.java
@@ -169,4 +169,70 @@ public interface PartitionedTable {
      * @see ProcessTableFunction
      */
     Table process(Class<? extends UserDefinedFunction> function, Object... arguments);
+
+    /**
+     * Converts this partitioned dynamic table into an append-only table with an explicit operation
+     * code column using the built-in {@code TO_CHANGELOG} process table function with set
+     * semantics.
+     *
+     * <p>Each input row - regardless of its original change operation - is emitted as an
+     * INSERT-only row with a string {@code "op"} column indicating the original operation (INSERT,
+     * UPDATE_AFTER, DELETE, etc.). With set semantics, rows for the same partition key are
+     * co-located in the same parallel operator instance.
+     *
+     * <p>For row semantics (each row processed independently), use {@link Table#toChangelog} on the
+     * unpartitioned table.
+     *
+     * <p>Example:
+     *
+     * <pre>{@code
+     * Table result = table
+     *     .partitionBy($("id"))
+     *     .toChangelog(
+     *         descriptor("op_code").asArgument("op"),
+     *         map("INSERT", "I", "UPDATE_AFTER", "U").asArgument("op_mapping")
+     *     );
+     * }</pre>
+     *
+     * @param arguments optional named arguments for {@code op} and {@code op_mapping}
+     * @return an append-only {@link Table} with an {@code op} column and the partition keys
+     *     prepended to the input columns
+     * @see Table#toChangelog(Expression...)
+     */
+    Table toChangelog(Expression... arguments);
+
+    /**
+     * Converts this partitioned append-only table with an explicit operation code column into a
+     * (potentially updating) dynamic table using the built-in {@code FROM_CHANGELOG} process table
+     * function with set semantics.
+     *
+     * <p>Each input row is expected to have a string column that indicates the change operation.
+     * The operation column is interpreted by the engine and removed from the output. With set
+     * semantics, rows for the same partition key are co-located in the same parallel operator
+     * instance, which is required when downstream operators are keyed on that column.
+     *
+     * <p>For row semantics (each row processed independently), use {@link Table#fromChangelog} on
+     * the unpartitioned table.
+     *
+     * <p>Example:
+     *
+     * <pre>{@code
+     * Table result = cdcStream
+     *     .partitionBy($("id"))
+     *     .fromChangelog(
+     *         descriptor("op").asArgument("op"),
+     *         map("c, r", "INSERT",
+     *             "ub", "UPDATE_BEFORE",
+     *             "ua", "UPDATE_AFTER",
+     *             "d", "DELETE").asArgument("op_mapping")
+     *     );
+     * }</pre>
+     *
+     * @param arguments optional named arguments for {@code op}, {@code op_mapping}, and {@code
+     *     error_handling}
+     * @return a dynamic {@link Table} with the op column removed and the partition keys prepended
+     *     to the remaining input columns
+     * @see Table#fromChangelog(Expression...)
+     */
+    Table fromChangelog(Expression... arguments);
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/PartitionedTable.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/PartitionedTable.java
@@ -183,20 +183,32 @@ public interface PartitionedTable {
      * <p>For row semantics (each row processed independently), use {@link Table#toChangelog} on the
      * unpartitioned table.
      *
-     * <p>Example:
+     * <p>Examples:
      *
      * <pre>{@code
+     * // Default: adds 'op' column and supports all changelog modes
+     * Table result = table.partitionBy($("id")).toChangelog();
+     *
+     * // Custom op column name and mapping
      * Table result = table
      *     .partitionBy($("id"))
      *     .toChangelog(
      *         descriptor("op_code").asArgument("op"),
      *         map("INSERT", "I", "UPDATE_AFTER", "U").asArgument("op_mapping")
      *     );
+     *
+     * // Deletion flag pattern: comma-separated keys map multiple change operations to the same code
+     * Table result = table
+     *     .partitionBy($("id"))
+     *     .toChangelog(
+     *         descriptor("deleted").asArgument("op"),
+     *         map("INSERT, UPDATE_AFTER", "false", "DELETE", "true").asArgument("op_mapping")
+     *     );
      * }</pre>
      *
      * @param arguments optional named arguments for {@code op} and {@code op_mapping}
-     * @return an append-only {@link Table} with an {@code op} column and the partition keys
-     *     prepended to the input columns
+     * @return an append-only {@link Table} ordered as {@code [partition_keys, op,
+     *     non_partition_input_columns]}
      * @see Table#toChangelog(Expression...)
      */
     Table toChangelog(Expression... arguments);
@@ -214,9 +226,18 @@ public interface PartitionedTable {
      * <p>For row semantics (each row processed independently), use {@link Table#fromChangelog} on
      * the unpartitioned table.
      *
-     * <p>Example:
+     * <p>Examples:
      *
      * <pre>{@code
+     * // Default: reads 'op' column with standard change operation names
+     * Table result = cdcStream.partitionBy($("id")).fromChangelog();
+     *
+     * // With custom op column name
+     * Table result = cdcStream
+     *     .partitionBy($("id"))
+     *     .fromChangelog(descriptor("operation").asArgument("op"));
+     *
+     * // With custom op_mapping
      * Table result = cdcStream
      *     .partitionBy($("id"))
      *     .fromChangelog(
@@ -226,12 +247,17 @@ public interface PartitionedTable {
      *             "ua", "UPDATE_AFTER",
      *             "d", "DELETE").asArgument("op_mapping")
      *     );
+     *
+     * // Silently skip rows with NULL or unmapped op codes instead of failing
+     * Table result = cdcStream
+     *     .partitionBy($("id"))
+     *     .fromChangelog(lit("SKIP").asArgument("error_handling"));
      * }</pre>
      *
      * @param arguments optional named arguments for {@code op}, {@code op_mapping}, and {@code
      *     error_handling}
-     * @return a dynamic {@link Table} with the op column removed and the partition keys prepended
-     *     to the remaining input columns
+     * @return a dynamic {@link Table} ordered as {@code [partition_keys,
+     *     non_partition_non_op_input_columns]}
      * @see Table#fromChangelog(Expression...)
      */
     Table fromChangelog(Expression... arguments);

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
@@ -1431,6 +1431,17 @@ public interface Table extends Explainable<Table>, Executable {
      * INSERT-only row with a string {@code "op"} column indicating the original operation (INSERT,
      * UPDATE_AFTER, DELETE, etc.).
      *
+     * <p>By default, the input is processed with row semantics (each row independently). To
+     * co-locate rows with the same key in the same parallel operator instance, partition the input
+     * first via {@link #partitionBy(Expression...)} and invoke {@link
+     * PartitionedTable#toChangelog(Expression...)}:
+     *
+     * <pre>{@code
+     * Table result = table
+     *     .partitionBy($("id"))
+     *     .toChangelog();
+     * }</pre>
+     *
      * <p>Optional arguments can be passed using named expressions:
      *
      * <pre>{@code
@@ -1469,13 +1480,13 @@ public interface Table extends Explainable<Table>, Executable {
      *
      * <p>By default, the input is processed with row semantics (each row independently). To
      * co-locate rows with the same key in the same parallel operator instance, partition the input
-     * first via {@link #partitionBy(Expression...)} and invoke the function via {@link
-     * PartitionedTable#process(String, Object...)}:
+     * first via {@link #partitionBy(Expression...)} and invoke {@link
+     * PartitionedTable#fromChangelog(Expression...)}:
      *
      * <pre>{@code
      * Table result = cdcStream
      *     .partitionBy($("id"))
-     *     .process("FROM_CHANGELOG");
+     *     .fromChangelog();
      * }</pre>
      *
      * <p>Optional arguments can be passed using named expressions:

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
@@ -1434,7 +1434,7 @@ public interface Table extends Explainable<Table>, Executable {
      * <p>By default, the input is processed with row semantics (each row independently). To
      * co-locate rows with the same key in the same parallel operator instance, partition the input
      * first via {@link #partitionBy(Expression...)} and invoke {@link
-     * PartitionedTable#toChangelog(Expression...)}:
+     * PartitionedTable#toChangelog(Expression...)} with set semantics:
      *
      * <pre>{@code
      * Table result = table
@@ -1481,7 +1481,7 @@ public interface Table extends Explainable<Table>, Executable {
      * <p>By default, the input is processed with row semantics (each row independently). To
      * co-locate rows with the same key in the same parallel operator instance, partition the input
      * first via {@link #partitionBy(Expression...)} and invoke {@link
-     * PartitionedTable#fromChangelog(Expression...)}:
+     * PartitionedTable#fromChangelog(Expression...)} with set semantics:
      *
      * <pre>{@code
      * Table result = cdcStream

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableImpl.java
@@ -922,6 +922,17 @@ public class TableImpl implements Table {
                             createQueryOperation(), table.tableEnvironment, arguments));
         }
 
+        @Override
+        public Table toChangelog(final Expression... arguments) {
+            return process(BuiltInFunctionDefinitions.TO_CHANGELOG.getName(), (Object[]) arguments);
+        }
+
+        @Override
+        public Table fromChangelog(final Expression... arguments) {
+            return process(
+                    BuiltInFunctionDefinitions.FROM_CHANGELOG.getName(), (Object[]) arguments);
+        }
+
         private QueryOperation createQueryOperation() {
             if (orderKeys.isEmpty()) {
                 return table.operationTreeBuilder.partition(partitionKeys, table.operationTree);

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/FromChangelogSemanticTests.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/FromChangelogSemanticTests.java
@@ -47,6 +47,7 @@ public class FromChangelogSemanticTests extends SemanticTestBase {
                 FromChangelogTestPrograms.SKIP_INVALID_OP_HANDLING,
                 FromChangelogTestPrograms.SKIP_NULL_OP_CODE,
                 FromChangelogTestPrograms.TABLE_API_DEFAULT,
+                FromChangelogTestPrograms.TABLE_API_RETRACT_PARTITION_BY,
                 FromChangelogTestPrograms.ROUND_TRIP,
                 FromChangelogTestPrograms.INVALID_OP_CODE,
                 FromChangelogTestPrograms.NULL_OP_CODE);

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/FromChangelogTestPrograms.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/FromChangelogTestPrograms.java
@@ -26,6 +26,8 @@ import org.apache.flink.table.test.program.TableTestProgram;
 import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
 
+import static org.apache.flink.table.api.Expressions.$;
+
 /** {@link TableTestProgram} definitions for testing the built-in FROM_CHANGELOG PTF. */
 public class FromChangelogTestPrograms {
 
@@ -248,6 +250,35 @@ public class FromChangelogTestPrograms {
                                             Row.ofKind(RowKind.INSERT, 2, "Bob"))
                                     .build())
                     .runTableApi(env -> env.from("cdc_stream").fromChangelog(), "sink")
+                    .build();
+
+    public static final TableTestProgram TABLE_API_RETRACT_PARTITION_BY =
+            TableTestProgram.of(
+                            "from-changelog-table-api-retract-partition-by",
+                            "PartitionedTable.fromChangelog() convenience method")
+                    .setupTableSource(
+                            SourceTestStep.newBuilder("cdc_stream")
+                                    .addSchema(SIMPLE_CDC_SCHEMA)
+                                    .producedValues(
+                                            Row.of(1, "INSERT", "Alice"),
+                                            Row.of(2, "INSERT", "Bob"),
+                                            Row.of(1, "UPDATE_BEFORE", "Alice"),
+                                            Row.of(1, "UPDATE_AFTER", "Alice2"),
+                                            Row.of(2, "DELETE", "Bob"))
+                                    .build())
+                    .setupTableSink(
+                            SinkTestStep.newBuilder("sink")
+                                    .addSchema("id INT", "name STRING")
+                                    .consumedValues(
+                                            Row.ofKind(RowKind.INSERT, 1, "Alice"),
+                                            Row.ofKind(RowKind.INSERT, 2, "Bob"),
+                                            Row.ofKind(RowKind.UPDATE_BEFORE, 1, "Alice"),
+                                            Row.ofKind(RowKind.UPDATE_AFTER, 1, "Alice2"),
+                                            Row.ofKind(RowKind.DELETE, 2, "Bob"))
+                                    .build())
+                    .runTableApi(
+                            env -> env.from("cdc_stream").partitionBy($("id")).fromChangelog(),
+                            "sink")
                     .build();
 
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ToChangelogSemanticTests.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ToChangelogSemanticTests.java
@@ -46,6 +46,7 @@ public class ToChangelogSemanticTests extends SemanticTestBase {
                 ToChangelogTestPrograms.CUSTOM_OP_MAPPING,
                 ToChangelogTestPrograms.CUSTOM_OP_NAME,
                 ToChangelogTestPrograms.TABLE_API_DEFAULT,
+                ToChangelogTestPrograms.TABLE_API_RETRACT_PARTITION_BY,
                 ToChangelogTestPrograms.LAG_ON_UPSERT_VIA_CHANGELOG,
                 ToChangelogTestPrograms.LAG_ON_RETRACT_VIA_CHANGELOG,
                 ToChangelogTestPrograms.DELETION_FLAG,

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ToChangelogTestPrograms.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ToChangelogTestPrograms.java
@@ -28,6 +28,8 @@ import org.apache.flink.types.RowKind;
 
 import java.time.Instant;
 
+import static org.apache.flink.table.api.Expressions.$;
+
 /** {@link TableTestProgram} definitions for testing the built-in TO_CHANGELOG PTF. */
 public class ToChangelogTestPrograms {
 
@@ -255,6 +257,34 @@ public class ToChangelogTestPrograms {
                                     .consumedValues("+I[INSERT, 1, Alice]", "+I[INSERT, 2, Bob]")
                                     .build())
                     .runTableApi(env -> env.from("t").toChangelog(), "sink")
+                    .build();
+
+    public static final TableTestProgram TABLE_API_RETRACT_PARTITION_BY =
+            TableTestProgram.of(
+                            "to-changelog-table-api-retract-partition-by",
+                            "PartitionedTable.toChangelog() convenience method")
+                    .setupTableSource(
+                            SourceTestStep.newBuilder("t")
+                                    .addSchema(
+                                            "name STRING PRIMARY KEY NOT ENFORCED",
+                                            "id STRING",
+                                            "score BIGINT")
+                                    .addMode(ChangelogMode.all())
+                                    .producedValues(
+                                            Row.ofKind(RowKind.INSERT, "Alice", "EU", 10L),
+                                            Row.ofKind(RowKind.UPDATE_BEFORE, "Alice", "EU", 10L),
+                                            Row.ofKind(RowKind.UPDATE_AFTER, "Alice", "EU", 30L))
+                                    .build())
+                    .setupTableSink(
+                            SinkTestStep.newBuilder("sink")
+                                    .addSchema(
+                                            "id STRING", "op STRING", "name STRING", "score BIGINT")
+                                    .consumedValues(
+                                            "+I[EU, INSERT, Alice, 10]",
+                                            "+I[EU, UPDATE_BEFORE, Alice, 10]",
+                                            "+I[EU, UPDATE_AFTER, Alice, 30]")
+                                    .build())
+                    .runTableApi(env -> env.from("t").partitionBy($("id")).toChangelog(), "sink")
                     .build();
 
     // --------------------------------------------------------------------------------------------


### PR DESCRIPTION
### What is the purpose of the change                                                                                                                                     
                                                                                                                                                                        
Adds `fromChangelog()` and `toChangelog()` convenience methods to PartitionedTable so users can invoke the built-in `FROM_CHANGELOG` and `TO_CHANGELOG PTF`s with set semantics from the Table API. Today this requires the verbose `partitionBy(...).process("FROM_CHANGELOG", ...)` form.

###  Brief change log                                                                                                                                                      
                                                                                                                                                                        
- Added `fromChangelog(Expression...)` and `toChangelog(Expression...)` to PartitionedTable.                                                                              
- Implemented them in PartitionedTableImpl by delegating to `process(...)` on the partitioned operation tree.                                                           
- Cross-linked the new methods from the row-semantics overloads in Table.java.                                                                                        
- Added `TABLE_API_RETRACT_PARTITION_BY` test programs to both `FromChangelogTestPrograms` and `ToChangelogTestPrograms`, registered in the corresponding *SemanticTests.   
- Updated `docs/content/docs/sql/reference/queries/changelog.md` with the new Table API entry points.                                                                   
                                                                                                                                                                        
### Verifying this change                                                                                                                                                 
                                                                                                                                                                        
This change added tests and can be verified as follows:                                                                                                               
                                                                                                                                                                        
- `FromChangelogSemanticTests#TABLE_API_RETRACT_PARTITION_BY` exercises `cdcStream.partitionBy($("id")).fromChangelog()` with a retract input.                            
- `ToChangelogSemanticTests#TABLE_API_RETRACT_PARTITION_BY` exercises `myTable.partitionBy($("id")).toChangelog()` with a retract input where the partition key is a non-leading column.                                                                                                                                                   
- Both verify the optimized plan and the produced changelog.                                                                                                          
                                                                                                                                                                        
### Does this pull request potentially affect one of the following parts:                                                                                                 
                                                                                                                                                                        
- Dependencies (does it add or upgrade a dependency): no                                                                                                              
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes. Two new methods on `@PublicEvolving` PartitionedTable.                              
- The serializers: no                                                                                                                                                 
- The runtime per-record code paths (performance sensitive): no                                                                                                       
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no                                        
- The S3 file system connector: no                                                                                                                                    
                                                                                                                                                                        
### Documentation                                                                                                                                                         
                                                                                                                                                                        
- Does this pull request introduce a new feature? yes                                                                                                                 
- If yes, how is the feature documented? docs and JavaDocs      

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [x] Yes (please specify the tool below)

Generated-by: Opus 4.7 (for docs only)
