### PR TITLE
[FLINK-22543][runtime-web] Fix Exception History table layout broken by long error label strings

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/pages/job/exceptions/job-exceptions.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/exceptions/job-exceptions.component.html
@@ -35,14 +35,15 @@
         [nzData]="exceptionHistory"
         [nzShowPagination]="false"
         [nzFrontPagination]="false"
+        nzTableLayout="fixed"
       >
         <thead>
           <tr>
-            <th nzWidth="60px"></th>
-            <th>Time</th>
+            <th nzWidth="4%"></th>
+            <th nzWidth="12%">Time</th>
             <th>Exception</th>
-            <th>Task Name</th>
-            <th>Location</th>
+            <th nzWidth="18%">Task Name</th>
+            <th nzWidth="12%">Location</th>
           </tr>
         </thead>
         <tbody>
@@ -50,7 +51,7 @@
             <tr>
               <td nzShowExpand [(nzExpand)]="item.expand"></td>
               <td>{{ item.selected.timestamp | date: 'yyyy-MM-dd HH:mm:ss' }}</td>
-              <td>
+              <td class="exception-cell">
                 <div class="name">{{ item.selected.exceptionName }}</div>
                 <nz-tag
                   *ngFor="let label of item.selected.failureLabels | keyvalue"

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/exceptions/job-exceptions.component.less
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/exceptions/job-exceptions.component.less
@@ -47,6 +47,18 @@
 
   nz-table {
     margin-top: -@margin-md;
+
+    .exception-cell {
+      word-break: break-all;
+
+      nz-tag {
+        max-width: 100%;
+        white-space: normal;
+        word-break: break-all;
+        height: auto;
+        line-height: 1.4;
+      }
+    }
   }
 
   nz-tag {
@@ -59,6 +71,6 @@
   }
 
   .exception-select {
-    width: 300px;
+    width: 100%;
   }
 }


### PR DESCRIPTION
## What is the purpose of the change

On the Job > Exceptions > Exception History tab, long error labels cause the Time column to collapse to near-zero width. Text wraps character-by-character vertically, making the entire row unreadable. The table also extends beyond the viewport with no horizontal scrollbar.

Similar issue was reported in FLINK-22543 where Flink SQL task names exacerbate the problem.

## Brief change log

  - Set `nzTableLayout="fixed"` on the Exception History `<nz-table>` so columns respect their declared widths regardless of content
  - Add percentage-based column widths for Time (12%), Task Name (18%), Location (12%), and the expand toggle (4%); Exception takes the remaining ~54%
  - Add `word-break: break-all` on the exception cell to force mid-word line wrapping for long unspaced strings
  - Style `nz-tag` elements inside the exception cell with `max-width: 100%` and `white-space: normal` to prevent tag overflow
  - Change `.exception-select` from fixed `width: 300px` to `width: 100%` so the dropdown fills available cell space under fixed layout

## Verifying this change

Manually verified with a minicluster producing long exception strings at multiple viewport sizes (4K 27", 16" laptop, heavily squashed window).

**Example before the fix:** 
<img width="2293" height="913" alt="image" src="https://github.com/user-attachments/assets/274bbd6d-7520-4e04-869c-bb67138dcdf6" />



**Examples after the fix:**

27 inch: (width="2288" height="810")

<img width="2288" height="810" alt="image" src="https://github.com/user-attachments/assets/a2c3ec9a-3a9f-44fa-9b69-7945a49d72ee" />

16 inch: (width="1448" height="946")
<img width="2896" height="1892" alt="image" src="https://github.com/user-attachments/assets/39cd7db6-9a52-4f92-a7b3-232f51dd0d59" />

somewhat squashed: (width="610" height="804")
<img width="1220" height="1608" alt="image" src="https://github.com/user-attachments/assets/6463fbdb-82bb-4f1b-adc7-cc7720df8c09" />

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Claude Opus 4.6)

Generated-by: Claude Code (Claude Opus 4.6)
