### PR TITLE
[FLINK-38192][table] Improve DynamicSourceUtils exception message

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/connectors/DynamicSourceUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/connectors/DynamicSourceUtils.java
@@ -436,10 +436,10 @@ public final class DynamicSourceUtils {
         if (!(source instanceof SupportsReadingMetadata)) {
             throw new ValidationException(
                     String.format(
-                            "Table '%s' declares metadata columns, but the underlying %s doesn't implement "
+                            "Table '%s' declares metadata columns, but the underlying DynamicTableSource class '%s' doesn't implement "
                                     + "the %s interface. Therefore, metadata cannot be read from the given source.",
-                            source.asSummaryString(),
-                            DynamicTableSource.class.getSimpleName(),
+                            tableDebugName,
+                            source.getClass().getName(),
                             SupportsReadingMetadata.class.getSimpleName()));
         }
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request resolves [FLINK-38192](https://issues.apache.org/jira/browse/FLINK-38192). 
It improves the exception message in `DynamicSourceUtils.validateAndApplyMetadata` when a `DynamicTableSource` does not implement the `SupportsReadingMetadata` interface. Previously, the error message hardcoded the string "DynamicTableSource", which made it difficult to identify the actual source causing the issue. This change ensures that the actual runtime class name of the table source is printed, providing more context to users for debugging.

## Brief change log

- Updated the exception string formatting in `DynamicSourceUtils.java` to use `source.getClass().getName()` instead of `DynamicTableSource.class.getSimpleName()`.
- Replaced `source.asSummaryString()` with `tableDebugName` to correctly display the actual table name in the error message.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage. Existing tests in the `flink-table-planner` module have been executed locally (`mvn clean test -pl flink-table/flink-table-planner`) and they pass successfully.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable