### PR TITLE
[FLINK-39642][s3] Fix Illegal argument error message

### DIFF
--- a/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/NativeS3FileSystemFactory.java
+++ b/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/NativeS3FileSystemFactory.java
@@ -356,17 +356,17 @@ public class NativeS3FileSystemFactory implements FileSystemFactory {
         // Validate part size: S3 requires minimum 5MB and maximum 5GB per part
         Preconditions.checkArgument(
                 s3minPartSize >= S3_MULTIPART_MIN_PART_SIZE,
-                "%s must be at least 5MB (5242880 bytes), but was %d bytes",
+                "%s must be at least 5MB (5242880 bytes), but was %s bytes",
                 PART_UPLOAD_MIN_SIZE.key(),
                 s3minPartSize);
         Preconditions.checkArgument(
                 s3minPartSize <= 5L * 1024 * 1024 * 1024,
-                "%s must not exceed 5GB (5368709120 bytes), but was %d bytes",
+                "%s must not exceed 5GB (5368709120 bytes), but was %s bytes",
                 PART_UPLOAD_MIN_SIZE.key(),
                 s3minPartSize);
         Preconditions.checkArgument(
                 maxConcurrentUploads > 0,
-                "%s must be positive, but was %d",
+                "%s must be positive, but was %s",
                 MAX_CONCURRENT_UPLOADS.key(),
                 maxConcurrentUploads);
 

--- a/flink-filesystems/flink-s3-fs-native/src/test/java/org/apache/flink/fs/s3native/NativeS3FileSystemFactoryTest.java
+++ b/flink-filesystems/flink-s3-fs-native/src/test/java/org/apache/flink/fs/s3native/NativeS3FileSystemFactoryTest.java
@@ -220,7 +220,8 @@ class NativeS3FileSystemFactoryTest {
         config.set(NativeS3FileSystemFactory.PART_UPLOAD_MIN_SIZE, 1024L);
         assertThatThrownBy(() -> createFs(config))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("must be at least");
+                .hasMessage(
+                        "s3.upload.min.part.size must be at least 5MB (5242880 bytes), but was 1024 bytes");
     }
 
     @Test
@@ -229,7 +230,8 @@ class NativeS3FileSystemFactoryTest {
         config.set(NativeS3FileSystemFactory.PART_UPLOAD_MIN_SIZE, 6L * 1024 * 1024 * 1024);
         assertThatThrownBy(() -> createFs(config))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("must not exceed 5GB");
+                .hasMessage(
+                        "s3.upload.min.part.size must not exceed 5GB (5368709120 bytes), but was 6442450944 bytes");
     }
 
     // --- Max concurrent uploads ---
@@ -240,7 +242,7 @@ class NativeS3FileSystemFactoryTest {
         config.set(NativeS3FileSystemFactory.MAX_CONCURRENT_UPLOADS, 0);
         assertThatThrownBy(() -> createFs(config))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("must be positive");
+                .hasMessage("s3.upload.max.concurrent.uploads must be positive, but was 0");
     }
 
     // --- Entropy injection ---


### PR DESCRIPTION
## What is the purpose of the change

`Preconditions.checkArgument` in Flink uses a simplified formatter that only supports `%s` placeholders (not `%d`, `%f`, etc.). Three validation error messages in `NativeS3FileSystemFactory` used `%d` for numeric values, causing the format specifier to appear literally in the output while the actual value was appended in brackets — e.g.:

```
s3.upload.min.part.size must be at least 5MB (5242880 bytes), but was %d bytes [1048576]
s3.upload.max.concurrent.uploads must be positive, but was %d [0]
```

This fix replaces `%d` with `%s` so values are substituted correctly.

## Brief change log

- Replace `%d` with `%s` in three `Preconditions.checkArgument` format strings in `NativeS3FileSystemFactory` (part size min, part size max, max concurrent uploads)
- Strengthen existing tests to assert the full error message, verifying values are correctly interpolated

## Verifying this change

The following tests have been updated to assert the full expected error message, confirming values appear correctly (not as `%d` with a bracketed suffix):
- `NativeS3FileSystemFactoryTest#testPartSizeTooSmallThrowsException`
- `NativeS3FileSystemFactoryTest#testPartSizeTooLargeThrowsException`
- `NativeS3FileSystemFactoryTest#testInvalidMaxConcurrentUploadsThrowsException`

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: no
- The S3 file system connector: yes

## Documentation

- Does this pull request introduce a new feature? no

---

##### Was generative AI tooling used to co-author this PR?
- [ ] Yes