### PR TITLE
[FLINK-39677][table] Fix ARRAY_SORT comparator contract violation

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -550,6 +550,16 @@ public final class BuiltInFunctionDefinitions {
                     .internal()
                     .build();
 
+    public static final BuiltInFunctionDefinition INTERNAL_COMPARE =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("$COMPARE$1")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(sequence(ANY, ANY))
+                    .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.INT().notNull())))
+                    .runtimeProvided()
+                    .internal()
+                    .build();
+
     public static final BuiltInFunctionDefinition ARRAY_EXCEPT =
             BuiltInFunctionDefinition.newBuilder()
                     .name("ARRAY_EXCEPT")

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
@@ -927,6 +927,9 @@ class ExprCodeGenerator(
           case BuiltInFunctionDefinitions.INTERNAL_HASHCODE =>
             new HashCodeCallGen().generate(ctx, operands, resultType)
 
+          case BuiltInFunctionDefinitions.INTERNAL_COMPARE =>
+            new CompareCallGen().generate(ctx, operands, resultType)
+
           case BuiltInFunctionDefinitions.AGG_DECIMAL_PLUS |
               BuiltInFunctionDefinitions.HIVE_AGG_DECIMAL_PLUS =>
             val left = operands.head

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/CompareCallGen.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/CompareCallGen.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.planner.codegen.calls
+
+import org.apache.flink.table.planner.codegen.{CodeGeneratorContext, GeneratedExpression, GenerateUtils}
+import org.apache.flink.table.planner.codegen.GenerateUtils.generateCallIfArgsNotNull
+import org.apache.flink.table.types.logical.LogicalType
+
+class CompareCallGen extends CallGenerator {
+  override def generate(
+      ctx: CodeGeneratorContext,
+      operands: Seq[GeneratedExpression],
+      returnType: LogicalType): GeneratedExpression = {
+    val left = operands.head
+    val right = operands(1)
+    val code = GenerateUtils.generateCompare(
+      ctx,
+      left.resultType,
+      // matches the default null ordering used elsewhere (e.g. ORDER BY)
+      nullsIsLast = true,
+      left.resultTerm,
+      right.resultTerm)
+    generateCallIfArgsNotNull(ctx, returnType, operands)(_ => code)
+  }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
@@ -26,7 +26,10 @@ import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CollectionUtil;
 
+import org.apache.commons.lang3.ArrayUtils;
+
 import java.time.LocalDate;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -56,6 +59,7 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                         arraySliceTestCases(),
                         arrayMinTestCases(),
                         arraySortTestCases(),
+                        arraySortBigIntDuplicatesTestCases(),
                         arrayExceptTestCases(),
                         arrayIntersectTestCases(),
                         splitTestCases(),
@@ -1600,6 +1604,43 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                                     LocalDate.of(2012, 5, 16)
                                 },
                                 DataTypes.ARRAY(DataTypes.DATE())));
