### PR TITLE
[FLINK-39821][table] Make REGEXP_REPLACE return type nullable

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -1728,7 +1728,7 @@ public final class BuiltInFunctionDefinitions {
                     .name("REGEXP_REPLACE")
                     .kind(SCALAR)
                     .inputTypeStrategy(SpecificInputTypeStrategies.REGEXP_REPLACE)
-                    .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.STRING())))
+                    .outputTypeStrategy(explicit(DataTypes.STRING().nullable()))
                     .runtimeProvided()
                     .build();
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/RegexpFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/RegexpFunctionsITCase.java
@@ -386,7 +386,17 @@ class RegexpFunctionsITCase extends BuiltInFunctionTestBase {
                                 "Invalid regular expression for REGEXP_REPLACE:")
                         .testSqlValidationError(
                                 "REGEXP_REPLACE(f0, '(', 'X')",
-                                "Invalid regular expression for REGEXP_REPLACE:"));
+                                "Invalid regular expression for REGEXP_REPLACE:"),
+                TestSetSpec.forFunction(
+                                BuiltInFunctionDefinitions.REGEXP_REPLACE,
+                                "Output stays nullable for non-null arguments")
+                        .onFieldsWithData("foobar", "(")
+                        .andDataTypes(DataTypes.STRING().notNull(), DataTypes.STRING().notNull())
+                        .testResult(
+                                $("f0").regexpReplace($("f1"), "X"),
+                                "REGEXP_REPLACE(f0, f1, 'X')",
+                                null,
+                                DataTypes.STRING().nullable()));
     }
 
     private Stream<TestSetSpec> regexpSubstrTestCases() {


### PR DESCRIPTION
Issue was mentioned post-merge in this PR: https://github.com/apache/flink/pull/28189#discussion_r3272445524
## What is the purpose of the change    
                                                                                                                                                  
`REGEXP_REPLACE` declared its output via `nullableIfArgs`, so the planner inferred a `NOT NULL` result when all three arguments were `NOT NULL`. But the runtime returns `null` for a     
non-literal regex that fails to compile: a column reference or a `CONCAT(...)` result is only validated at runtime, not at planning time. That let a `null` flow through a column the     
planner believed was non-null, which is unsound.                                                                                                                                          
                                                                                                                                                                                          
This is a sub-task of the FLINK-39648 umbrella.                                                                                                                                           
                                                                                                                                                                                          
## Brief change log 
                                                                                                                                                                      
- Change `BuiltInFunctionDefinitions.REGEXP_REPLACE` output type strategy from `nullableIfArgs(explicit(STRING()))` to `explicit(DataTypes.STRING().nullable())`, matching                
`REGEXP_EXTRACT`, which is always-nullable for the same reason. (`REGEXP` keeps `nullableIfArgs` because it returns `false`, not `null`, on an invalid pattern.)                          
                                                                                                                                                                                          
## Verifying this change                                                   
                                                                                                               
This change added a test and can be verified as follows:                                                                                                                                  
- New `RegexpFunctionsITCase` case with `NOT NULL` arguments and a non-literal invalid regex, asserting the output type stays nullable and the value is `null`.                           
- Existing `RegexpFunctionsITCase`, `ScalarFunctionsTest`, `SqlExpressionTest`, `MultiJoinTest` (plan digests unchanged), and `ExpressionSerializationTest` regress the function.         
                                                                                                                                                                                          
## Does this pull request potentially affect one of the following parts:             
                                                                                                     
- Dependencies (does it add or upgrade a dependency): no                                                                                                                                  
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no                                                                                                       
- The serializers: no                                                                                                                                                                     
- The runtime per-record code paths (performance sensitive): no                                                                                                                           
- Anything that affects deployment or recovery: no                                                                                                                                        
- The S3 file system connector: no                                                                                                                                                        
                                                                                                                                                                                          
## Documentation             
                                                                                                                                                             
- Does this pull request introduce a new feature? no                                                                                                                                      
- If yes, how is the feature documented? not applicable                                                                                                                                   
                                                                                                                                                                                          
---                                                                                                                                                                                       
##### Was generative AI tooling used to co-author this PR?    
                                                                                                                            
- [x] Yes (please specify the tool below)                                                                                                                                                 
                                                                                                                                                                                          
Generated-by: Opus 4.8    