### PR TITLE
[FLINK-35726][table] Honor @DataTypeHint on POJO fields in type conve…

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/DataTypeExtractor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/DataTypeExtractor.java
@@ -247,6 +247,27 @@ public final class DataTypeExtractor {
     // Methods that extract a data type from a JVM Class with prior logical information
     // --------------------------------------------------------------------------------------------
 
+    /**
+     * Extracts a data type from a reflective {@link Field}, honoring a {@link DataTypeHint} on the
+     * field if present and otherwise falling back to reflective extraction with default templates.
+     */
+    public static DataType extractFromField(DataTypeFactory typeFactory, Field field) {
+        final DataTypeHint hint = field.getAnnotation(DataTypeHint.class);
+        final DataTypeTemplate template =
+                hint != null
+                        ? DataTypeTemplate.fromDefaults()
+                                .mergeWithInnerAnnotation(typeFactory, hint)
+                        : DataTypeTemplate.fromDefaults();
+        return extractDataTypeWithClassContext(
+                typeFactory,
+                template,
+                field.getDeclaringClass(),
+                field.getGenericType(),
+                String.format(
+                        " in field '%s' of class '%s'",
+                        field.getName(), field.getDeclaringClass().getName()));
+    }
+
     public static DataType extractFromStructuredClass(
             DataTypeFactory typeFactory, Class<?> implementationClass) {
         final DataType dataType =

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/TypeInfoDataTypeConverter.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/TypeInfoDataTypeConverter.java
@@ -33,10 +33,12 @@ import org.apache.flink.api.java.typeutils.PojoField;
 import org.apache.flink.api.java.typeutils.PojoTypeInfo;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.api.java.typeutils.TupleTypeInfoBase;
+import org.apache.flink.table.annotation.DataTypeHint;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.catalog.DataTypeFactory;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.DataTypeQueryable;
+import org.apache.flink.table.types.extraction.DataTypeExtractor;
 import org.apache.flink.table.types.extraction.ExtractionUtils;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RawType;
@@ -54,6 +56,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -271,13 +274,37 @@ public final class TypeInfoDataTypeConverter {
         final String[] fieldNames = compositeType.getFieldNames();
         final Class<?> typeClass = compositeType.getTypeClass();
 
+        final Map<String, Field> hintedPojoFields;
+        if (compositeType instanceof PojoTypeInfo) {
+            final PojoTypeInfo<?> pojoTypeInfo = (PojoTypeInfo<?>) compositeType;
+            hintedPojoFields = new HashMap<>();
+            for (int pos = 0; pos < arity; pos++) {
+                final Field field = pojoTypeInfo.getPojoFieldAt(pos).getField();
+                if (field.isAnnotationPresent(DataTypeHint.class)) {
+                    hintedPojoFields.put(field.getName(), field);
+                }
+            }
+        } else {
+            hintedPojoFields = Collections.emptyMap();
+        }
+
         final Map<String, DataType> fieldDataTypes = new LinkedHashMap<>();
         IntStream.range(0, arity)
                 .forEachOrdered(
-                        pos ->
+                        pos -> {
+                            final String name = fieldNames[pos];
+                            final Field hintedField = hintedPojoFields.get(name);
+                            if (hintedField != null) {
                                 fieldDataTypes.put(
-                                        fieldNames[pos],
-                                        toDataType(dataTypeFactory, compositeType.getTypeAt(pos))));
+                                        name,
+                                        DataTypeExtractor.extractFromField(
+                                                dataTypeFactory, hintedField));
+                            } else {
+                                fieldDataTypes.put(
+                                        name,
+                                        toDataType(dataTypeFactory, compositeType.getTypeAt(pos)));
+                            }
+                        });
 
         final List<String> fieldNamesReordered;
         final boolean isNullable;
@@ -297,6 +324,10 @@ public final class TypeInfoDataTypeConverter {
             // therefore we need to check the reflective field for more details
             fieldDataTypes.replaceAll(
                     (name, dataType) -> {
+                        // hinted fields already resolved through DataTypeExtractor
+                        if (hintedPojoFields.containsKey(name)) {
+                            return dataType;
+                        }
                         final Class<?> fieldClass =
                                 pojoFields.stream()
                                         .filter(f -> f.getName().equals(name))

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/TypeInfoDataTypeConverterTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/TypeInfoDataTypeConverterTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.table.annotation.DataTypeHint;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.types.utils.DataTypeFactoryMock;
 import org.apache.flink.table.types.utils.TypeInfoDataTypeConverter;
@@ -32,6 +33,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.time.DayOfWeek;
+import java.util.HashMap;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -111,7 +113,17 @@ class TypeInfoDataTypeConverterTest {
                         .lookupExpects(DayOfWeek.class)
                         .expectDataType(dummyRaw(DayOfWeek.class)),
                 TestSpec.forType(Types.VARIANT).expectDataType(DataTypes.VARIANT()),
-                TestSpec.forType(Types.BITMAP).expectDataType(DataTypes.BITMAP()));
+                TestSpec.forType(Types.BITMAP).expectDataType(DataTypes.BITMAP()),
+                TestSpec.forType(Types.POJO(PojoWithHintedMapField.class))
+                        .rawFallback(HashMap.class)
+                        .expectDataType(
+                                DataTypes.STRUCTURED(
+                                        PojoWithHintedMapField.class,
+                                        DataTypes.FIELD(
+                                                "headers",
+                                                DataTypes.MAP(DataTypes.STRING(), DataTypes.BYTES())
+                                                        .bridgedTo(HashMap.class)),
+                                        DataTypes.FIELD("id", DataTypes.STRING()))));
     }
 
     @ParameterizedTest(name = "{index}: {0}")
@@ -148,6 +160,11 @@ class TypeInfoDataTypeConverterTest {
             return this;
         }
 
+        TestSpec rawFallback(Class<?> rawClass) {
+            typeFactory.dataType = Optional.of(dummyRaw(rawClass));
+            return this;
+        }
+
         TestSpec expectDataType(DataType expectedDataType) {
             this.expectedDataType = expectedDataType;
             return this;
@@ -180,6 +197,19 @@ class TypeInfoDataTypeConverterTest {
             this.name = name;
             this.gender = gender;
             this.age = age;
+        }
+    }
+
+    /** POJO with a field carrying a {@link DataTypeHint} that overrides reflective extraction. */
+    public static class PojoWithHintedMapField {
+
+        public String id;
+
+        @DataTypeHint("MAP<STRING, BYTES>")
+        public HashMap<String, byte[]> headers;
+
+        public PojoWithHintedMapField() {
+            // default constructor
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Fix a regression where `@DataTypeHint` placed on a POJO field is silently ignored when a `TypeInformation` is converted to a `DataType` (e.g., via `tableEnv.toDataStream(table, MyPojo.class).map(...)` followed by `fromDataStream`), causing fields like `Map<String, byte[]>` annotated `MAP<STRING, BYTES>` to fall back to `RAW`.

## Brief change log

- Add `DataTypeExtractor#extractFromField(DataTypeFactory, Field)` that resolves a field's `DataType` from its reflective `@DataTypeHint`, falling back to default extraction when no hint is present.
- In `TypeInfoDataTypeConverter#convertToStructuredType`, detect POJO fields that carry `@DataTypeHint` and delegate them to `DataTypeExtractor#extractFromField` instead of the `TypeInformation`-driven path; skip the subsequent primitive-bridging pass for those fields since the extractor already finalizes them.

## Verifying this change

Added a `PojoWithHintedMapField` test POJO and a parameterized case in `TypeInfoDataTypeConverterTest` that asserts a `HashMap<String, byte[]>` field annotated `@DataTypeHint("MAP<STRING, BYTES>")` resolves to `MAP<STRING, BYTES>` bridged to `HashMap` instead of `RAW('java.util.HashMap', ...)`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
