### PR TITLE
[FLINK-39704][runtime/jobmaster] Preserve globally terminal job result across leadership revocation

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/DefaultJobMasterServiceProcess.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/DefaultJobMasterServiceProcess.java
@@ -25,7 +25,6 @@ import org.apache.flink.runtime.jobmanager.OnCompletionActions;
 import org.apache.flink.runtime.jobmaster.factories.JobMasterServiceFactory;
 import org.apache.flink.runtime.scheduler.ExecutionGraphInfo;
 import org.apache.flink.util.FlinkException;
-import org.apache.flink.util.concurrent.FutureUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -154,18 +153,32 @@ public class DefaultJobMasterServiceProcess
                         jobId,
                         leaderSessionId);
 
-                resultFuture.completeExceptionally(new JobNotFinishedException(jobId));
                 jobMasterGatewayFuture.completeExceptionally(
                         new FlinkException("Process has been closed."));
 
                 jobMasterServiceFuture.whenComplete(
                         (jobMasterService, throwable) -> {
                             if (throwable != null) {
-                                // JobMasterService creation has failed. Nothing to stop then :-)
+                                resultFuture.completeExceptionally(
+                                        new JobNotFinishedException(jobId));
                                 terminationFuture.complete(null);
                             } else {
-                                FutureUtils.forward(
-                                        jobMasterService.closeAsync(), terminationFuture);
+                                // Defer JobNotFinishedException until after the JobMasterService
+                                // has fully closed, so any in-flight terminal completion from the
+                                // scheduler (jobReachedGloballyTerminalState) can win the race and
+                                // be observed by the runner. See FLINK-39704.
+                                jobMasterService
+                                        .closeAsync()
+                                        .whenComplete(
+                                                (unused, t) -> {
+                                                    resultFuture.completeExceptionally(
+                                                            new JobNotFinishedException(jobId));
+                                                    if (t != null) {
+                                                        terminationFuture.completeExceptionally(t);
+                                                    } else {
+                                                        terminationFuture.complete(null);
+                                                    }
+                                                });
                             }
                         });
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunner.java
@@ -39,6 +39,7 @@ import org.apache.flink.util.function.ThrowingRunnable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 
 import java.time.Duration;
@@ -62,11 +63,12 @@ import java.util.function.Supplier;
  * <p>All leadership operations are serialized. This means that granting the leadership has to
  * complete before the leadership can be revoked and vice versa.
  *
- * <p>The {@link #resultFuture} can be completed with the following values: * *
+ * <p>The {@link #resultFuture} can be completed with the following values:
  *
  * <ul>
  *   <li>{@link JobManagerRunnerResult} to signal an initialization failure of the {@link
- *       JobMasterService} or the completion of a job
+ *       JobMasterService}, the completion of a job, or a globally terminal result observed before
+ *       leadership revocation could be forwarded
  *   <li>{@link Exception} to signal an unexpected failure
  * </ul>
  */
@@ -108,6 +110,19 @@ public class JobMasterServiceLeadershipRunner implements JobManagerRunner, Leade
     @GuardedBy("lock")
     private boolean hasCurrentLeaderBeenCancelled = false;
 
+    @GuardedBy("lock")
+    private UUID currentJobMasterServiceProcessLeaderId = null;
+
+    /**
+     * Caches a globally terminal result the moment it is observed, to close the race between such a
+     * result and a leadership revocation that strips the forwarded result (see FLINK-39704). The
+     * cache is populated by {@link #cacheGloballyTerminalResultIfCurrentProcess}, drained by either
+     * {@link #grantLeadership} (on re-grant) or {@link #completeResultFutureAfterClose} (on close),
+     * and cleared by {@link #onJobCompletion} when forwarding succeeds normally.
+     */
+    @GuardedBy("lock")
+    private JobManagerRunnerResult pendingTerminalResult = null;
+
     public JobMasterServiceLeadershipRunner(
             JobMasterServiceProcessFactory jobMasterServiceProcessFactory,
             LeaderElection leaderElection,
@@ -137,12 +152,11 @@ public class JobMasterServiceLeadershipRunner implements JobManagerRunner, Leade
                     new FlinkException(
                             "JobMasterServiceLeadershipRunner is closed. Therefore, the corresponding JobMaster will never acquire the leadership."));
 
-            resultFuture.complete(
-                    JobManagerRunnerResult.forSuccess(
-                            createExecutionGraphInfoWithJobStatus(JobStatus.SUSPENDED)));
-
             processTerminationFuture = jobMasterServiceProcess.closeAsync();
         }
+
+        processTerminationFuture.whenComplete(
+                (ignored, throwable) -> completeResultFutureAfterClose());
 
         final CompletableFuture<Void> serviceTerminationFuture =
                 FutureUtils.runAfterwards(
@@ -251,19 +265,80 @@ public class JobMasterServiceLeadershipRunner implements JobManagerRunner, Leade
         sequentialOperation =
                 sequentialOperation.thenCompose(
                         unused ->
-                                jobResultStore
-                                        .hasJobResultEntryAsync(getJobID())
-                                        .thenCompose(
-                                                hasJobResult -> {
-                                                    if (hasJobResult) {
-                                                        return handleJobAlreadyDoneIfValidLeader(
-                                                                leaderSessionId);
-                                                    } else {
-                                                        return createNewJobMasterServiceProcessIfValidLeader(
-                                                                leaderSessionId);
-                                                    }
-                                                }));
+                                handleCachedGloballyTerminalJobOrStartNewProcessAsync(
+                                        leaderSessionId));
         handleAsyncOperationError(sequentialOperation, "Could not start the job manager.");
