### PR TITLE
[hotfix][table] Fix flaky TemporalJoinITCase

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TemporalJoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TemporalJoinITCase.scala
@@ -212,7 +212,7 @@ class TemporalJoinITCase(state: StateBackendMode) extends StreamingWithStateTest
                        |  currency_no STRING,
                        |  amount BIGINT,
                        |  order_time TIMESTAMP(3),
-                       |  WATERMARK FOR order_time AS order_time,
+                       |  WATERMARK FOR order_time AS order_time - interval '2' DAYS,
                        |  PRIMARY KEY (order_id) NOT ENFORCED
                        |) WITH (
                        |  'connector' = 'values',


### PR DESCRIPTION
## What is the purpose of the change

Fix was needed because FLINK-39719 modified TemporalRowTimeJoinOperator to drop late arriving probe-side records. TemporalJoinITCase's test data contained late records that would be dropped (or not) depending on when sources emitted watermarks. This fix adjusts the watermark definition of the source table such that no late data is produced.

## Brief change log

* adjusting watermark strategy in a test input table of `TemporalJoinITCase`

## Verifying this change

I've run the test class 80 times without any test failures.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? n/a

---

##### Was generative AI tooling used to co-author this PR?

No