### PR TITLE
[FLINK-34332][ci] Follow the principle of least privilege for GITHUB_TOKEN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,9 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
     cancel-in-progress: true
 
-permissions: read-all
+# Limit GITHUB_TOKEN to read-only access for the repository contents.
+permissions:
+  contents: read
 
 jobs:
   pre-compile-checks:

--- a/.github/workflows/community-review.yml
+++ b/.github/workflows/community-review.yml
@@ -26,12 +26,10 @@ on:
 
 # The community review script needs write permissions to label PRs.
 permissions:
-  # Required to add/remove labels (indirectly via issues API for PRs).
+  # Required for community-review.sh to create repository-level labels.
   issues: write
-  # Required to add/remove labels on PRs via the GitHub API.
+  # Required for community-review.sh to add/remove labels on PRs.
   pull-requests: write
-  # Required for the script to manage its execution state.
-  actions: write
 jobs:
   label:
     if: github.repository_owner == 'apache'

--- a/.github/workflows/community-review.yml
+++ b/.github/workflows/community-review.yml
@@ -24,10 +24,13 @@ on:
   schedule:
     - cron: '00 00,08,16 * * *'
 
-# Same permission as stale Github action
+# The community review script needs write permissions to label PRs.
 permissions:
+  # Required to add/remove labels (indirectly via issues API for PRs).
   issues: write
+  # Required to add/remove labels on PRs via the GitHub API.
   pull-requests: write
+  # Required for the script to manage its execution state.
   actions: write
 jobs:
   label:

--- a/.github/workflows/docs-legacy.yml
+++ b/.github/workflows/docs-legacy.yml
@@ -42,6 +42,10 @@ on:
           - release-1.1
           - release-1.0
 
+# Default permission grants write access; restrict to read-only for repository contents.
+permissions:
+  contents: read
+
 jobs:
   build-documentation:
     if: github.repository == 'apache/flink'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,6 +19,10 @@ on:
     - cron: '0 0 * * *' # Deploy every day
   workflow_dispatch:
 
+# Default permission grants write access; restrict to read-only for repository contents.
+permissions:
+  contents: read
+
 jobs:
   build-documentation:
     if: github.repository == 'apache/flink'

--- a/.github/workflows/nightly-trigger.yml
+++ b/.github/workflows/nightly-trigger.yml
@@ -22,10 +22,14 @@ on:
   schedule:
     - cron: '0 2 * * *'
 
+# No workflow-level access needed; each job requests only what it requires.
+permissions: {}
+
 jobs:
   Trigger:
     if: github.repository == 'apache/flink'
     permissions:
+      # Required for github-script action to call createWorkflowDispatch API.
       actions: write
     strategy:
       matrix:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,7 +21,9 @@ name: "Nightly (beta)"
 on:
   workflow_dispatch:
 
-permissions: read-all
+# Limit GITHUB_TOKEN to read-only access for the repository contents.
+permissions:
+  contents: read
 
 jobs:
   pre-compile-checks:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -28,9 +28,13 @@ on:
         default: 20
         type: number
 
+# The stale action needs write permissions to label and close stale PRs.
 permissions:
+  # Required for actions/stale to add/remove labels on issues.
   issues: write
+  # Required for actions/stale to add/remove labels on PRs and post comments.
   pull-requests: write
+  # Required for actions/stale to manage its own operation state.
   actions: write
 
 jobs:

--- a/.github/workflows/template.flink-ci.yml
+++ b/.github/workflows/template.flink-ci.yml
@@ -40,7 +40,9 @@ on:
       s3_secret_key:
         required: false
 
-permissions: read-all
+# Limit GITHUB_TOKEN to read-only access for the repository contents.
+permissions:
+  contents: read
 
 # Running logic within a container comes with challenges around file permissions (e.g. when trying
 # to generate the hash for a certain set of files; see https://github.com/actions/cache/issues/753):

--- a/.github/workflows/template.pre-compile-checks.yml
+++ b/.github/workflows/template.pre-compile-checks.yml
@@ -34,7 +34,9 @@ on:
         default: 17
         type: number
 
-permissions: read-all
+# Limit GITHUB_TOKEN to read-only access for the repository contents.
+permissions:
+  contents: read
 
 # This workflow should only contain steps that do not require the compilation of Flink (and therefore, are
 # independent of the used JDK)


### PR DESCRIPTION


## What is the purpose of the change

This pull request limits the scope of `GITHUB_TOKEN` permissions in GitHub Actions workflows
and documents why each permission is needed, as requested in FLINK-34332.

Previously, several workflows used `permissions: read-all`, which grants broader read access
than necessary. This change replaces `read-all` with the more restrictive `contents: read`
wherever possible, and adds comments explaining the purpose of each permission.

## Brief change log

- Replaced `permissions: read-all` with `contents: read` in `ci.yml`, `nightly.yml`,
  `template.flink-ci.yml`, and `template.pre-compile-checks.yml`
- Added `permissions: contents: read` to `docs.yml` and `docs-legacy.yml` (previously
  relying on default, potentially broader permissions)
- Added `permissions: {}` at workflow level in `nightly-trigger.yml`, keeping
  `actions: write` only at the job level with documented reason
- Added inline comments documenting why each permission is required in `stale.yml`
  and `community-review.yml`


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)