+    }
+
+    private Stream<TestSetSpec> arraySortBigIntDuplicatesTestCases() {
+        final int size = 64;
+        Long[] allEqual = new Long[size];
+        Arrays.fill(allEqual, 42L);
+
+        Long[] manyDuplicates = new Long[size];
+        for (int i = 0; i < size; i++) {
+            manyDuplicates[i] = (long) (i % 4);
+        }
+        Long[] manyDuplicatesSortedAsc = manyDuplicates.clone();
+        Arrays.sort(manyDuplicatesSortedAsc);
+        Long[] manyDuplicatesSortedDesc = manyDuplicatesSortedAsc.clone();
+        ArrayUtils.reverse(manyDuplicatesSortedDesc);
+
+        return Stream.of(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.ARRAY_SORT)
+                        .onFieldsWithData(allEqual, manyDuplicates)
+                        .andDataTypes(
+                                DataTypes.ARRAY(DataTypes.BIGINT()),
+                                DataTypes.ARRAY(DataTypes.BIGINT()))
+                        .testResult(
+                                call("ARRAY_SORT", $("f0")),
+                                "ARRAY_SORT(f0)",
+                                allEqual,
+                                DataTypes.ARRAY(DataTypes.BIGINT()))
+                        .testResult(
+                                call("ARRAY_SORT", $("f1")),
+                                "ARRAY_SORT(f1)",
+                                manyDuplicatesSortedAsc,
+                                DataTypes.ARRAY(DataTypes.BIGINT()))
+                        .testResult(
+                                call("ARRAY_SORT", $("f1"), false),
+                                "ARRAY_SORT(f1, false)",
+                                manyDuplicatesSortedDesc,
+                                DataTypes.ARRAY(DataTypes.BIGINT())));
     }
 
     private Stream<TestSetSpec> arrayExceptTestCases() {

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArraySortFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArraySortFunction.java
@@ -36,15 +36,16 @@ import java.util.Arrays;
 import java.util.Comparator;
 
 import static org.apache.flink.table.api.Expressions.$;
+import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedCall;
 
 /** Implementation of ARRAY_SORT function. */
 @Internal
 public class ArraySortFunction extends BuiltInScalarFunction {
 
     private final ArrayData.ElementGetter elementGetter;
-    private final SpecializedFunction.ExpressionEvaluator greaterEvaluator;
+    private final SpecializedFunction.ExpressionEvaluator compareEvaluator;
 
-    private transient MethodHandle greaterHandle;
+    private transient MethodHandle compareHandle;
 
     public ArraySortFunction(SpecializedFunction.SpecializedContext context) {
         super(BuiltInFunctionDefinitions.ARRAY_SORT, context);
@@ -54,17 +55,20 @@ public class ArraySortFunction extends BuiltInScalarFunction {
                         .toInternal();
         elementGetter =
                 ArrayData.createElementGetter(elementDataType.toInternal().getLogicalType());
-        greaterEvaluator =
+        compareEvaluator =
                 context.createEvaluator(
-                        $("element1").isGreater($("element2")),
-                        DataTypes.BOOLEAN(),
+                        unresolvedCall(
+                                BuiltInFunctionDefinitions.INTERNAL_COMPARE,
+                                $("element1"),
+                                $("element2")),
+                        DataTypes.INT().notNull(),
                         DataTypes.FIELD("element1", elementDataType.notNull().toInternal()),
                         DataTypes.FIELD("element2", elementDataType.notNull().toInternal()));
     }
 
     @Override
     public void open(FunctionContext context) throws Exception {
-        greaterHandle = greaterEvaluator.open(context);
+        compareHandle = compareEvaluator.open(context);
     }
 
     public @Nullable ArrayData eval(ArrayData array) {
@@ -109,8 +113,8 @@ public class ArraySortFunction extends BuiltInScalarFunction {
         @Override
         public int compare(Object o1, Object o2) {
             try {
-                boolean isGreater = (boolean) greaterHandle.invoke(o1, o2);
-                return isAscending ? (isGreater ? 1 : -1) : (isGreater ? -1 : 1);
+                int cmp = (int) compareHandle.invoke(o1, o2);
+                return isAscending ? cmp : -cmp;
             } catch (Throwable e) {
                 throw new RuntimeException(e);
             }
@@ -119,6 +123,6 @@ public class ArraySortFunction extends BuiltInScalarFunction {
 
     @Override
     public void close() throws Exception {
-        greaterEvaluator.close();
+        compareEvaluator.close();
     }
 }


### PR DESCRIPTION
The comparator built from a single SQL > probe returned +1 or -1 and never 0, so for equal elements compare(a,b) == compare(b,a) == -1. That violates antisymmetry and trips TimSort's contract check once an array is large enough to take the merge path (>= 32 elements with duplicates):

    java.lang.IllegalArgumentException: Comparison method violates its
    general contract!
        at java.util.TimSort.mergeHi(TimSort.java:903)
        ...
        at ArraySortFunction.eval(ArraySortFunction.java:91)

To fix this, we introduce an internal-only $COMPARE$1 function (analogous to the existing $HASHCODE$1) that returns a -1/0/+1 int and delegates its codegen to GenerateUtils.generateCompare - the same per-type compare helper ORDER BY already uses. ArraySortFunction now constructs a single INT-returning evaluator.

Coverage: a new 64-element BIGINT case in CollectionFunctionsITCase exercises the TimSort merge path with duplicates.

Generated-by: Claude (Opus 4.7)

## Verifying this change

This change added tests which fails without the fix.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): *no*
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: *no*
  - The serializers: *no*
  - The runtime per-record code paths (performance sensitive): *no*
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: *no*
  - The S3 file system connector: *no*

## Documentation

  - Does this pull request introduce a new feature? *no*
  - If yes, how is the feature documented? *not applicable*

---

##### Was generative AI tooling used to co-author this PR?

Generated-by: Claude (Opus 4.7)
