### PR TITLE
[FLINK-39811][s3] Optionally Adjust s5cmd part size to fully utilize s5cmd workers pool during downloads

### DIFF
--- a/docs/content.zh/docs/deployment/filesystems/s3.md
+++ b/docs/content.zh/docs/deployment/filesystems/s3.md
@@ -294,6 +294,8 @@ s3.s5cmd.args: -r 0
 s3.s5cmd.batch.max-size: 1024mb
 # Maximum number of files that will be uploaded via a single s5cmd call.
 s3.s5cmd.batch.max-files: 100
+# Use fileSize/concurrency for part size instead of the static default (50MiB)
+s3.s5cmd.adjust-part-size: true
 ```
 
 Both `s3.s5cmd.batch.max-size` and `s3.s5cmd.batch.max-files` control resource usage of the `s5cmd` binary to prevent it from overloading the task manager.

--- a/docs/content/docs/deployment/filesystems/s3.md
+++ b/docs/content/docs/deployment/filesystems/s3.md
@@ -294,6 +294,8 @@ s3.s5cmd.args: -r 0
 s3.s5cmd.batch.max-size: 1024mb
 # Maximum number of files that will be uploaded via a single s5cmd call.
 s3.s5cmd.batch.max-files: 100
+# Use fileSize/concurrency for part size instead of the static default (50MiB)
+s3.s5cmd.adjust-part-size: true
 ```
 
 Both `s3.s5cmd.batch.max-size` and `s3.s5cmd.batch.max-files` control resource usage of the `s5cmd` binary to prevent it from overloading the task manager.

--- a/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/AbstractS3FileSystemFactory.java
+++ b/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/AbstractS3FileSystemFactory.java
@@ -90,6 +90,19 @@ public abstract class AbstractS3FileSystemFactory implements FileSystemFactory {
                     .defaultValue(100)
                     .withDescription("Maximum number of files to download per one call to s5cmd");
 
+    public static final ConfigOption<Boolean> S5CMD_ADJUST_PART_SIZE =
+            ConfigOptions.key("s3.s5cmd.adjust-part-size")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "When set to true, s5cmd will dynamically adjust the part size for copy commands to fully utilize all "
+                                    + FlinkS3FileSystem.DEFAULT_S5CMD_CONCURRENCY
+                                    + " channels. "
+                                    + "A smaller part size will improve operations speed but might incur in increased S3 request costs. "
+                                    + "When set to false, part size will default to "
+                                    + FlinkS3FileSystem.DEFAULT_S5CMD_PART_SIZE_MB
+                                    + " MiB.");
+
     public static final ConfigOption<Long> PART_UPLOAD_MIN_SIZE =
             ConfigOptions.key("s3.upload.min.part.size")
                     .longType()

--- a/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/FlinkS3FileSystem.java
+++ b/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/FlinkS3FileSystem.java
@@ -61,6 +61,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.flink.fs.s3.common.AbstractS3FileSystemFactory.ACCESS_KEY;
 import static org.apache.flink.fs.s3.common.AbstractS3FileSystemFactory.ENDPOINT;
+import static org.apache.flink.fs.s3.common.AbstractS3FileSystemFactory.S5CMD_ADJUST_PART_SIZE;
 import static org.apache.flink.fs.s3.common.AbstractS3FileSystemFactory.S5CMD_BATCH_MAX_FILES;
 import static org.apache.flink.fs.s3.common.AbstractS3FileSystemFactory.S5CMD_BATCH_MAX_SIZE;
 import static org.apache.flink.fs.s3.common.AbstractS3FileSystemFactory.S5CMD_EXTRA_ARGS;
@@ -92,6 +93,12 @@ public class FlinkS3FileSystem extends HadoopFileSystem
     /** The minimum size of a part in the multipart upload, except for the last part: 5 MIBytes. */
     public static final long S3_MULTIPART_MIN_PART_SIZE = 5L << 20;
 
+    /** The maximum allowed part size by AWS: 5 GIBytes. */
+    public static final long S3_MULTIPART_MAX_PART_SIZE = 5L << 30;
+
+    public static final long DEFAULT_S5CMD_PART_SIZE_MB = 50;
+    public static final long DEFAULT_S5CMD_CONCURRENCY = 5;
+
     private final String localTmpDir;
 
     private final FunctionWithException<File, RefCountedFileWithStream, IOException> tmpFileCreator;
@@ -113,6 +120,7 @@ public class FlinkS3FileSystem extends HadoopFileSystem
         @Nullable private final String accessArtifact;
         @Nullable private final String secretArtifact;
         @Nullable private final String endpoint;
