### PR TITLE
[FLINK-39654][build] Add JDK 25 CI test lane (non-blocking)

### DIFF
--- a/.github/actions/job_init/action.yml
+++ b/.github/actions/job_init/action.yml
@@ -68,6 +68,21 @@ runs:
           fi
         done
 
+    - name: "Install JDK 25 (Zulu) if requested"
+      if: ${{ inputs.jdk_version == 25 }}
+      shell: bash
+      run: |
+        echo "::group::Installing Zulu JDK 25"
+        curl -sL -o /tmp/zulu25.tar.gz \
+          "https://cdn.azul.com/zulu/bin/zulu25.30.17-ca-jdk25.0.1-linux_x64.tar.gz"
+        sudo mkdir -p /usr/lib/jvm
+        sudo tar -xzf /tmp/zulu25.tar.gz -C /usr/lib/jvm
+        ZULU_DIR=$(ls -d /usr/lib/jvm/zulu25* | head -1)
+        echo "JAVA_HOME_25_X64=${ZULU_DIR}" >> "${GITHUB_ENV}"
+        echo "::endgroup::"
+        echo "Installed JDK 25 at ${ZULU_DIR}"
+        "${ZULU_DIR}/bin/java" -version
+
     - name: "Set JDK version to ${{ inputs.jdk_version }}"
       shell: bash
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,21 @@ jobs:
     name: "Default (Java 17)"
     uses: ./.github/workflows/template.flink-ci.yml
     with:
+      workflow-caller-id: "jdk17"
       environment: 'PROFILE="-Dinclude_hadoop_aws -Djdk17 -Pjava17-target"'
       jdk_version: 17
+    secrets:
+      s3_bucket: ${{ secrets.IT_CASE_S3_BUCKET }}
+      s3_access_key: ${{ secrets.IT_CASE_S3_ACCESS_KEY }}
+      s3_secret_key: ${{ secrets.IT_CASE_S3_SECRET_KEY }}
+  ci-jdk25:
+    name: "Java 25 (experimental)"
+    uses: ./.github/workflows/template.flink-ci.yml
+    continue-on-error: true
+    with:
+      workflow-caller-id: "jdk25"
+      environment: 'PROFILE="-Djdk25 -Pjava25-target"'
+      jdk_version: 25
     secrets:
       s3_bucket: ${{ secrets.IT_CASE_S3_BUCKET }}
       s3_access_key: ${{ secrets.IT_CASE_S3_ACCESS_KEY }}

--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -274,7 +274,7 @@ under the License.
 		<profile>
 			<id>java21</id>
 			<activation>
-				<jdk>[21,)</jdk>
+				<jdk>[21,24)</jdk>
 			</activation>
 
 			<properties>

--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -287,8 +287,9 @@ if [ -z "${FLINK_ENV_JAVA_OPTS}" ]; then
     FLINK_ENV_JAVA_OPTS="-XX:+IgnoreUnrecognizedVMOptions $( echo "${FLINK_ENV_JAVA_OPTS}" | sed -e 's/^"//'  -e 's/"$//' )"
 
     JAVA_SPEC_VERSION=`"${JAVA_RUN}" -XshowSettings:properties 2>&1 | grep "java.specification.version" | cut -d "=" -f 2 | tr -d '[:space:]' | rev | cut -d "." -f 1 | rev`
-    if [[ $(( $JAVA_SPEC_VERSION > 17 )) == 1 ]]; then
+    if [[ $(( $JAVA_SPEC_VERSION > 17 )) == 1 ]] && [[ $(( $JAVA_SPEC_VERSION < 24 )) == 1 ]]; then
       # set security manager property to allow calls to System.setSecurityManager() at runtime
+      # JDK 24+ (JEP-486) permanently removed SecurityManager; this flag is rejected on 24+
       FLINK_ENV_JAVA_OPTS="$FLINK_ENV_JAVA_OPTS -Djava.security.manager=allow"
     fi
 fi

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -490,7 +490,7 @@ under the License.
 		<profile>
 			<id>java21</id>
 			<activation>
-				<jdk>[21,)</jdk>
+				<jdk>[21,24)</jdk>
 			</activation>
 
 			<properties>

--- a/flink-streaming-java/pom.xml
+++ b/flink-streaming-java/pom.xml
@@ -174,7 +174,7 @@ under the License.
 		<profile>
 			<id>java21</id>
 			<activation>
-				<jdk>[21,)</jdk>
+				<jdk>[21,24)</jdk>
 			</activation>
 
 			<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -1245,6 +1245,12 @@ under the License.
 
 		<profile>
 			<id>java25-target</id>
+
+			<properties>
+				<target.java.version>25</target.java.version>
+				<spotless.skip>true</spotless.skip>
+			</properties>
+
 			<build>
 				<plugins>
 					<plugin>


### PR DESCRIPTION
## What is the purpose of the change

  Add a non-blocking JDK 25 CI test lane to provide continuous visibility into JDK 25 readiness, building on FLINK-38474 (java25-target profile) and the compilation fixes already resolved under FLINK-37719.

  This follows the same incremental approach used for JDK 17 (FLINK-15736) and JDK 21 (FLINK-33163) support.

  ## Brief change log

  - Install Zulu JDK 25 in `job_init` action (GHA runners only ship JDK 17/21)
  - Add parallel JDK 25 lane in `ci.yml` with `continue-on-error: true`
  - Add `workflow-caller-id` to disambiguate JDK 17 vs JDK 25 build artifacts
  - Add `target.java.version=25` and `spotless.skip=true` to `java25-target` profile
  - Bound `-Djava.security.manager=allow` to JDK 18–23 in surefire profiles and `config.sh` (JEP-486 permanently removes SecurityManager in JDK 24+)

  ## Verifying this change

  This change is already covered by existing tests. The CI lane itself is the verification — it will run the full test suite under JDK 25 in non-blocking mode.

  ## Does this pull request potentially affect one of the following parts:

    - Dependencies (does it add or upgrade a dependency): no
    - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
    - The serializers: no
    - The runtime per-record code paths (performance sensitive): no
    - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
    - The S3 file system connector: no

  ## Documentation

    - Does this pull request introduce a new feature? no
    - If yes, how is the feature documented? not applicable


  ##### Was generative AI tooling used to co-author this PR?
 
  co-authed by Claude Code