### PR TITLE
[FLINK-39768][tests][JUnit5 migration] Module: flink-avro - AvroStreamingFileSinkITCase straggler

### DIFF
--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroStreamingFileSinkITCase.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroStreamingFileSinkITCase.java
@@ -28,7 +28,8 @@ import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.UniqueBucketAssigner;
 import org.apache.flink.streaming.api.functions.sink.filesystem.legacy.StreamingFileSink;
-import org.apache.flink.test.util.AbstractTestBaseJUnit4;
+import org.apache.flink.test.util.AbstractTestBase;
+import org.apache.flink.testutils.junit.utils.TempDirUtils;
 
 import org.apache.avro.Schema;
 import org.apache.avro.file.DataFileReader;
@@ -38,9 +39,8 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumReader;
 import org.apache.avro.reflect.ReflectDatumReader;
 import org.apache.avro.specific.SpecificDatumReader;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.File;
 import java.io.IOException;
@@ -58,13 +58,12 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Simple integration test case for writing bulk encoded files with the {@link StreamingFileSink}
  * with Avro.
  */
-public class AvroStreamingFileSinkITCase extends AbstractTestBaseJUnit4 {
-
-    @Rule public final Timeout timeoutPerTest = Timeout.seconds(20);
+@Timeout(value = 20)
+class AvroStreamingFileSinkITCase extends AbstractTestBase {
 
     @Test
-    public void testWriteAvroSpecific() throws Exception {
-        File folder = TEMPORARY_FOLDER.newFolder();
+    void testWriteAvroSpecific() throws Exception {
+        File folder = TempDirUtils.newFolder(temporaryFolder.toPath());
 
         List<Address> data =
                 Arrays.asList(
@@ -94,8 +93,8 @@ public class AvroStreamingFileSinkITCase extends AbstractTestBaseJUnit4 {
     }
 
     @Test
-    public void testWriteAvroGeneric() throws Exception {
-        File folder = TEMPORARY_FOLDER.newFolder();
+    void testWriteAvroGeneric() throws Exception {
+        File folder = TempDirUtils.newFolder(temporaryFolder.toPath());
 
         Schema schema = Address.getClassSchema();
         Collection<GenericRecord> data = new GenericTestDataCollection();
@@ -122,8 +121,8 @@ public class AvroStreamingFileSinkITCase extends AbstractTestBaseJUnit4 {
     }
 
     @Test
-    public void testWriteAvroReflect() throws Exception {
-        File folder = TEMPORARY_FOLDER.newFolder();
+    void testWriteAvroReflect() throws Exception {
+        File folder = TempDirUtils.newFolder(temporaryFolder.toPath());
 
         List<Datum> data = Arrays.asList(new Datum("a", 1), new Datum("b", 2), new Datum("c", 3));
 

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroStreamingFileSinkITCase.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroStreamingFileSinkITCase.java
@@ -29,7 +29,6 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.UniqueBucketAssigner;
 import org.apache.flink.streaming.api.functions.sink.filesystem.legacy.StreamingFileSink;
 import org.apache.flink.test.util.AbstractTestBase;
-import org.apache.flink.testutils.junit.utils.TempDirUtils;
 
 import org.apache.avro.Schema;
 import org.apache.avro.file.DataFileReader;
@@ -41,6 +40,7 @@ import org.apache.avro.reflect.ReflectDatumReader;
 import org.apache.avro.specific.SpecificDatumReader;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
@@ -51,6 +51,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -58,13 +59,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Simple integration test case for writing bulk encoded files with the {@link StreamingFileSink}
  * with Avro.
  */
-@Timeout(value = 20)
+@Timeout(value = 20, unit = TimeUnit.SECONDS)
 class AvroStreamingFileSinkITCase extends AbstractTestBase {
 
     @Test
-    void testWriteAvroSpecific() throws Exception {
-        File folder = TempDirUtils.newFolder(temporaryFolder.toPath());
-
+    void testWriteAvroSpecific(@TempDir File folder) throws Exception {
         List<Address> data =
                 Arrays.asList(
                         new Address(1, "a", "b", "c", "12345"),
@@ -93,9 +92,7 @@ class AvroStreamingFileSinkITCase extends AbstractTestBase {
     }
 
     @Test
-    void testWriteAvroGeneric() throws Exception {
-        File folder = TempDirUtils.newFolder(temporaryFolder.toPath());
-
+    void testWriteAvroGeneric(@TempDir File folder) throws Exception {
         Schema schema = Address.getClassSchema();
         Collection<GenericRecord> data = new GenericTestDataCollection();
 
@@ -121,9 +118,7 @@ class AvroStreamingFileSinkITCase extends AbstractTestBase {
     }
 
     @Test
-    void testWriteAvroReflect() throws Exception {
-        File folder = TempDirUtils.newFolder(temporaryFolder.toPath());
-
+    void testWriteAvroReflect(@TempDir File folder) throws Exception {
         List<Datum> data = Arrays.asList(new Datum("a", 1), new Datum("b", 2), new Datum("c", 3));
 
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();


### PR DESCRIPTION
## What is the purpose of the change

Migrate the last remaining JUnit 4 test in `flink-formats/flink-avro` (`AvroStreamingFileSinkITCase`) to JUnit 5 (Jupiter). The rest of the module was migrated under [FLINK-26232](https://issues.apache.org/jira/browse/FLINK-26232) (fix 1.15.0); this file was a leftover. After this PR, `flink-avro` has zero JUnit 4 imports.

JIRA: [FLINK-39768](https://issues.apache.org/jira/browse/FLINK-39768) (sub-task of [FLINK-25325](https://issues.apache.org/jira/browse/FLINK-25325))

## Brief change log

- `org.junit.*` imports → `org.junit.jupiter.api.*`.
- `@Rule public Timeout timeoutPerTest = Timeout.seconds(20)` → class-level `@Timeout(value = 20, unit = TimeUnit.SECONDS)`.
- `extends AbstractTestBaseJUnit4` → `extends AbstractTestBase` (the JUnit 5 sibling; the JUnit 4 base is `@Deprecated`).
- `TEMPORARY_FOLDER.newFolder()` → per-test `@TempDir File folder` parameter injection (native JUnit 5 idiom; no `TempDirUtils` shim needed since each test takes exactly one fresh dir).
- Drop `public` on the test class and test methods per the [Flink JUnit 5 Migration Guide](https://docs.google.com/document/d/1514Wa_aNB9bJUen4xm5uiuXOooOJTtXqS_Jqk9KJitU/edit).

No production code is touched.

## Verifying this change

```
./mvnw -pl flink-formats/flink-avro test -Dtest=AvroStreamingFileSinkITCase
```

Result: **3 tests run, 0 failures, 0 errors, 0 skipped**, matching the pre-migration baseline.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes — Claude Code