### PR TITLE
[FLINK-39803][e2e] Ignore jdk25 native access and deprecated method warnings

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -519,7 +519,14 @@ function check_logs_for_non_empty_out_files {
     -e "WARNING: Please consider reporting"\
     -e "WARNING: Use --illegal-access"\
     -e "WARNING: All illegal access"\
+    -e "WARNING: A terminally deprecated method"\
+    -e "WARNING: sun.misc.Unsafe::"\
+    -e "WARNING: A restricted method"\
+    -e "WARNING: java.lang.System::"\
+    -e "WARNING: Restricted methods will be blocked"\
+    -e "WARNING: Use --enable-native-access"\
     -e "Picked up JAVA_TOOL_OPTIONS"\
+    -e "^$"\
     $FLINK_LOG_DIR/*.out\
    | grep "." \
    > /dev/null; then


### PR DESCRIPTION

## What is the purpose of the change
  When using restricted or terminally deprecated methods, the JVM prints warnings on JDK 25 like below:
```
  WARNING: A terminally deprecated method in java.lang.System has been called
  WARNING: java.lang.System::setSecurityManager has been called by org.apache.flink.runtime.security.NoOpSecurityManager
  WARNING: A restricted method in sun.misc.Unsafe has been called
  WARNING: sun.misc.Unsafe::objectFieldOffset has been called by org.apache.flink.core.memory.MemorySegment
  WARNING: Use --enable-native-access to avoid a warning for callers in this module
  WARNING: Restricted methods will be blocked in a future release unless native access is enabled
```
  These are printed into the .out file of the processes, and cause e2e tests to fail since we check for empty .out files.

  These warnings cannot be suppressed without {{--enable-native-access}}, which would require changes across the entire module structure. They also occur in third-party libraries (e.g. Netty, Kryo), so we cannot simply

  Additionally, empty lines appearing in .out files can cause false positives and should also be excluded.
## Brief change log
common.sh

## Verifying this change

e2e

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
