### PR TITLE
[FLINK-39663][table] Support ALTER MATERIALIZED TABLE ... RESET (...) conversion

### DIFF
--- a/docs/content.zh/docs/sql/materialized-table/statements.md
+++ b/docs/content.zh/docs/sql/materialized-table/statements.md
@@ -398,6 +398,7 @@ ALTER MATERIALIZED TABLE [catalog_name.][db_name.]table_name
     | DROP {column_name | (column_name, column_name, ...) | PRIMARY KEY | CONSTRAINT constraint_name | WATERMARK | DISTRIBUTION }
     | SUSPEND | RESUME [WITH (key1=val1, key2=val2, ...)]
     | REFRESH [PARTITION partition_spec] |
+    | RESET (key1, key2, ...)
     | AS <select_statement>
 <schema_component>:
   { <column_component> | <constraint_component> | <watermark_component> }
@@ -547,6 +548,27 @@ ALTER MATERIALIZED TABLE my_materialized_table RESUME;
 -- 恢复指定的物化表并指定 sink 的并行度
 ALTER MATERIALIZED TABLE my_materialized_table RESUME WITH ('sink.parallelism'='10');
 ```
+
+## RESET
+
+```
+ALTER MATERIALIZED TABLE [catalog_name.][db_name.]table_name RESET (key1, key2, ...)
+```
+
+`RESET` is used to remove table options from a materialized table. Keys that are not currently set on the table are silently ignored. The `connector` key cannot be reset.
+
+**Example:**
+
+```sql
+-- Remove the 'format' and 'sink.parallelism' options
+ALTER MATERIALIZED TABLE my_materialized_table RESET ('format', 'sink.parallelism');
+```
+
+<span class="label label-danger">Note</span> When run through the Flink SQL Gateway, the behavior depends on the refresh mode and current refresh status:
+- `FULL` mode: the change is applied to the catalog. The refresh workflow is not touched.
+- `CONTINUOUS` mode, `ACTIVATED` status: the running refresh job is stopped with savepoint, the change is applied to the catalog, and a new refresh job is started using the updated options. The new job does **not** restore from the savepoint taken during suspend, so streaming state is reset.
+- `CONTINUOUS` mode, `SUSPENDED` status: the change is applied to the catalog and the savepoint stored in the refresh handler is cleared, so the next `RESUME` will also start a fresh job.
+- `CONTINUOUS` mode, `INITIALIZING` status: the statement is rejected.
 
 ## REFRESH
 

--- a/docs/content.zh/docs/sql/materialized-table/statements.md
+++ b/docs/content.zh/docs/sql/materialized-table/statements.md
@@ -555,13 +555,26 @@ ALTER MATERIALIZED TABLE my_materialized_table RESUME WITH ('sink.parallelism'='
 ALTER MATERIALIZED TABLE [catalog_name.][db_name.]table_name RESET (key1, key2, ...)
 ```
 
-`RESET` is used to remove table options from a materialized table. Keys that are not currently set on the table are silently ignored. The `connector` key cannot be reset.
+`RESET` is used to remove table options from a materialized table.
+
+**Key handling:**
+- Keys that are not currently set on the table are silently ignored. The statement still succeeds.
+- Duplicate keys in the key list are de-duplicated and treated as a single reset for that key.
+- The empty key list `RESET ()` is rejected with a validation error.
+- The `connector` key is reserved and cannot be reset. Attempting to do so is rejected with a validation error.
 
 **Example:**
 
 ```sql
 -- Remove the 'format' and 'sink.parallelism' options
 ALTER MATERIALIZED TABLE my_materialized_table RESET ('format', 'sink.parallelism');
+
+-- 'sink.parallelism' is not currently set on the table: this is a no-op for that key,
+-- 'format' is still removed and the statement succeeds.
+ALTER MATERIALIZED TABLE my_materialized_table RESET ('format', 'sink.parallelism');
+
+-- Duplicates collapse to a single reset for 'format'.
+ALTER MATERIALIZED TABLE my_materialized_table RESET ('format', 'format');
 ```
 
 <span class="label label-danger">Note</span> When run through the Flink SQL Gateway, the behavior depends on the refresh mode and current refresh status:

