### PR TITLE
[FLINK-39677][table] Fix ARRAY_SORT comparator contract violation

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
@@ -26,7 +26,10 @@ import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CollectionUtil;
 
+import org.apache.commons.lang3.ArrayUtils;
+
 import java.time.LocalDate;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -56,6 +59,7 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                         arraySliceTestCases(),
                         arrayMinTestCases(),
                         arraySortTestCases(),
+                        arraySortBigIntDuplicatesTestCases(),
                         arrayExceptTestCases(),
                         arrayIntersectTestCases(),
                         splitTestCases(),
@@ -1600,6 +1604,43 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                                     LocalDate.of(2012, 5, 16)
                                 },
                                 DataTypes.ARRAY(DataTypes.DATE())));
+    }
+
+    private Stream<TestSetSpec> arraySortBigIntDuplicatesTestCases() {
+        final int size = 64;
+        Long[] allEqual = new Long[size];
+        Arrays.fill(allEqual, 42L);
+
+        Long[] manyDuplicates = new Long[size];
+        for (int i = 0; i < size; i++) {
+            manyDuplicates[i] = (long) (i % 4);
+        }
+        Long[] manyDuplicatesSortedAsc = manyDuplicates.clone();
+        Arrays.sort(manyDuplicatesSortedAsc);
+        Long[] manyDuplicatesSortedDesc = manyDuplicatesSortedAsc.clone();
+        ArrayUtils.reverse(manyDuplicatesSortedDesc);
+
+        return Stream.of(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.ARRAY_SORT)
+                        .onFieldsWithData(allEqual, manyDuplicates)
+                        .andDataTypes(
+                                DataTypes.ARRAY(DataTypes.BIGINT()),
+                                DataTypes.ARRAY(DataTypes.BIGINT()))
+                        .testResult(
+                                call("ARRAY_SORT", $("f0")),
+                                "ARRAY_SORT(f0)",
+                                allEqual,
+                                DataTypes.ARRAY(DataTypes.BIGINT()))
+                        .testResult(
+                                call("ARRAY_SORT", $("f1")),
+                                "ARRAY_SORT(f1)",
+                                manyDuplicatesSortedAsc,
+                                DataTypes.ARRAY(DataTypes.BIGINT()))
+                        .testResult(
+                                call("ARRAY_SORT", $("f1"), false),
+                                "ARRAY_SORT(f1, false)",
+                                manyDuplicatesSortedDesc,
+                                DataTypes.ARRAY(DataTypes.BIGINT())));
     }
 
     private Stream<TestSetSpec> arrayExceptTestCases() {

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArraySortFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArraySortFunction.java
@@ -109,8 +109,14 @@ public class ArraySortFunction extends BuiltInScalarFunction {
         @Override
         public int compare(Object o1, Object o2) {
             try {
-                boolean isGreater = (boolean) greaterHandle.invoke(o1, o2);
-                return isAscending ? (isGreater ? 1 : -1) : (isGreater ? -1 : 1);
+                // Two probes so equal elements return 0 (Comparator contract).
+                if ((boolean) greaterHandle.invoke(o1, o2)) {
+                    return isAscending ? 1 : -1;
+                }
+                if ((boolean) greaterHandle.invoke(o2, o1)) {
+                    return isAscending ? -1 : 1;
+                }
+                return 0;
             } catch (Throwable e) {
                 throw new RuntimeException(e);
             }


### PR DESCRIPTION
The comparator built from a single SQL > probe returned +1 or -1 and never 0, so for equal elements compare(a,b) == compare(b,a) == -1. That violates antisymmetry and trips TimSort's contract check once an array is large enough to take the merge path (>= 32 elements with duplicates):

    java.lang.IllegalArgumentException: Comparison method violates its
    general contract!
        at java.util.TimSort.mergeHi(TimSort.java:903)
        ...
        at ArraySortFunction.eval(ArraySortFunction.java:91)

Derive ordering from two greater-than probes - if neither side is greater, treat the elements as equal and return 0. This satisfies both antisymmetry and (for total orders) transitivity.

Coverage: a new 64-element BIGINT case in CollectionFunctionsITCase exercises the TimSort merge path with duplicates.

Generated-by: Claude (Opus 4.7)

## Verifying this change

This change added tests which fails without the fix.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): *no*
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: *no*
  - The serializers: *no*
  - The runtime per-record code paths (performance sensitive): *no*
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: *no*
  - The S3 file system connector: *no*

## Documentation

  - Does this pull request introduce a new feature? *no*
  - If yes, how is the feature documented? *not applicable*

---

##### Was generative AI tooling used to co-author this PR?

Generated-by: Claude (Opus 4.7)
