### PR TITLE
 [FLINK-39751][tests] Add `FailsOnJava25`

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/core/security/FlinkSecurityManagerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/security/FlinkSecurityManagerTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.testutils.executor.TestExecutorExtension;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -39,6 +40,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@code FlinkUserSecurityManager}. */
+@Tag("org.apache.flink.testutils.junit.FailsOnJava25")
 class FlinkSecurityManagerTest {
 
     @RegisterExtension

--- a/flink-end-to-end-tests/pom.xml
+++ b/flink-end-to-end-tests/pom.xml
@@ -138,6 +138,15 @@ under the License.
 				<excludeE2E>org.apache.flink.testutils.junit.FailsOnJava17</excludeE2E>
 			</properties>
 		</profile>
+		<profile>
+			<id>java25</id>
+			<activation>
+				<jdk>[25,)</jdk>
+			</activation>
+			<properties>
+				<excludeE2E>org.apache.flink.testutils.junit.FailsOnJava25</excludeE2E>
+			</properties>
+		</profile>
 	</profiles>
 
 	<build>

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/ClusterUncaughtExceptionHandlerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/ClusterUncaughtExceptionHandlerITCase.java
@@ -28,30 +28,31 @@ import org.apache.flink.runtime.testutils.TestJvmProcess;
 import org.apache.flink.runtime.util.ClusterUncaughtExceptionHandler;
 import org.apache.flink.util.FatalExitExceptionHandler;
 import org.apache.flink.util.OperatingSystem;
-import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.TestLoggerExtension;
 import org.apache.flink.util.concurrent.ScheduledExecutor;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assume.assumeTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 /** Integration test to check exit behaviour for the {@link ClusterUncaughtExceptionHandler}. */
-public class ClusterUncaughtExceptionHandlerITCase extends TestLogger {
+@ExtendWith(TestLoggerExtension.class)
+class ClusterUncaughtExceptionHandlerITCase {
 
-    @Before
-    public void ensureSupportedOS() {
+    @BeforeEach
+    void ensureSupportedOS() {
         // based on the assumption in JvmExitOnFatalErrorTest, and manual testing on Mac, we do not
         // support all platforms (in particular not Windows)
-        assumeTrue(OperatingSystem.isLinux() || OperatingSystem.isMac());
+        assumeThat(OperatingSystem.isLinux() || OperatingSystem.isMac()).isTrue();
     }
 
     @Test
-    public void testExitDueToUncaughtException() throws Exception {
+    void testExitDueToUncaughtException() throws Exception {
         final ForcedJVMExitProcess testProcess =
                 new ForcedJVMExitProcess(ClusterTestingEntrypoint.class);
 
@@ -64,7 +65,7 @@ public class ClusterUncaughtExceptionHandlerITCase extends TestLogger {
                     FatalExitExceptionHandler
                             .EXIT_CODE; // for FAIL mode, exit is done using this handler.
             int unsignedIntegerExitCode = ((byte) signedIntegerExitCode) & 0xFF;
-            assertThat(testProcess.exitCode(), is(unsignedIntegerExitCode));
+            assertThat(testProcess.exitCode()).isEqualTo(unsignedIntegerExitCode);
             success = true;
         } finally {
             if (!success) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/ClusterUncaughtExceptionHandlerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/ClusterUncaughtExceptionHandlerITCase.java
@@ -32,6 +32,7 @@ import org.apache.flink.util.TestLoggerExtension;
 import org.apache.flink.util.concurrent.ScheduledExecutor;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -41,6 +42,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 /** Integration test to check exit behaviour for the {@link ClusterUncaughtExceptionHandler}. */
+@Tag("org.apache.flink.testutils.junit.FailsOnJava25")
 @ExtendWith(TestLoggerExtension.class)
 class ClusterUncaughtExceptionHandlerITCase {
 

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/testutils/junit/FailsOnJava25.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/testutils/junit/FailsOnJava25.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.testutils.junit;
+
+/** Marker interface for tests that fail on Java 25. */
+public interface FailsOnJava25 {}

--- a/pom.xml
+++ b/pom.xml
@@ -1192,6 +1192,10 @@ under the License.
 				<jdk>[25,)</jdk>
 			</activation>
 
+			<properties>
+				<surefire.excludedGroups.jdk>org.apache.flink.testutils.junit.FailsOnJava25</surefire.excludedGroups.jdk>
+			</properties>
+
 			<build>
 				<pluginManagement>
 					<plugins>


### PR DESCRIPTION

## What is the purpose of the change

The PR introduces `FailsOnJava25` to mark  tests failing in java 25 (e.g. Security Manager related)

## Brief change log
FailsOnJava25

## Verifying this change

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
