### PR TITLE
[FLINK-39672][docs] Document Java records as supported POJO types

### DIFF
--- a/docs/content.zh/docs/deployment/java_compatibility.md
+++ b/docs/content.zh/docs/deployment/java_compatibility.md
@@ -52,6 +52,9 @@ The following Flink features have not been tested with Java 11:
 
 Experimental support for Java 17 was added in 1.18.0. ([FLINK-15736](https://issues.apache.org/jira/browse/FLINK-15736))
 
+Support for Java Records was added in Flink 1.19 ([FLINK-32380](https://issues.apache.org/jira/browse/FLINK-32380)).
+Java records are handled as [POJO types]({{< ref "docs/dev/datastream/fault-tolerance/serialization/types_serialization" >}}#pojos) and serialized via their canonical constructor.
+
 ### Untested Flink features
 
 These Flink features have not been tested with Java 17:

--- a/docs/content.zh/docs/dev/datastream/fault-tolerance/serialization/schema_evolution.md
+++ b/docs/content.zh/docs/dev/datastream/fault-tolerance/serialization/schema_evolution.md
@@ -85,6 +85,8 @@ Flink 基于下面的规则来支持 [POJO 类型]({{< ref "docs/dev/datastream/
  3. 不可以修改字段的声明类型。
  4. 不可以改变 POJO 类型的类名，包括类的命名空间。
 
+上述规则同样适用于 [Java records]({{< ref "docs/dev/datastream/fault-tolerance/serialization/types_serialization" >}}#pojos)，自 Flink 1.19 起 records 被作为 POJO 类型处理。
+
 需要注意，只有从 1.8.0 及以上版本的 Flink 生产的 savepoint 进行恢复时，POJO 类型的状态才可以进行升级。
 对 1.8.0 版本之前的 Flink 是没有办法进行 POJO 类型升级的。
 

--- a/docs/content.zh/docs/dev/datastream/fault-tolerance/serialization/types_serialization.md
+++ b/docs/content.zh/docs/dev/datastream/fault-tolerance/serialization/types_serialization.md
@@ -108,6 +108,9 @@ Java and Scala classes are treated by Flink as a special POJO data type if they 
 
 - The type of a field must be supported by a registered serializer.
 
+[Java records](https://docs.oracle.com/en/java/javase/17/language/records.html) are also recognized as POJO types since Flink 1.19 ([FLINK-32380](https://issues.apache.org/jira/browse/FLINK-32380)).
+A `public` record class is serialized by `PojoSerializer` through its canonical constructor; the no-argument constructor and getter/setter requirements above do not apply.
+
 POJOs are generally represented with a `PojoTypeInfo` and serialized with the `PojoSerializer` (using [Kryo](https://github.com/EsotericSoftware/kryo) as configurable fallback).
 The exception is when the POJOs are actually Avro types (Avro Specific Records) or produced as "Avro Reflect Types". 
 In that case the POJO's are represented by an `AvroTypeInfo` and serialized with the `AvroSerializer`.
@@ -313,6 +316,10 @@ conditions are fulfilled:
 * All non-static, non-transient fields in the class (and all superclasses) are either public (and non-final)
   or have a public getter- and a setter- method that follows the Java beans
   naming conventions for getters and setters.
+
+Java records are also recognized as POJO types.
+The class must still be `public`, but the no-argument constructor and getter/setter rules above are waived.
+Java records are instantiated via their canonical constructor.
 
 Note that when a user-defined data type can't be recognized as a POJO type, it must be processed as GenericType and
 serialized with Kryo.

--- a/docs/content/docs/deployment/java_compatibility.md
+++ b/docs/content/docs/deployment/java_compatibility.md
@@ -51,7 +51,9 @@ The following Flink features have not been tested with Java 11:
 ## Java 17
 
 Experimental support for Java 17 was added in 1.18. ([FLINK-15736](https://issues.apache.org/jira/browse/FLINK-15736))
-In Flink 1.19, we added support for Java Records. ([FLINK-32380](https://issues.apache.org/jira/browse/FLINK-32380))
+
+Support for Java Records was added in Flink 1.19 ([FLINK-32380](https://issues.apache.org/jira/browse/FLINK-32380)).
+Java records are handled as [POJO types]({{< ref "docs/dev/datastream/fault-tolerance/serialization/types_serialization" >}}#pojos) and serialized via their canonical constructor.
 
 ### Untested Flink features
 

--- a/docs/content/docs/dev/datastream/fault-tolerance/serialization/schema_evolution.md
+++ b/docs/content/docs/dev/datastream/fault-tolerance/serialization/schema_evolution.md
@@ -95,6 +95,8 @@ based on the following set of rules:
  3. Declared fields types cannot change.
  4. Class name of the POJO type cannot change, including the namespace of the class.
 
+The same rules apply to [Java records]({{< ref "docs/dev/datastream/fault-tolerance/serialization/types_serialization" >}}#pojos), which Flink treats as POJO types since Flink 1.19.
+
 Note that the schema of POJO type state can only be evolved when restoring from a previous savepoint with Flink versions
 newer than 1.8.0. When restoring with Flink versions older than 1.8.0, the schema cannot be changed.
 

--- a/docs/content/docs/dev/datastream/fault-tolerance/serialization/types_serialization.md
+++ b/docs/content/docs/dev/datastream/fault-tolerance/serialization/types_serialization.md
@@ -109,6 +109,9 @@ Java and Scala classes are treated by Flink as a special POJO data type if they 
 
 - The type of a field must be supported by a registered serializer.
 
+[Java records](https://docs.oracle.com/en/java/javase/17/language/records.html) are also recognized as POJO types since Flink 1.19 ([FLINK-32380](https://issues.apache.org/jira/browse/FLINK-32380)).
+A `public` record class is serialized by `PojoSerializer` through its canonical constructor; the no-argument constructor and getter/setter requirements above do not apply.
+
 POJOs are generally represented with a `PojoTypeInfo` and serialized with the `PojoSerializer` (using [Kryo](https://github.com/EsotericSoftware/kryo) as configurable fallback).
 The exception is when the POJOs are actually Avro types (Avro Specific Records) or produced as "Avro Reflect Types". 
 In that case the POJO's are represented by an `AvroTypeInfo` and serialized with the `AvroSerializer`.
@@ -340,6 +343,10 @@ conditions are fulfilled:
 * All non-static, non-transient fields in the class (and all superclasses) are either public (and non-final)
   or have a public getter- and a setter- method that follows the Java beans
   naming conventions for getters and setters.
+
+Java records are also recognized as POJO types.
+The class must still be `public`, but the no-argument constructor and getter/setter rules above are waived.
+Java records are instantiated via their canonical constructor.
 
 Note that when a user-defined data type can't be recognized as a POJO type, it must be processed as GenericType and
 serialized with Kryo.


### PR DESCRIPTION
## What is the purpose of the change

**This backports PR #28149 to `release-1.20` for FLINK-39672**

Adapted for release-1.20: drop the older one-liner about Java records introduced in 10157ff4545, which is now superseded by the more detailed POJO-types description added by this commit.

Java records have been supported as POJO types since Flink 1.19 (FLINK-32380), but the only doc mention lived on the release-1.20 java_compatibility page and was inadvertently removed on master by FLINK-37339.

## Brief change log

- Restores the FLINK-32380 reference under "Java 17" in java_compatibility.md and notes that records are handled as POJO types serialized via their canonical constructor.
- Adds a note in both POJO listings in types_serialization.md that a public record class is serialized by PojoSerializer; the no-argument constructor and getter/setter requirements do not apply.
- Mentions in schema_evolution.md that records follow the same POJO schema evolution rules.

Parallel updates in docs/content.zh.

## Verifying this change

Doc-only change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [X] Yes (please specify the tool below)

Generated-by: Claude Opus 4.7