### PR TITLE
[FLINK-39820][docs] Update delta join documentation with new features in 2.3

### DIFF
--- a/docs/content.zh/docs/dev/table/tuning.md
+++ b/docs/content.zh/docs/dev/table/tuning.md
@@ -405,7 +405,7 @@ FROM TenantKafka t
 该功能默认启用。当满足以下所有条件时， regular join 将自动优化为 delta join。
 
 1. 作业拓扑结构满足优化条件。具体可以查看[支持的功能和限制]({{< ref "docs/dev/table/tuning" >}}#supported-features-and-limitations)。
-2. 源表所在的外部存储系统提供了可供 delta join 快速查询的索引信息。目前 [Apache Fluss(Incubating)](https://fluss.apache.org/blog/fluss-open-source/) 已支持在 Flink 中提供表级别的索引信息，其上的表可作为 delta join 的源表。具体可参考 [Fluss 文档](https://fluss.apache.org/docs/engine-flink/delta-joins/#flink-version-support)。
+2. 源表所在的外部存储系统提供了可供 delta join 快速查询的索引信息。目前 [Apache Fluss (Incubating)](https://fluss.apache.org/blog/fluss-open-source/) 已支持在 Flink 中提供表级别的索引信息，其上的表可作为 delta join 的源表。具体可参考 [Fluss 文档](https://fluss.apache.org/docs/engine-flink/delta-joins/#flink-version-support)。
 
 <a name="working-principle"></a>
 
@@ -461,7 +461,7 @@ SET 'table.optimizer.delta-join.strategy' = 'NONE';
 6. 源表和 delta join 之间的 projection 或 filter 不能包含**非确定性函数**。
 
 {{< hint info >}}
-[1] Flink 支持定义表级别的**不可变列**（immutable columns）约束来丰富 upsert key，从而使更多场景能够被优化为 delta join。不可变列约束声明某些列一旦为给定主键设置后便不可修改，不可变列会联合主键，作为一组新的 upsert key 传播给下游。该信息由外部存储系统提供。[Apache Fluss(Incubating)](https://fluss.apache.org/) 已在未来计划支持表级别的不可变列约束。
+[1] Flink 支持定义表级别的**不可变列**（immutable columns）约束来丰富 upsert key，从而使更多场景能够被优化为 delta join。不可变列约束声明某些列一旦为给定主键设置后便不可修改，不可变列会联合主键，作为一组新的 upsert key 传播给下游。该信息由外部存储系统提供。[Apache Fluss (Incubating)](https://fluss.apache.org/) 已在未来计划支持表级别的不可变列约束。
 {{< /hint >}}
 
 {{< top >}}

--- a/docs/content.zh/docs/dev/table/tuning.md
+++ b/docs/content.zh/docs/dev/table/tuning.md
@@ -445,16 +445,23 @@ SET 'table.optimizer.delta-join.strategy' = 'NONE';
 
 1. 支持 **INSERT-only** 的表作为源表。
 2. 支持不带 **DELETE 操作**的 **CDC** 表作为源表。
-3. 支持源表和 delta join 间包含 **project** 和 **filter** 算子。
+3. 支持源表和 delta join 间包含 **projection** 和 **filter** 算子。
 4. Delta join 算子内支持**缓存**。
+5. 支持**级联 delta join**（cascaded delta join）—— 查询中符合条件的 join 节点从源表到结果表被依次转换为 delta join 节点。
+6. 支持 delta join 后接 **lookup join**。
+7. 支持在 delta join 与下游算子之间的 projection 和 filter 中使用**非确定性函数**。
 
 然而，delta join 也存在几个**限制**，包含以下任何条件的作业无法优化为 delta join。
 
 1. 表的**索引键**必须包含在 join 的**等值条件**中
 2. 目前仅支持 **INNER JOIN**。
 3. **下游节点**必须能够处理**冗余变更**。例如以 **UPSERT 模式**运行、不带 `upsertMaterialize` 的 sink 节点。
-4. 当消费 **CDC 流**时，**join key** 必须是**主键**的一部分。
-5. 当消费 **CDC 流**时，所有 **filter** 必须应用于 **upsert key** 上。
-6. 所有 project 和 filter 都不能包含**非确定性函数**。
+4. 当消费 **CDC 流**时，**join key** 必须是 **upsert key**<sup>[1]</sup> 的一部分。
+5. 当消费 **CDC 流**时，所有 **filter** 必须应用于 **upsert key**<sup>[1]</sup> 上。
+6. 源表和 delta join 之间的 projection 或 filter 不能包含**非确定性函数**。
+
+{{< hint info >}}
+[1] Flink 支持定义表级别的**不可变列**（immutable columns）约束来丰富 upsert key，从而使更多场景能够被优化为 delta join。不可变列约束声明某些列一旦为给定主键设置后便不可修改，不可变列会联合主键，作为一组新的 upsert key 传播给下游。该信息由外部存储系统提供。[Apache Fluss(Incubating)](https://fluss.apache.org/) 已在未来计划支持表级别的不可变列约束。
+{{< /hint >}}
 
 {{< top >}}

--- a/docs/content/docs/dev/table/tuning.md
+++ b/docs/content/docs/dev/table/tuning.md
@@ -431,12 +431,19 @@ Delta joins are continuously evolving, and supports the following features curre
 2. Support for **CDC** tables without **DELETE operations** as source tables.
 3. Support for **projection** and **filter** operations between the source and the delta join.
 4. Support for **caching** within the delta join operator.
+5. Support for **cascaded delta joins** — eligible join nodes in a query are sequentially converted into delta join nodes from source to sink.
+6. Support for **lookup join** after a delta join.
+7. Support for **non-deterministic functions** in projections and filters between the delta join and downstream operators.
 
 However, Delta Joins also have several **limitations**. Jobs containing any of the following conditions cannot be optimized into a delta join:
 
 1. The **index key** of the table must be included in the join’s **equivalence conditions**.
 2. Only **INNER JOIN** is currently supported.
 3. The **downstream operator** must be able to handle **duplicate changes**, such as a sink operating in **UPSERT mode** without `upsertMaterialize`.
-4. When consuming a **CDC stream**, the **join key** must be part of the **primary key**.
-5. When consuming a **CDC stream**, all **filters** must be applied on the **upsert key**.
-6. **Non-deterministic functions** are not allowed in filters or projections.
+4. When consuming a **CDC stream**, the **join key** must be part of the **upsert key**<sup>[1]</sup>.
+5. When consuming a **CDC stream**, all **filters** must be applied on the **upsert key**<sup>[1]</sup>.
+6. **Non-deterministic functions** are not allowed in projections or filters between the source and the delta join.
+
+{{< hint info >}}
+[1] Flink supports defining a table-level **immutable columns** constraint to enrich the upsert key, enabling delta join optimization in more scenarios. The immutable columns constraint declares that certain columns, once set for a given primary key, cannot be modified. The immutable columns are combined with the primary key to form a new upsert key that is propagated to downstream operators. This information is provided by the external storage system. [Apache Fluss(Incubating)](https://fluss.apache.org/) is planning to support table-level immutable columns constraint in the future.
+{{< /hint >}}

--- a/docs/content/docs/dev/table/tuning.md
+++ b/docs/content/docs/dev/table/tuning.md
@@ -395,7 +395,7 @@ To mitigate these challenges, Flink introduces the delta join operator. The key 
 This feature is enabled by default. A regular join will be automatically optimized into a delta join when all the following conditions are met:
 
 1. The sql pattern satisfies the optimization criteria. For details, please refer to [Supported Features and Limitations]({{< ref "docs/dev/table/tuning" >}}#supported-features-and-limitations)
-2. The external storage system of the source table provides index information for fast querying for delta joins. Currently, [Apache Fluss(Incubating)](https://fluss.apache.org/blog/fluss-open-source/) has provided index information at the table level for Flink, allowing such tables to be used as source tables for delta joins. Please refer to the [Fluss documentation](https://fluss.apache.org/docs/engine-flink/delta-joins/#flink-version-support) for more details.
+2. The external storage system of the source table provides index information for fast querying for delta joins. Currently, [Apache Fluss (Incubating)](https://fluss.apache.org/blog/fluss-open-source/) has provided index information at the table level for Flink, allowing such tables to be used as source tables for delta joins. Please refer to the [Fluss documentation](https://fluss.apache.org/docs/engine-flink/delta-joins/#flink-version-support) for more details.
 
 ### Working Principle
 
@@ -445,5 +445,5 @@ However, Delta Joins also have several **limitations**. Jobs containing any of t
 6. **Non-deterministic functions** are not allowed in projections or filters between the source and the delta join.
 
 {{< hint info >}}
-[1] Flink supports defining a table-level **immutable columns** constraint to enrich the upsert key, enabling delta join optimization in more scenarios. The immutable columns constraint declares that certain columns, once set for a given primary key, cannot be modified. The immutable columns are combined with the primary key to form a new upsert key that is propagated to downstream operators. This information is provided by the external storage system. [Apache Fluss(Incubating)](https://fluss.apache.org/) is planning to support table-level immutable columns constraint in the future.
+[1] Flink supports defining a table-level **immutable columns** constraint to enrich the upsert key, enabling delta join optimization in more scenarios. The immutable columns constraint declares that certain columns, once set for a given primary key, cannot be modified. The immutable columns are combined with the primary key to form a new upsert key that is propagated to downstream operators. This information is provided by the external storage system. [Apache Fluss (Incubating)](https://fluss.apache.org/) is planning to support table-level immutable columns constraint in the future.
 {{< /hint >}}


### PR DESCRIPTION
## What is the purpose of the change

This pull request updates the delta join documentation to reflect new capabilities introduced in Flink 2.3, including cascaded delta join, lookup join after delta join, non-deterministic function support, and the immutable columns constraint.


## Brief change log
 - Added cascaded delta join, lookup join after delta join, and non-deterministic function support to the "Supported Features" list
 - Updated the limitation on non-deterministic functions to clarify it only applies between the source and the delta join
 - Changed limitations 4 and 5 to reference "upsert key" instead of "primary key", with a footnote explaining the immutable columns constraint
 - Added a hint block describing the immutable columns constraint and its relationship to upsert key enrichment


## Verifying this change

None for doc.

## Does this pull request potentially affect one of the following parts:
 - Dependencies (does it add or upgrade a dependency): no
 - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
 - The serializers: no
 - The runtime per-record code paths (performance sensitive): no
 - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
 - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented?