### PR TITLE
[FLINK-39801][table] Skip serializing empty partition/order keys for PTF table args

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonDeserializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonDeserializer.java
@@ -69,6 +69,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 
 import static com.google.common.collect.ImmutableRangeSet.Builder;
 import static com.google.common.collect.ImmutableRangeSet.builder;
@@ -329,30 +330,36 @@ final class RexNodeJsonDeserializer extends StdDeserializer<RexNode> {
 
         final int inputIndex = jsonNode.required(FIELD_NAME_INPUT_INDEX).intValue();
 
-        final JsonNode partitionKeysNode = jsonNode.required(FIELD_NAME_PARTITION_KEYS);
-        final int[] partitionKeys = new int[partitionKeysNode.size()];
-        for (int i = 0; i < partitionKeysNode.size(); ++i) {
-            partitionKeys[i] = partitionKeysNode.get(i).asInt();
-        }
-
-        final JsonNode orderKeysNode = jsonNode.required(FIELD_NAME_ORDER_KEYS);
-        final int[] orderKeys = new int[orderKeysNode.size()];
-        for (int i = 0; i < orderKeysNode.size(); ++i) {
-            orderKeys[i] = orderKeysNode.get(i).asInt();
-        }
-
-        final JsonNode orderDirectionsNode = jsonNode.get(FIELD_NAME_ORDER_DIRECTIONS);
-        final SortOrder[] order;
-        if (orderDirectionsNode != null && !orderDirectionsNode.isEmpty()) {
-            order = new SortOrder[orderDirectionsNode.size()];
-            for (int i = 0; i < orderDirectionsNode.size(); ++i) {
-                order[i] = SortOrder.valueOf(orderDirectionsNode.get(i).asText());
-            }
-        } else {
-            order = new SortOrder[0];
-        }
+        final int[] partitionKeys =
+                deserializeArrayOrEmpty(jsonNode, FIELD_NAME_PARTITION_KEYS, JsonNode::asInt)
+                        .stream()
+                        .mapToInt(Integer::intValue)
+                        .toArray();
+        final int[] orderKeys =
+                deserializeArrayOrEmpty(jsonNode, FIELD_NAME_ORDER_KEYS, JsonNode::asInt).stream()
+                        .mapToInt(Integer::intValue)
+                        .toArray();
+        final SortOrder[] order =
+                deserializeArrayOrEmpty(
+                                jsonNode,
+                                FIELD_NAME_ORDER_DIRECTIONS,
+                                node -> SortOrder.valueOf(node.asText()))
+                        .toArray(new SortOrder[0]);
 
         return new RexTableArgCall(callType, inputIndex, partitionKeys, orderKeys, order);
+    }
+
+    private static <T> List<T> deserializeArrayOrEmpty(
+            JsonNode jsonNode, String fieldName, Function<JsonNode, T> elementDeserializer) {
+        final JsonNode arrayNode = jsonNode.get(fieldName);
+        if (arrayNode == null || arrayNode.isEmpty()) {
+            return List.of();
+        }
+        final List<T> result = new ArrayList<>(arrayNode.size());
+        for (final JsonNode element : arrayNode) {
+            result.add(elementDeserializer.apply(element));
+        }
+        return result;
     }
 
     private static RexNode deserializeCall(JsonNode jsonNode, SerdeContext serdeContext)

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonDeserializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonDeserializer.java
@@ -330,22 +330,30 @@ final class RexNodeJsonDeserializer extends StdDeserializer<RexNode> {
 
         final int inputIndex = jsonNode.required(FIELD_NAME_INPUT_INDEX).intValue();
 
-        final int[] partitionKeys = deserializeToIntArray(jsonNode, FIELD_NAME_PARTITION_KEYS);
-        final int[] orderKeys = deserializeToIntArray(jsonNode, FIELD_NAME_ORDER_KEYS);
-        final SortOrder[] order =
-                deserializeListOrEmpty(
-                                jsonNode,
-                                FIELD_NAME_ORDER_DIRECTIONS,
-                                node -> SortOrder.valueOf(node.asText()))
-                        .toArray(new SortOrder[0]);
+        final int[] partitionKeys = deserializeIntArray(jsonNode, FIELD_NAME_PARTITION_KEYS);
+        final int[] orderKeys = deserializeIntArray(jsonNode, FIELD_NAME_ORDER_KEYS);
+        final SortOrder[] sortOrders =
+                deserializeArray(
+                        jsonNode,
+                        FIELD_NAME_ORDER_DIRECTIONS,
+                        node -> SortOrder.valueOf(node.asText()),
+                        new SortOrder[0]);
 
-        return new RexTableArgCall(callType, inputIndex, partitionKeys, orderKeys, order);
+        return new RexTableArgCall(callType, inputIndex, partitionKeys, orderKeys, sortOrders);
     }
 
-    private static int[] deserializeToIntArray(JsonNode jsonNode, String fieldName) {
+    private static int[] deserializeIntArray(JsonNode jsonNode, String fieldName) {
         return deserializeListOrEmpty(jsonNode, fieldName, JsonNode::asInt).stream()
                 .mapToInt(Integer::intValue)
                 .toArray();
+    }
+
+    private static <T> T[] deserializeArray(
+            JsonNode jsonNode,
+            String fieldName,
+            Function<JsonNode, T> elementDeserializer,
+            T[] emptyArray) {
+        return deserializeListOrEmpty(jsonNode, fieldName, elementDeserializer).toArray(emptyArray);
     }
 
     private static <T> List<T> deserializeListOrEmpty(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonDeserializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonDeserializer.java
@@ -330,17 +330,10 @@ final class RexNodeJsonDeserializer extends StdDeserializer<RexNode> {
 
         final int inputIndex = jsonNode.required(FIELD_NAME_INPUT_INDEX).intValue();
 
-        final int[] partitionKeys =
-                deserializeArrayOrEmpty(jsonNode, FIELD_NAME_PARTITION_KEYS, JsonNode::asInt)
-                        .stream()
-                        .mapToInt(Integer::intValue)
-                        .toArray();
-        final int[] orderKeys =
-                deserializeArrayOrEmpty(jsonNode, FIELD_NAME_ORDER_KEYS, JsonNode::asInt).stream()
-                        .mapToInt(Integer::intValue)
-                        .toArray();
+        final int[] partitionKeys = deserializeToIntArray(jsonNode, FIELD_NAME_PARTITION_KEYS);
+        final int[] orderKeys = deserializeToIntArray(jsonNode, FIELD_NAME_ORDER_KEYS);
         final SortOrder[] order =
-                deserializeArrayOrEmpty(
+                deserializeListOrEmpty(
                                 jsonNode,
                                 FIELD_NAME_ORDER_DIRECTIONS,
                                 node -> SortOrder.valueOf(node.asText()))
@@ -349,7 +342,13 @@ final class RexNodeJsonDeserializer extends StdDeserializer<RexNode> {
         return new RexTableArgCall(callType, inputIndex, partitionKeys, orderKeys, order);
     }
 
-    private static <T> List<T> deserializeArrayOrEmpty(
+    private static int[] deserializeToIntArray(JsonNode jsonNode, String fieldName) {
+        return deserializeListOrEmpty(jsonNode, fieldName, JsonNode::asInt).stream()
+                .mapToInt(Integer::intValue)
+                .toArray();
+    }
+
+    private static <T> List<T> deserializeListOrEmpty(
             JsonNode jsonNode, String fieldName, Function<JsonNode, T> elementDeserializer) {
         final JsonNode arrayNode = jsonNode.get(fieldName);
         if (arrayNode == null || arrayNode.isEmpty()) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonSerializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonSerializer.java
@@ -340,16 +340,23 @@ final class RexNodeJsonSerializer extends StdSerializer<RexNode> {
         gen.writeStartObject();
         gen.writeStringField(FIELD_NAME_KIND, KIND_TABLE_ARG_CALL);
         gen.writeNumberField(FIELD_NAME_INPUT_INDEX, tableArgCall.getInputIndex());
-        gen.writeFieldName(FIELD_NAME_PARTITION_KEYS);
-        gen.writeArray(tableArgCall.getPartitionKeys(), 0, tableArgCall.getPartitionKeys().length);
-        gen.writeFieldName(FIELD_NAME_ORDER_KEYS);
-        gen.writeArray(tableArgCall.getOrderKeys(), 0, tableArgCall.getOrderKeys().length);
-        gen.writeFieldName(FIELD_NAME_ORDER_DIRECTIONS);
-        gen.writeStartArray();
-        for (SortOrder order : tableArgCall.getSortOrder()) {
-            gen.writeString(order.name());
+        if (tableArgCall.getPartitionKeys().length > 0) {
+            gen.writeFieldName(FIELD_NAME_PARTITION_KEYS);
+            gen.writeArray(
+                    tableArgCall.getPartitionKeys(), 0, tableArgCall.getPartitionKeys().length);
         }
-        gen.writeEndArray();
+        if (tableArgCall.getOrderKeys().length > 0) {
+            gen.writeFieldName(FIELD_NAME_ORDER_KEYS);
+            gen.writeArray(tableArgCall.getOrderKeys(), 0, tableArgCall.getOrderKeys().length);
+            if (tableArgCall.getSortOrder().length > 0) {
+                gen.writeFieldName(FIELD_NAME_ORDER_DIRECTIONS);
+                gen.writeStartArray();
+                for (SortOrder order : tableArgCall.getSortOrder()) {
+                    gen.writeString(order.name());
+                }
+                gen.writeEndArray();
+            }
+        }
         serializerProvider.defaultSerializeField(FIELD_NAME_TYPE, tableArgCall.getType(), gen);
         gen.writeEndObject();
     }

--- a/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-process-table-function_1/from-changelog-retract-restore/plan/from-changelog-retract-restore.json
+++ b/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-process-table-function_1/from-changelog-retract-restore/plan/from-changelog-retract-restore.json
@@ -43,9 +43,6 @@
       "operands" : [ {
         "kind" : "TABLE_ARG_CALL",
         "inputIndex" : 0,
-        "partitionKeys" : [ ],
-        "orderKeys" : [ ],
-        "orderDirections" : [ ],
         "type" : "ROW<`id` INT, `op` VARCHAR(2147483647), `name` VARCHAR(2147483647)> NOT NULL"
       }, {
         "kind" : "CALL",

--- a/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-process-table-function_1/process-late-events-restore/plan/process-late-events-restore.json
+++ b/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-process-table-function_1/process-late-events-restore/plan/process-late-events-restore.json
@@ -180,8 +180,6 @@
         "kind" : "TABLE_ARG_CALL",
         "inputIndex" : 0,
         "partitionKeys" : [ 0 ],
-        "orderKeys" : [ ],
-        "orderDirections" : [ ],
         "type" : {
           "type" : "ROW",
           "nullable" : false,

--- a/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-process-table-function_1/process-map-state-restore/plan/process-map-state-restore.json
+++ b/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-process-table-function_1/process-map-state-restore/plan/process-map-state-restore.json
@@ -54,7 +54,6 @@
         "kind" : "TABLE_ARG_CALL",
         "inputIndex" : 0,
         "partitionKeys" : [ 0 ],
-        "orderKeys" : [ ],
         "type" : "ROW<`name` VARCHAR(2147483647), `score` INT> NOT NULL"
       }, {
         "kind" : "CALL",

--- a/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-process-table-function_1/process-multi-input-restore/plan/process-multi-input-restore.json
+++ b/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-process-table-function_1/process-multi-input-restore/plan/process-multi-input-restore.json
@@ -94,13 +94,11 @@
         "kind" : "TABLE_ARG_CALL",
         "inputIndex" : 0,
         "partitionKeys" : [ 0 ],
-        "orderKeys" : [ ],
         "type" : "ROW<`name` VARCHAR(2147483647), `score` INT> NOT NULL"
       }, {
         "kind" : "TABLE_ARG_CALL",
         "inputIndex" : 1,
         "partitionKeys" : [ 0 ],
-        "orderKeys" : [ ],
         "type" : "ROW<`name` VARCHAR(2147483647), `city` VARCHAR(2147483647)> NOT NULL"
       }, {
         "kind" : "CALL",

--- a/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-process-table-function_1/process-multi-state-restore/plan/process-multi-state-restore.json
+++ b/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-process-table-function_1/process-multi-state-restore/plan/process-multi-state-restore.json
@@ -54,7 +54,6 @@
         "kind" : "TABLE_ARG_CALL",
         "inputIndex" : 0,
         "partitionKeys" : [ 0 ],
-        "orderKeys" : [ ],
         "type" : "ROW<`name` VARCHAR(2147483647), `score` INT> NOT NULL"
       }, {
         "kind" : "CALL",

--- a/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-process-table-function_1/process-partitioned-named-timers-restore/plan/process-partitioned-named-timers-restore.json
+++ b/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-process-table-function_1/process-partitioned-named-timers-restore/plan/process-partitioned-named-timers-restore.json
@@ -159,7 +159,6 @@
         "kind" : "TABLE_ARG_CALL",
         "inputIndex" : 0,
         "partitionKeys" : [ 0 ],
-        "orderKeys" : [ ],
         "type" : {
           "type" : "ROW",
           "nullable" : false,

--- a/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-process-table-function_1/process-row-semantic-table-restore/plan/process-row-semantic-table-restore.json
+++ b/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-process-table-function_1/process-row-semantic-table-restore/plan/process-row-semantic-table-restore.json
@@ -40,8 +40,6 @@
       "operands" : [ {
         "kind" : "TABLE_ARG_CALL",
         "inputIndex" : 0,
-        "partitionKeys" : [ ],
-        "orderKeys" : [ ],
         "type" : "ROW<`name` VARCHAR(2147483647), `score` INT> NOT NULL"
       }, {
         "kind" : "LITERAL",

--- a/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-process-table-function_1/process-updating-output-upsert-restore/plan/process-updating-output-upsert-restore.json
+++ b/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-process-table-function_1/process-updating-output-upsert-restore/plan/process-updating-output-upsert-restore.json
@@ -59,7 +59,6 @@
         "kind" : "TABLE_ARG_CALL",
         "inputIndex" : 0,
         "partitionKeys" : [ 0 ],
-        "orderKeys" : [ ],
         "type" : "ROW<`name` VARCHAR(2147483647) NOT NULL, `EXPR$1` BIGINT> NOT NULL"
       }, {
         "kind" : "CALL",

--- a/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-process-table-function_1/to-changelog-retract-restore/plan/to-changelog-retract-restore.json
+++ b/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-process-table-function_1/to-changelog-retract-restore/plan/to-changelog-retract-restore.json
@@ -45,9 +45,6 @@
       "operands" : [ {
         "kind" : "TABLE_ARG_CALL",
         "inputIndex" : 0,
-        "partitionKeys" : [ ],
-        "orderKeys" : [ ],
-        "orderDirections" : [ ],
         "type" : "ROW<`name` VARCHAR(2147483647) NOT NULL, `score` BIGINT> NOT NULL"
       }, {
         "kind" : "CALL",


### PR DESCRIPTION
## What is the purpose of the change                                                          
                                                                                                
`TABLE_ARG_CALL` nodes always wrote `partitionKeys`, `orderKeys`, and `orderDirections` into  the compiled plan JSON, even when empty. Table arguments without `PARTITION BY` and `ORDER BY`are common, so these empty arrays bloat the plan for no benefit. This change omits the arrays when empty, matching how `serializeCall` already skips empty operands.                        
                                                                                                
                                                                                                
## Brief change log                                                                           
                                                                                                
- `RexNodeJsonSerializer` skips `partitionKeys` / `orderKeys` / `orderDirections` when they  are empty.                                                                                    
- `RexNodeJsonDeserializer` treats the three fields as optional and defaults them to empty  arrays when absent, so plans written by older versions still load.                            
- Regenerated the affected PTF / `TO_CHANGELOG` / `FROM_CHANGELOG` restore plan files to  drop the now-omitted arrays.

## Verifying this change
  
This change is already covered by existing tests, such as the `stream-exec-process-table-function`, `TO_CHANGELOG`, and `FROM_CHANGELOG` restore tests. They load the regenerated plans through the deserializer and pass. The deserializer change keeps older plans that still contain the empty arrays loadable, preserving backward compatibility.
  
  
## Does this pull request potentially affect one of the following parts:
  
- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: yes. The compiled-plan JSON format changes, but it is backward compatible: the deserializer reads plans both with and without the arrays.
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no
  
## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable
  
---
  
##### Was generative AI tooling used to co-author this PR?
  
- [ ] Yes (please specify the tool below)
