### PR TITLE
[FLINK-36602][tests] Add pre Calcite 1.38.0 tests for CALCITE-7562 issue

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
@@ -2348,4 +2348,39 @@ class CalcITCase extends BatchTestBase {
       Seq(row(0, 1), row(1, 2), row(2, 3))
     );
   }
+
+  @Test
+  def testDateColumnInListWithStringLiterals(): Unit = {
+    val data = Seq(
+      row(localDate("2000-06-30"), "a"),
+      row(localDate("2000-09-27"), "b"),
+      row(localDate("2000-11-17"), "c"),
+      row(localDate("2001-01-01"), "d"))
+    registerCollection(
+      "DateTable",
+      data,
+      new RowTypeInfo(LOCAL_DATE, STRING_TYPE_INFO),
+      "d_date, val")
+
+    checkResult(
+      "SELECT val FROM DateTable WHERE d_date IN ('2000-06-30', '2000-09-27', '2000-11-17')",
+      Seq(row("a"), row("b"), row("c")))
+  }
+
+  @Test
+  def testTimestampColumnInListWithStringLiterals(): Unit = {
+    val data = Seq(
+      row(localDateTime("2000-06-30 12:00:00"), "a"),
+      row(localDateTime("2000-09-27 12:00:00"), "b"),
+      row(localDateTime("2001-01-01 12:00:00"), "c"))
+    registerCollection(
+      "TimestampTable",
+      data,
+      new RowTypeInfo(LOCAL_DATE_TIME, STRING_TYPE_INFO),
+      "ts, val")
+
+    checkResult(
+      "SELECT val FROM TimestampTable WHERE ts IN ('2000-06-30 12:00:00', '2000-09-27 12:00:00')",
+      Seq(row("a"), row("b")))
+  }
 }


### PR DESCRIPTION
## What is the purpose of the change

The PR is a preparation PR before Calcite 1.38.0 upgrade
these tests still pass in with 1.37.0 and will fail with dummy 1.38.0 upgrade
Tests are made based on TPC DS queries

## Brief change log
test


## Verifying this change

The change is tests itself
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
