### PR TITLE
[FLINK-36847][table] Fix enum field conversion in Table API to DataStream

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/DataTypeExtractor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/DataTypeExtractor.java
@@ -368,6 +368,12 @@ public final class DataTypeExtractor {
             return resultDataType;
         }
 
+        // handle enum types as STRING bridged to the enum class
+        resultDataType = extractEnumType(type);
+        if (resultDataType != null) {
+            return resultDataType;
+        }
+
         // MAP
         resultDataType = extractMapType(template, typeHierarchy, type);
         if (resultDataType != null) {
@@ -542,6 +548,15 @@ public final class DataTypeExtractor {
         }
 
         return ClassDataTypeConverter.extractDataType(clazz).orElse(null);
+    }
+
+    /** Maps an {@link Enum} class to STRING bridged to the enum class. */
+    private @Nullable DataType extractEnumType(Type type) {
+        final Class<?> clazz = toClass(type);
+        if (clazz == null || !clazz.isEnum()) {
+            return null;
+        }
+        return DataTypes.STRING().bridgedTo(clazz);
     }
 
     private @Nullable DataType extractMapType(

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/CharType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/CharType.java
@@ -125,12 +125,16 @@ public final class CharType extends LogicalType {
 
     @Override
     public boolean supportsInputConversion(Class<?> clazz) {
-        return INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+        // enum classes are bridged to their string representation
+        return INPUT_OUTPUT_CONVERSION.contains(clazz.getName())
+                || Enum.class.isAssignableFrom(clazz);
     }
 
     @Override
     public boolean supportsOutputConversion(Class<?> clazz) {
-        return INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+        // enum classes are bridged to their string representation
+        return INPUT_OUTPUT_CONVERSION.contains(clazz.getName())
+                || Enum.class.isAssignableFrom(clazz);
     }
 
     @Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/VarCharType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/VarCharType.java
@@ -135,12 +135,16 @@ public final class VarCharType extends LogicalType {
 
     @Override
     public boolean supportsInputConversion(Class<?> clazz) {
-        return INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+        // enum classes are bridged to their string representation
+        return INPUT_OUTPUT_CONVERSION.contains(clazz.getName())
+                || Enum.class.isAssignableFrom(clazz);
     }
 
     @Override
     public boolean supportsOutputConversion(Class<?> clazz) {
-        return INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+        // enum classes are bridged to their string representation
+        return INPUT_OUTPUT_CONVERSION.contains(clazz.getName())
+                || Enum.class.isAssignableFrom(clazz);
     }
 
     @Override

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/DataTypeExtractorTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/DataTypeExtractorTest.java
@@ -474,6 +474,21 @@ class DataTypeExtractorTest {
                                         PojoWithUnderscore.class,
                                         DataTypes.FIELD("int_field", DataTypes.INT()),
                                         DataTypes.FIELD("string_field", DataTypes.STRING()))),
+                TestSpec.forType(SimpleEnum.class)
+                        .expectDataType(DataTypes.STRING().bridgedTo(SimpleEnum.class)),
+                TestSpec.forType(DetailedEnum.class)
+                        .expectDataType(DataTypes.STRING().bridgedTo(DetailedEnum.class)),
+                TestSpec.forType(PojoWithEnum.class)
+                        .expectDataType(
+                                DataTypes.STRUCTURED(
+                                        PojoWithEnum.class,
+                                        DataTypes.FIELD(
+                                                "detailedEnumField",
+                                                DataTypes.STRING().bridgedTo(DetailedEnum.class)),
+                                        DataTypes.FIELD(
+                                                "enumField",
+                                                DataTypes.STRING().bridgedTo(SimpleEnum.class)),
+                                        DataTypes.FIELD("name", DataTypes.STRING()))),
                 TestSpec.forType(ColumnList.class).expectDataType(DataTypes.DESCRIPTOR()));
     }
 
@@ -1118,5 +1133,44 @@ class DataTypeExtractorTest {
         public Integer getIntField() {
             return int_field;
         }
+    }
+
+    // --------------------------------------------------------------------------------------------
+
+    /** A simple enum used for {@link PojoWithEnum}. */
+    public enum SimpleEnum {
+        FIRST,
+        SECOND,
+        THIRD
+    }
+
+    /** Enum whose constants have additional fields. */
+    public enum DetailedEnum {
+        FIRST(1, "first"),
+        SECOND(2, "second"),
+        THIRD(3, "third");
+
+        private final int code;
+        private final String label;
+
+        DetailedEnum(int code, String label) {
+            this.code = code;
+            this.label = label;
+        }
+
+        public int getCode() {
+            return code;
+        }
+
+        public String getLabel() {
+            return label;
+        }
+    }
+
+    /** POJO with enum fields. */
+    public static class PojoWithEnum {
+        public String name;
+        public SimpleEnum enumField;
+        public DetailedEnum detailedEnumField;
     }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
