### PR TITLE
[FLINK-39708][table] Support TO_CHANGELOG retract/upsert stream -> upsert stream with set semantics

### DIFF
--- a/docs/content/docs/sql/reference/queries/changelog.md
+++ b/docs/content/docs/sql/reference/queries/changelog.md
@@ -381,13 +381,6 @@ When `PARTITION BY` is provided, **the output schema changes**. The partition ke
 
 Prefer row semantics, when possible. `PARTITION BY` is only necessary when downstream operators are keyed on that column and you want to co-locate rows for the same key in the same parallel operator instance.
 
-#### Avoiding ChangelogNormalize for upsert sources
-
-When the input is an upsert source (emits `UPDATE_AFTER` but no `UPDATE_BEFORE`), the planner inserts a `ChangelogNormalize` operator by default to materialize `UPDATE_BEFORE` rows and complete `DELETE` payloads. This operator is stateful and can be expensive. When `PARTITION BY` is provided, the planner skips `ChangelogNormalize` if `op_mapping` does not emit the corresponding kinds:
-
-* Omit `UPDATE_BEFORE` from `op_mapping` to skip `UPDATE_BEFORE` materialization.
-* If the source emits partial `DELETE` events (only the keys flow through, common with Flink's `upsert-kafka` connector or other key-compacted topics), it's necessary to omit `DELETE` from `op_mapping` to skip the full-`DELETE` materialization step that also happens in `ChangelogNormalize`.
-
 #### Table API
 
 ```java

--- a/docs/content/docs/sql/reference/queries/changelog.md
+++ b/docs/content/docs/sql/reference/queries/changelog.md
@@ -337,6 +337,18 @@ SELECT * FROM TO_CHANGELOG(
 -- op_code values are 'I' and 'U' instead of full names
 ```
 
+#### Upsert stream
+
+```sql
+SELECT * FROM TO_CHANGELOG(
+  input => TABLE upsert_source PARTITION BY id,
+  op_mapping => MAP['INSERT, UPDATE_AFTER', 'u', 'DELETE', 'd']
+)
+-- INSERT and UPDATE_AFTER produce op='u' (upsert)
+-- DELETE produces op='d'
+-- UPDATE_BEFORE is omitted
+```
+
 #### Deletion flag pattern
 
 ```sql
@@ -368,6 +380,13 @@ When `PARTITION BY` is provided, **the output schema changes**. The partition ke
 ```
 
 Prefer row semantics, when possible. `PARTITION BY` is only necessary when downstream operators are keyed on that column and you want to co-locate rows for the same key in the same parallel operator instance.
+
+#### Avoiding ChangelogNormalize for upsert sources
+
+When the input is an upsert source (emits `UPDATE_AFTER` but no `UPDATE_BEFORE`), the planner inserts a `ChangelogNormalize` operator by default to materialize `UPDATE_BEFORE` rows and complete `DELETE` payloads. This operator is stateful and can be expensive. When `PARTITION BY` is provided, the planner skips `ChangelogNormalize` if `op_mapping` does not emit the corresponding kinds:
+
+* Omit `UPDATE_BEFORE` from `op_mapping` to skip `UPDATE_BEFORE` materialization.
+* If the source emits partial `DELETE` events (only the keys flow through, common with Flink's `upsert-kafka` connector or other key-compacted topics), it's necessary to omit `DELETE` from `op_mapping` to skip the full-`DELETE` materialization step that also happens in `ChangelogNormalize`.
 
 #### Table API
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -806,9 +806,10 @@ public final class BuiltInFunctionDefinitions {
                     .name("TO_CHANGELOG")
                     .kind(PROCESS_TABLE)
                     .staticArguments(
-                            // Row semantics (no PARTITION BY).
-                            // With PARTITION BY, switches to set
-                            // semantics for co-located parallel execution.
+                            // Row semantics by default; PARTITION BY switches to set semantics.
+                            // REQUIRE_UPDATE_BEFORE / REQUIRE_FULL_DELETE are conditional so the
+                            // planner can skip ChangelogNormalize for upsert sources whose
+                            // op_mapping does not emit UB or full deletes.
                             StaticArgument.table(
                                             "input",
                                             Row.class,
@@ -816,12 +817,18 @@ public final class BuiltInFunctionDefinitions {
                                             EnumSet.of(
                                                     StaticArgumentTrait.TABLE,
                                                     StaticArgumentTrait.ROW_SEMANTIC_TABLE,
-                                                    StaticArgumentTrait.SUPPORT_UPDATES,
-                                                    StaticArgumentTrait.REQUIRE_UPDATE_BEFORE,
-                                                    StaticArgumentTrait.REQUIRE_FULL_DELETE))
+                                                    StaticArgumentTrait.SUPPORT_UPDATES))
                                     .withConditionalTrait(
                                             StaticArgumentTrait.SET_SEMANTIC_TABLE,
-                                            TraitCondition.hasPartitionBy()),
+                                            TraitCondition.hasPartitionBy())
+                                    .withConditionalTrait(
+                                            StaticArgumentTrait.REQUIRE_UPDATE_BEFORE,
+                                            TraitCondition.mapArgIncludesKey(
+                                                    "op_mapping", "UPDATE_BEFORE"))
+                                    .withConditionalTrait(
+                                            StaticArgumentTrait.REQUIRE_FULL_DELETE,
+                                            TraitCondition.mapArgIncludesKey(
+                                                    "op_mapping", "DELETE")),
                             StaticArgument.scalar("op", DataTypes.DESCRIPTOR(), true),
                             StaticArgument.scalar(
                                     "op_mapping",

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -3414,8 +3414,8 @@ public final class BuiltInFunctionDefinitions {
      * comma-separated list (e.g. {@code "INSERT,UPDATE_AFTER"}) - each part is trimmed and compared
      * against {@code key}, so one entry can cover multiple change kinds.
      *
-     * <p>Used by {@code TO_CHANGELOG} conditional traits to inspect the
-     * user-provided {@code op_mapping} argument.
+     * <p>Used by {@code TO_CHANGELOG} conditional traits to inspect the user-provided {@code
+     * op_mapping} argument.
      */
     private static boolean opMappingContainsKey(
             final Map<String, String> opMapping, final String key) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -60,6 +60,7 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -824,19 +825,35 @@ public final class BuiltInFunctionDefinitions {
                                     .withConditionalTrait(
                                             StaticArgumentTrait.REQUIRE_UPDATE_BEFORE,
                                             TraitCondition.or(
+                                                    // op_mapping omitted: default mapping includes
+                                                    // UPDATE_BEFORE.
                                                     TraitCondition.not(
                                                             TraitCondition.argIsPresent(
                                                                     "op_mapping")),
-                                                    TraitCondition.mapArgIncludesKey(
-                                                            "op_mapping", "UPDATE_BEFORE")))
+                                                    TraitCondition.argMatches(
+                                                            "op_mapping",
+                                                            Map.class,
+                                                            mapping ->
+                                                                    opMappingContainsKey(
+                                                                            (Map<String, String>)
+                                                                                    mapping,
+                                                                            "UPDATE_BEFORE"))))
                                     .withConditionalTrait(
                                             StaticArgumentTrait.REQUIRE_FULL_DELETE,
                                             TraitCondition.or(
+                                                    // op_mapping omitted: default mapping includes
+                                                    // DELETE.
                                                     TraitCondition.not(
                                                             TraitCondition.argIsPresent(
                                                                     "op_mapping")),
-                                                    TraitCondition.mapArgIncludesKey(
-                                                            "op_mapping", "DELETE"))),
+                                                    TraitCondition.argMatches(
+                                                            "op_mapping",
+                                                            Map.class,
+                                                            mapping ->
+                                                                    opMappingContainsKey(
+                                                                            (Map<String, String>)
+                                                                                    mapping,
+                                                                            "DELETE")))),
                             StaticArgument.scalar("op", DataTypes.DESCRIPTOR(), true),
                             StaticArgument.scalar(
                                     "op_mapping",
@@ -3391,6 +3408,22 @@ public final class BuiltInFunctionDefinitions {
             new HashSet<>(Arrays.asList(PROCTIME, ROWTIME));
 
     public static final List<FunctionDefinition> ORDERING = Arrays.asList(ORDER_ASC, ORDER_DESC);
+
+    /**
+     * True when {@code key} appears among the {@code op_mapping} keys. Each map key may itself be a
+     * comma-separated list (e.g. {@code "INSERT,UPDATE_AFTER"}) - each part is trimmed and compared
+     * against {@code key}, so one entry can cover multiple change kinds.
+     *
+     * <p>Used by {@code TO_CHANGELOG} conditional traits to inspect the
+     * user-provided {@code op_mapping} argument.
+     */
+    private static boolean opMappingContainsKey(
+            final Map<String, String> opMapping, final String key) {
+        return opMapping.keySet().stream()
+                .flatMap(k -> Arrays.stream(k.split(",")))
+                .map(String::trim)
+                .anyMatch(key::equals);
+    }
 
     @Internal
     public static List<BuiltInFunctionDefinition> getDefinitions() {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -823,12 +823,20 @@ public final class BuiltInFunctionDefinitions {
                                             TraitCondition.hasPartitionBy())
                                     .withConditionalTrait(
                                             StaticArgumentTrait.REQUIRE_UPDATE_BEFORE,
-                                            TraitCondition.mapArgIncludesKey(
-                                                    "op_mapping", "UPDATE_BEFORE"))
+                                            TraitCondition.or(
+                                                    TraitCondition.not(
+                                                            TraitCondition.argIsPresent(
+                                                                    "op_mapping")),
+                                                    TraitCondition.mapArgIncludesKey(
+                                                            "op_mapping", "UPDATE_BEFORE")))
                                     .withConditionalTrait(
                                             StaticArgumentTrait.REQUIRE_FULL_DELETE,
-                                            TraitCondition.mapArgIncludesKey(
-                                                    "op_mapping", "DELETE")),
+                                            TraitCondition.or(
+                                                    TraitCondition.not(
+                                                            TraitCondition.argIsPresent(
+                                                                    "op_mapping")),
+                                                    TraitCondition.mapArgIncludesKey(
+                                                            "op_mapping", "DELETE"))),
                             StaticArgument.scalar("op", DataTypes.DESCRIPTOR(), true),
                             StaticArgument.scalar(
                                     "op_mapping",

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/BuiltInCondition.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/BuiltInCondition.java
@@ -37,7 +37,8 @@ final class BuiltInCondition implements TraitCondition {
     enum Kind {
         HAS_PARTITION_BY,
         ARG_IS_EQUAL_TO,
-        NOT
+        NOT,
+        MAP_ARG_INCLUDES_KEY
     }
 
     private final Kind kind;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/BuiltInCondition.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/BuiltInCondition.java
@@ -37,8 +37,10 @@ final class BuiltInCondition implements TraitCondition {
     enum Kind {
         HAS_PARTITION_BY,
         ARG_IS_EQUAL_TO,
+        ARG_IS_PRESENT,
         NOT,
-        MAP_ARG_INCLUDES_KEY
+        OR,
+        ARG_MATCHES
     }
 
     private final Kind kind;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TraitCondition.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TraitCondition.java
@@ -20,9 +20,7 @@ package org.apache.flink.table.types.inference;
 
 import org.apache.flink.annotation.PublicEvolving;
 
-import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Predicate;
 
 /**
@@ -93,7 +91,8 @@ public interface TraitCondition {
 
     /**
      * True when the named scalar argument is present and its value matches {@code predicate}. False
-     * when the argument is absent or cannot be resolved as a literal of {@code argClass}.
+     * when the argument is absent, cannot be resolved as a literal of {@code argClass},
+     * or {@code predicate} evaluates to `false`.
      *
      * <p>Use this for ad-hoc conditions on scalar literals. Prefer the named factories above when
      * one fits.
@@ -104,28 +103,5 @@ public interface TraitCondition {
                 BuiltInCondition.Kind.ARG_MATCHES,
                 List.of(argName, argClass, predicate),
                 ctx -> ctx.getScalarArgument(argName, argClass).stream().anyMatch(predicate));
-    }
-
-    /**
-     * True when the named {@code MAP<STRING, STRING>} scalar argument is present and contains
-     * {@code key} among its keys. False when the argument is absent or cannot be resolved as a
-     * literal {@link Map}.
-     *
-     * <p>Also matches compound keys: if a key contains commas (e.g. {@code "INSERT,UPDATE_AFTER"}),
-     * each comma-separated part is trimmed and compared against {@code key} - useful for mappings
-     * where one entry covers multiple kinds.
-     */
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    static TraitCondition mapArgIncludesKey(final String argName, final String key) {
-        return argMatches(
-                argName, Map.class, map -> mapKeysContain((Map<String, String>) map, key));
-    }
-
-    /** True when any key in {@code map}, split on comma and trimmed, equals {@code key}. */
-    private static boolean mapKeysContain(final Map<String, String> map, final String key) {
-        return map.keySet().stream()
-                .flatMap(k -> Arrays.stream(k.split(",")))
-                .map(String::trim)
-                .anyMatch(key::equals);
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TraitCondition.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TraitCondition.java
@@ -73,7 +73,10 @@ public interface TraitCondition {
                 BuiltInCondition.Kind.NOT, List.of(condition), ctx -> !condition.test(ctx));
     }
 
-    /** True when either {@code left} or {@code right} evaluates to true. */
+    /**
+     * True when either the {@code left} or the {@code right} {@link TraitCondition} evaluates to
+     * true.
+     */
     static TraitCondition or(final TraitCondition left, final TraitCondition right) {
         return new BuiltInCondition(
                 BuiltInCondition.Kind.OR,
@@ -91,14 +94,14 @@ public interface TraitCondition {
 
     /**
      * True when the named scalar argument is present and its value matches {@code predicate}. False
-     * when the argument is absent, cannot be resolved as a literal of {@code argClass},
-     * or {@code predicate} evaluates to `false`.
+     * when the argument is absent, cannot be resolved as a literal of {@code argClass}, or {@code
+     * predicate} evaluates to {@code false}.
      *
      * <p>Use this for ad-hoc conditions on scalar literals. Prefer the named factories above when
      * one fits.
      */
-    static <X> TraitCondition argMatches(
-            final String argName, final Class<X> argClass, final Predicate<X> predicate) {
+    static <T> TraitCondition argMatches(
+            final String argName, final Class<T> argClass, final Predicate<T> predicate) {
         return new BuiltInCondition(
                 BuiltInCondition.Kind.ARG_MATCHES,
                 List.of(argName, argClass, predicate),

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TraitCondition.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TraitCondition.java
@@ -23,6 +23,7 @@ import org.apache.flink.annotation.PublicEvolving;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 /**
  * A condition that determines whether a conditional trait on a {@link StaticArgument} should be
@@ -34,6 +35,9 @@ import java.util.Map;
  * <p>Implementations must implement {@code hashCode} and {@code equals} for {@link
  * StaticArgument#equals}/{@link StaticArgument#hashCode} to work correctly. The built-in factories
  * below return value-comparable instances; user-supplied lambdas do not - prefer the factories.
+ * {@link #argMatches} accepts a caller-supplied {@code Predicate} and is therefore only value-equal
+ * when the same {@code Predicate} reference is reused; build the predicate once and cache it if
+ * equality matters.
  *
  * <pre>{@code
  * import static org.apache.flink.table.types.inference.TraitCondition.*;
@@ -71,29 +75,57 @@ public interface TraitCondition {
                 BuiltInCondition.Kind.NOT, List.of(condition), ctx -> !condition.test(ctx));
     }
 
-    /**
-     * True when the named {@code MAP<STRING, STRING>} scalar argument has a key that, after
-     * splitting on comma and trimming each part, equals {@code key}. Returns true when the argument
-     * is omitted, on the assumption that an absent argument means the function falls back to a
-     * default that includes all keys.
-     */
-    @SuppressWarnings("rawtypes")
-    static TraitCondition mapArgIncludesKey(final String argName, final String key) {
+    /** True when either {@code left} or {@code right} evaluates to true. */
+    static TraitCondition or(final TraitCondition left, final TraitCondition right) {
         return new BuiltInCondition(
-                BuiltInCondition.Kind.MAP_ARG_INCLUDES_KEY,
-                List.of(argName, key),
-                ctx ->
-                        ctx.getScalarArgument(argName, Map.class)
-                                .map(map -> mapKeysContain(map, key))
-                                .orElse(true));
+                BuiltInCondition.Kind.OR,
+                List.of(left, right),
+                ctx -> left.test(ctx) || right.test(ctx));
     }
 
-    /** True when any key in {@code map}, split on comma and trimmed, equals {@code expected}. */
-    private static boolean mapKeysContain(final Map<?, ?> map, final String expected) {
+    /** True when the named scalar argument was provided by the caller. */
+    static TraitCondition argIsPresent(final String argName) {
+        return new BuiltInCondition(
+                BuiltInCondition.Kind.ARG_IS_PRESENT,
+                List.of(argName),
+                ctx -> ctx.hasScalarArgument(argName));
+    }
+
+    /**
+     * True when the named scalar argument is present and its value matches {@code predicate}. False
+     * when the argument is absent or cannot be resolved as a literal of {@code argClass}.
+     *
+     * <p>Use this for ad-hoc conditions on scalar literals. Prefer the named factories above when
+     * one fits.
+     */
+    static <X> TraitCondition argMatches(
+            final String argName, final Class<X> argClass, final Predicate<X> predicate) {
+        return new BuiltInCondition(
+                BuiltInCondition.Kind.ARG_MATCHES,
+                List.of(argName, argClass, predicate),
+                ctx -> ctx.getScalarArgument(argName, argClass).stream().anyMatch(predicate));
+    }
+
+    /**
+     * True when the named {@code MAP<STRING, STRING>} scalar argument is present and contains
+     * {@code key} among its keys. False when the argument is absent or cannot be resolved as a
+     * literal {@link Map}.
+     *
+     * <p>Also matches compound keys: if a key contains commas (e.g. {@code "INSERT,UPDATE_AFTER"}),
+     * each comma-separated part is trimmed and compared against {@code key} - useful for mappings
+     * where one entry covers multiple kinds.
+     */
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    static TraitCondition mapArgIncludesKey(final String argName, final String key) {
+        return argMatches(
+                argName, Map.class, map -> mapKeysContain((Map<String, String>) map, key));
+    }
+
+    /** True when any key in {@code map}, split on comma and trimmed, equals {@code key}. */
+    private static boolean mapKeysContain(final Map<String, String> map, final String key) {
         return map.keySet().stream()
-                .map(String.class::cast)
                 .flatMap(k -> Arrays.stream(k.split(",")))
                 .map(String::trim)
-                .anyMatch(expected::equals);
+                .anyMatch(key::equals);
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TraitCondition.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TraitCondition.java
@@ -20,7 +20,9 @@ package org.apache.flink.table.types.inference;
 
 import org.apache.flink.annotation.PublicEvolving;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 /**
  * A condition that determines whether a conditional trait on a {@link StaticArgument} should be
@@ -67,5 +69,31 @@ public interface TraitCondition {
     static TraitCondition not(final TraitCondition condition) {
         return new BuiltInCondition(
                 BuiltInCondition.Kind.NOT, List.of(condition), ctx -> !condition.test(ctx));
+    }
+
+    /**
+     * True when the named {@code MAP<STRING, STRING>} scalar argument has a key that, after
+     * splitting on comma and trimming each part, equals {@code key}. Returns true when the argument
+     * is omitted, on the assumption that an absent argument means the function falls back to a
+     * default that includes all keys.
+     */
+    @SuppressWarnings("rawtypes")
+    static TraitCondition mapArgIncludesKey(final String argName, final String key) {
+        return new BuiltInCondition(
+                BuiltInCondition.Kind.MAP_ARG_INCLUDES_KEY,
+                List.of(argName, key),
+                ctx ->
+                        ctx.getScalarArgument(argName, Map.class)
+                                .map(map -> mapKeysContain(map, key))
+                                .orElse(true));
+    }
+
+    /** True when any key in {@code map}, split on comma and trimmed, equals {@code expected}. */
+    private static boolean mapKeysContain(final Map<?, ?> map, final String expected) {
+        return map.keySet().stream()
+                .map(String.class::cast)
+                .flatMap(k -> Arrays.stream(k.split(",")))
+                .map(String::trim)
+                .anyMatch(expected::equals);
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TraitContext.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TraitContext.java
@@ -47,6 +47,12 @@ public interface TraitContext {
     <T> Optional<T> getScalarArgument(String name, Class<T> clazz);
 
     /**
+     * Whether the named scalar argument was provided by the caller. Returns false when the argument
+     * was omitted, or when an argument with the given name is not declared by the function.
+     */
+    boolean hasScalarArgument(String name);
+
+    /**
      * Builds a {@link TraitContext} from validation-time inputs.
      *
      * <p>Used by {@code SystemTypeInference} when wrapping a function's strategies. Planner-side
@@ -75,6 +81,17 @@ public interface TraitContext {
                     }
                 }
                 return Optional.empty();
+            }
+
+            @Override
+            public boolean hasScalarArgument(final String name) {
+                for (int i = 0; i < staticArgs.size(); i++) {
+                    final StaticArgument arg = staticArgs.get(i);
+                    if (arg.is(StaticArgumentTrait.SCALAR) && arg.getName().equals(name)) {
+                        return !callContext.isArgumentNull(i);
+                    }
+                }
+                return false;
             }
         };
     }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/bridging/BridgingSqlFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/bridging/BridgingSqlFunction.java
@@ -315,6 +315,17 @@ public class BridgingSqlFunction extends SqlFunction {
                 }
                 return Optional.empty();
             }
+
+            @Override
+            public boolean hasScalarArgument(String name) {
+                for (int i = 0; i < declared.size(); i++) {
+                    final StaticArgument arg = declared.get(i);
+                    if (arg.is(StaticArgumentTrait.SCALAR) && arg.getName().equals(name)) {
+                        return !callContext.isArgumentNull(i);
+                    }
+                }
+                return false;
+            }
         };
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ToChangelogSemanticTests.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ToChangelogSemanticTests.java
@@ -42,6 +42,7 @@ public class ToChangelogSemanticTests extends SemanticTestBase {
                 ToChangelogTestPrograms.INSERT,
                 ToChangelogTestPrograms.RETRACT,
                 ToChangelogTestPrograms.UPSERT,
+                ToChangelogTestPrograms.UPSERT_PARTITION_BY,
                 ToChangelogTestPrograms.RETRACT_PARTITION_BY,
                 ToChangelogTestPrograms.CUSTOM_OP_MAPPING,
                 ToChangelogTestPrograms.CUSTOM_OP_NAME,
@@ -52,6 +53,7 @@ public class ToChangelogSemanticTests extends SemanticTestBase {
                 ToChangelogTestPrograms.DELETION_FLAG,
                 ToChangelogTestPrograms.INVALID_DESCRIPTOR,
                 ToChangelogTestPrograms.INVALID_OP_MAPPING,
+                ToChangelogTestPrograms.OP_MAPPING_REFERENCES_UNSUPPORTED_KIND,
                 ToChangelogTestPrograms.DUPLICATE_ROW_KIND);
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ToChangelogSemanticTests.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ToChangelogSemanticTests.java
@@ -43,6 +43,7 @@ public class ToChangelogSemanticTests extends SemanticTestBase {
                 ToChangelogTestPrograms.RETRACT,
                 ToChangelogTestPrograms.UPSERT,
                 ToChangelogTestPrograms.UPSERT_PARTITION_BY,
+                ToChangelogTestPrograms.UPSERT_PARTITION_BY_KEY_ONLY_DELETES,
                 ToChangelogTestPrograms.RETRACT_PARTITION_BY,
                 ToChangelogTestPrograms.CUSTOM_OP_MAPPING,
                 ToChangelogTestPrograms.CUSTOM_OP_NAME,

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ToChangelogTestPrograms.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ToChangelogTestPrograms.java
@@ -184,6 +184,37 @@ public class ToChangelogTestPrograms {
                     .runSql("INSERT INTO sink SELECT * FROM TO_CHANGELOG(input => TABLE t)")
                     .build();
 
+    public static final TableTestProgram UPSERT_PARTITION_BY =
+            TableTestProgram.of(
+                            "to-changelog-upsert-partition-by",
+                            "PARTITION BY upsert key + mapping without UB skips ChangelogNormalize")
+                    .setupTableSource(
+                            SourceTestStep.newBuilder("t")
+                                    .addSchema(
+                                            "name STRING PRIMARY KEY NOT ENFORCED", "score BIGINT")
+                                    .addMode(ChangelogMode.upsert())
+                                    .producedValues(
+                                            Row.ofKind(RowKind.INSERT, "Alice", 10L),
+                                            Row.ofKind(RowKind.INSERT, "Bob", 20L),
+                                            Row.ofKind(RowKind.UPDATE_AFTER, "Alice", 30L),
+                                            Row.ofKind(RowKind.DELETE, "Bob", 20L))
+                                    .build())
+                    .setupTableSink(
+                            SinkTestStep.newBuilder("sink")
+                                    .addSchema("name STRING", "op STRING", "score BIGINT")
+                                    .consumedValues(
+                                            "+I[Alice, C, 10]",
+                                            "+I[Bob, C, 20]",
+                                            "+I[Alice, C, 30]",
+                                            "+I[Bob, D, 20]")
+                                    .build())
+                    .runSql(
+                            "INSERT INTO sink SELECT * FROM TO_CHANGELOG("
+                                    + "input => TABLE t PARTITION BY name, "
+                                    + "op => DESCRIPTOR(op), "
+                                    + "op_mapping => MAP['INSERT,UPDATE_AFTER', 'C', 'DELETE', 'D'])")
+                    .build();
+
     public static final TableTestProgram CUSTOM_OP_MAPPING =
             TableTestProgram.of(
                             "to-changelog-custom-op-mapping",
@@ -509,6 +540,19 @@ public class ToChangelogTestPrograms {
                                     + "op_mapping => MAP['INVALID_KIND', 'X'])",
                             ValidationException.class,
                             "Unknown change operation: 'INVALID_KIND'")
+                    .build();
+
+    public static final TableTestProgram OP_MAPPING_REFERENCES_UNSUPPORTED_KIND =
+            TableTestProgram.of(
+                            "to-changelog-op-mapping-references-unsupported-kind",
+                            "fails when op_mapping references a change operation the input cannot produce")
+                    .setupTableSource(SIMPLE_SOURCE)
+                    .runFailingSql(
+                            "SELECT * FROM TO_CHANGELOG("
+                                    + "input => TABLE t, "
+                                    + "op_mapping => MAP['INSERT', 'I', 'DELETE', 'D'])",
+                            ValidationException.class,
+                            "the input table only produces [INSERT] and does not produce [DELETE]")
                     .build();
 
     public static final TableTestProgram DUPLICATE_ROW_KIND =

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ToChangelogTestPrograms.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ToChangelogTestPrograms.java
@@ -215,6 +215,37 @@ public class ToChangelogTestPrograms {
                                     + "op_mapping => MAP['INSERT,UPDATE_AFTER', 'C', 'DELETE', 'D'])")
                     .build();
 
+    public static final TableTestProgram UPSERT_PARTITION_BY_KEY_ONLY_DELETES =
+            TableTestProgram.of(
+                            "to-changelog-upsert-partition-by-key-only-deletes",
+                            "PARTITION BY upsert key + mapping without UB/DELETE handles key-only deletes")
+                    .setupTableSource(
+                            SourceTestStep.newBuilder("t")
+                                    .addSchema(
+                                            "name STRING PRIMARY KEY NOT ENFORCED", "score BIGINT")
+                                    .addMode(ChangelogMode.upsert(true))
+                                    .producedValues(
+                                            Row.ofKind(RowKind.INSERT, "Alice", 10L),
+                                            Row.ofKind(RowKind.INSERT, "Bob", 20L),
+                                            Row.ofKind(RowKind.UPDATE_AFTER, "Alice", 30L),
+                                            // Key-only delete: source only knows the key.
+                                            Row.ofKind(RowKind.DELETE, "Bob", null))
+                                    .build())
+                    .setupTableSink(
+                            SinkTestStep.newBuilder("sink")
+                                    .addSchema("name STRING", "op STRING", "score BIGINT")
+                                    .consumedValues(
+                                            "+I[Alice, U, 10]",
+                                            "+I[Bob, U, 20]",
+                                            "+I[Alice, U, 30]")
+                                    .build())
+                    .runSql(
+                            "INSERT INTO sink SELECT * FROM TO_CHANGELOG("
+                                    + "input => TABLE t PARTITION BY name, "
+                                    + "op => DESCRIPTOR(op), "
+                                    + "op_mapping => MAP['INSERT,UPDATE_AFTER', 'U'])")
+                    .build();
+
     public static final TableTestProgram CUSTOM_OP_MAPPING =
             TableTestProgram.of(
                             "to-changelog-custom-op-mapping",

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ToChangelogTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ToChangelogTest.java
@@ -126,7 +126,7 @@ public class ToChangelogTest extends TableTestBase {
     }
 
     @Test
-    void testUpsertPartitionByNoUpdateBeforeOrDelete() {
+    void testUpsertPartitionByNoUpdateBeforeAndDelete() {
         util.tableEnv()
                 .executeSql(
                         "CREATE TABLE upsert_source ("

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ToChangelogTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ToChangelogTest.java
@@ -104,4 +104,44 @@ public class ToChangelogTest extends TableTestBase {
                 "SELECT * FROM TO_CHANGELOG(input => TABLE retract_source PARTITION BY id)",
                 CHANGELOG_MODE);
     }
+
+    @Test
+    void testUpsertPartitionBy() {
+        util.tableEnv()
+                .executeSql(
+                        "CREATE TABLE upsert_source ("
+                                + "  id INT,"
+                                + "  name STRING,"
+                                + "  PRIMARY KEY (id) NOT ENFORCED"
+                                + ") WITH ("
+                                + "  'connector' = 'values',"
+                                + "  'changelog-mode' = 'I,UA,D'"
+                                + ")");
+        util.verifyRelPlan(
+                "SELECT * FROM TO_CHANGELOG("
+                        + "input => TABLE upsert_source PARTITION BY id, "
+                        + "op => DESCRIPTOR(op), "
+                        + "op_mapping => MAP['INSERT,UPDATE_AFTER', 'C', 'DELETE', 'D'])",
+                CHANGELOG_MODE);
+    }
+
+    @Test
+    void testUpsertPartitionByNoUpdateBeforeOrDelete() {
+        util.tableEnv()
+                .executeSql(
+                        "CREATE TABLE upsert_source ("
+                                + "  id INT,"
+                                + "  name STRING,"
+                                + "  PRIMARY KEY (id) NOT ENFORCED"
+                                + ") WITH ("
+                                + "  'connector' = 'values',"
+                                + "  'changelog-mode' = 'I,UA,D'"
+                                + ")");
+        util.verifyRelPlan(
+                "SELECT * FROM TO_CHANGELOG("
+                        + "input => TABLE upsert_source PARTITION BY id, "
+                        + "op => DESCRIPTOR(op), "
+                        + "op_mapping => MAP['INSERT,UPDATE_AFTER', 'C'])",
+                CHANGELOG_MODE);
+    }
 }

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/ToChangelogTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/ToChangelogTest.xml
@@ -74,6 +74,46 @@ ProcessTableFunction(invocation=[TO_CHANGELOG(TABLE(#0), DEFAULT(), DEFAULT(), D
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testUpsertPartitionBy">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM TO_CHANGELOG(input => TABLE upsert_source PARTITION BY id, op => DESCRIPTOR(op), op_mapping => MAP['INSERT,UPDATE_AFTER', 'C', 'DELETE', 'D'])]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], op=[$1], name=[$2])
++- LogicalTableFunctionScan(invocation=[TO_CHANGELOG(TABLE(#0) PARTITION BY($0), DESCRIPTOR(_UTF-16LE'op'), MAP(_UTF-16LE'INSERT,UPDATE_AFTER':VARCHAR(19) CHARACTER SET "UTF-16LE", _UTF-16LE'C', _UTF-16LE'DELETE':VARCHAR(19) CHARACTER SET "UTF-16LE", _UTF-16LE'D'), DEFAULT(), DEFAULT())], rowType=[RecordType(INTEGER id, VARCHAR(2147483647) op, VARCHAR(2147483647) name)])
+   +- LogicalProject(id=[$0], name=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, upsert_source]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+ProcessTableFunction(invocation=[TO_CHANGELOG(TABLE(#0) PARTITION BY($0), DESCRIPTOR(_UTF-16LE'op'), MAP(_UTF-16LE'INSERT,UPDATE_AFTER':VARCHAR(19) CHARACTER SET "UTF-16LE", _UTF-16LE'C', _UTF-16LE'DELETE':VARCHAR(19) CHARACTER SET "UTF-16LE", _UTF-16LE'D'), DEFAULT(), DEFAULT())], uid=[TO_CHANGELOG], select=[id,op,name], rowType=[RecordType(INTEGER id, VARCHAR(2147483647) op, VARCHAR(2147483647) name)], changelogMode=[I])
++- Exchange(distribution=[hash[id]], changelogMode=[I,UA,D])
+   +- TableSourceScan(table=[[default_catalog, default_database, upsert_source]], fields=[id, name], changelogMode=[I,UA,D])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUpsertPartitionByNoUpdateBeforeOrDelete">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM TO_CHANGELOG(input => TABLE upsert_source PARTITION BY id, op => DESCRIPTOR(op), op_mapping => MAP['INSERT,UPDATE_AFTER', 'C'])]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], op=[$1], name=[$2])
++- LogicalTableFunctionScan(invocation=[TO_CHANGELOG(TABLE(#0) PARTITION BY($0), DESCRIPTOR(_UTF-16LE'op'), MAP(_UTF-16LE'INSERT,UPDATE_AFTER', _UTF-16LE'C'), DEFAULT(), DEFAULT())], rowType=[RecordType(INTEGER id, VARCHAR(2147483647) op, VARCHAR(2147483647) name)])
+   +- LogicalProject(id=[$0], name=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, upsert_source]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+ProcessTableFunction(invocation=[TO_CHANGELOG(TABLE(#0) PARTITION BY($0), DESCRIPTOR(_UTF-16LE'op'), MAP(_UTF-16LE'INSERT,UPDATE_AFTER', _UTF-16LE'C'), DEFAULT(), DEFAULT())], uid=[TO_CHANGELOG], select=[id,op,name], rowType=[RecordType(INTEGER id, VARCHAR(2147483647) op, VARCHAR(2147483647) name)], changelogMode=[I])
++- Exchange(distribution=[hash[id]], changelogMode=[I,UA,D])
+   +- TableSourceScan(table=[[default_catalog, default_database, upsert_source]], fields=[id, name], changelogMode=[I,UA,D])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testUpsertSource">
     <Resource name="sql">
       <![CDATA[SELECT * FROM TO_CHANGELOG(input => TABLE upsert_source)]]>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/ToChangelogTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/ToChangelogTest.xml
@@ -94,7 +94,7 @@ ProcessTableFunction(invocation=[TO_CHANGELOG(TABLE(#0) PARTITION BY($0), DESCRI
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testUpsertPartitionByNoUpdateBeforeOrDelete">
+  <TestCase name="testUpsertPartitionByNoUpdateBeforeAndDelete">
     <Resource name="sql">
       <![CDATA[SELECT * FROM TO_CHANGELOG(input => TABLE upsert_source PARTITION BY id, op => DESCRIPTOR(op), op_mapping => MAP['INSERT,UPDATE_AFTER', 'C'])]]>
     </Resource>

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/ptf/ToChangelogFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/ptf/ToChangelogFunction.java
@@ -19,6 +19,8 @@
 package org.apache.flink.table.runtime.functions.ptf;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.data.RowData;
@@ -38,6 +40,9 @@ import javax.annotation.Nullable;
 
 import java.util.EnumMap;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 /**
  * Runtime implementation of {@link BuiltInFunctionDefinitions#TO_CHANGELOG}.
@@ -77,6 +82,11 @@ public class ToChangelogFunction extends BuiltInProcessTableFunction<RowData> {
         final Map<String, String> opMapping =
                 callContext.getArgumentValue(2, Map.class).orElse(null);
         this.rawOpMap = buildOpMap(opMapping);
+        if (opMapping != null) {
+            // Only user-supplied mappings are validated. The default mapping covers all kinds by
+            // design and is harmless for insert-only or upsert inputs.
+            validateAgainstInputChangelogMode(this.rawOpMap, tableSemantics);
+        }
         this.outputIndices = ChangelogTypeStrategyUtils.computeOutputIndices(tableSemantics);
     }
 
@@ -106,6 +116,35 @@ public class ToChangelogFunction extends BuiltInProcessTableFunction<RowData> {
                     }
                 });
         return result;
+    }
+
+    /**
+     * Rejects mappings that reference change operations the input changelog cannot produce. Without
+     * this check the extra entries are dead code: the corresponding rows never arrive, so the user
+     * gets silently incorrect plans (for upsert input also a wasted {@code ChangelogNormalize}).
+     *
+     * <p>Lives here rather than in the input type strategy because {@link
+     * TableSemantics#changelogMode()} returns empty during type inference and is only populated at
+     * specialization time, which is when this constructor runs.
+     */
+    private static void validateAgainstInputChangelogMode(
+            final Map<RowKind, String> mapping, final TableSemantics tableSemantics) {
+        final ChangelogMode inputMode = tableSemantics.changelogMode().orElse(null);
+        if (inputMode == null) {
+            return;
+        }
+        final Set<RowKind> unsupported =
+                mapping.keySet().stream()
+                        .filter(kind -> !inputMode.contains(kind))
+                        .collect(Collectors.toCollection(TreeSet::new));
+        if (!unsupported.isEmpty()) {
+            throw new ValidationException(
+                    String.format(
+                            "Invalid 'op_mapping' for TO_CHANGELOG: the input table only produces "
+                                    + "%s and does not produce %s. Remove those entries from the "
+                                    + "mapping.",
+                            inputMode.getContainedKinds(), unsupported));
+        }
     }
 
     public void eval(

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/ptf/ToChangelogFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/ptf/ToChangelogFunction.java
@@ -39,10 +39,8 @@ import org.apache.flink.types.RowKind;
 import javax.annotation.Nullable;
 
 import java.util.EnumMap;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.stream.Collectors;
 
 /**
  * Runtime implementation of {@link BuiltInFunctionDefinitions#TO_CHANGELOG}.
@@ -133,10 +131,8 @@ public class ToChangelogFunction extends BuiltInProcessTableFunction<RowData> {
         if (inputMode == null) {
             return;
         }
-        final Set<RowKind> unsupported =
-                mapping.keySet().stream()
-                        .filter(kind -> !inputMode.contains(kind))
-                        .collect(Collectors.toCollection(TreeSet::new));
+        final List<RowKind> unsupported =
+                mapping.keySet().stream().filter(kind -> !inputMode.contains(kind)).toList();
         if (!unsupported.isEmpty()) {
             throw new ValidationException(
                     String.format(

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/ptf/ToChangelogFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/ptf/ToChangelogFunction.java
@@ -81,9 +81,7 @@ public class ToChangelogFunction extends BuiltInProcessTableFunction<RowData> {
                 callContext.getArgumentValue(2, Map.class).orElse(null);
         this.rawOpMap = buildOpMap(opMapping);
         if (opMapping != null) {
-            // Only user-supplied mappings are validated. The default mapping covers all kinds by
-            // design and is harmless for insert-only or upsert inputs.
-            validateAgainstInputChangelogMode(this.rawOpMap, tableSemantics);
+            validateOpMap(this.rawOpMap, tableSemantics);
         }
         this.outputIndices = ChangelogTypeStrategyUtils.computeOutputIndices(tableSemantics);
     }
@@ -117,15 +115,16 @@ public class ToChangelogFunction extends BuiltInProcessTableFunction<RowData> {
     }
 
     /**
-     * Rejects mappings that reference change operations the input changelog cannot produce. Without
-     * this check the extra entries are dead code: the corresponding rows never arrive, so the user
-     * gets silently incorrect plans (for upsert input also a wasted {@code ChangelogNormalize}).
+     * Rejects user-provided mappings that reference change operations the input changelog cannot
+     * produce. Without this check the extra entries are dead code: the corresponding rows never
+     * arrive. E.g., if the input is INSERT-only, then UPDATE_BEFORE and DELETE mappings are
+     * ignored, which is likely a user mistake.
      *
      * <p>Lives here rather than in the input type strategy because {@link
      * TableSemantics#changelogMode()} returns empty during type inference and is only populated at
      * specialization time, which is when this constructor runs.
      */
-    private static void validateAgainstInputChangelogMode(
+    private static void validateOpMap(
             final Map<RowKind, String> mapping, final TableSemantics tableSemantics) {
         final ChangelogMode inputMode = tableSemantics.changelogMode().orElse(null);
         if (inputMode == null) {


### PR DESCRIPTION
## What is the purpose of the change

Lets TO_CHANGELOG produce an upsert stream (instead of always retract) when called with PARTITION BY and an op_mapping that omits UPDATE_BEFORE and/or DELETE. The planner can then skip the stateful ChangelogNormalize operator that would otherwise materialize those rows.

## Brief change log

- Add TraitCondition.mapArgIncludesKey factory and BuiltInCondition.Kind.MAP_ARG_INCLUDES_KEY
- Make REQUIRE_UPDATE_BEFORE and REQUIRE_FULL_DELETE conditional on op_mapping in TO_CHANGELOG
- Reject user-supplied op_mapping entries referencing change kinds the input cannot produce
- Add plan tests for the new conditional-trait combinations
- Add semantic test for the new validation
- Document the optimization under TO_CHANGELOG

## Verifying this change

- ToChangelogRestoreTest (existing)
- ToChangelogTest (Added new)
- ToChangelogSemanticTests (Added new)

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes - TraitCondition is @PublicEvolving and gains a new factory
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? yes
- If yes, how is the feature documented? (docs/content/docs/sql/reference/queries/changelog.md, JavaDoc on TraitCondition.mapArgIncludesKey and ToChangelogFunction.validateAgainstInputChangelogMode)

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

2.1.117 (Claude Code) & Opus 4.7