### PR TITLE
[hotfix][table-runtime] Fix typo in RowTimeMiniBatchAssignerOperator class name

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecMiniBatchAssigner.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecMiniBatchAssigner.java
@@ -36,7 +36,7 @@ import org.apache.flink.table.planner.plan.nodes.exec.utils.ExecNodeUtil;
 import org.apache.flink.table.planner.plan.trait.MiniBatchInterval;
 import org.apache.flink.table.planner.plan.trait.MiniBatchMode;
 import org.apache.flink.table.runtime.operators.wmassigners.ProcTimeMiniBatchAssignerOperator;
-import org.apache.flink.table.runtime.operators.wmassigners.RowTimeMiniBatchAssginerOperator;
+import org.apache.flink.table.runtime.operators.wmassigners.RowTimeMiniBatchAssignerOperator;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.logical.RowType;
 
@@ -113,7 +113,7 @@ public class StreamExecMiniBatchAssigner extends ExecNodeBase<RowData>
         if (miniBatchInterval.getMode() == MiniBatchMode.ProcTime) {
             operator = new ProcTimeMiniBatchAssignerOperator(miniBatchInterval.getInterval());
         } else if (miniBatchInterval.getMode() == MiniBatchMode.RowTime) {
-            operator = new RowTimeMiniBatchAssginerOperator(miniBatchInterval.getInterval());
+            operator = new RowTimeMiniBatchAssignerOperator(miniBatchInterval.getInterval());
         } else {
             throw new TableException(
                     String.format(

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/wmassigners/ProcTimeMiniBatchAssignerOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/wmassigners/ProcTimeMiniBatchAssignerOperator.java
@@ -34,7 +34,7 @@ import org.apache.flink.table.data.RowData;
  *
  * <p>NOTE: currently, we use {@link Watermark} to represents the mini-batch marker.
  *
- * <p>The difference between this operator and {@link RowTimeMiniBatchAssginerOperator} is that,
+ * <p>The difference between this operator and {@link RowTimeMiniBatchAssignerOperator} is that,
  * this operator generates watermarks by itself using processing time, but the other forwards
  * watermarks from upstream.
  */

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/wmassigners/RowTimeMiniBatchAssignerOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/wmassigners/RowTimeMiniBatchAssignerOperator.java
@@ -41,7 +41,7 @@ import org.apache.flink.table.data.RowData;
  * this operator forwards watermarks from upstream, but the other generates watermarks by itself
  * using processing time.
  */
-public class RowTimeMiniBatchAssginerOperator extends AbstractStreamOperator<RowData>
+public class RowTimeMiniBatchAssignerOperator extends AbstractStreamOperator<RowData>
         implements OneInputStreamOperator<RowData, RowData> {
 
     private static final long serialVersionUID = 1L;
@@ -55,7 +55,7 @@ public class RowTimeMiniBatchAssginerOperator extends AbstractStreamOperator<Row
     /** The next watermark to be emitted. */
     private transient long nextWatermark;
 
-    public RowTimeMiniBatchAssginerOperator(long minibatchInterval) {
+    public RowTimeMiniBatchAssignerOperator(long minibatchInterval) {
         this.minibatchInterval = minibatchInterval;
     }
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/wmassigners/RowTimeMiniBatchAssignerOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/wmassigners/RowTimeMiniBatchAssignerOperatorTest.java
@@ -32,12 +32,12 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/** Tests of {@link RowTimeMiniBatchAssginerOperator}. */
-class RowTimeMiniBatchAssginerOperatorTest extends WatermarkAssignerOperatorTestBase {
+/** Tests of {@link RowTimeMiniBatchAssignerOperator}. */
+class RowTimeMiniBatchAssignerOperatorTest extends WatermarkAssignerOperatorTestBase {
 
     @Test
     void testRowTimeWatermarkAssigner() throws Exception {
-        final RowTimeMiniBatchAssginerOperator operator = new RowTimeMiniBatchAssginerOperator(5);
+        final RowTimeMiniBatchAssignerOperator operator = new RowTimeMiniBatchAssignerOperator(5);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 new OneInputStreamOperatorTestHarness<>(operator);
         testHarness.open();
@@ -86,7 +86,7 @@ class RowTimeMiniBatchAssginerOperatorTest extends WatermarkAssignerOperatorTest
 
     @Test
     void testEndWatermarkIsForwarded() throws Exception {
-        final RowTimeMiniBatchAssginerOperator operator = new RowTimeMiniBatchAssginerOperator(50);
+        final RowTimeMiniBatchAssignerOperator operator = new RowTimeMiniBatchAssignerOperator(50);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
                 new OneInputStreamOperatorTestHarness<>(operator);
         testHarness.open();


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes a typo in the class name `RowTimeMiniBatchAssginerOperator`. The class is renamed to `RowTimeMiniBatchAssignerOperator` (and the corresponding test class to `RowTimeMiniBatchAssignerOperatorTest`), matching the spelling already used by its sibling `ProcTimeMiniBatchAssignerOperator` and the surrounding package `wmassigners`.

The class is `@Internal` (it is an implementation-side stream operator with no stability annotation, instantiated only by the table planner) and holds no operator/keyed state, so the rename is safe to do directly.

## Brief change log

  - Rename `RowTimeMiniBatchAssginerOperator` → `RowTimeMiniBatchAssignerOperator` (file, class, and constructor) in `flink-table-runtime`.
  - Rename the matching test class `RowTimeMiniBatchAssginerOperatorTest` → `RowTimeMiniBatchAssignerOperatorTest`.
  - Update the only two callers/references: `StreamExecMiniBatchAssigner` (`flink-table-planner`) and the `{@link ...}` reference in the javadoc of `ProcTimeMiniBatchAssignerOperator`.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

The existing tests in `RowTimeMiniBatchAssignerOperatorTest` continue to pass under the renamed class:

```
./mvnw -pl flink-table/flink-table-runtime -Dtest='RowTimeMiniBatchAssignerOperatorTest' test
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no (the class is internal; it has no stability annotation and is only instantiated from `StreamExecMiniBatchAssigner`)
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no (identifier-only change, no behavior change)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no (the operator carries only `transient` runtime fields and a final config value, no operator/keyed state)
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
