### PR TITLE
[hotfix][runtime] Avoid duplicate serialization in adaptive broadcast

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/AdaptiveLoadBasedRecordWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/AdaptiveLoadBasedRecordWriter.java
@@ -129,7 +129,7 @@ public final class AdaptiveLoadBasedRecordWriter<T extends IOReadableWritable>
         ByteBuffer serializedRecord = serializeRecord(serializer, record);
         for (int channelIndex = 0; channelIndex < numberOfSubpartitions; channelIndex++) {
             serializedRecord.rewind();
-            emit(record, channelIndex);
+            emit(serializedRecord, channelIndex);
         }
 
         if (flushAlways) {


### PR DESCRIPTION
## What is the purpose of the change

Fix duplicate serialization in `AdaptiveLoadBasedRecordWriter#broadcastEmit`.

The method already serializes the record once before iterating over all subpartitions, but the loop called the record-based `emit(record, channelIndex)` overload, which serialized the record again for each subpartition. This change reuses the existing serialized `ByteBuffer` and calls the buffer-based emit overload.

## Brief change log

- Reuse the serialized broadcast record buffer in `AdaptiveLoadBasedRecordWriter#broadcastEmit`.

## Verifying this change

- `./mvnw -pl flink-runtime spotless:apply`
- `./mvnw -pl flink-runtime -am -Dtest=AdaptiveLoadBasedRecordWriterTest -Dsurefire.failIfNoSpecifiedTests=false test`