+        private final boolean adjustPartSize;
         private long maxBatchSizeFiles;
         private long maxBatchSizeBytes;
 
@@ -124,7 +132,8 @@ public class FlinkS3FileSystem extends HadoopFileSystem
                 @Nullable String secretArtifact,
                 @Nullable String endpoint,
                 int maxBatchSizeFiles,
-                long maxBatchSizeBytes) {
+                long maxBatchSizeBytes,
+                boolean adjustPartSize) {
             if (!path.isEmpty()) {
                 File s5CmdFile = new File(path);
                 checkArgument(s5CmdFile.isFile(), "Unable to find s5cmd binary under [%s]", path);
@@ -138,6 +147,7 @@ public class FlinkS3FileSystem extends HadoopFileSystem
             this.endpoint = endpoint;
             this.maxBatchSizeFiles = maxBatchSizeFiles;
             this.maxBatchSizeBytes = maxBatchSizeBytes;
+            this.adjustPartSize = adjustPartSize;
         }
 
         public static Optional<S5CmdConfiguration> of(Configuration flinkConfig) {
@@ -152,7 +162,8 @@ public class FlinkS3FileSystem extends HadoopFileSystem
                                             flinkConfig.get(SECRET_KEY),
                                             flinkConfig.get(ENDPOINT),
                                             flinkConfig.get(S5CMD_BATCH_MAX_FILES),
-                                            flinkConfig.get(S5CMD_BATCH_MAX_SIZE).getBytes()));
+                                            flinkConfig.get(S5CMD_BATCH_MAX_SIZE).getBytes(),
+                                            flinkConfig.get(S5CMD_ADJUST_PART_SIZE)));
         }
 
         private void configureEnvironment(Map<String, String> environment) {
@@ -204,6 +215,12 @@ public class FlinkS3FileSystem extends HadoopFileSystem
                     + ", endpoint='"
                     + endpoint
                     + '\''
+                    + ", maxBatchSizeFiles="
+                    + maxBatchSizeFiles
+                    + ", maxBatchSizeBytes="
+                    + maxBatchSizeBytes
+                    + ", adjustPartSize="
+                    + adjustPartSize
                     + '}';
         }
     }
@@ -301,13 +318,27 @@ public class FlinkS3FileSystem extends HadoopFileSystem
         }
     }
 
