### PR TITLE
[FLINK-39651][table] REGEXP plan-time validation and hot-path log cleanup

### DIFF
--- a/flink-python/pyflink/table/tests/test_expression.py
+++ b/flink-python/pyflink/table/tests/test_expression.py
@@ -193,7 +193,7 @@ class PyFlinkBatchExpressionTests(PyFlinkTestCase):
         self.assertEqual("MAKE_VALID_UTF8(a)", str(expr1.make_valid_utf8))
 
         # regexp functions
-        self.assertEqual("regexp(a, b)", str(expr1.regexp(expr2)))
+        self.assertEqual("REGEXP(a, b)", str(expr1.regexp(expr2)))
         self.assertEqual("REGEXP_COUNT(a, b)", str(expr1.regexp_count(expr2)))
         self.assertEqual('REGEXP_EXTRACT(a, b)', str(expr1.regexp_extract(expr2)))
         self.assertEqual('REGEXP_EXTRACT(a, b, 3)', str(expr1.regexp_extract(expr2, 3)))

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -1714,13 +1714,14 @@ public final class BuiltInFunctionDefinitions {
 
     public static final BuiltInFunctionDefinition REGEXP =
             BuiltInFunctionDefinition.newBuilder()
-                    .name("regexp")
+                    .name("REGEXP")
                     .kind(SCALAR)
                     .inputTypeStrategy(
                             sequence(
                                     logical(LogicalTypeFamily.CHARACTER_STRING),
                                     logical(LogicalTypeFamily.CHARACTER_STRING)))
                     .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.BOOLEAN())))
+                    .runtimeProvided()
                     .build();
 
     public static final BuiltInFunctionDefinition REGEXP_REPLACE =

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -1716,10 +1716,7 @@ public final class BuiltInFunctionDefinitions {
             BuiltInFunctionDefinition.newBuilder()
                     .name("REGEXP")
                     .kind(SCALAR)
-                    .inputTypeStrategy(
-                            sequence(
-                                    logical(LogicalTypeFamily.CHARACTER_STRING),
-                                    logical(LogicalTypeFamily.CHARACTER_STRING)))
+                    .inputTypeStrategy(SpecificInputTypeStrategies.REGEXP)
                     .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.BOOLEAN())))
                     .runtimeProvided()
                     .build();

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/RegexpInputTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/RegexpInputTypeStrategy.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference.strategies;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.ArgumentCount;
+import org.apache.flink.table.types.inference.ArgumentTypeStrategy;
+import org.apache.flink.table.types.inference.CallContext;
+import org.apache.flink.table.types.inference.ConstantArgumentCount;
+import org.apache.flink.table.types.inference.InputTypeStrategy;
+import org.apache.flink.table.types.inference.Signature;
+import org.apache.flink.table.types.inference.Signature.Argument;
+import org.apache.flink.table.types.logical.LogicalTypeFamily;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.apache.flink.table.types.inference.InputTypeStrategies.logical;
+
+/**
+ * Input type strategy for {@link BuiltInFunctionDefinitions#REGEXP}. Validates literal regex
+ * patterns at planning time.
+ */
+@Internal
+public class RegexpInputTypeStrategy implements InputTypeStrategy {
+
+    private static final int ARG_STR = 0;
+    private static final int ARG_REGEX = 1;
+
+    private static final ArgumentTypeStrategy STRING_ARG =
+            logical(LogicalTypeFamily.CHARACTER_STRING);
+
+    @Override
+    public ArgumentCount getArgumentCount() {
+        return ConstantArgumentCount.of(2);
+    }
+
+    @Override
+    public Optional<List<DataType>> inferInputTypes(
+            final CallContext callContext, final boolean throwOnFailure) {
+        if (STRING_ARG.inferArgumentType(callContext, ARG_STR, throwOnFailure).isEmpty()) {
+            return Optional.empty();
+        }
+        if (STRING_ARG.inferArgumentType(callContext, ARG_REGEX, throwOnFailure).isEmpty()) {
+            return Optional.empty();
+        }
+
+        final Optional<List<DataType>> patternError =
+                StrategyUtils.validateLiteralPattern(callContext, ARG_REGEX, throwOnFailure);
+        if (patternError.isPresent()) {
+            return patternError;
+        }
+
+        return Optional.of(callContext.getArgumentDataTypes());
+    }
+
+    @Override
+    public List<Signature> getExpectedSignatures(final FunctionDefinition definition) {
+        return List.of(
+                Signature.of(
+                        Argument.ofGroup("str", LogicalTypeFamily.CHARACTER_STRING),
+                        Argument.ofGroup("regex", LogicalTypeFamily.CHARACTER_STRING)));
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificInputTypeStrategies.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificInputTypeStrategies.java
@@ -194,6 +194,9 @@ public final class SpecificInputTypeStrategies {
     /** Type strategy for {@link BuiltInFunctionDefinitions#TO_TIMESTAMP_LTZ}. */
     public static final InputTypeStrategy TO_TIMESTAMP_LTZ = new ToTimestampLtzInputTypeStrategy();
 
+    /** Type strategy for {@link BuiltInFunctionDefinitions#REGEXP}. */
+    public static final InputTypeStrategy REGEXP = new RegexpInputTypeStrategy();
+
     /** Type strategy for {@link BuiltInFunctionDefinitions#REGEXP_EXTRACT}. */
     public static final InputTypeStrategy REGEXP_EXTRACT = new RegexpExtractInputTypeStrategy();
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/strategies/RegexpInputTypeStrategyTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/strategies/RegexpInputTypeStrategyTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference.strategies;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.types.inference.InputTypeStrategiesTestBase;
+
+import java.util.stream.Stream;
+
+import static org.apache.flink.table.types.inference.strategies.SpecificInputTypeStrategies.REGEXP;
+
+/** Tests for {@link RegexpInputTypeStrategy}. */
+class RegexpInputTypeStrategyTest extends InputTypeStrategiesTestBase {
+
+    @Override
+    protected Stream<TestSpec> testData() {
+        return Stream.of(
+                // Non-literal regex skips the plan-time compile check and is deferred to runtime.
+                TestSpec.forStrategy("Non-literal regex defers compile to runtime", REGEXP)
+                        .calledWithArgumentTypes(DataTypes.STRING(), DataTypes.STRING())
+                        .expectArgumentTypes(DataTypes.STRING(), DataTypes.STRING()),
+
+                // Valid literal regex compiles cleanly at plan time.
+                TestSpec.forStrategy("Valid literal regex compiles", REGEXP)
+                        .calledWithArgumentTypes(DataTypes.STRING(), DataTypes.STRING())
+                        .calledWithLiteralAt(1, "foo(.*?)bar")
+                        .expectArgumentTypes(DataTypes.STRING(), DataTypes.STRING()),
+
+                // Null literal regex short-circuits the plan-time check; runtime returns null.
+                TestSpec.forStrategy("Null regex literal is deferred", REGEXP)
+                        .calledWithArgumentTypes(DataTypes.STRING(), DataTypes.STRING())
+                        .calledWithLiteralAt(1, null)
+                        .expectArgumentTypes(DataTypes.STRING(), DataTypes.STRING()),
+
+                // Invalid literal regex surfaces as a ValidationException at plan time.
+                TestSpec.forStrategy("Invalid literal regex fails at plan time", REGEXP)
+                        .calledWithArgumentTypes(DataTypes.STRING(), DataTypes.STRING())
+                        .calledWithLiteralAt(1, "(")
+                        .expectErrorMessage("Invalid regular expression for"));
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/DirectConvertRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/DirectConvertRule.java
@@ -196,8 +196,6 @@ public class DirectConvertRule implements CallExpressionConvertRule {
         definitionSqlOperatorHashMap.put(
                 BuiltInFunctionDefinitions.REPEAT, FlinkSqlOperatorTable.REPEAT);
         definitionSqlOperatorHashMap.put(
-                BuiltInFunctionDefinitions.REGEXP, FlinkSqlOperatorTable.REGEXP);
-        definitionSqlOperatorHashMap.put(
                 BuiltInFunctionDefinitions.REVERSE, FlinkSqlOperatorTable.REVERSE);
         definitionSqlOperatorHashMap.put(
                 BuiltInFunctionDefinitions.SPLIT_INDEX, FlinkSqlOperatorTable.SPLIT_INDEX);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
@@ -597,15 +597,6 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
                             OperandTypes.family(SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER)),
                     SqlFunctionCategory.TIMEDATE);
 
-    public static final SqlFunction REGEXP =
-            new SqlFunction(
-                    "REGEXP",
-                    SqlKind.OTHER_FUNCTION,
-                    ReturnTypes.BOOLEAN_NULLABLE,
-                    null,
-                    OperandTypes.family(SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER),
-                    SqlFunctionCategory.STRING);
-
     public static final SqlFunction PARSE_URL =
             new SqlFunction(
                     "PARSE_URL",

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
@@ -952,6 +952,9 @@ class ExprCodeGenerator(
           case BuiltInFunctionDefinitions.JSON =>
             new JsonCallGen().generate(ctx, operands, FlinkTypeFactory.toLogicalType(call.getType))
 
+          case BuiltInFunctionDefinitions.REGEXP =>
+            StringCallGen.generateRegExp(ctx, operands, resultType)
+
           case BuiltInFunctionDefinitions.REGEXP_EXTRACT =>
             StringCallGen.generateRegexpExtract(ctx, operands, resultType)
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/StringCallGen.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/StringCallGen.scala
@@ -134,8 +134,6 @@ object StringCallGen {
 
       case CHR => generateChr(ctx, operands, returnType)
 
-      case REGEXP => generateRegExp(ctx, operands, returnType)
-
       case BIN => generateBin(ctx, operands, returnType)
 
       case CONCAT_FUNCTION =>

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/RegexpFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/RegexpFunctionsITCase.java
@@ -77,7 +77,16 @@ class RegexpFunctionsITCase extends BuiltInFunctionTestBase {
                                 $("f1").regexp(concat("(", "")),
                                 "REGEXP(f1, '(' || '')",
                                 false,
-                                DataTypes.BOOLEAN().nullable()));
+                                DataTypes.BOOLEAN().nullable()),
+                TestSetSpec.forFunction(
+                                BuiltInFunctionDefinitions.REGEXP,
+                                "Invalid literal regex fails at plan time")
+                        .onFieldsWithData("foobar")
+                        .andDataTypes(DataTypes.STRING())
+                        .testTableApiValidationError(
+                                $("f0").regexp("("), "Invalid regular expression for REGEXP:")
+                        .testSqlValidationError(
+                                "REGEXP(f0, '(')", "Invalid regular expression for REGEXP:"));
     }
 
     private Stream<TestSetSpec> regexpCountTestCases() {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/RegexpFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/RegexpFunctionsITCase.java
@@ -33,6 +33,7 @@ class RegexpFunctionsITCase extends BuiltInFunctionTestBase {
     @Override
     Stream<TestSetSpec> getTestSetSpecs() {
         return Stream.of(
+                        regexpTestCases(),
                         regexpCountTestCases(),
                         regexpExtractTestCases(),
                         regexpExtractAllTestCases(),
@@ -40,6 +41,43 @@ class RegexpFunctionsITCase extends BuiltInFunctionTestBase {
                         regexpReplaceTestCases(),
                         regexpSubstrTestCases())
                 .flatMap(s -> s);
+    }
+
+    private Stream<TestSetSpec> regexpTestCases() {
+        return Stream.of(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.REGEXP)
+                        .onFieldsWithData(null, "foobar", "(")
+                        .andDataTypes(DataTypes.STRING(), DataTypes.STRING(), DataTypes.STRING())
+                        .testResult(
+                                $("f0").regexp("foo"),
+                                "REGEXP(f0, 'foo')",
+                                null,
+                                DataTypes.BOOLEAN().nullable())
+                        .testResult(
+                                $("f1").regexp("foo"),
+                                "REGEXP(f1, 'foo')",
+                                true,
+                                DataTypes.BOOLEAN().nullable())
+                        .testResult(
+                                $("f1").regexp("xyz"),
+                                "REGEXP(f1, 'xyz')",
+                                false,
+                                DataTypes.BOOLEAN().nullable())
+                        .testResult(
+                                $("f1").regexp($("f2")),
+                                "REGEXP(f1, f2)",
+                                false,
+                                DataTypes.BOOLEAN().nullable())
+                        .testResult(
+                                $("f1").regexp(concat("fo", "o")),
+                                "REGEXP(f1, 'fo' || 'o')",
+                                true,
+                                DataTypes.BOOLEAN().nullable())
+                        .testResult(
+                                $("f1").regexp(concat("(", "")),
+                                "REGEXP(f1, '(' || '')",
+                                false,
+                                DataTypes.BOOLEAN().nullable()));
     }
 
     private Stream<TestSetSpec> regexpCountTestCases() {

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlFunctionUtils.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlFunctionUtils.java
@@ -1015,14 +1015,19 @@ public class SqlFunctionUtils {
         return Math.abs(str.hashCode());
     }
 
-    public static Boolean regExp(String s, String regex) {
-        if (regex.length() == 0) {
+    /**
+     * Returns whether {@code s} contains a match for the regular expression {@code regex}. Literal
+     * regexes are validated at planning time by the input type strategy.
+     */
+    public static boolean regExp(String s, String regex) {
+        if (regex.isEmpty()) {
             return false;
         }
         try {
-            return (REGEXP_PATTERN_CACHE.get(regex)).matcher(s).find(0);
-        } catch (Exception e) {
-            LOG.error("Exception when compile and match regex:" + regex + " on: " + s, e);
+            return REGEXP_PATTERN_CACHE.get(regex).matcher(s).find(0);
+        } catch (PatternSyntaxException e) {
+            // Literals are rejected at planning time; non-literal invalid regex
+            // returns false to preserve the prior runtime contract.
             return false;
         }
     }


### PR DESCRIPTION
## What is the purpose of the change      
                                                                                                                                                                                                                                                                                                                                                                                   
`REGEXP` does not validate literal regex patterns at planning time. When the regex is a string literal that fails `Pattern.compile`, the predicate logged an `ERROR` stack trace per record on the hot path (for example `... WHERE payload REGEXP '('`). This PR surfaces the failure as a `ValidationException` during type inference and removes the per-record log spam.                                                 
                                                                                                                                                                                                                                                                                                                                                                                                                             
This is a sub-task of the FLINK-39648 umbrella, following the pattern already established for `REGEXP_EXTRACT` (FLINK-39649) and `REGEXP_REPLACE` (FLINK-39650). It reuses the shared `StrategyUtils.validateLiteralPattern` helper introduced by those sub-tasks.                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                                                                             
## Brief change log                                                                                                                                                                                                                                                                                                                                                                                                          
- Drop the hot-path `LOG.error` in `SqlFunctionUtils.regExp`; catch `PatternSyntaxException` and return false. The pattern was already looked up through `REGEXP_PATTERN_CACHE`.                                                                                                                                                                                                                                             
- Migrate `BuiltInFunctionDefinitions.REGEXP` to `name("REGEXP")` + `runtimeProvided()`. Remove the legacy `FlinkSqlOperatorTable.REGEXP` entry, the `DirectConvertRule` mapping, and the `case REGEXP` arm in `StringCallGen`. Add a routing arm in `ExprCodeGenerator`'s `BridgingSqlFunction` block.                                                                                                                      
- Add `RegexpInputTypeStrategy` that validates 2 STRING args and the literal regex via `StrategyUtils.validateLiteralPattern`. Wire it through `SpecificInputTypeStrategies.REGEXP`.                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                                                                                             
## Verifying this change                                                                                                                                                                                                                                                                                                                                                                                                     
This change added tests and can be verified as follows:                                                                                                                                                                                                                                                                                                                                                                      
- New `RegexpInputTypeStrategyTest` covers four branches: non-literal regex defers, valid literal compiles, null literal is deferred, invalid literal fails at plan time.                                                                                                                                                                                                                                                    
- New `regexpTestCases()` in `RegexpFunctionsITCase` covers runtime behavior end-to-end (literal match/no-match, null input, column-ref invalid, function-call regex) plus a plan-time validation case via Table API and SQL.                                                                                                                                                                                                
- Existing `ScalarFunctionsTest`, `AsyncCalcSplitRuleTest`, and `AsyncCalcITCase` regress the operator.                                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                                                                             
## Does this pull request potentially affect one of the following parts:                                                                                                                                                                                                                                                                                                                                                     
- Dependencies (does it add or upgrade a dependency): no                                                                                                                                                                                                                                                                                                                                                                     
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no                                                                                                                                                                                                                                                                                                                                          
- The serializers: no                                                                                                                                                                                                                                                                                                                                                                                                        
- The runtime per-record code paths (performance sensitive): yes (removes per-record `LOG.error` in `regExp` on invalid patterns)                                                                                                                                                                                                                                                                                            
- Anything that affects deployment or recovery: no                                                                                                                                                                                                                                                                                                                                                                           
- The S3 file system connector: no                                                                                                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                                                                             
## Documentation                                                                                                                                                                                                                                                                                                                                                                                                             
- Does this pull request introduce a new feature? no                                                                                                                                                                                                                                                                                                                                                                         
- If yes, how is the feature documented? not applicable                                                                                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                                                                             
---                                                                                                                                                                                                                                                                                                                                                                                                                          
##### Was generative AI tooling used to co-author this PR?                                                                                                                                                                                                                                                                                                                                                                   
- [x] Yes (please specify the tool below)
  
Generated-by: Opus 4.8                                                                                                                                                                                                                                                                                                                                                                                                       