### PR TITLE
[FLINK-39790][state/metrics] Fix State latency/size tracking metrics not exported without sampling

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/metrics/StateMetricBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/metrics/StateMetricBase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.state.metrics;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.metrics.Histogram;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
@@ -61,6 +62,9 @@ class StateMetricBase implements AutoCloseable {
     }
 
     protected int loopUpdateCounter(int counter) {
+        if (sampleInterval == 1) {
+            return 1;
+        }
         return (counter + 1 < sampleInterval) ? counter + 1 : 0;
     }
 
@@ -83,5 +87,10 @@ class StateMetricBase implements AutoCloseable {
     @Override
     public void close() throws Exception {
         histogramMetrics.clear();
+    }
+
+    @VisibleForTesting
+    Map<String, Histogram> getHistogramMetrics() {
+        return histogramMetrics;
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/metrics/MetricsTrackingAggregatingStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/metrics/MetricsTrackingAggregatingStateTest.java
@@ -96,8 +96,8 @@ class MetricsTrackingAggregatingStateTest extends MetricsTrackingStateTestBase<I
 
             setCurrentKey(keyedBackend);
             ThreadLocalRandom random = ThreadLocalRandom.current();
-            for (int index = 1; index <= SAMPLE_INTERVAL; index++) {
-                int expectedResult = index == SAMPLE_INTERVAL ? 0 : index;
+            for (int index = 1; index <= DEFAULT_SAMPLE_INTERVAL; index++) {
+                int expectedResult = index == DEFAULT_SAMPLE_INTERVAL ? 0 : index;
                 latencyTrackingState.add(random.nextLong());
                 assertThat(latencyTrackingStateMetric.getAddCount()).isEqualTo(expectedResult);
 
@@ -136,8 +136,8 @@ class MetricsTrackingAggregatingStateTest extends MetricsTrackingStateTestBase<I
 
             setCurrentKey(keyedBackend);
             ThreadLocalRandom random = ThreadLocalRandom.current();
-            for (int index = 1; index <= SAMPLE_INTERVAL; index++) {
-                int expectedResult = index == SAMPLE_INTERVAL ? 0 : index;
+            for (int index = 1; index <= DEFAULT_SAMPLE_INTERVAL; index++) {
+                int expectedResult = index == DEFAULT_SAMPLE_INTERVAL ? 0 : index;
                 sizeTrackingState.add(random.nextLong());
                 assertThat(sizeTrackingStateMetric.getAddCount()).isEqualTo(expectedResult);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/metrics/MetricsTrackingListStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/metrics/MetricsTrackingListStateTest.java
@@ -70,8 +70,8 @@ class MetricsTrackingListStateTest extends MetricsTrackingStateTestBase<Integer>
             assertThat(latencyTrackingStateMetric.getMergeNamespaceCount()).isZero();
 
             setCurrentKey(keyedBackend);
-            for (int index = 1; index <= SAMPLE_INTERVAL; index++) {
-                int expectedResult = index == SAMPLE_INTERVAL ? 0 : index;
+            for (int index = 1; index <= DEFAULT_SAMPLE_INTERVAL; index++) {
+                int expectedResult = index == DEFAULT_SAMPLE_INTERVAL ? 0 : index;
                 latencyTrackingState.add(ThreadLocalRandom.current().nextLong());
                 assertThat(latencyTrackingStateMetric.getAddCount()).isEqualTo(expectedResult);
 
@@ -118,8 +118,8 @@ class MetricsTrackingListStateTest extends MetricsTrackingStateTestBase<Integer>
             assertThat(sizeTrackingStateMetric.getMergeNamespaceCount()).isZero();
 
             setCurrentKey(keyedBackend);
-            for (int index = 1; index <= SAMPLE_INTERVAL; index++) {
-                int expectedResult = index == SAMPLE_INTERVAL ? 0 : index;
+            for (int index = 1; index <= DEFAULT_SAMPLE_INTERVAL; index++) {
+                int expectedResult = index == DEFAULT_SAMPLE_INTERVAL ? 0 : index;
                 sizeTrackingState.add(ThreadLocalRandom.current().nextLong());
                 assertThat(sizeTrackingStateMetric.getAddCount()).isEqualTo(expectedResult);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/metrics/MetricsTrackingMapStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/metrics/MetricsTrackingMapStateTest.java
@@ -81,8 +81,8 @@ class MetricsTrackingMapStateTest extends MetricsTrackingStateTestBase<Integer> 
 
             setCurrentKey(keyedBackend);
             ThreadLocalRandom random = ThreadLocalRandom.current();
-            for (int index = 1; index <= SAMPLE_INTERVAL; index++) {
-                int expectedResult = index == SAMPLE_INTERVAL ? 0 : index;
+            for (int index = 1; index <= DEFAULT_SAMPLE_INTERVAL; index++) {
+                int expectedResult = index == DEFAULT_SAMPLE_INTERVAL ? 0 : index;
                 latencyTrackingState.put(random.nextLong(), random.nextDouble());
                 assertThat(latencyTrackingStateMetric.getPutCount()).isEqualTo(expectedResult);
 
@@ -153,8 +153,8 @@ class MetricsTrackingMapStateTest extends MetricsTrackingStateTestBase<Integer> 
 
             setCurrentKey(keyedBackend);
             ThreadLocalRandom random = ThreadLocalRandom.current();
-            for (int index = 1; index <= SAMPLE_INTERVAL; index++) {
-                int expectedResult = index == SAMPLE_INTERVAL ? 0 : index;
+            for (int index = 1; index <= DEFAULT_SAMPLE_INTERVAL; index++) {
+                int expectedResult = index == DEFAULT_SAMPLE_INTERVAL ? 0 : index;
                 sizeTrackingState.put(random.nextLong(), random.nextDouble());
                 assertThat(sizeTrackingStateMetric.getPutCount()).isEqualTo(expectedResult);
 
@@ -270,13 +270,13 @@ class MetricsTrackingMapStateTest extends MetricsTrackingStateTestBase<Integer> 
             boolean removeIterator)
             throws Exception {
         ThreadLocalRandom random = ThreadLocalRandom.current();
-        for (int index = 1; index <= SAMPLE_INTERVAL; index++) {
+        for (int index = 1; index <= DEFAULT_SAMPLE_INTERVAL; index++) {
             latencyTrackingState.put((long) index, random.nextDouble());
         }
         int count = 1;
         Iterator<E> iterator = iteratorSupplier.get();
         while (iterator.hasNext()) {
-            int expectedResult = count == SAMPLE_INTERVAL ? 0 : count;
+            int expectedResult = count == DEFAULT_SAMPLE_INTERVAL ? 0 : count;
             assertThat(latencyTrackingStateMetric.getIteratorHasNextCount())
                     .isEqualTo(expectedResult);
 
@@ -303,13 +303,13 @@ class MetricsTrackingMapStateTest extends MetricsTrackingStateTestBase<Integer> 
             boolean removeIterator)
             throws Exception {
         ThreadLocalRandom random = ThreadLocalRandom.current();
-        for (int index = 1; index <= SAMPLE_INTERVAL; index++) {
+        for (int index = 1; index <= DEFAULT_SAMPLE_INTERVAL; index++) {
             sizeTrackingState.put((long) index, random.nextDouble());
         }
         int count = 1;
         Iterator<E> iterator = iteratorSupplier.get();
         while (iterator.hasNext()) {
-            int expectedResult = count == SAMPLE_INTERVAL ? 0 : count;
+            int expectedResult = count == DEFAULT_SAMPLE_INTERVAL ? 0 : count;
 
             iterator.next();
             assertThat(sizeTrackingStateMetric.getIteratorNextCount()).isEqualTo(expectedResult);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/metrics/MetricsTrackingReducingStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/metrics/MetricsTrackingReducingStateTest.java
@@ -69,8 +69,8 @@ class MetricsTrackingReducingStateTest extends MetricsTrackingStateTestBase<Inte
 
             setCurrentKey(keyedBackend);
             ThreadLocalRandom random = ThreadLocalRandom.current();
-            for (int index = 1; index <= SAMPLE_INTERVAL; index++) {
-                int expectedResult = index == SAMPLE_INTERVAL ? 0 : index;
+            for (int index = 1; index <= DEFAULT_SAMPLE_INTERVAL; index++) {
+                int expectedResult = index == DEFAULT_SAMPLE_INTERVAL ? 0 : index;
                 latencyTrackingState.add(random.nextLong());
                 assertThat(latencyTrackingStateMetric.getAddCount()).isEqualTo(expectedResult);
 
@@ -108,8 +108,8 @@ class MetricsTrackingReducingStateTest extends MetricsTrackingStateTestBase<Inte
 
             setCurrentKey(keyedBackend);
             ThreadLocalRandom random = ThreadLocalRandom.current();
-            for (int index = 1; index <= SAMPLE_INTERVAL; index++) {
-                int expectedResult = index == SAMPLE_INTERVAL ? 0 : index;
+            for (int index = 1; index <= DEFAULT_SAMPLE_INTERVAL; index++) {
+                int expectedResult = index == DEFAULT_SAMPLE_INTERVAL ? 0 : index;
                 sizeTrackingState.add(random.nextLong());
                 assertThat(sizeTrackingStateMetric.getAddCount()).isEqualTo(expectedResult);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/metrics/MetricsTrackingStateTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/metrics/MetricsTrackingStateTestBase.java
@@ -50,10 +50,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test base for latency tracking state. */
 abstract class MetricsTrackingStateTestBase<K> {
-    protected static final int SAMPLE_INTERVAL = 10;
+    protected static final int DEFAULT_SAMPLE_INTERVAL = 10;
 
     protected AbstractKeyedStateBackend<K> createKeyedBackend(TypeSerializer<K> keySerializer)
             throws Exception {
+        return createKeyedBackend(keySerializer, DEFAULT_SAMPLE_INTERVAL);
+    }
+
+    protected AbstractKeyedStateBackend<K> createKeyedBackend(
+            TypeSerializer<K> keySerializer, int sampleInterval) throws Exception {
 
         Environment env = new DummyEnvironment();
         KeyGroupRange keyGroupRange = new KeyGroupRange(0, 127);
@@ -61,8 +66,8 @@ abstract class MetricsTrackingStateTestBase<K> {
         Configuration configuration = new Configuration();
         configuration.set(StateLatencyTrackOptions.LATENCY_TRACK_ENABLED, true);
         configuration.set(StateSizeTrackOptions.SIZE_TRACK_ENABLED, true);
-        configuration.set(StateLatencyTrackOptions.LATENCY_TRACK_SAMPLE_INTERVAL, SAMPLE_INTERVAL);
-        configuration.set(StateSizeTrackOptions.SIZE_TRACK_SAMPLE_INTERVAL, SAMPLE_INTERVAL);
+        configuration.set(StateLatencyTrackOptions.LATENCY_TRACK_SAMPLE_INTERVAL, sampleInterval);
+        configuration.set(StateSizeTrackOptions.SIZE_TRACK_SAMPLE_INTERVAL, sampleInterval);
         // use a very large value to not let metrics data overridden.
         int historySize = 1000_000;
         configuration.set(StateLatencyTrackOptions.LATENCY_TRACK_HISTORY_SIZE, historySize);
@@ -127,8 +132,8 @@ abstract class MetricsTrackingStateTestBase<K> {
             assertThat(latencyTrackingStateMetric.getClearCount()).isZero();
 
             setCurrentKey(keyedBackend);
-            for (int index = 1; index <= SAMPLE_INTERVAL; index++) {
-                int expectedResult = index == SAMPLE_INTERVAL ? 0 : index;
+            for (int index = 1; index <= DEFAULT_SAMPLE_INTERVAL; index++) {
+                int expectedResult = index == DEFAULT_SAMPLE_INTERVAL ? 0 : index;
                 latencyTrackingState.clear();
                 assertThat(latencyTrackingStateMetric.getClearCount()).isEqualTo(expectedResult);
             }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/metrics/MetricsTrackingValueStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/metrics/MetricsTrackingValueStateTest.java
@@ -65,8 +65,8 @@ class MetricsTrackingValueStateTest extends MetricsTrackingStateTestBase<Integer
             assertThat(latencyTrackingStateMetric.getGetCount()).isZero();
 
             setCurrentKey(keyedBackend);
-            for (int index = 1; index <= SAMPLE_INTERVAL; index++) {
-                int expectedResult = index == SAMPLE_INTERVAL ? 0 : index;
+            for (int index = 1; index <= DEFAULT_SAMPLE_INTERVAL; index++) {
+                int expectedResult = index == DEFAULT_SAMPLE_INTERVAL ? 0 : index;
                 latencyTrackingState.update(ThreadLocalRandom.current().nextLong());
                 assertThat(latencyTrackingStateMetric.getUpdateCount()).isEqualTo(expectedResult);
 
@@ -97,13 +97,57 @@ class MetricsTrackingValueStateTest extends MetricsTrackingStateTestBase<Integer
             assertThat(sizeTrackingStateMetric.getGetCount()).isZero();
 
             setCurrentKey(keyedBackend);
-            for (int index = 1; index <= SAMPLE_INTERVAL; index++) {
-                int expectedResult = index == SAMPLE_INTERVAL ? 0 : index;
+            for (int index = 1; index <= DEFAULT_SAMPLE_INTERVAL; index++) {
+                int expectedResult = index == DEFAULT_SAMPLE_INTERVAL ? 0 : index;
                 sizeTrackingState.update(ThreadLocalRandom.current().nextLong());
                 assertThat(sizeTrackingStateMetric.getUpdateCount()).isEqualTo(expectedResult);
 
                 sizeTrackingState.value();
                 assertThat(sizeTrackingStateMetric.getGetCount()).isEqualTo(expectedResult);
+            }
+        } finally {
+            if (keyedBackend != null) {
+                keyedBackend.close();
+                keyedBackend.dispose();
+            }
+        }
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void testTrackingWithoutSampling() throws Exception {
+        final int noSamplingSampleInterval = 1;
+        AbstractKeyedStateBackend<Integer> keyedBackend =
+                createKeyedBackend(getKeySerializer(), noSamplingSampleInterval);
+        try {
+            MetricsTrackingValueState<Integer, VoidNamespace, Long> latencyTrackingState =
+                    (MetricsTrackingValueState)
+                            createMetricsTrackingState(keyedBackend, getStateDescriptor());
+            latencyTrackingState.setCurrentNamespace(VoidNamespace.INSTANCE);
+            MetricsTrackingValueState.ValueStateMetrics latencyTrackingStateMetric =
+                    latencyTrackingState.getLatencyTrackingStateMetric();
+
+            assertThat(latencyTrackingStateMetric.getUpdateCount()).isZero();
+            assertThat(latencyTrackingStateMetric.getGetCount()).isZero();
+
+            setCurrentKey(keyedBackend);
+            for (int index = 1; index <= 3; index++) {
+                int expectedResult = index;
+                latencyTrackingState.update(ThreadLocalRandom.current().nextLong());
+                assertThat(
+                                latencyTrackingStateMetric
+                                        .getHistogramMetrics()
+                                        .get("valueStateUpdateLatency")
+                                        .getCount())
+                        .isEqualTo(expectedResult);
+
+                latencyTrackingState.value();
+                assertThat(
+                                latencyTrackingStateMetric
+                                        .getHistogramMetrics()
+                                        .get("valueStateGetLatency")
+                                        .getCount())
+                        .isEqualTo(expectedResult);
             }
         } finally {
             if (keyedBackend != null) {


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
Previousely when set to
```
state.*-track.keyed-state-enabled: true
state.*-track.sample-interval: 1
```
Metrics were not exported because for `sampleInterval` of 1, `StateMetricBase#loopUpdateCounter` will always return 0.

## Brief change log

- `StateMetricBase#loopUpdateCounter` to always return 1 if `sampleInterval` = 1

## Verifying this change

This change added tests and can be verified as follows:

  - A test to verify datapoint are reported to the histogram even when `sampleInterval` = 1

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

no
