### PR TITLE
[hotfix][state/tests] Dispose keyed state backend in testMapStateWithNullValue

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -1166,6 +1166,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> {
         } finally {
             // ensure that native resources are also released in case of exception
             if (backend != null) {
+                IOUtils.closeQuietly(backend);
                 backend.dispose();
             }
         }
@@ -1297,6 +1298,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> {
 
             snapshot.discardState();
         } finally {
+            IOUtils.closeQuietly(backend);
             backend.dispose();
         }
     }
@@ -1399,6 +1401,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> {
 
             snapshot.discardState();
         } finally {
+            IOUtils.closeQuietly(backend);
             backend.dispose();
         }
     }
@@ -5443,20 +5446,25 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> {
     public void testMapStateWithNullValue() throws Exception {
         CheckpointableKeyedStateBackend<String> keyedBackend =
                 createKeyedBackend(new NullUnsafeTypeSerializer());
-        MapStateDescriptor<Integer, String> kvId =
-                new MapStateDescriptor<>(
-                        "id", IntSerializer.INSTANCE, new NullUnsafeTypeSerializer());
-        MapState<Integer, String> state =
-                keyedBackend.getPartitionedState(
-                        VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, kvId);
+        try {
+            MapStateDescriptor<Integer, String> kvId =
+                    new MapStateDescriptor<>(
+                            "id", IntSerializer.INSTANCE, new NullUnsafeTypeSerializer());
+            MapState<Integer, String> state =
+                    keyedBackend.getPartitionedState(
+                            VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, kvId);
 
-        String key = "key";
-        int userKey = 1;
-        keyedBackend.setCurrentKey(key);
-        // this should not throw an exception
-        state.put(userKey, null);
-        assertThat(state.contains(userKey)).isTrue();
-        assertThat(state.get(userKey)).isNull();
+            String key = "key";
+            int userKey = 1;
+            keyedBackend.setCurrentKey(key);
+            // this should not throw an exception
+            state.put(userKey, null);
+            assertThat(state.contains(userKey)).isTrue();
+            assertThat(state.get(userKey)).isNull();
+        } finally {
+            IOUtils.closeQuietly(keyedBackend);
+            keyedBackend.dispose();
+        }
     }
 
     /**


### PR DESCRIPTION
## What is the purpose of the change

`StateBackendTestBase#testMapStateWithNullValue` creates a `CheckpointableKeyedStateBackend` via `createKeyedBackend(...)` but never closes/disposes it, leaking the resources held by the backend. Every other test in this file already wraps the body in `try { ... } finally { IOUtils.closeQuietly(backend); backend.dispose(); }`; this one was missed when it was added in FLINK-38137.

## Brief change log

- Wrap the body of `testMapStateWithNullValue` in a `try { ... } finally { IOUtils.closeQuietly(keyedBackend); keyedBackend.dispose(); }` block, matching the cleanup pattern used by every other test in `StateBackendTestBase`.

## Verifying this change

This change is a test-side resource cleanup with no behavior change for production code paths. It can be verified by running `StateBackendTestBase` and its existing implementations and observing that no test logic is affected.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): **no**
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
- The serializers: **no**
- The runtime per-record code paths (performance sensitive): **no**
- Anything that affects deployment or recovery: **no**
- The S3 file system connector: **no**

## Documentation

- Does this pull request introduce a new feature? **no**
- If yes, how is the feature documented? **not applicable**