### PR TITLE
[FLINK-36736][table] Fix target columns for row-level updates

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/connectors/DynamicSinkUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/connectors/DynamicSinkUtils.java
@@ -300,8 +300,7 @@ public final class DynamicSinkUtils {
                 isOverwrite,
                 sink,
                 contextResolvedTable.getResolvedTable(),
-                sinkAbilitySpecs,
-                targetColumns);
+                sinkAbilitySpecs);
 
         // rewrite rel node for delete
         if (isDelete) {
@@ -315,7 +314,7 @@ public final class DynamicSinkUtils {
                             typeFactory,
                             sinkAbilitySpecs);
         } else if (isUpdate) {
-            input =
+            Tuple2<RelNode, int[]> updateResult =
                     convertUpdate(
                             (LogicalTableModify) input,
                             sink,
@@ -324,7 +323,12 @@ public final class DynamicSinkUtils {
                             dataTypeFactory,
                             typeFactory,
                             sinkAbilitySpecs);
+            input = updateResult.f0;
+            // align target columns with the projected row delivered to the sink
+            targetColumns = toNestedIndexPaths(updateResult.f1);
         }
+        // apply target columns after UPDATE rewrite so the sink sees the final column set
+        validateAndApplyTargetColumns(sink, targetColumns, sinkAbilitySpecs);
 
         sinkAbilitySpecs.forEach(spec -> spec.apply(sink));
 
@@ -491,7 +495,7 @@ public final class DynamicSinkUtils {
         return deleteRelNodeAndRequireIndices.f0;
     }
 
-    private static RelNode convertUpdate(
+    private static Tuple2<RelNode, int[]> convertUpdate(
             LogicalTableModify tableModify,
             DynamicTableSink sink,
             ContextResolvedTable contextResolvedTable,
@@ -533,7 +537,7 @@ public final class DynamicSinkUtils {
                         updateInfo.getRowLevelUpdateMode(),
                         context,
                         updateRelNodeAndRequireIndices.f1));
-        return updateRelNodeAndRequireIndices.f0;
+        return updateRelNodeAndRequireIndices;
     }
 
     /** Append updated columns that are missing from the sink-declared required columns. */
@@ -604,6 +608,14 @@ public final class DynamicSinkUtils {
                         dataTypeFactory,
                         typeFactory),
                 getPhysicalColumnIndices(colIndexes, resolvedSchema));
+    }
+
+    private static int[][] toNestedIndexPaths(int[] columnIndices) {
+        int[][] result = new int[columnIndices.length][];
+        for (int i = 0; i < columnIndices.length; i++) {
+            result[i] = new int[] {columnIndices[i]};
+        }
+        return result;
     }
 
     /** Return the indices from {@param colIndexes} that belong to physical column. */
@@ -1046,8 +1058,7 @@ public final class DynamicSinkUtils {
             boolean isOverwrite,
             DynamicTableSink sink,
             ResolvedCatalogTable table,
-            List<SinkAbilitySpec> sinkAbilitySpecs,
-            int[][] targetColumns) {
+            List<SinkAbilitySpec> sinkAbilitySpecs) {
         table.getDistribution()
                 .ifPresent(
                         distribution ->
@@ -1059,8 +1070,6 @@ public final class DynamicSinkUtils {
         validateAndApplyOverwrite(tableDebugName, isOverwrite, sink, sinkAbilitySpecs);
 
         validateAndApplyMetadata(tableDebugName, sink, table.getResolvedSchema(), sinkAbilitySpecs);
-
-        validateAndApplyTargetColumns(sink, targetColumns, sinkAbilitySpecs);
     }
 
     /**

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/connectors/DynamicSinkUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/connectors/DynamicSinkUtils.java
@@ -106,6 +106,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -522,6 +523,7 @@ public final class DynamicSinkUtils {
                         tableModify,
                         contextResolvedTable,
                         updateInfo,
+                        updatedColumns,
                         tableDebugName,
                         dataTypeFactory,
                         typeFactory);
@@ -532,6 +534,20 @@ public final class DynamicSinkUtils {
                         context,
                         updateRelNodeAndRequireIndices.f1));
         return updateRelNodeAndRequireIndices.f0;
+    }
+
+    /** Append updated columns that are missing from the sink-declared required columns. */
+    private static List<Column> mergeRequiredAndUpdatedColumns(
+            List<Column> requiredColumns, List<Column> updatedColumns) {
+        Set<String> existingNames =
+                requiredColumns.stream().map(Column::getName).collect(Collectors.toSet());
+        List<Column> merged = new ArrayList<>(requiredColumns);
+        for (Column updated : updatedColumns) {
+            if (!existingNames.contains(updated.getName())) {
+                merged.add(updated);
+            }
+        }
+        return merged;
     }
 
     private static List<Column> getUpdatedColumns(
@@ -709,13 +725,17 @@ public final class DynamicSinkUtils {
             LogicalTableModify tableModify,
             ContextResolvedTable contextResolvedTable,
             SupportsRowLevelUpdate.RowLevelUpdateInfo rowLevelUpdateInfo,
+            List<Column> updatedColumns,
             String tableDebugName,
             DataTypeFactory dataTypeFactory,
             FlinkTypeFactory typeFactory) {
         // get the required columns
         ResolvedSchema resolvedSchema = contextResolvedTable.getResolvedSchema();
         Optional<List<Column>> optionalColumns = rowLevelUpdateInfo.requiredColumns();
-        List<Column> requiredColumns = optionalColumns.orElse(resolvedSchema.getColumns());
+        List<Column> requiredColumns =
+                optionalColumns
+                        .map(cols -> mergeRequiredAndUpdatedColumns(cols, updatedColumns))
+                        .orElse(resolvedSchema.getColumns());
         // get the root table scan which we may need rewrite it
         LogicalTableScan tableScan = getSourceTableScan(tableModify);
         Tuple2<List<Integer>, List<MetadataColumn>> colsIndexAndExtraMetaCols =

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestUpdateDeleteTableFactory.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestUpdateDeleteTableFactory.java
@@ -76,6 +76,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.apache.flink.table.data.RowData.createFieldGetter;
@@ -437,7 +438,9 @@ public class TestUpdateDeleteTableFactory
                                         resolvedCatalogTable.getResolvedSchema());
                     }
                     requiredColumnIndices =
-                            getRequiredColumnIndexes(resolvedCatalogTable, requiredCols);
+                            getRequiredColumnIndexes(
+                                    resolvedCatalogTable,
+                                    mergeRequiredWithUpdatedColumns(requiredCols, updatedColumns));
                     return Optional.ofNullable(requiredCols);
                 }
 
@@ -748,6 +751,22 @@ public class TestUpdateDeleteTableFactory
         public void executeTruncation() {
             registeredRowData.put(dataId, Collections.emptyList());
         }
+    }
+
+    private static List<Column> mergeRequiredWithUpdatedColumns(
+            @Nullable List<Column> requiredColumns, List<Column> updatedColumns) {
+        if (requiredColumns == null) {
+            return null;
+        }
+        Set<String> existingNames =
+                requiredColumns.stream().map(Column::getName).collect(Collectors.toSet());
+        List<Column> merged = new ArrayList<>(requiredColumns);
+        for (Column updated : updatedColumns) {
+            if (!existingNames.contains(updated.getName())) {
+                merged.add(updated);
+            }
+        }
+        return merged;
     }
 
     private static int[] getRequiredColumnIndexes(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestUpdateDeleteTableFactory.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestUpdateDeleteTableFactory.java
@@ -43,6 +43,7 @@ import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.sink.abilities.SupportsDeletePushDown;
 import org.apache.flink.table.connector.sink.abilities.SupportsRowLevelDelete;
 import org.apache.flink.table.connector.sink.abilities.SupportsRowLevelUpdate;
+import org.apache.flink.table.connector.sink.abilities.SupportsTargetColumnWriting;
 import org.apache.flink.table.connector.sink.abilities.SupportsTruncate;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.ScanTableSource;
@@ -157,10 +158,29 @@ public class TestUpdateDeleteTableFactory
     private static final AtomicInteger idCounter = new AtomicInteger(0);
     private static final Map<String, Collection<RowData>> registeredRowData = new HashMap<>();
 
+    private static final Map<ObjectIdentifier, Optional<int[][]>> capturedUpdateTargetColumns =
+            new HashMap<>();
+
+    private static final Map<ObjectIdentifier, int[][]> capturedAppliedTargetColumns =
+            new HashMap<>();
+
     public static String registerRowData(Collection<RowData> data) {
         String id = String.valueOf(idCounter.incrementAndGet());
         registeredRowData.put(id, data);
         return id;
+    }
+
+    public static Optional<int[][]> getCapturedUpdateTargetColumns(ObjectIdentifier id) {
+        return capturedUpdateTargetColumns.get(id);
+    }
+
+    public static int[][] getCapturedAppliedTargetColumns(ObjectIdentifier id) {
+        return capturedAppliedTargetColumns.get(id);
+    }
+
+    public static void clearCapturedTargetColumns(ObjectIdentifier id) {
+        capturedUpdateTargetColumns.remove(id);
+        capturedAppliedTargetColumns.remove(id);
     }
 
     @Override
@@ -324,7 +344,7 @@ public class TestUpdateDeleteTableFactory
 
     /** A sink that supports row-level update. */
     private static class SupportsRowLevelUpdateSink
-            implements DynamicTableSink, SupportsRowLevelUpdate {
+            implements DynamicTableSink, SupportsRowLevelUpdate, SupportsTargetColumnWriting {
 
         protected final ObjectIdentifier tableIdentifier;
         protected final ResolvedCatalogTable resolvedCatalogTable;
@@ -377,6 +397,7 @@ public class TestUpdateDeleteTableFactory
 
         @Override
         public SinkRuntimeProvider getSinkRuntimeProvider(Context context) {
+            capturedUpdateTargetColumns.put(tableIdentifier, context.getTargetColumns());
             return new DataStreamSinkProvider() {
 
                 @Override
@@ -416,6 +437,12 @@ public class TestUpdateDeleteTableFactory
         @Override
         public String asSummaryString() {
             return "SupportsRowLevelUpdateSink";
+        }
+
+        @Override
+        public boolean applyTargetColumns(int[][] targetColumns) {
+            capturedAppliedTargetColumns.put(tableIdentifier, targetColumns);
+            return false;
         }
 
         @Override

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/batch/sql/RowLevelUpdateTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/batch/sql/RowLevelUpdateTest.java
@@ -144,6 +144,21 @@ class RowLevelUpdateTest extends TableTestBase {
     }
 
     @TestTemplate
+    void testUpdateWithRequiredColumnsExcludingUpdatedColumns() {
+        util.tableEnv()
+                .executeSql(
+                        String.format(
+                                "CREATE TABLE t (a int PRIMARY KEY NOT ENFORCED, b string, c double) WITH"
+                                        + " ("
+                                        + "'connector' = 'test-update-delete', "
+                                        + "'required-columns-for-update' = 'a', "
+                                        + "'update-mode' = '%s'"
+                                        + ") ",
+                                updateMode));
+        util.verifyExplainInsert("UPDATE t SET b = 'v2' WHERE a = 1", explainDetails);
+    }
+
+    @TestTemplate
     void testUpdateWithMetaColumns() {
         util.tableEnv()
                 .executeSql(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/batch/sql/RowLevelUpdateTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/batch/sql/RowLevelUpdateTest.java
@@ -144,7 +144,7 @@ class RowLevelUpdateTest extends TableTestBase {
     }
 
     @TestTemplate
-    void testUpdateWithRequiredColumnsExcludingUpdatedColumns() {
+    void testUpdateColumnDisjointFromRequired() {
         util.tableEnv()
                 .executeSql(
                         String.format(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/UpdateTableITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/UpdateTableITCase.java
@@ -125,6 +125,27 @@ class UpdateTableITCase extends BatchTestBase {
     }
 
     @TestTemplate
+    void testUpdateWithRequiredColumnsExcludingUpdatedColumns() throws Exception {
+        // Sink declares only the primary key as required while SET updates a non-required column.
+        String dataId = registerData();
+        tEnv().executeSql(
+                        String.format(
+                                "CREATE TABLE t ("
+                                        + " a int PRIMARY KEY NOT ENFORCED,"
+                                        + " b string not null,"
+                                        + " c double not null) WITH"
+                                        + " ('connector' = 'test-update-delete', "
+                                        + "'data-id' = '%s',"
+                                        + " 'required-columns-for-update' = 'a', "
+                                        + " 'update-mode' = '%s')",
+                                dataId, updateMode));
+        tEnv().executeSql("UPDATE t SET b = 'uaa' WHERE a >= 1").await();
+        List<String> rows = toSortedResults(tEnv().executeSql("SELECT * FROM t"));
+        assertThat(rows.toString())
+                .isEqualTo("[+I[0, b_0, 0.0], +I[1, uaa, 2.0], +I[2, uaa, 4.0]]");
+    }
+
+    @TestTemplate
     void testStatementSetContainUpdateAndInsert() {
         tEnv().executeSql(
                         "CREATE TABLE t (a int, b string, c double) WITH"

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/UpdateTableITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/UpdateTableITCase.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.planner.runtime.batch.sql;
 import org.apache.flink.table.api.StatementSet;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.TableResult;
+import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.sink.abilities.SupportsRowLevelUpdate;
 import org.apache.flink.table.data.GenericRowData;
@@ -41,6 +42,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -62,6 +64,8 @@ class UpdateTableITCase extends BatchTestBase {
     @TestTemplate
     void testUpdate() throws Exception {
         String dataId = registerData();
+        ObjectIdentifier tableId = ObjectIdentifier.of("default_catalog", "default_database", "t");
+        TestUpdateDeleteTableFactory.clearCapturedTargetColumns(tableId);
         tEnv().executeSql(
                         String.format(
                                 "CREATE TABLE t ("
@@ -77,6 +81,14 @@ class UpdateTableITCase extends BatchTestBase {
         assertThat(rows.toString())
                 .isEqualTo("[+I[0, b_0, 0.0], +I[1, uaa, 4.0], +I[2, uaa, 16.0]]");
 
+        // Sink receives the full row, so both targetColumns paths should be [a,b,c].
+        Optional<int[][]> captured =
+                TestUpdateDeleteTableFactory.getCapturedUpdateTargetColumns(tableId);
+        assertThat(captured).isPresent();
+        assertThat(captured.get()).isEqualTo(new int[][] {{0}, {1}, {2}});
+        int[][] applied = TestUpdateDeleteTableFactory.getCapturedAppliedTargetColumns(tableId);
+        assertThat(applied).isEqualTo(new int[][] {{0}, {1}, {2}});
+
         tEnv().executeSql("UPDATE t SET b = 'uab' WHERE a > (SELECT count(1) FROM t WHERE a > 1)")
                 .await();
         rows = toSortedResults(tEnv().executeSql("SELECT * FROM t"));
@@ -87,6 +99,8 @@ class UpdateTableITCase extends BatchTestBase {
     @TestTemplate
     void testPartialUpdate() throws Exception {
         String dataId = registerData();
+        ObjectIdentifier tableId = ObjectIdentifier.of("default_catalog", "default_database", "t");
+        TestUpdateDeleteTableFactory.clearCapturedTargetColumns(tableId);
         tEnv().executeSql(
                         String.format(
                                 "CREATE TABLE t ("
@@ -102,6 +116,14 @@ class UpdateTableITCase extends BatchTestBase {
         List<String> rows = toSortedResults(tEnv().executeSql("SELECT * FROM t"));
         assertThat(rows.toString())
                 .isEqualTo("[+I[0, b_0, 0.0], +I[1, uaa, 2.0], +I[2, uaa, 4.0]]");
+
+        // Sink-required columns [a,b] should drive both targetColumns paths.
+        Optional<int[][]> captured =
+                TestUpdateDeleteTableFactory.getCapturedUpdateTargetColumns(tableId);
+        assertThat(captured).isPresent();
+        assertThat(captured.get()).isEqualTo(new int[][] {{0}, {1}});
+        int[][] applied = TestUpdateDeleteTableFactory.getCapturedAppliedTargetColumns(tableId);
+        assertThat(applied).isEqualTo(new int[][] {{0}, {1}});
 
         // test partial update with requiring partial primary keys
         dataId = registerData();
@@ -125,9 +147,11 @@ class UpdateTableITCase extends BatchTestBase {
     }
 
     @TestTemplate
-    void testUpdateWithRequiredColumnsExcludingUpdatedColumns() throws Exception {
-        // Sink declares only the primary key as required while SET updates a non-required column.
+    void testUpdateColumnDisjointFromRequired() throws Exception {
+        // The planner must merge updated columns into required columns for targetColumns.
         String dataId = registerData();
+        ObjectIdentifier tableId = ObjectIdentifier.of("default_catalog", "default_database", "t");
+        TestUpdateDeleteTableFactory.clearCapturedTargetColumns(tableId);
         tEnv().executeSql(
                         String.format(
                                 "CREATE TABLE t ("
@@ -143,6 +167,13 @@ class UpdateTableITCase extends BatchTestBase {
         List<String> rows = toSortedResults(tEnv().executeSql("SELECT * FROM t"));
         assertThat(rows.toString())
                 .isEqualTo("[+I[0, b_0, 0.0], +I[1, uaa, 2.0], +I[2, uaa, 4.0]]");
+
+        Optional<int[][]> captured =
+                TestUpdateDeleteTableFactory.getCapturedUpdateTargetColumns(tableId);
+        assertThat(captured).isPresent();
+        assertThat(captured.get()).isEqualTo(new int[][] {{0}, {1}});
+        int[][] applied = TestUpdateDeleteTableFactory.getCapturedAppliedTargetColumns(tableId);
+        assertThat(applied).isEqualTo(new int[][] {{0}, {1}});
     }
 
     @TestTemplate

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/RowLevelUpdateTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/RowLevelUpdateTest.xml
@@ -19,17 +19,17 @@ limitations under the License.
   <TestCase name="testUpdateAllColsWithOnlyRequireUpdatedCols[updateMode = ALL_ROWS]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
-LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[1],[0],[2]], fields=[a, b, c])
+LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[0],[1],[2]], fields=[a, b, c])
 +- LogicalProject(a=[IF(>($2, 123), 123, $0)], b=[IF(>($2, 123), _UTF-16LE'v2', $1)], c=[IF(>($2, 123), +($2, 1), $2)])
    +- LogicalTableScan(table=[[default_catalog, default_database, t]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.t], targetColumns=[[1],[0],[2]], fields=[a, b, c])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[0],[1],[2]], fields=[a, b, c])
 +- Calc(select=[IF(>(c, 123), 123, a) AS a, IF(>(c, 123), 'v2', b) AS b, IF(>(c, 123), +(c, 1), c) AS c])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
 
 == Optimized Execution Plan ==
-Sink(table=[default_catalog.default_database.t], targetColumns=[[1],[0],[2]], fields=[a, b, c])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[0],[1],[2]], fields=[a, b, c])
 +- Calc(select=[IF((c > 123), 123, a) AS a, IF((c > 123), 'v2', b) AS b, IF((c > 123), (c + 1), c) AS c])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
 
@@ -70,18 +70,18 @@ Sink(table=[default_catalog.default_database.t], targetColumns=[[1],[0],[2]], fi
   <TestCase name="testUpdateAllColsWithOnlyRequireUpdatedCols[updateMode = UPDATED_ROWS]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
-LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[1],[0],[2]], fields=[a, b, c])
+LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[0],[1],[2]], fields=[a, b, c])
 +- LogicalProject(a=[123], b=[_UTF-16LE'v2'], c=[+($2, 1)])
    +- LogicalFilter(condition=[>($2, 123)])
       +- LogicalTableScan(table=[[default_catalog, default_database, t]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.t], targetColumns=[[1],[0],[2]], fields=[a, b, c])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[0],[1],[2]], fields=[a, b, c])
 +- Calc(select=[123 AS a, 'v2' AS b, +(c, 1) AS c], where=[>(c, 123)])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
 
 == Optimized Execution Plan ==
-Sink(table=[default_catalog.default_database.t], targetColumns=[[1],[0],[2]], fields=[a, b, c])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[0],[1],[2]], fields=[a, b, c])
 +- Calc(select=[123 AS a, 'v2' AS b, (c + 1) AS c], where=[(c > 123)])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
 
@@ -133,17 +133,17 @@ Sink(table=[default_catalog.default_database.t], targetColumns=[[1],[0],[2]], fi
   <TestCase name="testUpdatePartColsWithOnlyRequireUpdatedCols[updateMode = ALL_ROWS]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
-LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[3],[2],[4]], fields=[a, b, c])
+LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[2],[3],[4]], fields=[a, b, c])
 +- LogicalProject(a=[IF(>($4, 123), 123, $2)], b=[IF(>($4, 123), _UTF-16LE'v2', $3)], c=[IF(>($4, 123), +($4, 1), $4)])
    +- LogicalTableScan(table=[[default_catalog, default_database, t]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.t], targetColumns=[[3],[2],[4]], fields=[a, b, c])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[2],[3],[4]], fields=[a, b, c])
 +- Calc(select=[IF(>(c, 123), 123, a) AS a, IF(>(c, 123), 'v2', b) AS b, IF(>(c, 123), +(c, 1), c) AS c])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[f0, f1, a, b, c, f2, f3])
 
 == Optimized Execution Plan ==
-Sink(table=[default_catalog.default_database.t], targetColumns=[[3],[2],[4]], fields=[a, b, c])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[2],[3],[4]], fields=[a, b, c])
 +- Calc(select=[IF((c > 123), 123, a) AS a, IF((c > 123), 'v2', b) AS b, IF((c > 123), (c + 1), c) AS c])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[f0, f1, a, b, c, f2, f3])
 
@@ -184,18 +184,18 @@ Sink(table=[default_catalog.default_database.t], targetColumns=[[3],[2],[4]], fi
   <TestCase name="testUpdatePartColsWithOnlyRequireUpdatedCols[updateMode = UPDATED_ROWS]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
-LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[3],[2],[4]], fields=[a, b, c])
+LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[2],[3],[4]], fields=[a, b, c])
 +- LogicalProject(a=[123], b=[_UTF-16LE'v2'], c=[+($4, 1)])
    +- LogicalFilter(condition=[>($4, 123)])
       +- LogicalTableScan(table=[[default_catalog, default_database, t]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.t], targetColumns=[[3],[2],[4]], fields=[a, b, c])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[2],[3],[4]], fields=[a, b, c])
 +- Calc(select=[123 AS a, 'v2' AS b, +(c, 1) AS c], where=[>(c, 123)])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[f0, f1, a, b, c, f2, f3])
 
 == Optimized Execution Plan ==
