### PR TITLE
[FLINK-39740][table-runtime] Do not regress highestSqnAndSizeState on row replace in LinkedMultiSetState

### DIFF
--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/sequencedmultisetstate/linked/LinkedMultiSetState.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/sequencedmultisetstate/linked/LinkedMultiSetState.java
@@ -185,8 +185,8 @@ public class LinkedMultiSetState implements SequencedMultiSetState<RowData> {
                 isNewRowKey
                         ? new Node(row, newSqn, highSqn, null, null, timestamp)
                         : sqnToNodeState.get(oldSqn).withRow(row, timestamp));
-        highestSqnAndSizeState.update(MetaSqnInfo.of(newSqn, newSize));
         if (isNewRowKey) {
+            highestSqnAndSizeState.update(MetaSqnInfo.of(newSqn, newSize));
             rowToSqnState.put(key, RowSqnInfo.ofSingle(newSqn));
             if (!isNewContextKey) {
                 sqnToNodeState.put(highSqn, sqnToNodeState.get(highSqn).withNext(newSqn));

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/sequencedmultisetstate/SequencedMultiSetStateTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/sequencedmultisetstate/SequencedMultiSetStateTest.java
@@ -202,9 +202,9 @@ public class SequencedMultiSetStateTest {
 
     @TestTemplate
     public void testAddAfterReplacingNonHighestRow() throws Exception {
-        // Regression test for FLINK-39740: replacing an existing row by key must not regress
-        // highestSqnAndSizeState.highSqn. Otherwise, the next genuinely new row reuses an SQN
-        // already taken by an existing row, overwriting its node in sqnToNodeState.
+        // Replacing an existing row by key must not regress highestSqnAndSizeState.highSqn.
+        // Otherwise, the next genuinely new row reuses an SQN already taken by an existing row,
+        // overwriting its node in sqnToNodeState.
         runTest(
                 state -> {
                     state.add(row("k1", "v1"), 1L); // SQN 0

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/sequencedmultisetstate/SequencedMultiSetStateTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/sequencedmultisetstate/SequencedMultiSetStateTest.java
@@ -201,6 +201,33 @@ public class SequencedMultiSetStateTest {
     }
 
     @TestTemplate
+    public void testAddAfterReplacingNonHighestRow() throws Exception {
+        // Regression test for FLINK-39740: replacing an existing row by key must not regress
+        // highestSqnAndSizeState.highSqn. Otherwise, the next genuinely new row reuses an SQN
+        // already taken by an existing row, overwriting its node in sqnToNodeState.
+        runTest(
+                state -> {
+                    state.add(row("k1", "v1"), 1L); // SQN 0
+                    state.add(row("k2", "v2"), 2L); // SQN 1
+                    state.add(row("k3", "v3"), 3L); // SQN 2, highSqn = 2
+
+                    // Replace a non-highest-SQN row. Pre-fix, this would regress highSqn from 2
+                    // to k1's SQN (0).
+                    state.add(row("k1", "v1-updated"), 4L);
+
+                    // New row must get SQN 3, not collide with k2's SQN 1.
+                    state.add(row("k4", "v4"), 5L);
+
+                    assertStateContents(
+                            state,
+                            Tuple2.of(row("k1", "v1-updated"), 4L),
+                            Tuple2.of(row("k2", "v2"), 2L),
+                            Tuple2.of(row("k3", "v3"), 3L),
+                            Tuple2.of(row("k4", "v4"), 5L));
+                });
+    }
+
+    @TestTemplate
     public void testRemove() throws Exception {
         runTest(
                 state -> {


### PR DESCRIPTION
## What is the purpose of the change

Fixes [FLINK-39740](https://issues.apache.org/jira/browse/FLINK-39740) — in `LinkedMultiSetState`, `highestSqnAndSizeState` tracks the highest sequence number ever assigned to a row in the doubly-linked list. It must grow monotonically, since new rows compute their SQN as `highSqn + 1`. However, `LinkedMultiSetState.add()` wrote the computed `newSqn` back into `highestSqnAndSizeState` unconditionally — including in the replace branch, where `newSqn` is set to the existing row's SQN (which is generally *less than* the current `highSqn`). The next genuinely new row would then compute `newSqn = staleHighSqn + 1` and collide with an existing node in `sqnToNodeState`, silently overwriting it. The doubly-linked list is then corrupt: iteration returns the wrong rows, and downstream operators reading from this state observe missing or stale data.

## Brief change log

- In [LinkedMultiSetState.add()](flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/sequencedmultisetstate/linked/LinkedMultiSetState.java#L188), moved the `highestSqnAndSizeState.update(MetaSqnInfo.of(newSqn, newSize))` call inside the `if (isNewRowKey) { ... }` block. The replace branch already enforces `newSqn = rowSqn` and `newSize = oldSize`, so the prior unconditional write was redundant (state value didn't actually change) *and* destructive (`rowSqn ≤ highSqn` regressed the monotonic invariant).
- No state schema, serializer, or public-API surface was modified — the fix is a single-line correction to the write path of an existing internal state primitive.

## Verifying this change

This change is covered by a new regression test in `SequencedMultiSetStateTest`:

- `testAddAfterReplacingNonHighestRow` — adds three rows with distinct keys (assigning SQNs 0, 1, 2), then replaces the first row (`add` on an existing key), then adds a fourth new row. The test asserts the iterator returns all four rows in insertion order with the replaced value visible. Before the fix, the replace regressed `highSqn` from 2 to 0, the fourth row reused SQN 1 and overwrote the second row's node in `sqnToNodeState`, and iteration returned only three rows with the second row missing.

Existing tests in `SequencedMultiSetStateTest` (`testBasicFlow`, `testAdd`, `testAppend`, `testRemove`, etc.) continue to pass, confirming the fix does not regress the happy path or the other state-mutation operations.

## Does this pull request potentially affect one of the following parts

- Dependencies (does it add or upgrade a dependency): **no**
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no** — `LinkedMultiSetState` is annotated `@Internal` (see line 80 of the class). The class is intended for internal use within Flink's table runtime, as its Javadoc explicitly states.
- The serializers: **no** — state shape, `MetaSqnInfoSerializer`, `NodeSerializer`, `RowSqnInfoSerializer`, and `RowDataKeySerializer` are all unchanged. Existing checkpointed state can still be read.
- The runtime per-record code paths (performance sensitive): **no** — the change removes one state write in the replace path (a small net positive). The add and append code paths are otherwise unchanged.
- Anything that affects deployment or recovery (JobManager, Checkpointing, Kubernetes/Yarn, ZooKeeper): **no** with one caveat — checkpoints/savepoints written by an affected version (≥ 2.3.0) that exercised the buggy replace-then-add sequence may already contain a corrupt linked list. This PR prevents *new* corruption but does not retroactively repair existing corruption. Repair would require a separate state-migration step and is out of scope here.
- The S3 file system connector: **no**

## Documentation

- Does this pull request introduce a new feature? **no** — this is a correctness fix to existing behavior. No user-visible API or configuration changes.
- If yes, how is the feature documented? n/a

## Was generative AI tooling used to co-author this PR?

- [x] Yes — Claude was used as a pair-programming assistant for discussing the approach and implementation structure. All code was written, understood, and verified by the author.

Generated-by: Claude Opus 4.7