@@ -76,6 +76,46 @@ class CalcITCase extends BatchTestBase {
   }
 
   @Test
+  def testInnerJoinFilterCastCanFailBeforeJoin(): Unit = {
+    val taxiOperationData = Seq(
+      row("1", "2022-02-07", 7.38d),
+      row("3", "2022-02-08", 2.38d),
+      row("4", "2022-02-30", 5.38d)
+    )
+    val taxiTimeCodeData = Seq(
+      row("2022-02-07"),
+      row("2022-02-08")
+    )
+    val taxiOperationType = new RowTypeInfo(STRING_TYPE_INFO, STRING_TYPE_INFO, Types.DOUBLE)
+    val taxiTimeCodeType = new RowTypeInfo(STRING_TYPE_INFO)
+    registerCollection(
+      "taxiOperation",
+      taxiOperationData,
+      taxiOperationType,
+      "id, startTime, amount")
+    registerCollection("taxiTimeCode", taxiTimeCodeData, taxiTimeCodeType, "codeTime")
+
+    val sql =
+      """
+        |SELECT *
+        |FROM taxiTimeCode tc
+        |JOIN taxiOperation tto ON tc.codeTime = tto.startTime
+        |WHERE CAST(tto.startTime AS DATE) < DATE '2099-01-01'
+        |""".stripMargin
+
+    assertThatThrownBy(
+      () =>
+        checkResult(
+          sql,
+          Seq(
+            row("2022-02-07", "1", "2022-02-07", 7.38d),
+            row("2022-02-08", "3", "2022-02-08", 2.38d)
+          )))
+      .hasRootCauseInstanceOf(classOf[DateTimeException])
+      .hasStackTraceContaining("2022-02-30")
+  }
+
+  @Test
   def testSimpleSelectAll(): Unit = {
     checkResult("SELECT a, b, c FROM Table3", data3)
   }

