### PR TITLE
[Flink 39717][docs] Document SET/RESET key handling for ALTER TABLE, CATALOG, MODEL and DATABASE

### DIFF
--- a/docs/content.zh/docs/sql/reference/ddl/alter.md
+++ b/docs/content.zh/docs/sql/reference/ddl/alter.md
@@ -668,22 +668,39 @@ ALTER MODEL [IF EXISTS] [catalog_name.][db_name.]model_name
 
 为指定的模型设置一个或多个属性。若个别属性已经存在，则使用新值覆盖旧值。
 
+**Key handling:**
+- Properties not listed in the statement are preserved.
+- If the same key appears multiple times in the list, the last value wins and a warning is logged.
+- The empty option list `SET ()` is rejected with a validation error.
+
 `SET` 语句示例如下。
 
 ```sql
 -- 设置模型的属性
 ALTER MODEL MyModel SET ('model-type'='linear', 'version'='2.0');
+
+-- duplicate keys: the last value wins. After this statement, 'version' is '2.0'.
+ALTER MODEL MyModel SET ('version'='1.0', 'version'='2.0');
 ```
 
 ### RESET
 
 为指定的模型重置一个或多个属性。
 
+**Key handling:**
+- Keys that are not currently set on the model are silently ignored. The statement still succeeds.
+- Duplicate keys in the key list are de-duplicated and treated as a single reset for that key.
+- The empty key list `RESET ()` is rejected with a validation error.
+
 `RESET` 语句示例如下。
 
 ```sql
 -- 重置模型的属性
 ALTER MODEL MyModel RESET ('model-type', 'version');
+
+-- 'unknown-key' is not currently set on the model: this is a no-op for that key,
+-- 'model-type' is still reset and the statement succeeds.
+ALTER MODEL MyModel RESET ('model-type', 'unknown-key');
 ```
 
 ### RENAME TO

--- a/docs/content.zh/docs/sql/reference/ddl/alter.md
+++ b/docs/content.zh/docs/sql/reference/ddl/alter.md
@@ -603,22 +603,40 @@ ALTER CATALOG catalog_name
 
 为指定的 catalog 设置一个或多个属性。若个别属性已经存在，则使用新值覆盖旧值。
 
+**Key handling:**
+- Properties not listed in the statement are preserved.
+- If the same key appears multiple times in the list, the last value wins and a warning is logged.
+- An empty option list `SET ()` is accepted and treated as a no-op.
+
 `SET` 语句示例如下。
 
 ```sql
 -- set 'default-database'
 ALTER CATALOG cat2 SET ('default-database'='db');
+
+-- duplicate keys: the last value wins. After this statement, 'default-database' is 'db2'.
+ALTER CATALOG cat2 SET ('default-database'='db', 'default-database'='db2');
 ```
 
 ### RESET
 
 为指定的 catalog 重置一个或多个属性。
 
+**Key handling:**
+- Keys that are not currently set on the catalog are silently ignored. The statement still succeeds.
+- Duplicate keys in the key list are de-duplicated and treated as a single reset for that key.
+- The empty key list `RESET ()` is rejected with a validation error.
+- The `type` key is reserved and cannot be reset. Attempting to do so is rejected with a validation error.
+
 `RESET` 语句示例如下。
 
 ```sql
 -- reset 'default-database'
 ALTER CATALOG cat2 RESET ('default-database');
+
+-- 'unknown-key' is not currently set on the catalog: this is a no-op for that key,
+-- 'default-database' is still reset and the statement succeeds.
+ALTER CATALOG cat2 RESET ('default-database', 'unknown-key');
 ```
 
 ### COMMENT

--- a/docs/content.zh/docs/sql/reference/ddl/alter.md
+++ b/docs/content.zh/docs/sql/reference/ddl/alter.md
@@ -491,22 +491,40 @@ ALTER TABLE MyTable RENAME TO MyTable2;
 
 为指定的表设置一个或多个属性。若个别属性已经存在于表中，则使用新值覆盖旧值。
 
+**Key handling:**
+- Properties not listed in the statement are preserved.
+- If the same key appears multiple times in the list, the last value wins and a warning is logged.
+- An empty option list `SET ()` is accepted and treated as a no-op.
+
 `SET` 语句示例如下。
 
 ```sql
 -- set 'rows-per-second'
 ALTER TABLE DataGenSource SET ('rows-per-second' = '10');
+
+-- duplicate keys: the last value wins. After this statement, 'rows-per-second' is '20'.
+ALTER TABLE DataGenSource SET ('rows-per-second' = '10', 'rows-per-second' = '20');
 ```
 
 ### RESET
 
 为指定的表重置一个或多个属性。
 
+**Key handling:**
+- Keys that are not currently set on the table are silently ignored. The statement still succeeds.
+- Duplicate keys in the key list are de-duplicated and treated as a single reset for that key.
+- The empty key list `RESET ()` is rejected with a validation error.
+- The `connector` key is reserved and cannot be reset. Attempting to do so is rejected with a validation error.
+
 `RESET` 语句示例如下。
 
 ```sql
 -- reset 'rows-per-second' to the default value
 ALTER TABLE DataGenSource RESET ('rows-per-second');
+
+-- 'invalid-key' is not currently set on the table: this is a no-op for that key,
+-- 'rows-per-second' is still reset and the statement succeeds.
+ALTER TABLE DataGenSource RESET ('rows-per-second', 'invalid-key');
 ```
 
 {{< top >}}

--- a/docs/content.zh/docs/sql/reference/ddl/alter.md
+++ b/docs/content.zh/docs/sql/reference/ddl/alter.md
@@ -556,6 +556,21 @@ ALTER DATABASE [catalog_name.]db_name SET (key1=val1, key2=val2, ...)
 
 在数据库中设置一个或多个属性。若个别属性已经在数据库中设定，将会使用新值覆盖旧值。
 
+**Key handling:**
+- Properties not listed in the statement are preserved.
+- If the same key appears multiple times in the list, the last value wins and a warning is logged.
+- An empty option list `SET ()` is accepted and treated as a no-op.
+
+The following examples illustrate the usage of the `SET` statements.
+
+```sql
+-- set a database property
+ALTER DATABASE my_db SET ('k1' = 'v1');
+
+-- duplicate keys: the last value wins. After this statement, 'k1' is 'v2'.
+ALTER DATABASE my_db SET ('k1' = 'v1', 'k1' = 'v2');
+```
+
 {{< top >}}
 
 ## ALTER FUNCTION

--- a/docs/content/docs/sql/reference/ddl/alter.md
+++ b/docs/content/docs/sql/reference/ddl/alter.md
@@ -601,22 +601,40 @@ ALTER CATALOG catalog_name
 
 Set one or more properties in the specified catalog. If a particular property is already set in the catalog, override the old value with the new one.
 
+**Key handling:**
+- Properties not listed in the statement are preserved.
+- If the same key appears multiple times in the list, the last value wins and a warning is logged.
+- An empty option list `SET ()` is accepted and treated as a no-op.
+
 The following examples illustrate the usage of the `SET` statements.
 
 ```sql
 -- set 'default-database'
 ALTER CATALOG cat2 SET ('default-database'='db');
+
+-- duplicate keys: the last value wins. After this statement, 'default-database' is 'db2'.
+ALTER CATALOG cat2 SET ('default-database'='db', 'default-database'='db2');
 ```
 
 ### RESET
 
 Reset one or more properties to its default value in the specified catalog.
 
+**Key handling:**
+- Keys that are not currently set on the catalog are silently ignored. The statement still succeeds.
+- Duplicate keys in the key list are de-duplicated and treated as a single reset for that key.
+- The empty key list `RESET ()` is rejected with a validation error.
+- The `type` key is reserved and cannot be reset. Attempting to do so is rejected with a validation error.
+
 The following examples illustrate the usage of the `RESET` statements.
 
 ```sql
 -- reset 'default-database'
 ALTER CATALOG cat2 RESET ('default-database');
+
+-- 'unknown-key' is not currently set on the catalog: this is a no-op for that key,
+-- 'default-database' is still reset and the statement succeeds.
+ALTER CATALOG cat2 RESET ('default-database', 'unknown-key');
 ```
 
 ### COMMENT

--- a/docs/content/docs/sql/reference/ddl/alter.md
+++ b/docs/content/docs/sql/reference/ddl/alter.md
@@ -554,6 +554,21 @@ ALTER DATABASE [catalog_name.]db_name SET (key1=val1, key2=val2, ...)
 
 Set one or more properties in the specified database. If a particular property is already set in the database, override the old value with the new one.
 
+**Key handling:**
+- Properties not listed in the statement are preserved.
+- If the same key appears multiple times in the list, the last value wins and a warning is logged.
+- An empty option list `SET ()` is accepted and treated as a no-op.
+
+The following examples illustrate the usage of the `SET` statements.
+
+```sql
+-- set a database property
+ALTER DATABASE my_db SET ('k1' = 'v1');
+
+-- duplicate keys: the last value wins. After this statement, 'k1' is 'v2'.
+ALTER DATABASE my_db SET ('k1' = 'v1', 'k1' = 'v2');
+```
+
 {{< top >}}
 
 ## ALTER FUNCTION

--- a/docs/content/docs/sql/reference/ddl/alter.md
+++ b/docs/content/docs/sql/reference/ddl/alter.md
@@ -489,22 +489,40 @@ ALTER TABLE MyTable RENAME TO MyTable2;
 
 Set one or more properties in the specified table. If a particular property is already set in the table, override the old value with the new one.
 
+**Key handling:**
+- Properties not listed in the statement are preserved.
+- If the same key appears multiple times in the list, the last value wins and a warning is logged.
+- An empty option list `SET ()` is accepted and treated as a no-op.
+
 The following examples illustrate the usage of the `SET` statements.
 
 ```sql
 -- set 'rows-per-second'
 ALTER TABLE DataGenSource SET ('rows-per-second' = '10');
+
+-- duplicate keys: the last value wins. After this statement, 'rows-per-second' is '20'.
+ALTER TABLE DataGenSource SET ('rows-per-second' = '10', 'rows-per-second' = '20');
 ```
 
 ### RESET
 
 Reset one or more properties to its default value.
 
+**Key handling:**
+- Keys that are not currently set on the table are silently ignored. The statement still succeeds.
+- Duplicate keys in the key list are de-duplicated and treated as a single reset for that key.
+- The empty key list `RESET ()` is rejected with a validation error.
+- The `connector` key is reserved and cannot be reset. Attempting to do so is rejected with a validation error.
+
 The following examples illustrate the usage of the `RESET` statements.
 
 ```sql
 -- reset 'rows-per-second' to the default value
 ALTER TABLE DataGenSource RESET ('rows-per-second');
+
+-- 'invalid-key' is not currently set on the table: this is a no-op for that key,
+-- 'rows-per-second' is still reset and the statement succeeds.
+ALTER TABLE DataGenSource RESET ('rows-per-second', 'invalid-key');
 ```
 
 {{< top >}}

--- a/docs/content/docs/sql/reference/ddl/alter.md
+++ b/docs/content/docs/sql/reference/ddl/alter.md
@@ -663,11 +663,19 @@ ALTER MODEL [IF EXISTS] [catalog_name.][db_name.]model_name
 
 Set one or more properties in the specified model. If a particular property is already set in the model, override the old value with the new one.
 
+**Key handling:**
+- Properties not listed in the statement are preserved.
+- If the same key appears multiple times in the list, the last value wins and a warning is logged.
+- The empty option list `SET ()` is rejected with a validation error.
+
 The following examples illustrate the usage of the `SET` statements.
 
 ```sql
 -- set model properties
 ALTER MODEL MyModel SET ('model-version'='2.0', 'batch-size'='32');
+
+-- duplicate keys: the last value wins. After this statement, 'batch-size' is '64'.
+ALTER MODEL MyModel SET ('batch-size'='32', 'batch-size'='64');
 ```
 
 **IF EXISTS**
@@ -678,11 +686,20 @@ If the model does not exist, nothing happens.
 
 Reset one or more properties to its default value in the specified model.
 
+**Key handling:**
+- Keys that are not currently set on the model are silently ignored. The statement still succeeds.
+- Duplicate keys in the key list are de-duplicated and treated as a single reset for that key.
+- The empty key list `RESET ()` is rejected with a validation error.
+
 The following examples illustrate the usage of the `RESET` statements.
 
 ```sql
 -- reset model properties
 ALTER MODEL MyModel RESET ('model-version', 'batch-size');
+
+-- 'unknown-key' is not currently set on the model: this is a no-op for that key,
+-- 'model-version' is still reset and the statement succeeds.
+ALTER MODEL MyModel RESET ('model-version', 'unknown-key');
 ```
 
 ### RENAME TO


### PR DESCRIPTION

## What is the purpose of the change

The reference docs for `ALTER TABLE`, `ALTER CATALOG`, `ALTER MODEL`, and `ALTER DATABASE` describe `SET`/`RESET` only as "override the old value with the new one". The actual converter behavior handles several edge cases (duplicate keys, unknown keys, empty lists, reserved keys) that are not documented and differ across the four DDLs. This PR documents that behavior so users can predict the outcome without reading the converter source.

Docs-only change. No code changes. Aligns with the per-DDL behavior already documented for `ALTER MATERIALIZED TABLE` in FLINK-39662 / FLINK-39663.

## Brief change log

- `docs/content/docs/sql/reference/ddl/alter.md`: spell out behavior for `ALTER TABLE`, `ALTER CATALOG`, `ALTER MODEL`, `ALTER DATABASE` under `SET` and `RESET`.
- `docs/content.zh/docs/sql/reference/ddl/alter.md`: mirror in the Chinese docs.

### Summary

| DDL      | SET empty | SET dupes      | SET reserved | RESET empty | RESET unknown | RESET reserved |
|----------|-----------|----------------|--------------|-------------|---------------|----------------|
| TABLE    | no-op     | last-wins+warn | —            | reject      | no-op         | `connector`    |
| CATALOG  | no-op     | last-wins+warn | —            | reject      | no-op         | `type`         |
| MODEL    | reject    | last-wins+warn | —            | reject      | no-op         | —              |
| DATABASE | no-op     | last-wins+warn | —            | n/a         | n/a           | n/a            |

## Verifying this change

Docs-only update. No tests added. Documented behavior is covered by existing parser/converter tests for each DDL.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? docs (this PR is the documentation)

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Opus: 4.7