### PR TITLE
[FLINK-39638][table] Make codegen reuse result of JSON parse in `JSON_VALUE`, `JSON_QUERY`

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
@@ -145,11 +145,6 @@ class CodeGeneratorContext(
   private val localRefScopes =
     mutable.ArrayBuffer(mutable.LinkedHashMap.empty[Int, GeneratedExpression])
 
-  // cache of pre-parsed JSON variables keyed by input result term, so that multiple
-  // JSON function calls on the same input share a single parse
-  private val reusableParsedJsonExprs: mutable.Map[String, String] =
-    mutable.Map[String, String]()
-
   // set of constructor statements that will be added only once
   // we use a LinkedHashSet to keep the insertion order
   private val reusableConstructorStatements: mutable.LinkedHashSet[(String, String)] =
@@ -491,12 +486,6 @@ class CodeGeneratorContext(
       inputTerm: String,
       index: Int,
       expr: GeneratedExpression): Unit = reusableInputUnboxingExprs((inputTerm, index)) = expr
-
-  def addReusableParsedJson(inputTerm: String, varName: String): Unit =
-    reusableParsedJsonExprs(inputTerm) = varName
-
-  def getReusableParsedJson(inputTerm: String): Option[String] =
-    reusableParsedJsonExprs.get(inputTerm)
 
   /** Adds a reusable output record statement to member area. */
   def addReusableOutputRecord(

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
@@ -145,6 +145,11 @@ class CodeGeneratorContext(
   private val localRefScopes =
     mutable.ArrayBuffer(mutable.LinkedHashMap.empty[Int, GeneratedExpression])
 
+  // cache of pre-parsed JSON variables keyed by input result term, so that multiple
+  // JSON function calls on the same input share a single parse
+  private val reusableParsedJsonExprs: mutable.Map[String, String] =
+    mutable.Map[String, String]()
+
   // set of constructor statements that will be added only once
   // we use a LinkedHashSet to keep the insertion order
   private val reusableConstructorStatements: mutable.LinkedHashSet[(String, String)] =
@@ -486,6 +491,12 @@ class CodeGeneratorContext(
       inputTerm: String,
       index: Int,
       expr: GeneratedExpression): Unit = reusableInputUnboxingExprs((inputTerm, index)) = expr
+
+  def addReusableParsedJson(inputTerm: String, varName: String): Unit =
+    reusableParsedJsonExprs(inputTerm) = varName
+
+  def getReusableParsedJson(inputTerm: String): Option[String] =
+    reusableParsedJsonExprs.get(inputTerm)
 
   /** Adds a reusable output record statement to member area. */
   def addReusableOutputRecord(

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
@@ -482,7 +482,7 @@ object BuiltInMethods {
   val JSON_VALUE = Types.lookupMethod(
     classOf[SqlJsonUtils],
     "jsonValue",
-    classOf[String],
+    classOf[SqlJsonUtils.JsonValueContext],
     classOf[String],
     classOf[JsonValueOnEmptyOrError],
     classOf[Any],
@@ -494,6 +494,20 @@ object BuiltInMethods {
     classOf[SqlJsonUtils],
     "jsonQuery",
     classOf[String],
+    classOf[String],
+    classOf[JsonQueryReturnType],
+    classOf[JsonQueryWrapper],
+    classOf[JsonQueryOnEmptyOrError],
+    classOf[JsonQueryOnEmptyOrError]
+  )
+
+  val JSON_PARSE =
+    Types.lookupMethod(classOf[SqlJsonUtils], "jsonParse", classOf[String])
+
+  val JSON_QUERY_PARSED = Types.lookupMethod(
+    classOf[SqlJsonUtils],
+    "jsonQueryParsed",
+    classOf[SqlJsonUtils.JsonValueContext],
     classOf[String],
     classOf[JsonQueryReturnType],
     classOf[JsonQueryWrapper],

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/JsonQueryCallGen.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/JsonQueryCallGen.scala
@@ -33,6 +33,23 @@ import org.apache.calcite.sql.SqlJsonEmptyOrError
  * We cannot use [[MethodCallGen]] for a few different reasons. First, the return type of the
  * built-in Calcite function is [[Object]] and needs to be cast based on the inferred return type
  * instead as users can change this using the RETURNING keyword.
+ *
+ * When multiple JSON function calls share the same input expression, the parsed JSON context is
+ * reused via a shared member variable. For example, a query like:
+ * {{{
+ * SELECT JSON_VALUE(json_data, '$.type'), JSON_QUERY(json_data, '$.address') FROM t
+ * }}}
+ * generates code similar to:
+ * {{{
+ * // member variable (declared once)
+ * SqlJsonUtils.JsonValueContext jsonParsed$0;
+ *
+ * // in processElement (parse emitted only by the first function)
+ * jsonParsed$0 = SqlJsonUtils.jsonParse(field$0.toString());
+ * Object rawResult$1 = SqlJsonUtils.jsonValue(jsonParsed$0, "$.type", ...);
+ * // second call reuses jsonParsed$123 without re-parsing
+ * Object rawResult$2 = SqlJsonUtils.jsonQuery(jsonParsed$0, "$.address", ...);
+ * }}}
  */
 class JsonQueryCallGen extends CallGenerator {
   override def generate(
@@ -53,19 +70,24 @@ class JsonQueryCallGen extends CallGenerator {
           }
           val inputTerm = s"${argTerms.head}.toString()"
 
-          val (parsedTerm, parseCode) = ctx.getReusableParsedJson(inputTerm) match {
-            case Some(existing) => (existing, "")
-            case None =>
-              val varName = CodeGenUtils.newName(ctx, "jsonParsed")
-              ctx.addReusableMember(s"${classOf[SqlJsonUtils.JsonValueContext].getName} $varName;")
-              ctx.addReusableParsedJson(inputTerm, varName)
-              val assign =
-                s"$varName = ${qualifyMethod(BuiltInMethods.JSON_PARSE)}($inputTerm);"
-              (varName, assign)
-          }
+          val (varName, parseCode) =
+            ctx.getReusableInputUnboxingExprs(inputTerm, Int.MinValue) match {
+              case Some(expr) => (expr.resultTerm, "")
+              case None =>
+                val newVarName = CodeGenUtils.newName(ctx, "jsonParsed")
+                val typeName = classOf[SqlJsonUtils.JsonValueContext].getName
+                ctx.addReusableMember(s"$typeName $newVarName;")
+                ctx.addReusableInputUnboxingExprs(
+                  inputTerm,
+                  Int.MinValue,
+                  GeneratedExpression(newVarName, "false", "", null))
+                val assign =
+                  s"$newVarName = ${qualifyMethod(BuiltInMethods.JSON_PARSE)}($inputTerm);"
+                (newVarName, assign)
+            }
 
           val terms = Seq(
-            parsedTerm,
+            varName,
             s"${argTerms(1)}.toString()",
             qualifyEnum(jsonQueryReturnType),
             qualifyEnum(wrapperBehavior),
@@ -76,7 +98,7 @@ class JsonQueryCallGen extends CallGenerator {
           val rawResultTerm = CodeGenUtils.newName(ctx, "rawResult")
           val call = s"""
                         |$parseCode
-                        | Object $rawResultTerm =
+                        |Object $rawResultTerm =
                         |    ${qualifyMethod(BuiltInMethods.JSON_QUERY_PARSED)}(${terms
                          .mkString(", ")});
            """.stripMargin

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/JsonQueryCallGen.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/JsonQueryCallGen.scala
@@ -21,6 +21,7 @@ import org.apache.flink.table.api.{JsonQueryOnEmptyOrError, JsonQueryWrapper, Js
 import org.apache.flink.table.planner.codegen.{CodeGeneratorContext, CodeGenException, CodeGenUtils, GeneratedExpression}
 import org.apache.flink.table.planner.codegen.CodeGenUtils.{qualifyEnum, qualifyMethod, BINARY_STRING, GENERIC_ARRAY}
 import org.apache.flink.table.planner.codegen.GenerateUtils.generateCallWithStmtIfArgsNotNull
+import org.apache.flink.table.runtime.functions.SqlJsonUtils
 import org.apache.flink.table.runtime.functions.SqlJsonUtils.JsonQueryReturnType
 import org.apache.flink.table.types.logical.{ArrayType, LogicalType, LogicalTypeRoot}
 
@@ -50,8 +51,21 @@ class JsonQueryCallGen extends CallGenerator {
           } else {
             JsonQueryReturnType.STRING
           }
+          val inputTerm = s"${argTerms.head}.toString()"
+
+          val (parsedTerm, parseCode) = ctx.getReusableParsedJson(inputTerm) match {
+            case Some(existing) => (existing, "")
+            case None =>
+              val varName = CodeGenUtils.newName(ctx, "jsonParsed")
+              ctx.addReusableMember(s"${classOf[SqlJsonUtils.JsonValueContext].getName} $varName;")
+              ctx.addReusableParsedJson(inputTerm, varName)
+              val assign =
+                s"$varName = ${qualifyMethod(BuiltInMethods.JSON_PARSE)}($inputTerm);"
+              (varName, assign)
+          }
+
           val terms = Seq(
-            s"${argTerms.head}.toString()",
+            parsedTerm,
             s"${argTerms(1)}.toString()",
             qualifyEnum(jsonQueryReturnType),
             qualifyEnum(wrapperBehavior),
@@ -61,8 +75,10 @@ class JsonQueryCallGen extends CallGenerator {
 
           val rawResultTerm = CodeGenUtils.newName(ctx, "rawResult")
           val call = s"""
-                        |Object $rawResultTerm =
-                        |    ${qualifyMethod(BuiltInMethods.JSON_QUERY)}(${terms.mkString(", ")});
+                        |$parseCode
+                        | Object $rawResultTerm =
+                        |    ${qualifyMethod(BuiltInMethods.JSON_QUERY_PARSED)}(${terms
+                         .mkString(", ")});
            """.stripMargin
 
           val convertedResult = returnType.getTypeRoot match {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/JsonValueCallGen.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/JsonValueCallGen.scala
@@ -33,6 +33,23 @@ import org.apache.calcite.sql.SqlJsonEmptyOrError
  * built-in Calcite function is [[Object]] and needs to be cast based on the inferred return type
  * instead as users can change this using the RETURNING keyword. Furthermore, we need to provide the
  * proper default values in case not all arguments were given.
+ *
+ * When multiple JSON function calls share the same input expression, the parsed JSON context is
+ * reused via a shared member variable. For example, a query like:
+ * {{{
+ * SELECT JSON_VALUE(json_data, '$.type'), JSON_VALUE(json_data, '$.age') FROM t
+ * }}}
+ * generates code similar to:
+ * {{{
+ * // member variable (declared once)
+ * SqlJsonUtils.JsonValueContext jsonParsed$0;
+ *
+ * // in processElement (parse emitted only by the first function)
+ * jsonParsed$0 = SqlJsonUtils.jsonParse(field$0.toString());
+ * Object rawResult$1 = SqlJsonUtils.jsonValue(jsonParsed$0, "$.type", ...);
+ * // second call reuses jsonParsed$0 without re-parsing
+ * Object rawResult$2 = SqlJsonUtils.jsonValue(jsonParsed$0, "$.age", ...);
+ * }}}
  */
 class JsonValueCallGen extends CallGenerator {
   override def generate(
@@ -47,19 +64,24 @@ class JsonValueCallGen extends CallGenerator {
           val errorBehavior = getBehavior(operands, SqlJsonEmptyOrError.ERROR)
           val inputTerm = s"${argTerms.head}.toString()"
 
-          val (parsedTerm, parseCode) = ctx.getReusableParsedJson(inputTerm) match {
-            case Some(existing) => (existing, "")
-            case None =>
-              val varName = CodeGenUtils.newName(ctx, "jsonParsed")
-              ctx.addReusableMember(s"${classOf[SqlJsonUtils.JsonValueContext].getName} $varName;")
-              ctx.addReusableParsedJson(inputTerm, varName)
-              val assign =
-                s"$varName = ${qualifyMethod(BuiltInMethods.JSON_PARSE)}($inputTerm);"
-              (varName, assign)
-          }
+          val (varName, parseCode) =
+            ctx.getReusableInputUnboxingExprs(inputTerm, Int.MinValue) match {
+              case Some(expr) => (expr.resultTerm, "")
+              case None =>
+                val newVarName = CodeGenUtils.newName(ctx, "jsonParsed")
+                val typeName = classOf[SqlJsonUtils.JsonValueContext].getName
+                ctx.addReusableMember(s"$typeName $newVarName;")
+                ctx.addReusableInputUnboxingExprs(
+                  inputTerm,
+                  Int.MinValue,
+                  GeneratedExpression(newVarName, "false", "", null))
+                val assign =
+                  s"$newVarName = ${qualifyMethod(BuiltInMethods.JSON_PARSE)}($inputTerm);"
+                (newVarName, assign)
+            }
 
           val terms = Seq(
-            parsedTerm,
+            varName,
             s"${argTerms(1)}.toString()",
             qualifyEnum(emptyBehavior._1),
             emptyBehavior._2,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/JsonValueCallGen.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/JsonValueCallGen.scala
@@ -21,6 +21,7 @@ import org.apache.flink.table.api.JsonValueOnEmptyOrError
 import org.apache.flink.table.planner.codegen.{CodeGeneratorContext, CodeGenException, CodeGenUtils, GeneratedExpression}
 import org.apache.flink.table.planner.codegen.CodeGenUtils.{qualifyEnum, qualifyMethod, BINARY_STRING}
 import org.apache.flink.table.planner.codegen.GenerateUtils.generateCallWithStmtIfArgsNotNull
+import org.apache.flink.table.runtime.functions.SqlJsonUtils
 import org.apache.flink.table.types.logical.{LogicalType, LogicalTypeRoot}
 
 import org.apache.calcite.sql.SqlJsonEmptyOrError
@@ -44,8 +45,21 @@ class JsonValueCallGen extends CallGenerator {
         {
           val emptyBehavior = getBehavior(operands, SqlJsonEmptyOrError.EMPTY)
           val errorBehavior = getBehavior(operands, SqlJsonEmptyOrError.ERROR)
+          val inputTerm = s"${argTerms.head}.toString()"
+
+          val (parsedTerm, parseCode) = ctx.getReusableParsedJson(inputTerm) match {
+            case Some(existing) => (existing, "")
+            case None =>
+              val varName = CodeGenUtils.newName(ctx, "jsonParsed")
+              ctx.addReusableMember(s"${classOf[SqlJsonUtils.JsonValueContext].getName} $varName;")
+              ctx.addReusableParsedJson(inputTerm, varName)
+              val assign =
+                s"$varName = ${qualifyMethod(BuiltInMethods.JSON_PARSE)}($inputTerm);"
+              (varName, assign)
+          }
+
           val terms = Seq(
-            s"${argTerms.head}.toString()",
+            parsedTerm,
             s"${argTerms(1)}.toString()",
             qualifyEnum(emptyBehavior._1),
             emptyBehavior._2,
@@ -55,8 +69,10 @@ class JsonValueCallGen extends CallGenerator {
 
           val rawResultTerm = CodeGenUtils.newName(ctx, "rawResult")
           val call = s"""
+                        |$parseCode
                         |Object $rawResultTerm =
-                        |    ${qualifyMethod(BuiltInMethods.JSON_VALUE)}(${terms.mkString(", ")});
+                        |    ${qualifyMethod(BuiltInMethods.JSON_VALUE)}(${terms
+                         .mkString(", ")});
            """.stripMargin
 
           val convertedResult = returnType.getTypeRoot match {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/codegen/JsonParseReuseTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/codegen/JsonParseReuseTest.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.codegen;
+
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.TableResult;
+import org.apache.flink.table.runtime.generated.CompileUtils;
+import org.apache.flink.testutils.logging.LoggerAuditingExtension;
+import org.apache.flink.types.Row;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.event.Level;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests that multiple JSON function calls on the same input reuse the parsed JSON. */
+class JsonParseReuseTest {
+
+    @RegisterExtension
+    private final LoggerAuditingExtension codeLog =
+            new LoggerAuditingExtension(CompileUtils.class, Level.DEBUG);
+
+    private TableEnvironment tEnv;
+
+    private static final String JSON_ROW1 =
+            "{\"type\":\"account\",\"age\":42,\"address\":{\"city\":\"Munich\"},\"roles\":[\"user\",\"viewer\"]}";
+    private static final String JSON_ROW2 =
+            "{\"type\":\"admin\",\"age\":30,\"address\":{\"city\":\"Berlin\"},\"roles\":[\"admin\"]}";
+
+    @BeforeEach
+    void setUp() {
+        tEnv = TableEnvironment.create(EnvironmentSettings.inStreamingMode());
+        tEnv.createTemporaryView(
+                "json_src", tEnv.fromValues(Row.of(JSON_ROW1), Row.of(JSON_ROW2)).as("json_data"));
+    }
+
+    private List<Row> collect(String sql) {
+        TableResult result = tEnv.executeSql(sql);
+        List<Row> rows = new ArrayList<>();
+        result.collect().forEachRemaining(rows::add);
+        return rows;
+    }
+
+    private int countJsonParseInGeneratedCode() {
+        Pattern pattern = Pattern.compile("jsonParse\\(");
+        int total = 0;
+        for (String msg : codeLog.getMessages()) {
+            Matcher m = pattern.matcher(msg);
+            while (m.find()) {
+                total++;
+            }
+        }
+        return total;
+    }
+
+    @Test
+    void testTwoJsonValueCalls() {
+        List<Row> rows =
+                collect(
+                        "SELECT JSON_VALUE(json_data, '$.type'), JSON_VALUE(json_data, '$.age') FROM json_src");
+        assertThat(rows).containsExactlyInAnyOrder(Row.of("account", "42"), Row.of("admin", "30"));
+        assertThat(countJsonParseInGeneratedCode())
+                .as("Two JSON_VALUE calls on the same input should parse once")
+                .isEqualTo(1);
+    }
+
+    @Test
+    void testTwoJsonQueryCalls() {
+        List<Row> rows =
+                collect(
+                        "SELECT JSON_QUERY(json_data, '$.address'), "
+                                + "JSON_QUERY(json_data, '$.roles' WITH WRAPPER) FROM json_src");
+        assertThat(rows)
+                .containsExactlyInAnyOrder(
+                        Row.of("{\"city\":\"Munich\"}", "[[\"user\",\"viewer\"]]"),
+                        Row.of("{\"city\":\"Berlin\"}", "[[\"admin\"]]"));
+        assertThat(countJsonParseInGeneratedCode())
+                .as("Two JSON_QUERY calls on the same input should parse once")
+                .isEqualTo(1);
+    }
+
+    @Test
+    void testJsonValueAndJsonQueryMixed() {
+        List<Row> rows =
+                collect(
+                        "SELECT JSON_VALUE(json_data, '$.type'), "
+                                + "JSON_QUERY(json_data, '$.address') FROM json_src");
+        assertThat(rows)
+                .containsExactlyInAnyOrder(
+                        Row.of("account", "{\"city\":\"Munich\"}"),
+                        Row.of("admin", "{\"city\":\"Berlin\"}"));
+        assertThat(countJsonParseInGeneratedCode())
+                .as("JSON_VALUE + JSON_QUERY on the same input should parse once")
+                .isEqualTo(1);
+    }
+
+    @Test
+    void testThreeJsonFunctionCalls() {
+        List<Row> rows =
+                collect(
+                        "SELECT JSON_VALUE(json_data, '$.type'), "
+                                + "JSON_VALUE(json_data, '$.age'), "
+                                + "JSON_QUERY(json_data, '$.address') FROM json_src");
+        assertThat(rows)
+                .containsExactlyInAnyOrder(
+                        Row.of("account", "42", "{\"city\":\"Munich\"}"),
+                        Row.of("admin", "30", "{\"city\":\"Berlin\"}"));
+        assertThat(countJsonParseInGeneratedCode())
+                .as("Three JSON function calls on the same input should parse once")
+                .isEqualTo(1);
+    }
+
+    @Test
+    void testThreeJsonFunctionCallsWithDifferentJson() {
+        collect(
+                "SELECT JSON_VALUE(json_data, '$.type'), "
+                        + "JSON_VALUE('{}', '$.age') FROM json_src");
+        assertThat(countJsonParseInGeneratedCode()).as("Call for different JSON").isEqualTo(2);
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/codegen/JsonParseReuseTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/codegen/JsonParseReuseTest.java
@@ -18,17 +18,19 @@
 
 package org.apache.flink.table.planner.codegen;
 
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.transformations.OneInputTransformation;
 import org.apache.flink.table.api.EnvironmentSettings;
-import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableResult;
-import org.apache.flink.table.runtime.generated.CompileUtils;
-import org.apache.flink.testutils.logging.LoggerAuditingExtension;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.planner.codegen.calls.BuiltInMethods;
+import org.apache.flink.table.runtime.operators.CodeGenOperatorFactory;
 import org.apache.flink.types.Row;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
-import org.slf4j.event.Level;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -40,11 +42,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 /** Tests that multiple JSON function calls on the same input reuse the parsed JSON. */
 class JsonParseReuseTest {
 
-    @RegisterExtension
-    private final LoggerAuditingExtension codeLog =
-            new LoggerAuditingExtension(CompileUtils.class, Level.DEBUG);
+    private static final Pattern JSON_PARSE_PATTERN =
+            Pattern.compile("\\b" + Pattern.quote(BuiltInMethods.JSON_PARSE().getName()) + "\\(");
 
-    private TableEnvironment tEnv;
+    private StreamTableEnvironment tEnv;
 
     private static final String JSON_ROW1 =
             "{\"type\":\"account\",\"age\":42,\"address\":{\"city\":\"Munich\"},\"roles\":[\"user\",\"viewer\"]}";
@@ -53,92 +54,115 @@ class JsonParseReuseTest {
 
     @BeforeEach
     void setUp() {
-        tEnv = TableEnvironment.create(EnvironmentSettings.inStreamingMode());
+        tEnv =
+                StreamTableEnvironment.create(
+                        StreamExecutionEnvironment.getExecutionEnvironment(),
+                        EnvironmentSettings.inStreamingMode());
         tEnv.createTemporaryView(
-                "json_src", tEnv.fromValues(Row.of(JSON_ROW1), Row.of(JSON_ROW2)).as("json_data"));
+                "json_src",
+                tEnv.fromValues(Row.of(JSON_ROW1, "{}"), Row.of(JSON_ROW2, "{\"x\":1}"))
+                        .as("json_data", "other_json"));
     }
 
-    private List<Row> collect(String sql) {
-        TableResult result = tEnv.executeSql(sql);
-        List<Row> rows = new ArrayList<>();
+    private List<Row> collect(final String sql) {
+        final TableResult result = tEnv.executeSql(sql);
+        final List<Row> rows = new ArrayList<>();
         result.collect().forEachRemaining(rows::add);
         return rows;
     }
 
-    private int countJsonParseInGeneratedCode() {
-        Pattern pattern = Pattern.compile("jsonParse\\(");
-        int total = 0;
-        for (String msg : codeLog.getMessages()) {
-            Matcher m = pattern.matcher(msg);
-            while (m.find()) {
-                total++;
+    private static int countJsonParse(final String code) {
+        final Matcher m = JSON_PARSE_PATTERN.matcher(code);
+        int count = 0;
+        while (m.find()) {
+            count++;
+        }
+        return count;
+    }
+
+    private String extractGeneratedCode(final String sql) {
+        final Table table = tEnv.sqlQuery(sql);
+        final Transformation<?> root = tEnv.toChangelogStream(table).getTransformation();
+        final StringBuilder allCode = new StringBuilder();
+        for (final Transformation<?> t : root.getTransitivePredecessors()) {
+            if (t instanceof OneInputTransformation
+                    && ((OneInputTransformation<?, ?>) t).getOperatorFactory()
+                            instanceof CodeGenOperatorFactory) {
+                final CodeGenOperatorFactory<?> factory =
+                        (CodeGenOperatorFactory<?>)
+                                ((OneInputTransformation<?, ?>) t).getOperatorFactory();
+                allCode.append(factory.getGeneratedClass().getCode());
             }
         }
-        return total;
+        return allCode.toString();
     }
 
     @Test
     void testTwoJsonValueCalls() {
-        List<Row> rows =
-                collect(
-                        "SELECT JSON_VALUE(json_data, '$.type'), JSON_VALUE(json_data, '$.age') FROM json_src");
+        final String sql =
+                "SELECT JSON_VALUE(json_data, '$.type'), JSON_VALUE(json_data, '$.age') FROM json_src";
+        final List<Row> rows = collect(sql);
         assertThat(rows).containsExactlyInAnyOrder(Row.of("account", "42"), Row.of("admin", "30"));
-        assertThat(countJsonParseInGeneratedCode())
+        assertThat(countJsonParse(extractGeneratedCode(sql)))
                 .as("Two JSON_VALUE calls on the same input should parse once")
                 .isEqualTo(1);
     }
 
     @Test
     void testTwoJsonQueryCalls() {
-        List<Row> rows =
-                collect(
-                        "SELECT JSON_QUERY(json_data, '$.address'), "
-                                + "JSON_QUERY(json_data, '$.roles' WITH WRAPPER) FROM json_src");
+        final String sql =
+                "SELECT JSON_QUERY(json_data, '$.address'), "
+                        + "JSON_QUERY(json_data, '$.roles' WITH WRAPPER) FROM json_src";
+        final List<Row> rows = collect(sql);
         assertThat(rows)
                 .containsExactlyInAnyOrder(
                         Row.of("{\"city\":\"Munich\"}", "[[\"user\",\"viewer\"]]"),
                         Row.of("{\"city\":\"Berlin\"}", "[[\"admin\"]]"));
-        assertThat(countJsonParseInGeneratedCode())
+        assertThat(countJsonParse(extractGeneratedCode(sql)))
                 .as("Two JSON_QUERY calls on the same input should parse once")
                 .isEqualTo(1);
     }
 
     @Test
     void testJsonValueAndJsonQueryMixed() {
-        List<Row> rows =
-                collect(
-                        "SELECT JSON_VALUE(json_data, '$.type'), "
-                                + "JSON_QUERY(json_data, '$.address') FROM json_src");
+        final String sql =
+                "SELECT JSON_VALUE(json_data, '$.type'), "
+                        + "JSON_QUERY(json_data, '$.address') FROM json_src";
+        final List<Row> rows = collect(sql);
         assertThat(rows)
                 .containsExactlyInAnyOrder(
                         Row.of("account", "{\"city\":\"Munich\"}"),
                         Row.of("admin", "{\"city\":\"Berlin\"}"));
-        assertThat(countJsonParseInGeneratedCode())
+        assertThat(countJsonParse(extractGeneratedCode(sql)))
                 .as("JSON_VALUE + JSON_QUERY on the same input should parse once")
                 .isEqualTo(1);
     }
 
     @Test
     void testThreeJsonFunctionCalls() {
-        List<Row> rows =
-                collect(
-                        "SELECT JSON_VALUE(json_data, '$.type'), "
-                                + "JSON_VALUE(json_data, '$.age'), "
-                                + "JSON_QUERY(json_data, '$.address') FROM json_src");
+        final String sql =
+                "SELECT JSON_VALUE(json_data, '$.type'), "
+                        + "JSON_VALUE(json_data, '$.age'), "
+                        + "JSON_QUERY(json_data, '$.address') FROM json_src";
+        final List<Row> rows = collect(sql);
         assertThat(rows)
                 .containsExactlyInAnyOrder(
                         Row.of("account", "42", "{\"city\":\"Munich\"}"),
                         Row.of("admin", "30", "{\"city\":\"Berlin\"}"));
-        assertThat(countJsonParseInGeneratedCode())
+        assertThat(countJsonParse(extractGeneratedCode(sql)))
                 .as("Three JSON function calls on the same input should parse once")
                 .isEqualTo(1);
     }
 
     @Test
-    void testThreeJsonFunctionCallsWithDifferentJson() {
-        collect(
+    void testDifferentJsonInputs() {
+        final String sql =
                 "SELECT JSON_VALUE(json_data, '$.type'), "
-                        + "JSON_VALUE('{}', '$.age') FROM json_src");
-        assertThat(countJsonParseInGeneratedCode()).as("Call for different JSON").isEqualTo(2);
+                        + "JSON_VALUE(other_json, '$.x') FROM json_src";
+        final List<Row> rows = collect(sql);
+        assertThat(rows).containsExactlyInAnyOrder(Row.of("account", null), Row.of("admin", "1"));
+        assertThat(countJsonParse(extractGeneratedCode(sql)))
+                .as("JSON_VALUE calls on different inputs should parse separately")
+                .isEqualTo(2);
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
@@ -292,7 +292,13 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                                         "wrong"),
                         "JSON_VALUE(f0, 'strict $.[''contains blank'']' NULL ON EMPTY DEFAULT 'wrong' ON ERROR)",
                         "right",
-                        STRING());
+                        STRING())
+
+                // Multiple JSON_VALUE calls on the same input should reuse parsed JSON
+                .testSqlResult(
+                        "JSON_VALUE(f0, '$.type'), JSON_VALUE(f0, '$.age')",
+                        List.of("account", "42"),
+                        List.of(STRING(), STRING()));
     }
 
     private static List<TestSetSpec> isJsonSpec() {

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlJsonUtils.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlJsonUtils.java
@@ -160,6 +160,22 @@ public class SqlJsonUtils {
                 defaultValueOnError);
     }
 
+    /** Accepts a pre-parsed context from {@link #jsonParse}. */
+    public static Object jsonValue(
+            JsonValueContext parsedInput,
+            String pathSpec,
+            JsonValueOnEmptyOrError emptyBehavior,
+            Object defaultValueOnEmpty,
+            JsonValueOnEmptyOrError errorBehavior,
+            Object defaultValueOnError) {
+        return jsonValue(
+                jsonApiCommonSyntax(parsedInput, pathSpec),
+                emptyBehavior,
+                defaultValueOnEmpty,
+                errorBehavior,
+                defaultValueOnError);
+    }
+
     private static Object jsonValue(
             JsonPathContext context,
             JsonValueOnEmptyOrError emptyBehavior,
@@ -215,6 +231,22 @@ public class SqlJsonUtils {
             JsonQueryOnEmptyOrError errorBehavior) {
         return jsonQuery(
                 jsonApiCommonSyntax(input, pathSpec),
+                returnType,
+                wrapperBehavior,
+                emptyBehavior,
+                errorBehavior);
+    }
+
+    /** Like {@link #jsonQuery} but accepts a pre-parsed context from {@link #jsonParse}. */
+    public static Object jsonQueryParsed(
+            JsonValueContext parsedInput,
+            String pathSpec,
+            JsonQueryReturnType returnType,
+            JsonQueryWrapper wrapperBehavior,
+            JsonQueryOnEmptyOrError emptyBehavior,
+            JsonQueryOnEmptyOrError errorBehavior) {
+        return jsonQuery(
+                jsonApiCommonSyntax(parsedInput, pathSpec),
                 returnType,
                 wrapperBehavior,
                 emptyBehavior,
@@ -412,6 +444,15 @@ public class SqlJsonUtils {
 
     private static Object dejsonize(String input) {
         return JSON_PATH_JSON_PROVIDER.parse(input);
+    }
+
+    /**
+     * Parses a JSON string into a reusable context object. The result can be passed to {@link
+     * #jsonValue} or {@link #jsonQueryParsed} to avoid re-parsing the same JSON string multiple
+     * times.
+     */
+    public static JsonValueContext jsonParse(String input) {
+        return jsonValueExpression(input);
     }
 
     private static JsonValueContext jsonValueExpression(String input) {
@@ -618,7 +659,7 @@ public class SqlJsonUtils {
         }
     }
 
-    private static class JsonValueContext {
+    public static class JsonValueContext {
         @JsonValue public final Object obj;
         public final Exception exc;
 


### PR DESCRIPTION
## What is the purpose of the change

The main idea of the PR is to make result of JSON parse reusale
e.g. for query
```sql
SELECT JSON_VALUE('some json', '$.a'), JSON_VALUE('some json', '$.b');
```

## Brief change log

codegen

## Verifying this change



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