-Sink(table=[default_catalog.default_database.t], targetColumns=[[3],[2],[4]], fields=[a, b, c])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[2],[3],[4]], fields=[a, b, c])
 +- Calc(select=[123 AS a, 'v2' AS b, (c + 1) AS c], where=[(c > 123)])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[f0, f1, a, b, c, f2, f3])
 
@@ -247,17 +247,17 @@ Sink(table=[default_catalog.default_database.t], targetColumns=[[3],[2],[4]], fi
   <TestCase name="testUpdateWithCustomColumns[updateMode = ALL_ROWS]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
-LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[b, c])
+LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[1],[2]], fields=[b, c])
 +- LogicalProject(b=[IF(=($1, _UTF-16LE'123'), _UTF-16LE'v2', $1)], c=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, t]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[b, c])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[1],[2]], fields=[b, c])
 +- Calc(select=[IF(=(b, '123'), 'v2', b) AS b, c])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
 
 == Optimized Execution Plan ==
-Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[b, c])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[1],[2]], fields=[b, c])
 +- Calc(select=[IF((b = '123'), 'v2', b) AS b, c])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
 
@@ -298,18 +298,18 @@ Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[b,
   <TestCase name="testUpdateWithCustomColumns[updateMode = UPDATED_ROWS]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
-LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[b, c])
+LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[1],[2]], fields=[b, c])
 +- LogicalProject(b=[_UTF-16LE'v2'], c=[$2])
    +- LogicalFilter(condition=[=($1, _UTF-16LE'123')])
       +- LogicalTableScan(table=[[default_catalog, default_database, t]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[b, c])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[1],[2]], fields=[b, c])
 +- Calc(select=['v2' AS b, c], where=[=(b, '123')])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
 
 == Optimized Execution Plan ==
-Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[b, c])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[1],[2]], fields=[b, c])
 +- Calc(select=['v2' AS b, c], where=[(b = '123')])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
 
@@ -361,17 +361,17 @@ Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[b,
   <TestCase name="testUpdateWithFilter[updateMode = ALL_ROWS]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
-LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
+LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[0],[1]], fields=[a, b])
 +- LogicalProject(a=[$0], b=[IF(AND(=($0, 123), =($1, _UTF-16LE'v1')), _UTF-16LE'v2', $1)])
    +- LogicalTableScan(table=[[default_catalog, default_database, t]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[0],[1]], fields=[a, b])
 +- Calc(select=[a, IF(AND(=(a, 123), =(b, 'v1')), 'v2', b) AS b])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])
 
 == Optimized Execution Plan ==
-Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[0],[1]], fields=[a, b])
 +- Calc(select=[a, IF(((a = 123) AND (b = 'v1')), 'v2', b) AS b])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])
 
@@ -412,18 +412,18 @@ Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a,
   <TestCase name="testUpdateWithFilter[updateMode = UPDATED_ROWS]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
-LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
+LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[0],[1]], fields=[a, b])
 +- LogicalProject(a=[$0], b=[_UTF-16LE'v2'])
    +- LogicalFilter(condition=[AND(=($0, 123), =($1, _UTF-16LE'v1'))])
       +- LogicalTableScan(table=[[default_catalog, default_database, t]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[0],[1]], fields=[a, b])
 +- Calc(select=[CAST(123 AS INTEGER) AS a, 'v2' AS b], where=[AND(=(a, 123), =(b, 'v1'))])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])
 
 == Optimized Execution Plan ==
-Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[0],[1]], fields=[a, b])
 +- Calc(select=[CAST(123 AS INTEGER) AS a, 'v2' AS b], where=[((a = 123) AND (b = 'v1'))])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])
 
@@ -475,17 +475,17 @@ Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a,
   <TestCase name="testUpdateWithMetaColumns[updateMode = ALL_ROWS]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
-LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[meta_f1, meta_f2, a, b])
+LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[0],[1]], fields=[meta_f1, meta_f2, a, b])
 +- LogicalProject(meta_f1=[$3], meta_f2=[$4], a=[$0], b=[IF(=($1, _UTF-16LE'123'), _UTF-16LE'v2', $1)])
    +- LogicalTableScan(table=[[default_catalog, default_database, t]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[meta_f1, meta_f2, a, b])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[0],[1]], fields=[meta_f1, meta_f2, a, b])
 +- Calc(select=[meta_f1, meta_f2, a, IF(=(b, '123'), 'v2', b) AS b])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c, meta_f1, meta_f2])
 
 == Optimized Execution Plan ==
-Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[meta_f1, meta_f2, a, b])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[0],[1]], fields=[meta_f1, meta_f2, a, b])
 +- Calc(select=[meta_f1, meta_f2, a, IF((b = '123'), 'v2', b) AS b])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c, meta_f1, meta_f2])
 