+    }
+
+    private CompletableFuture<Void> handleCachedGloballyTerminalJobOrStartNewProcessAsync(
+            UUID leaderSessionId) {
+        final JobManagerRunnerResult cachedTerminalResult;
+        synchronized (lock) {
+            if (!isRunning()) {
+                return FutureUtils.completedVoidFuture();
+            }
+            cachedTerminalResult = takePendingTerminalResult();
+            if (cachedTerminalResult != null) {
+                state = State.JOB_COMPLETED;
+                // resetting leader ID to handle concurrent
+                // cacheGloballyTerminalResultIfCurrentProcess call from updating the
+                // JobManagerResult
+                currentJobMasterServiceProcessLeaderId = null;
+            }
+        }
+
+        if (cachedTerminalResult != null) {
+            LOG.info(
+                    "Flushing previously observed globally terminal result for job {} on re-grant; not starting a new {}. Job state: {}.",
+                    getJobID(),
+                    JobMasterServiceProcess.class.getSimpleName(),
+                    cachedTerminalResult
+                            .getExecutionGraphInfo()
+                            .getArchivedExecutionGraph()
+                            .getState());
+            resultFuture.complete(cachedTerminalResult);
+            return FutureUtils.completedVoidFuture();
+        }
+
+        return jobResultStore
+                .hasJobResultEntryAsync(getJobID())
+                .thenCompose(
+                        hasJobResult ->
+                                hasJobResult
+                                        ? handleJobAlreadyDoneIfValidLeader(leaderSessionId)
+                                        : createNewJobMasterServiceProcessIfValidLeader(
+                                                leaderSessionId));
+    }
+
+    @GuardedBy("lock")
+    @Nullable
+    private JobManagerRunnerResult takePendingTerminalResult() {
+        final JobManagerRunnerResult terminalResult = pendingTerminalResult;
+        pendingTerminalResult = null;
+        return terminalResult;
+    }
+
+    private void completeResultFutureAfterClose() {
+        JobManagerRunnerResult closeResult;
+        synchronized (lock) {
+            closeResult = takePendingTerminalResult();
+            if (closeResult == null) {
+                closeResult =
+                        JobManagerRunnerResult.forSuccess(
+                                createExecutionGraphInfoWithJobStatus(JobStatus.SUSPENDED));
+            }
+            // resetting leader ID to handle concurrent cacheGloballyTerminalResultIfCurrentProcess
+            // call from updating the JobManagerResult
+            currentJobMasterServiceProcessLeaderId = null;
+        }
+
+        if (isGloballyTerminalResult(closeResult)) {
+            LOG.info(
+                    "Flushing globally terminal result for job {} during close. Job state: {}.",
+                    getJobID(),
+                    closeResult.getExecutionGraphInfo().getArchivedExecutionGraph().getState());
+        }
+        resultFuture.complete(closeResult);
     }
 
     private CompletableFuture<Void> handleJobAlreadyDoneIfValidLeader(UUID leaderSessionId) {
@@ -316,6 +391,9 @@ public class JobMasterServiceLeadershipRunner implements JobManagerRunner, Leade
     @GuardedBy("lock")
     private void createNewJobMasterServiceProcess(UUID leaderSessionId) {
         Preconditions.checkState(jobMasterServiceProcess.closeAsync().isDone());
+        Preconditions.checkState(
+                pendingTerminalResult == null,
+                "No new JobMasterServiceProcess should be created while a terminal result is pending.");
 
         LOG.info(
                 "{} for job {} was granted leadership with leader id {}. Creating new {}.",
@@ -324,6 +402,7 @@ public class JobMasterServiceLeadershipRunner implements JobManagerRunner, Leade
                 leaderSessionId,
                 JobMasterServiceProcess.class.getSimpleName());
 
+        currentJobMasterServiceProcessLeaderId = leaderSessionId;
         jobMasterServiceProcess = jobMasterServiceProcessFactory.create(leaderSessionId);
 
         forwardIfValidLeader(
@@ -355,17 +434,52 @@ public class JobMasterServiceLeadershipRunner implements JobManagerRunner, Leade
     private void forwardResultFuture(
             UUID leaderSessionId, CompletableFuture<JobManagerRunnerResult> resultFuture) {
         resultFuture.whenComplete(
-                (jobManagerRunnerResult, throwable) ->
-                        runIfValidLeader(
-                                leaderSessionId,
-                                () -> onJobCompletion(jobManagerRunnerResult, throwable),
-                                "result future forwarding"));
+                (jobManagerRunnerResult, throwable) -> {
+                    // The JobManagerResult needs to be cached for the current process even if the
+                    // leadership was lost
+                    cacheGloballyTerminalResultIfCurrentProcess(
+                            leaderSessionId, jobManagerRunnerResult);
+                    runIfValidLeader(
+                            leaderSessionId,
+                            () -> onJobCompletion(jobManagerRunnerResult, throwable),
+                            "result future forwarding");
+                });
+    }
+
+    private void cacheGloballyTerminalResultIfCurrentProcess(
+            UUID leaderSessionId, JobManagerRunnerResult jobManagerRunnerResult) {
+        synchronized (lock) {
+            if (resultFuture.isDone()) {
+                return;
+            }
+            if (leaderSessionId.equals(currentJobMasterServiceProcessLeaderId)
+                    // initialization failures should still result in the job being suspended;
+                    // caching it would trigger a job startup retry after failover
+                    && isGloballyTerminalResult(jobManagerRunnerResult)) {
+                LOG.debug(
+                        "Caching globally terminal job result for job {} in case leadership is lost before forwarding.",
+                        getJobID());
+                pendingTerminalResult = jobManagerRunnerResult;
+            }
+        }
+    }
+
+    private boolean isGloballyTerminalResult(JobManagerRunnerResult jobManagerRunnerResult) {
+        return jobManagerRunnerResult != null
+                && jobManagerRunnerResult.isSuccess()
+                && jobManagerRunnerResult
+                        .getExecutionGraphInfo()
+                        .getArchivedExecutionGraph()
+                        .getState()
+                        .isGloballyTerminalState();
     }
 
     @GuardedBy("lock")
     private void onJobCompletion(
             JobManagerRunnerResult jobManagerRunnerResult, Throwable throwable) {
         state = State.JOB_COMPLETED;
+        currentJobMasterServiceProcessLeaderId = null;
+        pendingTerminalResult = null;
 
         LOG.debug("Completing the result for job {}.", getJobID());
 
@@ -423,6 +537,10 @@ public class JobMasterServiceLeadershipRunner implements JobManagerRunner, Leade
 
         hasCurrentLeaderBeenCancelled = false;
 
+        // Intentionally NOT clearing currentJobMasterServiceProcessLeaderId here: a globally
+        // terminal result from the closing process can still complete its resultFuture during
+        // closeAsync, and the forwarding callback needs the matching leader id to cache it
+        // (see FLINK-39704).
         return jobMasterServiceProcess.closeAsync();
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/DefaultJobMasterServiceProcessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/DefaultJobMasterServiceProcessTest.java
@@ -268,6 +268,34 @@ class DefaultJobMasterServiceProcessTest {
                                         == JobStatus.FINISHED);
     }
 
+    @Test
+    void testTerminalResultPublishedDuringCloseWinsOverJobNotFinished() {
+        final CompletableFuture<JobMasterService> jobMasterServiceFuture =
+                new CompletableFuture<>();
+        DefaultJobMasterServiceProcess serviceProcess = createTestInstance(jobMasterServiceFuture);
+        final CompletableFuture<Void> serviceTerminationFuture = new CompletableFuture<>();
+        jobMasterServiceFuture.complete(
+                new TestingJobMasterService("localhost", serviceTerminationFuture, null));
+
+        final CompletableFuture<Void> processTerminationFuture = serviceProcess.closeAsync();
+
+        assertThat(serviceProcess.getResultFuture()).isNotDone();
+
+        serviceProcess.jobReachedGloballyTerminalState(
+                new ExecutionGraphInfo(
+                        new ArchivedExecutionGraphBuilder().setState(JobStatus.FAILED).build()));
+
+        serviceTerminationFuture.complete(null);
+        processTerminationFuture.join();
+
+        assertThat(serviceProcess.getResultFuture())
+                .isCompletedWithValueMatching(JobManagerRunnerResult::isSuccess)
+                .isCompletedWithValueMatching(
+                        r ->
+                                r.getExecutionGraphInfo().getArchivedExecutionGraph().getState()
+                                        == JobStatus.FAILED);
+    }
+
     private DefaultJobMasterServiceProcess createTestInstance(
             CompletableFuture<JobMasterService> jobMasterServiceFuture) {
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunnerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunnerITCase.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster;
+
+import org.apache.flink.api.common.JobStatus;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for the FLINK-39704 fix that exercise a real {@link
+ * JobMasterServiceLeadershipRunner} together with a real {@link DefaultJobMasterServiceProcess}
+ * (see {@link JobMasterServiceLeadershipRunnerTestHarness}).
+ *
+ * <p>They reproduce, deterministically, the race between a job reaching a globally terminal state
+ * and its leadership being revoked, covering both event orderings. In every case the terminal
+ * result must survive the revocation rather than being replaced by a suspended/not-finished result.
+ */
+class JobMasterServiceLeadershipRunnerITCase {
+
+    /**
+     * The result is observed while still leader, but leadership is lost before the runner manages
+     * to forward it. The cached result must still be flushed on close.
+     */
+    @ParameterizedTest
+    @EnumSource(
+            value = JobStatus.class,
+            names = {"FINISHED", "FAILED", "CANCELED"})
+    void globallyTerminalResultObservedBeforeRevocationIsPreserved(JobStatus terminalState)
+            throws Exception {
+        try (JobMasterServiceLeadershipRunnerTestHarness harness =
+                new JobMasterServiceLeadershipRunnerTestHarness()) {
+            harness.start();
+            harness.grantLeadership();
+
+            // Hold the forwarding leadership check so revocation can win the race against it.
+            harness.armDelayedForwardingCheck();
+            harness.reachGloballyTerminalState(terminalState);
+            harness.revokeLeadership();
+            harness.releaseDelayedForwardingCheck();
+            harness.completeCurrentServiceTermination();
+
+            harness.closeRunnerAsync().get();
+
+            assertThat(harness.getResultJobStatus()).isEqualTo(terminalState);
+        }
+    }
+
+    /**
+     * Leadership is revoked first, so the process is already closing when the result is observed.
+     * The process defers its {@link JobNotFinishedException} long enough for the terminal result to
+     * win, and the runner then flushes it on close.
+     */
+    @ParameterizedTest
+    @EnumSource(
+            value = JobStatus.class,
+            names = {"FINISHED", "FAILED", "CANCELED"})
+    void globallyTerminalResultObservedDuringCloseIsPreserved(JobStatus terminalState)
+            throws Exception {
+        try (JobMasterServiceLeadershipRunnerTestHarness harness =
+                new JobMasterServiceLeadershipRunnerTestHarness()) {
+            harness.start();
+            harness.grantLeadership();
+
+            harness.revokeLeadership();
+            harness.reachGloballyTerminalState(terminalState);
+            harness.completeCurrentServiceTermination();
+
+            harness.closeRunnerAsync().get();
+
+            assertThat(harness.getResultJobStatus()).isEqualTo(terminalState);
+        }
+    }
+
+    /** Without a globally terminal result, closing after revocation suspends the job as before. */
+    @Test
+    void closeWithoutGloballyTerminalResultSuspendsJob() throws Exception {
+        try (JobMasterServiceLeadershipRunnerTestHarness harness =
+                new JobMasterServiceLeadershipRunnerTestHarness()) {
+            harness.start();
+            harness.grantLeadership();
+
+            harness.revokeLeadership();
+            harness.completeCurrentServiceTermination();
+
+            harness.closeRunnerAsync().get();
+
+            assertThat(harness.getResultJobStatus()).isEqualTo(JobStatus.SUSPENDED);
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunnerTest.java
@@ -57,8 +57,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import javax.annotation.Nonnull;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.time.Duration;
 import java.util.ArrayDeque;
@@ -68,6 +68,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
@@ -244,17 +245,24 @@ class JobMasterServiceLeadershipRunnerTest {
         assertThat(jobManagerRunnerResult.getInitializationFailure()).isEqualTo(testException);
     }
 
-    @Nonnull
     private ExecutionGraphInfo createFailedExecutionGraphInfo(FlinkException testException) {
+        return createExecutionGraphInfo(JobStatus.FAILED, testException);
+    }
+
+    private ExecutionGraphInfo createExecutionGraphInfo(JobStatus jobStatus, Throwable cause) {
         return new ExecutionGraphInfo(
                 ArchivedExecutionGraph.createSparseArchivedExecutionGraph(
                         jobGraph.getJobID(),
                         jobGraph.getName(),
-                        JobStatus.FAILED,
+                        jobStatus,
                         jobGraph.getJobType(),
-                        testException,
+                        cause,
                         null,
                         1L));
+    }
+
+    private JobManagerRunnerResult createGloballyTerminalResult(JobStatus jobStatus) {
+        return JobManagerRunnerResult.forSuccess(createExecutionGraphInfo(jobStatus, null));
     }
 
     @Test
@@ -482,7 +490,7 @@ class JobMasterServiceLeadershipRunnerTest {
     }
 
     @Test
-    void testResultFutureCompletionOfOutdatedLeaderIsIgnored() throws Exception {
+    void testInitializationFailureCompletionOfOutdatedLeaderIsIgnored() throws Exception {
         final CompletableFuture<JobManagerRunnerResult> resultFuture = new CompletableFuture<>();
         final JobMasterServiceLeadershipRunner jobManagerRunner =
                 newJobMasterServiceLeadershipRunnerBuilder()
@@ -503,8 +511,9 @@ class JobMasterServiceLeadershipRunnerTest {
                 .isNotDone();
 
         resultFuture.complete(
-                JobManagerRunnerResult.forSuccess(
-                        createFailedExecutionGraphInfo(new FlinkException("test exception"))));
+                JobManagerRunnerResult.forInitializationFailure(
+                        createFailedExecutionGraphInfo(new FlinkException("test exception")),
+                        new FlinkException("test exception")));
 
         assertThat(jobManagerRunner.getResultFuture())
                 .as("The runner result should not be completed if the leadership is lost.")
@@ -525,6 +534,199 @@ class JobMasterServiceLeadershipRunnerTest {
                                                     .getState())
                                     .isEqualTo(JobStatus.SUSPENDED);
                         });
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(
+            value = JobStatus.class,
+            names = {"FAILED", "FINISHED", "CANCELED"})
+    void testCloseAsyncCompletesWithGloballyTerminalResultObservedBeforeLeadershipRevoke(
+            JobStatus terminalStatus) throws Exception {
+        final CompletableFuture<JobManagerRunnerResult> resultFuture = new CompletableFuture<>();
+        final ControlledForwardingCheck check = new ControlledForwardingCheck();
+        final JobMasterServiceLeadershipRunner jobManagerRunner =
+                newJobMasterServiceLeadershipRunnerBuilder()
+                        .setLeaderElection(check.election)
+                        .withSingleJobMasterServiceProcess(
+                                TestingJobMasterServiceProcess.newBuilder()
+                                        .setGetResultFutureSupplier(() -> resultFuture)
+                                        .build())
+                        .build();
+
+        jobManagerRunner.start();
+        try {
+            check.election.isLeader(UUID.randomUUID()).join();
+
+            resultFuture.complete(createGloballyTerminalResult(terminalStatus));
+            assertThat(jobManagerRunner.getResultFuture()).isNotDone();
+
+            check.election.notLeader();
+            jobManagerRunner.closeAsync().get();
+
+            assertRunnerResultHasJobStatus(jobManagerRunner, terminalStatus);
+        } finally {
+            check.release();
+        }
+    }
+
+    @Test
+    void testCloseAsyncFlushesCachedGloballyTerminalResultAfterRevoke() throws Exception {
+        final CompletableFuture<JobManagerRunnerResult> resultFuture = new CompletableFuture<>();
+        final ControlledForwardingCheck check = new ControlledForwardingCheck();
+        final JobMasterServiceLeadershipRunner jobManagerRunner =
+                newJobMasterServiceLeadershipRunnerBuilder()
+                        .setLeaderElection(check.election)
+                        .withSingleJobMasterServiceProcess(
+                                TestingJobMasterServiceProcess.newBuilder()
+                                        .setGetResultFutureSupplier(() -> resultFuture)
+                                        .build())
+                        .build();
+
+        jobManagerRunner.start();
+        try {
+            check.election.isLeader(UUID.randomUUID()).join();
+
+            check.election.notLeader();
+            resultFuture.complete(createGloballyTerminalResult(JobStatus.FAILED));
+
+            assertThat(jobManagerRunner.getResultFuture()).isNotDone();
+
+            jobManagerRunner.closeAsync().get();
+
+            assertRunnerResultHasJobStatus(jobManagerRunner, JobStatus.FAILED);
+        } finally {
+            check.release();
+        }
+    }
+
+    @Test
+    void testGrantLeadershipFlushesCachedTerminalResultObservedAfterRevoke() throws Exception {
+        final CompletableFuture<JobManagerRunnerResult> resultFuture = new CompletableFuture<>();
+        final AtomicInteger createdProcesses = new AtomicInteger();
+        final ControlledForwardingCheck check = new ControlledForwardingCheck();
+        final JobMasterServiceLeadershipRunner jobManagerRunner =
+                newJobMasterServiceLeadershipRunnerBuilder()
+                        .setLeaderElection(check.election)
+                        .setJobMasterServiceProcessFactory(
+                                TestingJobMasterServiceProcessFactory.newBuilder()
+                                        .setJobId(jobGraph.getJobID())
+                                        .setJobName(jobGraph.getName())
+                                        .setJobMasterServiceProcessFunction(
+                                                ignored -> {
+                                                    createdProcesses.incrementAndGet();
+                                                    return TestingJobMasterServiceProcess
+                                                            .newBuilder()
+                                                            .setGetResultFutureSupplier(
+                                                                    () -> resultFuture)
+                                                            .build();
+                                                })
+                                        .build())
+                        .build();
+
+        jobManagerRunner.start();
+        try {
+            check.election.isLeader(UUID.randomUUID()).join();
+            assertThat(createdProcesses).hasValue(1);
+
+            check.election.notLeader();
+            resultFuture.complete(createGloballyTerminalResult(JobStatus.FAILED));
+
+            assertThat(jobManagerRunner.getResultFuture()).isNotDone();
+
+            jobManagerRunner.grantLeadership(UUID.randomUUID());
+
+            assertThat(createdProcesses)
+                    .as(
+                            "A re-grant after a cached terminal result must flush it instead of starting a zombie process.")
+                    .hasValue(1);
+
+            assertRunnerResultHasJobStatus(jobManagerRunner, JobStatus.FAILED);
+        } finally {
+            check.release();
+        }
+    }
+
+    @Test
+    void testGloballyTerminalResultFromStaleProcessIsNotCached() throws Exception {
+        final CompletableFuture<JobManagerRunnerResult> staleProcessResultFuture =
+                new CompletableFuture<>();
+        final Queue<CompletableFuture<JobManagerRunnerResult>> processResultFutures =
+                new ArrayDeque<>(
+                        Arrays.asList(staleProcessResultFuture, new CompletableFuture<>()));
+        final JobMasterServiceLeadershipRunner jobManagerRunner =
+                newJobMasterServiceLeadershipRunnerBuilder()
+                        .setJobMasterServiceProcessFactory(
+                                TestingJobMasterServiceProcessFactory.newBuilder()
+                                        .setJobId(jobGraph.getJobID())
+                                        .setJobName(jobGraph.getName())
+                                        .setJobMasterServiceProcessFunction(
+                                                ignored ->
+                                                        TestingJobMasterServiceProcess.newBuilder()
+                                                                .setGetResultFutureSupplier(
+                                                                        processResultFutures::poll)
+                                                                .build())
+                                        .build())
+                        .build();
+
+        jobManagerRunner.start();
+
+        // First leadership term creates the process that later turns stale.
+        leaderElection.isLeader(UUID.randomUUID()).join();
+        leaderElection.notLeader();
+
+        // Second leadership term makes a different process the current one.
+        leaderElection.isLeader(UUID.randomUUID()).join();
+
+        // The stale process from the first term now observes a globally terminal result. Since its
+        // leader session id no longer matches the current process, the result must not be cached.
+        staleProcessResultFuture.complete(createGloballyTerminalResult(JobStatus.FAILED));
+
+        assertThat(jobManagerRunner.getResultFuture()).isNotDone();
+
+        jobManagerRunner.closeAsync().get();
+
+        assertRunnerResultHasJobStatus(jobManagerRunner, JobStatus.SUSPENDED);
+    }
+
+    private static void assertRunnerResultHasJobStatus(
+            JobMasterServiceLeadershipRunner runner, JobStatus expectedStatus) {
+        assertThatFuture(runner.getResultFuture())
+                .eventuallySucceeds()
+                .satisfies(
+                        result ->
+                                assertThat(
+                                                result.getExecutionGraphInfo()
+                                                        .getArchivedExecutionGraph()
+                                                        .getState())
+                                        .isEqualTo(expectedStatus));
+    }
+
+    private static final class ControlledForwardingCheck {
+        final CompletableFuture<Boolean> delayedForwardingCheck = new CompletableFuture<>();
+        final TestingLeaderElection election;
+
+        ControlledForwardingCheck() {
+            final Queue<CompletableFuture<Boolean>> hasLeadershipResults =
+                    new ArrayDeque<>(
+                            Arrays.asList(
+                                    CompletableFuture.completedFuture(true),
+                                    delayedForwardingCheck));
+            this.election =
+                    new TestingLeaderElection() {
+                        @Override
+                        public synchronized CompletableFuture<Boolean> hasLeadershipAsync(
+                                UUID leaderSessionId) {
+                            return hasLeadershipResults.isEmpty()
+                                    ? CompletableFuture.completedFuture(false)
+                                    : hasLeadershipResults.poll();
+                        }
+                    };
+        }
+
+        void release() throws Exception {
+            delayedForwardingCheck.complete(false);
+            election.close();
+        }
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunnerTestHarness.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunnerTestHarness.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.runtime.execution.librarycache.TestingClassLoaderLease;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.runtime.highavailability.nonha.embedded.EmbeddedJobResultStore;
+import org.apache.flink.runtime.jobgraph.JobType;
+import org.apache.flink.runtime.jobmanager.OnCompletionActions;
+import org.apache.flink.runtime.jobmaster.factories.DefaultJobMasterServiceProcessFactory;
+import org.apache.flink.runtime.jobmaster.factories.JobMasterServiceFactory;
+import org.apache.flink.runtime.jobmaster.factories.JobMasterServiceProcessFactory;
+import org.apache.flink.runtime.jobmaster.factories.TestingJobMasterServiceFactory;
+import org.apache.flink.runtime.leaderelection.TestingLeaderElection;
+import org.apache.flink.runtime.scheduler.ExecutionGraphInfo;
+import org.apache.flink.runtime.util.TestingFatalErrorHandler;
+
+import javax.annotation.Nullable;
+
+import java.util.Queue;
+import java.util.UUID;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Integration test harness that drives a real {@link JobMasterServiceLeadershipRunner} on top of
+ * real {@link DefaultJobMasterServiceProcess} instances, using a {@link TestingJobMasterService} as
+ * the only test double.
+ *
+ * <p>Unlike {@link JobMasterServiceLeadershipRunnerTest}, which stubs the process, this harness
+ * exercises the runner and the process together so the two halves of the FLINK-39704 fix (the
+ * runner caching a globally terminal result across leadership revocation and the process deferring
+ * its {@link JobNotFinishedException} during close) are tested in combination.
+ *
+ * <p>Every seam that decides the race outcome is controllable from the test thread:
+ *
+ * <ul>
+ *   <li>leadership grant/revoke via {@link #grantLeadership()} / {@link #revokeLeadership()},
+ *   <li>the moment a globally terminal result is observed via {@link #reachGloballyTerminalState},
+ *   <li>the moment the underlying {@link JobMasterService} finishes closing via {@link
+ *       #completeCurrentServiceTermination} (this is what opens the process's close window), and
+ *   <li>the leadership re-validation performed while forwarding the result via {@link
+ *       #armDelayedForwardingCheck} / {@link #releaseDelayedForwardingCheck}, which lets a
+ *       revocation interleave between observing the result and forwarding it.
+ * </ul>
+ *
+ * <p>This keeps the reproduction deterministic without relying on timing.
+ */
+final class JobMasterServiceLeadershipRunnerTestHarness implements AutoCloseable {
+
+    private final JobID jobId = new JobID();
+    private final String jobName = "test-job";
+    private final JobType jobType = JobType.STREAMING;
+
+    private final DelayableLeaderElection leaderElection = new DelayableLeaderElection();
+
+    private final BlockingQueue<OnCompletionActions> onCompletionActionsQueue =
+            new LinkedBlockingQueue<>();
+    private final Queue<CompletableFuture<Void>> serviceTerminationFutures =
+            new ConcurrentLinkedQueue<>();
+
+    private final JobMasterServiceLeadershipRunner runner;
+
+    @Nullable private CompletableFuture<Boolean> armedForwardingCheck;
+
+    JobMasterServiceLeadershipRunnerTestHarness() {
+        final JobMasterServiceFactory jobMasterServiceFactory =
+                new TestingJobMasterServiceFactory(
+                        onCompletionActions -> {
+                            final CompletableFuture<Void> serviceTerminationFuture =
+                                    new CompletableFuture<>();
+                            serviceTerminationFutures.add(serviceTerminationFuture);
+                            onCompletionActionsQueue.add(onCompletionActions);
+                            return CompletableFuture.completedFuture(
+                                    new TestingJobMasterService(
+                                            "localhost", serviceTerminationFuture, null));
+                        });
+
+        final JobMasterServiceProcessFactory processFactory =
+                new DefaultJobMasterServiceProcessFactory(
+                        jobId,
+                        jobName,
+                        jobType,
+                        null,
+                        System.currentTimeMillis(),
+                        jobMasterServiceFactory);
+
+        this.runner =
+                new JobMasterServiceLeadershipRunner(
+                        processFactory,
+                        leaderElection,
+                        new EmbeddedJobResultStore(),
+                        TestingClassLoaderLease.newBuilder().build(),
+                        new TestingFatalErrorHandler());
+    }
+
+    void start() throws Exception {
+        runner.start();
+    }
+
+    /** Grants leadership and waits until the new process has been confirmed as leader. */
+    UUID grantLeadership() throws Exception {
+        final UUID leaderSessionId = UUID.randomUUID();
+        leaderElection.isLeader(leaderSessionId).get();
+        return leaderSessionId;
+    }
+
+    void revokeLeadership() {
+        leaderElection.notLeader();
+    }
+
+    /** Makes the current process observe a globally terminal result, as the scheduler would. */
+    void reachGloballyTerminalState(JobStatus terminalState) throws InterruptedException {
+        onCompletionActionsQueue
+                .take()
+                .jobReachedGloballyTerminalState(createExecutionGraphInfo(terminalState));
+    }
+
+    /** Completes the current {@link JobMasterService}'s termination, unblocking process close. */
+    void completeCurrentServiceTermination() {
+        final CompletableFuture<Void> serviceTerminationFuture = serviceTerminationFutures.poll();
+        if (serviceTerminationFuture != null) {
+            serviceTerminationFuture.complete(null);
+        }
+    }
+
+    /**
+     * Holds back the next leadership re-validation performed while forwarding the result, so a
+     * revocation can be injected before {@link #releaseDelayedForwardingCheck} is called. Must be
+     * called after {@link #grantLeadership()} so it only affects the forwarding check.
+     */
+    void armDelayedForwardingCheck() {
+        armedForwardingCheck = leaderElection.armForwardingCheck();
+    }
+
+    /** Releases the held forwarding check, reporting that leadership has been lost. */
+    void releaseDelayedForwardingCheck() {
+        if (armedForwardingCheck != null) {
+            armedForwardingCheck.complete(false);
+            armedForwardingCheck = null;
+        }
+    }
+
+    CompletableFuture<Void> closeRunnerAsync() {
+        return runner.closeAsync();
+    }
+
+    JobStatus getResultJobStatus() throws Exception {
+        return runner.getResultFuture()
+                .get()
+                .getExecutionGraphInfo()
+                .getArchivedExecutionGraph()
+                .getState();
+    }
+
+    @Override
+    public void close() throws Exception {
+        releaseDelayedForwardingCheck();
+        CompletableFuture<Void> serviceTerminationFuture;
+        while ((serviceTerminationFuture = serviceTerminationFutures.poll()) != null) {
+            serviceTerminationFuture.complete(null);
+        }
+        runner.closeAsync().get();
+        leaderElection.close();
+    }
+
+    private ExecutionGraphInfo createExecutionGraphInfo(JobStatus jobStatus) {
+        return new ExecutionGraphInfo(
+                ArchivedExecutionGraph.createSparseArchivedExecutionGraph(
+                        jobId, jobName, jobStatus, jobType, null, null, 1L));
+    }
+
+    /**
+     * {@link TestingLeaderElection} whose next {@link #hasLeadershipAsync} call can be held back,
+     * to model a revocation racing with the result-forwarding leadership check.
+     */
+    private static final class DelayableLeaderElection extends TestingLeaderElection {
+        private final AtomicReference<CompletableFuture<Boolean>> nextForwardingCheck =
+                new AtomicReference<>();
+
+        @Override
+        public synchronized CompletableFuture<Boolean> hasLeadershipAsync(UUID leaderSessionId) {
+            final CompletableFuture<Boolean> delayed = nextForwardingCheck.getAndSet(null);
+            return delayed != null ? delayed : super.hasLeadershipAsync(leaderSessionId);
+        }
+
+        CompletableFuture<Boolean> armForwardingCheck() {
+            final CompletableFuture<Boolean> delayed = new CompletableFuture<>();
+            nextForwardingCheck.set(delayed);
+            return delayed;
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Fixes [FLINK-39704](https://issues.apache.org/jira/browse/FLINK-39704): a race between a JobMaster's globally terminal job completion and a leadership revocation that arrives in the same window. The terminal result (`FAILED`/`CANCELED`/`FINISHED`) was silently masked by a synthetic `SUSPENDED`, leaving the JobGraph and HA metadata behind. On the next leadership grant, the same `JobID` was recovered into a new `JobMasterServiceProcess` even though the job had already reached a globally terminal state — observed with Application Mode on Kubernetes HA; the same race is in the runner / process lifecycle (above the `LeaderElection` interface), so it can affect session clusters and ZooKeeper HA as well.

The fix has two parts that close two distinct orderings of the same underlying race.

## Brief change log

- **`DefaultJobMasterServiceProcess.closeAsync()`** — defer `resultFuture.completeExceptionally(JobNotFinishedException)` until after `jobMasterService.closeAsync()` settles. Previously it ran synchronously inside `closeAsync()`, so an in-flight terminal completion from the scheduler (`jobReachedGloballyTerminalState`) would race the eager failure and lose; the scheduler's later `resultFuture.complete(...)` then became a no-op. After the change, the scheduler has its full drain window to publish, and `JobNotFinishedException` is only declared if nothing else completes the future first.
- **`JobMasterServiceLeadershipRunner`** — cache a globally terminal result the moment it is observed on the result-forwarding path (`rememberGloballyTerminalResultIfCurrentProcess`), and flush it from either `completeResultFutureAfterClose` (on runner close) or `grantLeadership` (on re-grant). Drain is chained inside `sequentialOperation` so it runs only after the prior process's stop and forwarding have fully settled. Revoke intentionally does **not** clear `currentJobMasterServiceProcessLeaderId`, so late terminal callbacks from the closing process can still satisfy the cache's leader-equality check.

## Verifying this change

This change added tests and can be verified as follows:

### End-to-end reproduction on Kubernetes HA (before and after the fix)

*Setup:* minikube cluster with the Flink Kubernetes Operator running a `FlinkDeployment` (`apache/flink:2.2.0` base, Kubernetes HA, `StateMachineExample`, `restart-strategy: none`). Two builds were tested: the unmodified release and the same release with this PR applied. Both were instrumented with two test-only `Thread.sleep`s — one inside `forwardResultFuture.whenComplete` (Ordering A) and one inside `jobReachedGloballyTerminalState` (Ordering B) — gated behind JVM system properties so they are no-ops in production paths. The sleeps only widen the race window deterministically.

*Run sequence per repro:*
  1. Apply the CR with the corresponding sleep flag enabled (3000 ms).
  2. Wait for the job to be `RUNNING`, then delete the TaskManager pod to push the job toward a globally terminal state.
  3. When the instrumentation log line fires, force a leadership revocation by `kubectl patch`-ing the HA cluster ConfigMap to a foreign `holderIdentity` with a short fresh lease, then letting the lease expire so the original JM re-acquires.

*Results — 3 runs per cell:*

| Build | Ordering | `reached terminal state` | `Flushing globally terminal result` (fix fires) | `was recovered successfully` (reanimated terminal job) |
|---|---|---|---|---|
| unpatched | A | `SUSPENDED` (bug) | 0/3 | 3/3 |
| patched   | A | `FAILED` | 3/3 | 0/3 |
| unpatched | B | `SUSPENDED` (bug) | 0/3 | 3/3 |
| patched   | B | `FAILED` | 3/3 | 0/3 |

Unpatched runs show the bug: the terminal `FAILED` is masked as `SUSPENDED`, the JobGraph is left behind, and on the next leadership grant `Successfully recovered 1 persisted job graphs` → `Job ... was recovered successfully` → `Creating new JobMasterServiceProcess` for a `JobID` that already reached a globally terminal state. Patched runs show `Caching globally terminal job result` → `Flushing globally terminal result for job ... Job state: FAILED` → dispatcher sees `reached terminal state FAILED`, in the same JVM with no restart.

### Unit / integration tests

- **`DefaultJobMasterServiceProcessTest#testTerminalResultPublishedDuringCloseWinsOverJobNotFinished`** — holds the `JobMasterService` termination future open, calls `serviceProcess.closeAsync()`, asserts the result is not yet completed, calls `jobReachedGloballyTerminalState(FAILED)` mid-close, then releases the service termination. Asserts the runner result is `FAILED`, not `JobNotFinishedException`. Fails on the old code, passes on the new code.
- **`JobMasterServiceLeadershipRunnerTest#testCloseAsyncFlushesCachedGloballyTerminalResultAfterRevoke`** and **`#testGrantLeadershipFlushesCachedTerminalResultObservedAfterRevoke`** — cover the runner-level cache + flush behavior for the close path and the re-grant path respectively, with the terminal result completing after `notLeader()`. Both fail on a runner that fences `currentJobMasterServiceProcessLeaderId` on revoke.
- **`JobMasterServiceLeadershipRunnerTest#testCloseAsyncCompletesWithGloballyTerminalResultObservedBeforeLeadershipRevoke`** — parameterized over `FAILED`/`FINISHED`/`CANCELED`, covers the symmetric ordering (terminal observed before revoke).

Run locally with:

```
mvn -pl flink-runtime -am -Dtest='JobMasterServiceLeadershipRunnerTest,DefaultJobMasterServiceProcessTest' test
```

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): **no**
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
- The serializers: **no**
- The runtime per-record code paths (performance sensitive): **no**
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **yes** — touches the JobManager leadership runner and the JobMaster process lifecycle; relevant for both Kubernetes HA and ZooKeeper HA since the race is in the runner / process lifecycle (above the `LeaderElection` interface)
- The S3 file system connector: **no**

## Documentation

- Does this pull request introduce a new feature? **no** (bug fix)
- If yes, how is the feature documented? **not applicable**

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude and OpenAI Codex were used as pair-programming assistants for analysis and test drafting. The author reviewed and validated the final code and tests.

Generated-by: Claude (Opus 4.7); Codex (GPT-5.5)
