### PR TITLE
[FLINK-39669][table-planner] BatchPhysicalCorrelateRule / StreamPhysicalCorrelateRule drop right-side projection when a Calc sits between Correlate and TableFunctionScan

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalCorrelateRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalCorrelateRule.scala
@@ -19,15 +19,22 @@ package org.apache.flink.table.planner.plan.rules.physical.batch
 
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.nodes.logical.{FlinkLogicalCalc, FlinkLogicalCorrelate, FlinkLogicalTableFunctionScan}
-import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchPhysicalCorrelate
+import org.apache.flink.table.planner.plan.nodes.physical.batch.{BatchPhysicalCalc, BatchPhysicalCorrelate}
 import org.apache.flink.table.planner.plan.utils.PythonUtil
 
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall, RelTraitSet}
 import org.apache.calcite.plan.volcano.RelSubset
+import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.convert.ConverterRule
 import org.apache.calcite.rel.convert.ConverterRule.Config
-import org.apache.calcite.rex.RexNode
+import org.apache.calcite.rel.core.JoinRelType
+import org.apache.calcite.rex.{RexBuilder, RexInputRef, RexNode, RexProgram, RexProgramBuilder, RexShuttle}
+import org.apache.calcite.sql.validate.SqlValidatorUtil
+
+import java.util.Collections
+
+import scala.collection.JavaConverters._
 
 class BatchPhysicalCorrelateRule(config: Config) extends ConverterRule(config) {
 
@@ -39,7 +46,7 @@ class BatchPhysicalCorrelateRule(config: Config) extends ConverterRule(config) {
       // right node is a table function
       // return true if it is a non python table function
       case scan: FlinkLogicalTableFunctionScan => PythonUtil.isNonPythonCall(scan.getCall)
-      // a filter is pushed above the table function
+      // a calc (filter and/or projection) is pushed above the table function
       // return true if it is a non python table function
       case calc: FlinkLogicalCalc =>
         calc.getInput.asInstanceOf[RelSubset].getOriginal match {
@@ -56,30 +63,131 @@ class BatchPhysicalCorrelateRule(config: Config) extends ConverterRule(config) {
     val convInput: RelNode = RelOptRule.convert(join.getInput(0), FlinkConventions.BATCH_PHYSICAL)
     val right: RelNode = join.getInput(1)
 
-    def convertToCorrelate(relNode: RelNode, condition: Option[RexNode]): BatchPhysicalCorrelate = {
-      relNode match {
-        case rel: RelSubset =>
-          convertToCorrelate(rel.getRelList.get(0), condition)
+    // Walk through the right subtree to find the underlying TableFunctionScan and the
+    // Calc (if any) that sits between the Correlate and the TFS.
+    val (scan, calcOpt) = unwrapToScan(right)
 
-        case calc: FlinkLogicalCalc =>
-          convertToCorrelate(
-            calc.getInput.asInstanceOf[RelSubset].getOriginal,
-            if (calc.getProgram.getCondition == null) None
-            else Some(calc.getProgram.expandLocalRef(calc.getProgram.getCondition))
-          )
-
-        case scan: FlinkLogicalTableFunctionScan =>
-          new BatchPhysicalCorrelate(
-            rel.getCluster,
-            traitSet,
-            convInput,
-            scan,
-            condition,
-            rel.getRowType,
-            join.getJoinType)
-      }
+    val condition: Option[RexNode] = calcOpt.flatMap {
+      calc =>
+        val program = calc.getProgram
+        Option(program.getCondition).map(program.expandLocalRef)
     }
-    convertToCorrelate(right, None)
+
+    // The Correlate's output before any right-side projection is left ++ scan.rowType.
+    // When the Calc above the TFS has a non-identity projection, we cannot fold it into
+    // the physical Correlate's output rowType: the codegen concatenates left input with
+    // the *full* TFS output positionally, so a narrower rowType would cause downstream
+    // consumers to read the wrong fields. Build the physical Correlate with the full
+    // combined rowType and apply the projection via a wrapping Calc on top.
+    //
+    // Restricted to INNER/LEFT because SEMI/ANTI Correlates produce only the left fields;
+    // the right-side projection is only consumed by the join condition and never appears
+    // in the Correlate's output, so the bug cannot manifest there.
+    val needsProjectionAbove =
+      calcOpt.exists(calc => !calc.getProgram.projectsOnlyIdentity()) &&
+        (join.getJoinType == JoinRelType.INNER || join.getJoinType == JoinRelType.LEFT)
+
+    if (needsProjectionAbove) {
+      val combinedRowType = SqlValidatorUtil.deriveJoinRowType(
+        convInput.getRowType,
+        scan.getRowType,
+        join.getJoinType,
+        join.getCluster.getTypeFactory,
+        null,
+        Collections.emptyList())
+
+      val physicalCorrelate = new BatchPhysicalCorrelate(
+        join.getCluster,
+        traitSet,
+        convInput,
+        scan,
+        condition,
+        combinedRowType,
+        join.getJoinType)
+
+      val wrappingProgram = buildWrappingProgram(
+        calcOpt.get.getProgram,
+        combinedRowType,
+        join.getRowType,
+        convInput.getRowType.getFieldCount,
+        join.getCluster.getRexBuilder)
+
+      new BatchPhysicalCalc(
+        join.getCluster,
+        traitSet,
+        physicalCorrelate,
+        wrappingProgram,
+        join.getRowType)
+    } else {
+      new BatchPhysicalCorrelate(
+        join.getCluster,
+        traitSet,
+        convInput,
+        scan,
+        condition,
+        join.getRowType,
+        join.getJoinType)
+    }
+  }
+
+  /**
+   * Walks past planner shells to expose the {@link FlinkLogicalTableFunctionScan} at the bottom of
+   * the right subtree, returning the immediate {@link FlinkLogicalCalc} above it (if any).
+   */
+  private def unwrapToScan(
+      rel: RelNode): (FlinkLogicalTableFunctionScan, Option[FlinkLogicalCalc]) = {
+    rel match {
+      case subset: RelSubset => unwrapToScan(subset.getRelList.get(0))
+      case calc: FlinkLogicalCalc =>
+        val (scan, _) = unwrapToScan(calc.getInput.asInstanceOf[RelSubset].getOriginal)
+        (scan, Some(calc))
+      case scan: FlinkLogicalTableFunctionScan => (scan, None)
+    }
+  }
+
+  /**
+   * Builds a {@link RexProgram} that re-applies the Calc's original projection to the output of the
+   * physical Correlate (left ++ scan.rowType). Left fields are passed through unchanged; right-side
+   * projection expressions have their input references shifted by {@code leftFieldCount} so they
+   * index the combined input row.
+   */
+  private def buildWrappingProgram(
+      originalProgram: RexProgram,
+      combinedRowType: RelDataType,
+      outputRowType: RelDataType,
+      leftFieldCount: Int,
+      rexBuilder: RexBuilder): RexProgram = {
+
+    val shifter = new RexShuttle {
+      override def visitInputRef(inputRef: RexInputRef): RexNode =
+        new RexInputRef(inputRef.getIndex + leftFieldCount, inputRef.getType)
+    }
+
+    val builder = new RexProgramBuilder(combinedRowType, rexBuilder)
+
+    // Pass through the left fields by name and type from the combined row.
+    val combinedFields = combinedRowType.getFieldList
+    for (i <- 0 until leftFieldCount) {
+      val field = combinedFields.get(i)
+      builder.addProject(new RexInputRef(i, field.getType), field.getName)
+    }
+
+    // Append the original Calc's projection list, with input refs shifted to point at
+    // the right-hand portion of the combined row, and rename to match outputRowType.
+    val originalProjects = originalProgram.getProjectList.asScala
+    val outputFields = outputRowType.getFieldList
+    require(
+      leftFieldCount + originalProjects.size == outputFields.size,
+      s"output field count ${outputFields.size} != left ($leftFieldCount) + projection " +
+        s"(${originalProjects.size})"
+    )
+    for (i <- originalProjects.indices) {
+      val expanded = originalProgram.expandLocalRef(originalProjects(i)).accept(shifter)
+      val outputName = outputFields.get(leftFieldCount + i).getName
+      builder.addProject(expanded, outputName)
+    }
+
+    builder.getProgram
   }
 }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalCorrelateRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalCorrelateRule.scala
@@ -20,21 +20,19 @@ package org.apache.flink.table.planner.plan.rules.physical.batch
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.nodes.logical.{FlinkLogicalCalc, FlinkLogicalCorrelate, FlinkLogicalTableFunctionScan}
 import org.apache.flink.table.planner.plan.nodes.physical.batch.{BatchPhysicalCalc, BatchPhysicalCorrelate}
+import org.apache.flink.table.planner.plan.rules.physical.common.CorrelateProjectionUtils
 import org.apache.flink.table.planner.plan.utils.PythonUtil
 
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall, RelTraitSet}
 import org.apache.calcite.plan.volcano.RelSubset
-import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.convert.ConverterRule
 import org.apache.calcite.rel.convert.ConverterRule.Config
 import org.apache.calcite.rel.core.JoinRelType
-import org.apache.calcite.rex.{RexBuilder, RexInputRef, RexNode, RexProgram, RexProgramBuilder, RexShuttle}
+import org.apache.calcite.rex.RexNode
 import org.apache.calcite.sql.validate.SqlValidatorUtil
 
 import java.util.Collections
-
-import scala.collection.JavaConverters._
 
 class BatchPhysicalCorrelateRule(config: Config) extends ConverterRule(config) {
 
@@ -105,7 +103,7 @@ class BatchPhysicalCorrelateRule(config: Config) extends ConverterRule(config) {
         combinedRowType,
         join.getJoinType)
 
-      val wrappingProgram = buildWrappingProgram(
+      val wrappingProgram = CorrelateProjectionUtils.buildWrappingProgram(
         calcOpt.get.getProgram,
         combinedRowType,
         join.getRowType,
@@ -145,50 +143,6 @@ class BatchPhysicalCorrelateRule(config: Config) extends ConverterRule(config) {
     }
   }
 
-  /**
-   * Builds a {@link RexProgram} that re-applies the Calc's original projection to the output of the
-   * physical Correlate (left ++ scan.rowType). Left fields are passed through unchanged; right-side
-   * projection expressions have their input references shifted by {@code leftFieldCount} so they
-   * index the combined input row.
-   */
-  private def buildWrappingProgram(
-      originalProgram: RexProgram,
-      combinedRowType: RelDataType,
-      outputRowType: RelDataType,
-      leftFieldCount: Int,
-      rexBuilder: RexBuilder): RexProgram = {
-
-    val shifter = new RexShuttle {
-      override def visitInputRef(inputRef: RexInputRef): RexNode =
-        new RexInputRef(inputRef.getIndex + leftFieldCount, inputRef.getType)
-    }
-
-    val builder = new RexProgramBuilder(combinedRowType, rexBuilder)
-
-    // Pass through the left fields by name and type from the combined row.
-    val combinedFields = combinedRowType.getFieldList
-    for (i <- 0 until leftFieldCount) {
-      val field = combinedFields.get(i)
-      builder.addProject(new RexInputRef(i, field.getType), field.getName)
-    }
-
-    // Append the original Calc's projection list, with input refs shifted to point at
-    // the right-hand portion of the combined row, and rename to match outputRowType.
-    val originalProjects = originalProgram.getProjectList.asScala
-    val outputFields = outputRowType.getFieldList
-    require(
-      leftFieldCount + originalProjects.size == outputFields.size,
-      s"output field count ${outputFields.size} != left ($leftFieldCount) + projection " +
-        s"(${originalProjects.size})"
-    )
-    for (i <- originalProjects.indices) {
-      val expanded = originalProgram.expandLocalRef(originalProjects(i)).accept(shifter)
-      val outputName = outputFields.get(leftFieldCount + i).getName
-      builder.addProject(expanded, outputName)
-    }
-
-    builder.getProgram
-  }
 }
 
 object BatchPhysicalCorrelateRule {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalCorrelateRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalCorrelateRule.scala
@@ -61,8 +61,6 @@ class BatchPhysicalCorrelateRule(config: Config) extends ConverterRule(config) {
     val convInput: RelNode = RelOptRule.convert(join.getInput(0), FlinkConventions.BATCH_PHYSICAL)
     val right: RelNode = join.getInput(1)
 
-    // Walk through the right subtree to find the underlying TableFunctionScan and the
-    // Calc (if any) that sits between the Correlate and the TFS.
     val (scan, calcOpt) = unwrapToScan(right)
 
     val condition: Option[RexNode] = calcOpt.flatMap {
@@ -71,16 +69,10 @@ class BatchPhysicalCorrelateRule(config: Config) extends ConverterRule(config) {
         Option(program.getCondition).map(program.expandLocalRef)
     }
 
-    // The Correlate's output before any right-side projection is left ++ scan.rowType.
-    // When the Calc above the TFS has a non-identity projection, we cannot fold it into
-    // the physical Correlate's output rowType: the codegen concatenates left input with
-    // the *full* TFS output positionally, so a narrower rowType would cause downstream
-    // consumers to read the wrong fields. Build the physical Correlate with the full
-    // combined rowType and apply the projection via a wrapping Calc on top.
-    //
-    // Restricted to INNER/LEFT because SEMI/ANTI Correlates produce only the left fields;
-    // the right-side projection is only consumed by the join condition and never appears
-    // in the Correlate's output, so the bug cannot manifest there.
+    // Non-identity projection above the TFS cannot be folded into the physical Correlate's
+    // output rowType: the codegen concatenates the left input with the full TFS output
+    // positionally. Apply it via a wrapping Calc instead. SEMI/ANTI Correlates output only
+    // the left fields, so the projection has no effect there.
     val needsProjectionAbove =
       calcOpt.exists(calc => !calc.getProgram.projectsOnlyIdentity()) &&
         (join.getJoinType == JoinRelType.INNER || join.getJoinType == JoinRelType.LEFT)
@@ -128,10 +120,6 @@ class BatchPhysicalCorrelateRule(config: Config) extends ConverterRule(config) {
     }
   }
 
-  /**
-   * Walks past planner shells to expose the {@link FlinkLogicalTableFunctionScan} at the bottom of
-   * the right subtree, returning the immediate {@link FlinkLogicalCalc} above it (if any).
-   */
   private def unwrapToScan(
       rel: RelNode): (FlinkLogicalTableFunctionScan, Option[FlinkLogicalCalc]) = {
     rel match {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/common/CorrelateProjectionUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/common/CorrelateProjectionUtils.scala
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.planner.plan.rules.physical.common
+
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rex.{RexBuilder, RexInputRef, RexNode, RexProgram, RexProgramBuilder, RexShuttle}
+
+import scala.collection.JavaConverters._
+
+/**
+ * Shared helpers for the physical Correlate rules that need to preserve a right-side projection
+ * (originally on a {@link org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalCalc}
+ * between the Correlate and the {@link
+ * org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableFunctionScan}) by applying it
+ * via a wrapping Calc on top of the physical Correlate.
+ */
+object CorrelateProjectionUtils {
+
+  /**
+   * Builds a {@link RexProgram} that re-applies the Calc's original projection to the output of the
+   * physical Correlate (left ++ scan.rowType). Left fields are passed through unchanged; right-side
+   * projection expressions have their input references shifted by {@code leftFieldCount} so they
+   * index the combined input row.
+   */
+  def buildWrappingProgram(
+      originalProgram: RexProgram,
+      combinedRowType: RelDataType,
+      outputRowType: RelDataType,
+      leftFieldCount: Int,
+      rexBuilder: RexBuilder): RexProgram = {
+
+    val shifter = new RexShuttle {
+      override def visitInputRef(inputRef: RexInputRef): RexNode =
+        new RexInputRef(inputRef.getIndex + leftFieldCount, inputRef.getType)
+    }
+
+    val builder = new RexProgramBuilder(combinedRowType, rexBuilder)
+
+    // Pass through the left fields by name and type from the combined row.
+    val combinedFields = combinedRowType.getFieldList
+    for (i <- 0 until leftFieldCount) {
+      val field = combinedFields.get(i)
+      builder.addProject(new RexInputRef(i, field.getType), field.getName)
+    }
+
+    // Append the original Calc's projection list, with input refs shifted to point at the
+    // right-hand portion of the combined row, and rename to match outputRowType.
+    val originalProjects = originalProgram.getProjectList.asScala
+    val outputFields = outputRowType.getFieldList
+    require(
+      leftFieldCount + originalProjects.size == outputFields.size,
+      s"output field count ${outputFields.size} != left ($leftFieldCount) + projection " +
+        s"(${originalProjects.size})"
+    )
+    for (i <- originalProjects.indices) {
+      val expanded = originalProgram.expandLocalRef(originalProjects(i)).accept(shifter)
+      val outputName = outputFields.get(leftFieldCount + i).getName
+      builder.addProject(expanded, outputName)
+    }
+
+    builder.getProgram
+  }
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/common/CorrelateProjectionUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/common/CorrelateProjectionUtils.scala
@@ -22,20 +22,12 @@ import org.apache.calcite.rex.{RexBuilder, RexInputRef, RexNode, RexProgram, Rex
 
 import scala.collection.JavaConverters._
 
-/**
- * Shared helpers for the physical Correlate rules that need to preserve a right-side projection
- * (originally on a {@link org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalCalc}
- * between the Correlate and the {@link
- * org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableFunctionScan}) by applying it
- * via a wrapping Calc on top of the physical Correlate.
- */
+/** Shared helpers for the physical Correlate rules. */
 object CorrelateProjectionUtils {
 
   /**
-   * Builds a {@link RexProgram} that re-applies the Calc's original projection to the output of the
-   * physical Correlate (left ++ scan.rowType). Left fields are passed through unchanged; right-side
-   * projection expressions have their input references shifted by {@code leftFieldCount} so they
-   * index the combined input row.
+   * Re-applies a Calc's projection above the physical Correlate. Left fields are passed through;
+   * right-side input refs are shifted by {@code leftFieldCount} to index the combined row.
    */
   def buildWrappingProgram(
       originalProgram: RexProgram,
@@ -51,15 +43,12 @@ object CorrelateProjectionUtils {
 
     val builder = new RexProgramBuilder(combinedRowType, rexBuilder)
 
-    // Pass through the left fields by name and type from the combined row.
     val combinedFields = combinedRowType.getFieldList
     for (i <- 0 until leftFieldCount) {
       val field = combinedFields.get(i)
       builder.addProject(new RexInputRef(i, field.getType), field.getName)
     }
 
-    // Append the original Calc's projection list, with input refs shifted to point at the
-    // right-hand portion of the combined row, and rename to match outputRowType.
     val originalProjects = originalProgram.getProjectList.asScala
     val outputFields = outputRowType.getFieldList
     require(

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalCorrelateRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalCorrelateRule.scala
@@ -20,17 +20,24 @@ package org.apache.flink.table.planner.plan.rules.physical.stream
 import org.apache.flink.table.api.TableException
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.nodes.logical.{FlinkLogicalCalc, FlinkLogicalCorrelate, FlinkLogicalTableFunctionScan}
-import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalCorrelate
+import org.apache.flink.table.planner.plan.nodes.physical.stream.{StreamPhysicalCalc, StreamPhysicalCorrelate}
 import org.apache.flink.table.planner.plan.rules.physical.stream.StreamPhysicalCorrelateRule.{getMergedCalc, getTableScan}
 import org.apache.flink.table.planner.plan.utils.{AsyncUtil, PythonUtil}
 
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall, RelTraitSet}
 import org.apache.calcite.plan.hep.HepRelVertex
 import org.apache.calcite.plan.volcano.RelSubset
+import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.convert.ConverterRule
 import org.apache.calcite.rel.convert.ConverterRule.Config
-import org.apache.calcite.rex.{RexNode, RexProgram, RexProgramBuilder}
+import org.apache.calcite.rel.core.JoinRelType
+import org.apache.calcite.rex.{RexBuilder, RexInputRef, RexNode, RexProgram, RexProgramBuilder, RexShuttle}
+import org.apache.calcite.sql.validate.SqlValidatorUtil
+
+import java.util.Collections
+
+import scala.collection.JavaConverters._
 
 /** Rule that converts [[FlinkLogicalCorrelate]] to [[StreamPhysicalCorrelate]]. */
 class StreamPhysicalCorrelateRule(config: Config) extends ConverterRule(config) {
@@ -55,7 +62,7 @@ class StreamPhysicalCorrelateRule(config: Config) extends ConverterRule(config) 
       // right node is a table function
       case scan: FlinkLogicalTableFunctionScan =>
         PythonUtil.isNonPythonCall(scan.getCall) && AsyncUtil.isNonAsyncCall(scan.getCall)
-      // a filter is pushed above the table function
+      // a calc (filter and/or projection) is pushed above the table function
       case calc: FlinkLogicalCalc => findTableFunction(calc)
       case _ => false
     }
@@ -68,37 +75,129 @@ class StreamPhysicalCorrelateRule(config: Config) extends ConverterRule(config) 
       RelOptRule.convert(correlate.getInput(0), FlinkConventions.STREAM_PHYSICAL)
     val right: RelNode = correlate.getInput(1)
 
-    @scala.annotation.tailrec
-    def convertToCorrelate(
-        relNode: RelNode,
-        condition: Option[RexNode]): StreamPhysicalCorrelate = {
-      relNode match {
-        case rel: RelSubset =>
-          convertToCorrelate(rel.getRelList.get(0), condition)
+    // Find the underlying TFS and the merged Calc above it (if any).
+    val (scan, mergedCalc) = unwrapToScan(right)
 
-        case calc: FlinkLogicalCalc =>
-          val tableScan = getTableScan(calc)
-          val newCalc = getMergedCalc(calc)
-          convertToCorrelate(
-            tableScan,
-            if (newCalc.getProgram.getCondition == null) None
-            else Some(newCalc.getProgram.expandLocalRef(newCalc.getProgram.getCondition))
-          )
-
-        case scan: FlinkLogicalTableFunctionScan =>
-          new StreamPhysicalCorrelate(
-            rel.getCluster,
-            traitSet,
-            convInput,
-            scan,
-            condition,
-            rel.getRowType,
-            correlate.getJoinType)
-      }
+    val condition: Option[RexNode] = mergedCalc.flatMap {
+      calc =>
+        val program = calc.getProgram
+        Option(program.getCondition).map(program.expandLocalRef)
     }
-    convertToCorrelate(right, None)
+
+    // When the Calc above the TFS has a non-identity projection, build the physical
+    // Correlate with the full combined rowType (left ++ scan.rowType) and apply the
+    // projection via a wrapping Calc on top. Otherwise, the codegen would concatenate
+    // the left input with the full TFS output positionally and downstream consumers
+    // would read the wrong fields when the claimed rowType is narrower.
+    //
+    // Restricted to INNER/LEFT because SEMI/ANTI Correlates produce only the left
+    // fields; the right-side projection is only consumed by the join condition and
+    // never appears in the Correlate's output.
+    val needsProjectionAbove =
+      mergedCalc.exists(calc => !calc.getProgram.projectsOnlyIdentity()) &&
+        (correlate.getJoinType == JoinRelType.INNER ||
+          correlate.getJoinType == JoinRelType.LEFT)
+
+    if (needsProjectionAbove) {
+      val combinedRowType = SqlValidatorUtil.deriveJoinRowType(
+        convInput.getRowType,
+        scan.getRowType,
+        correlate.getJoinType,
+        correlate.getCluster.getTypeFactory,
+        null,
+        Collections.emptyList())
+
+      val physicalCorrelate = new StreamPhysicalCorrelate(
+        correlate.getCluster,
+        traitSet,
+        convInput,
+        scan,
+        condition,
+        combinedRowType,
+        correlate.getJoinType)
+
+      val wrappingProgram = buildWrappingProgram(
+        mergedCalc.get.getProgram,
+        combinedRowType,
+        correlate.getRowType,
+        convInput.getRowType.getFieldCount,
+        correlate.getCluster.getRexBuilder)
+
+      new StreamPhysicalCalc(
+        correlate.getCluster,
+        traitSet,
+        physicalCorrelate,
+        wrappingProgram,
+        correlate.getRowType)
+    } else {
+      new StreamPhysicalCorrelate(
+        correlate.getCluster,
+        traitSet,
+        convInput,
+        scan,
+        condition,
+        correlate.getRowType,
+        correlate.getJoinType)
+    }
   }
 
+  /**
+   * Walks past planner shells to expose the {@link FlinkLogicalTableFunctionScan} at the bottom of
+   * the right subtree, returning the Calc (with chained Calcs already merged into one) immediately
+   * above it (if any).
+   */
+  private def unwrapToScan(
+      rel: RelNode): (FlinkLogicalTableFunctionScan, Option[FlinkLogicalCalc]) = {
+    rel match {
+      case subset: RelSubset => unwrapToScan(subset.getRelList.get(0))
+      case calc: FlinkLogicalCalc =>
+        val merged = getMergedCalc(calc)
+        (getTableScan(merged), Some(merged))
+      case scan: FlinkLogicalTableFunctionScan => (scan, None)
+    }
+  }
+
+  /**
+   * Builds a {@link RexProgram} that re-applies the Calc's original projection to the output of the
+   * physical Correlate (left ++ scan.rowType). Left fields are passed through unchanged; right-side
+   * projection expressions have their input references shifted by {@code leftFieldCount} so they
+   * index the combined input row.
+   */
+  private def buildWrappingProgram(
+      originalProgram: RexProgram,
+      combinedRowType: RelDataType,
+      outputRowType: RelDataType,
+      leftFieldCount: Int,
+      rexBuilder: RexBuilder): RexProgram = {
+
+    val shifter = new RexShuttle {
+      override def visitInputRef(inputRef: RexInputRef): RexNode =
+        new RexInputRef(inputRef.getIndex + leftFieldCount, inputRef.getType)
+    }
+
+    val builder = new RexProgramBuilder(combinedRowType, rexBuilder)
+
+    val combinedFields = combinedRowType.getFieldList
+    for (i <- 0 until leftFieldCount) {
+      val field = combinedFields.get(i)
+      builder.addProject(new RexInputRef(i, field.getType), field.getName)
+    }
+
+    val originalProjects = originalProgram.getProjectList.asScala
+    val outputFields = outputRowType.getFieldList
+    require(
+      leftFieldCount + originalProjects.size == outputFields.size,
+      s"output field count ${outputFields.size} != left ($leftFieldCount) + projection " +
+        s"(${originalProjects.size})"
+    )
+    for (i <- originalProjects.indices) {
+      val expanded = originalProgram.expandLocalRef(originalProjects(i)).accept(shifter)
+      val outputName = outputFields.get(leftFieldCount + i).getName
+      builder.addProject(expanded, outputName)
+    }
+
+    builder.getProgram
+  }
 }
 
 object StreamPhysicalCorrelateRule {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalCorrelateRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalCorrelateRule.scala
@@ -73,7 +73,6 @@ class StreamPhysicalCorrelateRule(config: Config) extends ConverterRule(config) 
       RelOptRule.convert(correlate.getInput(0), FlinkConventions.STREAM_PHYSICAL)
     val right: RelNode = correlate.getInput(1)
 
-    // Find the underlying TFS and the merged Calc above it (if any).
     val (scan, mergedCalc) = unwrapToScan(right)
 
     val condition: Option[RexNode] = mergedCalc.flatMap {
@@ -82,15 +81,10 @@ class StreamPhysicalCorrelateRule(config: Config) extends ConverterRule(config) 
         Option(program.getCondition).map(program.expandLocalRef)
     }
 
-    // When the Calc above the TFS has a non-identity projection, build the physical
-    // Correlate with the full combined rowType (left ++ scan.rowType) and apply the
-    // projection via a wrapping Calc on top. Otherwise, the codegen would concatenate
-    // the left input with the full TFS output positionally and downstream consumers
-    // would read the wrong fields when the claimed rowType is narrower.
-    //
-    // Restricted to INNER/LEFT because SEMI/ANTI Correlates produce only the left
-    // fields; the right-side projection is only consumed by the join condition and
-    // never appears in the Correlate's output.
+    // Non-identity projection above the TFS cannot be folded into the physical Correlate's
+    // output rowType: the codegen concatenates the left input with the full TFS output
+    // positionally. Apply it via a wrapping Calc instead. SEMI/ANTI Correlates output only
+    // the left fields, so the projection has no effect there.
     val needsProjectionAbove =
       mergedCalc.exists(calc => !calc.getProgram.projectsOnlyIdentity()) &&
         (correlate.getJoinType == JoinRelType.INNER ||
@@ -139,11 +133,6 @@ class StreamPhysicalCorrelateRule(config: Config) extends ConverterRule(config) 
     }
   }
 
-  /**
-   * Walks past planner shells to expose the {@link FlinkLogicalTableFunctionScan} at the bottom of
-   * the right subtree, returning the Calc (with chained Calcs already merged into one) immediately
-   * above it (if any).
-   */
   private def unwrapToScan(
       rel: RelNode): (FlinkLogicalTableFunctionScan, Option[FlinkLogicalCalc]) = {
     rel match {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalCorrelateRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalCorrelateRule.scala
@@ -21,23 +21,21 @@ import org.apache.flink.table.api.TableException
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.nodes.logical.{FlinkLogicalCalc, FlinkLogicalCorrelate, FlinkLogicalTableFunctionScan}
 import org.apache.flink.table.planner.plan.nodes.physical.stream.{StreamPhysicalCalc, StreamPhysicalCorrelate}
+import org.apache.flink.table.planner.plan.rules.physical.common.CorrelateProjectionUtils
 import org.apache.flink.table.planner.plan.rules.physical.stream.StreamPhysicalCorrelateRule.{getMergedCalc, getTableScan}
 import org.apache.flink.table.planner.plan.utils.{AsyncUtil, PythonUtil}
 
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall, RelTraitSet}
 import org.apache.calcite.plan.hep.HepRelVertex
 import org.apache.calcite.plan.volcano.RelSubset
-import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.convert.ConverterRule
 import org.apache.calcite.rel.convert.ConverterRule.Config
 import org.apache.calcite.rel.core.JoinRelType
-import org.apache.calcite.rex.{RexBuilder, RexInputRef, RexNode, RexProgram, RexProgramBuilder, RexShuttle}
+import org.apache.calcite.rex.{RexNode, RexProgram, RexProgramBuilder}
 import org.apache.calcite.sql.validate.SqlValidatorUtil
 
 import java.util.Collections
-
-import scala.collection.JavaConverters._
 
 /** Rule that converts [[FlinkLogicalCorrelate]] to [[StreamPhysicalCorrelate]]. */
 class StreamPhysicalCorrelateRule(config: Config) extends ConverterRule(config) {
@@ -116,7 +114,7 @@ class StreamPhysicalCorrelateRule(config: Config) extends ConverterRule(config) 
         combinedRowType,
         correlate.getJoinType)
 
-      val wrappingProgram = buildWrappingProgram(
+      val wrappingProgram = CorrelateProjectionUtils.buildWrappingProgram(
         mergedCalc.get.getProgram,
         combinedRowType,
         correlate.getRowType,
@@ -157,47 +155,6 @@ class StreamPhysicalCorrelateRule(config: Config) extends ConverterRule(config) 
     }
   }
 
-  /**
-   * Builds a {@link RexProgram} that re-applies the Calc's original projection to the output of the
-   * physical Correlate (left ++ scan.rowType). Left fields are passed through unchanged; right-side
-   * projection expressions have their input references shifted by {@code leftFieldCount} so they
-   * index the combined input row.
-   */
-  private def buildWrappingProgram(
-      originalProgram: RexProgram,
-      combinedRowType: RelDataType,
-      outputRowType: RelDataType,
-      leftFieldCount: Int,
-      rexBuilder: RexBuilder): RexProgram = {
-
-    val shifter = new RexShuttle {
-      override def visitInputRef(inputRef: RexInputRef): RexNode =
-        new RexInputRef(inputRef.getIndex + leftFieldCount, inputRef.getType)
-    }
-
-    val builder = new RexProgramBuilder(combinedRowType, rexBuilder)
-
-    val combinedFields = combinedRowType.getFieldList
-    for (i <- 0 until leftFieldCount) {
-      val field = combinedFields.get(i)
-      builder.addProject(new RexInputRef(i, field.getType), field.getName)
-    }
-
-    val originalProjects = originalProgram.getProjectList.asScala
-    val outputFields = outputRowType.getFieldList
-    require(
-      leftFieldCount + originalProjects.size == outputFields.size,
-      s"output field count ${outputFields.size} != left ($leftFieldCount) + projection " +
-        s"(${originalProjects.size})"
-    )
-    for (i <- originalProjects.indices) {
-      val expanded = originalProgram.expandLocalRef(originalProjects(i)).accept(shifter)
-      val outputName = outputFields.get(leftFieldCount + i).getName
-      builder.addProject(expanded, outputName)
-    }
-
-    builder.getProgram
-  }
 }
 
 object StreamPhysicalCorrelateRule {

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/UnnestTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/UnnestTest.xml
@@ -689,8 +689,9 @@ LogicalProject(a=[$0], number=[$1], ordinality=[$2])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, number, ordinality])
-+- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b))], select=[a,b,number,ordinality], rowType=[RecordType(INTEGER a, INTEGER ARRAY b, INTEGER number, INTEGER ordinality)], joinType=[INNER], condition=[=($1, 1)])
-   +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b])
++- Calc(select=[a, b, b0 AS number, 1 AS ordinality])
+   +- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b))], select=[a,b,b0,ORDINALITY], rowType=[RecordType(INTEGER a, INTEGER ARRAY b, INTEGER b0, INTEGER ORDINALITY)], joinType=[INNER], condition=[=($1, 1)])
+      +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/UnnestTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/UnnestTest.xml
@@ -700,8 +700,8 @@ LogicalProject(a=[$0], number=[$1], ordinality=[$2])
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, number, ordinality])
-+- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b))], select=[a,b,number,ordinality], rowType=[RecordType(INTEGER a, INTEGER ARRAY b, INTEGER number, INTEGER ordinality)], joinType=[INNER], condition=[=($1, 1)])
+Calc(select=[a, b0 AS number, 1 AS ordinality])
++- Correlate(invocation=[$UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b)], correlate=[table($UNNEST_ROWS_WITH_ORDINALITY$1($cor0.b))], select=[a,b,b0,ORDINALITY], rowType=[RecordType(INTEGER a, INTEGER ARRAY b, INTEGER b0, INTEGER ORDINALITY)], joinType=[INNER], condition=[=($1, 1)])
    +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b])
 ]]>
     </Resource>


