### PR TITLE
[FLINK-36561][table] Fix ResultSet.wasNull() not reflecting per-column null values in JDBC driver

### DIFF
--- a/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkResultSet.java
+++ b/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkResultSet.java
@@ -168,8 +168,9 @@ public class FlinkResultSet extends BaseResultSet {
         checkValidColumn(columnIndex);
 
         StringData stringData = currentRow.getString(columnIndex - 1);
+        wasNull = stringData == null;
         try {
-            return stringData == null ? null : stringData.toString();
+            return wasNull ? null : stringData.toString();
         } catch (Exception e) {
             throw new SQLDataException(e);
         }
@@ -180,8 +181,9 @@ public class FlinkResultSet extends BaseResultSet {
         checkClosed();
         checkValidRow();
         checkValidColumn(columnIndex);
+        wasNull = currentRow.isNullAt(columnIndex - 1);
         try {
-            return !currentRow.isNullAt(columnIndex - 1) && currentRow.getBoolean(columnIndex - 1);
+            return !wasNull && currentRow.getBoolean(columnIndex - 1);
         } catch (Exception e) {
             throw new SQLDataException(e);
         }
@@ -192,8 +194,9 @@ public class FlinkResultSet extends BaseResultSet {
         checkClosed();
         checkValidRow();
         checkValidColumn(columnIndex);
+        wasNull = currentRow.isNullAt(columnIndex - 1);
         try {
-            return currentRow.isNullAt(columnIndex - 1) ? 0 : currentRow.getByte(columnIndex - 1);
+            return wasNull ? 0 : currentRow.getByte(columnIndex - 1);
         } catch (Exception e) {
             throw new SQLDataException(e);
         }
@@ -204,8 +207,9 @@ public class FlinkResultSet extends BaseResultSet {
         checkClosed();
         checkValidRow();
         checkValidColumn(columnIndex);
+        wasNull = currentRow.isNullAt(columnIndex - 1);
         try {
-            return currentRow.isNullAt(columnIndex - 1) ? 0 : currentRow.getShort(columnIndex - 1);
+            return wasNull ? 0 : currentRow.getShort(columnIndex - 1);
         } catch (Exception e) {
             throw new SQLDataException(e);
         }
@@ -216,8 +220,9 @@ public class FlinkResultSet extends BaseResultSet {
         checkClosed();
         checkValidRow();
         checkValidColumn(columnIndex);
+        wasNull = currentRow.isNullAt(columnIndex - 1);
         try {
-            return currentRow.isNullAt(columnIndex - 1) ? 0 : currentRow.getInt(columnIndex - 1);
+            return wasNull ? 0 : currentRow.getInt(columnIndex - 1);
         } catch (Exception e) {
             throw new SQLDataException(e);
         }
@@ -228,9 +233,9 @@ public class FlinkResultSet extends BaseResultSet {
         checkClosed();
         checkValidRow();
         checkValidColumn(columnIndex);
-
+        wasNull = currentRow.isNullAt(columnIndex - 1);
         try {
-            return currentRow.isNullAt(columnIndex - 1) ? 0L : currentRow.getLong(columnIndex - 1);
+            return wasNull ? 0L : currentRow.getLong(columnIndex - 1);
         } catch (Exception e) {
             throw new SQLDataException(e);
         }
@@ -241,8 +246,9 @@ public class FlinkResultSet extends BaseResultSet {
         checkClosed();
         checkValidRow();
         checkValidColumn(columnIndex);
+        wasNull = currentRow.isNullAt(columnIndex - 1);
         try {
-            return currentRow.isNullAt(columnIndex - 1) ? 0 : currentRow.getFloat(columnIndex - 1);
+            return wasNull ? 0 : currentRow.getFloat(columnIndex - 1);
         } catch (Exception e) {
             throw new SQLDataException(e);
         }
@@ -253,8 +259,9 @@ public class FlinkResultSet extends BaseResultSet {
         checkClosed();
         checkValidRow();
         checkValidColumn(columnIndex);
+        wasNull = currentRow.isNullAt(columnIndex - 1);
         try {
-            return currentRow.isNullAt(columnIndex - 1) ? 0 : currentRow.getDouble(columnIndex - 1);
+            return wasNull ? 0 : currentRow.getDouble(columnIndex - 1);
         } catch (Exception e) {
             throw new SQLDataException(e);
         }
@@ -270,8 +277,9 @@ public class FlinkResultSet extends BaseResultSet {
         checkClosed();
         checkValidRow();
         checkValidColumn(columnIndex);
+        wasNull = currentRow.isNullAt(columnIndex - 1);
         try {
-            return currentRow.getBinary(columnIndex - 1);
+            return wasNull ? null : currentRow.getBinary(columnIndex - 1);
         } catch (Exception e) {
             throw new SQLDataException(e);
         }
@@ -377,6 +385,7 @@ public class FlinkResultSet extends BaseResultSet {
         checkValidColumn(columnIndex);
         try {
             Object object = fieldGetterList.get(columnIndex - 1).getFieldOrNull(currentRow);
+            wasNull = object == null;
             DataType dataType = dataTypeList.get(columnIndex - 1);
             return convertToJavaObject(object, dataType.getLogicalType());
         } catch (Exception e) {
@@ -486,8 +495,9 @@ public class FlinkResultSet extends BaseResultSet {
                             dataType.getLogicalType().getClass().getSimpleName()));
         }
         DecimalType decimalType = (DecimalType) dataType.getLogicalType();
+        wasNull = currentRow.isNullAt(columnIndex - 1);
         try {
-            return currentRow.isNullAt(columnIndex - 1)
+            return wasNull
                     ? null
                     : currentRow
                             .getDecimal(

--- a/flink-table/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkResultSetTest.java
+++ b/flink-table/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkResultSetTest.java
@@ -45,6 +45,7 @@ import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -108,6 +109,67 @@ public class FlinkResultSetTest {
                         new StatementResult(
                                 SCHEMA, data, true, ResultKind.SUCCESS, JobID.generate()))) {
             validateResultData(resultSet);
+        }
+    }
+
+    @Test
+    public void testWasNullReflectsPerColumnNullness() throws Exception {
+        Map<StringData, MapData> map = new HashMap<>();
+        Map<Integer, Long> valueMap = new HashMap<>();
+        valueMap.put(1, 1L);
+        map.put(StringData.fromString("1"), new GenericMapData(valueMap));
+        RowData mixedRow =
+                GenericRowData.of(
+                        true,
+                        null,
+                        (short) 2,
+                        null,
+                        4L,
+                        null,
+                        6.0d,
+                        null,
+                        StringData.fromString("v"),
+                        null,
+                        new GenericMapData(map));
+        CloseableIterator<RowData> data =
+                CloseableIterator.adapterForIterator(
+                        Collections.singletonList(mixedRow).iterator());
+        try (ResultSet resultSet =
+                new FlinkResultSet(
+                        new TestingStatement(),
+                        new StatementResult(
+                                SCHEMA, data, true, ResultKind.SUCCESS, JobID.generate()))) {
+            assertTrue(resultSet.next());
+
+            assertTrue(resultSet.getBoolean(1));
+            assertFalse(resultSet.wasNull());
+            resultSet.getByte(2);
+            assertTrue(resultSet.wasNull());
+            assertEquals((short) 2, resultSet.getShort(3));
+            assertFalse(resultSet.wasNull());
+            resultSet.getInt(4);
+            assertTrue(resultSet.wasNull());
+            assertEquals(4L, resultSet.getLong(5));
+            assertFalse(resultSet.wasNull());
+            resultSet.getFloat(6);
+            assertTrue(resultSet.wasNull());
+            assertEquals(6.0d, resultSet.getDouble(7));
+            assertFalse(resultSet.wasNull());
+            assertNull(resultSet.getBigDecimal(8));
+            assertTrue(resultSet.wasNull());
+            assertEquals("v", resultSet.getString(9));
+            assertFalse(resultSet.wasNull());
+            assertNull(resultSet.getBytes(10));
+            assertTrue(resultSet.wasNull());
+            assertNotNull(resultSet.getObject(11));
+            assertFalse(resultSet.wasNull());
+
+            assertNull(resultSet.getString(2));
+            assertTrue(resultSet.wasNull());
+            assertNull(resultSet.getObject(4));
+            assertTrue(resultSet.wasNull());
+            assertEquals(4L, resultSet.getLong(5));
+            assertFalse(resultSet.wasNull());
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Fix `ResultSet.wasNull()` in the Flink JDBC driver, which previously only tracked whether the whole row was null and so always returned `false` for individual null columns — violating the JDBC contract that `wasNull()` must reflect the value most recently read.

## Brief change log

- Update each column getter in `FlinkResultSet` (`getString`, `getBoolean`, `getByte`, `getShort`, `getInt`, `getLong`, `getFloat`, `getDouble`, `getBytes`, `getObject`, `getBigDecimal`) to set the `wasNull` flag from `currentRow.isNullAt(...)` (or the equivalent null check on the returned value) before returning. Label-based overloads and `getDate`/`getTime`/`getTimestamp` inherit the fix by delegation.

## Verifying this change

Added `FlinkResultSetTest#testWasNullReflectsPerColumnNullness`, which reads a row of alternating null and non-null columns across BOOLEAN/TINYINT/SMALLINT/INT/BIGINT/FLOAT/DOUBLE/DECIMAL/STRING/BYTES/MAP and asserts that `wasNull()` flips to `true` after each null read and back to `false` after each non-null read.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no