@@ -526,18 +526,18 @@ Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[me
   <TestCase name="testUpdateWithMetaColumns[updateMode = UPDATED_ROWS]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
-LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[meta_f1, meta_f2, a, b])
+LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[0],[1]], fields=[meta_f1, meta_f2, a, b])
 +- LogicalProject(meta_f1=[$3], meta_f2=[$4], a=[$0], b=[_UTF-16LE'v2'])
    +- LogicalFilter(condition=[=($1, _UTF-16LE'123')])
       +- LogicalTableScan(table=[[default_catalog, default_database, t]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[meta_f1, meta_f2, a, b])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[0],[1]], fields=[meta_f1, meta_f2, a, b])
 +- Calc(select=[meta_f1, meta_f2, a, 'v2' AS b], where=[=(b, '123')])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c, meta_f1, meta_f2])
 
 == Optimized Execution Plan ==
-Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[meta_f1, meta_f2, a, b])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[0],[1]], fields=[meta_f1, meta_f2, a, b])
 +- Calc(select=[meta_f1, meta_f2, a, 'v2' AS b], where=[(b = '123')])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c, meta_f1, meta_f2])
 
@@ -586,20 +586,20 @@ Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[me
 }]]>
     </Resource>
   </TestCase>
-  <TestCase name="testUpdateWithRequiredColumnsExcludingUpdatedColumns[updateMode = ALL_ROWS]">
+  <TestCase name="testUpdateColumnDisjointFromRequired[updateMode = ALL_ROWS]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
-LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
+LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[0], [1]], fields=[a, b])
 +- LogicalProject(a=[$0], b=[IF(=($0, 1), _UTF-16LE'v2', $1)])
    +- LogicalTableScan(table=[[default_catalog, default_database, t]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[0], [1]], fields=[a, b])
 +- Calc(select=[a, IF(=(a, 1), 'v2', b) AS b])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
 
 == Optimized Execution Plan ==
-Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[0], [1]], fields=[a, b])
 +- Calc(select=[a, IF((a = 1), 'v2', b) AS b])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
 
@@ -648,21 +648,21 @@ Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a,
 }]]>
     </Resource>
   </TestCase>
-  <TestCase name="testUpdateWithRequiredColumnsExcludingUpdatedColumns[updateMode = UPDATED_ROWS]">
+  <TestCase name="testUpdateColumnDisjointFromRequired[updateMode = UPDATED_ROWS]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
-LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
+LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[0], [1]], fields=[a, b])
 +- LogicalProject(a=[$0], b=[_UTF-16LE'v2'])
    +- LogicalFilter(condition=[=($0, 1)])
       +- LogicalTableScan(table=[[default_catalog, default_database, t]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[0], [1]], fields=[a, b])
 +- Calc(select=[1 AS a, 'v2' AS b], where=[=(a, 1)])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
 
 == Optimized Execution Plan ==
-Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[0], [1]], fields=[a, b])
 +- Calc(select=[1 AS a, 'v2' AS b], where=[(a = 1)])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
 
@@ -725,7 +725,7 @@ Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a,
   <TestCase name="testUpdateWithSubQuery[updateMode = ALL_ROWS]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
-LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
+LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[0],[1]], fields=[a, b])
 +- LogicalProject(a=[$0], b=[IF(=(CAST($0):BIGINT, $SCALAR_QUERY({
 LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
   LogicalTableScan(table=[[default_catalog, default_database, t1]])
@@ -733,7 +733,7 @@ LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
    +- LogicalTableScan(table=[[default_catalog, default_database, t]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[0],[1]], fields=[a, b])
 +- Calc(select=[a, IF(=(CAST(a AS BIGINT), EXPR$0), 'v2', b) AS b])
    +- NestedLoopJoin(joinType=[LeftOuterJoin], where=[true], select=[a, b, EXPR$0], build=[right], singleRowJoin=[true])
       :- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])
@@ -745,7 +745,7 @@ Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a,
                      +- TableSourceScan(table=[[default_catalog, default_database, t1]], fields=[a, b])
 
 == Optimized Execution Plan ==
-Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[0],[1]], fields=[a, b])
 +- Calc(select=[a, IF((CAST(a AS BIGINT) = EXPR$0), 'v2', b) AS b])
    +- NestedLoopJoin(joinType=[LeftOuterJoin], where=[true], select=[a, b, EXPR$0], build=[right], singleRowJoin=[true])
       :- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])
@@ -847,7 +847,7 @@ Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a,
   <TestCase name="testUpdateWithSubQuery[updateMode = UPDATED_ROWS]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
-LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
+LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[0],[1]], fields=[a, b])
 +- LogicalProject(a=[$0], b=[_UTF-16LE'v2'])
    +- LogicalFilter(condition=[=(CAST($0):BIGINT, $SCALAR_QUERY({
 LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
@@ -856,7 +856,7 @@ LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
       +- LogicalTableScan(table=[[default_catalog, default_database, t]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[0],[1]], fields=[a, b])
 +- Calc(select=[a, 'v2' AS b])
    +- NestedLoopJoin(joinType=[InnerJoin], where=[=(a0, EXPR$0)], select=[a, a0, EXPR$0], build=[right], singleRowJoin=[true])
       :- Calc(select=[a, CAST(a AS BIGINT) AS a0])
@@ -869,7 +869,7 @@ Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a,
                      +- TableSourceScan(table=[[default_catalog, default_database, t1]], fields=[a, b])
 
 == Optimized Execution Plan ==
-Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[0],[1]], fields=[a, b])
 +- Calc(select=[a, 'v2' AS b])
    +- NestedLoopJoin(joinType=[InnerJoin], where=[(a0 = EXPR$0)], select=[a, a0, EXPR$0], build=[right], singleRowJoin=[true])
       :- Calc(select=[a, CAST(a AS BIGINT) AS a0])
@@ -994,17 +994,17 @@ Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a,
   <TestCase name="testUpdateWithoutFilter[updateMode = ALL_ROWS]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
-LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[1],[0]], fields=[a, b])
+LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[0],[1]], fields=[a, b])
 +- LogicalProject(a=[*(CHAR_LENGTH($1), $0)], b=[_UTF-16LE'n1'])
    +- LogicalTableScan(table=[[default_catalog, default_database, t]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.t], targetColumns=[[1],[0]], fields=[a, b])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[0],[1]], fields=[a, b])
 +- Calc(select=[*(CHAR_LENGTH(b), a) AS a, 'n1' AS b])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])
 
 == Optimized Execution Plan ==
