### PR TITLE
[FLINK-39641][runtime-web] Fix unstable position of the Rescales Tab

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/pages/job/job-detail/status/job-status.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/job-detail/status/job-status.component.ts
@@ -63,7 +63,6 @@ export class JobStatusComponent implements OnInit, OnDestroy {
   urlLoading = true;
   readonly listOfNavigation: RouterTab[];
   private readonly checkpointIndexOfNavigation: number;
-  private readonly rescalesIndexOfNavigation: number;
 
   webCancelEnabled = this.statusService.configuration.features['web-cancel'];
   isHistoryServer = this.statusService.configuration.features['web-history'];
@@ -82,7 +81,6 @@ export class JobStatusComponent implements OnInit, OnDestroy {
     // Create a copy to avoid mutating the shared config
     this.listOfNavigation = [...(moduleConfig.routerTabs || JOB_MODULE_DEFAULT_CONFIG.routerTabs)];
     this.checkpointIndexOfNavigation = this.checkpointIndexOfNav();
-    this.rescalesIndexOfNavigation = this.rescalesIndexOfNav();
   }
 
   ngOnInit(): void {
@@ -133,6 +131,11 @@ export class JobStatusComponent implements OnInit, OnDestroy {
     return this.listOfNavigation.findIndex(item => item.path === 'rescales');
   }
 
+  private getRescalesTabIndexAfter(path: string): number {
+    const index = this.listOfNavigation.findIndex(item => item.path === path);
+    return index >= 0 ? index + 1 : this.listOfNavigation.length;
+  }
+
   private handleJobDetailChanged(data: JobDetailCorrect): void {
     this.jobDetail = data;
     const checkpointNavIndex = this.checkpointIndexOfNav();
@@ -150,7 +153,9 @@ export class JobStatusComponent implements OnInit, OnDestroy {
     if (!shouldShowRescales && rescalesNavIndex > -1) {
       this.listOfNavigation.splice(rescalesNavIndex, 1);
     } else if (shouldShowRescales && rescalesNavIndex == -1) {
-      this.listOfNavigation.splice(this.rescalesIndexOfNavigation, 0, {
+      // Insert deterministically after configuration to avoid stale index issues across job transitions.
+      const insertIndex = this.getRescalesTabIndexAfter('configuration');
+      this.listOfNavigation.splice(insertIndex, 0, {
         path: 'rescales',
         title: 'Rescales'
       });


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

[FLINK-39641][runtime-web] Fix unstable position of the Rescales Tab


## Brief change log

- Fix the target position of **Rescales** finding logic

## Verifying this change

- Before the fix:

<img width="885" height="335" alt="image" src="https://github.com/user-attachments/assets/ecabf214-3da8-4dd7-a2e4-225d1f9b45fb" />

- After the fix:

<img width="2490" height="961" alt="image" src="https://github.com/user-attachments/assets/7a8397e8-8132-4338-97a5-d60c4bc4be40" />


I followed the reproduction steps[1] and tried 10 times, the issue no longer occurred.
[1] https://issues.apache.org/jira/browse/FLINK-39494

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
