### PR TITLE
[FLINK-36781][table] Fix SQL REPL lag when using remote gateways

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -318,8 +318,18 @@ public class CliClient implements AutoCloseable {
     }
 
     private LineReader createLineReader(Terminal terminal, ExecutionMode mode) {
+        final SqlClientSyntaxHighlighter highlighter =
+                mode == ExecutionMode.INTERACTIVE_EXECUTION
+                        ? new SqlClientSyntaxHighlighter(executor)
+                        : null;
         SqlMultiLineParser parser =
-                new SqlMultiLineParser(new SqlCommandParserImpl(), executor, mode);
+                highlighter == null
+                        ? new SqlMultiLineParser(new SqlCommandParserImpl(), executor, mode)
+                        : new SqlMultiLineParser(
+                                new SqlCommandParserImpl(),
+                                executor,
+                                mode,
+                                highlighter::updateSessionConfig);
 
         // initialize line lineReader
         LineReaderBuilder builder =
@@ -330,7 +340,7 @@ public class CliClient implements AutoCloseable {
 
         if (mode == ExecutionMode.INTERACTIVE_EXECUTION) {
             builder.completer(new SqlCompleter(executor));
-            builder.highlighter(new SqlClientSyntaxHighlighter(executor));
+            builder.highlighter(highlighter);
         }
         LineReader lineReader = builder.build();
 

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/parser/SqlClientSyntaxHighlighter.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/parser/SqlClientSyntaxHighlighter.java
@@ -47,15 +47,23 @@ public class SqlClientSyntaxHighlighter extends DefaultHighlighter {
                             .map(t -> t.replaceAll("\"", ""))
                             .collect(Collectors.toSet()));
 
-    private final Executor executor;
+    private ReadableConfig configuration;
 
     public SqlClientSyntaxHighlighter(Executor executor) {
-        this.executor = executor;
+        updateSessionConfig(executor.getSessionConfig());
+    }
+
+    public void updateSessionConfig(ReadableConfig configuration) {
+        if (configuration != null) {
+            this.configuration = configuration;
+        }
     }
 
     @Override
     public AttributedString highlight(LineReader reader, String buffer) {
-        ReadableConfig configuration = executor.getSessionConfig();
+        if (configuration == null) {
+            return super.highlight(reader, buffer);
+        }
         final SyntaxHighlightStyle.BuiltInStyle style =
                 SyntaxHighlightStyle.BuiltInStyle.fromString(
                         configuration.get(SqlClientOptions.DISPLAY_DEFAULT_COLOR_SCHEMA));

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/parser/SqlMultiLineParser.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/parser/SqlMultiLineParser.java
@@ -36,6 +36,7 @@ import org.jline.reader.SyntaxError;
 import org.jline.reader.impl.DefaultParser;
 
 import java.util.List;
+import java.util.function.Consumer;
 
 import static org.apache.flink.table.client.config.ResultMode.TABLEAU;
 import static org.apache.flink.table.client.config.SqlClientOptions.EXECUTION_RESULT_MODE;
@@ -60,6 +61,9 @@ public class SqlMultiLineParser extends DefaultParser {
     /** Sql command executor. */
     private final Executor executor;
 
+    /** Callback for updated session configuration. */
+    private final Consumer<ReadableConfig> sessionConfigConsumer;
+
     /** Exception caught in parsing. */
     private SqlExecutionException parseException = null;
 
@@ -68,9 +72,18 @@ public class SqlMultiLineParser extends DefaultParser {
 
     public SqlMultiLineParser(
             SqlCommandParser parser, Executor executor, CliClient.ExecutionMode mode) {
+        this(parser, executor, mode, ignored -> {});
+    }
+
+    public SqlMultiLineParser(
+            SqlCommandParser parser,
+            Executor executor,
+            CliClient.ExecutionMode mode,
+            Consumer<ReadableConfig> sessionConfigConsumer) {
         this.parser = parser;
         this.mode = mode;
         this.executor = executor;
+        this.sessionConfigConsumer = sessionConfigConsumer;
         setEscapeChars(null);
         setQuoteChars(null);
     }
@@ -117,6 +130,7 @@ public class SqlMultiLineParser extends DefaultParser {
                             long queryBeginTime = System.currentTimeMillis();
                             StatementResult result = executor.executeStatement(line);
                             ReadableConfig sessionConfig = executor.getSessionConfig();
+                            sessionConfigConsumer.accept(sessionConfig);
                             if (mode == CliClient.ExecutionMode.NON_INTERACTIVE_EXECUTION
                                     && result.isQueryResult()
                                     && sessionConfig.get(SqlClientOptions.EXECUTION_RESULT_MODE)

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/parser/SqlClientSyntaxHighlighterTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/parser/SqlClientSyntaxHighlighterTest.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.client.cli.parser;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.table.api.ResultKind;
+import org.apache.flink.table.api.SqlDialect;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.client.cli.CliClient;
+import org.apache.flink.table.client.config.SqlClientOptions;
+import org.apache.flink.table.client.gateway.Executor;
+import org.apache.flink.table.client.gateway.StatementResult;
+import org.apache.flink.util.CloseableIterator;
+
+import org.jline.reader.Parser;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nullable;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.table.client.cli.parser.SyntaxHighlightStyle.BuiltInStyle.DARK;
+import static org.apache.flink.table.client.cli.parser.SyntaxHighlightStyle.BuiltInStyle.LIGHT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link SqlClientSyntaxHighlighter}. */
+class SqlClientSyntaxHighlighterTest {
+
+    private static final String SQL = "select * from t";
+    private static final String SET_COLOR_SCHEMA =
+            "SET 'sql-client.display.color-schema' = 'light';";
+
+    @Test
+    void refreshesConfigurationAfterAcceptedStatement() {
+        TestingExecutor executor = new TestingExecutor();
+        executor.setColorSchema(DARK);
+
+        SqlClientSyntaxHighlighter highlighter = new SqlClientSyntaxHighlighter(executor);
+        SqlMultiLineParser parser =
+                new SqlMultiLineParser(
+                        new SqlCommandParserImpl(),
+                        executor,
+                        CliClient.ExecutionMode.INTERACTIVE_EXECUTION,
+                        highlighter::updateSessionConfig);
+
+        assertHighlightedAs(highlighter, DARK);
+        assertThat(executor.getSessionConfigCalls).isEqualTo(1);
+
+        executor.setColorSchemaAfterExecute(LIGHT);
+
+        assertHighlightedAs(highlighter, DARK);
+        assertThat(executor.getSessionConfigCalls).isEqualTo(1);
+
+        parser.parse(SET_COLOR_SCHEMA, SET_COLOR_SCHEMA.length(), Parser.ParseContext.ACCEPT_LINE);
+
+        assertThat(executor.executedStatement).isEqualTo(SET_COLOR_SCHEMA);
+        assertHighlightedAs(highlighter, LIGHT);
+        assertThat(executor.getSessionConfigCalls).isEqualTo(3);
+    }
+
+    @Test
+    void ignoresNullConfigurationRefreshes() {
+        TestingExecutor executor = new TestingExecutor();
+        executor.setColorSchema(DARK);
+
+        SqlClientSyntaxHighlighter highlighter = new SqlClientSyntaxHighlighter(executor);
+
+        highlighter.updateSessionConfig(null);
+
+        assertHighlightedAs(highlighter, DARK);
+        assertThat(executor.getSessionConfigCalls).isEqualTo(1);
+    }
+
+    private static void assertHighlightedAs(
+            SqlClientSyntaxHighlighter highlighter, SyntaxHighlightStyle.BuiltInStyle style) {
+        assertThat(highlighter.highlight(null, SQL).toAnsi())
+                .isEqualTo(
+                        SqlClientSyntaxHighlighter.getHighlightedOutput(
+                                        SQL, style.getHighlightStyle(), SqlDialect.DEFAULT)
+                                .toAnsi());
+    }
+
+    private static class TestingExecutor implements Executor {
+
+        private final Configuration configuration = new Configuration();
+        private int getSessionConfigCalls;
+        private SyntaxHighlightStyle.BuiltInStyle colorSchemaAfterExecute;
+        private String executedStatement;
+
+        private void setColorSchema(SyntaxHighlightStyle.BuiltInStyle style) {
+            configuration.set(SqlClientOptions.DISPLAY_DEFAULT_COLOR_SCHEMA, style.name());
+        }
+
+        private void setColorSchemaAfterExecute(SyntaxHighlightStyle.BuiltInStyle style) {
+            colorSchemaAfterExecute = style;
+        }
+
+        @Override
+        public void configureSession(String statement) {}
+
+        @Override
+        public ReadableConfig getSessionConfig() {
+            getSessionConfigCalls++;
+            return Configuration.fromMap(configuration.toMap());
+        }
+
+        @Override
+        public Map<String, String> getSessionConfigMap() {
+            return configuration.toMap();
+        }
+
+        @Override
+        public StatementResult executeStatement(String statement) {
+            executedStatement = statement;
+            if (colorSchemaAfterExecute != null) {
+                setColorSchema(colorSchemaAfterExecute);
+            }
+            return new StatementResult(
+                    ResolvedSchema.of(),
+                    CloseableIterator.empty(),
+                    false,
+                    ResultKind.SUCCESS,
+                    null);
+        }
+
+        @Override
+        public List<String> completeStatement(String statement, int position) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public String deployScript(@Nullable String script, @Nullable URI uri) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void close() {}
+    }
+}

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/parser/SqlClientSyntaxHighlighterTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/parser/SqlClientSyntaxHighlighterTest.java
@@ -79,16 +79,25 @@ class SqlClientSyntaxHighlighterTest {
     }
 
     @Test
-    void ignoresNullConfigurationRefreshes() {
+    void keepsExistingConfigurationWhenStatementRefreshReturnsNull() {
         TestingExecutor executor = new TestingExecutor();
         executor.setColorSchema(DARK);
 
         SqlClientSyntaxHighlighter highlighter = new SqlClientSyntaxHighlighter(executor);
+        SqlMultiLineParser parser =
+                new SqlMultiLineParser(
+                        new SqlCommandParserImpl(),
+                        executor,
+                        CliClient.ExecutionMode.INTERACTIVE_EXECUTION,
+                        highlighter::updateSessionConfig);
 
-        highlighter.updateSessionConfig(null);
+        executor.returnNullSessionConfigAfterExecute();
 
+        parser.parse(SET_COLOR_SCHEMA, SET_COLOR_SCHEMA.length(), Parser.ParseContext.ACCEPT_LINE);
+
+        assertThat(executor.executedStatement).isEqualTo(SET_COLOR_SCHEMA);
         assertHighlightedAs(highlighter, DARK);
-        assertThat(executor.getSessionConfigCalls).isEqualTo(1);
+        assertThat(executor.getSessionConfigCalls).isEqualTo(3);
     }
 
     private static void assertHighlightedAs(
@@ -105,6 +114,8 @@ class SqlClientSyntaxHighlighterTest {
         private final Configuration configuration = new Configuration();
         private int getSessionConfigCalls;
         private SyntaxHighlightStyle.BuiltInStyle colorSchemaAfterExecute;
+        private boolean returnNullSessionConfigAfterExecute;
+        private boolean returnNullSessionConfig;
         private String executedStatement;
 
         private void setColorSchema(SyntaxHighlightStyle.BuiltInStyle style) {
@@ -115,12 +126,19 @@ class SqlClientSyntaxHighlighterTest {
             colorSchemaAfterExecute = style;
         }
 
+        private void returnNullSessionConfigAfterExecute() {
+            returnNullSessionConfigAfterExecute = true;
+        }
+
         @Override
         public void configureSession(String statement) {}
 
         @Override
         public ReadableConfig getSessionConfig() {
             getSessionConfigCalls++;
+            if (returnNullSessionConfig) {
+                return null;
+            }
             return Configuration.fromMap(configuration.toMap());
         }
 
@@ -134,6 +152,9 @@ class SqlClientSyntaxHighlighterTest {
             executedStatement = statement;
             if (colorSchemaAfterExecute != null) {
                 setColorSchema(colorSchemaAfterExecute);
+            }
+            if (returnNullSessionConfigAfterExecute) {
+                returnNullSessionConfig = true;
             }
             return new StatementResult(
                     ResolvedSchema.of(),


### PR DESCRIPTION
## What is the purpose of the change

Fix the SQL Client REPL becoming unresponsive when connected to a remote SQL Gateway because a blocking session-config request was issued on every key press. The change keeps interactive highlighting responsive while still picking up session configuration updates after statements are executed.

## Brief change log

- Update `SqlClientSyntaxHighlighter#highlight` to use cached session configuration instead of calling `Executor#getSessionConfig()` on every highlight invocation, and add `updateSessionConfig(...)` to refresh that cache safely.
- Wire `CliClient#createLineReader` and `SqlMultiLineParser#parse` so the syntax highlighter is refreshed with the latest session configuration after an accepted statement has been executed.

## Verifying this change

Added `SqlClientSyntaxHighlighterTest` to verify that repeated highlighting does not refetch session config on each input, that executing a `SET` statement refreshes the cached configuration, and that null refreshes do not overwrite the existing cache.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable