### PR TITLE
[FLINK-39720][table] SubQueryDecorrelator produces incorrect plans for correlated EXISTS with HAVING on aggregate outputs

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/SubQueryDecorrelator.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/SubQueryDecorrelator.java
@@ -532,8 +532,19 @@ public class SubQueryDecorrelator extends RelShuttleImpl {
                     unsupportedCorConditions);
             assert unsupportedCorConditions.isEmpty();
 
-            final RexNode remainingCondition =
+            RexNode remainingCondition =
                     RexUtil.composeConjunction(rexBuilder, nonCorConditions, false);
+
+            // Re-index the remaining (non-correlated) condition against the rewritten input.
+            // The child may have shifted its row type during decorrelation (e.g. an Aggregate
+            // injects correlated columns into its group key), so RexInputRefs in HAVING /
+            // Filter predicates that survive in nonCorConditions must be remapped through
+            // frame.oldToNewOutputs. Otherwise they silently point at the wrong column.
+            if (remainingCondition != null) {
+                remainingCondition =
+                        adjustInputRefs(
+                                remainingCondition, frame.oldToNewOutputs, frame.r.getRowType());
+            }
 
             // Using LogicalFilter.create instead of RelBuilder.filter to create Filter
             // because RelBuilder.filter method does not have VariablesSet arg.

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/subquery/SubQuerySemiJoinTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/subquery/SubQuerySemiJoinTest.xml
@@ -369,6 +369,35 @@ LogicalProject(a=[$0], b=[$1], c=[$2])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testExistsWithCorrelatedOnWhere_Aggregate_LocalWhere">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM l WHERE EXISTS (SELECT 1 FROM r WHERE l.a = r.d AND r.e > 10 GROUP BY r.f)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalFilter(condition=[EXISTS({
+LogicalAggregate(group=[{0}])
+  LogicalProject(f=[$2])
+    LogicalFilter(condition=[AND(=($cor0.a, $0), >($1, 10))])
+      LogicalTableScan(table=[[default_catalog, default_database, r]])
+})], variablesSet=[[$cor0]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, l]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalJoin(condition=[=($0, $3)], joinType=[semi])
+   :- LogicalTableScan(table=[[default_catalog, default_database, l]])
+   +- LogicalProject(d=[$1])
+      +- LogicalAggregate(group=[{0, 1}])
+         +- LogicalProject(f=[$2], d=[$0])
+            +- LogicalFilter(condition=[>($1, 10)])
+               +- LogicalTableScan(table=[[default_catalog, default_database, r]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testExistsWithCorrelatedOnWhere_ComplexCondition1">
     <Resource name="sql">
       <![CDATA[SELECT * FROM l WHERE EXISTS (SELECT CAST(e AS INTEGER), 1 FROM r where CAST(l.b AS INTEGER) = CAST(r.d AS INTEGER))]]>
@@ -446,6 +475,130 @@ LogicalProject(a=[$0], b=[$1])
    +- LogicalProject(d=[$1])
       +- LogicalFilter(condition=[true])
          +- LogicalTableScan(table=[[default_catalog, default_database, y]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testExistsWithCorrelatedOnWhere_Having1">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM l WHERE EXISTS (SELECT 1 FROM r WHERE l.a = r.d GROUP BY r.f HAVING SUM(r.e) >= 3)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalFilter(condition=[EXISTS({
+LogicalFilter(condition=[>=($1, 3)])
+  LogicalAggregate(group=[{0}], agg#0=[SUM($1)])
+    LogicalProject(f=[$2], e=[$1])
+      LogicalFilter(condition=[=($cor0.a, $0)])
+        LogicalTableScan(table=[[default_catalog, default_database, r]])
+})], variablesSet=[[$cor0]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, l]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalJoin(condition=[=($0, $3)], joinType=[semi])
+   :- LogicalTableScan(table=[[default_catalog, default_database, l]])
+   +- LogicalProject(d=[$1])
+      +- LogicalFilter(condition=[>=($2, 3)])
+         +- LogicalAggregate(group=[{0, 1}], agg#0=[SUM($2)])
+            +- LogicalProject(f=[$2], d=[$0], e=[$1])
+               +- LogicalFilter(condition=[true])
+                  +- LogicalTableScan(table=[[default_catalog, default_database, r]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testExistsWithCorrelatedOnWhere_Having2">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM l WHERE EXISTS (SELECT 1 FROM r WHERE l.a = r.d GROUP BY r.f HAVING SUM(r.e) >= 3 AND MAX(r.e) < 100)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalFilter(condition=[EXISTS({
+LogicalFilter(condition=[AND(>=($1, 3), <($2, 100))])
+  LogicalAggregate(group=[{0}], agg#0=[SUM($1)], agg#1=[MAX($1)])
+    LogicalProject(f=[$2], e=[$1])
+      LogicalFilter(condition=[=($cor0.a, $0)])
+        LogicalTableScan(table=[[default_catalog, default_database, r]])
+})], variablesSet=[[$cor0]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, l]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalJoin(condition=[=($0, $3)], joinType=[semi])
+   :- LogicalTableScan(table=[[default_catalog, default_database, l]])
+   +- LogicalProject(d=[$1])
+      +- LogicalFilter(condition=[AND(>=($2, 3), <($3, 100))])
+         +- LogicalAggregate(group=[{0, 1}], agg#0=[SUM($2)], agg#1=[MAX($2)])
+            +- LogicalProject(f=[$2], d=[$0], e=[$1])
+               +- LogicalFilter(condition=[true])
+                  +- LogicalTableScan(table=[[default_catalog, default_database, r]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testExistsWithCorrelatedOnWhere_Having3">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM l WHERE EXISTS (SELECT 1 FROM r WHERE l.a = r.d GROUP BY r.f HAVING SUM(r.e) >= 3 AND COUNT(*) > 1)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalFilter(condition=[EXISTS({
+LogicalFilter(condition=[AND(>=($1, 3), >($2, 1))])
+  LogicalAggregate(group=[{0}], agg#0=[SUM($1)], agg#1=[COUNT()])
+    LogicalProject(f=[$2], e=[$1])
+      LogicalFilter(condition=[=($cor0.a, $0)])
+        LogicalTableScan(table=[[default_catalog, default_database, r]])
+})], variablesSet=[[$cor0]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, l]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalJoin(condition=[=($0, $3)], joinType=[semi])
+   :- LogicalTableScan(table=[[default_catalog, default_database, l]])
+   +- LogicalProject(d=[$1])
+      +- LogicalFilter(condition=[AND(>=($2, 3), >($3, 1))])
+         +- LogicalAggregate(group=[{0, 1}], agg#0=[SUM($2)], agg#1=[COUNT()])
+            +- LogicalProject(f=[$2], d=[$0], e=[$1])
+               +- LogicalFilter(condition=[true])
+                  +- LogicalTableScan(table=[[default_catalog, default_database, r]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testExistsWithCorrelatedOnWhere_Having4">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM l WHERE EXISTS (SELECT 1 FROM r WHERE l.a = r.d AND l.b = r.e GROUP BY r.f HAVING COUNT(r.d) >= 2)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalFilter(condition=[EXISTS({
+LogicalFilter(condition=[>=($1, 2)])
+  LogicalAggregate(group=[{0}], agg#0=[COUNT($1)])
+    LogicalProject(f=[$2], d=[$0])
+      LogicalFilter(condition=[AND(=($cor0.a, $0), =($cor0.b, $1))])
+        LogicalTableScan(table=[[default_catalog, default_database, r]])
+})], variablesSet=[[$cor0]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, l]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalJoin(condition=[AND(=($0, $3), =($1, $4))], joinType=[semi])
+   :- LogicalTableScan(table=[[default_catalog, default_database, l]])
+   +- LogicalProject(d=[$1], e=[$2])
+      +- LogicalFilter(condition=[>=($3, 2)])
+         +- LogicalAggregate(group=[{0, 1, 2}], agg#0=[COUNT($1)])
+            +- LogicalProject(f=[$2], d=[$0], e=[$1])
+               +- LogicalFilter(condition=[true])
+                  +- LogicalTableScan(table=[[default_catalog, default_database, r]])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/subquery/SubQuerySemiJoinTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/subquery/SubQuerySemiJoinTest.scala
@@ -1324,6 +1324,51 @@ class SubQuerySemiJoinTest extends SubQueryTestBase {
   }
 
   @Test
+  def testExistsWithCorrelatedOnWhere_Having1(): Unit = {
+    // Correlated WHERE plus HAVING on a single aggregate output.
+    // Regression for SubQueryDecorrelator: the non-correlated HAVING predicate must be
+    // re-indexed against the rewritten Aggregate (which receives the correlated column
+    // injected into its group key).
+    val sqlQuery = "SELECT * FROM l WHERE EXISTS " +
+      "(SELECT 1 FROM r WHERE l.a = r.d GROUP BY r.f HAVING SUM(r.e) >= 3)"
+    util.verifyRelPlan(sqlQuery)
+  }
+
+  @Test
+  def testExistsWithCorrelatedOnWhere_Having2(): Unit = {
+    // Compound HAVING with multiple aggregate refs.
+    val sqlQuery = "SELECT * FROM l WHERE EXISTS " +
+      "(SELECT 1 FROM r WHERE l.a = r.d GROUP BY r.f HAVING SUM(r.e) >= 3 AND MAX(r.e) < 100)"
+    util.verifyRelPlan(sqlQuery)
+  }
+
+  @Test
+  def testExistsWithCorrelatedOnWhere_Having3(): Unit = {
+    // HAVING that mixes an aggregate ref with COUNT(*).
+    val sqlQuery = "SELECT * FROM l WHERE EXISTS " +
+      "(SELECT 1 FROM r WHERE l.a = r.d GROUP BY r.f HAVING SUM(r.e) >= 3 AND COUNT(*) > 1)"
+    util.verifyRelPlan(sqlQuery)
+  }
+
+  @Test
+  def testExistsWithCorrelatedOnWhere_Having4(): Unit = {
+    // Multiple correlated WHERE columns combined with a HAVING on aggregate output.
+    val sqlQuery = "SELECT * FROM l WHERE EXISTS " +
+      "(SELECT 1 FROM r WHERE l.a = r.d AND l.b = r.e GROUP BY r.f HAVING COUNT(r.d) >= 2)"
+    util.verifyRelPlan(sqlQuery)
+  }
+
+  @Test
+  def testExistsWithCorrelatedOnWhere_Aggregate_LocalWhere(): Unit = {
+    // Mixed correlated + local WHERE, no HAVING. Guards against an over-eager fix:
+    // the local predicate `r.e > 10` sits below the Aggregate, so its RexInputRef must
+    // remain stable through decorrelation.
+    val sqlQuery = "SELECT * FROM l WHERE EXISTS " +
+      "(SELECT 1 FROM r WHERE l.a = r.d AND r.e > 10 GROUP BY r.f)"
+    util.verifyRelPlan(sqlQuery)
+  }
+
+  @Test
   def testExistsWithCorrelatedOnWhere_UnsupportedAggregate1(): Unit = {
     util.addTableSource[(Int, Long)]("l1", 'a, 'b)
     util.addTableSource[(Int, Long, Double, String)]("r1", 'c, 'd, 'e, 'f)


### PR DESCRIPTION
## What is the purpose of the change
This pull request fixes a silent wrong-result bug in SubQueryDecorrelator: correlated EXISTS / NOT EXISTS sub-queries that combine a correlated WHERE with a HAVING
   clause on aggregate output produced plans where the HAVING predicate pointed at the wrong column.

  When decorrelateRel(LogicalAggregate) rewrites the inner aggregate, it injects the correlated columns into the group key, which shifts the position of the original
   aggregate-output fields. The Frame records this shift in oldToNewOutputs. But decorrelateRel(LogicalFilter) then reattaches the non-correlated remainder of the
  Filter condition (the HAVING clause, for example SUM(r.e) >= 3) to the rewritten input without remapping its RexInputRefs through frame.oldToNewOutputs. Every
  other decorrelateRel(...) method in the same file (Project, Aggregate, Join, Correlate) already calls adjustInputRefs on surviving expressions before reattaching
  them — the Filter path was the only one missing the call.

  The result is a structurally valid but semantically wrong plan: HAVING SUM(r.e) >= 3 ends up applied to the injected correlated column (e.g. r.d) instead of the
  SUM(r.e) output. This restores symmetry with Calcite's bottom-up RelDecorrelator.decorrelateRel(Filter), which walks every RexInputRef through oldToNewOutputs in a
   single pass.

## Brief change log
SubQueryDecorrelator.decorrelateRel(LogicalFilter): re-index remainingCondition (the non-correlated remainder built from nonCorConditions) through
  adjustInputRefs(remainingCondition, frame.oldToNewOutputs, frame.r.getRowType()) between RexUtil.composeConjunction(...) and LogicalFilter.create(...). The
  defensive null guard mirrors surrounding style; composeConjunction(..., /*nullOnEmpty=*/false) returns TRUE for an empty list, and adjustInputRefs(TRUE, ...) is a
  no-op, so the all-correlated case is unaffected.

## Verifying this change
 SubQuerySemiJoinTest — five new test cases

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (no)