### PR TITLE
[FLINK-36267][table] Fix SPLIT not preserving SMP characters when delimiter is empty

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
@@ -1814,7 +1814,7 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                                 123,
                                 "12345",
                                 ",123,,,123,",
-                                "123😊笑脸")
+                                "123😊👍🏽笑脸")
                         .andDataTypes(
                                 DataTypes.STRING().notNull(),
                                 DataTypes.STRING(),
@@ -1872,7 +1872,7 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                         .testResult(
                                 $("f7").split(""),
                                 "SPLIT(f7, '')",
-                                new String[] {"1", "2", "3", "😊", "笑", "脸"},
+                                new String[] {"1", "2", "3", "😊", "👍", "🏽", "笑", "脸"},
                                 DataTypes.ARRAY(DataTypes.STRING()).notNull())
                         .testTableApiValidationError(
                                 $("f4").split(","),

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
@@ -1813,13 +1813,15 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                                 ",123,123,",
                                 123,
                                 "12345",
-                                ",123,,,123,")
+                                ",123,,,123,",
+                                "123😊笑脸")
                         .andDataTypes(
                                 DataTypes.STRING().notNull(),
                                 DataTypes.STRING(),
                                 DataTypes.STRING().notNull(),
                                 DataTypes.STRING().notNull(),
                                 DataTypes.INT().notNull(),
+                                DataTypes.STRING().notNull(),
                                 DataTypes.STRING().notNull(),
                                 DataTypes.STRING().notNull())
                         .testResult(
@@ -1866,6 +1868,11 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                                 $("f6").split(","),
                                 "SPLIT(f6, ',')",
                                 new String[] {"", "123", "", "", "123", ""},
+                                DataTypes.ARRAY(DataTypes.STRING()).notNull())
+                        .testResult(
+                                $("f7").split(""),
+                                "SPLIT(f7, '')",
+                                new String[] {"1", "2", "3", "😊", "笑", "脸"},
                                 DataTypes.ARRAY(DataTypes.STRING()).notNull())
                         .testTableApiValidationError(
                                 $("f4").split(","),

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/SplitFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/SplitFunction.java
@@ -52,9 +52,9 @@ public class SplitFunction extends BuiltInScalarFunction {
                 int i = 0;
                 while (i < str.length()) {
                     int codePoint = str.codePointAt(i);
-                    int charCount = Character.charCount(codePoint);
-                    res.add(StringData.fromString(str.substring(i, i + charCount)));
-                    i += charCount;
+                    int nextIndex = i + Character.charCount(codePoint);
+                    res.add(StringData.fromString(str.substring(i, nextIndex)));
+                    i = nextIndex;
                 }
                 return new GenericArrayData(res.toArray());
             }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/SplitFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/SplitFunction.java
@@ -49,8 +49,12 @@ public class SplitFunction extends BuiltInScalarFunction {
             if (delimiter.toString().isEmpty()) {
                 String str = string.toString();
                 List<StringData> res = new ArrayList<>();
-                for (int i = 0; i < str.length(); i++) {
-                    res.add(StringData.fromString(String.valueOf(str.charAt(i))));
+                int i = 0;
+                while (i < str.length()) {
+                    int codePoint = str.codePointAt(i);
+                    int charCount = Character.charCount(codePoint);
+                    res.add(StringData.fromString(str.substring(i, i + charCount)));
+                    i += charCount;
                 }
                 return new GenericArrayData(res.toArray());
             }


### PR DESCRIPTION
## What is the purpose of the change

Fix the SQL `SPLIT` function so that, when called with an empty delimiter, it preserves Supplementary Multilingual Plane characters (e.g. emoji) as single elements instead of breaking surrogate pairs into invalid "?" placeholders.

## Brief change log

- Change the empty-delimiter branch in `SplitFunction#eval` to iterate by Unicode code points (`codePointAt` + `Character.charCount`) instead of by UTF-16 code units, so surrogate-pair characters are emitted as one element.

## Verifying this change

Added a new test case in `CollectionFunctionsITCase#splitTestCases` that asserts `SPLIT('123😊笑脸', '')` returns `["1", "2", "3", "😊", "笑", "脸"]`, covering the SMP character path across both Table API and SQL.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
