### PR TITLE
[FLINK-38262][table] add CreateConnectionOperation and converter

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -1736,68 +1736,6 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
     }
 
     /**
-     * Creates a connection in a given fully qualified path.
-     *
-     * <p>Permanent connections require secret-store integration before writing to the catalog, so
-     * this method rejects them instead of persisting raw sensitive values.
-     *
-     * @param connection The resolved connection to put in the given path.
-     * @param objectIdentifier The fully qualified path where to put the connection.
-     * @param ignoreIfExists If false exception will be thrown if a connection exists in the given
-     *     path.
-     */
-    public void createConnection(
-            SensitiveConnection connection,
-            ObjectIdentifier objectIdentifier,
-            boolean ignoreIfExists) {
-        checkNotNull(connection, "Connection must not be null.");
-        checkNotNull(objectIdentifier, "Object identifier must not be null.");
-        throw new ValidationException(
-                "Permanent CREATE CONNECTION is not supported until secret store integration is "
-                        + "available for catalog connections.");
-    }
-
-    /**
-     * Creates a temporary connection in a given fully qualified path.
-     *
-     * @param connection The resolved connection to put in the given path.
-     * @param objectIdentifier The fully qualified path where to put the connection.
-     * @param ignoreIfExists If false exception will be thrown if a connection exists in the given
-     *     path.
-     */
-    public void createTemporaryConnection(
-            SensitiveConnection connection,
-            ObjectIdentifier objectIdentifier,
-            boolean ignoreIfExists) {
-        checkNotNull(connection, "Connection must not be null.");
-        checkNotNull(objectIdentifier, "Object identifier must not be null.");
-        temporaryConnections.compute(
-                objectIdentifier,
-                (k, v) -> {
-                    if (v != null) {
-                        if (!ignoreIfExists) {
-                            throw new ValidationException(
-                                    String.format(
-                                            "Temporary connection '%s' already exists",
-                                            objectIdentifier));
-                        }
-                        return v;
-                    }
-                    return copySensitiveConnection(connection);
-                });
-    }
-
-    public Optional<SensitiveConnection> getTemporaryConnection(ObjectIdentifier objectIdentifier) {
-        return Optional.ofNullable(temporaryConnections.get(objectIdentifier));
-    }
-
-    private static SensitiveConnection copySensitiveConnection(SensitiveConnection connection) {
-        return SensitiveConnection.of(
-                Collections.unmodifiableMap(new LinkedHashMap<>(connection.getOptions())),
-                connection.getComment());
-    }
-
-    /**
      * Alters a model in a given fully qualified path.
      *
      * @param newModel The new model containing changes.

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -1736,6 +1736,68 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
     }
 
     /**
+     * Creates a connection in a given fully qualified path.
+     *
+     * <p>Permanent connections require secret-store integration before writing to the catalog, so
+     * this method rejects them instead of persisting raw sensitive values.
+     *
+     * @param connection The resolved connection to put in the given path.
+     * @param objectIdentifier The fully qualified path where to put the connection.
+     * @param ignoreIfExists If false exception will be thrown if a connection exists in the given
+     *     path.
+     */
+    public void createConnection(
+            SensitiveConnection connection,
+            ObjectIdentifier objectIdentifier,
+            boolean ignoreIfExists) {
+        checkNotNull(connection, "Connection must not be null.");
+        checkNotNull(objectIdentifier, "Object identifier must not be null.");
+        throw new ValidationException(
+                "Permanent CREATE CONNECTION is not supported until secret store integration is "
+                        + "available for catalog connections.");
+    }
+
+    /**
+     * Creates a temporary connection in a given fully qualified path.
+     *
+     * @param connection The resolved connection to put in the given path.
+     * @param objectIdentifier The fully qualified path where to put the connection.
+     * @param ignoreIfExists If false exception will be thrown if a connection exists in the given
+     *     path.
+     */
+    public void createTemporaryConnection(
+            SensitiveConnection connection,
+            ObjectIdentifier objectIdentifier,
+            boolean ignoreIfExists) {
+        checkNotNull(connection, "Connection must not be null.");
+        checkNotNull(objectIdentifier, "Object identifier must not be null.");
+        temporaryConnections.compute(
+                objectIdentifier,
+                (k, v) -> {
+                    if (v != null) {
+                        if (!ignoreIfExists) {
+                            throw new ValidationException(
+                                    String.format(
+                                            "Temporary connection '%s' already exists",
+                                            objectIdentifier));
+                        }
+                        return v;
+                    }
+                    return copySensitiveConnection(connection);
+                });
+    }
+
+    public Optional<SensitiveConnection> getTemporaryConnection(ObjectIdentifier objectIdentifier) {
+        return Optional.ofNullable(temporaryConnections.get(objectIdentifier));
+    }
+
+    private static SensitiveConnection copySensitiveConnection(SensitiveConnection connection) {
+        return SensitiveConnection.of(
+                Collections.unmodifiableMap(new LinkedHashMap<>(connection.getOptions())),
+                connection.getComment());
+    }
+
+    /**
      * Alters a model in a given fully qualified path.
      *
      * @param newModel The new model containing changes.

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/CreateConnectionOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/CreateConnectionOperation.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations.ddl;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.internal.TableResultImpl;
+import org.apache.flink.table.api.internal.TableResultInternal;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.SensitiveConnection;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.OperationUtils;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/** Operation to describe a CREATE CONNECTION statement. */
+@Internal
+public class CreateConnectionOperation implements CreateOperation {
+
+    private static final String MASKED_VALUE = "****";
+
+    private final ObjectIdentifier connectionIdentifier;
+    private final SensitiveConnection sensitiveConnection;
+    private final boolean ignoreIfExists;
+    private final boolean isTemporary;
+
+    public CreateConnectionOperation(
+            ObjectIdentifier connectionIdentifier,
+            SensitiveConnection sensitiveConnection,
+            boolean ignoreIfExists,
+            boolean isTemporary) {
+        this.connectionIdentifier = connectionIdentifier;
+        this.sensitiveConnection = sensitiveConnection;
+        this.ignoreIfExists = ignoreIfExists;
+        this.isTemporary = isTemporary;
+    }
+
+    public ObjectIdentifier getConnectionIdentifier() {
+        return connectionIdentifier;
+    }
+
+    public SensitiveConnection getSensitiveConnection() {
+        return sensitiveConnection;
+    }
+
+    public boolean isIgnoreIfExists() {
+        return ignoreIfExists;
+    }
+
+    public boolean isTemporary() {
+        return isTemporary;
+    }
+
+    @Override
+    public String asSummaryString() {
+        Map<String, String> maskedOptions =
+                sensitiveConnection.getOptions().entrySet().stream()
+                        .collect(
+                                Collectors.toMap(
+                                        Map.Entry::getKey,
+                                        e -> MASKED_VALUE,
+                                        (a, b) -> a,
+                                        LinkedHashMap::new));
+        Map<String, Object> params = new LinkedHashMap<>();
+        params.put("connectionOptions", maskedOptions);
+        params.put("identifier", connectionIdentifier);
+        params.put("ignoreIfExists", ignoreIfExists);
+        params.put("isTemporary", isTemporary);
+
+        return OperationUtils.formatWithChildren(
+                "CREATE CONNECTION", params, Collections.emptyList(), Operation::asSummaryString);
+    }
+
+    @Override
+    public TableResultInternal execute(Context ctx) {
+        if (isTemporary) {
+            ctx.getCatalogManager()
+                    .createTemporaryConnection(
+                            sensitiveConnection, connectionIdentifier, ignoreIfExists);
+        } else {
+            ctx.getCatalogManager()
+                    .createConnection(sensitiveConnection, connectionIdentifier, ignoreIfExists);
+        }
+        return TableResultImpl.TABLE_RESULT_OK;
+    }
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/CreateConnectionOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/CreateConnectionOperation.java
@@ -26,8 +26,8 @@ import org.apache.flink.table.catalog.SensitiveConnection;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.OperationUtils;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -86,7 +86,7 @@ public class CreateConnectionOperation implements CreateOperation {
         params.put("isTemporary", isTemporary);
 
         return OperationUtils.formatWithChildren(
-                "CREATE CONNECTION", params, Collections.emptyList(), Operation::asSummaryString);
+                "CREATE CONNECTION", params, List.of(), Operation::asSummaryString);
     }
 
     @Override

