### PR TITLE
[FLINK-39736][build] Do not allow Security Manager for jdk24+

### DIFF
--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -272,9 +272,9 @@ under the License.
 			</build>
 		</profile>
 		<profile>
-			<id>java21</id>
+			<id>security-manager</id>
 			<activation>
-				<jdk>[21,)</jdk>
+				<jdk>[21,24)</jdk>
 			</activation>
 
 			<properties>

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -488,9 +488,9 @@ under the License.
 			</build>
 		</profile>
 		<profile>
-			<id>java21</id>
+			<id>security-manager</id>
 			<activation>
-				<jdk>[21,)</jdk>
+				<jdk>[21,24)</jdk>
 			</activation>
 
 			<properties>

--- a/flink-streaming-java/pom.xml
+++ b/flink-streaming-java/pom.xml
@@ -172,9 +172,9 @@ under the License.
 			</build>
 		</profile>
 		<profile>
-			<id>java21</id>
+			<id>security-manager</id>
 			<activation>
-				<jdk>[21,)</jdk>
+				<jdk>[21,24)</jdk>
 			</activation>
 
 			<properties>


### PR DESCRIPTION
## What is the purpose of the change

Since it is constantly enabled by jdk, just fail fast for now
also more info at https://openjdk.org/jeps/486

## Brief change log

pom
## Verifying this change

existing tests
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
