### PR TITLE
[FLINK-39714][docs] Backport AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,6 +196,7 @@ Every module from the root pom.xml, organized by function. Flink provides three 
 Key separations:
 
 - **Planner vs Runtime:** The table planner generates code and execution plans; the runtime executes them. Changes to planning logic live in `flink-table-planner`; changes to runtime operators live in `flink-table-runtime` or `flink-streaming-java`.
+- **Codegen vs hand-written operators:** Per-record expression logic (casts, projections, filters, function calls) is generated at planning time by cast rules in `flink-table-planner/.../functions/casting/` and call generators in `flink-table-planner/.../codegen/calls/`, then compiled by Janino into the surrounding operator class. Operators with fixed structure (joins, aggregations, source/sink runtime) are hand-written Java in `flink-table-runtime` or `flink-streaming-java`. New scalar functions usually only need a `BuiltInFunctionDefinitions` entry plus a `BuiltInScalarFunction` subclass - the planner wires up codegen automatically. New cast behaviour or a custom call shape needs a cast rule or call generator.
 - **API vs Implementation:** Public API surfaces (`flink-core-api`, `flink-datastream-api`, `flink-table-api-java`) are separate from implementation modules. API stability annotations control what users can depend on.
 - **ArchUnit enforcement:** `flink-architecture-tests/` contains ArchUnit tests that enforce module boundaries. New violations should be avoided; if unavoidable, follow the freeze procedure in `flink-architecture-tests/README.md`.
 
@@ -294,6 +295,7 @@ This section maps common types of Flink changes to the modules they touch and th
 - Ensure `./mvnw clean verify` passes before opening a PR
 - Always push to your fork, not directly to `apache/flink`
 - Rebase onto the latest target branch before submitting
+- For user-visible behaviour changes, breaking changes, new SQL features, or new config options: fill in the **Release Notes** field on the JIRA ticket. The release manager consolidates these when cutting a release. The next version's `docs/content/release-notes/flink-X.Y.md` will be generated based of the jira tickets, so make sure to fill them in properly.
 
 ### AI-assisted contributions
 


### PR DESCRIPTION
## What is the purpose of the change

Backport of [AGENTS.md](https://github.com/apache/flink/blob/master/AGENTS.md) to `release-2.3`, so AI coding agents working on backports here find the same conventions they get on `master`.

## Brief change log
- Adds the two AGENTS.md bullets that were added on master in FLINK-39623 (d1e3d13de8a) but were never backported to release-2.3.

Follows up on review feedback from #28179.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)

---

##### Was generative AI tooling used to co-author this PR?
- [X] Yes — Claude Opus 4.7 (1M context)

Generated-by: Claude Opus 4.7 (1M context)