+    private long partSizeFrom(long fileSizeBytes) {
+        return Math.max(
+                        S3_MULTIPART_MIN_PART_SIZE,
+                        Math.min(
+                                S3_MULTIPART_MAX_PART_SIZE,
+                                fileSizeBytes / DEFAULT_S5CMD_CONCURRENCY))
+                / (1L << 20);
+    }
+
     private List<String> convertToSpells(List<CopyRequest> requests) throws IOException {
         List<String> spells = new ArrayList<>();
         for (CopyRequest request : requests) {
             Files.createDirectories(Paths.get(request.getDestination().toUri()).getParent());
+            final long partSize =
+                    s5CmdConfiguration.adjustPartSize
+                            ? partSizeFrom(request.getSize())
+                            : DEFAULT_S5CMD_PART_SIZE_MB;
             spells.add(
                     String.format(
-                            "cp %s %s",
+                            "cp --part-size %s %s %s",
+                            partSize,
                             request.getSource().toUri().toString(),
                             request.getDestination().getPath()));
         }
@@ -320,7 +351,7 @@ public class FlinkS3FileSystem extends HadoopFileSystem
         int exitCode = 0;
         final AtomicReference<IOException> maybeCloseableRegistryException =
                 new AtomicReference<>();
-
+        LOG.debug("Casting spells: {}", spells);
         // Setup temporary working directory for the process
         File tmpWorkingDir = new File(localTmpDir, "s5cmd_" + UUID.randomUUID());
         java.nio.file.Path tmpWorkingPath = Files.createDirectories(tmpWorkingDir.toPath());

--- a/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/FlinkS3FileSystemTest.java
+++ b/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/FlinkS3FileSystemTest.java
@@ -33,6 +33,8 @@ import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import javax.annotation.Nonnull;
@@ -53,6 +55,7 @@ import java.util.stream.IntStream;
 
 import static org.apache.flink.fs.s3.common.AbstractS3FileSystemFactory.ACCESS_KEY;
 import static org.apache.flink.fs.s3.common.AbstractS3FileSystemFactory.ENDPOINT;
+import static org.apache.flink.fs.s3.common.AbstractS3FileSystemFactory.S5CMD_ADJUST_PART_SIZE;
 import static org.apache.flink.fs.s3.common.AbstractS3FileSystemFactory.S5CMD_BATCH_MAX_FILES;
 import static org.apache.flink.fs.s3.common.AbstractS3FileSystemFactory.S5CMD_EXTRA_ARGS;
 import static org.apache.flink.fs.s3.common.AbstractS3FileSystemFactory.S5CMD_PATH;
@@ -184,5 +187,75 @@ class FlinkS3FileSystemTest {
                         "The total number of issued s5cmd subcommands did not match the number of copy tasks:\n%s,\n%s",
                         totalSubcommands, tasks)
                 .isEqualTo(numFiles);
+    }
+
+    private static List<Arguments> partSizeTestArguments() {
+        return List.of(
+                Arguments.of(true, 123L * (1L << 20), 24L),
+                Arguments.of(
+                        true,
+                        25_605L * (1L << 20),
+                        FlinkS3FileSystem.S3_MULTIPART_MAX_PART_SIZE / (1L << 20)),
+                Arguments.of(
+                        true,
+                        25_600L * (1L << 20),
+                        FlinkS3FileSystem.S3_MULTIPART_MAX_PART_SIZE / (1L << 20)),
+                Arguments.of(
+                        true,
+                        10L * (1L << 20),
+                        FlinkS3FileSystem.S3_MULTIPART_MIN_PART_SIZE / (1L << 20)),
+                Arguments.of(
+                        false, 123L * (1L << 20), FlinkS3FileSystem.DEFAULT_S5CMD_PART_SIZE_MB));
+    }
+
+    @ParameterizedTest
+    @MethodSource("partSizeTestArguments")
+    @EnabledOnOs({OS.LINUX, OS.MAC}) // POSIX OS only to run shell script
+    public void testCopyUsesPartSize(
+            boolean adjustPartSize,
+            long copyRequestSize,
+            long expectedPartSize,
+            @TempDir File temporaryDirectory)
+            throws Exception {
+        File cmdFile = new File(temporaryDirectory, "cmd");
+        File inputToCmd = new File(temporaryDirectory, "input");
+        Preconditions.checkState(inputToCmd.mkdir());
+
+        String cmd =
+                String.format(
+                        "file=$(mktemp %s/s5cmd-input-XXX)\n"
+                                + "while read line; do echo $line >> $file; done < /dev/stdin",
+                        inputToCmd.getAbsolutePath());
+
+        FileUtils.writeStringToFile(cmdFile, cmd);
+        Preconditions.checkState(cmdFile.setExecutable(true), "Cannot set script file executable.");
+
+        final Configuration conf = new Configuration();
+        conf.set(S5CMD_PATH, cmdFile.getAbsolutePath());
+        conf.set(S5CMD_EXTRA_ARGS, "");
+        conf.set(S5CMD_ADJUST_PART_SIZE, adjustPartSize);
+        conf.set(ACCESS_KEY, "test-access-key");
+        conf.set(SECRET_KEY, "test-secret-key");
+        conf.set(ENDPOINT, "test-endpoint");
+
+        TestS3FileSystemFactory factory = new TestS3FileSystemFactory();
+        factory.configure(conf);
+
+        FlinkS3FileSystem fs = (FlinkS3FileSystem) factory.create(new URI("s3://test"));
+        List<CopyRequest> tasks =
+                Collections.singletonList(
+                        CopyRequest.of(
+                                new Path("file:///src-file"),
+                                new Path("file:///dst-file"),
+                                copyRequestSize));
+        fs.copyFiles(tasks, ICloseableRegistry.NO_OP);
+        File[] files = inputToCmd.listFiles();
+        Assertions.assertThat(files).isNotNull().hasSize(1);
+        List<String> subcommands = FileUtils.readLines(files[0], StandardCharsets.UTF_8);
+        Assertions.assertThat(subcommands).hasSize(1);
+        String command = subcommands.get(0);
+        Assertions.assertThat(command)
+                .describedAs("s5cmd command should contain --part-size %d", expectedPartSize)
+                .contains("--part-size " + expectedPartSize);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Allow s5cmd to be adjusted to file size and concurrency instead of the static 50MiB

## Brief change log

- Introduced part-size to s5cmd cp command, taking fileSize/concurrency if `s3.s5cmd.adjust-part-size` is enabled and 50MiB otherwise (50MiB being s5cmd default)

## Verifying this change

This change added tests and can be verified as follows:

- Added a parameterized test ensuring the part-size is used with s5cmd, adjusted correctly to different file sizes, aws min and max, and uses the default part-size when the flag is disabled.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes - Recovery from s3
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs

---

##### Was generative AI tooling used to co-author this PR?

Claude Opus 4.7 was used to generate the tests in `flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/FlinkS3FileSystemTest.java`