--- a/flink-table/flink-table-type-utils/src/main/java/org/apache/flink/table/data/conversion/DataStructureConverters.java
+++ b/flink-table/flink-table-type-utils/src/main/java/org/apache/flink/table/data/conversion/DataStructureConverters.java
@@ -220,6 +220,13 @@ public final class DataStructureConverters {
         }
         // special cases
         switch (logicalType.getTypeRoot()) {
+            case CHAR:
+            case VARCHAR:
+                // support enum classes by converting via Enum#name()
+                if (Enum.class.isAssignableFrom(dataType.getConversionClass())) {
+                    return StringEnumConverter.create(dataType);
+                }
+                throw new TableException("Could not find converter for data type: " + dataType);
             case ARRAY:
                 // for subclasses of List
                 if (List.class.isAssignableFrom(dataType.getConversionClass())) {

--- a/flink-table/flink-table-type-utils/src/main/java/org/apache/flink/table/data/conversion/StringEnumConverter.java
+++ b/flink-table/flink-table-type-utils/src/main/java/org/apache/flink/table/data/conversion/StringEnumConverter.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.data.conversion;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.CharType;
+import org.apache.flink.table.types.logical.VarCharType;
+
+/**
+ * Converter for {@link CharType}/{@link VarCharType} of {@link Enum} external type. The enum is
+ * represented as its {@link Enum#name()}.
+ */
+@Internal
+@SuppressWarnings({"rawtypes", "unchecked"})
+public class StringEnumConverter implements DataStructureConverter<StringData, Enum> {
+
+    private static final long serialVersionUID = 1L;
+
+    private final Class<? extends Enum> enumClass;
+
+    public StringEnumConverter(Class<? extends Enum> enumClass) {
+        this.enumClass = enumClass;
+    }
+
+    @Override
+    public StringData toInternal(Enum external) {
+        return StringData.fromString(external.name());
+    }
+
+    @Override
+    public Enum toExternal(StringData internal) {
+        return Enum.valueOf(enumClass, internal.toString());
+    }
+
+    public static StringEnumConverter create(DataType dataType) {
+        final Class<?> conversionClass = dataType.getConversionClass();
+        return new StringEnumConverter((Class<? extends Enum>) conversionClass);
+    }
+}

--- a/flink-table/flink-table-type-utils/src/main/java/org/apache/flink/table/data/conversion/StringEnumConverter.java
+++ b/flink-table/flink-table-type-utils/src/main/java/org/apache/flink/table/data/conversion/StringEnumConverter.java
@@ -47,7 +47,17 @@ public class StringEnumConverter implements DataStructureConverter<StringData, E
 
     @Override
     public Enum toExternal(StringData internal) {
-        return Enum.valueOf(enumClass, internal.toString());
+        try {
+            return Enum.valueOf(enumClass, internal.toString());
+        } catch (IllegalArgumentException e) {
+            throw new UnsupportedOperationException(
+                    "Unsupported enum value: "
+                            + internal
+                            + " for enum class "
+                            + enumClass.getSimpleName()
+                            + ".",
+                    e);
+        }
     }
 
     public static StringEnumConverter create(DataType dataType) {

--- a/flink-table/flink-table-type-utils/src/test/java/org/apache/flink/table/data/DataStructureConvertersTest.java
+++ b/flink-table/flink-table-type-utils/src/test/java/org/apache/flink/table/data/DataStructureConvertersTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.types.bitmap.Bitmap;
 import org.apache.flink.types.variant.Variant;
 import org.apache.flink.util.InstantiationUtil;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -467,6 +468,27 @@ class DataStructureConvertersTest {
         }
     }
 
+    @Test
+    void testStringEnumConverterRejectsInvalidEnumName() {
+        final DataStructureConverter<Object, Object> converter =
+                DataStructureConverters.getConverter(STRING().bridgedTo(ConverterEnum.class));
+
+        assertThatThrownBy(() -> converter.toExternal(StringData.fromString("INVALID")))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("Unsupported enum value: INVALID for enum class ConverterEnum.");
+    }
+
+    @Test
+    void testStringEnumConverterUsesEnumName() {
+        final DataStructureConverter<Object, Object> converter =
+                DataStructureConverters.getConverter(STRING().bridgedTo(CustomStringEnum.class));
+
+        assertThat(converter.toInternal(CustomStringEnum.FIRST))
+                .isEqualTo(StringData.fromString("FIRST"));
+        assertThat(converter.toExternal(StringData.fromString("FIRST")))
+                .isEqualTo(CustomStringEnum.FIRST);
+    }
+
     // --------------------------------------------------------------------------------------------
     // Test utilities
     // --------------------------------------------------------------------------------------------
@@ -601,6 +623,15 @@ class DataStructureConvertersTest {
     private enum ConverterEnum {
         FIRST,
         SECOND
+    }
+
+    private enum CustomStringEnum {
+        FIRST {
+            @Override
+            public String toString() {
+                return "first";
+            }
+        }
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-type-utils/src/test/java/org/apache/flink/table/data/DataStructureConvertersTest.java
+++ b/flink-table/flink-table-type-utils/src/test/java/org/apache/flink/table/data/DataStructureConvertersTest.java
@@ -101,6 +101,9 @@ class DataStructureConvertersTest {
                         .convertedTo(String.class, "12345")
                         .convertedTo(byte[].class, "12345".getBytes(StandardCharsets.UTF_8))
                         .convertedTo(StringData.class, StringData.fromString("12345")),
+                TestSpec.forDataType(STRING())
+                        .convertedTo(StringData.class, StringData.fromString("SECOND"))
+                        .convertedTo(ConverterEnum.class, ConverterEnum.SECOND),
                 TestSpec.forDataType(BOOLEAN().notNull())
                         .convertedTo(Boolean.class, true)
                         .convertedTo(boolean.class, true),
@@ -593,6 +596,13 @@ class DataStructureConvertersTest {
 
     // --------------------------------------------------------------------------------------------
     // Structured types
+    // --------------------------------------------------------------------------------------------
+
+    private enum ConverterEnum {
+        FIRST,
+        SECOND
+    }
+
     // --------------------------------------------------------------------------------------------
 
     /** POJO as superclass. */


### PR DESCRIPTION
## What is the purpose of the change

Fix `TableEnvironment.toDataStream(..., clazz)` for POJOs that contain enum fields. The change makes enum fields extractable and convertible when the table side represents them as string values.

## Brief change log

- Update `DataTypeExtractor#extractDataTypeOrError` to recognize enum classes via `extractEnumType`, and extend `CharType`/`VarCharType` conversion checks so enum classes can be bridged to string logical types.
- Extend `DataStructureConverters#getConverterInternal` with enum handling for `CHAR`/`VARCHAR` and add `StringEnumConverter` to convert between `StringData` and enum values via `Enum.name()` / `Enum.valueOf()`.

## Verifying this change

Updated `DataTypeExtractorTest` to cover plain enums, enums with additional fields, and POJOs containing enum fields, asserting that they are extracted as `STRING` bridged to the enum class. Updated `DataStructureConvertersTest` to verify round-trip conversion between `StringData` and enum values for string logical types.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable