### PR TITLE
[FLINK-39818][ci] Filter org.eclipse.parsson:parsson false positive for Elasticsearch connector

### DIFF
--- a/tools/ci/flink-ci-tools/src/main/java/org/apache/flink/tools/ci/licensecheck/JarFileChecker.java
+++ b/tools/ci/flink-ci-tools/src/main/java/org/apache/flink/tools/ci/licensecheck/JarFileChecker.java
@@ -214,6 +214,13 @@ public class JarFileChecker {
                     // dual-licensed under GPL 2 and EPL 2.0
                     // contained in sql-avro-confluent-registry
                     .filter(path -> !pathStartsWith(path, "/org/glassfish/jersey/internal"))
+                    // dual-licensed under GPL-2.0-with-Classpath-exception and EPL 2.0
+                    // contained in flink-sql-connector-elasticsearch8
+                    .filter(
+                            path ->
+                                    !pathStartsWith(
+                                            path,
+                                            "/org/apache/flink/elasticsearch8/shaded/org/eclipse/parsson"))
                     // contained in sql-connector-pulsar
                     // while the Pulsar connector is externalized, this is still needed for PyFlink
                     .filter(


### PR DESCRIPTION
## What is the purpose of the change

*`elasticsearch-java` client depends on `parsson` for JSON parsing, but it fails to pass the `JarFileChecker` (due to the presence of GPL 2.0 in the License). However`org.eclipse.parsson:parsson` use `GPL-2.0-with-Classpath-exception` or `EPL-2.0` license. I think it's ok to ship it into uber jar per Apache license policy Catagory B(https://www.apache.org/legal/resolved.html#category-b)*

This block https://github.com/apache/flink-connector-elasticsearch/pull/156.

The license in the header of parsson source code

```
/*
 * Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0, which is available at
 * http://www.eclipse.org/legal/epl-2.0.
 *
 * This Source Code may also be made available under the following Secondary
 * Licenses when the conditions for such availability set forth in the
 * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
 * version 2 with the GNU Classpath Exception, which is available at
 * https://www.gnu.org/software/classpath/license.html.
 *
 * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 */
```


## Brief change log

  - *Add parsson to the whitelist of JarFileChecker*


## Verifying this change

Manually testing

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no

---

##### Was generative AI tooling used to co-author this PR?

No
