### PR TITLE
[FLINK-39726][table] Support USING CONNECTION clause in CREATE TABLE

### DIFF
--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -1596,6 +1596,7 @@ SqlCreate SqlCreateTable(Span s, boolean replace, boolean isTemporary) :
     SqlNodeList propertyList = SqlNodeList.EMPTY;
     SqlDistribution distribution = null;
     SqlNodeList partitionColumns = SqlNodeList.EMPTY;
+    SqlIdentifier connection = null;
     SqlParserPos pos = startPos;
     boolean isColumnsIdentifiersOnly = false;
 }
@@ -1630,6 +1631,10 @@ SqlCreate SqlCreateTable(Span s, boolean replace, boolean isTemporary) :
         partitionColumns = ParenthesizedSimpleIdentifierList()
     ]
     [
+        <USING> <CONNECTION>
+        connection = CompoundIdentifier()
+    ]
+    [
         <WITH>
         propertyList = Properties()
     ]
@@ -1652,6 +1657,7 @@ SqlCreate SqlCreateTable(Span s, boolean replace, boolean isTemporary) :
                 partitionColumns,
                 watermark,
                 comment,
+                connection,
                 tableLike,
                 isTemporary,
                 ifNotExists);
@@ -1660,6 +1666,11 @@ SqlCreate SqlCreateTable(Span s, boolean replace, boolean isTemporary) :
         <AS>
         asQuery = OrderedQueryOrExpr(ExprContext.ACCEPT_QUERY)
         {
+            if (connection != null) {
+                throw SqlUtil.newContextException(
+                    pos,
+                    ParserResource.RESOURCE.usingConnectionWithAsUnsupported());
+            }
             if (replace) {
                 return new SqlReplaceTableAs(startPos.plus(getPos()),
                     tableName,
@@ -1706,6 +1717,7 @@ SqlCreate SqlCreateTable(Span s, boolean replace, boolean isTemporary) :
             partitionColumns,
             watermark,
             comment,
+            connection,
             isTemporary,
             ifNotExists);
     }

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/SqlUnparseUtils.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/SqlUnparseUtils.java
@@ -25,6 +25,7 @@ import org.apache.flink.sql.parser.ddl.constraint.SqlTableConstraint;
 import org.apache.flink.sql.parser.ddl.materializedtable.SqlStartMode;
 
 import org.apache.calcite.sql.SqlCharStringLiteral;
+import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlIntervalLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
@@ -98,6 +99,17 @@ public class SqlUnparseUtils {
         SqlWriter.Frame partitionedByFrame = writer.startList("(", ")");
         partitionKeyList.unparse(writer, leftPrec, rightPrec);
         writer.endList(partitionedByFrame);
+    }
+
+    public static void unparseUsingConnection(
+            SqlIdentifier connection, SqlWriter writer, int leftPrec, int rightPrec) {
+        if (connection == null) {
+            return;
+        }
+        writer.newlineAndIndent();
+        writer.keyword("USING");
+        writer.keyword("CONNECTION");
+        connection.unparse(writer, leftPrec, rightPrec);
     }
 
     public static void unparseFreshness(

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlReplaceTableAs.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlReplaceTableAs.java
@@ -107,6 +107,7 @@ public class SqlReplaceTableAs extends SqlCreateTable implements ExtendedSqlNode
                 partitionKeyList,
                 watermark,
                 comment,
+                null,
                 isTemporary,
                 ifNotExists,
                 true);

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/table/SqlCreateTable.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/table/SqlCreateTable.java
@@ -66,6 +66,8 @@ public class SqlCreateTable extends SqlCreateObject implements ExtendedSqlNode {
 
     private final SqlWatermark watermark;
 
+    private final SqlIdentifier connection;
+
     public SqlCreateTable(
             SqlParserPos pos,
             SqlIdentifier tableName,
@@ -76,6 +78,7 @@ public class SqlCreateTable extends SqlCreateObject implements ExtendedSqlNode {
             SqlNodeList partitionKeyList,
             @Nullable SqlWatermark watermark,
             @Nullable SqlCharStringLiteral comment,
+            @Nullable SqlIdentifier connection,
             boolean isTemporary,
             boolean ifNotExists) {
         this(
@@ -89,6 +92,7 @@ public class SqlCreateTable extends SqlCreateObject implements ExtendedSqlNode {
                 partitionKeyList,
                 watermark,
                 comment,
+                connection,
                 isTemporary,
                 ifNotExists,
                 false);
@@ -105,6 +109,7 @@ public class SqlCreateTable extends SqlCreateObject implements ExtendedSqlNode {
             SqlNodeList partitionKeyList,
             @Nullable SqlWatermark watermark,
             @Nullable SqlCharStringLiteral comment,
+            @Nullable SqlIdentifier connection,
             boolean isTemporary,
             boolean ifNotExists,
             boolean replace) {
@@ -117,6 +122,7 @@ public class SqlCreateTable extends SqlCreateObject implements ExtendedSqlNode {
         this.partitionKeyList =
                 requireNonNull(partitionKeyList, "partitionKeyList should not be null");
         this.watermark = watermark;
+        this.connection = connection;
     }
 
     @Override
@@ -128,7 +134,8 @@ public class SqlCreateTable extends SqlCreateObject implements ExtendedSqlNode {
                 properties,
                 partitionKeyList,
                 watermark,
-                comment);
+                comment,
+                connection);
     }
 
     public SqlNodeList getColumnList() {
@@ -149,6 +156,10 @@ public class SqlCreateTable extends SqlCreateObject implements ExtendedSqlNode {
 
     public Optional<SqlWatermark> getWatermark() {
         return Optional.ofNullable(watermark);
+    }
+
+    public Optional<SqlIdentifier> getConnection() {
+        return Optional.ofNullable(connection);
     }
 
     @Override
@@ -214,6 +225,11 @@ public class SqlCreateTable extends SqlCreateObject implements ExtendedSqlNode {
         SqlUnparseUtils.unparseComment(comment, true, writer, leftPrec, rightPrec);
         SqlUnparseUtils.unparseDistribution(distribution, writer, leftPrec, rightPrec);
         SqlUnparseUtils.unparsePartitionKeyList(partitionKeyList, writer, leftPrec, rightPrec);
+        if (connection != null) {
+            writer.newlineAndIndent();
+            writer.keyword("USING CONNECTION");
+            connection.unparse(writer, leftPrec, rightPrec);
+        }
         SqlUnparseUtils.unparseProperties(properties, writer, leftPrec, rightPrec);
     }
 }

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/table/SqlCreateTable.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/table/SqlCreateTable.java
@@ -225,11 +225,7 @@ public class SqlCreateTable extends SqlCreateObject implements ExtendedSqlNode {
         SqlUnparseUtils.unparseComment(comment, true, writer, leftPrec, rightPrec);
         SqlUnparseUtils.unparseDistribution(distribution, writer, leftPrec, rightPrec);
         SqlUnparseUtils.unparsePartitionKeyList(partitionKeyList, writer, leftPrec, rightPrec);
-        if (connection != null) {
-            writer.newlineAndIndent();
-            writer.keyword("USING CONNECTION");
-            connection.unparse(writer, leftPrec, rightPrec);
-        }
+        SqlUnparseUtils.unparseUsingConnection(connection, writer, leftPrec, rightPrec);
         SqlUnparseUtils.unparseProperties(properties, writer, leftPrec, rightPrec);
     }
 }

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/table/SqlCreateTableAs.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/table/SqlCreateTableAs.java
@@ -99,6 +99,7 @@ public class SqlCreateTableAs extends SqlCreateTable {
                 partitionKeyList,
                 watermark,
                 comment,
+                null,
                 isTemporary,
                 ifNotExists,
                 false);

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/table/SqlCreateTableLike.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/table/SqlCreateTableLike.java
@@ -86,6 +86,7 @@ public class SqlCreateTableLike extends SqlCreateTable {
             SqlNodeList partitionKeyList,
             @Nullable SqlWatermark watermark,
             @Nullable SqlCharStringLiteral comment,
+            @Nullable SqlIdentifier connection,
             SqlTableLike tableLike,
             boolean isTemporary,
             boolean ifNotExists) {
@@ -100,6 +101,7 @@ public class SqlCreateTableLike extends SqlCreateTable {
                 partitionKeyList,
                 watermark,
                 comment,
+                connection,
                 isTemporary,
                 ifNotExists,
                 false);

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/utils/ParserResource.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/utils/ParserResource.java
@@ -83,4 +83,8 @@ public interface ParserResource {
 
     @Resources.BaseMessage("DROP TEMPORARY MATERIALIZED TABLE is not supported.")
     Resources.ExInst<ParseException> dropTemporaryMaterializedTableUnsupported();
+
+    @Resources.BaseMessage(
+            "USING CONNECTION clause is not supported with CREATE TABLE AS SELECT or REPLACE TABLE AS SELECT statements.")
+    Resources.ExInst<ParseException> usingConnectionWithAsUnsupported();
 }

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -1050,6 +1050,93 @@ class FlinkSqlParserImplTest extends SqlParserTest {
         sql(sql).ok(expected);
     }
 
+    @Test
+    void testCreateTableUsingConnection() {
+        final String sql =
+                "CREATE TABLE orders (\n"
+                        + "  order_id INT,\n"
+                        + "  customer_id INT,\n"
+                        + "  amount DECIMAL(10, 2)\n"
+                        + ") USING CONNECTION mycat.mydb.mysql_prod\n"
+                        + "WITH (\n"
+                        + "  'connector' = 'jdbc',\n"
+                        + "  'tables' = 'orders'\n"
+                        + ")";
+        final String expected =
+                "CREATE TABLE `ORDERS` (\n"
+                        + "  `ORDER_ID` INTEGER,\n"
+                        + "  `CUSTOMER_ID` INTEGER,\n"
+                        + "  `AMOUNT` DECIMAL(10, 2)\n"
+                        + ")\n"
+                        + "USING CONNECTION `MYCAT`.`MYDB`.`MYSQL_PROD`\n"
+                        + "WITH (\n"
+                        + "  'connector' = 'jdbc',\n"
+                        + "  'tables' = 'orders'\n"
+                        + ")";
+        sql(sql).ok(expected);
+    }
+
+    @Test
+    void testCreateTableUsingConnectionWithPartitionAndDistribution() {
+        final String sql =
+                "CREATE TABLE tbl1 (\n"
+                        + "  a bigint,\n"
+                        + "  h varchar,\n"
+                        + "  b varchar\n"
+                        + ")\n"
+                        + "DISTRIBUTED BY HASH(a) INTO 3 BUCKETS\n"
+                        + "PARTITIONED BY (a, h)\n"
+                        + "USING CONNECTION cat1.db1.conn1\n"
+                        + "WITH (\n"
+                        + "  'connector' = 'jdbc'\n"
+                        + ")";
+        final String expected =
+                "CREATE TABLE `TBL1` (\n"
+                        + "  `A` BIGINT,\n"
+                        + "  `H` VARCHAR,\n"
+                        + "  `B` VARCHAR\n"
+                        + ")\n"
+                        + "DISTRIBUTED BY HASH(`A`) INTO 3 BUCKETS\n"
+                        + "PARTITIONED BY (`A`, `H`)\n"
+                        + "USING CONNECTION `CAT1`.`DB1`.`CONN1`\n"
+                        + "WITH (\n"
+                        + "  'connector' = 'jdbc'\n"
+                        + ")";
+        sql(sql).ok(expected);
+    }
+
+    @Test
+    void testCreateTableAsWithUsingConnectionFails() {
+        final String sql =
+                "^CREATE^ TABLE t1\n"
+                        + "USING CONNECTION cat1.db1.conn1\n"
+                        + "WITH ('connector' = 'jdbc')\n"
+                        + "AS SELECT 1 AS a";
+        sql(sql).fails(
+                        "(?s).*USING CONNECTION clause is not supported with CREATE TABLE AS SELECT or REPLACE TABLE AS SELECT statements.*");
+    }
+
+    @Test
+    void testCreateTableLikeUsingConnection() {
+        final String sql =
+                "CREATE TABLE t1 (\n"
+                        + "  a INT\n"
+                        + ")\n"
+                        + "USING CONNECTION cat1.db1.conn1\n"
+                        + "WITH ('connector' = 'jdbc')\n"
+                        + "LIKE base_table";
+        final String expected =
+                "CREATE TABLE `T1` (\n"
+                        + "  `A` INTEGER\n"
+                        + ")\n"
+                        + "USING CONNECTION `CAT1`.`DB1`.`CONN1`\n"
+                        + "WITH (\n"
+                        + "  'connector' = 'jdbc'\n"
+                        + ")\n"
+                        + "LIKE `BASE_TABLE`";
+        sql(sql).ok(expected);
+    }
+
     String buildDistributionInput(final String distributionClause) {
         return "CREATE TABLE tbl1 (\n"
                 + "  a bigint,\n"

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -1107,13 +1107,42 @@ class FlinkSqlParserImplTest extends SqlParserTest {
 
     @Test
     void testCreateTableAsWithUsingConnectionFails() {
+        // CTAS goes through SqlCreateTable with replace=false; the parser explicitly rejects
+        // USING CONNECTION + AS via ParserResource.usingConnectionWithAsUnsupported().
         final String sql =
                 "^CREATE^ TABLE t1\n"
                         + "USING CONNECTION cat1.db1.conn1\n"
                         + "WITH ('connector' = 'jdbc')\n"
                         + "AS SELECT 1 AS a";
         sql(sql).fails(
-                        "(?s).*USING CONNECTION clause is not supported with CREATE TABLE AS SELECT or REPLACE TABLE AS SELECT statements.*");
+                        "(?s).*USING CONNECTION clause is not supported with "
+                                + "CREATE TABLE AS SELECT or REPLACE TABLE AS SELECT statements\\..*");
+    }
+
+    @Test
+    void testReplaceTableAsWithUsingConnectionFails() {
+        // REPLACE TABLE always has an AS clause, so USING CONNECTION is never valid;
+        // it's not even accepted by the SqlReplaceTable production.
+        final String sql =
+                "REPLACE TABLE t1\n"
+                        + "^USING^ CONNECTION cat1.db1.conn1\n"
+                        + "WITH ('connector' = 'jdbc')\n"
+                        + "AS SELECT 1 AS a";
+        sql(sql).fails("(?s).*Encountered \"USING\" at line 2, column 1.\n.*");
+    }
+
+    @Test
+    void testCreateOrReplaceTableAsWithUsingConnectionFails() {
+        // CREATE OR REPLACE TABLE AS goes through SqlCreateTable with replace=true and hits
+        // the same usingConnectionWithAsUnsupported() error path as CTAS.
+        final String sql =
+                "^CREATE^ OR REPLACE TABLE t1\n"
+                        + "USING CONNECTION cat1.db1.conn1\n"
+                        + "WITH ('connector' = 'jdbc')\n"
+                        + "AS SELECT 1 AS a";
+        sql(sql).fails(
+                        "(?s).*USING CONNECTION clause is not supported with "
+                                + "CREATE TABLE AS SELECT or REPLACE TABLE AS SELECT statements\\..*");
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Adds parser support for an optional `USING CONNECTION <identifier>` clause in `CREATE TABLE` and `CREATE TABLE ... LIKE` statements, per [FLIP-529](https://cwiki.apache.org/confluence/display/FLINK/FLIP-529%3A+Connections+in+Flink+SQL+and+TableAPI). This lets a table reference a previously registered connection (catalog object) for connector configuration:

```sql
CREATE TABLE orders (
    order_id INT,
    customer_id INT,
    amount DECIMAL(10, 2)
) USING CONNECTION mycat.mydb.mysql_prod
WITH (
    'connector' = 'jdbc',
    'tables' = 'orders'
);
```

The clause is intentionally not allowed with CTAS / RTAS — those raise a parser error.

## Brief change log

- Grammar: added optional `[ <USING> <CONNECTION> CompoundIdentifier() ]` between `PARTITIONED BY` and `WITH` in the `SqlCreateTable` production.
- `SqlCreateTable` / `SqlCreateTableLike`: new optional `connection` field, constructor parameter, `getConnection()` getter, `getOperandList()` entry, and `unparse` output.
- `SqlCreateTableAs` / `SqlReplaceTableAs`: explicitly pass `null` for `connection`; parser rejects `USING CONNECTION` combined with `AS` via a new `ParserResource#usingConnectionWithAsUnsupported` message.
- Tests: positive cases for plain `CREATE TABLE`, `CREATE TABLE` with partition/distribution, and `CREATE TABLE ... LIKE`; negative case for CTAS.

## Verifying this change

This change is covered by unit tests in `FlinkSqlParserImplTest`:
- `testCreateTableUsingConnection`
- `testCreateTableUsingConnectionWithPartitionAndDistribution`
- `testCreateTableLikeUsingConnection`
- `testCreateTableAsWithUsingConnectionFails`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes, parser-level syntax addition; planner / runtime wiring will come in follow-up subtasks of FLIP-529)
  - If yes, how is the feature documented? (not documented yet — user-facing docs to follow once the planner/runtime side lands)