### PR TITLE
[hotfix] Fix typo in upload artifact condition

### DIFF
--- a/.github/workflows/template.flink-ci.yml
+++ b/.github/workflows/template.flink-ci.yml
@@ -305,7 +305,7 @@ jobs:
 
       - name: "Upload build artifacts"
         uses: actions/upload-artifact@v7
-        if: ${{ failure() && steps.test-run.outputs.debug-files-output-dir }} != ''
+        if: ${{ failure() && steps.test-run.outputs.debug-files-output-dir != '' }}
         with:
           name: logs-test-${{ needs.compile.outputs.stringified-workflow-name }}-${{ github.run_number }}-${{ matrix.stringified-module-name }}-${{ steps.test-run.outputs.debug-files-name }}
           path: ${{ steps.test-run.outputs.debug-files-output-dir }}


### PR DESCRIPTION
## What is the purpose of the change
there is a typo in upload artifact condition

and GHA complains with warning about that (could be seen at every action, e.g. https://github.com/apache/flink/actions/runs/26073467202)
```

Workflow syntax warning: .github/workflows/nightly.yml#L55
In .github/workflows/nightly.yml (Line: 55, Col: 11): Error from called workflow apache/flink/.github/workflows/template.flink-ci.yml@1e6a73616eb4e224a149e684c832f20bcba93148 (Line: 308, Col: 13): Conditional expression contains literal text outside replacement tokens. This will cause the expression to always evaluate to truthy. Did you mean to put the entire expression inside ${{ }}?
```

## Brief change log

gha

## Verifying this change

GHA: see whether warning is present
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
