### PR TITLE
[FLINK-36735][table] Include updated columns when sink declares partial required columns for row-level update

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/connectors/DynamicSinkUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/connectors/DynamicSinkUtils.java
@@ -106,6 +106,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -522,6 +523,7 @@ public final class DynamicSinkUtils {
                         tableModify,
                         contextResolvedTable,
                         updateInfo,
+                        updatedColumns,
                         tableDebugName,
                         dataTypeFactory,
                         typeFactory);
@@ -532,6 +534,20 @@ public final class DynamicSinkUtils {
                         context,
                         updateRelNodeAndRequireIndices.f1));
         return updateRelNodeAndRequireIndices.f0;
+    }
+
+    /** Append updated columns that are missing from the sink-declared required columns. */
+    private static List<Column> mergeRequiredAndUpdatedColumns(
+            List<Column> requiredColumns, List<Column> updatedColumns) {
+        Set<String> existingNames =
+                requiredColumns.stream().map(Column::getName).collect(Collectors.toSet());
+        List<Column> merged = new ArrayList<>(requiredColumns);
+        for (Column updated : updatedColumns) {
+            if (!existingNames.contains(updated.getName())) {
+                merged.add(updated);
+            }
+        }
+        return merged;
     }
 
     private static List<Column> getUpdatedColumns(
@@ -709,13 +725,17 @@ public final class DynamicSinkUtils {
             LogicalTableModify tableModify,
             ContextResolvedTable contextResolvedTable,
             SupportsRowLevelUpdate.RowLevelUpdateInfo rowLevelUpdateInfo,
+            List<Column> updatedColumns,
             String tableDebugName,
             DataTypeFactory dataTypeFactory,
             FlinkTypeFactory typeFactory) {
         // get the required columns
         ResolvedSchema resolvedSchema = contextResolvedTable.getResolvedSchema();
         Optional<List<Column>> optionalColumns = rowLevelUpdateInfo.requiredColumns();
-        List<Column> requiredColumns = optionalColumns.orElse(resolvedSchema.getColumns());
+        List<Column> requiredColumns =
+                optionalColumns
+                        .map(cols -> mergeRequiredAndUpdatedColumns(cols, updatedColumns))
+                        .orElse(resolvedSchema.getColumns());
         // get the root table scan which we may need rewrite it
         LogicalTableScan tableScan = getSourceTableScan(tableModify);
         Tuple2<List<Integer>, List<MetadataColumn>> colsIndexAndExtraMetaCols =

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestUpdateDeleteTableFactory.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestUpdateDeleteTableFactory.java
@@ -76,6 +76,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.apache.flink.table.data.RowData.createFieldGetter;
@@ -437,7 +438,9 @@ public class TestUpdateDeleteTableFactory
                                         resolvedCatalogTable.getResolvedSchema());
                     }
                     requiredColumnIndices =
-                            getRequiredColumnIndexes(resolvedCatalogTable, requiredCols);
+                            getRequiredColumnIndexes(
+                                    resolvedCatalogTable,
+                                    mergeRequiredWithUpdatedColumns(requiredCols, updatedColumns));
                     return Optional.ofNullable(requiredCols);
                 }
 
@@ -748,6 +751,22 @@ public class TestUpdateDeleteTableFactory
         public void executeTruncation() {
             registeredRowData.put(dataId, Collections.emptyList());
         }
