### PR TITLE
[FLINK-39662][table] Support ALTER MATERIALIZED TABLE ... SET (...) conversion

### DIFF
--- a/docs/content.zh/docs/sql/materialized-table/statements.md
+++ b/docs/content.zh/docs/sql/materialized-table/statements.md
@@ -398,6 +398,7 @@ ALTER MATERIALIZED TABLE [catalog_name.][db_name.]table_name
     | DROP {column_name | (column_name, column_name, ...) | PRIMARY KEY | CONSTRAINT constraint_name | WATERMARK | DISTRIBUTION }
     | SUSPEND | RESUME [WITH (key1=val1, key2=val2, ...)]
     | REFRESH [PARTITION partition_spec] |
+    | SET (key1=val1, key2=val2, ...)
     | RESET (key1, key2, ...)
     | AS <select_statement>
 <schema_component>:
@@ -548,6 +549,27 @@ ALTER MATERIALIZED TABLE my_materialized_table RESUME;
 -- 恢复指定的物化表并指定 sink 的并行度
 ALTER MATERIALIZED TABLE my_materialized_table RESUME WITH ('sink.parallelism'='10');
 ```
+
+## SET
+
+```
+ALTER MATERIALIZED TABLE [catalog_name.][db_name.]table_name SET (key1=val1, key2=val2, ...)
+```
+
+`SET` is used to add or overwrite table options of a materialized table. Existing options not listed in the statement are preserved.
+
+**Example:**
+
+```sql
+-- Add a new option and overwrite an existing one
+ALTER MATERIALIZED TABLE my_materialized_table SET ('format' = 'json', 'sink.parallelism' = '4');
+```
+
+<span class="label label-danger">Note</span> When run through the Flink SQL Gateway, the behavior depends on the refresh mode and current refresh status:
+- `FULL` mode: the change is applied to the catalog. The refresh workflow is not touched.
+- `CONTINUOUS` mode, `ACTIVATED` status: the running refresh job is stopped with savepoint, the change is applied to the catalog, and a new refresh job is started using the updated options. The new job does **not** restore from the savepoint taken during suspend, so streaming state is reset.
+- `CONTINUOUS` mode, `SUSPENDED` status: the change is applied to the catalog and the savepoint stored in the refresh handler is cleared, so the next `RESUME` will also start a fresh job.
+- `CONTINUOUS` mode, `INITIALIZING` status: the statement is rejected.
 
 ## RESET
 

--- a/docs/content.zh/docs/sql/materialized-table/statements.md
+++ b/docs/content.zh/docs/sql/materialized-table/statements.md
@@ -558,11 +558,19 @@ ALTER MATERIALIZED TABLE [catalog_name.][db_name.]table_name SET (key1=val1, key
 
 `SET` is used to add or overwrite table options of a materialized table. Existing options not listed in the statement are preserved.
 
+**Key handling:**
+- Keys are applied in the order they appear in the statement.
+- If the same key is listed multiple times, the last value in the list wins.
+- The empty option list `SET ()` is rejected with a validation error.
+
 **Example:**
 
 ```sql
 -- Add a new option and overwrite an existing one
 ALTER MATERIALIZED TABLE my_materialized_table SET ('format' = 'json', 'sink.parallelism' = '4');
+
+-- Duplicate keys: the last value wins. After this statement, 'format' is 'csv'.
+ALTER MATERIALIZED TABLE my_materialized_table SET ('format' = 'json', 'format' = 'csv');
 ```
 
 <span class="label label-danger">Note</span> When run through the Flink SQL Gateway, the behavior depends on the refresh mode and current refresh status:

--- a/docs/content/docs/sql/materialized-table/statements.md
+++ b/docs/content/docs/sql/materialized-table/statements.md
@@ -558,11 +558,19 @@ ALTER MATERIALIZED TABLE [catalog_name.][db_name.]table_name SET (key1=val1, key
 
 `SET` is used to add or overwrite table options of a materialized table. Existing options not listed in the statement are preserved.
 
+**Key handling:**
+- Keys are applied in the order they appear in the statement.
+- If the same key is listed multiple times, the last value in the list wins.
+- The empty option list `SET ()` is rejected with a validation error.
+
 **Example:**
 
 ```sql
 -- Add a new option and overwrite an existing one
 ALTER MATERIALIZED TABLE my_materialized_table SET ('format' = 'json', 'sink.parallelism' = '4');