--- a/docs/content/docs/sql/materialized-table/statements.md
+++ b/docs/content/docs/sql/materialized-table/statements.md
@@ -555,13 +555,26 @@ ALTER MATERIALIZED TABLE my_materialized_table RESUME WITH ('sink.parallelism'='
 ALTER MATERIALIZED TABLE [catalog_name.][db_name.]table_name RESET (key1, key2, ...)
 ```
 
-`RESET` is used to remove table options from a materialized table. Keys that are not currently set on the table are silently ignored. The `connector` key cannot be reset.
+`RESET` is used to remove table options from a materialized table.
+
+**Key handling:**
+- Keys that are not currently set on the table are silently ignored. The statement still succeeds.
+- Duplicate keys in the key list are de-duplicated and treated as a single reset for that key.
+- The empty key list `RESET ()` is rejected with a validation error.
+- The `connector` key is reserved and cannot be reset. Attempting to do so is rejected with a validation error.
 
 **Example:**
 
 ```sql
 -- Remove the 'format' and 'sink.parallelism' options
 ALTER MATERIALIZED TABLE my_materialized_table RESET ('format', 'sink.parallelism');
+
+-- 'sink.parallelism' is not currently set on the table: this is a no-op for that key,
+-- 'format' is still removed and the statement succeeds.
+ALTER MATERIALIZED TABLE my_materialized_table RESET ('format', 'sink.parallelism');
+
+-- Duplicates collapse to a single reset for 'format'.
+ALTER MATERIALIZED TABLE my_materialized_table RESET ('format', 'format');
 ```
 
 <span class="label label-danger">Note</span> When run through the Flink SQL Gateway, the behavior depends on the refresh mode and current refresh status:

--- a/docs/content/docs/sql/materialized-table/statements.md
+++ b/docs/content/docs/sql/materialized-table/statements.md
@@ -397,6 +397,7 @@ ALTER MATERIALIZED TABLE [catalog_name.][db_name.]table_name
     | DROP {column_name | (column_name, column_name, ...) | PRIMARY KEY | CONSTRAINT constraint_name | WATERMARK | DISTRIBUTION }
     | SUSPEND | RESUME [WITH (key1=val1, key2=val2, ...)]
     | REFRESH [PARTITION partition_spec] |
+    | RESET (key1, key2, ...)
     | AS <select_statement>
 <schema_component>:
   { <column_component> | <constraint_component> | <watermark_component> }
@@ -547,6 +548,27 @@ ALTER MATERIALIZED TABLE my_materialized_table RESUME;
 -- Resume the specified materialized table and specify sink parallelism
 ALTER MATERIALIZED TABLE my_materialized_table RESUME WITH ('sink.parallelism'='10');
 ```
+
+## RESET
+
+```
+ALTER MATERIALIZED TABLE [catalog_name.][db_name.]table_name RESET (key1, key2, ...)
+```
+
+`RESET` is used to remove table options from a materialized table. Keys that are not currently set on the table are silently ignored. The `connector` key cannot be reset.
+
+**Example:**
+
+```sql
+-- Remove the 'format' and 'sink.parallelism' options
+ALTER MATERIALIZED TABLE my_materialized_table RESET ('format', 'sink.parallelism');
+```
+
+<span class="label label-danger">Note</span> When run through the Flink SQL Gateway, the behavior depends on the refresh mode and current refresh status:
+- `FULL` mode: the change is applied to the catalog. The refresh workflow is not touched.
+- `CONTINUOUS` mode, `ACTIVATED` status: the running refresh job is stopped with savepoint, the change is applied to the catalog, and a new refresh job is started using the updated options. The new job does **not** restore from the savepoint taken during suspend, so streaming state is reset.
+- `CONTINUOUS` mode, `SUSPENDED` status: the change is applied to the catalog and the savepoint stored in the refresh handler is cleared, so the next `RESUME` will also start a fresh job.
+- `CONTINUOUS` mode, `INITIALIZING` status: the statement is rejected.
 
 ## REFRESH
 

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/MaterializedTableStatementITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/MaterializedTableStatementITCase.java
@@ -1156,6 +1156,35 @@ class MaterializedTableStatementITCase extends AbstractMaterializedTableStatemen
     }
 
     @Test