+    }
+
+    private static List<Column> mergeRequiredWithUpdatedColumns(
+            @Nullable List<Column> requiredColumns, List<Column> updatedColumns) {
+        if (requiredColumns == null) {
+            return null;
+        }
+        Set<String> existingNames =
+                requiredColumns.stream().map(Column::getName).collect(Collectors.toSet());
+        List<Column> merged = new ArrayList<>(requiredColumns);
+        for (Column updated : updatedColumns) {
+            if (!existingNames.contains(updated.getName())) {
+                merged.add(updated);
+            }
+        }
+        return merged;
     }
 
     private static int[] getRequiredColumnIndexes(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/batch/sql/RowLevelUpdateTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/batch/sql/RowLevelUpdateTest.java
@@ -144,6 +144,21 @@ class RowLevelUpdateTest extends TableTestBase {
     }
 
     @TestTemplate
+    void testUpdateWithRequiredColumnsExcludingUpdatedColumns() {
+        util.tableEnv()
+                .executeSql(
+                        String.format(
+                                "CREATE TABLE t (a int PRIMARY KEY NOT ENFORCED, b string, c double) WITH"
+                                        + " ("
+                                        + "'connector' = 'test-update-delete', "
+                                        + "'required-columns-for-update' = 'a', "
+                                        + "'update-mode' = '%s'"
+                                        + ") ",
+                                updateMode));
+        util.verifyExplainInsert("UPDATE t SET b = 'v2' WHERE a = 1", explainDetails);
+    }
+
+    @TestTemplate
     void testUpdateWithMetaColumns() {
         util.tableEnv()
                 .executeSql(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/UpdateTableITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/UpdateTableITCase.java
@@ -125,6 +125,27 @@ class UpdateTableITCase extends BatchTestBase {
     }
 
     @TestTemplate
+    void testUpdateWithRequiredColumnsExcludingUpdatedColumns() throws Exception {
+        // Sink declares only the primary key as required while SET updates a non-required column.
+        String dataId = registerData();
+        tEnv().executeSql(
+                        String.format(
+                                "CREATE TABLE t ("
+                                        + " a int PRIMARY KEY NOT ENFORCED,"
+                                        + " b string not null,"
+                                        + " c double not null) WITH"
+                                        + " ('connector' = 'test-update-delete', "
+                                        + "'data-id' = '%s',"
+                                        + " 'required-columns-for-update' = 'a', "
+                                        + " 'update-mode' = '%s')",
+                                dataId, updateMode));
+        tEnv().executeSql("UPDATE t SET b = 'uaa' WHERE a >= 1").await();
+        List<String> rows = toSortedResults(tEnv().executeSql("SELECT * FROM t"));
+        assertThat(rows.toString())
+                .isEqualTo("[+I[0, b_0, 0.0], +I[1, uaa, 2.0], +I[2, uaa, 4.0]]");
+    }
+
+    @TestTemplate
     void testStatementSetContainUpdateAndInsert() {
         tEnv().executeSql(
                         "CREATE TABLE t (a int, b string, c double) WITH"

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/RowLevelUpdateTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/RowLevelUpdateTest.xml
@@ -586,6 +586,142 @@ Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[me
 }]]>
     </Resource>
   </TestCase>
+  <TestCase name="testUpdateWithRequiredColumnsExcludingUpdatedColumns[updateMode = ALL_ROWS]">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
++- LogicalProject(a=[$0], b=[IF(=($0, 1), _UTF-16LE'v2', $1)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, t]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
++- Calc(select=[a, IF(=(a, 1), 'v2', b) AS b])
+   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
++- Calc(select=[a, IF((a = 1), 'v2', b) AS b])
+   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: t[]",
+    "pact" : "Data Source",
+    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=[a, IF((a = 1), 'v2', b) AS b])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "ConstraintEnforcer[]",
+    "pact" : "Operator",
+    "contents" : "[]:ConstraintEnforcer[NotNullEnforcer(fields=[a])]",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Sink: Unnamed",
+    "pact" : "Data Sink",
+    "contents" : "Sink: Unnamed",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUpdateWithRequiredColumnsExcludingUpdatedColumns[updateMode = UPDATED_ROWS]">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
++- LogicalProject(a=[$0], b=[_UTF-16LE'v2'])
+   +- LogicalFilter(condition=[=($0, 1)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, t]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
++- Calc(select=[1 AS a, 'v2' AS b], where=[=(a, 1)])
+   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
++- Calc(select=[1 AS a, 'v2' AS b], where=[(a = 1)])
+   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: t[]",
+    "pact" : "Data Source",
+    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=[1 AS a, 'v2' AS b], where=[(a = 1)])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "ConstraintEnforcer[]",
+    "pact" : "Operator",
+    "contents" : "[]:ConstraintEnforcer[NotNullEnforcer(fields=[a])]",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "RowKindSetter[]",
+    "pact" : "Operator",
+    "contents" : "[]:RowKindSetter(TargetRowKind=[UPDATE_AFTER])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Sink: Unnamed",
+    "pact" : "Data Sink",
+    "contents" : "Sink: Unnamed",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testUpdateWithSubQuery[updateMode = ALL_ROWS]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==


### PR DESCRIPTION
## What is the purpose of the change

Fix `SupportsRowLevelUpdate` so that when a sink returns `RowLevelUpdateInfo#requiredColumns` containing only a subset of columns (e.g., primary keys), the rows it receives still carry the new values for the columns being updated. Previously the planner projected only the sink-declared required columns, dropping the SET expressions and leaving the sink unable to perform the update.

## Brief change log

- In `DynamicSinkUtils#convertToRowLevelUpdate`, merge the SET-clause `updatedColumns` into the sink-declared `requiredColumns` (de-duplicated, required first) before building the projection and the `RowLevelUpdateSpec` physical column indices.
- Add helper `DynamicSinkUtils#mergeRequiredAndUpdatedColumns` and thread `updatedColumns` from `convertUpdate` into `convertToRowLevelUpdate`.
- Align `TestUpdateDeleteTableFactory.SupportsRowLevelUpdateSink#applyRowLevelUpdate` so its tracked `requiredColumnIndices` reflect the merged column set the sink actually receives at runtime.

## Verifying this change

Added `RowLevelUpdateTest#testUpdateWithRequiredColumnsExcludingUpdatedColumns` (plan test) which asserts the projection now contains both the sink-declared required column and the updated column, and `UpdateTableITCase#testUpdateWithRequiredColumnsExcludingUpdatedColumns` (batch IT) which asserts the table's non-required column is correctly updated end-to-end. Both run under `UPDATED_ROWS` and `ALL_ROWS` modes.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no