### PR TITLE
[FLINK-39729][table] Fix flaky CorrelateRestoreTest by using materialized data assertion

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/common/CorrelateTestPrograms.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/common/CorrelateTestPrograms.java
@@ -225,8 +225,8 @@ public class CorrelateTestPrograms {
                     .setupTableSink(
                             SinkTestStep.newBuilder("sink_t")
                                     .addSchema("b BIGINT")
-                                    .consumedBeforeRestore(
-                                            "+I[2]", "+I[3]", "-D[2]", "-D[3]", "+I[2]", "+I[3]")
+                                    .consumedValues("+I[2]", "+I[3]")
+                                    .testMaterializedData()
                                     .build())
                     .runSql(
                             "INSERT INTO sink_t SELECT b FROM source_t1 "


### PR DESCRIPTION
Backport of #28224 to release-2.3.

## What is the purpose of the change

Fix flaky `CorrelateRestoreTest.testRestore[8]` (`CORRELATE_WITH_LITERAL_AGG`) by switching from changelog sequence assertion to materialized data assertion.

## Brief change log

- Changed `CORRELATE_WITH_LITERAL_AGG` test program sink from `consumedBeforeRestore()`/changelog mode to `consumedValues()` + `testMaterializedData()`, checking final materialized state `[+I[2], +I[3]]` instead of exact changelog ordering.

Generated-by: Claude Code (claude-opus-4-6)