### PR DESCRIPTION
## What is the purpose of the change

Fixes [FLINK-39669](https://issues.apache.org/jira/browse/FLINK-39669). `BatchPhysicalCorrelateRule.convertToCorrelate` and `StreamPhysicalCorrelateRule.convertToCorrelate` walk through a `FlinkLogicalCalc` between the `Correlate` and the underlying `FlinkLogicalTableFunctionScan` to extract the Calc's condition, but silently discard the Calc's projection list. The physical Correlate is then constructed with a narrower output rowType while `CorrelateCodeGenerator` concatenates the left input with the full TFS output positionally — so downstream consumers read the wrong TFS column.

The bug is dormant in mainline Flink because no production rule produces the `Correlate(left, Calc(non-identity-projection) over TFS)` shape today. It surfaces when Calcite's stock `ProjectCorrelateTransposeRule` is enabled, or when Flink-specific rules push a non-identity projection above a TFS (e.g., extending FLINK-32940 to prune the right side of UNNEST's Correlate).

## Brief change log

- When the Calc above the TFS has a non-identity projection (`!program.projectsOnlyIdentity()`) and the join type is `INNER` or `LEFT`, build the physical Correlate with the full combined rowType (`left ++ scan.rowType`) and apply the projection via a wrapping `BatchPhysicalCalc` / `StreamPhysicalCalc`. Identity-projection cases (today's common path: Calc with only a condition) are unchanged. SEMI/ANTI Correlates output only the left fields, so the bug cannot manifest there.
- Updates two plan-test goldens (`testUnnestWithOrdinalityInSubquery`, batch + stream) that previously locked in the buggy plan folding the projection into the Correlate's claimed rowType.

## Verifying this change

- 175 UNNEST tests (plan + IT, batch + stream) pass.
- 198 `*Correlate*` tests (incl. `AsyncCorrelate`, `PythonCorrelate`, restore tests) pass.
- The plan-test golden update for `testUnnestWithOrdinalityInSubquery` demonstrates the fix: the new plan correctly applies the projection (renaming + literal substitution from `WHERE ordinality = 1`) via a wrapping Calc rather than silently merging it into the Correlate's rowType.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): **no**
- The public API: **no** — planner-internal only.
- The serializers: **no**
- The runtime per-record code paths: **no** — physical operators unchanged.
- Anything that affects deployment or recovery: **no**
- The S3 file system connector: **no**

## Documentation

- Does this pull request introduce a new feature? **no** — bug fix.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Code, Anthropic Claude Opus 4.7)