### PR TITLE
[FLINK-39589][table] Fix incorrect TVF aggregation results with RocksDB

### DIFF
--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/buffers/RecordsWindowBuffer.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/buffers/RecordsWindowBuffer.java
@@ -49,6 +49,7 @@ public final class RecordsWindowBuffer implements WindowBuffer {
 
     private final RecordsCombiner combineFunction;
     private final WindowBytesMultiMap recordsBuffer;
+    private final WindowKeySerializer windowKeySerializer;
     private final WindowKey reuseWindowKey;
     private final AbstractRowDataSerializer<RowData> recordSerializer;
     private final ZoneId shiftTimeZone;
@@ -72,7 +73,8 @@ public final class RecordsWindowBuffer implements WindowBuffer {
                 new WindowBytesMultiMap(
                         operatorOwner, memoryManager, memorySize, keySer, inputSer.getArity());
         this.recordSerializer = inputSer;
-        this.reuseWindowKey = new WindowKeySerializer(keySer).createInstance();
+        this.windowKeySerializer = new WindowKeySerializer(keySer);
+        this.reuseWindowKey = windowKeySerializer.createInstance();
         this.requiresCopy = requiresCopy;
         this.shiftTimeZone = shiftTimeZone;
     }
@@ -117,7 +119,10 @@ public final class RecordsWindowBuffer implements WindowBuffer {
             KeyValueIterator<WindowKey, Iterator<RowData>> entryIterator =
                     recordsBuffer.getEntryIterator(requiresCopy);
             while (entryIterator.advanceNext()) {
-                combineFunction.combine(entryIterator.getKey(), entryIterator.getValue());
+                WindowKey windowKey = entryIterator.getKey();
+                combineFunction.combine(
+                        requiresCopy ? windowKey : windowKeySerializer.copy(windowKey),
+                        entryIterator.getValue());
             }
             recordsBuffer.reset();
             // reset trigger time

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/buffers/RecordsWindowBuffer.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/buffers/RecordsWindowBuffer.java
@@ -120,6 +120,9 @@ public final class RecordsWindowBuffer implements WindowBuffer {
                     recordsBuffer.getEntryIterator(requiresCopy);
             while (entryIterator.advanceNext()) {
                 WindowKey windowKey = entryIterator.getKey();
+                // When requiresCopy=true the iterator already returned a fresh copy.
+                // Otherwise it reuses a mutable WindowKey, so we must copy here before
+                // it escapes into the timer queue via combine().
                 combineFunction.combine(
                         requiresCopy ? windowKey : windowKeySerializer.copy(windowKey),
                         entryIterator.getValue());

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/window/tvf/combines/RecordsCombiner.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/window/tvf/combines/RecordsCombiner.java
@@ -36,8 +36,7 @@ public interface RecordsCombiner {
     /**
      * Combines the buffered data into state based on the given window-key pair.
      *
-     * @param windowKey the window-key pair that the buffered data belong to, the window-key object
-     *     is reused.
+     * @param windowKey the window-key pair that the buffered data belong to.
      * @param records the buffered data, the iterator and {@link RowData} objects are reused.
      */
     void combine(WindowKey windowKey, Iterator<RowData> records) throws Exception;

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/aggregate/window/buffers/RecordsWindowBufferTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/aggregate/window/buffers/RecordsWindowBufferTest.java
@@ -102,6 +102,42 @@ class RecordsWindowBufferTest {
         return new String(chars);
     }
 
+    @Test
+    void testFlushUsesStableWindowKeys() throws Exception {
+        List<WindowKey> windowKeys = new ArrayList<>();
+        RecordsCombiner combiner =
+                new RecordsCombiner() {
+                    @Override
+                    public void combine(WindowKey windowKey, Iterator<RowData> records) {
+                        windowKeys.add(windowKey);
+                        while (records.hasNext()) {
+                            records.next();
+                        }
+                    }
+
+                    @Override
+                    public void close() {}
+                };
+
+        try (RecordsWindowBuffer buffer = createBuffer(combiner)) {
+            buffer.addElement(
+                    GenericRowData.of(1),
+                    1000L,
+                    GenericRowData.of(1, StringData.fromString("first")));
+            buffer.addElement(
+                    GenericRowData.of(2),
+                    1000L,
+                    GenericRowData.of(2, StringData.fromString("second")));
+
+            buffer.flush();
+
+            assertThat(windowKeys).hasSize(2);
+            assertThat(windowKeys)
+                    .extracting(windowKey -> windowKey.getKey().getInt(0))
+                    .containsExactlyInAnyOrder(1, 2);
+        }
+    }
+
     /**
      * Recoverable scenario: buffer has data (numKeys > 0), EOFException triggers flush, retry
      * succeeds.


### PR DESCRIPTION
## What is the purpose of the change

Fix incorrect results from Window TVF aggregation when using the RocksDB state backend. The bug could make multiple window timers fire with the last buffered key instead of the correct per-key state.

## Brief change log

- Update RecordsWindowBuffer#flush to copy WindowKey before passing it to RecordsCombiner on the reusable-key path, so timer registration does not retain a mutable key reference.
- Adjust the RecordsCombiner contract to reflect that callers now pass a stable window key object.

## Verifying this change

Added RecordsWindowBufferTest#testFlushUsesStableWindowKeys, which asserts that flushing buffered records keeps distinct keys instead of reusing the last key for all entries. Also ran RecordsWindowBufferTest and the full flink-table-runtime module test suite.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with @Public(Evolving): no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable