### PR TITLE
[FLINK-39764] Support dynamic table options in Table API

### DIFF
--- a/docs/content/docs/dev/table/common.md
+++ b/docs/content/docs/dev/table/common.md
@@ -543,6 +543,47 @@ revenue = orders \
 
 {{< top >}}
 
+#### Dynamic Table Options
+
+The Table API supports overriding a table's options at query time via `from(String, Map)`.
+This is the programmatic equivalent of the SQL `OPTIONS` hint.
+
+Use this when you want to temporarily change connector behavior (e.g., read from earliest offset,
+override a format setting) without modifying the table's DDL definition.
+
+{{< tabs "dynamic-table-options-example" >}}
+{{< tab "Java" >}}
+```java
+// Override scan.startup.mode for this query only
+Table orders = tableEnv.from("kafka_orders", Map.of(
+        "scan.startup.mode", "earliest-offset"
+));
+
+Table result = orders
+        .filter($("amount").isGreater(100))
+        .select($("orderId"), $("amount"));
+```
+{{< /tab >}}
+{{< tab "Scala" >}}
+```scala
+// Override scan.startup.mode for this query only
+val orders = tableEnv.from("kafka_orders", Map(
+        "scan.startup.mode" -> "earliest-offset"
+        ).asJava)
+
+val result = orders
+        .filter($"amount" > 100)
+        .select($"orderId", $"amount")
+```
+{{< /tab >}}
+{{< /tabs >}}
+
+**Notes:**
+  - Dynamic options work for regular tables and materialized tables, but not views.
+  - The configuration option table.dynamic-table-options.enabled must be true (the default).
+  - Option validation happens at execution time, not when from() is called.
+  - For the SQL equivalent, see [Dynamic Table Options]({{< ref "docs/sql/reference/queries/hints">}} `dynamic-table-options`).
+
 ### SQL
 
 Flink's SQL integration is based on [Apache Calcite](https://calcite.apache.org), which implements the SQL standard. SQL queries are specified as regular Strings.

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -1085,8 +1085,10 @@ public interface TableEnvironment {
      * Reads a registered table and applies dynamic options, returning the corresponding {@link
      * Table}.
      *
-     * <p>Dynamic options override the table's static options defined at creation time (DDL).
-     * This is the Table API equivalent of SQL's {@code OPTIONS} hint:
+     * <p>This is the Table API equivalent of SQL's {@code OPTIONS} hint. Use it to override table
+     * options at query time without modifying the table's DDL definition. Typical use cases include
+     * changing the scan startup mode, adjusting parallelism hints, or overriding format settings
+     * for a specific query.
      *
      * <pre>{@code
      * // Table API (this method)
@@ -1096,16 +1098,28 @@ public interface TableEnvironment {
      * // SELECT * FROM kafka_table1 /*+ OPTIONS('scan.startup.mode'='earliest-offset') * /
      * }</pre>
      *
-     * <p>The configuration option {@code table.dynamic-table-options.enabled} must be set to
-     * {@code true} (the default) for dynamic options to take effect.
+     * <p>Dynamic options override the table's static options defined at creation time (DDL). This
+     * method supports both regular catalog tables and materialized tables, but <b>not views</b>.
      *
-     * <p>Note: Dynamic options cannot be applied to views.
+     * <p>Options are represented as {@code Map<String, String>} for consistency with the rest of
+     * the Table/SQL ecosystem (DDL WITH clauses, SQL OPTIONS hints, {@link
+     * CatalogTable#getOptions()}). Typed values are parsed from their string representation by the
+     * connector factory at execution time.
+     *
+     * <p>Note that option validation (e.g., unrecognized keys or invalid values) is performed
+     * lazily when the query is optimized or executed, not at the time this method is called.
+     * Invalid options will result in a {@link ValidationException} during planning or execution.
+     *
+     * <p>The configuration option {@code table.dynamic-table-options.enabled} must be set to {@code
+     * true} (the default) for dynamic options to take effect.
      *
      * @param path The path of a table API object to scan.
-     * @param dynamicOptions A map of option key-value pairs to override on the table.
+     * @param dynamicOptions A map of option key-value pairs to override on the table. Must not be
+     *     null. An empty map is treated as a no-op (original options are preserved).
      * @return The {@link Table} object describing the pipeline for further transformations.
      * @throws ValidationException if the table is not found, is a view, or dynamic options are
      *     disabled.
+     * @see TableEnvironment#from(String)
      */
     Table from(String path, Map<String, String> dynamicOptions);
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -43,6 +43,7 @@ import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -1079,6 +1080,34 @@ public interface TableEnvironment {
      * @see TableEnvironment#useDatabase(String)
      */
     Table from(String path);
+
+    /**
+     * Reads a registered table and applies dynamic options, returning the corresponding {@link
+     * Table}.
+     *
+     * <p>Dynamic options override the table's static options defined at creation time (DDL).
+     * This is the Table API equivalent of SQL's {@code OPTIONS} hint:
+     *
+     * <pre>{@code
+     * // Table API (this method)
+     * Table tab = tableEnv.from("kafka_table1", Map.of("scan.startup.mode", "earliest-offset"));
+     *
+     * // Equivalent SQL
+     * // SELECT * FROM kafka_table1 /*+ OPTIONS('scan.startup.mode'='earliest-offset') * /
+     * }</pre>
+     *
+     * <p>The configuration option {@code table.dynamic-table-options.enabled} must be set to
+     * {@code true} (the default) for dynamic options to take effect.
+     *
+     * <p>Note: Dynamic options cannot be applied to views.
+     *
+     * @param path The path of a table API object to scan.
+     * @param dynamicOptions A map of option key-value pairs to override on the table.
+     * @return The {@link Table} object describing the pipeline for further transformations.
+     * @throws ValidationException if the table is not found, is a view, or dynamic options are
+     *     disabled.
+     */
+    Table from(String path, Map<String, String> dynamicOptions);
 
     /**
      * Returns a {@link Table} backed by the given {@link TableDescriptor descriptor}.

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -674,6 +674,48 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
     }
 
     @Override
+    public Table from(String path, Map<String, String> dynamicOptions) {
+        Preconditions.checkNotNull(dynamicOptions, "Dynamic options must not be null.");
+
+        if (!tableConfig.get(TableConfigOptions.TABLE_DYNAMIC_TABLE_OPTIONS_ENABLED)) {
+            throw new ValidationException(
+                    String.format(
+                            "Dynamic table options are disabled. Set '%s' to 'true' to enable them.",
+                            TableConfigOptions.TABLE_DYNAMIC_TABLE_OPTIONS_ENABLED.key()));
+        }
+
+        UnresolvedIdentifier unresolvedIdentifier = getParser().parseIdentifier(path);
+        ObjectIdentifier tableIdentifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
+        ContextResolvedTable contextResolvedTable =
+                catalogManager
+                        .getTable(tableIdentifier)
+                        .orElseThrow(
+                                () ->
+                                        new ValidationException(
+                                                String.format(
+                                                        "Table %s was not found.",
+                                                        unresolvedIdentifier)));
+
+        if (dynamicOptions.isEmpty()) {
+            return createTable(new SourceQueryOperation(contextResolvedTable));
+        }
+
+        if (contextResolvedTable.getResolvedTable().getTableKind()
+                == CatalogBaseTable.TableKind.VIEW) {
+            throw new ValidationException(
+                    String.format(
+                            "View '%s' cannot be enriched with dynamic options.",
+                            unresolvedIdentifier));
+        }
+
+        Map<String, String> mergedOptions =
+                new HashMap<>(contextResolvedTable.getResolvedTable().getOptions());
+        mergedOptions.putAll(dynamicOptions);
+        ContextResolvedTable withOptions = contextResolvedTable.copy(mergedOptions);
+        return createTable(new SourceQueryOperation(withOptions));
+    }
+
+    @Override
     public Table from(TableDescriptor descriptor) {
         Preconditions.checkNotNull(descriptor, "Table descriptor must not be null.");
 

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/api/TableEnvironmentTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/api/TableEnvironmentTest.java
@@ -257,6 +257,80 @@ class TableEnvironmentTest {
         assertThat(tEnv.listModels()).containsExactly("M1", "M2");
     }
 
+    @Test
+    void testFromWithDynamicOptions() {
+        tEnv.createTable("T", TEST_DESCRIPTOR);
+
+        final Table table = tEnv.from("T", Map.of("b", "Override"));
+
+        assertThat(table.getQueryOperation())
+                .asInstanceOf(type(SourceQueryOperation.class))
+                .extracting(SourceQueryOperation::getContextResolvedTable)
+                .satisfies(
+                        crt -> {
+                            assertThat(crt.getResolvedTable().getOptions())
+                                    .contains(entry("a", "Test"), entry("b", "Override"));
+                        });
+    }
+
+    @Test
+    void testFromWithDynamicOptionsOverridesExisting() {
+        tEnv.createTable("T", TEST_DESCRIPTOR);
+
+        final Table table = tEnv.from("T", Map.of("a", "Overridden"));
+
+        assertThat(table.getQueryOperation())
+                .asInstanceOf(type(SourceQueryOperation.class))
+                .extracting(SourceQueryOperation::getContextResolvedTable)
+                .satisfies(
+                        crt -> {
+                            assertThat(crt.getResolvedTable().getOptions())
+                                    .containsEntry("a", "Overridden");
+                        });
+    }
+
+    @Test
+    void testFromWithEmptyDynamicOptions() {
+        tEnv.createTable("T", TEST_DESCRIPTOR);
+
+        final Table table = tEnv.from("T", Map.of());
+
+        assertThat(table.getQueryOperation())
+                .asInstanceOf(type(SourceQueryOperation.class))
+                .extracting(SourceQueryOperation::getContextResolvedTable)
+                .satisfies(
+                        crt -> {
+                            assertThat(crt.getResolvedTable().getOptions())
+                                    .containsEntry("a", "Test");
+                        });
+    }
+
+    @Test
+    void testFromWithDynamicOptionsOnViewThrows() {
+        tEnv.createTable("T", TEST_DESCRIPTOR);
+        tEnv.createView("V", tEnv.from("T"));
+
+        assertThatThrownBy(() -> tEnv.from("V", Map.of("key", "value")))
+                .isInstanceOf(ValidationException.class);
+    }
+
+    @Test
+    void testFromWithDynamicOptionsDisabledThrows() {
+        tEnv.getConfig().set("table.dynamic-table-options.enabled", "false");
+        tEnv.createTable("T", TEST_DESCRIPTOR);
+
+        assertThatThrownBy(() -> tEnv.from("T", Map.of("key", "value")))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("Dynamic table options are disabled");
+    }
+
+    @Test
+    void testFromWithDynamicOptionsTableNotFound() {
+        assertThatThrownBy(() -> tEnv.from("NonExistent", Map.of("key", "value")))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("was not found");
+    }
+
     private static void assertCreateTableFromDescriptor(
             TableEnvironmentMock tEnv, Schema schema, boolean ignoreIfExists)
             throws org.apache.flink.table.catalog.exceptions.TableNotExistException {

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/test/program/FailingTableApiTestStep.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/test/program/FailingTableApiTestStep.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.test.program.TableApiTestStep.TableEnvAccessor;
 import org.apache.flink.table.types.AbstractDataType;
 import org.apache.flink.util.Preconditions;
 
+import java.util.Map;
 import java.util.function.Function;
 
 import static org.apache.flink.core.testutils.FlinkAssertions.anyCauseMatches;
@@ -102,6 +103,11 @@ public final class FailingTableApiTestStep implements TestStep {
                     @Override
                     public Table sqlQuery(String query) {
                         return env.sqlQuery(query);
+                    }
+
+                    @Override
+                    public Table from(String path, Map<String, String> dynamicOptions) {
+                        return null;
                     }
 
                     @Override

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/test/program/TableApiTestStep.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/test/program/TableApiTestStep.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.expressions.DefaultSqlFactory;
 import org.apache.flink.table.functions.UserDefinedFunction;
 import org.apache.flink.table.types.AbstractDataType;
 
+import java.util.Map;
 import java.util.function.Function;
 
 /** Test step for execution of a Table API. Similar to {@link SqlTestStep}. */
@@ -85,6 +86,11 @@ public class TableApiTestStep implements TestStep {
                     }
 
                     @Override
+                    public Table from(String path, Map<String, String> dynamicOptions) {
+                        return env.from(path, dynamicOptions);
+                    }
+
+                    @Override
                     public Model fromModel(String modelPath) {
                         return env.fromModel(modelPath);
                     }
@@ -136,6 +142,8 @@ public class TableApiTestStep implements TestStep {
 
         /** See {@link TableEnvironment#sqlQuery(String)}. */
         Table sqlQuery(String query);
+
+        Table from(String path, Map<String, String> dynamicOptions);
 
         /** See {@link TableEnvironment#fromModel(String)}. */
         Model fromModel(String modelPath);


### PR DESCRIPTION
## What is the purpose of the change
Currently, dynamic table options (e.g., overriding `scan.startup.mode` at query time) are only available through the SQL API via `OPTIONS` hints:
sql: SELECT id, name FROM kafka_table1 /*+ OPTIONS('scan.startup.mode'='earliest-offset') */;
Table API users who want to override table options dynamically have **no equivalent mechanism**. They are forced to drop into `tEnv.executeSql()` with raw SQL strings, which negates the purpose of using the type-safe Table API.


## Brief change log
Add a new overloaded method `from(String path, Map<String, String> dynamicOptions)` to the `TableEnvironment` interface. This provides Table API users with the same dynamic option override capability that SQL users have via `OPTIONS` hints.


## Verifying this change
Added 6 test methods:                                                                                                                                                                                                                                    `testFromWithDynamicOptions` : Verifies dynamic options are merged with existing table options `testFromWithDynamicOptionsOverridesExisting` :  Verifies dynamic options override static options on key conflict |         `testFromWithEmptyDynamicOptions` :  Verifies empty map is a no-op, original options preserved |                           `testFromWithDynamicOptionsOnViewThrows` : Verifies `ValidationException` when applied to a view `testFromWithDynamicOptionsDisabledThrows` : Verifies `ValidationException` when config is disabled `testFromWithDynamicOptionsTableNotFound` : Verifies `ValidationException` for non-existent table 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) - no 
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) - yes
  - The serializers: (yes / no / don't know) - no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) - no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) - no
  - The S3 file system connector: (yes / no / don't know) - no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) - no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) - no

---

##### Was generative AI tooling used to co-author this PR?
Yes, had taken help from kiro.
