### PR TITLE
[FLINK-39799][table] Preserve user-typed query text for materialized table and view definitions

### DIFF
--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -1923,7 +1923,7 @@ SqlCreate SqlCreateOrAlterMaterializedTable(Span s, boolean replace, boolean isT
     SqlNode freshness = null;
     SqlRefreshMode refreshMode = null;
     SqlNode asQuery = null;
-    SqlParserPos asKeywordPos = null;
+    SqlParserPos asQueryKeywordPos = null;
     SqlParserPos pos = startPos;
     boolean isColumnsIdentifiersOnly = false;
     boolean isOrAlter = false;
@@ -2063,7 +2063,7 @@ SqlCreate SqlCreateOrAlterMaterializedTable(Span s, boolean replace, boolean isT
             }
         )
     ]
-    <AS> { asKeywordPos = getPos(); }
+    <AS> { asQueryKeywordPos = getPos(); }
     asQuery = OrderedQueryOrExpr(ExprContext.ACCEPT_QUERY)
     {
         final SqlCreateOrAlterMaterializedTable createMaterializedTable =
@@ -2082,7 +2082,7 @@ SqlCreate SqlCreateOrAlterMaterializedTable(Span s, boolean replace, boolean isT
                 startMode,
                 asQuery,
                 isOrAlter,
-                asKeywordPos);
+                asQueryKeywordPos);
         return createMaterializedTable;
     }
 }
@@ -2127,7 +2127,7 @@ SqlAlterMaterializedTable SqlAlterMaterializedTable() :
     SqlNodeList partSpec = SqlNodeList.EMPTY;
     SqlNode freshness = null;
     SqlNode asQuery = null;
-    SqlParserPos asKeywordPos = null;
+    SqlParserPos asQueryKeywordPos = null;
     SqlIdentifier constraintName;
     AlterTableSchemaContext ctx = new AlterTableSchemaContext();
 }
@@ -2208,7 +2208,7 @@ SqlAlterMaterializedTable SqlAlterMaterializedTable() :
                     propertyKeyList);
             }
         |
-        <AS> { asKeywordPos = getPos(); }
+        <AS> { asQueryKeywordPos = getPos(); }
             asQuery = OrderedQueryOrExpr(ExprContext.ACCEPT_QUERY)
             {
                 final SqlAlterMaterializedTableAsQuery alterMaterializedTableAsQuery =
@@ -2216,7 +2216,7 @@ SqlAlterMaterializedTable SqlAlterMaterializedTable() :
                         startPos.plus(getPos()),
                         tableIdentifier,
                         asQuery,
-                        asKeywordPos);
+                        asQueryKeywordPos);
                 return alterMaterializedTableAsQuery;
             }
         |
@@ -2435,7 +2435,7 @@ SqlCreate SqlCreateView(Span s, boolean replace, boolean isTemporary) : {
     SqlIdentifier viewName;
     SqlCharStringLiteral comment = null;
     SqlNode query;
-    SqlParserPos asKeywordPos = null;
+    SqlParserPos asQueryKeywordPos = null;
     SqlNodeList fieldList = SqlNodeList.EMPTY;
     boolean ifNotExists = false;
 }
@@ -2452,7 +2452,7 @@ SqlCreate SqlCreateView(Span s, boolean replace, boolean isTemporary) : {
             comment = Comment();
         }
     ]
-    <AS> { asKeywordPos = getPos(); }
+    <AS> { asQueryKeywordPos = getPos(); }
     query = OrderedQueryOrExpr(ExprContext.ACCEPT_QUERY)
     {
       final SqlCreateView createView =
@@ -2466,7 +2466,7 @@ SqlCreate SqlCreateView(Span s, boolean replace, boolean isTemporary) : {
                       ifNotExists,
                       comment,
                       null,
-                      asKeywordPos);
+                      asQueryKeywordPos);
         return createView;
     }
 }
@@ -2493,7 +2493,7 @@ SqlAlterView SqlAlterView() :
   SqlIdentifier viewName;
   SqlIdentifier newViewName;
   SqlNode newQuery;
-  SqlParserPos asKeywordPos = null;
+  SqlParserPos asQueryKeywordPos = null;
 }
 {
   <ALTER> <VIEW> { startPos = getPos(); }
@@ -2505,11 +2505,11 @@ SqlAlterView SqlAlterView() :
         return new SqlAlterViewRename(startPos.plus(getPos()), viewName, newViewName);
       }
   |
-      <AS> { asKeywordPos = getPos(); }
+      <AS> { asQueryKeywordPos = getPos(); }
       newQuery = OrderedQueryOrExpr(ExprContext.ACCEPT_QUERY)
       {
         final SqlAlterViewAs alterViewAs =
-                new SqlAlterViewAs(startPos.plus(getPos()), viewName, newQuery, asKeywordPos);
+                new SqlAlterViewAs(startPos.plus(getPos()), viewName, newQuery, asQueryKeywordPos);
         return alterViewAs;
       }
   )

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -1923,6 +1923,7 @@ SqlCreate SqlCreateOrAlterMaterializedTable(Span s, boolean replace, boolean isT
     SqlNode freshness = null;
     SqlRefreshMode refreshMode = null;
     SqlNode asQuery = null;
+    SqlParserPos asKeywordPos = null;
     SqlParserPos pos = startPos;
     boolean isColumnsIdentifiersOnly = false;
     boolean isOrAlter = false;
@@ -2062,24 +2063,27 @@ SqlCreate SqlCreateOrAlterMaterializedTable(Span s, boolean replace, boolean isT
             }
         )
     ]
-    <AS>
+    <AS> { asKeywordPos = getPos(); }
     asQuery = OrderedQueryOrExpr(ExprContext.ACCEPT_QUERY)
     {
-        return new SqlCreateOrAlterMaterializedTable(
-            startPos.plus(getPos()),
-            tableName,
-            columnList,
-            constraints,
-            watermark,
-            comment,
-            distribution,
-            partitionColumns,
-            propertyList,
-            (SqlIntervalLiteral) freshness,
-            refreshMode,
-            startMode,
-            asQuery,
-            isOrAlter);
+        final SqlCreateOrAlterMaterializedTable createMaterializedTable =
+            new SqlCreateOrAlterMaterializedTable(
+                startPos.plus(getPos()),
+                tableName,
+                columnList,
+                constraints,
+                watermark,
+                comment,
+                distribution,
+                partitionColumns,
+                propertyList,
+                (SqlIntervalLiteral) freshness,
+                refreshMode,
+                startMode,
+                asQuery,
+                isOrAlter,
+                asKeywordPos);
+        return createMaterializedTable;
     }
 }
 
@@ -2123,6 +2127,7 @@ SqlAlterMaterializedTable SqlAlterMaterializedTable() :
     SqlNodeList partSpec = SqlNodeList.EMPTY;
     SqlNode freshness = null;
     SqlNode asQuery = null;
+    SqlParserPos asKeywordPos = null;
     SqlIdentifier constraintName;
     AlterTableSchemaContext ctx = new AlterTableSchemaContext();
 }
@@ -2203,13 +2208,16 @@ SqlAlterMaterializedTable SqlAlterMaterializedTable() :
                     propertyKeyList);
             }
         |
-        <AS>
+        <AS> { asKeywordPos = getPos(); }
             asQuery = OrderedQueryOrExpr(ExprContext.ACCEPT_QUERY)
             {
-                return new SqlAlterMaterializedTableAsQuery(
-                    startPos.plus(getPos()),
-                    tableIdentifier,
-                    asQuery);
+                final SqlAlterMaterializedTableAsQuery alterMaterializedTableAsQuery =
+                    new SqlAlterMaterializedTableAsQuery(
+                        startPos.plus(getPos()),
+                        tableIdentifier,
+                        asQuery,
+                        asKeywordPos);
+                return alterMaterializedTableAsQuery;
             }
         |
         <ADD>
@@ -2427,6 +2435,7 @@ SqlCreate SqlCreateView(Span s, boolean replace, boolean isTemporary) : {
     SqlIdentifier viewName;
     SqlCharStringLiteral comment = null;
     SqlNode query;
+    SqlParserPos asKeywordPos = null;
     SqlNodeList fieldList = SqlNodeList.EMPTY;
     boolean ifNotExists = false;
 }
@@ -2443,10 +2452,22 @@ SqlCreate SqlCreateView(Span s, boolean replace, boolean isTemporary) : {
             comment = Comment();
         }
     ]
-    <AS>
+    <AS> { asKeywordPos = getPos(); }
     query = OrderedQueryOrExpr(ExprContext.ACCEPT_QUERY)
     {
-        return new SqlCreateView(s.pos(), viewName, fieldList, query, replace, isTemporary, ifNotExists, comment, null);
+      final SqlCreateView createView =
+              new SqlCreateView(
+                      s.pos(),
+                      viewName,
+                      fieldList,
+                      query,
+                      replace,
+                      isTemporary,
+                      ifNotExists,
+                      comment,
+                      null,
+                      asKeywordPos);
+        return createView;
     }
 }
 
@@ -2472,6 +2493,7 @@ SqlAlterView SqlAlterView() :
   SqlIdentifier viewName;
   SqlIdentifier newViewName;
   SqlNode newQuery;
+  SqlParserPos asKeywordPos = null;
 }
 {
   <ALTER> <VIEW> { startPos = getPos(); }
@@ -2483,10 +2505,12 @@ SqlAlterView SqlAlterView() :
         return new SqlAlterViewRename(startPos.plus(getPos()), viewName, newViewName);
       }
   |
-      <AS>
+      <AS> { asKeywordPos = getPos(); }
       newQuery = OrderedQueryOrExpr(ExprContext.ACCEPT_QUERY)
       {
-        return new SqlAlterViewAs(startPos.plus(getPos()), viewName, newQuery);
+        final SqlAlterViewAs alterViewAs =
+                new SqlAlterViewAs(startPos.plus(getPos()), viewName, newQuery, asKeywordPos);
+        return alterViewAs;
       }
   )
 }

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlAlterMaterializedTableAsQuery.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlAlterMaterializedTableAsQuery.java
@@ -26,8 +26,6 @@ import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.util.ImmutableNullableList;
 
-import javax.annotation.Nullable;
-
 import java.util.List;
 
 /**
@@ -38,20 +36,10 @@ public class SqlAlterMaterializedTableAsQuery extends SqlAlterMaterializedTable 
 
     private final SqlNode asQuery;
 
-    private final @Nullable SqlParserPos asKeywordPos;
+    private final SqlParserPos asKeywordPos;
 
     public SqlAlterMaterializedTableAsQuery(
-            SqlParserPos pos, SqlIdentifier tableName, SqlNode asQuery) {
-        super(pos, tableName);
-        this.asQuery = asQuery;
-        this.asKeywordPos = null;
-    }
-
-    public SqlAlterMaterializedTableAsQuery(
-            SqlParserPos pos,
-            SqlIdentifier tableName,
-            SqlNode asQuery,
-            @Nullable SqlParserPos asKeywordPos) {
+            SqlParserPos pos, SqlIdentifier tableName, SqlNode asQuery, SqlParserPos asKeywordPos) {
         super(pos, tableName);
         this.asQuery = asQuery;
         this.asKeywordPos = asKeywordPos;
@@ -61,8 +49,7 @@ public class SqlAlterMaterializedTableAsQuery extends SqlAlterMaterializedTable 
         return asQuery;
     }
 
-    /** Returns the parser position of the {@code AS} keyword, or {@code null} if not recorded. */
-    @Nullable
+    /** Returns the parser position of the {@code AS} keyword. */
     public SqlParserPos getAsKeywordPos() {
         return asKeywordPos;
     }

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlAlterMaterializedTableAsQuery.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlAlterMaterializedTableAsQuery.java
@@ -36,13 +36,16 @@ public class SqlAlterMaterializedTableAsQuery extends SqlAlterMaterializedTable 
 
     private final SqlNode asQuery;
 
