### PR TITLE
[hotfix][build] Use sparse-checkout paths for Flink template in GHA.

### DIFF
--- a/.github/workflows/template.flink-ci.yml
+++ b/.github/workflows/template.flink-ci.yml
@@ -138,6 +138,11 @@ jobs:
         uses: actions/checkout@v5
         with:
           persist-credentials: false
+          sparse-checkout: |
+            .github
+            .mvn
+            .scalafmt.conf
+            tools
 
       - name: "Initialize job"
         uses: "./.github/actions/job_init"
@@ -200,6 +205,11 @@ jobs:
         uses: actions/checkout@v5
         with:
           persist-credentials: false
+          sparse-checkout: |
+            .github
+            .mvn
+            .scalafmt.conf
+            tools
 
       - name: "Initialize job"
         uses: "./.github/actions/job_init"
@@ -337,6 +347,10 @@ jobs:
         uses: actions/checkout@v5
         with:
           persist-credentials: false
+          sparse-checkout: |
+            .github
+            .mvn
+            tools
 
       - name: "Initialize job"
         uses: "./.github/actions/job_init"


### PR DESCRIPTION

## What is the purpose of the change
No need to run full repo checkout each time since (in e2e and test tasks)

## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change
GHA
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
