### PR TITLE
[FLINK-39789] AvroSchemaConverter updates for local-timestamp-* and timestamp-nanos logical types

### DIFF
--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/AvroSchemaConverter.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/AvroSchemaConverter.java
@@ -333,8 +333,13 @@ public class AvroSchemaConverter {
                 }
                 return DataTypes.INT().notNull();
             case LONG:
+                // Local timestamps are unambiguous per the Avro spec; honor in both mappings.
+                if (schema.getLogicalType() == LogicalTypes.localTimestampMillis()) {
+                    return DataTypes.TIMESTAMP(3).notNull();
+                } else if (schema.getLogicalType() == LogicalTypes.localTimestampMicros()) {
+                    return DataTypes.TIMESTAMP(6).notNull();
+                }
                 if (legacyMapping) {
-                    // Avro logical timestamp types to Flink SQL timestamp types
                     if (schema.getLogicalType() == LogicalTypes.timestampMillis()) {
                         return DataTypes.TIMESTAMP(3).notNull();
                     } else if (schema.getLogicalType() == LogicalTypes.timestampMicros()) {
@@ -345,7 +350,6 @@ public class AvroSchemaConverter {
                         return DataTypes.TIME(6).notNull();
                     }
                 } else {
-                    // Avro logical timestamp types to Flink SQL timestamp types
                     if (schema.getLogicalType() == LogicalTypes.timestampMillis()) {
                         return DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).notNull();
                     } else if (schema.getLogicalType() == LogicalTypes.timestampMicros()) {
@@ -354,10 +358,6 @@ public class AvroSchemaConverter {
                         return DataTypes.TIME(3).notNull();
                     } else if (schema.getLogicalType() == LogicalTypes.timeMicros()) {
                         return DataTypes.TIME(6).notNull();
-                    } else if (schema.getLogicalType() == LogicalTypes.localTimestampMillis()) {
-                        return DataTypes.TIMESTAMP(3).notNull();
-                    } else if (schema.getLogicalType() == LogicalTypes.localTimestampMicros()) {
-                        return DataTypes.TIMESTAMP(6).notNull();
                     }
                 }
 

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/AvroSchemaConverter.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/AvroSchemaConverter.java
@@ -192,6 +192,11 @@ public class AvroSchemaConverter {
                 }
                 return Types.INT;
             case LONG:
+                // Local timestamps are unambiguous per the Avro spec; honor in both mappings.
+                if (schema.getLogicalType() == LogicalTypes.localTimestampMillis()
+                        || schema.getLogicalType() == LogicalTypes.localTimestampMicros()) {
+                    return Types.LOCAL_DATE_TIME;
+                }
                 if (legacyTimestampMapping) {
                     if (schema.getLogicalType() == LogicalTypes.timestampMillis()
                             || schema.getLogicalType() == LogicalTypes.timestampMicros()) {
@@ -201,13 +206,9 @@ public class AvroSchemaConverter {
                         return Types.SQL_TIME;
                     }
                 } else {
-                    // Avro logical timestamp types to Flink DataStream timestamp types
                     if (schema.getLogicalType() == LogicalTypes.timestampMillis()
                             || schema.getLogicalType() == LogicalTypes.timestampMicros()) {
                         return Types.INSTANT;
-                    } else if (schema.getLogicalType() == LogicalTypes.localTimestampMillis()
-                            || schema.getLogicalType() == LogicalTypes.localTimestampMicros()) {
-                        return Types.LOCAL_DATE_TIME;
                     } else if (schema.getLogicalType() == LogicalTypes.timeMicros()
                             || schema.getLogicalType() == LogicalTypes.timeMillis()) {
                         return Types.SQL_TIME;

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroSchemaConverterLocalTimestampBehaviorTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroSchemaConverterLocalTimestampBehaviorTest.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.formats.avro.typeutils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
+import org.junit.jupiter.api.Test;
+
+class AvroSchemaConverterLocalTimestampBehaviorTest {
+
+    private static String record(String fieldName, String logicalType) {
+        return "{ \"type\": \"record\", \"name\": \"R\", \"fields\": ["
+                + "{ \"name\": \""
+                + fieldName
+                + "\", \"type\": { \"type\": \"long\", \"logicalType\": \""
+                + logicalType
+                + "\" } } ] }";
+    }
+
+    private static DataType firstFieldType(DataType row) {
+        RowType rowType = (RowType) row.getLogicalType();
+        return DataTypes.of(rowType.getTypeAt(0)).notNull();
+    }
+
+    @Test
+    void readTimestampMillisSingleArg() {
+        DataType dt = AvroSchemaConverter.convertToDataType(record("ts", "timestamp-millis"));
+        assertThat(firstFieldType(dt)).isEqualTo(DataTypes.TIMESTAMP(3).notNull());
+    }
+
+    @Test
+    void readTimestampMicrosSingleArg() {
+        DataType dt = AvroSchemaConverter.convertToDataType(record("ts", "timestamp-micros"));
+        assertThat(firstFieldType(dt)).isEqualTo(DataTypes.TIMESTAMP(6).notNull());
+    }
+
+    @Test
+    void readLocalTimestampMillisSingleArg() {
+        DataType dt =
+                AvroSchemaConverter.convertToDataType(record("ts", "local-timestamp-millis"));
+        assertThat(firstFieldType(dt)).isEqualTo(DataTypes.TIMESTAMP(3).notNull());
+    }
+
+    @Test
+    void readLocalTimestampMicrosSingleArg() {
+        DataType dt =
+                AvroSchemaConverter.convertToDataType(record("ts", "local-timestamp-micros"));
+        assertThat(firstFieldType(dt)).isEqualTo(DataTypes.TIMESTAMP(6).notNull());
+    }
+
+    @Test
+    void readTimestampMillisTwoArgLegacyFalse() {
+        DataType dt =
+                AvroSchemaConverter.convertToDataType(record("ts", "timestamp-millis"), false);
+        assertThat(firstFieldType(dt))
+                .isEqualTo(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).notNull());
+    }
+
+    @Test
+    void readLocalTimestampMillisTwoArgLegacyFalse() {
+        DataType dt =
+                AvroSchemaConverter.convertToDataType(
+                        record("ts", "local-timestamp-millis"), false);
+        assertThat(firstFieldType(dt)).isEqualTo(DataTypes.TIMESTAMP(3).notNull());
+    }
+
+    @Test
+    void readLocalTimestampMicrosTwoArgLegacyFalse() {
+        DataType dt =
+                AvroSchemaConverter.convertToDataType(
+                        record("ts", "local-timestamp-micros"), false);
+        assertThat(firstFieldType(dt)).isEqualTo(DataTypes.TIMESTAMP(6).notNull());
+    }
+
+    @Test
+    void readLocalTimestampMillisTwoArgLegacyTrue() {
+        DataType dt =
+                AvroSchemaConverter.convertToDataType(record("ts", "local-timestamp-millis"), true);
+        assertThat(firstFieldType(dt)).isEqualTo(DataTypes.TIMESTAMP(3).notNull());
+    }
+
+    @Test
+    void typeInfoLocalTimestampMicrosSingleArg() {
+        TypeInformation<?> ti =
+                AvroSchemaConverter.convertToTypeInfo(record("ts", "local-timestamp-micros"));
+        RowTypeInfoLike.assertFirstField(ti, Types.LOCAL_DATE_TIME);
+    }
+
+    @Test
+    void typeInfoLocalTimestampMicrosTwoArgLegacyFalse() {
+        TypeInformation<?> ti =
+                AvroSchemaConverter.convertToTypeInfo(
+                        record("ts", "local-timestamp-micros"), false);
+        RowTypeInfoLike.assertFirstField(ti, Types.LOCAL_DATE_TIME);
+    }
+
+    @Test
+    void typeInfoLocalTimestampMicrosTwoArgLegacyTrue() {
+        TypeInformation<?> ti =
+                AvroSchemaConverter.convertToTypeInfo(
+                        record("ts", "local-timestamp-micros"), true);
+        RowTypeInfoLike.assertFirstField(ti, Types.LOCAL_DATE_TIME);
+    }
+
+    @Test
+    void fieldGetterFromConvertedRowTypeAcceptsTimestampData() {
+        DataType dt =
+                AvroSchemaConverter.convertToDataType(record("ts", "local-timestamp-micros"));
+        RowType row = (RowType) dt.getLogicalType();
+        RowData.FieldGetter getter = RowData.createFieldGetter(row.getTypeAt(0), 0);
+        GenericRowData data = new GenericRowData(1);
+        data.setField(0, TimestampData.fromEpochMillis(0L));
+        assertThatCode(() -> getter.getFieldOrNull(data)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void roundTripTimestampMicrosTwoArgLegacyFalse() {
+        org.apache.avro.Schema schema =
+                AvroSchemaConverter.convertToSchema(
+                        DataTypes.ROW(DataTypes.FIELD("ts", DataTypes.TIMESTAMP(6).notNull()))
+                                .getLogicalType(),
+                        false);
+        DataType dt = AvroSchemaConverter.convertToDataType(schema.toString(), false);
+        assertThat(firstFieldType(dt)).isEqualTo(DataTypes.TIMESTAMP(6).notNull());
+    }
+
+    private static final class RowTypeInfoLike {
+        static void assertFirstField(TypeInformation<?> rowTypeInfo, TypeInformation<?> expected) {
+            assertThat(rowTypeInfo).isInstanceOf(org.apache.flink.api.java.typeutils.RowTypeInfo.class);
+            org.apache.flink.api.java.typeutils.RowTypeInfo r =
+                    (org.apache.flink.api.java.typeutils.RowTypeInfo) rowTypeInfo;
+            assertThat(r.getTypeAt(0)).isEqualTo(expected);
+        }
+    }
+}

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroSchemaConverterTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroSchemaConverterTest.java
@@ -671,8 +671,8 @@ class AvroSchemaConverterTest {
                         },
                         Types.SQL_TIMESTAMP,
                         Types.SQL_TIMESTAMP,
-                        Types.LONG,
-                        Types.LONG);
+                        Types.LOCAL_DATE_TIME,
+                        Types.LOCAL_DATE_TIME);
         final RowTypeInfo timestampsRowTypeInfo = (RowTypeInfo) timestamps;
         assertThat(timestampsRowTypeInfo.schemaEquals(actual)).isTrue();
     }
@@ -686,10 +686,10 @@ class AvroSchemaConverterTest {
                                         "type_timestamp_micros", DataTypes.TIMESTAMP(6).notNull()),
                                 DataTypes.FIELD(
                                         "type_local_timestamp_millis",
-                                        DataTypes.BIGINT().notNull()),
+                                        DataTypes.TIMESTAMP(3).notNull()),
                                 DataTypes.FIELD(
                                         "type_local_timestamp_micros",
-                                        DataTypes.BIGINT().notNull()))
+                                        DataTypes.TIMESTAMP(6).notNull()))
                         .notNull();
 
         assertThat(actual).isEqualTo(timestamps);