-Sink(table=[default_catalog.default_database.t], targetColumns=[[1],[0]], fields=[a, b])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[0],[1]], fields=[a, b])
 +- Calc(select=[(CHAR_LENGTH(b) * a) AS a, 'n1' AS b])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])
 
@@ -1045,17 +1045,17 @@ Sink(table=[default_catalog.default_database.t], targetColumns=[[1],[0]], fields
   <TestCase name="testUpdateWithoutFilter[updateMode = UPDATED_ROWS]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
-LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[1],[0]], fields=[a, b])
+LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[0],[1]], fields=[a, b])
 +- LogicalProject(a=[*(CHAR_LENGTH($1), $0)], b=[_UTF-16LE'n1'])
    +- LogicalTableScan(table=[[default_catalog, default_database, t]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.t], targetColumns=[[1],[0]], fields=[a, b])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[0],[1]], fields=[a, b])
 +- Calc(select=[*(CHAR_LENGTH(b), a) AS a, 'n1' AS b])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])
 
 == Optimized Execution Plan ==
-Sink(table=[default_catalog.default_database.t], targetColumns=[[1],[0]], fields=[a, b])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[0],[1]], fields=[a, b])
 +- Calc(select=[(CHAR_LENGTH(b) * a) AS a, 'n1' AS b])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])
 

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/RowLevelUpdateTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/RowLevelUpdateTest.xml
@@ -586,6 +586,142 @@ Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[me
 }]]>
     </Resource>
   </TestCase>
+  <TestCase name="testUpdateWithRequiredColumnsExcludingUpdatedColumns[updateMode = ALL_ROWS]">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
++- LogicalProject(a=[$0], b=[IF(=($0, 1), _UTF-16LE'v2', $1)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, t]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
++- Calc(select=[a, IF(=(a, 1), 'v2', b) AS b])
+   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
++- Calc(select=[a, IF((a = 1), 'v2', b) AS b])
+   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: t[]",
+    "pact" : "Data Source",
+    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=[a, IF((a = 1), 'v2', b) AS b])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "ConstraintEnforcer[]",
+    "pact" : "Operator",
+    "contents" : "[]:ConstraintEnforcer[NotNullEnforcer(fields=[a])]",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Sink: Unnamed",
+    "pact" : "Data Sink",
+    "contents" : "Sink: Unnamed",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUpdateWithRequiredColumnsExcludingUpdatedColumns[updateMode = UPDATED_ROWS]">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
++- LogicalProject(a=[$0], b=[_UTF-16LE'v2'])
+   +- LogicalFilter(condition=[=($0, 1)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, t]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
++- Calc(select=[1 AS a, 'v2' AS b], where=[=(a, 1)])
+   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
++- Calc(select=[1 AS a, 'v2' AS b], where=[(a = 1)])
+   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: t[]",
+    "pact" : "Data Source",
+    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=[1 AS a, 'v2' AS b], where=[(a = 1)])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "ConstraintEnforcer[]",
+    "pact" : "Operator",
+    "contents" : "[]:ConstraintEnforcer[NotNullEnforcer(fields=[a])]",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "RowKindSetter[]",
+    "pact" : "Operator",
+    "contents" : "[]:RowKindSetter(TargetRowKind=[UPDATE_AFTER])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Sink: Unnamed",
+    "pact" : "Data Sink",
+    "contents" : "Sink: Unnamed",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testUpdateWithSubQuery[updateMode = ALL_ROWS]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==


### PR DESCRIPTION
## What is the purpose of the change

Fix `DynamicTableSink.Context#getTargetColumns` for row-level UPDATE so it contains all columns delivered to the sink, instead of only the columns from the SET clause.

Due to the dependency on the pre-PR FLINK-36735, it is set to draft PR.

## Brief change log

- Change `DynamicSinkUtils#convertSinkToRel` to apply target columns after the UPDATE rewrite, using the required physical columns returned by `convertUpdate`.
- Add target-column capture support in `TestUpdateDeleteTableFactory` for both sink ability application and runtime sink context.

## Verifying this change

Updated `RowLevelUpdateTest` plan expectations and `UpdateTableITCase` assertions to verify full-row, partial required-column, and disjoint required/updated-column UPDATE cases expose the correct target columns.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
