### PR TITLE
[FLINK-39755][tests] `RuntimeOpenRestAPIDocsCompletenessITCase` fails for jdk 21+

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/ConfigurationInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/ConfigurationInfo.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.runtime.rest.handler.cluster.ClusterConfigHandler;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import java.util.ArrayList;
 import java.util.Map;
@@ -32,6 +33,7 @@ import java.util.Map;
  * Response of the {@link ClusterConfigHandler}, represented as a list of key-value pairs of the
  * cluster {@link Configuration}.
  */
+@JsonIgnoreProperties({"first", "last"})
 public class ConfigurationInfo extends ArrayList<ConfigurationInfoEntry> implements ResponseBody {
 
     private static final long serialVersionUID = -1170348873871206964L;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/rescales/JobRescalesHistory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/rescales/JobRescalesHistory.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.scheduler.adaptive.timeline.Rescale;
 import org.apache.flink.runtime.scheduler.adaptive.timeline.RescalesStatsSnapshot;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -34,6 +35,7 @@ import java.util.stream.Collectors;
 
 /** Response body for {@link JobRescalesHistoryHandler}. */
 @Schema(name = "JobRescalesHistory")
+@JsonIgnoreProperties({"first", "last"})
 public class JobRescalesHistory extends ArrayList<JobRescaleDetails>
         implements ResponseBody, Serializable {
 


### PR DESCRIPTION
## What is the purpose of the change

The reason is that starting java 21 there is `SequenceCollection` which brings `last` and `first` methods
On the other side `ConfigurationInfo` and `JobRescalesHistory` extend `ArrayList`
as a result in case of java 21 or java 25 it fails as (in case of java 11, 17 it is green)
```
May 25 21:18:01 21:18:01.920 [ERROR]   RuntimeOpenRestAPIDocsCompletenessITCase.testRuntimeRestApiDocsUpToDate:73 [Committed `rest_v1_dispatcher.yml` file is out of date. Please regenerate docs under `flink-docs` module based on `README.md`.] 
May 25 21:18:01 Path:
May 25 21:18:01   /__w/1/s/docs/static/generated/rest_v1_dispatcher.yml
May 25 21:18:01 and path:
May 25 21:18:01   /tmp/junit-2445394591213322851/rest_v1_dispatcher.yml
May 25 21:18:01 do not have same content:
May 25 21:18:01 
May 25 21:18:01 Missing content at line 90:
May 25 21:18:01   ["                properties:",
May 25 21:18:01    "                  first:",
May 25 21:18:01    "                    $ref: "#/components/schemas/ConfigurationInfoEntry"",
May 25 21:18:01    "                  last:",
May 25 21:18:01    "                    $ref: "#/components/schemas/ConfigurationInfoEntry""]
May 25 21:18:01 
May 25 21:18:01 Missing content at line 409:
May 25 21:18:01   ["                properties:",
May 25 21:18:01    "                  first:",
May 25 21:18:01    "                    $ref: "#/components/schemas/ConfigurationInfoEntry"",
May 25 21:18:01    "                  last:",
May 25 21:18:01    "                    $ref: "#/components/schemas/ConfigurationInfoEntry""]
May 25 21:18:01 

```

## Brief change log
 `ConfigurationInfo` and `JobRescalesHistory` 


## Verifying this change

java 21

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable )

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
