### PR TITLE
[FLINK-39794][tests] Bind StreamNetworkBenchmarkEnvironment to loopback

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
@@ -50,7 +50,6 @@ import org.apache.flink.runtime.util.NettyShuffleDescriptorBuilder;
 
 import java.io.IOException;
 import java.net.InetAddress;
-import java.net.UnknownHostException;
 
 import static org.apache.flink.runtime.io.network.partition.InputChannelTestUtils.newUnregisteredInputChannelMetrics;
 import static org.apache.flink.util.ExceptionUtils.suppressExceptions;
@@ -61,15 +60,7 @@ import static org.apache.flink.util.ExceptionUtils.suppressExceptions;
  */
 public class StreamNetworkBenchmarkEnvironment<T extends IOReadableWritable> {
 
-    private static final InetAddress LOCAL_ADDRESS;
-
-    static {
-        try {
-            LOCAL_ADDRESS = InetAddress.getLocalHost();
-        } catch (UnknownHostException e) {
-            throw new Error(e);
-        }
-    }
+    private static final InetAddress LOCAL_ADDRESS = InetAddress.getLoopbackAddress();
 
     private final ResourceID location = ResourceID.generate();
     protected final JobID jobId = new JobID();


### PR DESCRIPTION
## What is the purpose of the change

`StreamNetworkBenchmarkEnvironment` bound its test NettyServer to `InetAddress.getLocalHost()`, whose reverse DNS is not guaranteed to match `local127.keystore`'s SAN list (`localhost`, `127.0.0.1`, `::1`). On GitHub-hosted Azure runners the reverse DNS returns an internal `cloudapp.net` FQDN, the SSL handshake in `NettyClient` fails with `No subject alternative DNS name matching <fqdn> found`, and the SSL benchmarks hang until the runner times out. This is the root cause of FLINK-39787.

## Brief change log

  - Initialise `StreamNetworkBenchmarkEnvironment.LOCAL_ADDRESS` with `InetAddress.getLoopbackAddress()`; drop the now-unnecessary static initialiser block.

## Verifying this change

This change is exercised by the SSL / OpenSSL variants of `StreamNetworkThroughputBenchmark` in the external [flink-benchmarks](https://github.com/apache/flink-benchmarks) project. End-to-end verified on flink-benchmarks CI with the equivalent loopback bind applied at the `/etc/hosts` level: the SSL benchmark suite completes in normal time on Azure-hosted GitHub runners, versus the prior 6-hour timeout.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Opus 4.7
