### PR TITLE
[FLINK-36567][table] Honor io.tmp.dirs from flink-conf.yaml when extracting planner JAR

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/planner/loader/PlannerModule.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/planner/loader/PlannerModule.java
@@ -19,9 +19,11 @@
 package org.apache.flink.table.planner.loader;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.core.classloading.ComponentClassLoader;
 import org.apache.flink.core.classloading.SubmoduleClassLoader;
 import org.apache.flink.table.api.TableException;
@@ -101,8 +103,7 @@ public class PlannerModule {
         try {
             final ClassLoader flinkClassLoader = PlannerModule.class.getClassLoader();
 
-            final Path tmpDirectory =
-                    Paths.get(ConfigurationUtils.parseTempDirectories(new Configuration())[0]);
+            final Path tmpDirectory = resolveTmpDirectory(GlobalConfiguration.loadConfiguration());
             Files.createDirectories(FileUtils.getTargetPathIfContainsSymbolicPath(tmpDirectory));
             final Path tempFile =
                     Files.createFile(
@@ -134,6 +135,11 @@ public class PlannerModule {
             throw new TableException(
                     "Could not initialize the table planner components loader.", e);
         }
+    }
+
+    @VisibleForTesting
+    static Path resolveTmpDirectory(Configuration configuration) {
+        return Paths.get(ConfigurationUtils.parseTempDirectories(configuration)[0]);
     }
 
     public URLClassLoader getSubmoduleClassLoader() {

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/planner/loader/PlannerModuleTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/planner/loader/PlannerModuleTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.loader;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.configuration.GlobalConfiguration;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link PlannerModule}. */
+class PlannerModuleTest {
+
+    @TempDir private Path tempDir;
+
+    @Test
+    void resolveTmpDirectoryHonorsIoTmpDirsFromYaml() throws IOException {
+        Path confDir = Files.createDirectory(tempDir.resolve("conf"));
+        Path configuredTmp = Files.createDirectory(tempDir.resolve("custom-tmp"));
+        Files.write(
+                confDir.resolve(GlobalConfiguration.FLINK_CONF_FILENAME),
+                ("io.tmp.dirs: " + configuredTmp.toAbsolutePath() + System.lineSeparator())
+                        .getBytes());
+
+        Configuration configuration =
+                GlobalConfiguration.loadConfiguration(confDir.toAbsolutePath().toString(), null);
+
+        assertThat(PlannerModule.resolveTmpDirectory(configuration))
+                .isEqualTo(Paths.get(configuredTmp.toAbsolutePath().toString()));
+    }
+
+    @Test
+    void resolveTmpDirectoryFallsBackToDefaultWhenIoTmpDirsUnset() {
+        assertThat(PlannerModule.resolveTmpDirectory(new Configuration()))
+                .isEqualTo(Paths.get(CoreOptions.TMP_DIRS.defaultValue()));
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

`PlannerModule` extracted the `flink-table-planner` JAR into the JVM default temp directory (e.g. `/tmp`) regardless of the `io.tmp.dirs` value configured in `flink-conf.yaml`. This fix makes the loader honor the configured directory.

## Brief change log

- Replace `new Configuration()` with `GlobalConfiguration.loadConfiguration()` in `PlannerModule`'s constructor so the loaded `flink-conf.yaml` is used when resolving the temp directory.
- Extract the temp-directory resolution into a package-private `PlannerModule#resolveTmpDirectory(Configuration)` (annotated `@VisibleForTesting`) to keep the constructor focused and to make the logic unit-testable.

## Verifying this change

Added `PlannerModuleTest` with two cases: `resolveTmpDirectoryHonorsIoTmpDirsFromYaml` writes a `config.yaml` with a custom `io.tmp.dirs`, loads it via `GlobalConfiguration.loadConfiguration(configDir, null)`, and asserts `PlannerModule.resolveTmpDirectory(...)` returns the configured path; `resolveTmpDirectoryFallsBackToDefaultWhenIoTmpDirsUnset` asserts the fallback to `CoreOptions.TMP_DIRS` default for an empty configuration.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
