### PR TITLE
[FLINK-39754][core] Fix int overflow in DataOutputSerializer.resize

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/memory/DataOutputSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/DataOutputSerializer.java
@@ -354,6 +354,8 @@ public class DataOutputSerializer implements DataOutputView, MemorySegmentWritab
      */
     @VisibleForTesting
     static int computeNewBufferLength(int currentLength, int minCapacityAdd) throws IOException {
+        Preconditions.checkArgument(currentLength >= 0, "currentLength must be non-negative");
+        Preconditions.checkArgument(minCapacityAdd > 0, "minCapacityAdd must be positive");
         long requiredLen = (long) currentLength + minCapacityAdd;
         if (requiredLen > MAX_ARRAY_SIZE) {
             throw new IOException(

--- a/flink-core/src/main/java/org/apache/flink/core/memory/DataOutputSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/DataOutputSerializer.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.core.memory;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.util.Preconditions;
 
 import java.io.EOFException;
@@ -29,6 +30,13 @@ import java.util.Arrays;
 
 /** A simple and efficient serializer for the {@link java.io.DataOutput} interface. */
 public class DataOutputSerializer implements DataOutputView, MemorySegmentWritable {
+
+    /**
+     * Maximum array length the JVM can allocate. Some VMs reserve a few header bytes, so we cap
+     * below {@link Integer#MAX_VALUE} for safety. Matches the bound used by {@code
+     * java.util.ArrayList}.
+     */
+    @VisibleForTesting static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
 
     private byte[] buffer;
 
@@ -333,26 +341,52 @@ public class DataOutputSerializer implements DataOutputView, MemorySegmentWritab
         }
     }
 
+    /**
+     * Computes the new buffer length for a {@link #resize(int)} call.
+     *
+     * <p>Uses {@code long} arithmetic so that doubling does not silently overflow once the current
+     * buffer length crosses {@code Integer.MAX_VALUE / 2}. When doubling would exceed {@link
+     * #MAX_ARRAY_SIZE}, the buffer jumps directly to the cap rather than growing by {@code
+     * minCapacityAdd} bytes at a time — the latter would degrade every subsequent resize into a
+     * full copy of a ~1–2 GB buffer.
+     *
+     * @throws IOException if the required size exceeds {@link #MAX_ARRAY_SIZE}.
+     */
+    @VisibleForTesting
+    static int computeNewBufferLength(int currentLength, int minCapacityAdd) throws IOException {
+        long requiredLen = (long) currentLength + minCapacityAdd;
+        if (requiredLen > MAX_ARRAY_SIZE) {
+            throw new IOException(
+                    "Serialization failed because the record length ("
+                            + requiredLen
+                            + " bytes) would exceed the maximum Java array size ("
+                            + MAX_ARRAY_SIZE
+                            + " bytes).");
+        }
+        long doubledLen = (long) currentLength * 2L;
+        if (doubledLen > MAX_ARRAY_SIZE) {
+            return MAX_ARRAY_SIZE;
+        }
+        return (int) Math.max(doubledLen, requiredLen);
+    }
+
     private void resize(int minCapacityAdd) throws IOException {
-        int newLen = Math.max(this.buffer.length * 2, this.buffer.length + minCapacityAdd);
+        int newLen = computeNewBufferLength(this.buffer.length, minCapacityAdd);
         byte[] nb;
         try {
             nb = new byte[newLen];
-        } catch (NegativeArraySizeException e) {
-            throw new IOException(
-                    "Serialization failed because the record length would exceed 2GB (max addressable array size in Java).");
         } catch (OutOfMemoryError e) {
             // this was too large to allocate, try the smaller size (if possible)
-            if (newLen > this.buffer.length + minCapacityAdd) {
-                newLen = this.buffer.length + minCapacityAdd;
+            int minLen = this.buffer.length + minCapacityAdd;
+            if (newLen > minLen) {
                 try {
-                    nb = new byte[newLen];
+                    nb = new byte[minLen];
                 } catch (OutOfMemoryError ee) {
                     // still not possible. give an informative exception message that reports the
                     // size
                     throw new IOException(
                             "Failed to serialize element. Serialized size (> "
-                                    + newLen
+                                    + minLen
                                     + " bytes) exceeds JVM heap space",
                             ee);
                 }

--- a/flink-core/src/test/java/org/apache/flink/core/memory/DataInputOutputSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/DataInputOutputSerializerTest.java
@@ -31,7 +31,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.Random;
 
+import static org.apache.flink.core.memory.DataOutputSerializer.MAX_ARRAY_SIZE;
+import static org.apache.flink.core.memory.DataOutputSerializer.computeNewBufferLength;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for the combination of {@link DataOutputSerializer} and {@link DataInputDeserializer}. */
 class DataInputOutputSerializerTest {
@@ -138,5 +141,33 @@ class DataInputOutputSerializerTest {
 
         String actual = deserializer.readUTF();
         assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void testComputeNewBufferLengthNormalDoubling() throws IOException {
+        assertThat(computeNewBufferLength(1024, 1)).isEqualTo(2048);
+    }
+
+    @Test
+    void testComputeNewBufferLengthMinCapacityDominates() throws IOException {
+        assertThat(computeNewBufferLength(1000, 5000)).isEqualTo(6000);
+    }
+
+    @Test
+    void testComputeNewBufferLengthJumpsToCapWhenDoublingOverflows() throws IOException {
+        // currentLength * 2 overflows int and would otherwise produce a linear-step resize loop.
+        assertThat(computeNewBufferLength(1_500_000_000, 100)).isEqualTo(MAX_ARRAY_SIZE);
+    }
+
+    @Test
+    void testComputeNewBufferLengthExactlyAtCap() throws IOException {
+        assertThat(computeNewBufferLength(MAX_ARRAY_SIZE - 100, 50)).isEqualTo(MAX_ARRAY_SIZE);
+    }
+
+    @Test
+    void testComputeNewBufferLengthThrowsWhenRequiredExceedsCap() {
+        assertThatThrownBy(() -> computeNewBufferLength(MAX_ARRAY_SIZE - 10, 100))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("would exceed the maximum Java array size");
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Fixes [FLINK-39754](https://issues.apache.org/jira/browse/FLINK-39754). `DataOutputSerializer.resize()` uses `int` arithmetic for `buffer.length * 2`. Once `buffer.length` crosses `Integer.MAX_VALUE / 2` (~1.07 GB), doubling overflows to a negative `int`, `Math.max` then picks `buffer.length + minCapacityAdd`, and every subsequent resize grows the buffer by a handful of bytes instead of doubling — doing a full `System.arraycopy` of the ~1+ GB buffer each call. On large heaps this manifests as a silent O(n²) hang until `buffer.length + minCapacityAdd` itself overflows and the existing `catch (NegativeArraySizeException)` translates it to an `IOException`.

## Brief change log

  - Extract the size computation from `resize(int)` into a `@VisibleForTesting` package-private static helper `computeNewBufferLength(int, int)`.
  - The helper uses `long` arithmetic, validates against a new `MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8` cap (matching `java.util.ArrayList`), and jumps to the cap when doubling would overflow — so serializations that just barely fit under 2 GB still complete instead of grinding through a linear-step resize loop.
  - Remove the now-unreachable `catch (NegativeArraySizeException)` block from `resize`. The existing `OutOfMemoryError` retry path is preserved (it addresses an independent concern — doubled size exceeding available heap).

## Verifying this change

This change added tests and can be verified as follows:

  - Five pure-arithmetic unit tests on `computeNewBufferLength` in `DataInputOutputSerializerTest` covering: normal doubling, `minCapacityAdd`-dominated growth, jump-to-cap when `currentLength * 2` would overflow, exact-cap boundary, and `IOException` when the required size exceeds the cap. No multi-GB allocations required.
  - Existing `DataInputOutputSerializerTest` tests continue to pass, confirming the normal write/read paths through `resize()` are unchanged.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no (`DataOutputSerializer` is unannotated / internal)
  - The serializers: no (this is the byte-buffer growth path, not record (de)serialization logic)
  - The runtime per-record code paths (performance sensitive): no (the helper runs only on buffer growth, not per record; the buggy linear-step path it replaces is what was previously degrading performance)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no behavior change for serializations < ~1 GB. Serializations that previously silently O(n²)-hung near 2 GB now either complete cleanly (one final grow to the cap) or fail with an actionable `IOException` instead of an opaque `NegativeArraySizeException`-derived message.
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude (Anthropic, Opus 4.7) via Zed editor