### PR DESCRIPTION

Fix [FLINK-39789](https://issues.apache.org/jira/browse/FLINK-39789).


## What is the purpose of the change


`AvroSchemaConverter.convertToDataType(String)` and `convertToTypeInfo(String)` — the only public Avro→Flink type-mapping entry points — silently dropped the logical type for `local-timestamp-millis` and `local-timestamp-micros` and returned `BIGINT` / `Long`, producing a Flink `RowType` that is incompatible with `TimestampData` at runtime.

The internal two-arg overloads contained branches for `local-timestamp-*`, but only on the `legacyTimestampMapping=false` arm. The single-arg public APIs hard-code `legacyTimestampMapping=true`, so those branches were unreachable from any public API.
## Brief change log

### Verifying this change

- `AvroSchemaConverter.convertToDataType(Schema, boolean)` — hoist `localTimestampMillis` / `localTimestampMicros` checks above the `legacyMapping` switch so they are honoured in both modes.
- `AvroSchemaConverter.convertToTypeInfo(Schema, boolean)` — identical hoist, mapping to `Types.LOCAL_DATE_TIME`.
- Add `AvroSchemaConverterLocalTimestampBehaviorTest` — 13 tests covering the single-arg public API, the two-arg overloads in both modes, the `convertToTypeInfo` mirror, the JIRA's exact runtime `ClassCastException` reproducer, and a round-trip sanity check.
- Update `AvroSchemaConverterTest.validateLegacyTimestampsSchema(...)` helpers — they previously hard-coded `Types.LONG` / `BIGINT` for `local_timestamp_*` (asserting the bug); now assert the spec-correct `Types.LOCAL_DATE_TIME` / `TIMESTAMP(p)`.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)no
  - The serializers: (yes / no / don't know)no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)no
  - The S3 file system connector: (yes / no / don't know)no

## Documentation

  - Does this pull request introduce a new feature? (yes / no)no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)no

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [x] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
