### PR TITLE
[FLINK-39700][table-planner] Fix column-order sensitivity in validateAndExtractColumnChanges

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/materializedtable/AlterMaterializedTableChangeOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/materializedtable/AlterMaterializedTableChangeOperation.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.table.operations.materializedtable;
 
-import org.apache.flink.annotation.Confluent;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.table.api.ValidationException;
@@ -82,31 +81,21 @@ public class AlterMaterializedTableChangeOperation extends AlterMaterializedTabl
 
     public CatalogMaterializedTable getNewTable() {
         if (newTable == null) {
-            newTable =
-                    MaterializedTableChangeHandler.buildNewMaterializedTable(
-                            getHandlerWithChanges());
+            newTable = computeNewTable();
         }
         return newTable;
     }
 
-    @Confluent
     public ResolvedCatalogMaterializedTable getOldTable() {
         return oldTable;
     }
 
-    @Confluent
     public void setOldTable(final ResolvedCatalogMaterializedTable oldTable) {
         this.oldTable = oldTable;
+        // All caches are derived from oldTable; invalidate them together.
+        this.tableChanges = null;
+        this.handler = null;
         this.newTable = null;
-    }
-
-    protected MaterializedTableChangeHandler getHandlerWithChanges() {
-        if (handler == null) {
-            handler =
-                    MaterializedTableChangeHandler.getHandlerWithChanges(
-                            oldTable, getTableChanges());
-        }
-        return handler;
     }
 
     @VisibleForTesting
@@ -137,18 +126,55 @@ public class AlterMaterializedTableChangeOperation extends AlterMaterializedTabl
         }
     }
 
