### PR TITLE
[FLINK-39645][connector-base] Preserve restored HybridSource splits during snapshot

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReader.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReader.java
@@ -32,7 +32,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -107,10 +106,11 @@ public class HybridSourceReader<T> implements SourceReader<T, HybridSourceSplit>
 
     @Override
     public List<HybridSourceSplit> snapshotState(long checkpointId) {
-        List<? extends SourceSplit> state =
-                currentReader != null
-                        ? currentReader.snapshotState(checkpointId)
-                        : Collections.emptyList();
+        if (currentReader == null) {
+            return new ArrayList<>(restoredSplits);
+        }
+
+        List<? extends SourceSplit> state = currentReader.snapshotState(checkpointId);
         return HybridSourceSplit.wrapSplits(state, currentSourceIndex, switchedSources);
     }
 

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReaderTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReaderTest.java
@@ -283,6 +283,36 @@ class HybridSourceReaderTest {
     }
 
     @Test
+    void testReaderRecoverySnapshotBeforeSwitchSourceEvent() throws Exception {
+        TestingReaderContext readerContext = new TestingReaderContext();
+        MockBaseSource source = new MockBaseSource(1, 1, Boundedness.BOUNDED);
+
+        HybridSourceReader<Integer> reader = new HybridSourceReader<>(readerContext);
+        reader.start();
+        assertAndClearSourceReaderFinishedEvent(readerContext, -1);
+        reader.handleSourceEvents(new SwitchSourceEvent(0, source, false));
+
+        MockSourceSplit mockSplit = new MockSourceSplit(0, 0, 2147483647);
+        SwitchedSources switchedSources = new SwitchedSources();
+        switchedSources.put(0, source);
+        HybridSourceSplit hybridSplit = HybridSourceSplit.wrapSplit(mockSplit, 0, switchedSources);
+        reader.addSplits(Collections.singletonList(hybridSplit));
+        List<HybridSourceSplit> snapshot = reader.snapshotState(0);
+        reader.close();
+
+        readerContext.clearSentEvents();
+        HybridSourceReader<Integer> recoveredReader = new HybridSourceReader<>(readerContext);
+        recoveredReader.addSplits(snapshot);
+        recoveredReader.start();
+        assertThat(currentReader(recoveredReader)).isNull();
+
+        List<HybridSourceSplit> recoverySnapshot = recoveredReader.snapshotState(1);
+        assertThat(recoverySnapshot).containsExactly(hybridSplit);
+
+        recoveredReader.close();
+    }
+
+    @Test
     void testReaderRecoveryInitializationOrder() throws Exception {
         TestingReaderContext readerContext = new TestingReaderContext();
         MockBaseSource source = new MockBaseSource(1, 1, Boundedness.BOUNDED);

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReaderTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReaderTest.java
@@ -254,7 +254,7 @@ class HybridSourceReaderTest {
         assertAndClearSourceReaderFinishedEvent(readerContext, -1);
         reader.handleSourceEvents(new SwitchSourceEvent(0, source, false));
 
-        MockSourceSplit mockSplit = new MockSourceSplit(0, 0, 2147483647);
+        MockSourceSplit mockSplit = new MockSourceSplit(0, 0, Integer.MAX_VALUE);
 
         SwitchedSources switchedSources = new SwitchedSources();
         switchedSources.put(0, source);
@@ -292,7 +292,7 @@ class HybridSourceReaderTest {
         assertAndClearSourceReaderFinishedEvent(readerContext, -1);
         reader.handleSourceEvents(new SwitchSourceEvent(0, source, false));
 
-        MockSourceSplit mockSplit = new MockSourceSplit(0, 0, 2147483647);
+        MockSourceSplit mockSplit = new MockSourceSplit(0, 0, Integer.MAX_VALUE);
         SwitchedSources switchedSources = new SwitchedSources();
         switchedSources.put(0, source);
         HybridSourceSplit hybridSplit = HybridSourceSplit.wrapSplit(mockSplit, 0, switchedSources);
@@ -323,7 +323,7 @@ class HybridSourceReaderTest {
         assertAndClearSourceReaderFinishedEvent(readerContext, -1);
         reader.handleSourceEvents(new SwitchSourceEvent(0, source, false));
 
-        MockSourceSplit mockSplit = new MockSourceSplit(0, 0, 2147483647);
+        MockSourceSplit mockSplit = new MockSourceSplit(0, 0, Integer.MAX_VALUE);
         SwitchedSources switchedSources = new SwitchedSources();
         switchedSources.put(0, source);
         HybridSourceSplit hybridSplit = HybridSourceSplit.wrapSplit(mockSplit, 0, switchedSources);


### PR DESCRIPTION
## What is the purpose of the change

`HybridSourceReader` can be checkpointed during recovery after restored `HybridSourceSplit` instances were added back, but before the `SwitchSourceEvent` creates the underlying reader. In that window `currentReader` is still `null`, and `snapshotState()` previously snapshotted an empty list. A second failure from that checkpoint would then lose the recovered splits.

This keeps the already-restored hybrid splits in the checkpoint state until the source switch hands them to the underlying reader.

## Brief change log

- Add a regression test for snapshotting recovered `HybridSourceSplit` state before the recovery `SwitchSourceEvent`.
- Return a defensive copy of `restoredSplits` when `snapshotState()` runs before a current reader exists.

## Verifying this change

- `./mvnw -pl flink-connectors/flink-connector-base -DskipITs -Dtest=HybridSourceReaderTest#testReaderRecoverySnapshotBeforeSwitchSourceEvent -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl flink-connectors/flink-connector-base -DskipITs -Dtest=HybridSourceReaderTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl flink-connectors/flink-connector-base -DskipITs test`
- `git diff --check`