--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -158,6 +158,12 @@ under the License.
 			<artifactId>flink-table-runtime</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-type-utils</artifactId>
+			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
+		</dependency>
 
 		<!-- Table Calcite Bridge (included in the uber) -->
 		<dependency>

--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -159,26 +159,6 @@ under the License.
 			<version>${project.version}</version>
 		</dependency>
 
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-table-type-utils</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-table-code-splitter</artifactId>
-			<version>${project.version}</version>
-			<optional>${flink.markBundledAsOptional}</optional>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-shaded-jsonpath</artifactId>
-			<version>${flink.shaded.jsonpath.version}-${flink.shaded.version}</version>
-			<optional>${flink.markBundledAsOptional}</optional>
-		</dependency>
-
 		<!-- Table Calcite Bridge (included in the uber) -->
 		<dependency>
 			<groupId>org.apache.flink</groupId>
@@ -215,13 +195,6 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-table-api-scala-bridge_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.antlr</groupId>
-			<artifactId>antlr4-runtime</artifactId>
-			<version>4.7</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -159,6 +159,26 @@ under the License.
 			<version>${project.version}</version>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-type-utils</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-code-splitter</artifactId>
+			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-shaded-jsonpath</artifactId>
+			<version>${flink.shaded.jsonpath.version}-${flink.shaded.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
+		</dependency>
+
 		<!-- Table Calcite Bridge (included in the uber) -->
 		<dependency>
 			<groupId>org.apache.flink</groupId>
@@ -195,6 +215,13 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-table-api-scala-bridge_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.antlr</groupId>
+			<artifactId>antlr4-runtime</artifactId>
+			<version>4.7</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlCreateConnectionConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlCreateConnectionConverter.java
@@ -25,8 +25,6 @@ import org.apache.flink.table.catalog.UnresolvedIdentifier;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.ddl.CreateConnectionOperation;
 
-import org.apache.calcite.sql.SqlCharStringLiteral;
-
 import java.util.Map;
 
 /** A converter for {@link SqlCreateConnection}. */
@@ -41,8 +39,7 @@ public class SqlCreateConnectionConverter implements SqlNodeConverter<SqlCreateC
                 context.getCatalogManager().qualifyIdentifier(unresolvedIdentifier);
 
         Map<String, String> options = sqlCreateConnection.getProperties();
-        SqlCharStringLiteral commentLiteral = sqlCreateConnection.getComment();
-        String comment = commentLiteral == null ? null : commentLiteral.getValueAs(String.class);
+        String comment = sqlCreateConnection.getComment();
 
         SensitiveConnection sensitiveConnection = SensitiveConnection.of(options, comment);
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlCreateConnectionConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlCreateConnectionConverter.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.operations.converters;
+
+import org.apache.flink.sql.parser.ddl.connection.SqlCreateConnection;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.SensitiveConnection;
+import org.apache.flink.table.catalog.UnresolvedIdentifier;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.ddl.CreateConnectionOperation;
+
+import org.apache.calcite.sql.SqlCharStringLiteral;
+
+import java.util.Map;
+
+/** A converter for {@link SqlCreateConnection}. */
+public class SqlCreateConnectionConverter implements SqlNodeConverter<SqlCreateConnection> {
+
+    @Override
+    public Operation convertSqlNode(
+            SqlCreateConnection sqlCreateConnection, ConvertContext context) {
+        UnresolvedIdentifier unresolvedIdentifier =
+                UnresolvedIdentifier.of(sqlCreateConnection.getFullName());
+        ObjectIdentifier identifier =
+                context.getCatalogManager().qualifyIdentifier(unresolvedIdentifier);
+
+        Map<String, String> options = sqlCreateConnection.getProperties();
+        SqlCharStringLiteral commentLiteral = sqlCreateConnection.getComment();
+        String comment = commentLiteral == null ? null : commentLiteral.getValueAs(String.class);
+
+        SensitiveConnection sensitiveConnection = SensitiveConnection.of(options, comment);
+
+        return new CreateConnectionOperation(
+                identifier,
+                sensitiveConnection,
+                sqlCreateConnection.isIfNotExists(),
+                sqlCreateConnection.isTemporary());
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverters.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverters.java
@@ -90,6 +90,7 @@ public class SqlNodeConverters {
         register(new SqlShowProcedureConverter());
 
         registerCatalogConverters();
+        registerConnectionConverters();
         registerMaterializedTableConverters();
         registerModelConverters();
         registerTableConverters();
@@ -136,6 +137,10 @@ public class SqlNodeConverters {
         register(new SqlDescribeCatalogConverter());
         register(new SqlShowCatalogsConverter());
         register(new SqlShowCreateCatalogConverter());
+    }
+
+    private static void registerConnectionConverters() {
+        register(new SqlCreateConnectionConverter());
     }
 
     private static void registerMaterializedTableConverters() {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlConnectionOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlConnectionOperationConverterTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.planner.operations;
 
 import org.apache.flink.sql.parser.error.SqlValidateException;
+import org.apache.flink.table.api.SqlParserException;
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.CatalogManager;
@@ -122,8 +123,8 @@ class SqlConnectionOperationConverterTest extends SqlNodeToOperationConversionTe
     @Test
     void testCreateSystemConnectionWithoutTemporaryRejected() {
         assertThatThrownBy(() -> parse("CREATE SYSTEM CONNECTION my_conn WITH ('k' = 'v')"))
-                .hasRootCauseInstanceOf(SqlValidateException.class)
-                .hasMessageContaining("CREATE SYSTEM CONNECTION");
+                .isInstanceOf(SqlParserException.class)
+                .hasMessageContaining("CREATE SYSTEM CONNECTION is not supported");
     }
 
     @Test

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlConnectionOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlConnectionOperationConverterTest.java
@@ -32,7 +32,6 @@ import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.ddl.CreateConnectionOperation;
 import org.apache.flink.table.resource.ResourceManager;
 
-import org.apache.calcite.sql.parser.SqlParseException;
 import org.junit.jupiter.api.Test;
 
 import java.util.LinkedHashMap;
@@ -130,9 +129,8 @@ class SqlConnectionOperationConverterTest extends SqlNodeToOperationConversionTe
     @Test
     void testCreateConnectionWithEmptyOptionsRejected() {
         assertThatThrownBy(() -> parse("CREATE CONNECTION my_conn WITH ()"))
-                .satisfiesAnyOf(
-                        t -> assertThat(t).isInstanceOf(SqlParseException.class),
-                        t -> assertThat(t.getCause()).isInstanceOf(SqlValidateException.class));
+                .isInstanceOf(SqlValidateException.class)
+                .hasMessageContaining("Connection property list can not be empty.");
     }
 
     @Test

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlConnectionOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlConnectionOperationConverterTest.java
@@ -20,21 +20,13 @@ package org.apache.flink.table.planner.operations;
 
 import org.apache.flink.sql.parser.error.SqlValidateException;
 import org.apache.flink.table.api.SqlParserException;
-import org.apache.flink.table.api.TableConfig;
-import org.apache.flink.table.api.ValidationException;
-import org.apache.flink.table.catalog.CatalogManager;
-import org.apache.flink.table.catalog.FunctionCatalog;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.SensitiveConnection;
-import org.apache.flink.table.module.ModuleManager;
-import org.apache.flink.table.operations.ExecutableOperation;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.ddl.CreateConnectionOperation;
-import org.apache.flink.table.resource.ResourceManager;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -102,11 +94,8 @@ class SqlConnectionOperationConverterTest extends SqlNodeToOperationConversionTe
         Operation operation =
                 parse("CREATE CONNECTION my_conn WITH ('k1' = 'v1', 'k2' = 'v2', 'k3' = 'v3')");
         CreateConnectionOperation op = (CreateConnectionOperation) operation;
-        Map<String, String> expected = new LinkedHashMap<>();
-        expected.put("k1", "v1");
-        expected.put("k2", "v2");
-        expected.put("k3", "v3");
-        assertThat(op.getSensitiveConnection().getOptions()).containsAllEntriesOf(expected);
+        assertThat(op.getSensitiveConnection().getOptions())
+                .isEqualTo(Map.of("k1", "v1", "k2", "v2", "k3", "v3"));
     }
 
     @Test
@@ -131,93 +120,5 @@ class SqlConnectionOperationConverterTest extends SqlNodeToOperationConversionTe
         assertThatThrownBy(() -> parse("CREATE CONNECTION my_conn WITH ()"))
                 .isInstanceOf(SqlValidateException.class)
                 .hasMessageContaining("Connection property list can not be empty.");
-    }
-
-    @Test
-    void testExecuteCreateTemporaryConnection() {
-        CreateConnectionOperation operation =
-                (CreateConnectionOperation)
-                        parse(
-                                "CREATE TEMPORARY CONNECTION my_conn COMMENT 'hi there' "
-                                        + "WITH ('k' = 'v')");
-
-        operation.execute(operationContext());
-
-        assertThat(catalogManager.getTemporaryConnection(operation.getConnectionIdentifier()))
-                .hasValueSatisfying(
-                        connection -> {
-                            assertThat(connection.getOptions()).containsEntry("k", "v");
-                            assertThat(connection.getComment()).isEqualTo("hi there");
-                        });
-    }
-
-    @Test
-    void testExecuteCreateTemporaryConnectionRejectsDuplicate() {
-        CreateConnectionOperation first =
-                (CreateConnectionOperation)
-                        parse("CREATE TEMPORARY CONNECTION my_conn WITH ('k' = 'v1')");
-        first.execute(operationContext());
-
-        CreateConnectionOperation duplicate =
-                (CreateConnectionOperation)
-                        parse("CREATE TEMPORARY CONNECTION my_conn WITH ('k' = 'v2')");
-        assertThatThrownBy(() -> duplicate.execute(operationContext()))
-                .isInstanceOf(ValidationException.class)
-                .hasMessageContaining("Temporary connection");
-
-        CreateConnectionOperation ignoredDuplicate =
-                (CreateConnectionOperation)
-                        parse(
-                                "CREATE TEMPORARY CONNECTION IF NOT EXISTS my_conn "
-                                        + "WITH ('k' = 'v2')");
-        ignoredDuplicate.execute(operationContext());
-
-        assertThat(catalogManager.getTemporaryConnection(first.getConnectionIdentifier()))
-                .hasValueSatisfying(
-                        connection -> assertThat(connection.getOptions()).containsEntry("k", "v1"));
-    }
-
-    @Test
-    void testExecuteCreatePermanentConnectionRejectedUntilSecretStoreIntegration() {
-        CreateConnectionOperation operation =
-                (CreateConnectionOperation) parse("CREATE CONNECTION my_conn WITH ('k' = 'v')");
-
-        assertThatThrownBy(() -> operation.execute(operationContext()))
-                .isInstanceOf(ValidationException.class)
-                .hasMessageContaining("secret store integration");
-    }
-
-    private ExecutableOperation.Context operationContext() {
-        return new ExecutableOperation.Context() {
-            @Override
-            public CatalogManager getCatalogManager() {
-                return catalogManager;
-            }
-
-            @Override
-            public FunctionCatalog getFunctionCatalog() {
-                return functionCatalog;
-            }
-
-            @Override
-            public ModuleManager getModuleManager() {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public ResourceManager getResourceManager() {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public TableConfig getTableConfig() {
-                return TableConfig.getDefault();
-            }
-
-            @Override
-            public boolean isStreamingMode() {
-                return false;
-            }
-        };
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlConnectionOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlConnectionOperationConverterTest.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.operations;
+
+import org.apache.flink.sql.parser.error.SqlValidateException;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.SensitiveConnection;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.ddl.CreateConnectionOperation;
+
+import org.apache.calcite.sql.parser.SqlParseException;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Test for converting connection statements to operations. */
+class SqlConnectionOperationConverterTest extends SqlNodeToOperationConversionTestBase {
+
+    @Test
+    void testCreateConnection() {
+        Operation operation = parse("CREATE CONNECTION my_conn WITH ('k' = 'v')");
+        assertThat(operation).isInstanceOf(CreateConnectionOperation.class);
+        CreateConnectionOperation op = (CreateConnectionOperation) operation;
+
+        assertThat(op.getConnectionIdentifier())
+                .isEqualTo(ObjectIdentifier.of("builtin", "default", "my_conn"));
+        assertThat(op.getSensitiveConnection().getOptions()).isEqualTo(Map.of("k", "v"));
+        assertThat(op.getSensitiveConnection().getComment()).isNull();
+        assertThat(op.isIgnoreIfExists()).isFalse();
+        assertThat(op.isTemporary()).isFalse();
+    }
+
+    @Test
+    void testCreateConnectionIfNotExists() {
+        Operation operation = parse("CREATE CONNECTION IF NOT EXISTS my_conn WITH ('k' = 'v')");
+        CreateConnectionOperation op = (CreateConnectionOperation) operation;
+        assertThat(op.isIgnoreIfExists()).isTrue();
+        assertThat(op.isTemporary()).isFalse();
+    }
+
+    @Test
+    void testCreateTemporaryConnection() {
+        Operation operation = parse("CREATE TEMPORARY CONNECTION my_conn WITH ('k' = 'v')");
+        CreateConnectionOperation op = (CreateConnectionOperation) operation;
+        assertThat(op.isTemporary()).isTrue();
+        assertThat(op.isIgnoreIfExists()).isFalse();
+    }
+
+    @Test
+    void testCreateTemporarySystemConnection() {
+        Operation operation = parse("CREATE TEMPORARY SYSTEM CONNECTION my_conn WITH ('k' = 'v')");
+        CreateConnectionOperation op = (CreateConnectionOperation) operation;
+        assertThat(op.isTemporary()).isTrue();
+    }
+
+    @Test
+    void testCreateConnectionWithComment() {
+        Operation operation =
+                parse("CREATE CONNECTION my_conn COMMENT 'hi there' WITH ('k' = 'v')");
+        CreateConnectionOperation op = (CreateConnectionOperation) operation;
+        SensitiveConnection conn = op.getSensitiveConnection();
+        assertThat(conn.getComment()).isEqualTo("hi there");
+    }
+
+    @Test
+    void testCreateConnectionWithFullyQualifiedName() {
+        Operation operation = parse("CREATE CONNECTION cat1.db1.my_conn WITH ('k' = 'v')");
+        CreateConnectionOperation op = (CreateConnectionOperation) operation;
+        assertThat(op.getConnectionIdentifier())
+                .isEqualTo(ObjectIdentifier.of("cat1", "db1", "my_conn"));
+    }
+
+    @Test
+    void testCreateConnectionPreservesOptionOrder() {
+        Operation operation =
+                parse("CREATE CONNECTION my_conn WITH ('k1' = 'v1', 'k2' = 'v2', 'k3' = 'v3')");
+        CreateConnectionOperation op = (CreateConnectionOperation) operation;
+        Map<String, String> expected = new LinkedHashMap<>();
+        expected.put("k1", "v1");
+        expected.put("k2", "v2");
+        expected.put("k3", "v3");
+        assertThat(op.getSensitiveConnection().getOptions()).containsExactlyEntriesOf(expected);
+    }
+
+    @Test
+    void testAsSummaryStringMasksOptionValues() {
+        Operation operation =
+                parse(
+                        "CREATE CONNECTION my_conn WITH ('user' = 'alice', 'password' = 'super-secret')");
+        String summary = operation.asSummaryString();
+        assertThat(summary).contains("user").contains("password").contains("****");
+        assertThat(summary).doesNotContain("alice").doesNotContain("super-secret");
+    }
+
+    @Test
+    void testCreateSystemConnectionWithoutTemporaryRejected() {
+        assertThatThrownBy(() -> parse("CREATE SYSTEM CONNECTION my_conn WITH ('k' = 'v')"))
+                .hasRootCauseInstanceOf(SqlValidateException.class)
+                .hasMessageContaining("CREATE SYSTEM CONNECTION");
+    }
+
+    @Test
+    void testCreateConnectionWithEmptyOptionsRejected() {
+        assertThatThrownBy(() -> parse("CREATE CONNECTION my_conn WITH ()"))
+                .satisfiesAnyOf(
+                        t -> assertThat(t).isInstanceOf(SqlParseException.class),
+                        t -> assertThat(t.getCause()).isInstanceOf(SqlValidateException.class));
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlConnectionOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlConnectionOperationConverterTest.java
@@ -19,10 +19,17 @@
 package org.apache.flink.table.planner.operations;
 
 import org.apache.flink.sql.parser.error.SqlValidateException;
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.CatalogManager;
+import org.apache.flink.table.catalog.FunctionCatalog;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.SensitiveConnection;
+import org.apache.flink.table.module.ModuleManager;
+import org.apache.flink.table.operations.ExecutableOperation;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.ddl.CreateConnectionOperation;
+import org.apache.flink.table.resource.ResourceManager;
 
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.junit.jupiter.api.Test;
@@ -91,7 +98,7 @@ class SqlConnectionOperationConverterTest extends SqlNodeToOperationConversionTe
     }
 
     @Test
-    void testCreateConnectionPreservesOptionOrder() {
+    void testCreateConnectionOptions() {
         Operation operation =
                 parse("CREATE CONNECTION my_conn WITH ('k1' = 'v1', 'k2' = 'v2', 'k3' = 'v3')");
         CreateConnectionOperation op = (CreateConnectionOperation) operation;
@@ -99,7 +106,7 @@ class SqlConnectionOperationConverterTest extends SqlNodeToOperationConversionTe
         expected.put("k1", "v1");
         expected.put("k2", "v2");
         expected.put("k3", "v3");
-        assertThat(op.getSensitiveConnection().getOptions()).containsExactlyEntriesOf(expected);
+        assertThat(op.getSensitiveConnection().getOptions()).containsAllEntriesOf(expected);
     }
 
     @Test
@@ -125,5 +132,93 @@ class SqlConnectionOperationConverterTest extends SqlNodeToOperationConversionTe
                 .satisfiesAnyOf(
                         t -> assertThat(t).isInstanceOf(SqlParseException.class),
                         t -> assertThat(t.getCause()).isInstanceOf(SqlValidateException.class));
+    }
+
+    @Test
+    void testExecuteCreateTemporaryConnection() {
+        CreateConnectionOperation operation =
+                (CreateConnectionOperation)
+                        parse(
+                                "CREATE TEMPORARY CONNECTION my_conn COMMENT 'hi there' "
+                                        + "WITH ('k' = 'v')");
+
+        operation.execute(operationContext());
+
+        assertThat(catalogManager.getTemporaryConnection(operation.getConnectionIdentifier()))
+                .hasValueSatisfying(
+                        connection -> {
+                            assertThat(connection.getOptions()).containsEntry("k", "v");
+                            assertThat(connection.getComment()).isEqualTo("hi there");
+                        });
+    }
+
+    @Test
+    void testExecuteCreateTemporaryConnectionRejectsDuplicate() {
+        CreateConnectionOperation first =
+                (CreateConnectionOperation)
+                        parse("CREATE TEMPORARY CONNECTION my_conn WITH ('k' = 'v1')");
+        first.execute(operationContext());
+
+        CreateConnectionOperation duplicate =
+                (CreateConnectionOperation)
+                        parse("CREATE TEMPORARY CONNECTION my_conn WITH ('k' = 'v2')");
+        assertThatThrownBy(() -> duplicate.execute(operationContext()))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("Temporary connection");
+
+        CreateConnectionOperation ignoredDuplicate =
+                (CreateConnectionOperation)
+                        parse(
+                                "CREATE TEMPORARY CONNECTION IF NOT EXISTS my_conn "
+                                        + "WITH ('k' = 'v2')");
+        ignoredDuplicate.execute(operationContext());
+
+        assertThat(catalogManager.getTemporaryConnection(first.getConnectionIdentifier()))
+                .hasValueSatisfying(
+                        connection -> assertThat(connection.getOptions()).containsEntry("k", "v1"));
+    }
+
+    @Test
+    void testExecuteCreatePermanentConnectionRejectedUntilSecretStoreIntegration() {
+        CreateConnectionOperation operation =
+                (CreateConnectionOperation) parse("CREATE CONNECTION my_conn WITH ('k' = 'v')");
+
+        assertThatThrownBy(() -> operation.execute(operationContext()))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("secret store integration");
+    }
+
+    private ExecutableOperation.Context operationContext() {
+        return new ExecutableOperation.Context() {
+            @Override
+            public CatalogManager getCatalogManager() {
+                return catalogManager;
+            }
+
+            @Override
+            public FunctionCatalog getFunctionCatalog() {
+                return functionCatalog;
+            }
+
+            @Override
+            public ModuleManager getModuleManager() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public ResourceManager getResourceManager() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public TableConfig getTableConfig() {
+                return TableConfig.getDefault();
+            }
+
+            @Override
+            public boolean isStreamingMode() {
+                return false;
+            }
+        };
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/CreateConnectionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/CreateConnectionITCase.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.entry;
 
 /** IT case for CREATE CONNECTION statement. */
 class CreateConnectionITCase extends BatchTestBase {
@@ -41,7 +42,7 @@ class CreateConnectionITCase extends BatchTestBase {
         assertThat(catalogManager().getConnection(connectionIdentifier("my_conn")))
                 .hasValueSatisfying(
                         connection -> {
-                            assertThat(connection.getOptions()).containsEntry("k", "v");
+                            assertThat(connection.getOptions()).containsOnly(entry("k", "v"));
                             assertThat(connection.getComment()).isEqualTo("hi there");
                         });
     }
@@ -61,7 +62,9 @@ class CreateConnectionITCase extends BatchTestBase {
 
         assertThat(catalogManager().getConnection(connectionIdentifier("my_conn")))
                 .hasValueSatisfying(
-                        connection -> assertThat(connection.getOptions()).containsEntry("k", "v1"));
+                        connection ->
+                                assertThat(connection.getOptions())
+                                        .containsOnly(entry("k", "v1")));
     }
 
     @Test

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/CreateConnectionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/CreateConnectionITCase.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime.batch.sql;
+
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.api.internal.TableEnvironmentInternal;
+import org.apache.flink.table.catalog.CatalogManager;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.planner.runtime.utils.BatchTestBase;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** IT case for CREATE CONNECTION statement. */
+class CreateConnectionITCase extends BatchTestBase {
+
+    @Test
+    void testCreateTemporaryConnection() {
+        tEnv().executeSql(
+                        "CREATE TEMPORARY CONNECTION my_conn COMMENT 'hi there' "
+                                + "WITH ('k' = 'v')");
+
+        assertThat(catalogManager().getConnection(connectionIdentifier("my_conn")))
+                .hasValueSatisfying(
+                        connection -> {
+                            assertThat(connection.getOptions()).containsEntry("k", "v");
+                            assertThat(connection.getComment()).isEqualTo("hi there");
+                        });
+    }
+
+    @Test
+    void testCreateTemporaryConnectionRejectsDuplicate() {
+        tEnv().executeSql("CREATE TEMPORARY CONNECTION my_conn WITH ('k' = 'v1')");
+
+        assertThatThrownBy(
+                        () ->
+                                tEnv().executeSql(
+                                                "CREATE TEMPORARY CONNECTION my_conn WITH ('k' = 'v2')"))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("Temporary connection");
+
+        tEnv().executeSql("CREATE TEMPORARY CONNECTION IF NOT EXISTS my_conn WITH ('k' = 'v2')");
+
+        assertThat(catalogManager().getConnection(connectionIdentifier("my_conn")))
+                .hasValueSatisfying(
+                        connection -> assertThat(connection.getOptions()).containsEntry("k", "v1"));
+    }
+
+    @Test
+    void testCreatePermanentConnectionRejectedWithoutSecretStore() {
+        assertThatThrownBy(() -> tEnv().executeSql("CREATE CONNECTION my_conn WITH ('k' = 'v')"))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("WritableSecretStore must be configured");
+    }
+
+    private CatalogManager catalogManager() {
+        return ((TableEnvironmentInternal) tEnv()).getCatalogManager();
+    }
+
+    private ObjectIdentifier connectionIdentifier(String connectionName) {
+        CatalogManager catalogManager = catalogManager();
+        return ObjectIdentifier.of(
+                catalogManager.getCurrentCatalog(),
+                catalogManager.getCurrentDatabase(),
+                connectionName);
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/CreateConnectionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/CreateConnectionITCase.java
@@ -63,8 +63,7 @@ class CreateConnectionITCase extends BatchTestBase {
         assertThat(catalogManager().getConnection(connectionIdentifier("my_conn")))
                 .hasValueSatisfying(
                         connection ->
-                                assertThat(connection.getOptions())
-                                        .containsOnly(entry("k", "v1")));
+                                assertThat(connection.getOptions()).containsOnly(entry("k", "v1")));
     }
 
     @Test


### PR DESCRIPTION


## What is the purpose of the change

Adds CreateConnectionOperation and SqlCreateConnectionConverter to translate SqlCreateConnection AST nodes into executable Operations.

## Brief change log

Adds CreateConnectionOperation and SqlCreateConnectionConverter 

## Verifying this change

unit tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

---

##### Was generative AI tooling used to co-author this PR?
Yes