+    void testAlterMaterializedTableResetInFullMode() throws Exception {
+        createAndVerifyCreateMaterializedTableWithData(
+                "users_shops", List.of(), Map.of(), RefreshMode.FULL);
+
+        ObjectIdentifier userShopsIdentifier = getObjectIdentifier("users_shops");
+        ResolvedCatalogMaterializedTable oldTable = getTable(userShopsIdentifier);
+        assertThat(oldTable.getOptions()).containsKey("format");
+
+        String alterMaterializedTableResetDDL =
+                "ALTER MATERIALIZED TABLE users_shops RESET ('format', 'unknown_key')";
+        OperationHandle alterMaterializedTableResetHandle =
+                executeStatement(alterMaterializedTableResetDDL);
+        awaitOperationTermination(service, sessionHandle, alterMaterializedTableResetHandle);
+
+        ResolvedCatalogMaterializedTable newTable = getTable(userShopsIdentifier);
+
+        // the existing key is removed, the unknown key is a no-op
+        assertThat(newTable.getOptions()).doesNotContainKey("format");
+
+        // unchanged: schema, query, distribution, freshness, refresh handler
+        assertThat(newTable.getResolvedSchema()).isEqualTo(oldTable.getResolvedSchema());
+        assertThat(newTable.getExpandedQuery()).isEqualTo(oldTable.getExpandedQuery());
+        assertThat(newTable.getDistribution()).isEqualTo(oldTable.getDistribution());
+        assertThat(newTable.getDefinitionFreshness()).isEqualTo(oldTable.getDefinitionFreshness());
+        assertThat(newTable.getSerializedRefreshHandler())
+                .isEqualTo(oldTable.getSerializedRefreshHandler());
+    }
+
+    @Test
     void testAlterMaterializedTableAsQueryInFullModeWithSuspendStatus() throws Exception {
         createAndVerifyCreateMaterializedTableWithData(
                 "users_shops", List.of(), Map.of(), RefreshMode.FULL);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverters.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverters.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.planner.operations.converters.materializedtable.Sq
 import org.apache.flink.table.planner.operations.converters.materializedtable.SqlAlterMaterializedTableDropSchemaConverter.SqlAlterMaterializedTableSchemaDropColumnConverter;
 import org.apache.flink.table.planner.operations.converters.materializedtable.SqlAlterMaterializedTableModifyDistributionConverter;
 import org.apache.flink.table.planner.operations.converters.materializedtable.SqlAlterMaterializedTableRefreshConverter;
+import org.apache.flink.table.planner.operations.converters.materializedtable.SqlAlterMaterializedTableResetConverter;
 import org.apache.flink.table.planner.operations.converters.materializedtable.SqlAlterMaterializedTableResumeConverter;
 import org.apache.flink.table.planner.operations.converters.materializedtable.SqlAlterMaterializedTableSchemaConverter.SqlAlterMaterializedTableAddSchemaConverter;
 import org.apache.flink.table.planner.operations.converters.materializedtable.SqlAlterMaterializedTableSchemaConverter.SqlAlterMaterializedTableModifySchemaConverter;
@@ -148,6 +149,7 @@ public class SqlNodeConverters {
         register(new SqlAlterMaterializedTableDropWatermarkConverter());
         register(new SqlAlterMaterializedTableModifySchemaConverter());
         register(new SqlAlterMaterializedTableRefreshConverter());
+        register(new SqlAlterMaterializedTableResetConverter());
         register(new SqlAlterMaterializedTableResumeConverter());
         register(new SqlAlterMaterializedTableSuspendConverter());
         register(new SqlCreateOrAlterMaterializedTableConverter());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/materializedtable/SqlAlterMaterializedTableResetConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/materializedtable/SqlAlterMaterializedTableResetConverter.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.operations.converters.materializedtable;
+
+import org.apache.flink.sql.parser.SqlParseUtils;
+import org.apache.flink.sql.parser.ddl.materializedtable.SqlAlterMaterializedTableReset;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.ResolvedCatalogMaterializedTable;
+import org.apache.flink.table.catalog.TableChange;
+import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.materializedtable.AlterMaterializedTableChangeOperation;
+
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+/** A converter for {@link SqlAlterMaterializedTableReset}. */
+public class SqlAlterMaterializedTableResetConverter
+        extends AbstractAlterMaterializedTableConverter<SqlAlterMaterializedTableReset> {
+
+    @Override
+    protected Operation convertToOperation(
+            SqlAlterMaterializedTableReset sqlAlterTable,
+            ResolvedCatalogMaterializedTable oldTable,
+            ConvertContext context) {
+        return new AlterMaterializedTableChangeOperation(
+                resolveIdentifier(sqlAlterTable, context),
+                gatherTableChanges(sqlAlterTable, context),
+                oldTable);
+    }
+
+    @Override
+    protected Function<ResolvedCatalogMaterializedTable, List<TableChange>> gatherTableChanges(
+            SqlAlterMaterializedTableReset sqlAlterTable, ConvertContext context) {
+        final SqlNodeList propertyKeyList = sqlAlterTable.getPropertyKeyList();
+        if (propertyKeyList.getList().isEmpty()) {
+            throw new ValidationException(
+                    EX_MSG_PREFIX + "ALTER MATERIALIZED TABLE RESET does not support empty key.");
+        }
+        final Set<String> resetKeys = new LinkedHashSet<>(propertyKeyList.size());
+        for (SqlNode key : propertyKeyList) {
+            resetKeys.add(SqlParseUtils.extractString((SqlLiteral) key));
+        }
+        if (resetKeys.contains(FactoryUtil.CONNECTOR.key())) {
+            throw new ValidationException(
+                    EX_MSG_PREFIX
+                            + "ALTER MATERIALIZED TABLE RESET does not support changing 'connector'.");
+        }
+        final List<TableChange> changes = new ArrayList<>(resetKeys.size());
+        for (String key : resetKeys) {
+            changes.add(TableChange.reset(key));
+        }
+        return oldTable -> changes;
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/materializedtable/SqlAlterMaterializedTableResetConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/materializedtable/SqlAlterMaterializedTableResetConverter.java
@@ -28,13 +28,10 @@ import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.materializedtable.AlterMaterializedTableChangeOperation;
 
 import org.apache.calcite.sql.SqlLiteral;
-import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
 
 import java.util.ArrayList;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Function;
 
 /** A converter for {@link SqlAlterMaterializedTableReset}. */
@@ -60,10 +57,9 @@ public class SqlAlterMaterializedTableResetConverter
             throw new ValidationException(
                     EX_MSG_PREFIX + "ALTER MATERIALIZED TABLE RESET does not support empty key.");
         }
-        final Set<String> resetKeys = new LinkedHashSet<>(propertyKeyList.size());
-        for (SqlNode key : propertyKeyList) {
-            resetKeys.add(SqlParseUtils.extractString((SqlLiteral) key));
-        }
+        final List<String> resetKeys =
+                SqlParseUtils.extractList(
+                        propertyKeyList, key -> SqlParseUtils.extractString((SqlLiteral) key));
         if (resetKeys.contains(FactoryUtil.CONNECTOR.key())) {
             throw new ValidationException(
                     EX_MSG_PREFIX

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/materializedtable/SqlAlterMaterializedTableResetConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/materializedtable/SqlAlterMaterializedTableResetConverter.java
@@ -32,6 +32,7 @@ import org.apache.calcite.sql.SqlNodeList;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Function;
 
 /** A converter for {@link SqlAlterMaterializedTableReset}. */
@@ -53,13 +54,13 @@ public class SqlAlterMaterializedTableResetConverter
     protected Function<ResolvedCatalogMaterializedTable, List<TableChange>> gatherTableChanges(
             SqlAlterMaterializedTableReset sqlAlterTable, ConvertContext context) {
         final SqlNodeList propertyKeyList = sqlAlterTable.getPropertyKeyList();
-        if (propertyKeyList.getList().isEmpty()) {
+        final Set<String> resetKeys =
+                SqlParseUtils.extractSet(
+                        propertyKeyList, key -> SqlParseUtils.extractString((SqlLiteral) key));
+        if (resetKeys.isEmpty()) {
             throw new ValidationException(
                     EX_MSG_PREFIX + "ALTER MATERIALIZED TABLE RESET does not support empty key.");
         }
-        final List<String> resetKeys =
-                SqlParseUtils.extractList(
-                        propertyKeyList, key -> SqlParseUtils.extractString((SqlLiteral) key));
         if (resetKeys.contains(FactoryUtil.CONNECTOR.key())) {
             throw new ValidationException(
                     EX_MSG_PREFIX

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlMaterializedTableNodeToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlMaterializedTableNodeToOperationConverterTest.java
@@ -524,6 +524,63 @@ class SqlMaterializedTableNodeToOperationConverterTest
     }
 
     @Test
+    void testAlterMaterializedTableReset() {
+        final String sql = "ALTER MATERIALIZED TABLE base_mtbl RESET ('format', 'unknown_key')";
+        Operation operation = parse(sql);
+        assertThat(operation).isInstanceOf(AlterMaterializedTableChangeOperation.class);
+
+        AlterMaterializedTableChangeOperation op =
+                (AlterMaterializedTableChangeOperation) operation;
+        assertThat(op.getTableIdentifier().toString()).isEqualTo("`builtin`.`default`.`base_mtbl`");
+        assertThat(op.getTableChanges())
+                .containsExactly(TableChange.reset("format"), TableChange.reset("unknown_key"));
+        // resetting an unknown key is a no-op for the catalog state
+        assertThat(op.getNewTable().getOptions())
+                .containsOnly(Map.entry("connector", "filesystem"));
+        assertThat(op.asSummaryString())
+                .isEqualTo(
+                        "ALTER MATERIALIZED TABLE builtin.default.base_mtbl\n"
+                                + "  RESET 'format',\n"
+                                + "  RESET 'unknown_key'");
+    }
+
+    @Test
+    void testAlterMaterializedTableResetWithEmptyKey() {
+        final String sql = "ALTER MATERIALIZED TABLE base_mtbl RESET ()";
+        assertThatThrownBy(() -> parse(sql))
+                .isInstanceOf(ValidationException.class)
+                .hasMessage(
+                        "Failed to execute ALTER MATERIALIZED TABLE statement.\n"
+                                + "ALTER MATERIALIZED TABLE RESET does not support empty key.");
+    }
+
+    @Test
+    void testAlterMaterializedTableResetConnector() {
+        final String sql = "ALTER MATERIALIZED TABLE base_mtbl RESET ('connector')";
+        assertThatThrownBy(() -> parse(sql))
+                .isInstanceOf(ValidationException.class)
+                .hasMessage(
+                        "Failed to execute ALTER MATERIALIZED TABLE statement.\n"
+                                + "ALTER MATERIALIZED TABLE RESET does not support changing 'connector'.");
+    }
+
+    @Test
+    void testAlterMaterializedTableResetOnUnknownTable() {
+        final String sql = "ALTER MATERIALIZED TABLE unknown_mtbl RESET ('format')";
+        assertThatThrownBy(() -> parse(sql))
+                .isInstanceOf(ValidationException.class)
+                .hasMessage("Materialized table `builtin`.`default`.`unknown_mtbl` doesn't exist.");
+    }
+
+    @Test
+    void testAlterMaterializedTableResetOnRegularTable() {
+        final String sql = "ALTER MATERIALIZED TABLE t3 RESET ('format')";
+        assertThatThrownBy(() -> parse(sql))
+                .isInstanceOf(ValidationException.class)
+                .hasMessage("ALTER MATERIALIZED TABLE for a table is not allowed");
+    }
+
+    @Test
     void testAlterMaterializedTableAsQuery() throws TableNotExistException {
         String sql =
                 "ALTER MATERIALIZED TABLE base_mtbl AS SELECT a, b, c, d, d as e, cast('123' as string) as f FROM t3";

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlMaterializedTableNodeToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlMaterializedTableNodeToOperationConverterTest.java
@@ -533,15 +533,14 @@ class SqlMaterializedTableNodeToOperationConverterTest
                 (AlterMaterializedTableChangeOperation) operation;
         assertThat(op.getTableIdentifier().toString()).isEqualTo("`builtin`.`default`.`base_mtbl`");
         assertThat(op.getTableChanges())
-                .containsExactly(TableChange.reset("format"), TableChange.reset("unknown_key"));
+                .containsExactlyInAnyOrder(
+                        TableChange.reset("format"), TableChange.reset("unknown_key"));
         // resetting an unknown key is a no-op for the catalog state
         assertThat(op.getNewTable().getOptions())
                 .containsOnly(Map.entry("connector", "filesystem"));
         assertThat(op.asSummaryString())
-                .isEqualTo(
-                        "ALTER MATERIALIZED TABLE builtin.default.base_mtbl\n"
-                                + "  RESET 'format',\n"
-                                + "  RESET 'unknown_key'");
+                .startsWith("ALTER MATERIALIZED TABLE builtin.default.base_mtbl\n")
+                .contains("  RESET 'format'", "  RESET 'unknown_key'");
     }
 
     @Test

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlMaterializedTableNodeToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlMaterializedTableNodeToOperationConverterTest.java
@@ -545,42 +545,6 @@ class SqlMaterializedTableNodeToOperationConverterTest
     }
 
     @Test
-    void testAlterMaterializedTableResetWithEmptyKey() {
-        final String sql = "ALTER MATERIALIZED TABLE base_mtbl RESET ()";
-        assertThatThrownBy(() -> parse(sql))
-                .isInstanceOf(ValidationException.class)
-                .hasMessage(
-                        "Failed to execute ALTER MATERIALIZED TABLE statement.\n"
-                                + "ALTER MATERIALIZED TABLE RESET does not support empty key.");
-    }
-
-    @Test
-    void testAlterMaterializedTableResetConnector() {
-        final String sql = "ALTER MATERIALIZED TABLE base_mtbl RESET ('connector')";
-        assertThatThrownBy(() -> parse(sql))
-                .isInstanceOf(ValidationException.class)
-                .hasMessage(
-                        "Failed to execute ALTER MATERIALIZED TABLE statement.\n"
-                                + "ALTER MATERIALIZED TABLE RESET does not support changing 'connector'.");
-    }
-
-    @Test
-    void testAlterMaterializedTableResetOnUnknownTable() {
-        final String sql = "ALTER MATERIALIZED TABLE unknown_mtbl RESET ('format')";
-        assertThatThrownBy(() -> parse(sql))
-                .isInstanceOf(ValidationException.class)
-                .hasMessage("Materialized table `builtin`.`default`.`unknown_mtbl` doesn't exist.");
-    }
-
-    @Test
-    void testAlterMaterializedTableResetOnRegularTable() {
-        final String sql = "ALTER MATERIALIZED TABLE t3 RESET ('format')";
-        assertThatThrownBy(() -> parse(sql))
-                .isInstanceOf(ValidationException.class)
-                .hasMessage("ALTER MATERIALIZED TABLE for a table is not allowed");
-    }
-
-    @Test
     void testAlterMaterializedTableAsQuery() throws TableNotExistException {
         String sql =
                 "ALTER MATERIALIZED TABLE base_mtbl AS SELECT a, b, c, d, d as e, cast('123' as string) as f FROM t3";
@@ -716,6 +680,7 @@ class SqlMaterializedTableNodeToOperationConverterTest
         list.addAll(alterModifyWithInvalidSchema());
         list.addAll(alterQuery());
         list.addAll(alterDrop());
+        list.addAll(alterReset());
         return list;
     }
 
@@ -1056,6 +1021,22 @@ class SqlMaterializedTableNodeToOperationConverterTest
                         "ALTER MATERIALIZED TABLE base_mtbl_with_metadata DROP m_p",
                         "Failed to execute ALTER MATERIALIZED TABLE statement.\n"
                                 + "The column `m_p` is a persisted column. Dropping of persisted columns is not supported."));
+    }
+
+    private static Collection<TestSpec> alterReset() {
+        return List.of(
+                TestSpec.of(
+                        "ALTER MATERIALIZED TABLE base_mtbl RESET ()",
+                        "ALTER MATERIALIZED TABLE RESET does not support empty key."),
+                TestSpec.of(
+                        "ALTER MATERIALIZED TABLE base_mtbl RESET ('connector')",
+                        "ALTER MATERIALIZED TABLE RESET does not support changing 'connector'."),
+                TestSpec.of(
+                        "ALTER MATERIALIZED TABLE unknown_mtbl RESET ('format')",
+                        "Materialized table `builtin`.`default`.`unknown_mtbl` doesn't exist."),
+                TestSpec.of(
+                        "ALTER MATERIALIZED TABLE t3 RESET ('format')",
+                        "ALTER MATERIALIZED TABLE for a table is not allowed"));
     }
 
     private static Collection<TestSpec> alterSuccessCase() {


### PR DESCRIPTION
## What is the purpose of the change

The parser already accepted `ALTER MATERIALIZED TABLE t RESET ('k')`, but the planner had no converter registered for `SqlAlterMaterializedTableReset`. As a result, the statement was rejected at plan time with `TableException: Unsupported query`.

Add `SqlAlterMaterializedTableResetConverter` and register it in `SqlNodeConverters#registerMaterializedTableConverters`. The converter emits an `AlterMaterializedTableChangeOperation` with one `TableChange.reset(key)` per key. Merging is handled by `MaterializedTableChangeHandler.resetTableOption`, which is a no-op for keys not currently set. Empty key lists and resetting the `connector` key are rejected, matching the non-materialized-table RESET path.

Planner-level tests cover success (with order-preserving summary string), empty key list, the `connector` key, unknown table, and applying RESET to a regular table. A gateway IT test exercises the end-to-end flow in FULL refresh mode where the change is applied directly to the catalog. The user-facing docs are updated for the new RESET clause.


## Brief change log

- Add `SqlAlterMaterializedTableResetConverter`
- register the new converter in `SqlNodeConverters#registerMaterializedTableConverters`
- Planner-level tests


## Verifying this change

- Added test in planner-level under `SqlMaterializedTableNodeToOperationConverterTest.java`
- Added IT cases in `MaterializedTableStatementITCase.java`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [X] Yes (please specify the tool below)


Generated-by: Opus 4.7