-    private final SqlParserPos asKeywordPos;
+    private final SqlParserPos asQueryKeywordPos;
 
     public SqlAlterMaterializedTableAsQuery(
-            SqlParserPos pos, SqlIdentifier tableName, SqlNode asQuery, SqlParserPos asKeywordPos) {
+            SqlParserPos pos,
+            SqlIdentifier tableName,
+            SqlNode asQuery,
+            SqlParserPos asQueryKeywordPos) {
         super(pos, tableName);
         this.asQuery = asQuery;
-        this.asKeywordPos = asKeywordPos;
+        this.asQueryKeywordPos = asQueryKeywordPos;
     }
 
     public SqlNode getAsQuery() {
@@ -50,8 +53,8 @@ public class SqlAlterMaterializedTableAsQuery extends SqlAlterMaterializedTable 
     }
 
     /** Returns the parser position of the {@code AS} keyword. */
-    public SqlParserPos getAsKeywordPos() {
-        return asKeywordPos;
+    public SqlParserPos getAsQueryKeywordPos() {
+        return asQueryKeywordPos;
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlAlterMaterializedTableAsQuery.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlAlterMaterializedTableAsQuery.java
@@ -26,6 +26,8 @@ import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.util.ImmutableNullableList;
 
+import javax.annotation.Nullable;
+
 import java.util.List;
 
 /**
@@ -36,14 +38,33 @@ public class SqlAlterMaterializedTableAsQuery extends SqlAlterMaterializedTable 
 
     private final SqlNode asQuery;
 
+    private final @Nullable SqlParserPos asKeywordPos;
+
     public SqlAlterMaterializedTableAsQuery(
             SqlParserPos pos, SqlIdentifier tableName, SqlNode asQuery) {
         super(pos, tableName);
         this.asQuery = asQuery;
+        this.asKeywordPos = null;
+    }
+
+    public SqlAlterMaterializedTableAsQuery(
+            SqlParserPos pos,
+            SqlIdentifier tableName,
+            SqlNode asQuery,
+            @Nullable SqlParserPos asKeywordPos) {
+        super(pos, tableName);
+        this.asQuery = asQuery;
+        this.asKeywordPos = asKeywordPos;
     }
 
     public SqlNode getAsQuery() {
         return asQuery;
+    }
+
+    /** Returns the parser position of the {@code AS} keyword, or {@code null} if not recorded. */
+    @Nullable
+    public SqlParserPos getAsKeywordPos() {
+        return asKeywordPos;
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlCreateMaterializedTable.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlCreateMaterializedTable.java
@@ -71,6 +71,8 @@ public class SqlCreateMaterializedTable extends SqlCreateObject implements Exten
 
     private final SqlNode asQuery;
 
+    private final SqlParserPos asKeywordPos;
+
     public SqlCreateMaterializedTable(
             SqlSpecialOperator operator,
             SqlParserPos pos,
@@ -85,7 +87,8 @@ public class SqlCreateMaterializedTable extends SqlCreateObject implements Exten
             @Nullable SqlIntervalLiteral freshness,
             @Nullable SqlRefreshMode refreshMode,
             @Nullable SqlStartMode startMode,
-            SqlNode asQuery) {
+            SqlNode asQuery,
+            SqlParserPos asKeywordPos) {
         super(operator, pos, tableName, false, false, false, propertyList, comment);
         this.columnList = columnList;
         this.tableConstraints = tableConstraints;
@@ -98,6 +101,7 @@ public class SqlCreateMaterializedTable extends SqlCreateObject implements Exten
         this.refreshMode = refreshMode;
         this.startMode = startMode;
         this.asQuery = requireNonNull(asQuery, "asQuery should not be null");
+        this.asKeywordPos = asKeywordPos;
     }
 
     @Override
@@ -151,6 +155,11 @@ public class SqlCreateMaterializedTable extends SqlCreateObject implements Exten
 
     public SqlNode getAsQuery() {
         return asQuery;
+    }
+
+    /** Returns the parser position of the {@code AS} keyword. */
+    public SqlParserPos getAsKeywordPos() {
+        return asKeywordPos;
     }
 
     /** Returns the column constraints plus the table constraints. */

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlCreateMaterializedTable.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlCreateMaterializedTable.java
@@ -71,7 +71,7 @@ public class SqlCreateMaterializedTable extends SqlCreateObject implements Exten
 
     private final SqlNode asQuery;
 
-    private final SqlParserPos asKeywordPos;
+    private final SqlParserPos asQueryKeywordPos;
 
     public SqlCreateMaterializedTable(
             SqlSpecialOperator operator,
@@ -88,7 +88,7 @@ public class SqlCreateMaterializedTable extends SqlCreateObject implements Exten
             @Nullable SqlRefreshMode refreshMode,
             @Nullable SqlStartMode startMode,
             SqlNode asQuery,
-            SqlParserPos asKeywordPos) {
+            SqlParserPos asQueryKeywordPos) {
         super(operator, pos, tableName, false, false, false, propertyList, comment);
         this.columnList = columnList;
         this.tableConstraints = tableConstraints;
@@ -101,7 +101,7 @@ public class SqlCreateMaterializedTable extends SqlCreateObject implements Exten
         this.refreshMode = refreshMode;
         this.startMode = startMode;
         this.asQuery = requireNonNull(asQuery, "asQuery should not be null");
-        this.asKeywordPos = asKeywordPos;
+        this.asQueryKeywordPos = asQueryKeywordPos;
     }
 
     @Override
@@ -158,8 +158,8 @@ public class SqlCreateMaterializedTable extends SqlCreateObject implements Exten
     }
 
     /** Returns the parser position of the {@code AS} keyword. */
-    public SqlParserPos getAsKeywordPos() {
-        return asKeywordPos;
+    public SqlParserPos getAsQueryKeywordPos() {
+        return asQueryKeywordPos;
     }
 
     /** Returns the column constraints plus the table constraints. */

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlCreateOrAlterMaterializedTable.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlCreateOrAlterMaterializedTable.java
@@ -57,7 +57,8 @@ public class SqlCreateOrAlterMaterializedTable extends SqlCreateMaterializedTabl
             @Nullable SqlRefreshMode refreshMode,
             @Nullable SqlStartMode startMode,
             SqlNode asQuery,
-            boolean isOrAlter) {
+            boolean isOrAlter,
+            SqlParserPos asKeywordPos) {
         super(
                 isOrAlter ? CREATE_OR_ALTER_OPERATOR : CREATE_OPERATOR,
                 pos,
@@ -72,7 +73,8 @@ public class SqlCreateOrAlterMaterializedTable extends SqlCreateMaterializedTabl
                 freshness,
                 refreshMode,
                 startMode,
-                asQuery);
+                asQuery,
+                asKeywordPos);
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlCreateOrAlterMaterializedTable.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlCreateOrAlterMaterializedTable.java
@@ -58,7 +58,7 @@ public class SqlCreateOrAlterMaterializedTable extends SqlCreateMaterializedTabl
             @Nullable SqlStartMode startMode,
             SqlNode asQuery,
             boolean isOrAlter,
-            SqlParserPos asKeywordPos) {
+            SqlParserPos asQueryKeywordPos) {
         super(
                 isOrAlter ? CREATE_OR_ALTER_OPERATOR : CREATE_OPERATOR,
                 pos,
@@ -74,7 +74,7 @@ public class SqlCreateOrAlterMaterializedTable extends SqlCreateMaterializedTabl
                 refreshMode,
                 startMode,
                 asQuery,
-                asKeywordPos);
+                asQueryKeywordPos);
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/view/SqlAlterViewAs.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/view/SqlAlterViewAs.java
@@ -27,7 +27,6 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.util.ImmutableNullableList;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 import java.util.List;
 
@@ -36,13 +35,13 @@ public class SqlAlterViewAs extends SqlAlterView {
 
     private final SqlNode newQuery;
 
-    private final @Nullable SqlParserPos asKeywordPos;
+    private final SqlParserPos asKeywordPos;
 
     public SqlAlterViewAs(
             SqlParserPos pos,
             SqlIdentifier viewIdentifier,
             SqlNode newQuery,
-            @Nullable SqlParserPos asKeywordPos) {
+            SqlParserPos asKeywordPos) {
         super(pos, viewIdentifier);
         this.newQuery = newQuery;
         this.asKeywordPos = asKeywordPos;
@@ -64,7 +63,7 @@ public class SqlAlterViewAs extends SqlAlterView {
         return newQuery;
     }
 
-    @Nullable
+    /** Returns the parser position of the {@code AS} keyword. */
     public SqlParserPos getAsKeywordPos() {
         return asKeywordPos;
     }

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/view/SqlAlterViewAs.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/view/SqlAlterViewAs.java
@@ -35,16 +35,16 @@ public class SqlAlterViewAs extends SqlAlterView {
 
     private final SqlNode newQuery;
 
-    private final SqlParserPos asKeywordPos;
+    private final SqlParserPos asQueryKeywordPos;
 
     public SqlAlterViewAs(
             SqlParserPos pos,
             SqlIdentifier viewIdentifier,
             SqlNode newQuery,
-            SqlParserPos asKeywordPos) {
+            SqlParserPos asQueryKeywordPos) {
         super(pos, viewIdentifier);
         this.newQuery = newQuery;
-        this.asKeywordPos = asKeywordPos;
+        this.asQueryKeywordPos = asQueryKeywordPos;
     }
 
     @Nonnull
@@ -64,7 +64,7 @@ public class SqlAlterViewAs extends SqlAlterView {
     }
 
     /** Returns the parser position of the {@code AS} keyword. */
-    public SqlParserPos getAsKeywordPos() {
-        return asKeywordPos;
+    public SqlParserPos getAsQueryKeywordPos() {
+        return asQueryKeywordPos;
     }
 }

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/view/SqlAlterViewAs.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/view/SqlAlterViewAs.java
@@ -27,6 +27,7 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.util.ImmutableNullableList;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import java.util.List;
 
@@ -35,9 +36,16 @@ public class SqlAlterViewAs extends SqlAlterView {
 
     private final SqlNode newQuery;
 
-    public SqlAlterViewAs(SqlParserPos pos, SqlIdentifier viewIdentifier, SqlNode newQuery) {
+    private final @Nullable SqlParserPos asKeywordPos;
+
+    public SqlAlterViewAs(
+            SqlParserPos pos,
+            SqlIdentifier viewIdentifier,
+            SqlNode newQuery,
+            @Nullable SqlParserPos asKeywordPos) {
         super(pos, viewIdentifier);
         this.newQuery = newQuery;
+        this.asKeywordPos = asKeywordPos;
     }
 
     @Nonnull
@@ -54,5 +62,10 @@ public class SqlAlterViewAs extends SqlAlterView {
 
     public SqlNode getNewQuery() {
         return newQuery;
+    }
+
+    @Nullable
+    public SqlParserPos getAsKeywordPos() {
+        return asKeywordPos;
     }
 }

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/view/SqlCreateView.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/view/SqlCreateView.java
@@ -43,7 +43,7 @@ public class SqlCreateView extends SqlCreateObject {
 
     private final SqlNodeList fieldList;
     private final SqlNode query;
-    private final SqlParserPos asKeywordPos;
+    private final SqlParserPos asQueryKeywordPos;
 
     public SqlCreateView(
             SqlParserPos pos,
@@ -55,11 +55,11 @@ public class SqlCreateView extends SqlCreateObject {
             boolean ifNotExists,
             SqlCharStringLiteral comment,
             SqlNodeList properties,
-            SqlParserPos asKeywordPos) {
+            SqlParserPos asQueryKeywordPos) {
         super(OPERATOR, pos, viewName, isTemporary, replace, ifNotExists, properties, comment);
         this.fieldList = requireNonNull(fieldList, "fieldList should not be null");
         this.query = requireNonNull(query, "query should not be null");
-        this.asKeywordPos = asKeywordPos;
+        this.asQueryKeywordPos = asQueryKeywordPos;
     }
 
     @Override
@@ -81,8 +81,8 @@ public class SqlCreateView extends SqlCreateObject {
     }
 
     /** Returns the parser position of the {@code AS} keyword. */
-    public SqlParserPos getAsKeywordPos() {
-        return asKeywordPos;
+    public SqlParserPos getAsQueryKeywordPos() {
+        return asQueryKeywordPos;
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/view/SqlCreateView.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/view/SqlCreateView.java
@@ -31,6 +31,8 @@ import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 
+import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -44,6 +46,8 @@ public class SqlCreateView extends SqlCreateObject {
     private final SqlNodeList fieldList;
     private final SqlNode query;
 
+    private final SqlParserPos asKeywordPos;
+
     public SqlCreateView(
             SqlParserPos pos,
             SqlIdentifier viewName,
@@ -53,10 +57,12 @@ public class SqlCreateView extends SqlCreateObject {
             boolean isTemporary,
             boolean ifNotExists,
             SqlCharStringLiteral comment,
-            SqlNodeList properties) {
+            SqlNodeList properties,
+            SqlParserPos asKeywordPos) {
         super(OPERATOR, pos, viewName, isTemporary, replace, ifNotExists, properties, comment);
         this.fieldList = requireNonNull(fieldList, "fieldList should not be null");
         this.query = requireNonNull(query, "query should not be null");
+        this.asKeywordPos = asKeywordPos;
     }
 
     @Override
@@ -75,6 +81,12 @@ public class SqlCreateView extends SqlCreateObject {
 
     public SqlNode getQuery() {
         return query;
+    }
+
+    /** Returns the parser position of the {@code AS} keyword, or {@code null} if not recorded. */
+    @Nullable
+    public SqlParserPos getAsKeywordPos() {
+        return asKeywordPos;
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/view/SqlCreateView.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/view/SqlCreateView.java
@@ -31,8 +31,6 @@ import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 
-import javax.annotation.Nullable;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -45,7 +43,6 @@ public class SqlCreateView extends SqlCreateObject {
 
     private final SqlNodeList fieldList;
     private final SqlNode query;
-
     private final SqlParserPos asKeywordPos;
 
     public SqlCreateView(
@@ -83,8 +80,7 @@ public class SqlCreateView extends SqlCreateObject {
         return query;
     }
 
-    /** Returns the parser position of the {@code AS} keyword, or {@code null} if not recorded. */
-    @Nullable
+    /** Returns the parser position of the {@code AS} keyword. */
     public SqlParserPos getAsKeywordPos() {
         return asKeywordPos;
     }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/delegation/ParserImpl.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/delegation/ParserImpl.java
@@ -103,7 +103,8 @@ public class ParserImpl implements Parser {
         List<SqlNode> parsed = sqlNodeList.getList();
         Preconditions.checkArgument(parsed.size() == 1, "only single statement supported");
         return Collections.singletonList(
-                SqlNodeToOperationConversion.convert(planner, catalogManager, parsed.get(0))
+                SqlNodeToOperationConversion.convert(
+                                planner, catalogManager, parsed.get(0), statement)
                         .orElseThrow(() -> new TableException("Unsupported query: " + statement)));
     }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeConvertContext.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeConvertContext.java
@@ -51,10 +51,15 @@ public class SqlNodeConvertContext implements SqlNodeConverter.ConvertContext {
 
     private final FlinkPlannerImpl flinkPlanner;
     private final CatalogManager catalogManager;
+    private final @Nullable String statement;
 
-    public SqlNodeConvertContext(FlinkPlannerImpl flinkPlanner, CatalogManager catalogManager) {
+    public SqlNodeConvertContext(
+            FlinkPlannerImpl flinkPlanner,
+            CatalogManager catalogManager,
+            @Nullable String statement) {
         this.flinkPlanner = flinkPlanner;
         this.catalogManager = catalogManager;
+        this.statement = statement;
     }
 
     @Override
@@ -108,6 +113,12 @@ public class SqlNodeConvertContext implements SqlNodeConverter.ConvertContext {
     @Override
     public String toQuotedSqlString(SqlNode sqlNode) {
         return sqlNode.toSqlString(getSqlDialect()).getSql();
+    }
+
+    @Override
+    @Nullable
+    public String getStatementText() {
+        return this.statement;
     }
 
     private SqlDialect getSqlDialect() {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeConvertContext.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeConvertContext.java
@@ -51,15 +51,15 @@ public class SqlNodeConvertContext implements SqlNodeConverter.ConvertContext {
 
     private final FlinkPlannerImpl flinkPlanner;
     private final CatalogManager catalogManager;
-    private final @Nullable String statement;
+    private final @Nullable String originalSql;
 
     public SqlNodeConvertContext(
             FlinkPlannerImpl flinkPlanner,
             CatalogManager catalogManager,
-            @Nullable String statement) {
+            @Nullable String originalSql) {
         this.flinkPlanner = flinkPlanner;
         this.catalogManager = catalogManager;
-        this.statement = statement;
+        this.originalSql = originalSql;
     }
 
     @Override
@@ -118,7 +118,7 @@ public class SqlNodeConvertContext implements SqlNodeConverter.ConvertContext {
     @Override
     @Nullable
     public String getStatementText() {
-        return this.statement;
+        return this.originalSql;
     }
 
     private SqlDialect getSqlDialect() {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeToOperationConversion.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeToOperationConversion.java
@@ -151,17 +151,17 @@ import java.util.stream.Collectors;
 public class SqlNodeToOperationConversion {
     private final FlinkPlannerImpl flinkPlanner;
     private final CatalogManager catalogManager;
-    @Nullable private final String statement;
+    @Nullable private final String originalSql;
 
     // ~ Constructors -----------------------------------------------------------
 
     private SqlNodeToOperationConversion(
             FlinkPlannerImpl flinkPlanner,
             CatalogManager catalogManager,
-            @Nullable String statement) {
+            @Nullable String originalSql) {
         this.flinkPlanner = flinkPlanner;
         this.catalogManager = catalogManager;
-        this.statement = statement;
+        this.originalSql = originalSql;
     }
 
     /**
@@ -172,16 +172,16 @@ public class SqlNodeToOperationConversion {
      * @param flinkPlanner FlinkPlannerImpl to convertCreateTable sql node to rel node
      * @param catalogManager CatalogManager to resolve full path for operations
      * @param sqlNode SqlNode to execute on
-     * @param statement original SQL statement text, or {@code null} when the node has no source
+     * @param originalSql original SQL statement text, or {@code null} when the node has no source
      *     text (e.g. a synthesized node)
      */
     public static Optional<Operation> convert(
             FlinkPlannerImpl flinkPlanner,
             CatalogManager catalogManager,
             SqlNode sqlNode,
-            @Nullable String statement) {
+            @Nullable String originalSql) {
         final SqlNode validated = flinkPlanner.validate(sqlNode);
-        return convertValidatedSqlNode(flinkPlanner, catalogManager, validated, statement);
+        return convertValidatedSqlNode(flinkPlanner, catalogManager, validated, originalSql);
     }
 
     /**
@@ -303,7 +303,7 @@ public class SqlNodeToOperationConversion {
     }
 
     private Operation convertValidatedSqlNodeOrFail(SqlNode validated) {
-        return convertValidatedSqlNode(flinkPlanner, catalogManager, validated, statement)
+        return convertValidatedSqlNode(flinkPlanner, catalogManager, validated, originalSql)
                 .orElseThrow(
                         () ->
                                 new TableException(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeToOperationConversion.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeToOperationConversion.java
@@ -151,13 +151,17 @@ import java.util.stream.Collectors;
 public class SqlNodeToOperationConversion {
     private final FlinkPlannerImpl flinkPlanner;
     private final CatalogManager catalogManager;
+    @Nullable private final String statement;
 
     // ~ Constructors -----------------------------------------------------------
 
     private SqlNodeToOperationConversion(
-            FlinkPlannerImpl flinkPlanner, CatalogManager catalogManager) {
+            FlinkPlannerImpl flinkPlanner,
+            CatalogManager catalogManager,
+            @Nullable String statement) {
         this.flinkPlanner = flinkPlanner;
         this.catalogManager = catalogManager;
+        this.statement = statement;
     }
 
     /**
@@ -168,21 +172,39 @@ public class SqlNodeToOperationConversion {
      * @param flinkPlanner FlinkPlannerImpl to convertCreateTable sql node to rel node
      * @param catalogManager CatalogManager to resolve full path for operations
      * @param sqlNode SqlNode to execute on
+     * @param statement original SQL statement text, or {@code null} when the node has no source
+     *     text (e.g. a synthesized node)
+     */
+    public static Optional<Operation> convert(
+            FlinkPlannerImpl flinkPlanner,
+            CatalogManager catalogManager,
+            SqlNode sqlNode,
+            @Nullable String statement) {
+        final SqlNode validated = flinkPlanner.validate(sqlNode);
+        return convertValidatedSqlNode(flinkPlanner, catalogManager, validated, statement);
+    }
+
+    /**
+     * Converts the given {@link SqlNode} without an original statement text. Used for nested
+     * conversions where the node was reached recursively (e.g. the {@code AS} query of {@code
+     * CREATE TABLE AS}) and the verbatim source text is neither available nor needed.
      */
     public static Optional<Operation> convert(
             FlinkPlannerImpl flinkPlanner, CatalogManager catalogManager, SqlNode sqlNode) {
-        // validate the query
-        final SqlNode validated = flinkPlanner.validate(sqlNode);
-        return convertValidatedSqlNode(flinkPlanner, catalogManager, validated);
+        return convert(flinkPlanner, catalogManager, sqlNode, null);
     }
 
     /** Convert a validated sql node to Operation. */
     private static Optional<Operation> convertValidatedSqlNode(
-            FlinkPlannerImpl flinkPlanner, CatalogManager catalogManager, SqlNode validated) {
+            FlinkPlannerImpl flinkPlanner,
+            CatalogManager catalogManager,
+            SqlNode validated,
+            @Nullable String statement) {
         beforeConversion();
 
         // delegate conversion to the registered converters first
-        SqlNodeConvertContext context = new SqlNodeConvertContext(flinkPlanner, catalogManager);
+        SqlNodeConvertContext context =
+                new SqlNodeConvertContext(flinkPlanner, catalogManager, statement);
         Optional<Operation> operation = SqlNodeConverters.convertSqlNode(validated, context);
         if (operation.isPresent()) {
             return operation;
@@ -190,7 +212,7 @@ public class SqlNodeToOperationConversion {
 
         // TODO: all the below conversion logic should be migrated to SqlNodeConverters
         SqlNodeToOperationConversion converter =
-                new SqlNodeToOperationConversion(flinkPlanner, catalogManager);
+                new SqlNodeToOperationConversion(flinkPlanner, catalogManager, statement);
         if (validated instanceof SqlDropCatalog) {
             return Optional.of(converter.convertDropCatalog((SqlDropCatalog) validated));
         } else if (validated instanceof SqlLoadModule) {
@@ -258,7 +280,10 @@ public class SqlNodeToOperationConversion {
             return Optional.of(converter.convertSqlStatementSet((SqlStatementSet) validated));
         } else if (validated instanceof SqlExecute) {
             return convertValidatedSqlNode(
-                    flinkPlanner, catalogManager, ((SqlExecute) validated).getStatement());
+                    flinkPlanner,
+                    catalogManager,
+                    ((SqlExecute) validated).getStatement(),
+                    statement);
         } else if (validated instanceof SqlExecutePlan) {
             return Optional.of(converter.convertExecutePlan((SqlExecutePlan) validated));
         } else if (validated instanceof SqlCompilePlan) {
@@ -277,9 +302,8 @@ public class SqlNodeToOperationConversion {
         }
     }
 
-    private static Operation convertValidatedSqlNodeOrFail(
-            FlinkPlannerImpl flinkPlanner, CatalogManager catalogManager, SqlNode validated) {
-        return convertValidatedSqlNode(flinkPlanner, catalogManager, validated)
+    private Operation convertValidatedSqlNodeOrFail(SqlNode validated) {
+        return convertValidatedSqlNode(flinkPlanner, catalogManager, validated, statement)
                 .orElseThrow(
                         () ->
                                 new TableException(
@@ -330,9 +354,7 @@ public class SqlNodeToOperationConversion {
                 catalogManager.getTableOrError(identifier).toCatalogTable();
 
         PlannerQueryOperation query =
-                (PlannerQueryOperation)
-                        convertValidatedSqlNodeOrFail(
-                                flinkPlanner, catalogManager, insert.getSource());
+                (PlannerQueryOperation) convertValidatedSqlNodeOrFail(insert.getSource());
         // TODO calc target column list to index array, currently only simple SqlIdentifiers are
         // available, this should be updated after FLINK-31301 fixed
         int[][] columnIndices =
@@ -650,17 +672,13 @@ public class SqlNodeToOperationConversion {
         return new CompilePlanOperation(
                 compilePlan.getPlanFile(),
                 compilePlan.isIfNotExists(),
-                convertValidatedSqlNodeOrFail(
-                        flinkPlanner, catalogManager, compilePlan.getOperandList().get(0)));
+                convertValidatedSqlNodeOrFail(compilePlan.getOperandList().get(0)));
     }
 
     private Operation convertCompileAndExecutePlan(SqlCompileAndExecutePlan compileAndExecutePlan) {
         return new CompileAndExecutePlanOperation(
                 compileAndExecutePlan.getPlanFile(),
-                convertValidatedSqlNodeOrFail(
-                        flinkPlanner,
-                        catalogManager,
-                        compileAndExecutePlan.getOperandList().get(0)));
+                convertValidatedSqlNodeOrFail(compileAndExecutePlan.getOperandList().get(0)));
     }
 
     private Operation convertShowJobs(SqlShowJobs sqlStopJob) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlAlterViewAsConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlAlterViewAsConverter.java
@@ -46,6 +46,7 @@ public class SqlAlterViewAsConverter implements SqlNodeConverter<SqlAlterViewAs>
         CatalogView newView =
                 toCatalogView(
                         newQuery,
+                        alterView.getAsKeywordPos(),
                         Collections.emptyList(),
                         oldView.getOptions(),
                         oldView.getComment(),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlAlterViewAsConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlAlterViewAsConverter.java
@@ -46,7 +46,7 @@ public class SqlAlterViewAsConverter implements SqlNodeConverter<SqlAlterViewAs>
         CatalogView newView =
                 toCatalogView(
                         newQuery,
-                        alterView.getAsKeywordPos(),
+                        alterView.getAsQueryKeywordPos(),
                         Collections.emptyList(),
                         oldView.getOptions(),
                         oldView.getComment(),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlCreateViewConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlCreateViewConverter.java
@@ -47,7 +47,12 @@ public class SqlCreateViewConverter implements SqlNodeConverter<SqlCreateView> {
         Map<String, String> viewOptions = sqlCreateView.getProperties();
         CatalogView catalogView =
                 SqlNodeConvertUtils.toCatalogView(
-                        query, viewFields, viewOptions, viewComment, context);
+                        query,
+                        sqlCreateView.getAsKeywordPos(),
+                        viewFields,
+                        viewOptions,
+                        viewComment,
+                        context);
         return new CreateViewOperation(
                 identifier,
                 catalogView,

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlCreateViewConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlCreateViewConverter.java
@@ -48,7 +48,7 @@ public class SqlCreateViewConverter implements SqlNodeConverter<SqlCreateView> {
         CatalogView catalogView =
                 SqlNodeConvertUtils.toCatalogView(
                         query,
-                        sqlCreateView.getAsKeywordPos(),
+                        sqlCreateView.getAsQueryKeywordPos(),
                         viewFields,
                         viewOptions,
                         viewComment,

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConvertUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConvertUtils.java
@@ -60,18 +60,18 @@ import java.util.stream.Collectors;
 public class SqlNodeConvertUtils {
 
     /**
-     * Returns the {@code AS}-query verbatim: the statement text from just after {@code AS} to its
-     * end, trimmed. Slicing to the statement end (the {@code AS}-query is the last clause) keeps a
-     * comment after {@code AS} and queries whose node position is narrower than their text, e.g.
-     * {@code WITH ... SELECT}.
+     * Returns the {@code AS}-query of a VIEW or MATERIALIZED TABLE DDL in verbatim shape: the
+     * statement text from just after {@code AS} to its end, trimmed. Slicing to the statement end
+     * (the {@code AS}-query is the last clause) keeps a comment after {@code AS} and queries whose
+     * node position is narrower than their text, e.g. {@code WITH ... SELECT}.
      *
      * @param asKeywordPos parser position of the {@code AS} keyword
      * @return the verbatim AS-query, or empty when no statement text is available
      */
-    public static Optional<String> originalAsQueryText(
-            ConvertContext context, @Nullable SqlParserPos asKeywordPos) {
+    public static Optional<String> extractOriginalAsQueryText(
+            ConvertContext context, SqlParserPos asKeywordPos) {
         final String statementText = context.getStatementText();
-        if (asKeywordPos == null || statementText == null) {
+        if (statementText == null) {
             return Optional.empty();
         }
         return offsetAfter(statementText, asKeywordPos).stream()
@@ -111,7 +111,7 @@ public class SqlNodeConvertUtils {
     /** convert the query part of a VIEW statement into a {@link CatalogView}. */
     static CatalogView toCatalogView(
             SqlNode query,
-            @Nullable SqlParserPos asKeywordPos,
+            SqlParserPos asKeywordPos,
             List<SqlNode> viewFields,
             Map<String, String> viewOptions,
             String viewComment,
@@ -151,7 +151,8 @@ public class SqlNodeConvertUtils {
         }
 
         final String originalQuery =
-                originalAsQueryText(context, asKeywordPos).orElse(context.toQuotedSqlString(query));
+                extractOriginalAsQueryText(context, asKeywordPos)
+                        .orElse(context.toQuotedSqlString(query));
 
         return new ResolvedCatalogView(
                 CatalogView.of(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConvertUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConvertUtils.java
@@ -34,6 +34,8 @@ import org.apache.flink.table.operations.utils.ValidationUtils;
 import org.apache.flink.table.planner.operations.PlannerQueryOperation;
 import org.apache.flink.table.planner.operations.converters.SqlNodeConverter.ConvertContext;
 
+import org.apache.flink.shaded.guava33.com.google.common.base.Splitter;
+
 import org.apache.calcite.rel.RelRoot;
 import org.apache.calcite.sql.SqlBasicCall;
 import org.apache.calcite.sql.SqlNode;
@@ -46,14 +48,58 @@ import org.apache.calcite.sql.validate.SqlValidatorNamespace;
 import javax.annotation.Nullable;
 
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.stream.Collectors;
 
 /** Utilities for SqlNode conversions. */
-class SqlNodeConvertUtils {
+public class SqlNodeConvertUtils {
+
+    /**
+     * Returns the {@code AS}-query verbatim: the statement text from just after {@code AS} to its
+     * end, trimmed. Slicing to the statement end (the {@code AS}-query is the last clause) keeps a
+     * comment after {@code AS} and queries whose node position is narrower than their text, e.g.
+     * {@code WITH ... SELECT}.
+     *
+     * @param asKeywordPos parser position of the {@code AS} keyword
+     * @return the verbatim AS-query, or empty when no statement text is available
+     */
+    public static Optional<String> originalAsQueryText(
+            ConvertContext context, @Nullable SqlParserPos asKeywordPos) {
+        final String statementText = context.getStatementText();
+        if (asKeywordPos == null || statementText == null) {
+            return Optional.empty();
+        }
+        return offsetAfter(statementText, asKeywordPos).stream()
+                .mapToObj(start -> statementText.substring(start).strip())
+                .findFirst();
+    }
+
+    /**
+     * Returns the offset of the first character after the given parser position, or empty if the
+     * position's end line falls outside {@code statementText}.
+     */
+    private static OptionalInt offsetAfter(String statementText, SqlParserPos pos) {
+        final int endLine = pos.getEndLineNum();
+        final int endCol = pos.getEndColumnNum();
+
+        final Iterator<String> iterator = Splitter.on('\n').split(statementText).iterator();
+        int currentLine = 0;
+        int lineStartOffset = 0;
+        while (iterator.hasNext()) {
+            final String lineText = iterator.next();
+            currentLine++;
+            if (currentLine == endLine) {
+                return OptionalInt.of(lineStartOffset + endCol);
+            }
+            lineStartOffset += lineText.length() + 1;
+        }
+        return OptionalInt.empty();
+    }
 
     static PlannerQueryOperation toQueryOperation(SqlNode validated, ConvertContext context) {
         // transform to a relational tree
@@ -65,17 +111,11 @@ class SqlNodeConvertUtils {
     /** convert the query part of a VIEW statement into a {@link CatalogView}. */
     static CatalogView toCatalogView(
             SqlNode query,
+            @Nullable SqlParserPos asKeywordPos,
             List<SqlNode> viewFields,
             Map<String, String> viewOptions,
             String viewComment,
             ConvertContext context) {
-        // Put the sql string unparse (getQuotedSqlString()) in front of
-        // the node conversion (toQueryOperation()),
-        // because before Calcite 1.22.0, during sql-to-rel conversion, the SqlWindow
-        // bounds state would be mutated as default when they are null (not specified).
-
-        // This bug is fixed in CALCITE-3877 of Calcite 1.23.0.
-        String originalQuery = context.toQuotedSqlString(query);
         SqlNode validateQuery = context.getSqlValidator().validate(query);
         // FLINK-38950: SqlValidator.validate() mutates its input parameter. Always use the
         // returned validateQuery instead of the mutated query for all subsequent operations.
@@ -109,6 +149,9 @@ class SqlNodeConvertUtils {
 
             schema = ResolvedSchema.physical(aliasFieldNames, schema.getColumnDataTypes());
         }
+
+        final String originalQuery =
+                originalAsQueryText(context, asKeywordPos).orElse(context.toQuotedSqlString(query));
 
         return new ResolvedCatalogView(
                 CatalogView.of(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConvertUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConvertUtils.java
@@ -65,16 +65,16 @@ public class SqlNodeConvertUtils {
      * (the {@code AS}-query is the last clause) keeps a comment after {@code AS} and queries whose
      * node position is narrower than their text, e.g. {@code WITH ... SELECT}.
      *
-     * @param asKeywordPos parser position of the {@code AS} keyword
+     * @param asQueryKeywordPos parser position of the {@code AS} keyword
      * @return the verbatim AS-query, or empty when no statement text is available
      */
     public static Optional<String> extractOriginalAsQueryText(
-            ConvertContext context, SqlParserPos asKeywordPos) {
+            ConvertContext context, SqlParserPos asQueryKeywordPos) {
         final String statementText = context.getStatementText();
         if (statementText == null) {
             return Optional.empty();
         }
-        return offsetAfter(statementText, asKeywordPos).stream()
+        return offsetAfter(statementText, asQueryKeywordPos).stream()
                 .mapToObj(start -> statementText.substring(start).strip())
                 .findFirst();
     }
@@ -111,7 +111,7 @@ public class SqlNodeConvertUtils {
     /** convert the query part of a VIEW statement into a {@link CatalogView}. */
     static CatalogView toCatalogView(
             SqlNode query,
-            SqlParserPos asKeywordPos,
+            SqlParserPos asQueryKeywordPos,
             List<SqlNode> viewFields,
             Map<String, String> viewOptions,
             String viewComment,
@@ -151,7 +151,7 @@ public class SqlNodeConvertUtils {
         }
 
         final String originalQuery =
-                extractOriginalAsQueryText(context, asKeywordPos)
+                extractOriginalAsQueryText(context, asQueryKeywordPos)
                         .orElse(context.toQuotedSqlString(query));
 
         return new ResolvedCatalogView(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverter.java
@@ -101,6 +101,13 @@ public interface SqlNodeConverter<S extends SqlNode> {
         String toQuotedSqlString(SqlNode sqlNode);
 
         /**
+         * Returns the original SQL statement text being converted, or {@code null} when the node
+         * was synthesized (e.g. produced by an internal rewrite) and has no source text.
+         */
+        @Nullable
+        String getStatementText();
+
+        /**
          * Expands identifiers in a given SQL string.
          *
          * @see Expander

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/materializedtable/AbstractCreateMaterializedTableConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/materializedtable/AbstractCreateMaterializedTableConverter.java
@@ -151,7 +151,7 @@ public abstract class AbstractCreateMaterializedTableConverter<T extends SqlCrea
     protected final String getDerivedOriginalQuery(
             T sqlCreateMaterializedTable, ConvertContext context) {
         return SqlNodeConvertUtils.extractOriginalAsQueryText(
-                        context, sqlCreateMaterializedTable.getAsKeywordPos())
+                        context, sqlCreateMaterializedTable.getAsQueryKeywordPos())
                 .orElse(context.toQuotedSqlString(sqlCreateMaterializedTable.getAsQuery()));
     }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/materializedtable/AbstractCreateMaterializedTableConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/materializedtable/AbstractCreateMaterializedTableConverter.java
@@ -150,7 +150,7 @@ public abstract class AbstractCreateMaterializedTableConverter<T extends SqlCrea
      */
     protected final String getDerivedOriginalQuery(
             T sqlCreateMaterializedTable, ConvertContext context) {
-        return SqlNodeConvertUtils.originalAsQueryText(
+        return SqlNodeConvertUtils.extractOriginalAsQueryText(
                         context, sqlCreateMaterializedTable.getAsKeywordPos())
                 .orElse(context.toQuotedSqlString(sqlCreateMaterializedTable.getAsQuery()));
     }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/materializedtable/AbstractCreateMaterializedTableConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/materializedtable/AbstractCreateMaterializedTableConverter.java
@@ -34,6 +34,7 @@ import org.apache.flink.table.catalog.StartMode;
 import org.apache.flink.table.catalog.TableDistribution;
 import org.apache.flink.table.catalog.UnresolvedIdentifier;
 import org.apache.flink.table.planner.operations.PlannerQueryOperation;
+import org.apache.flink.table.planner.operations.converters.SqlNodeConvertUtils;
 import org.apache.flink.table.planner.operations.converters.SqlNodeConverter;
 import org.apache.flink.table.planner.utils.MaterializedTableUtils;
 import org.apache.flink.table.planner.utils.OperationConverterUtils;
@@ -141,10 +142,17 @@ public abstract class AbstractCreateMaterializedTableConverter<T extends SqlCrea
         return MaterializedTableUtils.fromLogicalRefreshModeToRefreshMode(logicalRefreshMode);
     }
 
+    /**
+     * Returns the user's original {@code AS} query text, sliced verbatim from the statement so
+     * formatting and identifier casing are preserved (e.g. {@code int} is not normalized to {@code
+     * INTEGER}). A comment placed between {@code AS} and the query is kept; the {@code AS} keyword
+     * itself is excluded.
+     */
     protected final String getDerivedOriginalQuery(
             T sqlCreateMaterializedTable, ConvertContext context) {
-        SqlNode selectQuery = sqlCreateMaterializedTable.getAsQuery();
-        return context.toQuotedSqlString(selectQuery);
+        return SqlNodeConvertUtils.originalAsQueryText(
+                        context, sqlCreateMaterializedTable.getAsKeywordPos())
+                .orElse(context.toQuotedSqlString(sqlCreateMaterializedTable.getAsQuery()));
     }
 
     protected final String getDerivedExpandedQuery(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/materializedtable/SqlAlterMaterializedTableAsQueryConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/materializedtable/SqlAlterMaterializedTableAsQueryConverter.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.catalog.TableChange;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.materializedtable.AlterMaterializedTableAsQueryOperation;
 import org.apache.flink.table.planner.operations.PlannerQueryOperation;
+import org.apache.flink.table.planner.operations.converters.SqlNodeConvertUtils;
 import org.apache.flink.table.planner.utils.MaterializedTableUtils;
 
 import org.apache.calcite.sql.SqlNode;
@@ -54,13 +55,12 @@ public class SqlAlterMaterializedTableAsQueryConverter
             SqlAlterMaterializedTableAsQuery sqlAlterTableAsQuery, ConvertContext context) {
         return oldTable -> {
             // Validate and extract schema from query
-            String originalQuery = context.toQuotedSqlString(sqlAlterTableAsQuery.getAsQuery());
-            SqlNode validatedQuery =
-                    context.getSqlValidator().validate(sqlAlterTableAsQuery.getAsQuery());
-            String definitionQuery = context.toQuotedSqlString(validatedQuery);
+            SqlNode asQuery = sqlAlterTableAsQuery.getAsQuery();
+            SqlNode validatedQuery = context.getSqlValidator().validate(asQuery);
+            String expandedQuery = context.toQuotedSqlString(validatedQuery);
             PlannerQueryOperation queryOperation =
                     new PlannerQueryOperation(
-                            context.toRelRoot(validatedQuery).project(), () -> definitionQuery);
+                            context.toRelRoot(validatedQuery).project(), () -> expandedQuery);
 
             ResolvedSchema oldSchema = oldTable.getResolvedSchema();
             ResolvedSchema newSchema = queryOperation.getResolvedSchema();
@@ -78,7 +78,11 @@ public class SqlAlterMaterializedTableAsQueryConverter
                                     + "consider using CREATE OR ALTER MATERIALIZED TABLE instead");
                 }
             }
-            tableChanges.add(TableChange.modifyDefinitionQuery(originalQuery, definitionQuery));
+            String originalQuery =
+                    SqlNodeConvertUtils.originalAsQueryText(
+                                    context, sqlAlterTableAsQuery.getAsKeywordPos())
+                            .orElse(context.toQuotedSqlString(asQuery));
+            tableChanges.add(TableChange.modifyDefinitionQuery(originalQuery, expandedQuery));
             return tableChanges;
         };
     }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/materializedtable/SqlAlterMaterializedTableAsQueryConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/materializedtable/SqlAlterMaterializedTableAsQueryConverter.java
@@ -80,7 +80,7 @@ public class SqlAlterMaterializedTableAsQueryConverter
             }
             String originalQuery =
                     SqlNodeConvertUtils.extractOriginalAsQueryText(
-                                    context, sqlAlterTableAsQuery.getAsKeywordPos())
+                                    context, sqlAlterTableAsQuery.getAsQueryKeywordPos())
                             .orElse(context.toQuotedSqlString(asQuery));
             tableChanges.add(TableChange.modifyDefinitionQuery(originalQuery, expandedQuery));
             return tableChanges;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/materializedtable/SqlAlterMaterializedTableAsQueryConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/materializedtable/SqlAlterMaterializedTableAsQueryConverter.java
@@ -79,7 +79,7 @@ public class SqlAlterMaterializedTableAsQueryConverter
                 }
             }
             String originalQuery =
-                    SqlNodeConvertUtils.originalAsQueryText(
+                    SqlNodeConvertUtils.extractOriginalAsQueryText(
                                     context, sqlAlterTableAsQuery.getAsKeywordPos())
                             .orElse(context.toQuotedSqlString(asQuery));
             tableChanges.add(TableChange.modifyDefinitionQuery(originalQuery, expandedQuery));

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlCTASNodeToOperationTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlCTASNodeToOperationTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.TableDistribution;
 import org.apache.flink.table.operations.CreateTableASOperation;
+import org.apache.flink.table.operations.ExplainOperation;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.planner.calcite.FlinkPlannerImpl;
 import org.apache.flink.table.planner.parse.CalciteParser;
@@ -420,6 +421,15 @@ class SqlCTASNodeToOperationTest extends SqlNodeToOperationConversionTestBase {
                                                         .column("f1", DataTypes.TIMESTAMP(3))
                                                         .column("f2", DataTypes.INT().notNull())
                                                         .build()))));
+    }
+
+    @Test
+    void testExplainCreateTableAs() {
+        final Operation operation = parse("EXPLAIN CREATE TABLE myTable123 AS SELECT 123");
+
+        assertThat(operation).isInstanceOf(ExplainOperation.class);
+        assertThat(((ExplainOperation) operation).getChild())
+                .isInstanceOf(CreateTableASOperation.class);
     }
 
     private Operation parseAndConvert(String sql) {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlDdlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlDdlToOperationConverterTest.java
@@ -2602,110 +2602,26 @@ class SqlDdlToOperationConverterTest extends SqlNodeToOperationConversionTestBas
 
     private static Stream<Arguments> viewOriginalQueryCases() {
         return Stream.of(
-                        viewCommentHandlingCases(),
-                        viewLineBreakCases(),
-                        viewComplexQueryShapeCases(),
-                        viewAdversarialTextCases())
-                .flatMap(s -> s);
-    }
-
-    private static Stream<Arguments> viewCommentHandlingCases() {
-        return Stream.of(
+                // The AS query is sliced verbatim, preserving the user's wording.
                 viewAsQueryCase(
-                        "comments around the AS query are kept",
-                        "/* leading comment */\nSELECT 1\n/* trailing comment */"),
-                viewAsQueryCase(
-                        "block comment inside the AS query is kept",
-                        "SELECT /* inline comment */ 1"),
+                        "AS query with a leading comment is kept verbatim",
+                        "/* keep me */\nselect 1"),
                 viewAsQueryCase(
                         "trailing comment after the AS query is kept",
-                        "SELECT 1 -- trailing comment"));
-    }
-
-    private static Stream<Arguments> viewLineBreakCases() {
-        return Stream.of(
+                        "select 1 -- trailing comment"),
+                // Everything before AS must be excluded and must not shift the slice.
                 Arguments.of(
-                        "line comment mentioning AS before the AS keyword is dropped",
-                        "CREATE VIEW v1 --AS\nAS SELECT 1",
-                        "SELECT 1"),
-                viewAsQueryCase(
-                        "line comment mentioning AS between AS and the query is kept",
-                        "--AS\nSELECT 1"),
-                viewAsQueryCase(
-                        "line comments mentioning AS in mixed case between AS and the query are kept",
-                        "--line AS\n--comment as\n--break As\nSELECT 1"),
-                Arguments.of(
-                        "blank lines and line comments between AS and the query are kept",
-                        "CREATE VIEW v1 AS \n\n\n--AS\n --line\n--comment\n--break\nSELECT 1",
-                        "--AS\n --line\n--comment\n--break\nSELECT 1"),
-                viewAsQueryCase(
-                        "multi-line block comment between AS and the query is kept",
-                        "/* multi\n line */\nSELECT 1"),
-                Arguments.of(
-                        "multi-line block comment before AS is dropped",
-                        "CREATE VIEW v1\n/* note\n before AS */\nAS SELECT 1",
+                        "comment before AS is dropped",
+                        "CREATE VIEW v1\n-- note before AS\nAS SELECT 1",
                         "SELECT 1"),
                 Arguments.of(
-                        "column list and comment before AS are dropped",
+                        "As-query is stripped and comments are kept",
+                        "CREATE VIEW v1 AS \n\n\n\n--keep\n--me\nSELECT * FROM t1\n\n",
+                        "--keep\n--me\nSELECT * FROM t1"),
+                Arguments.of(
+                        "column list and COMMENT before AS are dropped",
                         "CREATE VIEW v1 (w, x, y, z)\nCOMMENT 'a view'\nAS SELECT a, b, c, d FROM t1",
                         "SELECT a, b, c, d FROM t1"));
-    }
-
-    private static Stream<Arguments> viewComplexQueryShapeCases() {
-        return Stream.of(
-                viewAsQueryCase(
-                        "aggregation with GROUP BY spanning multiple lines",
-                        "SELECT a, SUM(c) AS total_spend,\n"
-                                + "COUNT(*) AS order_count\n"
-                                + "FROM t1 GROUP BY a"),
-                viewAsQueryCase(
-                        "aggregation with indented continuation lines",
-                        "SELECT a,\n"
-                                + "       SUM(c) AS total,\n"
-                                + "       AVG(c) AS avg_c,\n"
-                                + "       COUNT(*) AS cnt\n"
-                                + "FROM t1\n"
-                                + "GROUP BY a"),
-                viewAsQueryCase(
-                        "two-table inner join",
-                        "SELECT o.a AS oa, c.b AS customer_name, o.c\n"
-                                + "FROM t1 o\n"
-                                + "JOIN t2 c\n"
-                                + "ON o.a = c.a"),
-                viewAsQueryCase(
-                        "three-table join",
-                        "SELECT o.a, c.b AS customer_name, p.d AS extra\n"
-                                + "FROM t1 o\n"
-                                + "JOIN t2 c ON o.a = c.a\n"
-                                + "JOIN t1 p ON o.c = p.c"),
-                viewAsQueryCase("cast expression", "SELECT CAST(c AS VARCHAR) AS cs, a FROM t1"));
-    }
-
-    private static Stream<Arguments> viewAdversarialTextCases() {
-        return Stream.of(
-                viewAsQueryCase(
-                        "CTE whose own AS must not be mistaken for the view's",
-                        "WITH q AS (SELECT a, c FROM t1 WHERE c > 0) SELECT a, c FROM q"),
-                viewAsQueryCase(
-                        "set operation", "SELECT a, b FROM t1 UNION ALL SELECT a, b FROM t2"),
-                viewAsQueryCase(
-                        "window function over",
-                        "SELECT a, ROW_NUMBER() OVER (PARTITION BY c ORDER BY a) AS rn FROM t1"),
-                viewAsQueryCase(
-                        "case expression",
-                        "SELECT a, CASE WHEN c > 0 THEN 'pos' ELSE 'neg' END AS s FROM t1"),
-                viewAsQueryCase(
-                        "nested subquery",
-                        "SELECT x.a FROM (SELECT a, c FROM t1 WHERE c > 100) AS x"),
-                viewAsQueryCase(
-                        "string literal with SQL keywords, comment markers and escaped quote",
-                        "SELECT a, 'AS SELECT FROM -- /* not a comment */ it''s ok' AS lit FROM t1"),
-                viewAsQueryCase(
-                        "string literal with semicolon and backtick",
-                        "SELECT 'a;b`c' AS s, a FROM t1"),
-                viewAsQueryCase(
-                        "string literal with accented and astral characters",
-                        "SELECT 'café 🦅' AS s, a FROM t1"));
     }
 
     private static Arguments viewAsQueryCase(String name, String query) {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlDdlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlDdlToOperationConverterTest.java
@@ -1459,7 +1459,7 @@ class SqlDdlToOperationConverterTest extends SqlNodeToOperationConversionTestBas
                                 + "  `user_id` INT NOT NULL,\n"
                                 + "  CONSTRAINT `PK_user_id` PRIMARY KEY (`user_id`) NOT ENFORCED\n"
                                 + "), comment='null', distribution=null, partitionKeys=[], "
-                                + "options={format=debezium-json}, snapshot=null, originalQuery='SELECT 1 AS `shop_id`, 2 AS `user_id`', expandedQuery='SELECT 1 AS `shop_id`, 2 AS `user_id`', "
+                                + "options={format=debezium-json}, snapshot=null, originalQuery='SELECT 1 as shop_id, 2 as user_id', expandedQuery='SELECT 1 AS `shop_id`, 2 AS `user_id`', "
                                 + "freshness=INTERVAL '30' SECOND, logicalRefreshMode=CONTINUOUS, refreshMode=CONTINUOUS, "
                                 + "refreshStatus=INITIALIZING, refreshHandlerDescription='null', serializedRefreshHandler=null}, resolvedSchema=(\n"
                                 + "  `shop_id` INT,\n"
@@ -1491,7 +1491,7 @@ class SqlDdlToOperationConverterTest extends SqlNodeToOperationConversionTestBas
                                 + "  `user_id` INT NOT NULL,\n"
                                 + "  CONSTRAINT `PK_user_id` PRIMARY KEY (`user_id`) NOT ENFORCED\n"
                                 + "), comment='null', distribution=DISTRIBUTED BY HASH(`user_id`) INTO 7 BUCKETS, partitionKeys=[], "
-                                + "options={format=debezium-json}, snapshot=null, originalQuery='SELECT 1 AS `shop_id`, 2 AS `user_id`', expandedQuery='SELECT 1 AS `shop_id`, 2 AS `user_id`', "
+                                + "options={format=debezium-json}, snapshot=null, originalQuery='SELECT 1 as shop_id, 2 as user_id', expandedQuery='SELECT 1 AS `shop_id`, 2 AS `user_id`', "
                                 + "freshness=INTERVAL '30' SECOND, logicalRefreshMode=AUTOMATIC, refreshMode=null, "
                                 + "refreshStatus=INITIALIZING, refreshHandlerDescription='null', serializedRefreshHandler=null}, resolvedSchema=(\n"
                                 + "  `shop_id` INT NOT NULL,\n"
@@ -2589,6 +2589,127 @@ class SqlDdlToOperationConverterTest extends SqlNodeToOperationConversionTestBas
 
         Operation operation = parse(sql);
         assertThat(operation).isInstanceOf(CreateViewOperation.class);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("viewOriginalQueryCases")
+    void testCreateViewOriginalQuery(String name, String sql, String expectedOriginalQuery) {
+        final Operation operation = parse(sql);
+        assertThat(operation).isInstanceOf(CreateViewOperation.class);
+        assertThat(((CreateViewOperation) operation).getCatalogView().getOriginalQuery())
+                .isEqualTo(expectedOriginalQuery);
+    }
+
+    private static Stream<Arguments> viewOriginalQueryCases() {
+        return Stream.of(
+                        viewCommentHandlingCases(),
+                        viewLineBreakCases(),
+                        viewComplexQueryShapeCases(),
+                        viewAdversarialTextCases())
+                .flatMap(s -> s);
+    }
+
+    private static Stream<Arguments> viewCommentHandlingCases() {
+        return Stream.of(
+                viewAsQueryCase(
+                        "comments around the AS query are kept",
+                        "/* leading comment */\nSELECT 1\n/* trailing comment */"),
+                viewAsQueryCase(
+                        "block comment inside the AS query is kept",
+                        "SELECT /* inline comment */ 1"),
+                viewAsQueryCase(
+                        "trailing comment after the AS query is kept",
+                        "SELECT 1 -- trailing comment"));
+    }
+
+    private static Stream<Arguments> viewLineBreakCases() {
+        return Stream.of(
+                Arguments.of(
+                        "line comment mentioning AS before the AS keyword is dropped",
+                        "CREATE VIEW v1 --AS\nAS SELECT 1",
+                        "SELECT 1"),
+                viewAsQueryCase(
+                        "line comment mentioning AS between AS and the query is kept",
+                        "--AS\nSELECT 1"),
+                viewAsQueryCase(
+                        "line comments mentioning AS in mixed case between AS and the query are kept",
+                        "--line AS\n--comment as\n--break As\nSELECT 1"),
+                Arguments.of(
+                        "blank lines and line comments between AS and the query are kept",
+                        "CREATE VIEW v1 AS \n\n\n--AS\n --line\n--comment\n--break\nSELECT 1",
+                        "--AS\n --line\n--comment\n--break\nSELECT 1"),
+                viewAsQueryCase(
+                        "multi-line block comment between AS and the query is kept",
+                        "/* multi\n line */\nSELECT 1"),
+                Arguments.of(
+                        "multi-line block comment before AS is dropped",
+                        "CREATE VIEW v1\n/* note\n before AS */\nAS SELECT 1",
+                        "SELECT 1"),
+                Arguments.of(
+                        "column list and comment before AS are dropped",
+                        "CREATE VIEW v1 (w, x, y, z)\nCOMMENT 'a view'\nAS SELECT a, b, c, d FROM t1",
+                        "SELECT a, b, c, d FROM t1"));
+    }
+
+    private static Stream<Arguments> viewComplexQueryShapeCases() {
+        return Stream.of(
+                viewAsQueryCase(
+                        "aggregation with GROUP BY spanning multiple lines",
+                        "SELECT a, SUM(c) AS total_spend,\n"
+                                + "COUNT(*) AS order_count\n"
+                                + "FROM t1 GROUP BY a"),
+                viewAsQueryCase(
+                        "aggregation with indented continuation lines",
+                        "SELECT a,\n"
+                                + "       SUM(c) AS total,\n"
+                                + "       AVG(c) AS avg_c,\n"
+                                + "       COUNT(*) AS cnt\n"
+                                + "FROM t1\n"
+                                + "GROUP BY a"),
+                viewAsQueryCase(
+                        "two-table inner join",
+                        "SELECT o.a AS oa, c.b AS customer_name, o.c\n"
+                                + "FROM t1 o\n"
+                                + "JOIN t2 c\n"
+                                + "ON o.a = c.a"),
+                viewAsQueryCase(
+                        "three-table join",
+                        "SELECT o.a, c.b AS customer_name, p.d AS extra\n"
+                                + "FROM t1 o\n"
+                                + "JOIN t2 c ON o.a = c.a\n"
+                                + "JOIN t1 p ON o.c = p.c"),
+                viewAsQueryCase("cast expression", "SELECT CAST(c AS VARCHAR) AS cs, a FROM t1"));
+    }
+
+    private static Stream<Arguments> viewAdversarialTextCases() {
+        return Stream.of(
+                viewAsQueryCase(
+                        "CTE whose own AS must not be mistaken for the view's",
+                        "WITH q AS (SELECT a, c FROM t1 WHERE c > 0) SELECT a, c FROM q"),
+                viewAsQueryCase(
+                        "set operation", "SELECT a, b FROM t1 UNION ALL SELECT a, b FROM t2"),
+                viewAsQueryCase(
+                        "window function over",
+                        "SELECT a, ROW_NUMBER() OVER (PARTITION BY c ORDER BY a) AS rn FROM t1"),
+                viewAsQueryCase(
+                        "case expression",
+                        "SELECT a, CASE WHEN c > 0 THEN 'pos' ELSE 'neg' END AS s FROM t1"),
+                viewAsQueryCase(
+                        "nested subquery",
+                        "SELECT x.a FROM (SELECT a, c FROM t1 WHERE c > 100) AS x"),
+                viewAsQueryCase(
+                        "string literal with SQL keywords, comment markers and escaped quote",
+                        "SELECT a, 'AS SELECT FROM -- /* not a comment */ it''s ok' AS lit FROM t1"),
+                viewAsQueryCase(
+                        "string literal with semicolon and backtick",
+                        "SELECT 'a;b`c' AS s, a FROM t1"),
+                viewAsQueryCase(
+                        "string literal with accented and astral characters",
+                        "SELECT 'café 🦅' AS s, a FROM t1"));
+    }
+
+    private static Arguments viewAsQueryCase(String name, String query) {
+        return Arguments.of(name, "CREATE VIEW v1 AS " + query, query);
     }
 
     @Test

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlMaterializedTableNodeToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlMaterializedTableNodeToOperationConverterTest.java
@@ -332,66 +332,35 @@ class SqlMaterializedTableNodeToOperationConverterTest
     }
 
     private static Stream<Arguments> originalQueryCases() {
-        return Stream.of(
-                        commentHandlingCases(),
-                        lineBreakCases(),
-                        ddlPrefixTokenCases(),
-                        complexQueryShapeCases(),
-                        adversarialTextCases())
-                .flatMap(s -> s);
-    }
-
-    private static Stream<Arguments> commentHandlingCases() {
-        return Stream.of(
-                asQueryCase(
-                        "inline line comment inside the AS query is kept",
-                        "SELECT a, -- inline line comment\n b FROM t1"),
-                asQueryCase(
-                        "block comment inside the AS query is kept",
-                        "SELECT /* block comment */ * FROM t1"),
-                asQueryCase(
-                        "comment between AS and the query is kept",
-                        "-- leading comment\n SELECT * FROM t1"),
-                asQueryCase(
-                        "trailing comment after the AS query is kept",
-                        "SELECT * FROM t1 -- trailing comment"));
-    }
-
-    private static Stream<Arguments> lineBreakCases() {
         final String query = "SELECT * FROM t1";
         return Stream.of(
+                // The AS query is sliced verbatim from just after AS to the end of the statement,
+                // preserving the user's wording (case, formatting, comments).
+                asQueryCase(
+                        "AS query with a leading comment is kept verbatim",
+                        "/* keep me */\nselect a, b from t1"),
+                asQueryCase(
+                        "trailing comment after the AS query is kept",
+                        "select a, b from t1 -- trailing comment"),
+                asQueryCase(
+                        "WITH query is kept whole (its node position is narrower than its text)",
+                        "WITH q AS (SELECT a FROM t1) SELECT a FROM q"),
                 Arguments.of(
-                        "line comment mentioning AS before the AS keyword is dropped",
-                        "CREATE MATERIALIZED TABLE mtbl1 --AS\nAS " + query,
-                        query),
-                asQueryCase(
-                        "line comment mentioning AS between AS and the query is kept",
-                        "--AS\n" + query),
-                asQueryCase(
-                        "line comments mentioning AS in mixed case between AS and the query are kept",
-                        "--line AS\n--comment as\n--break As\n" + query),
+                        "As-query is stripped and comments are kept",
+                        "CREATE MATERIALIZED TABLE mtbl1 AS \n\n\n\n--keep\n--me\nSELECT * FROM t1\n\n",
+                        "--keep\n--me\nSELECT * FROM t1"),
+                // Everything before AS must be excluded and must not shift the slice, regardless of
+                // comments, identifier quoting, or a multi-line clause prefix.
                 Arguments.of(
-                        "blank lines and line comments between AS and the query are kept",
-                        "CREATE MATERIALIZED TABLE mtbl1 AS \n\n\n--AS\n --line\n--comment\n--break\n"
-                                + query,
-                        "--AS\n --line\n--comment\n--break\n" + query),
-                asQueryCase(
-                        "multi-line block comment between AS and the query is kept",
-                        "/* multi\n line\n comment */\n" + query),
-                asQueryCase(
-                        "multi-line block comment inside the AS query is kept",
-                        "SELECT a, /* spanning\n two lines */ b FROM t1"),
-                Arguments.of(
-                        "line comment before AS is dropped",
+                        "comment before AS is dropped",
                         "CREATE MATERIALIZED TABLE mtbl1\n-- note before AS\nAS " + query,
                         query),
                 Arguments.of(
-                        "multi-line block comment before AS is dropped",
-                        "CREATE MATERIALIZED TABLE mtbl1\n/* a\n multiline\n note before AS */\nAS "
-                                + query,
+                        "escaped-backtick identifier and COMMENT before AS are dropped",
+                        "CREATE MATERIALIZED TABLE `m``tbl` COMMENT 'a''b' AS " + query,
                         query),
                 Arguments.of(
-                        "multi-line DDL prefix before AS",
+                        "multi-line DDL prefix before AS is dropped",
                         "CREATE MATERIALIZED TABLE mtbl1 (\n"
                                 + "   CONSTRAINT ct1 PRIMARY KEY(a) NOT ENFORCED\n"
                                 + ")\n"
@@ -406,81 +375,6 @@ class SqlMaterializedTableNodeToOperationConverterTest
                                 + "AS "
                                 + query,
                         query));
-    }
-
-    private static Stream<Arguments> ddlPrefixTokenCases() {
-        final String query = "SELECT * FROM t1";
-        return Stream.of(
-                Arguments.of(
-                        "quoted identifier", "CREATE MATERIALIZED TABLE `mtbl` AS " + query, query),
-                Arguments.of(
-                        "escaped backtick in identifier",
-                        "CREATE MATERIALIZED TABLE `m``tbl` AS " + query,
-                        query),
-                Arguments.of(
-                        "escaped backtick with comment",
-                        "CREATE MATERIALIZED TABLE `m``tbl` COMMENT 'a' AS " + query,
-                        query),
-                Arguments.of(
-                        "escaped quote inside comment",
-                        "CREATE MATERIALIZED TABLE `m``tbl` COMMENT 'a''b' AS " + query,
-                        query));
-    }
-
-    private static Stream<Arguments> complexQueryShapeCases() {
-        return Stream.of(
-                asQueryCase(
-                        "aggregation with GROUP BY spanning multiple lines",
-                        "SELECT a, SUM(c) AS total_spend,\n"
-                                + "COUNT(*) AS order_count\n"
-                                + "FROM t1 GROUP BY a"),
-                asQueryCase(
-                        "aggregation with indented continuation lines",
-                        "SELECT a,\n"
-                                + "       SUM(c) AS total,\n"
-                                + "       AVG(c) AS avg_c,\n"
-                                + "       COUNT(*) AS cnt\n"
-                                + "FROM t1\n"
-                                + "GROUP BY a"),
-                asQueryCase(
-                        "two-table inner join",
-                        "SELECT o.a AS oa, c.b AS customer_name, o.c\n"
-                                + "FROM t1 o\n"
-                                + "JOIN t2 c\n"
-                                + "ON o.a = c.a"),
-                asQueryCase(
-                        "three-table join",
-                        "SELECT o.a, c.b AS customer_name, p.d AS product_name\n"
-                                + "FROM t1 o\n"
-                                + "JOIN t2 c ON o.a = c.a\n"
-                                + "JOIN t3 p ON o.c = p.c"),
-                asQueryCase("cast expression", "SELECT CAST(c AS VARCHAR) AS cs, a FROM t1"));
-    }
-
-    private static Stream<Arguments> adversarialTextCases() {
-        return Stream.of(
-                asQueryCase(
-                        "CTE whose own AS must not be mistaken for the table's",
-                        "WITH q AS (SELECT a, c FROM t1 WHERE c > 0) SELECT a, c FROM q"),
-                asQueryCase("set operation", "SELECT a, b FROM t1 UNION ALL SELECT a, b FROM t2"),
-                asQueryCase(
-                        "window function over",
-                        "SELECT a, ROW_NUMBER() OVER (PARTITION BY c ORDER BY a) AS rn FROM t1"),
-                asQueryCase(
-                        "case expression",
-                        "SELECT a, CASE WHEN c > 0 THEN 'pos' ELSE 'neg' END AS s FROM t1"),
-                asQueryCase(
-                        "nested subquery",
-                        "SELECT x.a FROM (SELECT a, c FROM t1 WHERE c > 100) AS x"),
-                asQueryCase(
-                        "string literal with SQL keywords, comment markers and escaped quote",
-                        "SELECT a, '/*adldkfa*/ AS SELECT FROM -- /* not a comment */ it''s ok' AS lit FROM t1"),
-                asQueryCase(
-                        "string literal with semicolon and backtick",
-                        "SELECT 'a;b`c' AS s, a FROM t1"),
-                asQueryCase(
-                        "string literal with accented and astral characters",
-                        "SELECT 'café 🦅' AS s, a FROM t1"));
     }
 
     private static Arguments asQueryCase(String name, String query) {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlMaterializedTableNodeToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlMaterializedTableNodeToOperationConverterTest.java
@@ -66,6 +66,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -320,6 +321,172 @@ class SqlMaterializedTableNodeToOperationConverterTest
                                 + "LATERAL TABLE(`builtin`.`default`.`myFunc`(`b`)) AS `T` (`f1`, `f2`)");
     }
 
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("originalQueryCases")
+    void testOriginalQuery(String name, String sql, String expectedOriginalQuery) {
+        final String originalQuery =
+                createMaterializedTableOperation(sql)
+                        .getCatalogMaterializedTable()
+                        .getOriginalQuery();
+        assertThat(originalQuery).isEqualTo(expectedOriginalQuery);
+    }
+
+    private static Stream<Arguments> originalQueryCases() {
+        return Stream.of(
+                        commentHandlingCases(),
+                        lineBreakCases(),
+                        ddlPrefixTokenCases(),
+                        complexQueryShapeCases(),
+                        adversarialTextCases())
+                .flatMap(s -> s);
+    }
+
+    private static Stream<Arguments> commentHandlingCases() {
+        return Stream.of(
+                asQueryCase(
+                        "inline line comment inside the AS query is kept",
+                        "SELECT a, -- inline line comment\n b FROM t1"),
+                asQueryCase(
+                        "block comment inside the AS query is kept",
+                        "SELECT /* block comment */ * FROM t1"),
+                asQueryCase(
+                        "comment between AS and the query is kept",
+                        "-- leading comment\n SELECT * FROM t1"),
+                asQueryCase(
+                        "trailing comment after the AS query is kept",
+                        "SELECT * FROM t1 -- trailing comment"));
+    }
+
+    private static Stream<Arguments> lineBreakCases() {
+        final String query = "SELECT * FROM t1";
+        return Stream.of(
+                Arguments.of(
+                        "line comment mentioning AS before the AS keyword is dropped",
+                        "CREATE MATERIALIZED TABLE mtbl1 --AS\nAS " + query,
+                        query),
+                asQueryCase(
+                        "line comment mentioning AS between AS and the query is kept",
+                        "--AS\n" + query),
+                asQueryCase(
+                        "line comments mentioning AS in mixed case between AS and the query are kept",
+                        "--line AS\n--comment as\n--break As\n" + query),
+                Arguments.of(
+                        "blank lines and line comments between AS and the query are kept",
+                        "CREATE MATERIALIZED TABLE mtbl1 AS \n\n\n--AS\n --line\n--comment\n--break\n"
+                                + query,
+                        "--AS\n --line\n--comment\n--break\n" + query),
+                asQueryCase(
+                        "multi-line block comment between AS and the query is kept",
+                        "/* multi\n line\n comment */\n" + query),
+                asQueryCase(
+                        "multi-line block comment inside the AS query is kept",
+                        "SELECT a, /* spanning\n two lines */ b FROM t1"),
+                Arguments.of(
+                        "line comment before AS is dropped",
+                        "CREATE MATERIALIZED TABLE mtbl1\n-- note before AS\nAS " + query,
+                        query),
+                Arguments.of(
+                        "multi-line block comment before AS is dropped",
+                        "CREATE MATERIALIZED TABLE mtbl1\n/* a\n multiline\n note before AS */\nAS "
+                                + query,
+                        query),
+                Arguments.of(
+                        "multi-line DDL prefix before AS",
+                        "CREATE MATERIALIZED TABLE mtbl1 (\n"
+                                + "   CONSTRAINT ct1 PRIMARY KEY(a) NOT ENFORCED\n"
+                                + ")\n"
+                                + "COMMENT 'materialized table comment'\n"
+                                + "PARTITIONED BY (a)\n"
+                                + "WITH (\n"
+                                + "  'connector' = 'filesystem',\n"
+                                + "  'format' = 'json'\n"
+                                + ")\n"
+                                + "FRESHNESS = INTERVAL '30' SECOND\n"
+                                + "REFRESH_MODE = FULL\n"
+                                + "AS "
+                                + query,
+                        query));
+    }
+
+    private static Stream<Arguments> ddlPrefixTokenCases() {
+        final String query = "SELECT * FROM t1";
+        return Stream.of(
+                Arguments.of(
+                        "quoted identifier", "CREATE MATERIALIZED TABLE `mtbl` AS " + query, query),
+                Arguments.of(
+                        "escaped backtick in identifier",
+                        "CREATE MATERIALIZED TABLE `m``tbl` AS " + query,
+                        query),
+                Arguments.of(
+                        "escaped backtick with comment",
+                        "CREATE MATERIALIZED TABLE `m``tbl` COMMENT 'a' AS " + query,
+                        query),
+                Arguments.of(
+                        "escaped quote inside comment",
+                        "CREATE MATERIALIZED TABLE `m``tbl` COMMENT 'a''b' AS " + query,
+                        query));
+    }
+
+    private static Stream<Arguments> complexQueryShapeCases() {
+        return Stream.of(
+                asQueryCase(
+                        "aggregation with GROUP BY spanning multiple lines",
+                        "SELECT a, SUM(c) AS total_spend,\n"
+                                + "COUNT(*) AS order_count\n"
+                                + "FROM t1 GROUP BY a"),
+                asQueryCase(
+                        "aggregation with indented continuation lines",
+                        "SELECT a,\n"
+                                + "       SUM(c) AS total,\n"
+                                + "       AVG(c) AS avg_c,\n"
+                                + "       COUNT(*) AS cnt\n"
+                                + "FROM t1\n"
+                                + "GROUP BY a"),
+                asQueryCase(
+                        "two-table inner join",
+                        "SELECT o.a AS oa, c.b AS customer_name, o.c\n"
+                                + "FROM t1 o\n"
+                                + "JOIN t2 c\n"
+                                + "ON o.a = c.a"),
+                asQueryCase(
+                        "three-table join",
+                        "SELECT o.a, c.b AS customer_name, p.d AS product_name\n"
+                                + "FROM t1 o\n"
+                                + "JOIN t2 c ON o.a = c.a\n"
+                                + "JOIN t3 p ON o.c = p.c"),
+                asQueryCase("cast expression", "SELECT CAST(c AS VARCHAR) AS cs, a FROM t1"));
+    }
+
+    private static Stream<Arguments> adversarialTextCases() {
+        return Stream.of(
+                asQueryCase(
+                        "CTE whose own AS must not be mistaken for the table's",
+                        "WITH q AS (SELECT a, c FROM t1 WHERE c > 0) SELECT a, c FROM q"),
+                asQueryCase("set operation", "SELECT a, b FROM t1 UNION ALL SELECT a, b FROM t2"),
+                asQueryCase(
+                        "window function over",
+                        "SELECT a, ROW_NUMBER() OVER (PARTITION BY c ORDER BY a) AS rn FROM t1"),
+                asQueryCase(
+                        "case expression",
+                        "SELECT a, CASE WHEN c > 0 THEN 'pos' ELSE 'neg' END AS s FROM t1"),
+                asQueryCase(
+                        "nested subquery",
+                        "SELECT x.a FROM (SELECT a, c FROM t1 WHERE c > 100) AS x"),
+                asQueryCase(
+                        "string literal with SQL keywords, comment markers and escaped quote",
+                        "SELECT a, '/*adldkfa*/ AS SELECT FROM -- /* not a comment */ it''s ok' AS lit FROM t1"),
+                asQueryCase(
+                        "string literal with semicolon and backtick",
+                        "SELECT 'a;b`c' AS s, a FROM t1"),
+                asQueryCase(
+                        "string literal with accented and astral characters",
+                        "SELECT 'café 🦅' AS s, a FROM t1"));
+    }
+
+    private static Arguments asQueryCase(String name, String query) {
+        return Arguments.of(name, "CREATE MATERIALIZED TABLE mtbl1 AS " + query, query);
+    }
+
     @Test
     void testCreateMaterializedTableWithUDTFQueryWithoutAlias() {
         functionCatalog.registerCatalogFunction(
@@ -572,7 +739,7 @@ class SqlMaterializedTableNodeToOperationConverterTest
     @Test
     void testAlterMaterializedTableAsQuery() throws TableNotExistException {
         String sql =
-                "ALTER MATERIALIZED TABLE base_mtbl AS SELECT a, b, c, d, d as e, cast('123' as string) as f FROM t3";
+                "ALTER MATERIALIZED TABLE base_mtbl AS SELECT a, b, c, d, d as e, cast('123' as string) as f\n FROM\n t3";
         Operation operation = parse(sql);
 
         assertThat(operation).isInstanceOf(AlterMaterializedTableAsQueryOperation.class);
@@ -584,7 +751,7 @@ class SqlMaterializedTableNodeToOperationConverterTest
                         TableChange.add(Column.physical("e", DataTypes.VARCHAR(Integer.MAX_VALUE))),
                         TableChange.add(Column.physical("f", DataTypes.VARCHAR(Integer.MAX_VALUE))),
                         TableChange.modifyDefinitionQuery(
-                                "SELECT `a`, `b`, `c`, `d`, `d` AS `e`, CAST('123' AS STRING) AS `f`\nFROM `t3`",
+                                "SELECT a, b, c, d, d as e, cast('123' as string) as f\n FROM\n t3",
                                 "SELECT `t3`.`a`, `t3`.`b`, `t3`.`c`, `t3`.`d`, `t3`.`d` AS `e`, CAST('123' AS STRING) AS `f`\n"
                                         + "FROM `builtin`.`default`.`t3` AS `t3`"));
         assertThat(operation.asSummaryString())
@@ -638,7 +805,7 @@ class SqlMaterializedTableNodeToOperationConverterTest
                 .containsExactly(
                         TableChange.add(Column.physical("a0", DataTypes.INT())),
                         TableChange.modifyDefinitionQuery(
-                                "SELECT `a`, `b`, `c`, `d`, `c` AS `a`\nFROM `t3`",
+                                "SELECT a, b, c, d, c as a FROM t3",
                                 "SELECT `t3`.`a`, `t3`.`b`, `t3`.`c`, `t3`.`d`, `t3`.`c` AS `a`\n"
                                         + "FROM `builtin`.`default`.`t3` AS `t3`"));
     }
@@ -1373,7 +1540,7 @@ class SqlMaterializedTableNodeToOperationConverterTest
                 .comment("materialized table comment")
                 .options(Map.of("connector", "filesystem", "format", "json"))
                 .partitionKeys(List.of("a", "d"))
-                .originalQuery("SELECT *\nFROM `t1`")
+                .originalQuery("SELECT * FROM t1")
                 .expandedQuery(
                         "SELECT `t1`.`a`, `t1`.`b`, `t1`.`c`, `t1`.`d`\n"
                                 + "FROM `builtin`.`default`.`t1` AS `t1`");

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlNodeToOperationConversionTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlNodeToOperationConversionTestBase.java
@@ -131,14 +131,14 @@ class SqlNodeToOperationConversionTestBase {
 
     protected Operation parse(String sql, FlinkPlannerImpl planner, CalciteParser parser) {
         SqlNode node = parser.parse(sql);
-        return SqlNodeToOperationConversion.convert(planner, catalogManager, node).get();
+        return SqlNodeToOperationConversion.convert(planner, catalogManager, node, sql).get();
     }
 
     protected Operation parse(String sql) {
         FlinkPlannerImpl planner = getPlannerBySqlDialect(SqlDialect.DEFAULT);
         final CalciteParser parser = getParserBySqlDialect(SqlDialect.DEFAULT);
         SqlNode node = parser.parse(sql);
-        return SqlNodeToOperationConversion.convert(planner, catalogManager, node).get();
+        return SqlNodeToOperationConversion.convert(planner, catalogManager, node, sql).get();
     }
 
     protected FlinkPlannerImpl getPlannerBySqlDialect(SqlDialect sqlDialect) {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlNodeToOperationSqlCreateOrAlterMaterializedTableConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlNodeToOperationSqlCreateOrAlterMaterializedTableConverterTest.java
@@ -92,7 +92,7 @@ class SqlNodeToOperationSqlCreateOrAlterMaterializedTableConverterTest
                         TableChange.add(Column.physical("f", DataTypes.INT())),
                         TableChange.dropConstraint("ct1"),
                         TableChange.modifyDefinitionQuery(
-                                "SELECT `a`, `b`, `c`, `d`, `a` AS `a1`, 3 AS `f`\nFROM `t1`",
+                                "SELECT a, b, c, d, a as `a1`, 3 as f FROM t1",
                                 "SELECT `t1`.`a`, `t1`.`b`, `t1`.`c`, `t1`.`d`, `t1`.`a` AS `a1`, 3 AS `f`\n"
                                         + "FROM `builtin`.`default`.`t1` AS `t1`"),
                         TableChange.reset("connector"),
@@ -112,7 +112,7 @@ class SqlNodeToOperationSqlCreateOrAlterMaterializedTableConverterTest
                         // No explicit schema, so nullable will be used
                         TableChange.add(Column.physical("a1", DataTypes.BIGINT())),
                         TableChange.modifyDefinitionQuery(
-                                "SELECT `a`, `b`, `c`, `d`, `a` AS `a1`\nFROM `t1`",
+                                "SELECT a, b, c, d, a as `a1` FROM t1",
                                 "SELECT `t1`.`a`, `t1`.`b`, `t1`.`c`, `t1`.`d`, `t1`.`a` AS `a1`\n"
                                         + "FROM `builtin`.`default`.`t1` AS `t1`"),
                         TableChange.reset("connector"),
@@ -201,7 +201,7 @@ class SqlNodeToOperationSqlCreateOrAlterMaterializedTableConverterTest
                         TableChange.add(Column.physical("e", DataTypes.VARCHAR(Integer.MAX_VALUE))),
                         TableChange.add(Column.physical("f", DataTypes.VARCHAR(Integer.MAX_VALUE))),
                         TableChange.modifyDefinitionQuery(
-                                "SELECT `a`, `b`, `c`, `d`, `d` AS `e`, CAST('123' AS STRING) AS `f`\nFROM `t1`",
+                                "SELECT a, b, c, d, d as e, cast('123' as string) as f FROM t1",
                                 "SELECT `t1`.`a`, `t1`.`b`, `t1`.`c`, `t1`.`d`, `t1`.`d` AS `e`, CAST('123' AS STRING) AS `f`\n"
                                         + "FROM `builtin`.`default`.`t1` AS `t1`"),
                         TableChange.set("format", "json2"),

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlRTASNodeToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlRTASNodeToOperationConverterTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.TableDistribution;
+import org.apache.flink.table.operations.ExplainOperation;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.ReplaceTableAsOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
@@ -278,6 +279,15 @@ class SqlRTASNodeToOperationConverterTest extends SqlNodeToOperationConversionTe
                         .build();
 
         testCommonReplaceTableAs(sql, tableName, null, tableSchema, null, Collections.emptyList());
+    }
+
+    @Test
+    void testExplainReplaceTableAs() {
+        final Operation operation = parse("EXPLAIN REPLACE TABLE myTable123 AS SELECT 123");
+
+        assertThat(operation).isInstanceOf(ExplainOperation.class);
+        assertThat(((ExplainOperation) operation).getChild())
+                .isInstanceOf(ReplaceTableAsOperation.class);
     }
 
     private void testCommonReplaceTableAs(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableITCase.scala
@@ -1234,7 +1234,7 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends TableITCaseBase {
       .get()
       .getTable(objectPath)
       .asInstanceOf[CatalogView]
-    assertThat(view.getOriginalQuery).isEqualTo("SELECT `b`\nFROM `T`")
+    assertThat(view.getOriginalQuery).isEqualTo("SELECT b FROM T")
   }
 
   @TestTemplate


### PR DESCRIPTION
## What is the purpose of the change

`CREATE/ALTER MATERIALIZED TABLE … AS …` and `CREATE VIEW … AS …` currently persist `originalQuery` by re-rendering the parsed `SqlNode` via `SqlNode#toSqlString()`. This normalizes identifier casing, expands type aliases (`int` → `INTEGER`), reflows whitespace, and rewrites quoting, so `SHOW CREATE MATERIALIZED TABLE` / `SHOW CREATE VIEW` no longer reflect what the user typed.

This PR makes `originalQuery` the verbatim substring of the user's input statement, sliced via `SqlParserPos` of the AS-query subtree. `expandedQuery` continues to hold the planner-normalized form.

### Example

Input:

```sql
CREATE MATERIALIZED TABLE mt AS
  select a, b, cast(c as int) as int_c from t1 where c > 200
```

Before:

```sql
SELECT `a`, `b`, CAST(`c` AS INTEGER) AS `int_c`
FROM `t1`
WHERE `c` > 200
```

after:
```sql
select a, b, cast(c as int) as int_c from t1 where c > 200
```

## Brief change log                                                                                                                                     
                                                                                                                                                        
- Record the parser position of the `AS` keyword on the affected parser nodes (`SqlCreateMaterializedTable`, `SqlAlterMaterializedTableAsQuery`, `SqlCreateView`, `SqlAlterViewAs`) in the grammar.                                                                                                      
- Expose the original statement text on the conversion context via `ConvertContext#getStatementText()`.                                                 
- Add `SqlNodeConvertUtils#rawAsQueryText(...)` which slices the statement from just after the `AS` keyword to the end of the statement. The `AS`-query  is the last clause of these DDLs, so this captures the whole query verbatim — including a comment placed between `AS` and the query — while excluding   
the `AS` keyword itself. Slicing to the statement end (rather than the query node's `SqlParserPos`) also keeps queries whose node position does not span their full text, e.g. `WITH … SELECT` (`SqlWith` ends at the with-list).                                                                                
- Use it in `AbstractCreateMaterializedTableConverter#getDerivedOriginalQuery`, `SqlAlterMaterializedTableAsQueryConverter`, and                        
`SqlNodeConvertUtils#toCatalogView` (covers `CREATE VIEW` and `ALTER VIEW … AS`). When no source text is available (e.g. a synthesized node), the caller falls back to the re-rendered `toQuotedSqlString`.                                                                                                      
                                                                                                                                                        
Scope and decisions:                                                                                                                                    
- Limited to materialized tables and views. `CREATE/REPLACE TABLE AS` do not persist an `originalQuery`, so they are intentionally left unchanged.      
- `expandedQuery` semantics are unchanged.                                                                                                              
- Pre-existing catalog entries keep their previously-normalized `originalQuery`; no migration is performed.                                             
                                                                                                                                                        
## Verifying this change                                                                                                                                
                                                                                                                                                        
This change added tests and can be verified as follows:                                                                                                 
                                                                                                                                                        
- Parameterized tests in `SqlMaterializedTableNodeToOperationConverterTest` and `SqlDdlToOperationConverterTest` assert that the persisted `originalQuery` is the verbatim `AS`-query text across:                                                                                                 
- comment handling — comments inside the query, between `AS` and the query, and after the query are all preserved;                                    
- multi-line block comments and a multi-line DDL prefix before `AS` (so the line/offset counting is exercised);                                       
- identifier quoting and escaped tokens in the prefix that must not shift the slice;                          
- complex query shapes: CTEs, set operations, window functions, multi-table joins, aggregations, nested subqueries, and string literals containing SQL keywords, comment markers, escaped quotes and astral characters.                                                                                        
- Existing `expandedQuery` assertions are retained unchanged. 

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no (signature change on SqlNodeToOperationConversion is `@Internal`; backward-compatible overload kept)
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no
- Note: catalog entries persisted before this change still hold the normalized originalQuery. No migration performed.

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable

#### Was generative AI tooling used to co-author this PR?
- [x] Yes - Claude Opus 4.7 to go through the implementation once and check for inconsistencies 