### PR TITLE
[FLINK-39773][tests] Use random ports in `ClusterEntryPointTest`

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/ClusterEntrypointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/ClusterEntrypointTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.SchedulerExecutionMode;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
@@ -93,6 +94,8 @@ public class ClusterEntrypointTest extends TestLogger {
     @Before
     public void before() {
         flinkConfig = new Configuration();
+        flinkConfig.set(RestOptions.BIND_PORT, "0");
+        flinkConfig.set(JobManagerOptions.PORT, 0);
         ExceptionThrowingDelegationTokenProvider.reset();
         ExceptionThrowingDelegationTokenReceiver.reset();
     }


### PR DESCRIPTION
## What is the purpose of the change

This test is failing in java25 since the ports are going to be free in async mode, in java 25 tests might started before ports are freed from previous test.
To make it more reliable: the PR makes using random ports
another way: making sure ports are freed before next test is started will require more changes

## Brief change log

ClusterEntryPointTest
## Verifying this change

the change is test itself
my CI with java25 where this test fails https://dev.azure.com/snuyanzin/flink/_build/results?buildId=4810&view=logs&j=7f652c99-c3cd-5aee-11e2-f8e88140dbea&t=d3173862-60e8-57db-ccd6-465075b97bea&l=8802

same ci with this fix (now the next test failed which will be fixed separately)
https://dev.azure.com/snuyanzin/flink/_build/results?buildId=4836&view=logs&j=9dc1b5dc-bcfa-5f83-eaa7-0cb181ddc267&t=e72e9469-7bd1-5a7c-cfdb-1df1c1c7d1dc&l=10544

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable )

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
