### PR TITLE
[FLINK-39670][build] Update test-scope dependencies (kafka-clients, okhttp, wiremock)

### DIFF
--- a/flink-end-to-end-tests/flink-sql-client-test/pom.xml
+++ b/flink-end-to-end-tests/flink-sql-client-test/pom.xml
@@ -68,7 +68,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
 			<artifactId>kafka-clients</artifactId>
-			<version>3.2.3</version>
+			<version>3.9.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/flink-metrics/flink-metrics-influxdb/pom.xml
+++ b/flink-metrics/flink-metrics-influxdb/pom.xml
@@ -71,7 +71,7 @@ under the License.
 		<dependency>
 			<groupId>com.github.tomakehurst</groupId>
 			<artifactId>wiremock-jre8</artifactId>
-			<version>2.32.0</version>
+			<version>2.35.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -295,7 +295,6 @@ under the License.
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>okhttp</artifactId>
-			<version>3.7.0</version>
 			<scope>test</scope>
 		</dependency>
 


### PR DESCRIPTION
## What is the purpose of the change

Routine version updates for three test-scope dependencies. Follow-up to FLINK-39580 / PR #28072.

No production code paths are affected — every bump is either test-scope or test-scope-via-managed-pin.

No overlap with the in-flight PR #27479 (FLINK-39148, kafka-connector): it touches the same `flink-sql-client-test/pom.xml` but on a different dependency (`flink-sql-connector-kafka` vs the direct `kafka-clients` test dep), so the two merge cleanly.

## Brief change log

- `flink-sql-client-test`: `kafka-clients` 3.2.3 → 3.9.2 (direct test dep). The in-pom `<dependencyManagement>` pin at 2.2.2 is intentionally left alone — its only purpose is to satisfy the enforcer-plugin, per the comment in the file.
- `flink-runtime`: drop the hardcoded `okhttp` 3.7.0 in test scope so it inherits `${okhttp.version}` (3.14.9) from the root pom.
- `flink-metrics-influxdb`: `wiremock-jre8` 2.32.0 → 2.35.2 (test scope).

## Verifying this change

Dependency-only change with no new test coverage. Verified by `mvn clean install -DskipTests -pl <touched-modules> -am`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies: yes (test-scope only)
  - Public API (`@Public(Evolving)`): no
  - Serializers: no
  - Runtime per-record code paths: no
  - Deployment/recovery — JobManager, Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - S3 file system connector: no

## Documentation

  - New feature? no

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Code)