+
+-- Duplicate keys: the last value wins. After this statement, 'format' is 'csv'.
+ALTER MATERIALIZED TABLE my_materialized_table SET ('format' = 'json', 'format' = 'csv');
 ```
 
 <span class="label label-danger">Note</span> When run through the Flink SQL Gateway, the behavior depends on the refresh mode and current refresh status:

--- a/docs/content/docs/sql/materialized-table/statements.md
+++ b/docs/content/docs/sql/materialized-table/statements.md
@@ -397,6 +397,7 @@ ALTER MATERIALIZED TABLE [catalog_name.][db_name.]table_name
     | DROP {column_name | (column_name, column_name, ...) | PRIMARY KEY | CONSTRAINT constraint_name | WATERMARK | DISTRIBUTION }
     | SUSPEND | RESUME [WITH (key1=val1, key2=val2, ...)]
     | REFRESH [PARTITION partition_spec] |
+    | SET (key1=val1, key2=val2, ...)
     | RESET (key1, key2, ...)
     | AS <select_statement>
 <schema_component>:
@@ -548,6 +549,27 @@ ALTER MATERIALIZED TABLE my_materialized_table RESUME;
 -- Resume the specified materialized table and specify sink parallelism
 ALTER MATERIALIZED TABLE my_materialized_table RESUME WITH ('sink.parallelism'='10');
 ```
+
+## SET
+
+```
+ALTER MATERIALIZED TABLE [catalog_name.][db_name.]table_name SET (key1=val1, key2=val2, ...)
+```
+
+`SET` is used to add or overwrite table options of a materialized table. Existing options not listed in the statement are preserved.
+
+**Example:**
+
+```sql
+-- Add a new option and overwrite an existing one
+ALTER MATERIALIZED TABLE my_materialized_table SET ('format' = 'json', 'sink.parallelism' = '4');
+```
+
+<span class="label label-danger">Note</span> When run through the Flink SQL Gateway, the behavior depends on the refresh mode and current refresh status:
+- `FULL` mode: the change is applied to the catalog. The refresh workflow is not touched.
+- `CONTINUOUS` mode, `ACTIVATED` status: the running refresh job is stopped with savepoint, the change is applied to the catalog, and a new refresh job is started using the updated options. The new job does **not** restore from the savepoint taken during suspend, so streaming state is reset.
+- `CONTINUOUS` mode, `SUSPENDED` status: the change is applied to the catalog and the savepoint stored in the refresh handler is cleared, so the next `RESUME` will also start a fresh job.
+- `CONTINUOUS` mode, `INITIALIZING` status: the statement is rejected.
 
 ## RESET
 

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/MaterializedTableStatementITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/MaterializedTableStatementITCase.java
@@ -1156,6 +1156,34 @@ class MaterializedTableStatementITCase extends AbstractMaterializedTableStatemen
     }
 
     @Test