+    @Override
+    public TableResultInternal execute(Context ctx) {
+        validateChanges();
+        ctx.getCatalogManager()
+                .alterTable(getNewTable(), getTableChanges(), getTableIdentifier(), false);
+        return TableResultImpl.TABLE_RESULT_OK;
+    }
+
+    @Override
+    public String asSummaryString() {
+        String changes =
+                getTableChanges().stream()
+                        .map(AlterMaterializedTableChangeOperation::toString)
+                        .collect(Collectors.joining(",\n"));
+        return String.format(
+                "%s %s\n%s", getOperationName(), tableIdentifier.asSummaryString(), changes);
+    }
+
+    /** Hook for subclasses to provide a different new-table builder. */
+    protected CatalogMaterializedTable computeNewTable() {
+        return MaterializedTableChangeHandler.buildNewMaterializedTable(getHandlerWithChanges());
+    }
+
+    protected MaterializedTableChangeHandler getHandlerWithChanges() {
+        if (handler == null) {
+            handler =
+                    MaterializedTableChangeHandler.getHandlerWithChanges(
+                            oldTable, getTableChanges());
+        }
+        return handler;
+    }
+
+    protected String getOperationName() {
+        return "ALTER MATERIALIZED TABLE";
+    }
+
     private void checkDroppedColumn(
             DropColumn change,
             List<Column> oldColumns,
             Map<String, Integer> columnIndex,
             List<String> errors) {
-        final Integer idx = columnIndex.get(change.getColumnName());
-        if (idx != null && oldColumns.get(idx).isPersisted()) {
-            errors.add(
-                    String.format(
-                            "Dropping of persisted column `%s` is not supported.",
-                            change.getColumnName()));
+        final int idx = columnIndex.getOrDefault(change.getColumnName(), -1);
+        if (idx < 0 || !oldColumns.get(idx).isPersisted()) {
+            return;
         }
+        errors.add(
+                String.format(
+                        "Dropping of persisted column `%s` is not supported.",
+                        change.getColumnName()));
     }
 
     private void checkPositionChange(
@@ -172,14 +198,15 @@ public class AlterMaterializedTableChangeOperation extends AlterMaterializedTabl
             List<Column> oldColumns,
             Map<String, Integer> columnIndex,
             List<String> errors) {
-        final Integer idx = columnIndex.get(change.getOldColumn().getName());
-        if (idx != null) {
-            errors.add(
-                    positionChangeError(
-                            change.getOldColumn().asSummaryString(),
-                            change.getNewColumn().asSummaryString(),
-                            idx));
+        final int idx = columnIndex.getOrDefault(change.getOldColumn().getName(), -1);
+        if (idx < 0) {
+            return;
         }
+        errors.add(
+                positionChangeError(
+                        change.getOldColumn().asSummaryString(),
+                        change.getNewColumn().asSummaryString(),
+                        idx));
     }
 
     /**
@@ -203,28 +230,6 @@ public class AlterMaterializedTableChangeOperation extends AlterMaterializedTabl
                         + "currently only support appending columns at the end of original schema, dropping, renaming, and reordering columns are not supported.\n"
                         + "Column mismatch at position %d: Original column is [%s], but new column is [%s].",
                 position + 1, oldColumn, newColumn);
-    }
-
-    @Override
-    public TableResultInternal execute(Context ctx) {
-        validateChanges();
-        ctx.getCatalogManager()
-                .alterTable(getNewTable(), getTableChanges(), getTableIdentifier(), false);
-        return TableResultImpl.TABLE_RESULT_OK;
-    }
-
-    @Override
-    public String asSummaryString() {
-        String changes =
-                getTableChanges().stream()
-                        .map(AlterMaterializedTableChangeOperation::toString)
-                        .collect(Collectors.joining(",\n"));
-        return String.format(
-                "%s %s\n%s", getOperationName(), tableIdentifier.asSummaryString(), changes);
-    }
-
-    protected String getOperationName() {
-        return "ALTER MATERIALIZED TABLE";
     }
 
     private static String toString(TableChange tableChange) {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/materializedtable/AlterMaterializedTableChangeOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/materializedtable/AlterMaterializedTableChangeOperation.java
@@ -18,22 +18,34 @@
 
 package org.apache.flink.table.operations.materializedtable;
 
+import org.apache.flink.annotation.Confluent;
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.api.internal.TableResultImpl;
 import org.apache.flink.table.api.internal.TableResultInternal;
 import org.apache.flink.table.catalog.CatalogMaterializedTable;
+import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ResolvedCatalogMaterializedTable;
 import org.apache.flink.table.catalog.TableChange;
+import org.apache.flink.table.catalog.TableChange.After;
+import org.apache.flink.table.catalog.TableChange.ColumnPosition;
+import org.apache.flink.table.catalog.TableChange.DropColumn;
+import org.apache.flink.table.catalog.TableChange.ModifyColumnPosition;
 import org.apache.flink.table.catalog.TableChange.ModifyDefinitionQuery;
+import org.apache.flink.table.catalog.TableChange.ModifyPhysicalColumnType;
 import org.apache.flink.table.catalog.TableChange.ModifyRefreshHandler;
 import org.apache.flink.table.catalog.TableChange.ModifyRefreshStatus;
 import org.apache.flink.table.catalog.TableChange.ModifyStartMode;
 import org.apache.flink.table.operations.ddl.AlterTableChangeOperation;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * Alter materialized table with new table definition and table changes represents the modification.
@@ -42,7 +54,7 @@ import java.util.stream.Collectors;
 public class AlterMaterializedTableChangeOperation extends AlterMaterializedTableOperation {
 
     private final Function<ResolvedCatalogMaterializedTable, List<TableChange>> tableChangeForTable;
-    private final ResolvedCatalogMaterializedTable oldTable;
+    private ResolvedCatalogMaterializedTable oldTable;
     private MaterializedTableChangeHandler handler;
     private CatalogMaterializedTable newTable;
     private List<TableChange> tableChanges;
@@ -77,6 +89,17 @@ public class AlterMaterializedTableChangeOperation extends AlterMaterializedTabl
         return newTable;
     }
 
+    @Confluent
+    public ResolvedCatalogMaterializedTable getOldTable() {
+        return oldTable;
+    }
+
+    @Confluent
+    public void setOldTable(final ResolvedCatalogMaterializedTable oldTable) {
+        this.oldTable = oldTable;
+        this.newTable = null;
+    }
+
     protected MaterializedTableChangeHandler getHandlerWithChanges() {
         if (handler == null) {
             handler =
@@ -86,8 +109,105 @@ public class AlterMaterializedTableChangeOperation extends AlterMaterializedTabl
         return handler;
     }
 
+    @VisibleForTesting
+    public void validateChanges() {
+        final List<TableChange> changes = getTableChanges();
+        final boolean isQueryChange =
+                changes.stream().anyMatch(ModifyDefinitionQuery.class::isInstance);
+        final List<Column> oldColumns = oldTable.getResolvedSchema().getColumns();
+        final Map<String, Integer> columnIndex =
+                IntStream.range(0, oldColumns.size())
+                        .boxed()
+                        .collect(
+                                Collectors.toMap(
+                                        i -> oldColumns.get(i).getName(), Function.identity()));
+        final List<String> errors = new ArrayList<>();
+        for (final TableChange change : changes) {
+            if (change instanceof DropColumn) {
+                checkDroppedColumn((DropColumn) change, oldColumns, columnIndex, errors);
+            } else if (isQueryChange && change instanceof ModifyColumnPosition) {
+                checkPositionChange((ModifyColumnPosition) change, oldColumns, columnIndex, errors);
+            } else if (isQueryChange && change instanceof ModifyPhysicalColumnType) {
+                checkPhysicalTypeChange(
+                        (ModifyPhysicalColumnType) change, oldColumns, columnIndex, errors);
+            }
+        }
+        if (!errors.isEmpty()) {
+            throw new ValidationException(String.join("\n", errors));
+        }
+    }
+
+    private void checkDroppedColumn(
+            DropColumn change,
+            List<Column> oldColumns,
+            Map<String, Integer> columnIndex,
+            List<String> errors) {
+        final Integer idx = columnIndex.get(change.getColumnName());
+        if (idx != null && oldColumns.get(idx).isPersisted()) {
+            errors.add(
+                    String.format(
+                            "Dropping of persisted column `%s` is not supported.",
+                            change.getColumnName()));
+        }
+    }
+
+    private void checkPositionChange(
+            ModifyColumnPosition change,
+            List<Column> oldColumns,
+            Map<String, Integer> columnIndex,
+            List<String> errors) {
+        final int index = displacedColumnIndex(change.getNewPosition(), columnIndex);
+        if (index < 0) {
+            return;
+        }
+        errors.add(
+                positionChangeError(
+                        oldColumns.get(index).asSummaryString(),
+                        change.getNewColumn().asSummaryString(),
+                        index));
+    }
+
+    private void checkPhysicalTypeChange(
+            ModifyPhysicalColumnType change,
+            List<Column> oldColumns,
+            Map<String, Integer> columnIndex,
+            List<String> errors) {
+        final Integer idx = columnIndex.get(change.getOldColumn().getName());
+        if (idx != null) {
+            errors.add(
+                    positionChangeError(
+                            change.getOldColumn().asSummaryString(),
+                            change.getNewColumn().asSummaryString(),
+                            idx));
+        }
+    }
+
+    /**
+     * Returns the index in oldColumns of the column displaced by this position change, or -1 if
+     * positioned after a column absent from the old schema (i.e., appended after a new column).
+     */
+    private static int displacedColumnIndex(
+            ColumnPosition position, Map<String, Integer> columnIndex) {
+        if (position == ColumnPosition.first()) {
+            return 0;
+        }
+        final Integer afterIdx = columnIndex.get(((After) position).column());
+        // afterIdx == null  → after a new column not in the old schema → treat as append
+        // afterIdx == last  → after the last old column → also treat as append (no displacement)
+        return afterIdx != null && afterIdx < columnIndex.size() - 1 ? afterIdx + 1 : -1;
+    }
+
+    private static String positionChangeError(String oldColumn, String newColumn, int position) {
+        return String.format(
+                "When modifying the query of a materialized table, "
+                        + "currently only support appending columns at the end of original schema, dropping, renaming, and reordering columns are not supported.\n"
+                        + "Column mismatch at position %d: Original column is [%s], but new column is [%s].",
+                position + 1, oldColumn, newColumn);
+    }
+
     @Override
     public TableResultInternal execute(Context ctx) {
+        validateChanges();
         ctx.getCatalogManager()
                 .alterTable(getNewTable(), getTableChanges(), getTableIdentifier(), false);
         return TableResultImpl.TABLE_RESULT_OK;

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/materializedtable/FullAlterMaterializedTableOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/materializedtable/FullAlterMaterializedTableOperation.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.operations.materializedtable;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.catalog.CatalogMaterializedTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ResolvedCatalogMaterializedTable;
 import org.apache.flink.table.catalog.TableChange;
@@ -33,11 +34,22 @@ import java.util.function.Function;
 @Internal
 public class FullAlterMaterializedTableOperation extends AlterMaterializedTableChangeOperation {
 
+    private final Function<ResolvedCatalogMaterializedTable, CatalogMaterializedTable>
+            newTableBuilder;
+
     public FullAlterMaterializedTableOperation(
             final ObjectIdentifier tableIdentifier,
             final Function<ResolvedCatalogMaterializedTable, List<TableChange>> tableChangeForTable,
-            final ResolvedCatalogMaterializedTable oldTable) {
+            final ResolvedCatalogMaterializedTable oldTable,
+            final Function<ResolvedCatalogMaterializedTable, CatalogMaterializedTable>
+                    newTableBuilder) {
         super(tableIdentifier, tableChangeForTable, oldTable);
+        this.newTableBuilder = newTableBuilder;
+    }
+
+    @Override
+    protected CatalogMaterializedTable computeNewTable() {
+        return newTableBuilder.apply(getOldTable());
     }
 
     @Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/materializedtable/MaterializedTableChangeHandler.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/materializedtable/MaterializedTableChangeHandler.java
@@ -58,7 +58,6 @@ import org.apache.flink.table.types.DataType;
 
 import javax.annotation.Nullable;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.LinkedList;
@@ -66,16 +65,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.BiConsumer;
-import java.util.stream.Collectors;
 
-/** Applying table changes to old materialized table and gathering validation errors. */
+/** Applies table changes to a materialized table and builds the resulting definition. */
 @Internal
 public class MaterializedTableChangeHandler {
     private static final HandlerRegistry HANDLER_REGISTRY = createHandlerRegistry();
 
     private final List<UnresolvedColumn> columns;
     private final CatalogMaterializedTable oldTable;
-    private boolean isQueryChange;
     private @Nullable TableDistribution distribution;
     private CatalogMaterializedTable.RefreshStatus refreshStatus;
     private @Nullable String refreshHandlerDesc;
@@ -83,12 +80,10 @@ public class MaterializedTableChangeHandler {
     private List<UnresolvedWatermarkSpec> watermarkSpecs;
     private String primaryKeyName = null;
     private List<String> primaryKeyColumns = null;
-    private int droppedPersistedCnt = 0;
     private String originalQuery;
     private String expandedQuery;
     private StartMode startMode;
     private final Map<String, String> options;
-    private final List<String> validationErrors = new ArrayList<>();
 
     public MaterializedTableChangeHandler(CatalogMaterializedTable oldTable) {
         this.distribution = oldTable.getDistribution().orElse(null);
@@ -122,10 +117,10 @@ public class MaterializedTableChangeHandler {
         private void apply(MaterializedTableChangeHandler context, TableChange change) {
             HandlerRegistry.HandlerWrapper<?> wrapper = HANDLERS.get(change.getClass());
             if (wrapper == null) {
-                context.validationErrors.add("Unknown table change " + change.getClass());
-            } else {
-                wrapper.accept(context, change);
+                throw new ValidationException(
+                        "Unsupported table change: " + change.getClass().getName());
             }
+            wrapper.accept(context, change);
         }
 
         private static final class HandlerWrapper<T extends TableChange> {
@@ -141,24 +136,15 @@ public class MaterializedTableChangeHandler {
         }
     }
 
-    public List<String> getValidationErrors() {
-        return List.copyOf(validationErrors);
-    }
-
     public static MaterializedTableChangeHandler getHandlerWithChanges(
             CatalogMaterializedTable oldTable, List<TableChange> tableChanges) {
-        MaterializedTableChangeHandler handler = new MaterializedTableChangeHandler(oldTable);
+        final MaterializedTableChangeHandler handler = new MaterializedTableChangeHandler(oldTable);
         handler.applyTableChanges(tableChanges);
         return handler;
     }
 
     public static CatalogMaterializedTable buildNewMaterializedTable(
             MaterializedTableChangeHandler context) {
-        final List<String> validationErrors = context.getValidationErrors();
-        if (!validationErrors.isEmpty()) {
-            throw new ValidationException(String.join("\n", validationErrors));
-        }
-
         final CatalogMaterializedTable oldTable = context.getOldTable();
         return CatalogMaterializedTable.newBuilder()
                 .schema(context.retrieveSchema())
@@ -217,6 +203,9 @@ public class MaterializedTableChangeHandler {
         registry.register(
                 ModifyRefreshStatus.class, MaterializedTableChangeHandler::modifyRefreshStatus);
 
+        // Start mode
+        registry.register(ModifyStartMode.class, MaterializedTableChangeHandler::modifyStartMode);
+
         // Distribution operations
         registry.register(AddDistribution.class, MaterializedTableChangeHandler::addDistribution);
         registry.register(
@@ -233,24 +222,8 @@ public class MaterializedTableChangeHandler {
     }
 
     void applyTableChanges(List<TableChange> tableChanges) {
-        isQueryChange = tableChanges.stream().anyMatch(t -> t instanceof ModifyDefinitionQuery);
-        Schema oldSchema = oldTable.getUnresolvedSchema();
-        if (isQueryChange) {
-            checkForChangedPositionByQuery(tableChanges, oldSchema);
-        }
-
         for (TableChange tableChange : tableChanges) {
             HANDLER_REGISTRY.apply(this, tableChange);
-        }
-
-        if (droppedPersistedCnt > 0 && isQueryChange) {
-            final int schemaSize = oldSchema.getColumns().size();
-            validationErrors.add(
-                    String.format(
-                            "Failed to modify query because drop column is unsupported. "
-                                    + "When modifying a query, you can only append new columns at the end of original schema. "
-                                    + "The original schema has %d columns, but the newly derived schema from the query has %d columns.",
-                            schemaSize, schemaSize - droppedPersistedCnt));
         }
     }
 
@@ -324,15 +297,7 @@ public class MaterializedTableChangeHandler {
     }
 
     private void dropColumn(TableChange.DropColumn dropColumn) {
-        String droppedColumnName = dropColumn.getColumnName();
-        int index = getColumnIndex(droppedColumnName);
-        UnresolvedColumn column = columns.get(index);
-        if (isQueryChange && isNonPersistedColumn(column)) {
-            // noop
-        } else {
-            columns.remove(index);
-            droppedPersistedCnt++;
-        }
+        columns.remove(getColumnIndex(dropColumn.getColumnName()));
     }
 
     private void modifyPhysicalColumnType(ModifyPhysicalColumnType modifyPhysicalColumnType) {
@@ -350,15 +315,6 @@ public class MaterializedTableChangeHandler {
     private void modifyColumnPosition(ModifyColumnPosition columnWithChangedPosition) {
         Column column = columnWithChangedPosition.getOldColumn();
         int oldPosition = getColumnIndex(column.getName());
-        if (isQueryChange) {
-            validationErrors.add(
-                    String.format(
-                            "When modifying the query of a materialized table, "
-                                    + "currently only support appending columns at the end of original schema, dropping, renaming, and reordering columns are not supported.\n"
-                                    + "Column mismatch at position %d: Original column is [%s], but new column is [%s].",
-                            oldPosition + 1, column, column));
-        }
-
         ColumnPosition position = columnWithChangedPosition.getNewPosition();
         UnresolvedColumn changedPositionColumn = columns.get(oldPosition);
         columns.remove(oldPosition);
@@ -368,12 +324,6 @@ public class MaterializedTableChangeHandler {
     private void modifyDefinitionQuery(ModifyDefinitionQuery queryChange) {
         expandedQuery = queryChange.getDefinitionQuery();
         originalQuery = queryChange.getOriginalQuery();
-    }
-
-    private boolean isNonPersistedColumn(UnresolvedColumn column) {
-        return column instanceof Schema.UnresolvedComputedColumn
-                || column instanceof Schema.UnresolvedMetadataColumn
-                        && ((Schema.UnresolvedMetadataColumn) column).isVirtual();
     }
 
     private void addUniqueConstraint(AddUniqueConstraint addUniqueConstraint) {
@@ -459,88 +409,6 @@ public class MaterializedTableChangeHandler {
             return new Schema.UnresolvedComputedColumn(
                     name, ((Column.ComputedColumn) column).getExpression(), comment);
         }
-    }
-
-    private void checkForChangedPositionByQuery(List<TableChange> tableChanges, Schema oldSchema) {
-        List<ModifyColumnPosition> positionChanges =
-                tableChanges.stream()
-                        .filter(t -> t instanceof ModifyColumnPosition)
-                        .map(t -> (ModifyColumnPosition) t)
-                        .collect(Collectors.toList());
-
-        List<ModifyPhysicalColumnType> physicalTypeChanges =
-                tableChanges.stream()
-                        .filter(t -> t instanceof ModifyPhysicalColumnType)
-                        .map(t -> (ModifyPhysicalColumnType) t)
-                        .collect(Collectors.toList());
-
-        if (positionChanges.isEmpty() && physicalTypeChanges.isEmpty()) {
-            return;
-        }
-
-        int persistedColumnOffset = 0;
-        List<UnresolvedColumn> oldColumns = oldSchema.getColumns();
-        for (UnresolvedColumn column : oldColumns) {
-            if (!isNonPersistedColumn(column)) {
-                persistedColumnOffset++;
-            }
-        }
-
-        Map<String, Column> afterToColumnName = new HashMap<>();
-        for (ModifyColumnPosition change : positionChanges) {
-            final ColumnPosition position = change.getNewPosition();
-            final Column newColumn = change.getNewColumn();
-            if (position == ColumnPosition.first()) {
-                if (persistedColumnOffset == 0) {
-                    positionChangeError(
-                            newColumn.asSummaryString(),
-                            oldColumns.get(persistedColumnOffset).toString(),
-                            persistedColumnOffset);
-                } else {
-                    afterToColumnName.put(
-                            oldColumns.get(persistedColumnOffset).getName(), newColumn);
-                }
-            } else {
-                afterToColumnName.put(((After) position).column(), newColumn);
-            }
-        }
-
-        for (int i = 0; i < oldColumns.size() - 1; i++) {
-            Column newColumn = afterToColumnName.get(oldColumns.get(i).getName());
-            if (newColumn != null) {
-                positionChangeError(oldColumns.get(i + 1), newColumn, i + 1);
-            }
-        }
-
-        Map<String, Integer> nameToIndex = new HashMap<>();
-        for (int i = 0; i < oldColumns.size(); i++) {
-            UnresolvedColumn column = oldColumns.get(i);
-            if (!isNonPersistedColumn(column)) {
-                nameToIndex.put(column.getName(), i);
-            }
-        }
-
-        for (ModifyPhysicalColumnType change : physicalTypeChanges) {
-            final int index = nameToIndex.get(change.getOldColumn().getName());
-            positionChangeError(change.getOldColumn(), change.getNewColumn(), index);
-        }
-    }
-
-    private void positionChangeError(UnresolvedColumn oldColumn, Column newColumn, int position) {
-        positionChangeError(oldColumn.toString(), newColumn.asSummaryString(), position);
-    }
-
-    private void positionChangeError(Column oldColumn, Column newColumn, int position) {
-        positionChangeError(oldColumn.asSummaryString(), newColumn.asSummaryString(), position);
-    }
-
-    private void positionChangeError(String oldColumn, String newColumn, int position) {
-        validationErrors.add(
-                String.format(
-                        "When modifying the query of a materialized table, "
-                                + "currently only support appending columns at the end of original schema, dropping, renaming, and reordering columns are not supported.\n"
-                                + "Column mismatch at position %d: Original column is [%s], but new column is [%s].",
-                        position + 1, oldColumn, newColumn));
     }
 
     private void setColumnAtPosition(UnresolvedColumn column, ColumnPosition position) {

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/operations/materializedtable/AlterMaterializedTableAsQueryOperationValidationTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/operations/materializedtable/AlterMaterializedTableAsQueryOperationValidationTest.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations.materializedtable;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.ResolvedCatalogMaterializedTable;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.catalog.TableChange;
+import org.apache.flink.table.catalog.TableChange.ColumnPosition;
+import org.apache.flink.table.expressions.utils.ResolvedExpressionMock;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.apache.flink.table.catalog.Column.computed;
+import static org.apache.flink.table.catalog.Column.physical;
+import static org.apache.flink.table.operations.materializedtable.AlterMaterializedTableChangeOperationValidationTest.resolvedTable;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for validation of {@link AlterMaterializedTableAsQueryOperation} (ALTER MATERIALIZED TABLE
+ * ... AS &lt;query&gt;). CREATE OR ALTER goes through {@link FullAlterMaterializedTableOperation}
+ * and is exercised separately by the planner integration tests.
+ */
+class AlterMaterializedTableAsQueryOperationValidationTest {
+
+    private static final TableChange QUERY_CHANGE =
+            TableChange.modifyDefinitionQuery(
+                    "SELECT a, b FROM src", "SELECT `src`.`a`, `src`.`b` FROM `src`");
+
+    @Test
+    void rejectDropPersistedColumn() {
+        final ResolvedCatalogMaterializedTable oldTable =
+                resolvedTable(
+                        ResolvedSchema.of(
+                                physical("a", DataTypes.INT()), physical("b", DataTypes.STRING())));
+
+        final AlterMaterializedTableAsQueryOperation op =
+                operation(
+                        oldTable,
+                        List.of(
+                                TableChange.modifyDefinitionQuery(
+                                        "SELECT b FROM src", "SELECT `src`.`b` FROM `src`"),
+                                TableChange.dropColumn("a")));
+
+        assertThatThrownBy(op::validateChanges)
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("Dropping of persisted column `a` is not supported.");
+    }
+
+    @Test
+    void acceptDropNonPersistedColumn() {
+        final ResolvedCatalogMaterializedTable oldTable =
+                resolvedTable(
+                        ResolvedSchema.of(
+                                physical("a", DataTypes.INT()),
+                                computed(
+                                        "comp",
+                                        new ResolvedExpressionMock(
+                                                DataTypes.STRING(), () -> "UPPER(a)"))));
+
+        final AlterMaterializedTableAsQueryOperation op =
+                operation(
+                        oldTable,
+                        List.of(
+                                TableChange.modifyDefinitionQuery(
+                                        "SELECT a FROM src2", "SELECT `src2`.`a` FROM `src2`"),
+                                TableChange.dropColumn("comp")));
+
+        assertThatNoException().isThrownBy(op::validateChanges);
+    }
+
+    @Test
+    void rejectReorderColumn() {
+        final ResolvedCatalogMaterializedTable oldTable =
+                resolvedTable(
+                        ResolvedSchema.of(
+                                physical("a", DataTypes.INT()),
+                                physical("b", DataTypes.STRING()),
+                                physical("c", DataTypes.BIGINT())));
+
+        final AlterMaterializedTableAsQueryOperation op =
+                operation(
+                        oldTable,
+                        List.of(
+                                TableChange.modifyDefinitionQuery(
+                                        "SELECT a, c, b FROM src",
+                                        "SELECT `src`.`a`, `src`.`c`, `src`.`b` FROM `src`"),
+                                TableChange.modifyColumnPosition(
+                                        physical("c", DataTypes.BIGINT()),
+                                        ColumnPosition.after("a"))));
+
+        assertThatThrownBy(op::validateChanges)
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining(
+                        "Column mismatch at position 2: Original column is [`b` STRING], but new column is [`c` BIGINT].");
+    }
+
+    @Test
+    void rejectReorderColumnToFirst() {
+        final ResolvedCatalogMaterializedTable oldTable =
+                resolvedTable(
+                        ResolvedSchema.of(
+                                physical("a", DataTypes.INT()), physical("b", DataTypes.STRING())));
+
+        final AlterMaterializedTableAsQueryOperation op =
+                operation(
+                        oldTable,
+                        List.of(
+                                TableChange.modifyDefinitionQuery(
+                                        "SELECT b, a FROM src",
+                                        "SELECT `src`.`b`, `src`.`a` FROM `src`"),
+                                TableChange.modifyColumnPosition(
+                                        physical("b", DataTypes.STRING()),
+                                        ColumnPosition.first())));
+
+        assertThatThrownBy(op::validateChanges)
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining(
+                        "Column mismatch at position 1: Original column is [`a` INT], but new column is [`b` STRING].");
+    }
+
+    @Test
+    void rejectTypeChange() {
+        final ResolvedCatalogMaterializedTable oldTable =
+                resolvedTable(
+                        ResolvedSchema.of(
+                                physical("a", DataTypes.INT()), physical("b", DataTypes.STRING())));
+
+        final AlterMaterializedTableAsQueryOperation op =
+                operation(
+                        oldTable,
+                        List.of(
+                                TableChange.modifyDefinitionQuery(
+                                        "SELECT CAST(a AS BIGINT), b FROM src",
+                                        "SELECT CAST(`src`.`a` AS BIGINT), `src`.`b` FROM `src`"),
+                                TableChange.modifyPhysicalColumnType(
+                                        physical("a", DataTypes.INT()), DataTypes.BIGINT())));
+
+        assertThatThrownBy(op::validateChanges)
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining(
+                        "Column mismatch at position 1: Original column is [`a` INT], but new column is [`a` BIGINT].");
+    }
+
+    @Test
+    void acceptAppendColumn() {
+        final ResolvedCatalogMaterializedTable oldTable =
+                resolvedTable(
+                        ResolvedSchema.of(
+                                physical("a", DataTypes.INT()), physical("b", DataTypes.STRING())));
+
+        final AlterMaterializedTableAsQueryOperation op =
+                operation(
+                        oldTable,
+                        List.of(QUERY_CHANGE, TableChange.add(physical("c", DataTypes.BIGINT()))));
+
+        assertThatNoException().isThrownBy(op::validateChanges);
+    }
+
+    @Test
+    void acceptQueryOnlyChange() {
+        final ResolvedCatalogMaterializedTable oldTable =
+                resolvedTable(
+                        ResolvedSchema.of(
+                                physical("a", DataTypes.INT()), physical("b", DataTypes.STRING())));
+
+        final AlterMaterializedTableAsQueryOperation op =
+                operation(oldTable, List.of(QUERY_CHANGE));
+
+        assertThatNoException().isThrownBy(op::validateChanges);
+    }
+
+    private static AlterMaterializedTableAsQueryOperation operation(
+            ResolvedCatalogMaterializedTable oldTable, List<TableChange> changes) {
+        return new AlterMaterializedTableAsQueryOperation(
+                ObjectIdentifier.of("cat", "db", "mt"), ignored -> changes, oldTable);
+    }
+}

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/operations/materializedtable/AlterMaterializedTableChangeOperationValidationTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/operations/materializedtable/AlterMaterializedTableChangeOperationValidationTest.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations.materializedtable;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.CatalogMaterializedTable;
+import org.apache.flink.table.catalog.CatalogMaterializedTable.LogicalRefreshMode;
+import org.apache.flink.table.catalog.CatalogMaterializedTable.RefreshMode;
+import org.apache.flink.table.catalog.CatalogMaterializedTable.RefreshStatus;
+import org.apache.flink.table.catalog.IntervalFreshness;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.ResolvedCatalogMaterializedTable;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.catalog.StartMode;
+import org.apache.flink.table.catalog.StartMode.StartModeKind;
+import org.apache.flink.table.catalog.TableChange;
+import org.apache.flink.table.expressions.utils.ResolvedExpressionMock;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.table.catalog.Column.computed;
+import static org.apache.flink.table.catalog.Column.metadata;
+import static org.apache.flink.table.catalog.Column.physical;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link AlterMaterializedTableChangeOperation#validateChanges()} when the operation
+ * carries explicit DDL changes (no query change). Query-change validation is exercised by {@link
+ * AlterMaterializedTableAsQueryOperationValidationTest}.
+ */
+class AlterMaterializedTableChangeOperationValidationTest {
+
+    @Test
+    void rejectDropPersistedColumn() {
+        final ResolvedCatalogMaterializedTable oldTable =
+                resolvedTable(
+                        ResolvedSchema.of(
+                                physical("a", DataTypes.INT()), physical("b", DataTypes.STRING())));
+
+        final AlterMaterializedTableChangeOperation op =
+                operation(oldTable, List.of(TableChange.dropColumn("a")));
+
+        assertThatThrownBy(op::validateChanges)
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("Dropping of persisted column `a` is not supported.");
+    }
+
+    @Test
+    void rejectDropPersistedMetadataColumn() {
+        final ResolvedCatalogMaterializedTable oldTable =
+                resolvedTable(
+                        ResolvedSchema.of(
+                                physical("a", DataTypes.INT()),
+                                metadata("m", DataTypes.STRING(), null, false)));
+
+        final AlterMaterializedTableChangeOperation op =
+                operation(oldTable, List.of(TableChange.dropColumn("m")));
+
+        assertThatThrownBy(op::validateChanges)
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("Dropping of persisted column `m` is not supported.");
+    }
+
+    @Test
+    void acceptDropComputedColumn() {
+        final ResolvedCatalogMaterializedTable oldTable =
+                resolvedTable(
+                        ResolvedSchema.of(
+                                physical("a", DataTypes.INT()),
+                                computed(
+                                        "c",
+                                        new ResolvedExpressionMock(
+                                                DataTypes.STRING(), () -> "UPPER(a)"))));
+
+        final AlterMaterializedTableChangeOperation op =
+                operation(oldTable, List.of(TableChange.dropColumn("c")));
+
+        assertThatNoException().isThrownBy(op::validateChanges);
+    }
+
+    @Test
+    void acceptDropVirtualMetadataColumn() {
+        final ResolvedCatalogMaterializedTable oldTable =
+                resolvedTable(
+                        ResolvedSchema.of(
+                                physical("a", DataTypes.INT()),
+                                metadata("v", DataTypes.STRING(), null, true)));
+
+        final AlterMaterializedTableChangeOperation op =
+                operation(oldTable, List.of(TableChange.dropColumn("v")));
+
+        assertThatNoException().isThrownBy(op::validateChanges);
+    }
+
+    @Test
+    void acceptDropNonExistentColumn() {
+        final ResolvedCatalogMaterializedTable oldTable =
+                resolvedTable(
+                        ResolvedSchema.of(
+                                physical("a", DataTypes.INT()), physical("b", DataTypes.STRING())));
+
+        final AlterMaterializedTableChangeOperation op =
+                operation(oldTable, List.of(TableChange.dropColumn("does-not-exist")));
+
+        // No column to validate against; planner-level checks handle this elsewhere.
+        assertThatNoException().isThrownBy(op::validateChanges);
+    }
+
+    @Test
+    void acceptAddColumn() {
+        final ResolvedCatalogMaterializedTable oldTable =
+                resolvedTable(
+                        ResolvedSchema.of(
+                                physical("a", DataTypes.INT()), physical("b", DataTypes.STRING())));
+
+        final AlterMaterializedTableChangeOperation op =
+                operation(oldTable, List.of(TableChange.add(physical("c", DataTypes.BIGINT()))));
+
+        assertThatNoException().isThrownBy(op::validateChanges);
+    }
+
+    @Test
+    void acceptCommentChange() {
+        final ResolvedCatalogMaterializedTable oldTable =
+                resolvedTable(
+                        ResolvedSchema.of(
+                                physical("a", DataTypes.INT()), physical("b", DataTypes.STRING())));
+
+        final AlterMaterializedTableChangeOperation op =
+                operation(
+                        oldTable,
+                        List.of(
+                                TableChange.modifyColumnComment(
+                                        physical("a", DataTypes.INT()), "new comment")));
+
+        assertThatNoException().isThrownBy(op::validateChanges);
+    }
+
+    static ResolvedCatalogMaterializedTable resolvedTable(ResolvedSchema resolvedSchema) {
+        final CatalogMaterializedTable origin =
+                CatalogMaterializedTable.newBuilder()
+                        .schema(Schema.newBuilder().fromResolvedSchema(resolvedSchema).build())
+                        .comment("")
+                        .partitionKeys(List.of())
+                        .options(Map.of())
+                        .originalQuery("SELECT a FROM src")
+                        .expandedQuery("SELECT `src`.`a` FROM `src`")
+                        .freshness(IntervalFreshness.ofSecond(60))
+                        .logicalRefreshMode(LogicalRefreshMode.AUTOMATIC)
+                        .refreshMode(RefreshMode.CONTINUOUS)
+                        .refreshStatus(RefreshStatus.INITIALIZING)
+                        .startMode(StartMode.of(StartModeKind.FROM_BEGINNING))
+                        .build();
+        return new ResolvedCatalogMaterializedTable(
+                origin,
+                resolvedSchema,
+                RefreshMode.CONTINUOUS,
+                IntervalFreshness.ofSecond(60),
+                StartMode.of(StartModeKind.FROM_BEGINNING));
+    }
+
+    static AlterMaterializedTableChangeOperation operation(
+            ResolvedCatalogMaterializedTable oldTable, List<TableChange> changes) {
+        return new AlterMaterializedTableChangeOperation(
+                ObjectIdentifier.of("cat", "db", "mt"), ignored -> changes, oldTable);
+    }
+}

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/operations/materializedtable/MaterializedTableChangeHandlerTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/operations/materializedtable/MaterializedTableChangeHandlerTest.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations.materializedtable;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.CatalogMaterializedTable;
+import org.apache.flink.table.catalog.CatalogMaterializedTable.LogicalRefreshMode;
+import org.apache.flink.table.catalog.CatalogMaterializedTable.RefreshMode;
+import org.apache.flink.table.catalog.CatalogMaterializedTable.RefreshStatus;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.IntervalFreshness;
+import org.apache.flink.table.catalog.StartMode;
+import org.apache.flink.table.catalog.StartMode.StartModeKind;
+import org.apache.flink.table.catalog.TableChange;
+import org.apache.flink.table.catalog.TableChange.ColumnPosition;
+import org.apache.flink.table.expressions.utils.ResolvedExpressionMock;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
+
+/**
+ * Tests for {@link MaterializedTableChangeHandler} — pure applier behavior exercised without the
+ * planner stack. Validation lives in {@link
+ * AlterMaterializedTableChangeOperation#validateChanges()}; tests there assert what is rejected.
+ */
+class MaterializedTableChangeHandlerTest {
+
+    /** Default schema used by tests that don't refine it: [a INT, b STRING]. */
+    private static final Schema DEFAULT_SCHEMA =
+            Schema.newBuilder()
+                    .column("a", DataTypes.INT())
+                    .column("b", DataTypes.STRING())
+                    .build();
+
+    private static CatalogMaterializedTable.Builder defaultBuilder() {
+        return CatalogMaterializedTable.newBuilder()
+                .schema(DEFAULT_SCHEMA)
+                .comment("")
+                .partitionKeys(List.of())
+                .options(Map.of())
+                .originalQuery("dummy")
+                .expandedQuery("dummy")
+                .freshness(IntervalFreshness.ofSecond(60))
+                .logicalRefreshMode(LogicalRefreshMode.AUTOMATIC)
+                .refreshMode(RefreshMode.CONTINUOUS)
+                .refreshStatus(RefreshStatus.INITIALIZING)
+                .startMode(StartMode.of(StartModeKind.FROM_BEGINNING));
+    }
+
+    @Test
+    void shouldDropPersistedColumn() {
+        // old schema: [a INT, b STRING]
+        final CatalogMaterializedTable newTable =
+                applyChanges(defaultBuilder().build(), List.of(TableChange.dropColumn("a")));
+
+        assertThat(newTable.getUnresolvedSchema().getColumns())
+                .extracting(Schema.UnresolvedColumn::getName)
+                .containsExactly("b");
+    }
+
+    @Test
+    void shouldDropComputedColumn() {
+        // old schema: [a INT, comp AS UPPER(a)]
+        final CatalogMaterializedTable tableWithComputed =
+                defaultBuilder()
+                        .schema(
+                                Schema.newBuilder()
+                                        .column("a", DataTypes.INT())
+                                        .columnByExpression("comp", "UPPER(a)")
+                                        .build())
+                        .build();
+
+        final CatalogMaterializedTable newTable =
+                applyChanges(tableWithComputed, List.of(TableChange.dropColumn("comp")));
+
+        assertThat(newTable.getUnresolvedSchema().getColumns())
+                .extracting(Schema.UnresolvedColumn::getName)
+                .containsExactly("a");
+    }
+
+    @Test
+    void shouldDropVirtualMetadataColumn() {
+        // old schema: [a INT, v STRING METADATA VIRTUAL]
+        final CatalogMaterializedTable tableWithMetadata =
+                defaultBuilder()
+                        .schema(
+                                Schema.newBuilder()
+                                        .column("a", DataTypes.INT())
+                                        .columnByMetadata("v", DataTypes.STRING(), null, true)
+                                        .build())
+                        .build();
+
+        final CatalogMaterializedTable newTable =
+                applyChanges(tableWithMetadata, List.of(TableChange.dropColumn("v")));
+
+        assertThat(newTable.getUnresolvedSchema().getColumns())
+                .extracting(Schema.UnresolvedColumn::getName)
+                .containsExactly("a");
+    }
+
+    @Test
+    void shouldApplyAddColumnAfter() {
+        // old schema: [a INT, b STRING]
+        final CatalogMaterializedTable newTable =
+                applyChanges(
+                        defaultBuilder().build(),
+                        List.of(
+                                TableChange.add(
+                                        Column.physical("x", DataTypes.BIGINT()),
+                                        ColumnPosition.after("a"))));
+
+        assertThat(newTable.getUnresolvedSchema().getColumns())
+                .extracting(Schema.UnresolvedColumn::getName)
+                .containsExactly("a", "x", "b");
+        assertThat(newTable.getUnresolvedSchema().getColumns())
+                .element(1)
+                .asInstanceOf(type(Schema.UnresolvedPhysicalColumn.class))
+                .returns(DataTypes.BIGINT(), Schema.UnresolvedPhysicalColumn::getDataType);
+    }
+
+    @Test
+    void shouldApplyAddComputedColumnFirst() {
+        // old schema: [a INT, b STRING]
+        final CatalogMaterializedTable newTable =
+                applyChanges(
+                        defaultBuilder().build(),
+                        List.of(
+                                TableChange.add(
+                                        Column.computed(
+                                                "comp",
+                                                new ResolvedExpressionMock(
+                                                        DataTypes.INT(), () -> "1")),
+                                        ColumnPosition.first())));
+
+        assertThat(newTable.getUnresolvedSchema().getColumns())
+                .extracting(Schema.UnresolvedColumn::getName)
+                .containsExactly("comp", "a", "b");
+    }
+
+    @Test
+    void shouldApplyAddVirtualMetadataColumn() {
+        // old schema: [a INT, b STRING]
+        final CatalogMaterializedTable newTable =
+                applyChanges(
+                        defaultBuilder().build(),
+                        List.of(
+                                TableChange.add(
+                                        Column.metadata("m", DataTypes.STRING(), null, true))));
+
+        assertThat(newTable.getUnresolvedSchema().getColumns())
+                .extracting(Schema.UnresolvedColumn::getName)
+                .containsExactly("a", "b", "m");
+    }
+
+    @Test
+    void shouldRejectUnsupportedTableChange() {
+        // old schema: [a INT, b STRING]
+        final TableChange unsupported = new TableChange() {};
+
+        assertThatThrownBy(() -> applyChanges(defaultBuilder().build(), List.of(unsupported)))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("Unsupported table change");
+    }
+
+    private static CatalogMaterializedTable applyChanges(
+            CatalogMaterializedTable oldTable, List<TableChange> changes) {
+        final MaterializedTableChangeHandler handler =
+                MaterializedTableChangeHandler.getHandlerWithChanges(oldTable, changes);
+        return MaterializedTableChangeHandler.buildNewMaterializedTable(handler);
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/materializedtable/AbstractCreateMaterializedTableConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/materializedtable/AbstractCreateMaterializedTableConverter.java
@@ -81,7 +81,13 @@ public abstract class AbstractCreateMaterializedTableConverter<T extends SqlCrea
 
         RefreshMode getMergedRefreshMode();
 
+        LogicalRefreshMode getMergedLogicalRefreshMode();
+
         StartMode getMergedStartMode();
+
+        String getMergedComment();
+
+        IntervalFreshness getMergedFreshness();
     }
 
     protected abstract MergeContext getMergeContext(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/materializedtable/SqlAlterMaterializedTableDropSchemaConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/materializedtable/SqlAlterMaterializedTableDropSchemaConverter.java
@@ -24,7 +24,6 @@ import org.apache.flink.sql.parser.ddl.materializedtable.SqlAlterMaterializedTab
 import org.apache.flink.sql.parser.ddl.materializedtable.SqlAlterMaterializedTableSchema.SqlAlterMaterializedTableDropSchema;
 import org.apache.flink.sql.parser.ddl.materializedtable.SqlAlterMaterializedTableSchema.SqlAlterMaterializedTableDropWatermark;
 import org.apache.flink.table.api.ValidationException;
-import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ResolvedCatalogMaterializedTable;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.TableChange;
@@ -170,14 +169,6 @@ public abstract class SqlAlterMaterializedTableDropSchemaConverter<
                     OperationConverterUtils.validateAndGatherDropColumn(
                             oldTable, columnsToDrop, EX_MSG_PREFIX);
             validateColumnsUsedInQuery(oldTable, alterTableSchema, context);
-            for (Column column : oldTable.getResolvedSchema().getColumns()) {
-                if (column.isPersisted() && columnsToDrop.contains(column.getName())) {
-                    throw new ValidationException(
-                            String.format(
-                                    "%sThe column `%s` is a persisted column. Dropping of persisted columns is not supported.",
-                                    EX_MSG_PREFIX, column.getName()));
-                }
-            }
             return tableChanges;
         }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/materializedtable/SqlCreateOrAlterMaterializedTableConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/materializedtable/SqlCreateOrAlterMaterializedTableConverter.java
@@ -23,7 +23,10 @@ import org.apache.flink.sql.parser.ddl.materializedtable.SqlCreateOrAlterMateria
 import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.CatalogBaseTable.TableKind;
+import org.apache.flink.table.catalog.CatalogMaterializedTable;
+import org.apache.flink.table.catalog.CatalogMaterializedTable.LogicalRefreshMode;
 import org.apache.flink.table.catalog.CatalogMaterializedTable.RefreshMode;
+import org.apache.flink.table.catalog.IntervalFreshness;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ResolvedCatalogBaseTable;
 import org.apache.flink.table.catalog.ResolvedCatalogMaterializedTable;
@@ -37,6 +40,7 @@ import org.apache.flink.table.catalog.WatermarkSpec;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.materializedtable.CreateMaterializedTableOperation;
 import org.apache.flink.table.operations.materializedtable.FullAlterMaterializedTableOperation;
+import org.apache.flink.table.operations.materializedtable.MaterializedTableChangeHandler;
 import org.apache.flink.table.planner.operations.converters.MergeTableAsUtil;
 import org.apache.flink.table.planner.utils.MaterializedTableUtils;
 
@@ -50,7 +54,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
 
 /** A converter for {@link SqlCreateOrAlterMaterializedTable}. */
 public class SqlCreateOrAlterMaterializedTableConverter
@@ -105,11 +108,40 @@ public class SqlCreateOrAlterMaterializedTableConverter
             final ResolvedCatalogMaterializedTable oldTable,
             final ConvertContext context,
             final ObjectIdentifier identifier) {
+        final SchemaResolver schemaResolver = context.getCatalogManager().getSchemaResolver();
         final MergeContext mergeContext = getMergeContext(sqlCreateOrAlterTable, context);
         return new FullAlterMaterializedTableOperation(
                 identifier,
-                buildTableChanges(mergeContext, context.getCatalogManager().getSchemaResolver()),
-                oldTable);
+                currentTable -> buildTableChanges(currentTable, mergeContext, schemaResolver),
+                oldTable,
+                currentTable -> buildNewTable(currentTable, mergeContext, schemaResolver));
+    }
+
+    private CatalogMaterializedTable buildNewTable(
+            final ResolvedCatalogMaterializedTable currentTable,
+            final MergeContext mergeContext,
+            final SchemaResolver schemaResolver) {
+        return CatalogMaterializedTable.newBuilder()
+                .schema(
+                        MaterializedTableChangeHandler.getHandlerWithChanges(
+                                        currentTable,
+                                        getSchemaTableChanges(
+                                                mergeContext, schemaResolver, currentTable))
+                                .retrieveSchema())
+                .comment(mergeContext.getMergedComment())
+                .partitionKeys(mergeContext.getMergedPartitionKeys())
+                .options(mergeContext.getMergedTableOptions())
+                .originalQuery(mergeContext.getMergedOriginalQuery())
+                .expandedQuery(mergeContext.getMergedExpandedQuery())
+                .distribution(mergeContext.getMergedTableDistribution().orElse(null))
+                .freshness(mergeContext.getMergedFreshness())
+                .logicalRefreshMode(mergeContext.getMergedLogicalRefreshMode())
+                .refreshMode(mergeContext.getMergedRefreshMode())
+                .refreshStatus(currentTable.getRefreshStatus())
+                .refreshHandlerDescription(currentTable.getRefreshHandlerDescription().orElse(null))
+                .serializedRefreshHandler(currentTable.getSerializedRefreshHandler())
+                .startMode(mergeContext.getMergedStartMode())
+                .build();
     }
 
     private Operation handleCreate(
@@ -122,33 +154,37 @@ public class SqlCreateOrAlterMaterializedTableConverter
         return new CreateMaterializedTableOperation(identifier, resolvedTable);
     }
 
-    private Function<ResolvedCatalogMaterializedTable, List<TableChange>> buildTableChanges(
-            final MergeContext mergeContext, final SchemaResolver schemaResolver) {
-        return oldTable -> {
-            final List<TableChange> changes =
-                    getSchemaTableChanges(mergeContext, schemaResolver, oldTable);
+    private List<TableChange> buildTableChanges(
+            final ResolvedCatalogMaterializedTable oldTable,
+            final MergeContext mergeContext,
+            final SchemaResolver schemaResolver) {
+        final List<TableChange> changes =
+                getSchemaTableChanges(mergeContext, schemaResolver, oldTable);
 
-            changes.addAll(getQueryTableChanges(mergeContext, oldTable));
-            changes.addAll(getOptionsTableChanges(mergeContext, oldTable));
-            changes.addAll(getDistributionTableChanges(mergeContext, oldTable));
+        changes.addAll(getQueryTableChanges(mergeContext, oldTable));
+        changes.addAll(getOptionsTableChanges(mergeContext, oldTable));
+        changes.addAll(getDistributionTableChanges(mergeContext, oldTable));
 
-            final RefreshMode oldRefreshMode = oldTable.getRefreshMode();
-            final RefreshMode newRefreshMode = mergeContext.getMergedRefreshMode();
-            if (oldRefreshMode != newRefreshMode && newRefreshMode != null) {
-                throw new ValidationException("Changing of REFRESH MODE is unsupported");
-            }
+        final RefreshMode oldRefreshMode = oldTable.getRefreshMode();
+        final RefreshMode newRefreshMode = mergeContext.getMergedRefreshMode();
+        if (oldRefreshMode != newRefreshMode && newRefreshMode != null) {
+            throw new ValidationException("Changing of REFRESH MODE is unsupported");
+        }
 
-            final StartMode newStartMode = mergeContext.getMergedStartMode();
+        final StartMode newStartMode = mergeContext.getMergedStartMode();
+        if (newStartMode != null) {
             final StartMode oldStartMode =
                     oldTable.getStartMode()
                             .orElseThrow(
-                                    () -> new ValidationException("START_MODE must not be null"));
+                                    () ->
+                                            new ValidationException(
+                                                    "Start mode must be set on materialized table."));
             if (!Objects.equals(oldStartMode, newStartMode)) {
                 changes.add(TableChange.modifyStartMode(newStartMode));
             }
+        }
 
-            return changes;
-        };
+        return changes;
     }
 
     private List<TableChange> getDistributionTableChanges(
@@ -295,21 +331,12 @@ public class SqlCreateOrAlterMaterializedTableConverter
 
             @Override
             public Schema getMergedSchema() {
-                final Set<String> querySchemaColumnNames =
-                        new HashSet<>(querySchema.getColumnNames());
                 final SqlNodeList sqlNodeList = sqlCreateMaterializedTable.getColumnList();
-                for (SqlNode column : sqlNodeList) {
-                    if (!(column instanceof SqlRegularColumn)) {
-                        continue;
-                    }
-
-                    SqlRegularColumn physicalColumn = (SqlRegularColumn) column;
-                    if (!querySchemaColumnNames.contains(physicalColumn.getName().getSimple())) {
-                        throw new ValidationException(
-                                String.format(
-                                        "Invalid as physical column '%s' is defined in the DDL, but is not used in a query column.",
-                                        physicalColumn.getName().getSimple()));
-                    }
+                if (createOrAlterOperation(sqlCreateMaterializedTable)) {
+                    MaterializedTableUtils.validatePersistedColumnsUsedByQuery(
+                            sqlNodeList, querySchema);
+                } else {
+                    validatePhysicalColumnsUsedByQuery(sqlNodeList, querySchema);
                 }
                 if (sqlCreateMaterializedTable.isSchemaWithColumnsIdentifiersOnly()) {
                     // If only column identifiers are provided, then these are used to
@@ -358,14 +385,45 @@ public class SqlCreateOrAlterMaterializedTableConverter
 
             @Override
             public RefreshMode getMergedRefreshMode() {
-                return getDerivedRefreshMode(
-                        getDerivedLogicalRefreshMode(sqlCreateMaterializedTable));
+                return getDerivedRefreshMode(getMergedLogicalRefreshMode());
+            }
+
+            @Override
+            public LogicalRefreshMode getMergedLogicalRefreshMode() {
+                return getDerivedLogicalRefreshMode(sqlCreateMaterializedTable);
             }
 
             @Override
             public StartMode getMergedStartMode() {
                 return getStartMode(sqlCreateMaterializedTable, context);
             }
+
+            @Override
+            public String getMergedComment() {
+                return getComment(sqlCreateMaterializedTable);
+            }
+
+            @Override
+            public IntervalFreshness getMergedFreshness() {
+                return getDerivedFreshness(sqlCreateMaterializedTable);
+            }
         };
+    }
+
+    private static void validatePhysicalColumnsUsedByQuery(
+            SqlNodeList sqlNodeList, ResolvedSchema querySchema) {
+        final Set<String> querySchemaColumnNames = new HashSet<>(querySchema.getColumnNames());
+        for (SqlNode column : sqlNodeList) {
+            if (!(column instanceof SqlRegularColumn)) {
+                continue;
+            }
+            final SqlRegularColumn physicalColumn = (SqlRegularColumn) column;
+            if (!querySchemaColumnNames.contains(physicalColumn.getName().getSimple())) {
+                throw new ValidationException(
+                        String.format(
+                                "Invalid as physical column '%s' is defined in the DDL, but is not used in a query column.",
+                                physicalColumn.getName().getSimple()));
+            }
+        }
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/MaterializedTableUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/MaterializedTableUtils.java
@@ -54,7 +54,6 @@ import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlTimestampLiteral;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.TimestampString;
-import org.apache.commons.lang3.StringUtils;
 
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -447,68 +446,106 @@ public class MaterializedTableUtils {
 
     public static List<TableChange> validateAndExtractColumnChanges(
             ResolvedSchema oldSchema, ResolvedSchema newSchema, boolean schemaDefinedInQuery) {
-        final List<Column> newColumns = getPersistedColumns(newSchema);
-        final List<Column> oldColumns = getPersistedColumns(oldSchema);
-        final int originalColumnSize = oldColumns.size();
-        final int newColumnSize = newColumns.size();
-
-        if (originalColumnSize > newColumnSize) {
-            throw new ValidationException(
-                    String.format(
-                            "Failed to modify query because drop column is unsupported. "
-                                    + "When modifying a query, you can only append new columns at the end of original schema. "
-                                    + "The original schema has %d columns, but the newly derived schema from the query has %d columns.",
-                            originalColumnSize, newColumnSize));
-        }
-
-        final List<TableChange> columnChanges = new ArrayList<>();
+        final List<Column> oldColumns = oldSchema.getColumns();
+        final Map<String, Tuple2<Column, Integer>> oldByName = new HashMap<>();
         for (int i = 0; i < oldColumns.size(); i++) {
-            final Column oldColumn = oldColumns.get(i);
-            final Column newColumn = newColumns.get(i);
-            final DataType newColumnDataType =
-                    getNewColumnDatatype(oldColumn, newColumns.get(i), schemaDefinedInQuery);
-            if (!oldColumn.equals(newColumn)) {
-                if (!oldColumn.getName().equals(newColumn.getName())
-                        || !oldColumn.getDataType().equals(newColumnDataType)) {
-                    throw new ValidationException(
-                            String.format(
-                                    "When modifying the query of a materialized table, "
-                                            + "currently only support appending columns at the end of original schema, dropping, renaming, and reordering columns are not supported.\n"
-                                            + "Column mismatch at position %d: Original column is [%s], but new column is [%s].",
-                                    i + 1, oldColumn, newColumn));
-                }
+            oldByName.put(oldColumns.get(i).getName(), Tuple2.of(oldColumns.get(i), i));
+        }
+        final Set<String> seen = new HashSet<>();
+        final List<Column> newColumns = newSchema.getColumns();
+        final List<TableChange> changes = new ArrayList<>();
+        for (int newIndex = 0; newIndex < newColumns.size(); newIndex++) {
+            final Column newColumn = newColumns.get(newIndex);
+            seen.add(newColumn.getName());
+            final Tuple2<Column, Integer> oldEntry = oldByName.get(newColumn.getName());
+            if (oldEntry == null) {
+                changes.add(addChange(newColumn, schemaDefinedInQuery));
+                continue;
+            }
+            final Column oldColumn = oldEntry.f0;
+            // No position diff: DDL order is arbitrary; query-driven reorders are caught by
+            // buildSchemaTableChanges on the ALTER MT AS path.
+            if (oldColumn.isPhysical()
+                    && newColumn.isPhysical()
+                    && typeChanged(oldColumn, newColumn, schemaDefinedInQuery)) {
+                final DataType newType =
+                        schemaDefinedInQuery
+                                ? newColumn.getDataType()
+                                : newColumn.getDataType().nullable();
+                changes.add(TableChange.modifyPhysicalColumnType(oldColumn, newType));
+                // Type changed; still check whether the comment also changed.
                 final String oldComment = oldColumn.getComment().orElse(null);
                 final String newComment = newColumn.getComment().orElse(null);
-
-                if (StringUtils.isEmpty(oldComment) != StringUtils.isEmpty(newComment)
-                        || StringUtils.isNotEmpty(oldComment)
-                                && !Objects.equals(oldComment, newComment)) {
-                    columnChanges.add(TableChange.modifyColumnComment(oldColumn, newComment));
+                if (!Objects.equals(oldComment, newComment)) {
+                    changes.add(TableChange.modifyColumnComment(oldColumn, newComment));
                 }
+                continue;
+            }
+            if (oldColumn.getClass() != newColumn.getClass()
+                    || !definitionEquals(oldColumn, newColumn)) {
+                changes.add(
+                        new TableChange.ModifyColumn(
+                                oldColumn,
+                                normalizedColumn(newColumn, schemaDefinedInQuery),
+                                null));
+                continue;
+            }
+            final String oldComment = oldColumn.getComment().orElse(null);
+            final String newComment = newColumn.getComment().orElse(null);
+            if (!Objects.equals(oldComment, newComment)) {
+                changes.add(TableChange.modifyColumnComment(oldColumn, newComment));
             }
         }
 
-        for (int i = oldColumns.size(); i < newColumns.size(); i++) {
-            Column newColumn = newColumns.get(i);
-            columnChanges.add(
-                    TableChange.add(
-                            schemaDefinedInQuery
-                                    ? newColumn
-                                    : newColumn.copy(newColumn.getDataType().nullable())));
+        for (Map.Entry<String, Tuple2<Column, Integer>> entry : oldByName.entrySet()) {
+            if (seen.contains(entry.getKey())) {
+                continue;
+            }
+            // Without an explicit DDL column list the new schema only reflects the query
+            // projection, so old non-persisted columns are retained, not dropped.
+            if (!schemaDefinedInQuery && !entry.getValue().f0.isPersisted()) {
+                continue;
+            }
+            changes.add(TableChange.dropColumn(entry.getKey()));
         }
-
-        return columnChanges;
+        return changes;
     }
 
-    private static DataType getNewColumnDatatype(
+    private static TableChange.AddColumn addChange(Column column, boolean schemaDefinedInQuery) {
+        return TableChange.add(normalizedColumn(column, schemaDefinedInQuery));
+    }
+
+    private static Column normalizedColumn(Column column, boolean schemaDefinedInQuery) {
+        return schemaDefinedInQuery ? column : column.copy(column.getDataType().nullable());
+    }
+
+    private static boolean definitionEquals(Column oldColumn, Column newColumn) {
+        if (oldColumn instanceof MetadataColumn && newColumn instanceof MetadataColumn) {
+            final MetadataColumn oldMeta = (MetadataColumn) oldColumn;
+            final MetadataColumn newMeta = (MetadataColumn) newColumn;
+            return oldMeta.isVirtual() == newMeta.isVirtual()
+                    && Objects.equals(
+                            oldMeta.getMetadataKey().orElse(null),
+                            newMeta.getMetadataKey().orElse(null))
+                    && oldMeta.getDataType().equals(newMeta.getDataType());
+        }
+        if (oldColumn instanceof ComputedColumn && newColumn instanceof ComputedColumn) {
+            return Objects.equals(
+                    ((ComputedColumn) oldColumn).getExpression(),
+                    ((ComputedColumn) newColumn).getExpression());
+        }
+        return true;
+    }
+
+    private static boolean typeChanged(
             Column oldColumn, Column newColumn, boolean schemaDefinedInQuery) {
-        if (schemaDefinedInQuery) {
-            return newColumn.getDataType();
-        }
-        if (oldColumn.getDataType().nullable().equals(newColumn.getDataType().nullable())) {
-            return oldColumn.getDataType();
-        }
-        return newColumn.getDataType();
+        final DataType oldType = oldColumn.getDataType();
+        final DataType newType = newColumn.getDataType();
+        // schemaDefinedInQuery=false: schema is inferred from the query, which may flip
+        // nullability without intent — only the base type difference is a real change.
+        return schemaDefinedInQuery
+                ? !oldType.equals(newType)
+                : !oldType.nullable().equals(newType.nullable());
     }
 
     public static ResolvedSchema getQueryOperationResolvedSchema(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlMaterializedTableNodeToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlMaterializedTableNodeToOperationConverterTest.java
@@ -403,7 +403,7 @@ class SqlMaterializedTableNodeToOperationConverterTest
                         () -> {
                             AlterMaterializedTableChangeOperation operation =
                                     (AlterMaterializedTableChangeOperation) parse(spec.sql);
-                            operation.getNewTable();
+                            operation.validateChanges();
                         })
                 .as(spec.sql)
                 .isInstanceOf(spec.expectedException)
@@ -666,10 +666,7 @@ class SqlMaterializedTableNodeToOperationConverterTest
         return List.of(
                 TestSpec.of(
                         "ALTER MATERIALIZED TABLE base_mtbl AS SELECT a, b FROM t3",
-                        "Failed to modify query because drop column is unsupported. When modifying "
-                                + "a query, you can only append new columns at the end of original "
-                                + "schema. The original schema has 4 columns, but the newly derived "
-                                + "schema from the query has 2 columns."),
+                        "Dropping of persisted column `c` is not supported."),
                 TestSpec.of(
                         "ALTER MATERIALIZED TABLE base_mtbl AS SELECT a, b, d, c FROM t3",
                         "When modifying the query of a materialized table, currently only support "
@@ -997,8 +994,7 @@ class SqlMaterializedTableNodeToOperationConverterTest
                                 + "Column(s) ('d') are used in query."),
                 TestSpec.of(
                         "ALTER MATERIALIZED TABLE base_mtbl_with_metadata DROP m_p",
-                        "Failed to execute ALTER MATERIALIZED TABLE statement.\n"
-                                + "The column `m_p` is a persisted column. Dropping of persisted columns is not supported."));
+                        "Dropping of persisted column `m_p` is not supported."));
     }
 
     private static Collection<TestSpec> alterSuccessCase() {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlMaterializedTableNodeToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlMaterializedTableNodeToOperationConverterTest.java
@@ -1189,13 +1189,10 @@ class SqlMaterializedTableNodeToOperationConverterTest
 
         list.add(
                 TestSpec.withExpectedSchema(
+                        // Explicit DDL omits `m` and `calc` — CREATE OR ALTER is declarative,
+                        // so non-persisted columns absent from the DDL are dropped.
                         "CREATE OR ALTER MATERIALIZED TABLE base_mtbl_with_non_persisted (`EXPR$0` INT NOT NULL, `sec` CHAR(1)) AS SELECT 2, 'a' AS sec",
-                        "(\n"
-                                + "  `m` STRING METADATA VIRTUAL,\n"
-                                + "  `calc` AS ['a' || 'b'],\n"
-                                + "  `EXPR$0` INT NOT NULL,\n"
-                                + "  `sec` CHAR(1)\n"
-                                + ")"));
+                        "(\n" + "  `EXPR$0` INT NOT NULL,\n" + "  `sec` CHAR(1)\n" + ")"));
 
         list.add(
                 TestSpec.withExpectedSchema(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/ValidateAndExtractColumnChangesTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/ValidateAndExtractColumnChangesTest.java
@@ -1,0 +1,281 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.utils;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.catalog.TableChange;
+import org.apache.flink.table.expressions.ResolvedExpression;
+import org.apache.flink.table.expressions.utils.ResolvedExpressionMock;
+import org.apache.flink.table.types.DataType;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Collection;
+import java.util.List;
+
+import static org.apache.flink.table.catalog.Column.computed;
+import static org.apache.flink.table.catalog.Column.metadata;
+import static org.apache.flink.table.catalog.Column.physical;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link MaterializedTableUtils#validateAndExtractColumnChanges}. */
+class ValidateAndExtractColumnChangesTest {
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("input")
+    void test(TestSpec spec) {
+        assertThat(
+                        MaterializedTableUtils.validateAndExtractColumnChanges(
+                                spec.oldSchema, spec.newSchema, spec.schemaDefinedInQuery))
+                .containsExactlyInAnyOrderElementsOf(spec.expected);
+    }
+
+    private static Collection<TestSpec> input() {
+        return List.of(
+                TestSpec.of(
+                        "identical schemas",
+                        schema(physical("a", DataTypes.INT())),
+                        schema(physical("a", DataTypes.INT())),
+                        true,
+                        List.of()),
+                TestSpec.of(
+                        "comment added",
+                        schema(physical("a", DataTypes.INT())),
+                        schema(physical("a", DataTypes.INT()).withComment("hello")),
+                        true,
+                        List.of(
+                                TableChange.modifyColumnComment(
+                                        physical("a", DataTypes.INT()), "hello"))),
+                TestSpec.of(
+                        "comment removed",
+                        schema(physical("a", DataTypes.INT()).withComment("hello")),
+                        schema(physical("a", DataTypes.INT())),
+                        true,
+                        List.of(
+                                TableChange.modifyColumnComment(
+                                        physical("a", DataTypes.INT()).withComment("hello"),
+                                        null))),
+                TestSpec.of(
+                        "comment changed",
+                        schema(physical("a", DataTypes.INT()).withComment("old")),
+                        schema(physical("a", DataTypes.INT()).withComment("new")),
+                        true,
+                        List.of(
+                                TableChange.modifyColumnComment(
+                                        physical("a", DataTypes.INT()).withComment("old"), "new"))),
+                TestSpec.of(
+                        "single column appended",
+                        schema(physical("a", DataTypes.INT())),
+                        schema(physical("a", DataTypes.INT()), physical("b", DataTypes.STRING())),
+                        true,
+                        List.of(TableChange.add(physical("b", DataTypes.STRING())))),
+                TestSpec.of(
+                        "multiple columns appended",
+                        schema(physical("a", DataTypes.INT())),
+                        schema(
+                                physical("a", DataTypes.INT()),
+                                physical("b", DataTypes.STRING()),
+                                physical("c", DataTypes.BOOLEAN())),
+                        true,
+                        List.of(
+                                TableChange.add(physical("b", DataTypes.STRING())),
+                                TableChange.add(physical("c", DataTypes.BOOLEAN())))),
+                TestSpec.of(
+                        "nullability differs but schema is not defined in query",
+                        schema(physical("a", DataTypes.INT().notNull())),
+                        schema(physical("a", DataTypes.INT())),
+                        false,
+                        List.of()),
+                TestSpec.of(
+                        "computed columns are ignored in persisted comparison",
+                        schema(
+                                physical("a", DataTypes.INT()),
+                                computed("comp", expr(DataTypes.INT()))),
+                        schema(
+                                physical("a", DataTypes.INT()),
+                                physical("b", DataTypes.STRING()),
+                                computed("comp", expr(DataTypes.INT()))),
+                        true,
+                        List.of(TableChange.add(physical("b", DataTypes.STRING())))),
+                TestSpec.of(
+                        "virtual metadata column drop emits dropColumn",
+                        schema(
+                                physical("a", DataTypes.INT()),
+                                metadata("v", DataTypes.INT(), null, true)),
+                        schema(physical("a", DataTypes.INT())),
+                        true,
+                        List.of(TableChange.dropColumn("v"))),
+                TestSpec.of(
+                        "non-virtual metadata column treated as persisted",
+                        schema(physical("a", DataTypes.INT())),
+                        schema(
+                                physical("a", DataTypes.INT()),
+                                metadata("m", DataTypes.STRING(), null, false)),
+                        true,
+                        List.of(TableChange.add(metadata("m", DataTypes.STRING(), null, false)))),
+                TestSpec.of(
+                        "schemaDefinedInQuery=false makes added column nullable",
+                        schema(physical("a", DataTypes.INT())),
+                        schema(
+                                physical("a", DataTypes.INT()),
+                                physical("b", DataTypes.STRING().notNull())),
+                        false,
+                        List.of(TableChange.add(physical("b", DataTypes.STRING())))),
+                TestSpec.of(
+                        "drop persisted column emits dropColumn",
+                        schema(physical("a", DataTypes.INT()), physical("b", DataTypes.STRING())),
+                        schema(physical("a", DataTypes.INT())),
+                        true,
+                        List.of(TableChange.dropColumn("b"))),
+                TestSpec.of(
+                        "rename persisted column emits drop + add",
+                        schema(physical("a", DataTypes.INT())),
+                        schema(physical("b", DataTypes.INT())),
+                        true,
+                        List.of(
+                                TableChange.dropColumn("a"),
+                                TableChange.add(physical("b", DataTypes.INT())))),
+                TestSpec.of(
+                        "persisted type change emits modifyPhysicalColumnType",
+                        schema(physical("a", DataTypes.INT())),
+                        schema(physical("a", DataTypes.STRING())),
+                        true,
+                        List.of(
+                                TableChange.modifyPhysicalColumnType(
+                                        physical("a", DataTypes.INT()), DataTypes.STRING()))),
+                TestSpec.of(
+                        "nullability change with schemaDefinedInQuery=true emits modifyPhysicalColumnType",
+                        schema(physical("a", DataTypes.INT().notNull())),
+                        schema(physical("a", DataTypes.INT())),
+                        true,
+                        List.of(
+                                TableChange.modifyPhysicalColumnType(
+                                        physical("a", DataTypes.INT().notNull()),
+                                        DataTypes.INT()))),
+                TestSpec.of(
+                        "type change + comment change both emitted",
+                        schema(physical("a", DataTypes.INT()).withComment("old")),
+                        schema(physical("a", DataTypes.STRING()).withComment("new")),
+                        true,
+                        List.of(
+                                TableChange.modifyPhysicalColumnType(
+                                        physical("a", DataTypes.INT()).withComment("old"),
+                                        DataTypes.STRING()),
+                                TableChange.modifyColumnComment(
+                                        physical("a", DataTypes.INT()).withComment("old"), "new"))),
+                TestSpec.of(
+                        "reorder persisted columns is silent (DDL order is arbitrary)",
+                        schema(physical("a", DataTypes.INT()), physical("b", DataTypes.STRING())),
+                        schema(physical("b", DataTypes.STRING()), physical("a", DataTypes.INT())),
+                        true,
+                        List.of()),
+                TestSpec.of(
+                        "add computed column",
+                        schema(physical("a", DataTypes.INT())),
+                        schema(
+                                physical("a", DataTypes.INT()),
+                                computed("comp", expr(DataTypes.INT()))),
+                        true,
+                        List.of(TableChange.add(computed("comp", expr(DataTypes.INT()))))),
+                TestSpec.of(
+                        "add virtual metadata column",
+                        schema(physical("a", DataTypes.INT())),
+                        schema(
+                                physical("a", DataTypes.INT()),
+                                metadata("v", DataTypes.STRING(), null, true)),
+                        true,
+                        List.of(TableChange.add(metadata("v", DataTypes.STRING(), null, true)))),
+                TestSpec.of(
+                        "drop computed column",
+                        schema(
+                                physical("a", DataTypes.INT()),
+                                computed("comp", expr(DataTypes.INT()))),
+                        schema(physical("a", DataTypes.INT())),
+                        true,
+                        List.of(TableChange.dropColumn("comp"))),
+                TestSpec.of(
+                        "drop virtual metadata column",
+                        schema(
+                                physical("a", DataTypes.INT()),
+                                metadata("v", DataTypes.STRING(), null, true)),
+                        schema(physical("a", DataTypes.INT())),
+                        true,
+                        List.of(TableChange.dropColumn("v"))),
+                TestSpec.of(
+                        "modify computed column expression emits modifyColumn",
+                        schema(
+                                physical("a", DataTypes.INT()),
+                                computed("comp", expr(DataTypes.INT()))),
+                        schema(
+                                physical("a", DataTypes.INT()),
+                                computed("comp", expr(DataTypes.BIGINT()))),
+                        true,
+                        List.of(
+                                new TableChange.ModifyColumn(
+                                        computed("comp", expr(DataTypes.INT())),
+                                        computed("comp", expr(DataTypes.BIGINT())),
+                                        null))));
+    }
+
+    private static ResolvedSchema schema(Column... columns) {
+        return ResolvedSchema.of(columns);
+    }
+
+    private static ResolvedExpression expr(DataType type) {
+        return new ResolvedExpressionMock(type, () -> "1");
+    }
+
+    private static class TestSpec {
+        private final String name;
+        private final ResolvedSchema oldSchema;
+        private final ResolvedSchema newSchema;
+        private final boolean schemaDefinedInQuery;
+        private final List<TableChange> expected;
+
+        TestSpec(
+                String name,
+                ResolvedSchema oldSchema,
+                ResolvedSchema newSchema,
+                boolean schemaDefinedInQuery,
+                List<TableChange> expected) {
+            this.name = name;
+            this.oldSchema = oldSchema;
+            this.newSchema = newSchema;
+            this.schemaDefinedInQuery = schemaDefinedInQuery;
+            this.expected = expected;
+        }
+
+        static TestSpec of(
+                String name,
+                ResolvedSchema oldSchema,
+                ResolvedSchema newSchema,
+                boolean schemaDefinedInQuery,
+                List<TableChange> expected) {
+            return new TestSpec(name, oldSchema, newSchema, schemaDefinedInQuery, expected);
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Physical DDL columns in `CREATE OR ALTER MATERIALIZED TABLE` could not be declared in a different order than the `AS SELECT` projection, because `validateAndExtractColumnChanges` compared old and new schemas positionally. This PR switches to name-based matching so that type changes, computed-column definition changes, drops, and additions each generate the appropriate `TableChange` entry.

It also consolidates query-change and persisted-column-drop validation — previously scattered across `MaterializedTableChangeHandler` and `SqlAlterMaterializedTableDropSchemaConverter` — into `AlterMaterializedTableChangeOperation.validateChanges()`. The handler becomes a pure applier.

`CREATE OR ALTER` now uses declarative semantics: non-persisted columns absent from the explicit DDL are dropped instead of kept.

## Brief change log

- `MaterializedTableUtils.validateAndExtractColumnChanges`: replace positional comparison with name-based lookup over all column kinds (physical, computed, metadata):
  - Physical type change → `ModifyPhysicalColumnType` (instead of throwing)
  - Computed/metadata definition change → `ModifyColumn`
  - Comment-only change → `ModifyColumnComment` (also emitted alongside `ModifyPhysicalColumnType` when both change)
  - Column absent in new schema → `DropColumn`; non-persisted columns are skipped when `schemaDefinedInQuery=false` (schema derived from query projection, so absent non-persisted columns are assumed to still exist rather than being intentionally removed)
  - New column → `AddColumn`; nullable coercion applied when `schemaDefinedInQuery=false`
  - Removes the `apache-commons-lang3` `StringUtils` dependency from this class
- `AlterMaterializedTableChangeOperation`: new `validateChanges()` method called from `execute()` rejects:
  - Column reordering (`ModifyColumnPosition`) when the change set includes `ModifyDefinitionQuery`
  - Physical type changes (`ModifyPhysicalColumnType`) when the change set includes `ModifyDefinitionQuery`
  - Persisted-column drops (`DropColumn`) unconditionally
  Also gains `computeNewTable()` (protected hook), `getOldTable()`, and `setOldTable()` (invalidates derived caches)
- `MaterializedTableChangeHandler`: remove `isQueryChange`, `droppedPersistedCnt`, `validationErrors`, `checkForChangedPositionByQuery`, and all `positionChangeError` helpers; `dropColumn` is now unconditional; unknown changes throw immediately
- `SqlAlterMaterializedTableDropSchemaConverter`: remove the per-column persisted-column-drop guard (now handled by `validateChanges`)
- `FullAlterMaterializedTableOperation`: override `computeNewTable()` with a `newTableBuilder` lambda supplied by `SqlCreateOrAlterMaterializedTableConverter`, so the caller controls the new-table construction without shadowing the cached `newTable` field on the parent
- `SqlCreateOrAlterMaterializedTableConverter`: extract `buildNewTable()` that builds the new table definition with non-persisted columns absent from the explicit DDL dropped (declarative semantics); unfold `buildTableChanges` from a returned lambda into a direct method; add `getMergedLogicalRefreshMode`, `getMergedComment`, `getMergedFreshness` to `MergeContext`

## Verifying this change

This change added tests and can be verified as follows:

- `AlterMaterializedTableChangeOperationValidationTest`: rejects position changes, type changes, and persisted-column drops via `validateChanges()`
- `AlterMaterializedTableAsQueryOperationValidationTest`: end-to-end validation of `CREATE OR ALTER` and `ALTER ... AS SELECT` through `execute()`
- `MaterializedTableChangeHandlerTest`: handler applies changes without validation side effects
- `ValidateAndExtractColumnChangesTest`: parametrized suite covering identical schemas, comment add/remove, column appended (with/without `schemaDefinedInQuery`), reordered persisted columns (no-op), type change, drop, rename, computed add/drop/modify, metadata add/drop
- `SqlMaterializedTableNodeToOperationConverterTest`: updated expected error messages and schema assertions

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no (correctness fix and refactor for materialized table schema evolution)
- If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Code)

Generated-by: Claude Code (claude-sonnet-4-6)
