### PR TITLE
[FLINK-39145][tests] Skip counters accumulation when state isn't initialized

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
@@ -1121,10 +1121,13 @@ abstract class UnalignedCheckpointTestBase {
 
         @Override
         public void close() throws Exception {
-            numOutputCounter.add(state.numOutput);
-            outOfOrderCounter.add(state.numOutOfOrderness);
-            duplicatesCounter.add(state.numDuplicates);
-            lostCounter.add(state.numLostValues);
+            // sink task might be cancelled before state was initialized
+            if (state != null) {
+                numOutputCounter.add(state.numOutput);
+                outOfOrderCounter.add(state.numOutOfOrderness);
+                duplicatesCounter.add(state.numDuplicates);
+                lostCounter.add(state.numLostValues);
+            }
             if (getRuntimeContext().getTaskInfo().getIndexOfThisSubtask() == 0) {
                 numFailures.add(getRuntimeContext().getTaskInfo().getAttemptNumber());
             }


### PR DESCRIPTION
## What is the purpose of the change

Sink task might be cancelled before state was initialized, should be handled as a valid scenario to avoid test failures due to null state.

## Brief change log

  - Skip counters accumulation in `VerifyingSinkBase#close` when state isn't initialized to avoid test falkiness

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no 
  - The runtime per-record code paths (performance sensitive): no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no 

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

no