### PR TITLE
[FLINK-39762][ci] Add wget in case of java 25

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -287,7 +287,7 @@ if [ -z "${FLINK_ENV_JAVA_OPTS}" ]; then
     FLINK_ENV_JAVA_OPTS="-XX:+IgnoreUnrecognizedVMOptions $( echo "${FLINK_ENV_JAVA_OPTS}" | sed -e 's/^"//'  -e 's/"$//' )"
 
     JAVA_SPEC_VERSION=`"${JAVA_RUN}" -XshowSettings:properties 2>&1 | grep "java.specification.version" | cut -d "=" -f 2 | tr -d '[:space:]' | rev | cut -d "." -f 1 | rev`
-    if [[ $(( $JAVA_SPEC_VERSION > 17 )) == 1 ]]; then
+    if [[ $JAVA_SPEC_VERSION -gt 17 && $JAVA_SPEC_VERSION -lt 24 ]]; then
       # set security manager property to allow calls to System.setSecurityManager() at runtime
       FLINK_ENV_JAVA_OPTS="$FLINK_ENV_JAVA_OPTS -Djava.security.manager=allow"
     fi

--- a/flink-end-to-end-tests/test-scripts/common_docker.sh
+++ b/flink-end-to-end-tests/test-scripts/common_docker.sh
@@ -63,6 +63,9 @@ function build_image() {
     cd flink-docker
     ./add-custom.sh -u ${file_server_address}:9999/flink.tgz -n ${image_name} -j ${java_version}
 
+    # eclipse-temurin:25+ images don't include wget; add it to the install step
+    sed -i 's/apt-get -y install gpg/apt-get -y install gpg wget/' dev/${image_name}-ubuntu/Dockerfile
+
     echo "Building images"
     run_with_timeout 600 docker build --no-cache --network="host" -t ${image_name} dev/${image_name}-ubuntu
     local build_image_result=$?


### PR DESCRIPTION
## What is the purpose of the change

The PR is doing 2 things
1. adds wget to docker image used in tests (it is missed in case of java25)
2. restricts allowance of security manager till java 24 (excluding)

## Verifying this change
finally it allows to pass e2e_1
I have my own Azure pipeline for java25 
https://dev.azure.com/snuyanzin/flink/_build/results?buildId=4818&view=results  (e2e_1 is passed there)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
