### PR TITLE
[BP-2.3][hotfix][runtime] Avoid duplicate serialization in adaptive broadcast

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/AdaptiveLoadBasedRecordWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/AdaptiveLoadBasedRecordWriter.java
@@ -129,7 +129,7 @@ public final class AdaptiveLoadBasedRecordWriter<T extends IOReadableWritable>
         ByteBuffer serializedRecord = serializeRecord(serializer, record);
         for (int channelIndex = 0; channelIndex < numberOfSubpartitions; channelIndex++) {
             serializedRecord.rewind();
-            emit(record, channelIndex);
+            emit(serializedRecord, channelIndex);
         }
 
         if (flushAlways) {


### PR DESCRIPTION
## What is the purpose of the change

Backport #28135 to `release-2.3`.

This fixes duplicate serialization in `AdaptiveLoadBasedRecordWriter#broadcastEmit`. The method already serializes the record once before iterating over all subpartitions; the loop should reuse that serialized buffer instead of calling the record-based emit overload, which serializes the same record again for each subpartition.

## Brief change log

- Reuse the serialized broadcast record buffer in `AdaptiveLoadBasedRecordWriter#broadcastEmit`.

## Verifying this change

- `./mvnw -pl flink-runtime -am -Dtest=AdaptiveLoadBasedRecordWriterTest -Dsurefire.failIfNoSpecifiedTests=false test`
