### PR TITLE
[FLINK-39034][streaming] Fix timestamp loss in SortPartitionOperator

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/sortpartition/SortPartitionOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/sortpartition/SortPartitionOperator.java
@@ -30,6 +30,7 @@ import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.configuration.AlgorithmOptions;
 import org.apache.flink.configuration.Configuration;
@@ -44,7 +45,6 @@ import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.OperatorAttributes;
 import org.apache.flink.streaming.api.operators.OperatorAttributesBuilder;
 import org.apache.flink.streaming.api.operators.Output;
-import org.apache.flink.streaming.api.operators.TimestampedCollector;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.util.MutableObjectIterator;
@@ -86,10 +86,10 @@ public class SortPartitionOperator<INPUT> extends AbstractStreamOperator<INPUT>
     private final int positionSortField;
 
     /** The sorter to sort record if the record is not sorted by {@link KeySelector}. */
-    private PushSorter<INPUT> recordSorter = null;
+    private PushSorter<Tuple2<INPUT, Long>> recordSorter = null;
 
     /** The sorter to sort record if the record is sorted by {@link KeySelector}. */
-    private PushSorter<Tuple2<?, INPUT>> recordSorterForKeySelector = null;
+    private PushSorter<Tuple3<?, INPUT, Long>> recordSorterForKeySelector = null;
 
     public SortPartitionOperator(
             TypeInformation<INPUT> inputType, int positionSortField, Order sortOrder) {
@@ -131,14 +131,15 @@ public class SortPartitionOperator<INPUT> extends AbstractStreamOperator<INPUT>
         super.setup(containingTask, config, output);
         ExecutionConfig executionConfig = containingTask.getEnvironment().getExecutionConfig();
         if (sortFieldSelector != null) {
-            TypeInformation<Tuple2<?, INPUT>> sortTypeInfo =
+            TypeInformation<Tuple3<?, INPUT, Long>> sortTypeInfo =
                     Types.TUPLE(
                             TypeExtractor.getKeySelectorTypes(sortFieldSelector, inputType),
-                            inputType);
+                            inputType,
+                            Types.LONG);
             recordSorterForKeySelector =
                     getSorter(
                             sortTypeInfo.createSerializer(executionConfig.getSerializerConfig()),
-                            ((CompositeType<Tuple2<?, INPUT>>) sortTypeInfo)
+                            ((CompositeType<Tuple3<?, INPUT, Long>>) sortTypeInfo)
                                     .createComparator(
                                             getSortFieldIndex(),
                                             getSortOrderIndicator(),
@@ -146,10 +147,11 @@ public class SortPartitionOperator<INPUT> extends AbstractStreamOperator<INPUT>
                                             executionConfig),
                             containingTask);
         } else {
+            TypeInformation<Tuple2<INPUT, Long>> sortTypeInfo = Types.TUPLE(inputType, Types.LONG);
             recordSorter =
                     getSorter(
-                            inputType.createSerializer(executionConfig.getSerializerConfig()),
-                            ((CompositeType<INPUT>) inputType)
+                            sortTypeInfo.createSerializer(executionConfig.getSerializerConfig()),
+                            ((CompositeType<Tuple2<INPUT, Long>>) sortTypeInfo)
                                     .createComparator(
                                             getSortFieldIndex(),
                                             getSortOrderIndicator(),
@@ -163,31 +165,33 @@ public class SortPartitionOperator<INPUT> extends AbstractStreamOperator<INPUT>
     public void processElement(StreamRecord<INPUT> element) throws Exception {
         if (sortFieldSelector != null) {
             recordSorterForKeySelector.writeRecord(
-                    Tuple2.of(sortFieldSelector.getKey(element.getValue()), element.getValue()));
+                    Tuple3.of(
+                            sortFieldSelector.getKey(element.getValue()),
+                            element.getValue(),
+                            element.getTimestamp()));
         } else {
-            recordSorter.writeRecord(element.getValue());
+            recordSorter.writeRecord(Tuple2.of(element.getValue(), element.getTimestamp()));
         }
     }
 
     @Override
     public void endInput() throws Exception {
-        TimestampedCollector<INPUT> outputCollector = new TimestampedCollector<>(output);
         if (sortFieldSelector != null) {
             recordSorterForKeySelector.finishReading();
-            MutableObjectIterator<Tuple2<?, INPUT>> dataIterator =
+            MutableObjectIterator<Tuple3<?, INPUT, Long>> dataIterator =
                     recordSorterForKeySelector.getIterator();
-            Tuple2<?, INPUT> record = dataIterator.next();
+            Tuple3<?, INPUT, Long> record = dataIterator.next();
             while (record != null) {
-                outputCollector.collect(record.f1);
+                output.collect(new StreamRecord<>(record.f1, record.f2));
                 record = dataIterator.next();
             }
             recordSorterForKeySelector.close();
         } else {
             recordSorter.finishReading();
-            MutableObjectIterator<INPUT> dataIterator = recordSorter.getIterator();
-            INPUT record = dataIterator.next();
+            MutableObjectIterator<Tuple2<INPUT, Long>> dataIterator = recordSorter.getIterator();
+            Tuple2<INPUT, Long> record = dataIterator.next();
             while (record != null) {
-                outputCollector.collect(record);
+                output.collect(new StreamRecord<>(record.f0, record.f1));
                 record = dataIterator.next();
             }
             recordSorter.close();

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/sortpartition/SortPartitionOperatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/sortpartition/SortPartitionOperatorTest.java
@@ -47,12 +47,13 @@ class SortPartitionOperatorTest {
                 testHarness1 = new OneInputStreamOperatorTestHarness<>(operator1);
         Queue<Object> expectedOutput1 = new LinkedList<>();
         testHarness1.setup();
-        testHarness1.processElement(new StreamRecord<>(Tuple2.of(3, "3")));
-        testHarness1.processElement(new StreamRecord<>(Tuple2.of(1, "1")));
+        long timestamp = 1L;
+        testHarness1.processElement(new StreamRecord<>(Tuple2.of(3, "3"), timestamp));
+        testHarness1.processElement(new StreamRecord<>(Tuple2.of(1, "1"), timestamp));
         testHarness1.endInput();
         testHarness1.close();
-        expectedOutput1.add(new StreamRecord<>(Tuple2.of(1, "1")));
-        expectedOutput1.add(new StreamRecord<>(Tuple2.of(3, "3")));
+        expectedOutput1.add(new StreamRecord<>(Tuple2.of(1, "1"), timestamp));
+        expectedOutput1.add(new StreamRecord<>(Tuple2.of(3, "3"), timestamp));
         TestHarnessUtil.assertOutputEquals(
                 "The sort partition result is not correct.",
                 expectedOutput1,
@@ -63,12 +64,12 @@ class SortPartitionOperatorTest {
                 new OneInputStreamOperatorTestHarness<>(operator2);
         Queue<Object> expectedOutput2 = new LinkedList<>();
         testHarness2.setup();
-        testHarness2.processElement(new StreamRecord<>(new TestPojo("3", 3)));
-        testHarness2.processElement(new StreamRecord<>(new TestPojo("1", 1)));
+        testHarness2.processElement(new StreamRecord<>(new TestPojo("3", 3), timestamp));
+        testHarness2.processElement(new StreamRecord<>(new TestPojo("1", 1), timestamp));
         testHarness2.endInput();
         testHarness2.close();
-        expectedOutput2.add(new StreamRecord<>(new TestPojo("1", 1)));
-        expectedOutput2.add(new StreamRecord<>(new TestPojo("3", 3)));
+        expectedOutput2.add(new StreamRecord<>(new TestPojo("1", 1), timestamp));
+        expectedOutput2.add(new StreamRecord<>(new TestPojo("3", 3), timestamp));
         TestHarnessUtil.assertOutputEquals(
                 "The sort partition result is not correct.",
                 expectedOutput2,
@@ -79,12 +80,12 @@ class SortPartitionOperatorTest {
                 new OneInputStreamOperatorTestHarness<>(operator3);
         Queue<Object> expectedOutput3 = new LinkedList<>();
         testHarness3.setup();
-        testHarness3.processElement(new StreamRecord<>(new TestPojo("3", 3)));
-        testHarness3.processElement(new StreamRecord<>(new TestPojo("1", 1)));
+        testHarness3.processElement(new StreamRecord<>(new TestPojo("3", 3), timestamp));
+        testHarness3.processElement(new StreamRecord<>(new TestPojo("1", 1), timestamp));
         testHarness3.endInput();
         testHarness3.close();
-        expectedOutput3.add(new StreamRecord<>(new TestPojo("1", 1)));
-        expectedOutput3.add(new StreamRecord<>(new TestPojo("3", 3)));
+        expectedOutput3.add(new StreamRecord<>(new TestPojo("1", 1), timestamp));
+        expectedOutput3.add(new StreamRecord<>(new TestPojo("3", 3), timestamp));
         TestHarnessUtil.assertOutputEquals(
                 "The sort partition result is not correct.",
                 expectedOutput3,


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull request fixes the timestamp loss issue in `SortPartitionOperator` when running in STREAMING mode. 

When users use `fullWindowPartition().sortPartition()` operator combination in Flink DataStream API, the timestamp was being lost during `SortPartitionOperator` processing, causing `ctx.timestamp()` in downstream `KeyedProcessFunction` to return `null`.


## Brief change log

**Modified `SortPartitionOperator.java`**, add timestamp in sorter and set in streamrecord when collecting output


## Verifying this change

fix unit test in SortPartitionOperatorTest.java

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
