### PR TITLE
[FLINK-38503] Adapt `DefaultClusterClientServiceLoader` to java 25

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/DefaultClusterClientServiceLoader.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/DefaultClusterClientServiceLoader.java
@@ -52,14 +52,21 @@ public class DefaultClusterClientServiceLoader implements ClusterClientServiceLo
 
         final List<ClusterClientFactory> compatibleFactories = new ArrayList<>();
         final Iterator<ClusterClientFactory> factories = loader.iterator();
-        while (factories.hasNext()) {
+        while (true) {
             try {
+                // hasNext might lead to error in java 24, 25
+                // for more details take a look at https://bugs.openjdk.org/browse/JDK-8196182
+                // and https://bugs.openjdk.org/browse/JDK-8350481
+                if (!factories.hasNext()) {
+                    break;
+                }
                 final ClusterClientFactory factory = factories.next();
                 if (factory != null && factory.isCompatibleWith(configuration)) {
                     compatibleFactories.add(factory);
                 }
             } catch (Throwable e) {
-                if (e.getCause() instanceof NoClassDefFoundError) {
+                if (e instanceof NoClassDefFoundError
+                        || e.getCause() instanceof NoClassDefFoundError) {
                     LOG.info("Could not load factory due to missing dependencies.");
                 } else {
                     throw e;
@@ -98,8 +105,14 @@ public class DefaultClusterClientServiceLoader implements ClusterClientServiceLo
         final List<String> result = new ArrayList<>();
 
         final Iterator<ClusterClientFactory> it = loader.iterator();
-        while (it.hasNext()) {
+        while (true) {
             try {
+                // hasNext might lead to error in java 24, 25
+                // for more details take a look at https://bugs.openjdk.org/browse/JDK-8196182
+                // and https://bugs.openjdk.org/browse/JDK-8350481
+                if (!it.hasNext()) {
+                    break;
+                }
                 final ClusterClientFactory clientFactory = it.next();
 
                 final Optional<String> applicationName = clientFactory.getApplicationTargetName();
@@ -107,7 +120,7 @@ public class DefaultClusterClientServiceLoader implements ClusterClientServiceLo
                     result.add(applicationName.get());
                 }
 
-            } catch (ServiceConfigurationError e) {
+            } catch (ServiceConfigurationError | NoClassDefFoundError e) {
                 // cannot be loaded, most likely because Hadoop is not
                 // in the classpath, we can ignore it for now.
             }


### PR DESCRIPTION
## What is the purpose of the change

The problem is that in jdk 25 there are bugs https://bugs.openjdk.org/browse/JDK-8350481 and https://bugs.openjdk.org/browse/JDK-8196182
which result into throwing `NoClassDefFoundError` while `hasNext` for `ServideLoader`
Unfortunately it was fixed only for jdk27. The PR is to adapt behavior of `DefaultClusterClientServiceLoader` for java25

Also I have java25 CI in my own Azure setup https://dev.azure.com/snuyanzin/flink/_build/results?buildId=4811&view=results where this fix is applied (together with some others which will come in other PRs). Before this change none of e2e was able to pass, now 2 passes, others are able to go further however still under investigation

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
