### PR TITLE
[FLINK-39742][tests] FlinkImageBuilder checks for Java 25

### DIFF
--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/container/FlinkImageBuilder.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/container/FlinkImageBuilder.java
@@ -282,6 +282,8 @@ public class FlinkImageBuilder {
                     return "17";
                 case "21":
                     return "21";
+                case "25":
+                    return "25";
                 default:
                     throw new IllegalStateException("Unexpected Java version: " + javaSpecVersion);
             }


### PR DESCRIPTION
## What is the purpose of the change

The PR allows to pass `FlinkImageBuilder` to proceed with e2e tests in case jdk25


## Verifying this change


This change is a trivial rework 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