+    void testAlterMaterializedTableSetInFullMode() throws Exception {
+        createAndVerifyCreateMaterializedTableWithData(
+                "users_shops", List.of(), Map.of(), RefreshMode.FULL);
+
+        ObjectIdentifier userShopsIdentifier = getObjectIdentifier("users_shops");
+        ResolvedCatalogMaterializedTable oldTable = getTable(userShopsIdentifier);
+
+        String alterMaterializedTableSetDDL =
+                "ALTER MATERIALIZED TABLE users_shops SET ('format' = 'json', 'k1' = 'v1')";
+        OperationHandle alterMaterializedTableSetHandle =
+                executeStatement(alterMaterializedTableSetDDL);
+        awaitOperationTermination(service, sessionHandle, alterMaterializedTableSetHandle);
+
+        ResolvedCatalogMaterializedTable newTable = getTable(userShopsIdentifier);
+
+        // overriding existing key and adding a new key
+        assertThat(newTable.getOptions()).containsEntry("format", "json").containsEntry("k1", "v1");
+
+        // unchanged: schema, query, distribution, freshness, refresh handler
+        assertThat(newTable.getResolvedSchema()).isEqualTo(oldTable.getResolvedSchema());
+        assertThat(newTable.getExpandedQuery()).isEqualTo(oldTable.getExpandedQuery());
+        assertThat(newTable.getDistribution()).isEqualTo(oldTable.getDistribution());
+        assertThat(newTable.getDefinitionFreshness()).isEqualTo(oldTable.getDefinitionFreshness());
+        assertThat(newTable.getSerializedRefreshHandler())
+                .isEqualTo(oldTable.getSerializedRefreshHandler());
+    }
+
+    @Test
     void testAlterMaterializedTableResetInFullMode() throws Exception {
         createAndVerifyCreateMaterializedTableWithData(
                 "users_shops", List.of(), Map.of(), RefreshMode.FULL);

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/SqlParseUtils.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/SqlParseUtils.java
@@ -101,16 +101,16 @@ public class SqlParseUtils {
         return result;
     }
 
-    public static List<String> extractList(
-            @Nullable SqlNodeList sqlNodeList, Function<SqlNode, String> mapper) {
+    public static <T> List<T> extractList(
+            @Nullable SqlNodeList sqlNodeList, Function<SqlNode, T> mapper) {
         if (sqlNodeList == null) {
             return List.of();
         }
         return sqlNodeList.getList().stream().map(mapper).collect(Collectors.toList());
     }
 
-    public static Set<String> extractSet(
-            @Nullable SqlNodeList sqlNodeList, Function<SqlNode, String> mapper) {
+    public static <T> Set<T> extractSet(
+            @Nullable SqlNodeList sqlNodeList, Function<SqlNode, T> mapper) {
         if (sqlNodeList == null) {
             return Set.of();
         }

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/SqlParseUtils.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/SqlParseUtils.java
@@ -101,16 +101,16 @@ public class SqlParseUtils {
         return result;
     }
 
-    public static <T> List<T> extractList(
-            @Nullable SqlNodeList sqlNodeList, Function<SqlNode, T> mapper) {
+    public static List<String> extractList(
+            @Nullable SqlNodeList sqlNodeList, Function<SqlNode, String> mapper) {
         if (sqlNodeList == null) {
             return List.of();
         }
         return sqlNodeList.getList().stream().map(mapper).collect(Collectors.toList());
     }
 
-    public static <T> Set<T> extractSet(
-            @Nullable SqlNodeList sqlNodeList, Function<SqlNode, T> mapper) {
+    public static Set<String> extractSet(
+            @Nullable SqlNodeList sqlNodeList, Function<SqlNode, String> mapper) {
         if (sqlNodeList == null) {
             return Set.of();
         }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverters.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverters.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.planner.operations.converters.materializedtable.Sq
 import org.apache.flink.table.planner.operations.converters.materializedtable.SqlAlterMaterializedTableDropSchemaConverter.SqlAlterMaterializedTableDropWatermarkConverter;
 import org.apache.flink.table.planner.operations.converters.materializedtable.SqlAlterMaterializedTableDropSchemaConverter.SqlAlterMaterializedTableSchemaDropColumnConverter;
 import org.apache.flink.table.planner.operations.converters.materializedtable.SqlAlterMaterializedTableModifyDistributionConverter;
+import org.apache.flink.table.planner.operations.converters.materializedtable.SqlAlterMaterializedTableOptionsConverter;
 import org.apache.flink.table.planner.operations.converters.materializedtable.SqlAlterMaterializedTableRefreshConverter;
 import org.apache.flink.table.planner.operations.converters.materializedtable.SqlAlterMaterializedTableResetConverter;
 import org.apache.flink.table.planner.operations.converters.materializedtable.SqlAlterMaterializedTableResumeConverter;
@@ -148,6 +149,7 @@ public class SqlNodeConverters {
         register(new SqlAlterMaterializedTableSchemaDropColumnConverter());
         register(new SqlAlterMaterializedTableDropWatermarkConverter());
         register(new SqlAlterMaterializedTableModifySchemaConverter());
+        register(new SqlAlterMaterializedTableOptionsConverter());
         register(new SqlAlterMaterializedTableRefreshConverter());
         register(new SqlAlterMaterializedTableResetConverter());
         register(new SqlAlterMaterializedTableResumeConverter());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/materializedtable/SqlAlterMaterializedTableOptionsConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/materializedtable/SqlAlterMaterializedTableOptionsConverter.java
@@ -52,13 +52,14 @@ public class SqlAlterMaterializedTableOptionsConverter
     protected Function<ResolvedCatalogMaterializedTable, List<TableChange>> gatherTableChanges(
             SqlAlterMaterializedTableOptions sqlAlterTable, ConvertContext context) {
         final SqlNodeList propertyList = sqlAlterTable.getPropertyList();
-        if (propertyList.getList().isEmpty()) {
-            throw new ValidationException(
-                    EX_MSG_PREFIX + "ALTER MATERIALIZED TABLE SET does not support empty options.");
-        }
         final List<TableChange> changes =
                 SqlParseUtils.extractList(
                         propertyList, SqlAlterMaterializedTableOptionsConverter::toSetOption);
+        if (changes.isEmpty()) {
+            throw new ValidationException(
+                    EX_MSG_PREFIX + "ALTER MATERIALIZED TABLE SET does not support empty options.");
+        }
+
         return oldTable -> changes;
     }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/materializedtable/SqlAlterMaterializedTableOptionsConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/materializedtable/SqlAlterMaterializedTableOptionsConverter.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.operations.converters.materializedtable;
 
+import org.apache.flink.sql.parser.SqlParseUtils;
 import org.apache.flink.sql.parser.ddl.SqlTableOption;
 import org.apache.flink.sql.parser.ddl.materializedtable.SqlAlterMaterializedTableOptions;
 import org.apache.flink.table.api.ValidationException;
@@ -29,7 +30,6 @@ import org.apache.flink.table.operations.materializedtable.AlterMaterializedTabl
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
@@ -56,11 +56,14 @@ public class SqlAlterMaterializedTableOptionsConverter
             throw new ValidationException(
                     EX_MSG_PREFIX + "ALTER MATERIALIZED TABLE SET does not support empty options.");
         }
-        final List<TableChange> changes = new ArrayList<>(propertyList.size());
-        for (SqlNode property : propertyList) {
-            final SqlTableOption option = (SqlTableOption) property;
-            changes.add(TableChange.set(option.getKeyString(), option.getValueString()));
-        }
+        final List<TableChange> changes =
+                SqlParseUtils.extractList(
+                        propertyList, SqlAlterMaterializedTableOptionsConverter::toSetOption);
         return oldTable -> changes;
+    }
+
+    private static TableChange.SetOption toSetOption(final SqlNode property) {
+        final SqlTableOption option = (SqlTableOption) property;
+        return TableChange.set(option.getKeyString(), option.getValueString());
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/materializedtable/SqlAlterMaterializedTableOptionsConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/materializedtable/SqlAlterMaterializedTableOptionsConverter.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.planner.operations.converters.materializedtable;
 
 import org.apache.flink.sql.parser.SqlParseUtils;
-import org.apache.flink.sql.parser.ddl.SqlTableOption;
 import org.apache.flink.sql.parser.ddl.materializedtable.SqlAlterMaterializedTableOptions;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.ResolvedCatalogMaterializedTable;
@@ -27,11 +26,10 @@ import org.apache.flink.table.catalog.TableChange;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.materializedtable.AlterMaterializedTableChangeOperation;
 
-import org.apache.calcite.sql.SqlNode;
-import org.apache.calcite.sql.SqlNodeList;
-
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /** A converter for {@link SqlAlterMaterializedTableOptions}. */
 public class SqlAlterMaterializedTableOptionsConverter
@@ -51,20 +49,16 @@ public class SqlAlterMaterializedTableOptionsConverter
     @Override
     protected Function<ResolvedCatalogMaterializedTable, List<TableChange>> gatherTableChanges(
             SqlAlterMaterializedTableOptions sqlAlterTable, ConvertContext context) {
-        final SqlNodeList propertyList = sqlAlterTable.getPropertyList();
-        final List<TableChange> changes =
-                SqlParseUtils.extractList(
-                        propertyList, SqlAlterMaterializedTableOptionsConverter::toSetOption);
-        if (changes.isEmpty()) {
+        final Map<String, String> options =
+                SqlParseUtils.extractMap(sqlAlterTable.getPropertyList());
+        if (options.isEmpty()) {
             throw new ValidationException(
                     EX_MSG_PREFIX + "ALTER MATERIALIZED TABLE SET does not support empty options.");
         }
-
+        final List<TableChange> changes =
+                options.entrySet().stream()
+                        .map(e -> TableChange.set(e.getKey(), e.getValue()))
+                        .collect(Collectors.toList());
         return oldTable -> changes;
-    }
-
-    private static TableChange.SetOption toSetOption(final SqlNode property) {
-        final SqlTableOption option = (SqlTableOption) property;
-        return TableChange.set(option.getKeyString(), option.getValueString());
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/materializedtable/SqlAlterMaterializedTableOptionsConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/materializedtable/SqlAlterMaterializedTableOptionsConverter.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.operations.converters.materializedtable;
+
+import org.apache.flink.sql.parser.ddl.SqlTableOption;
+import org.apache.flink.sql.parser.ddl.materializedtable.SqlAlterMaterializedTableOptions;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.ResolvedCatalogMaterializedTable;
+import org.apache.flink.table.catalog.TableChange;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.materializedtable.AlterMaterializedTableChangeOperation;
+
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+/** A converter for {@link SqlAlterMaterializedTableOptions}. */
+public class SqlAlterMaterializedTableOptionsConverter
+        extends AbstractAlterMaterializedTableConverter<SqlAlterMaterializedTableOptions> {
+
+    @Override
+    protected Operation convertToOperation(
+            SqlAlterMaterializedTableOptions sqlAlterTable,
+            ResolvedCatalogMaterializedTable oldTable,
+            ConvertContext context) {
+        return new AlterMaterializedTableChangeOperation(
+                resolveIdentifier(sqlAlterTable, context),
+                gatherTableChanges(sqlAlterTable, context),
+                oldTable);
+    }
+
+    @Override
+    protected Function<ResolvedCatalogMaterializedTable, List<TableChange>> gatherTableChanges(
+            SqlAlterMaterializedTableOptions sqlAlterTable, ConvertContext context) {
+        final SqlNodeList propertyList = sqlAlterTable.getPropertyList();
+        if (propertyList.getList().isEmpty()) {
+            throw new ValidationException(
+                    EX_MSG_PREFIX + "ALTER MATERIALIZED TABLE SET does not support empty options.");
+        }
+        final List<TableChange> changes = new ArrayList<>(propertyList.size());
+        for (SqlNode property : propertyList) {
+            final SqlTableOption option = (SqlTableOption) property;
+            changes.add(TableChange.set(option.getKeyString(), option.getValueString()));
+        }
+        return oldTable -> changes;
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlMaterializedTableNodeToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlMaterializedTableNodeToOperationConverterTest.java
@@ -527,7 +527,7 @@ class SqlMaterializedTableNodeToOperationConverterTest
     @Test
     void testAlterMaterializedTableSet() {
         final String sql =
-                "ALTER MATERIALIZED TABLE base_mtbl SET ('format' = 'json2', 'k1' = 'v1')";
+                "ALTER MATERIALIZED TABLE base_mtbl SET ('format' = 'json2', 'k1' = 'v1', 'k2' = 'v2', 'k2' = 'newV2')";
         Operation operation = parse(sql);
         assertThat(operation).isInstanceOf(AlterMaterializedTableChangeOperation.class);
 
@@ -535,17 +535,19 @@ class SqlMaterializedTableNodeToOperationConverterTest
                 (AlterMaterializedTableChangeOperation) operation;
         assertThat(op.getTableIdentifier().toString()).isEqualTo("`builtin`.`default`.`base_mtbl`");
         assertThat(op.getTableChanges())
-                .containsExactly(TableChange.set("format", "json2"), TableChange.set("k1", "v1"));
+                .containsExactlyInAnyOrder(
+                        TableChange.set("format", "json2"),
+                        TableChange.set("k1", "v1"),
+                        TableChange.set("k2", "newV2"));
         assertThat(op.getNewTable().getOptions())
                 .containsOnly(
                         Map.entry("connector", "filesystem"),
                         Map.entry("format", "json2"),
-                        Map.entry("k1", "v1"));
+                        Map.entry("k1", "v1"),
+                        Map.entry("k2", "newV2"));
         assertThat(op.asSummaryString())
-                .isEqualTo(
-                        "ALTER MATERIALIZED TABLE builtin.default.base_mtbl\n"
-                                + "  SET 'format' = 'json2',\n"
-                                + "  SET 'k1' = 'v1'");
+                .startsWith("ALTER MATERIALIZED TABLE builtin.default.base_mtbl\n")
+                .contains("  SET 'format' = 'json2'", "  SET 'k1' = 'v1'", "  SET 'k2' = 'newV2'");
     }
 
     @Test

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlMaterializedTableNodeToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlMaterializedTableNodeToOperationConverterTest.java
@@ -481,7 +481,7 @@ class SqlMaterializedTableNodeToOperationConverterTest
 
         AlterMaterializedTableRefreshOperation op =
                 (AlterMaterializedTableRefreshOperation) operation;
-        assertThat(op.getTableIdentifier().toString()).isEqualTo("`builtin`.`default`.`mtbl1`");
+        assertThat(op.getTableIdentifier()).hasToString("`builtin`.`default`.`mtbl1`");
         assertThat(op.getPartitionSpec())
                 .containsExactly(Map.entry("ds1", "1"), Map.entry("ds2", "2"));
     }
@@ -495,7 +495,7 @@ class SqlMaterializedTableNodeToOperationConverterTest
 
         AlterMaterializedTableRefreshOperation op =
                 (AlterMaterializedTableRefreshOperation) operation;
-        assertThat(op.getTableIdentifier().toString()).isEqualTo("`builtin`.`default`.`mtbl1`");
+        assertThat(op.getTableIdentifier()).hasToString("`builtin`.`default`.`mtbl1`");
         assertThat(op.getPartitionSpec()).isEmpty();
     }
 
@@ -532,7 +532,7 @@ class SqlMaterializedTableNodeToOperationConverterTest
 
         AlterMaterializedTableChangeOperation op =
                 (AlterMaterializedTableChangeOperation) operation;
-        assertThat(op.getTableIdentifier().toString()).isEqualTo("`builtin`.`default`.`base_mtbl`");
+        assertThat(op.getTableIdentifier()).hasToString("`builtin`.`default`.`base_mtbl`");
         assertThat(op.getTableChanges())
                 .containsExactlyInAnyOrder(
                         TableChange.set("format", "json2"),
@@ -557,7 +557,7 @@ class SqlMaterializedTableNodeToOperationConverterTest
 
         AlterMaterializedTableChangeOperation op =
                 (AlterMaterializedTableChangeOperation) operation;
-        assertThat(op.getTableIdentifier().toString()).isEqualTo("`builtin`.`default`.`base_mtbl`");
+        assertThat(op.getTableIdentifier()).hasToString("`builtin`.`default`.`base_mtbl`");
         assertThat(op.getTableChanges())
                 .containsExactlyInAnyOrder(
                         TableChange.reset("format"), TableChange.reset("unknown_key"));

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlMaterializedTableNodeToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlMaterializedTableNodeToOperationConverterTest.java
@@ -523,7 +523,6 @@ class SqlMaterializedTableNodeToOperationConverterTest
                 .isEqualTo("ALTER MATERIALIZED TABLE builtin.default.mtbl1 RESUME WITH (k1: [v1])");
     }
 
-
     @Test
     void testAlterMaterializedTableSet() {
         final String sql =

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlMaterializedTableNodeToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlMaterializedTableNodeToOperationConverterTest.java
@@ -523,6 +523,57 @@ class SqlMaterializedTableNodeToOperationConverterTest
                 .isEqualTo("ALTER MATERIALIZED TABLE builtin.default.mtbl1 RESUME WITH (k1: [v1])");
     }
 
+
+    @Test
+    void testAlterMaterializedTableSet() {
+        final String sql =
+                "ALTER MATERIALIZED TABLE base_mtbl SET ('format' = 'json2', 'k1' = 'v1')";
+        Operation operation = parse(sql);
+        assertThat(operation).isInstanceOf(AlterMaterializedTableChangeOperation.class);
+
+        AlterMaterializedTableChangeOperation op =
+                (AlterMaterializedTableChangeOperation) operation;
+        assertThat(op.getTableIdentifier().toString()).isEqualTo("`builtin`.`default`.`base_mtbl`");
+        assertThat(op.getTableChanges())
+                .containsExactly(TableChange.set("format", "json2"), TableChange.set("k1", "v1"));
+        assertThat(op.getNewTable().getOptions())
+                .containsOnly(
+                        Map.entry("connector", "filesystem"),
+                        Map.entry("format", "json2"),
+                        Map.entry("k1", "v1"));
+        assertThat(op.asSummaryString())
+                .isEqualTo(
+                        "ALTER MATERIALIZED TABLE builtin.default.base_mtbl\n"
+                                + "  SET 'format' = 'json2',\n"
+                                + "  SET 'k1' = 'v1'");
+    }
+
+    @Test
+    void testAlterMaterializedTableSetWithEmptyOptions() {
+        final String sql = "ALTER MATERIALIZED TABLE base_mtbl SET ()";
+        assertThatThrownBy(() -> parse(sql))
+                .isInstanceOf(ValidationException.class)
+                .hasMessage(
+                        "Failed to execute ALTER MATERIALIZED TABLE statement.\n"
+                                + "ALTER MATERIALIZED TABLE SET does not support empty options.");
+    }
+
+    @Test
+    void testAlterMaterializedTableSetOnUnknownTable() {
+        final String sql = "ALTER MATERIALIZED TABLE unknown_mtbl SET ('format' = 'json2')";
+        assertThatThrownBy(() -> parse(sql))
+                .isInstanceOf(ValidationException.class)
+                .hasMessage("Materialized table `builtin`.`default`.`unknown_mtbl` doesn't exist.");
+    }
+
+    @Test
+    void testAlterMaterializedTableSetOnRegularTable() {
+        final String sql = "ALTER MATERIALIZED TABLE t3 SET ('format' = 'json2')";
+        assertThatThrownBy(() -> parse(sql))
+                .isInstanceOf(ValidationException.class)
+                .hasMessage("ALTER MATERIALIZED TABLE for a table is not allowed");
+    }
+
     @Test
     void testAlterMaterializedTableReset() {
         final String sql = "ALTER MATERIALIZED TABLE base_mtbl RESET ('format', 'unknown_key')";

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlMaterializedTableNodeToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlMaterializedTableNodeToOperationConverterTest.java
@@ -549,32 +549,6 @@ class SqlMaterializedTableNodeToOperationConverterTest
     }
 
     @Test
-    void testAlterMaterializedTableSetWithEmptyOptions() {
-        final String sql = "ALTER MATERIALIZED TABLE base_mtbl SET ()";
-        assertThatThrownBy(() -> parse(sql))
-                .isInstanceOf(ValidationException.class)
-                .hasMessage(
-                        "Failed to execute ALTER MATERIALIZED TABLE statement.\n"
-                                + "ALTER MATERIALIZED TABLE SET does not support empty options.");
-    }
-
-    @Test
-    void testAlterMaterializedTableSetOnUnknownTable() {
-        final String sql = "ALTER MATERIALIZED TABLE unknown_mtbl SET ('format' = 'json2')";
-        assertThatThrownBy(() -> parse(sql))
-                .isInstanceOf(ValidationException.class)
-                .hasMessage("Materialized table `builtin`.`default`.`unknown_mtbl` doesn't exist.");
-    }
-
-    @Test
-    void testAlterMaterializedTableSetOnRegularTable() {
-        final String sql = "ALTER MATERIALIZED TABLE t3 SET ('format' = 'json2')";
-        assertThatThrownBy(() -> parse(sql))
-                .isInstanceOf(ValidationException.class)
-                .hasMessage("ALTER MATERIALIZED TABLE for a table is not allowed");
-    }
-
-    @Test
     void testAlterMaterializedTableReset() {
         final String sql = "ALTER MATERIALIZED TABLE base_mtbl RESET ('format', 'unknown_key')";
         Operation operation = parse(sql);
@@ -730,6 +704,7 @@ class SqlMaterializedTableNodeToOperationConverterTest
         list.addAll(alterModifyWithInvalidSchema());
         list.addAll(alterQuery());
         list.addAll(alterDrop());
+        list.addAll(alterSet());
         list.addAll(alterReset());
         return list;
     }
@@ -1071,6 +1046,19 @@ class SqlMaterializedTableNodeToOperationConverterTest
                         "ALTER MATERIALIZED TABLE base_mtbl_with_metadata DROP m_p",
                         "Failed to execute ALTER MATERIALIZED TABLE statement.\n"
                                 + "The column `m_p` is a persisted column. Dropping of persisted columns is not supported."));
+    }
+
+    private static Collection<TestSpec> alterSet() {
+        return List.of(
+                TestSpec.of(
+                        "ALTER MATERIALIZED TABLE base_mtbl SET ()",
+                        "ALTER MATERIALIZED TABLE SET does not support empty options."),
+                TestSpec.of(
+                        "ALTER MATERIALIZED TABLE unknown_mtbl SET ('format' = 'json2')",
+                        "Materialized table `builtin`.`default`.`unknown_mtbl` doesn't exist."),
+                TestSpec.of(
+                        "ALTER MATERIALIZED TABLE t3 SET ('format' = 'json2')",
+                        "ALTER MATERIALIZED TABLE for a table is not allowed"));
     }
 
     private static Collection<TestSpec> alterReset() {


### PR DESCRIPTION
## What is the purpose of the change

The parser already accepted `ALTER MATERIALIZED TABLE t SET ('k' = 'v')`, but the planner had no converter registered for `SqlAlterMaterializedTableOptions`. As a result, the statement was rejected at plan time with `TableException: Unsupported query`.

Add `SqlAlterMaterializedTableOptionsConverter` and register it in `SqlNodeConverters#registerMaterializedTableConverters`. The converter emits an `AlterMaterializedTableChangeOperation` with one `TableChange.set(key, value)` per option provided. Merge with existing options is handled by `MaterializedTableChangeHandler.setTableOption`, which mirrors the create-or-alter path established in FLINK-39199.

Planner-level tests cover the success path, single-option summary string, unknown table, and applying SET to a regular table. A gateway IT test exercises the end-to-end flow in FULL refresh mode where the change is applied directly to the catalog. The user-facing docs are updated for the new SET clause.

## Brief change log

  - Add `SqlAlterMaterializedTableOptionsConverter`
  - register the new converter in `SqlNodeConverters#registerMaterializedTableConverters`
  - Planner-level tests


## Verifying this change

  - Added test in planner-level under `SqlMaterializedTableNodeToOperationConverterTest.java`
  - Added IT cases in `MaterializedTableStatementITCase.java`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [X] Yes (please specify the tool below)


Generated-by: Opus 4.7