### PR TITLE
[FLINK-36973][config] Skip options not explicitly set when converting SavepointRestoreSettings to Configuration

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -20,7 +20,6 @@ package org.apache.flink.client.cli;
 
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.ConfigurationUtils;
-import org.apache.flink.configuration.StateRecoveryOptions;
 import org.apache.flink.core.execution.RecoveryClaimMode;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 
@@ -654,9 +653,11 @@ public class CliFrontendParser {
 
     public static SavepointRestoreSettings createSavepointRestoreSettings(CommandLine commandLine) {
         if (commandLine.hasOption(SAVEPOINT_PATH_OPTION.getOpt())) {
-            String savepointPath = commandLine.getOptionValue(SAVEPOINT_PATH_OPTION.getOpt());
-            boolean allowNonRestoredState =
-                    commandLine.hasOption(SAVEPOINT_ALLOW_NON_RESTORED_OPTION.getOpt());
+            final String savepointPath = commandLine.getOptionValue(SAVEPOINT_PATH_OPTION.getOpt());
+            final Boolean allowNonRestoredState =
+                    commandLine.hasOption(SAVEPOINT_ALLOW_NON_RESTORED_OPTION.getOpt())
+                            ? Boolean.TRUE
+                            : null;
             final RecoveryClaimMode recoveryClaimMode;
             if (commandLine.hasOption(SAVEPOINT_CLAIM_MODE)) {
                 recoveryClaimMode =
@@ -672,7 +673,7 @@ public class CliFrontendParser {
                         "The option '%s' is deprecated. Please use '%s' instead.%n",
                         SAVEPOINT_RESTORE_MODE.getLongOpt(), SAVEPOINT_CLAIM_MODE.getLongOpt());
             } else {
-                recoveryClaimMode = StateRecoveryOptions.RESTORE_MODE.defaultValue();
+                recoveryClaimMode = null;
             }
             return SavepointRestoreSettings.forPath(
                     savepointPath, allowNonRestoredState, recoveryClaimMode);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/SavepointRestoreSettings.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/SavepointRestoreSettings.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.StateRecoveryOptions;
 import org.apache.flink.core.execution.RecoveryClaimMode;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import java.io.Serializable;
 import java.util.Objects;
@@ -37,10 +38,10 @@ public class SavepointRestoreSettings implements Serializable {
 
     /** No restore should happen. */
     private static final SavepointRestoreSettings NONE =
-            new SavepointRestoreSettings(null, false, RecoveryClaimMode.NO_CLAIM);
+            new SavepointRestoreSettings(null, null, null);
 
     /** Savepoint restore path. */
-    private final String restorePath;
+    private final @Nullable String restorePath;
 
     /**
      * Flag indicating whether non restored state is allowed if the savepoint contains state for an
@@ -48,22 +49,30 @@ public class SavepointRestoreSettings implements Serializable {
      */
     private final boolean allowNonRestoredState;
 
-    private final @Nonnull RecoveryClaimMode recoveryClaimMode;
+    /** Whether {@link #allowNonRestoredState} was explicitly set by the user. */
+    private final boolean allowNonRestoredStateExplicitlySet;
+
+    private final @Nullable RecoveryClaimMode recoveryClaimMode;
 
     /**
      * Creates the restore settings.
      *
      * @param restorePath Savepoint restore path.
-     * @param allowNonRestoredState Ignore unmapped state.
-     * @param recoveryClaimMode how to restore from the savepoint
+     * @param allowNonRestoredState Ignore unmapped state, or {@code null} if not explicitly set.
+     * @param recoveryClaimMode how to restore from the savepoint, or {@code null} if not explicitly
+     *     set.
      */
     private SavepointRestoreSettings(
-            String restorePath,
-            boolean allowNonRestoredState,
-            @Nonnull RecoveryClaimMode recoveryClaimMode) {
+            @Nullable String restorePath,
+            @Nullable Boolean allowNonRestoredState,
+            @Nullable RecoveryClaimMode recoveryClaimMode) {
         this.restorePath = restorePath;
-        this.allowNonRestoredState = allowNonRestoredState;
+        this.allowNonRestoredState =
+                allowNonRestoredState != null
+                        ? allowNonRestoredState
+                        : StateRecoveryOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE.defaultValue();
         this.recoveryClaimMode = recoveryClaimMode;
+        this.allowNonRestoredStateExplicitlySet = allowNonRestoredState != null;
     }
 
     /**
@@ -96,8 +105,10 @@ public class SavepointRestoreSettings implements Serializable {
     }
 
     /** Tells how to restore from the given savepoint. */
-    public @Nonnull RecoveryClaimMode getRecoveryClaimMode() {
-        return recoveryClaimMode;
+    public RecoveryClaimMode getRecoveryClaimMode() {
+        return recoveryClaimMode != null
+                ? recoveryClaimMode
+                : StateRecoveryOptions.RESTORE_MODE.defaultValue();
     }
 
     @Override
@@ -111,16 +122,18 @@ public class SavepointRestoreSettings implements Serializable {
 
         SavepointRestoreSettings that = (SavepointRestoreSettings) o;
         return allowNonRestoredState == that.allowNonRestoredState
+                && allowNonRestoredStateExplicitlySet == that.allowNonRestoredStateExplicitlySet
                 && Objects.equals(restorePath, that.restorePath)
                 && Objects.equals(recoveryClaimMode, that.recoveryClaimMode);
     }
 
     @Override
     public int hashCode() {
-        int result = restorePath != null ? restorePath.hashCode() : 0;
-        result = 31 * result + recoveryClaimMode.hashCode();
-        result = 31 * result + (allowNonRestoredState ? 1 : 0);
-        return result;
+        return Objects.hash(
+                restorePath,
+                allowNonRestoredState,
+                allowNonRestoredStateExplicitlySet,
+                recoveryClaimMode);
     }
 
     @Override
@@ -131,9 +144,9 @@ public class SavepointRestoreSettings implements Serializable {
                     + restorePath
                     + '\''
                     + ", allowNonRestoredState="
-                    + allowNonRestoredState
+                    + allowNonRestoredState()
                     + ", recoveryClaimMode="
-                    + recoveryClaimMode
+                    + getRecoveryClaimMode()
                     + ')';
         } else {
             return "SavepointRestoreSettings.none()";
@@ -146,25 +159,31 @@ public class SavepointRestoreSettings implements Serializable {
         return NONE;
     }
 
-    public static SavepointRestoreSettings forPath(String savepointPath) {
-        return forPath(
-                savepointPath,
-                StateRecoveryOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE.defaultValue());
+    public static SavepointRestoreSettings forPath(@Nonnull String savepointPath) {
+        return forPath(savepointPath, null, null);
     }
 
     public static SavepointRestoreSettings forPath(
-            String savepointPath, boolean allowNonRestoredState) {
-        checkNotNull(savepointPath, "Savepoint restore path.");
-        return new SavepointRestoreSettings(
-                savepointPath,
-                allowNonRestoredState,
-                StateRecoveryOptions.RESTORE_MODE.defaultValue());
+            @Nonnull String savepointPath, boolean allowNonRestoredState) {
+        return forPath(savepointPath, allowNonRestoredState, null);
     }
 
+    /**
+     * Creates restore settings. Parameters that are {@code null} indicate the user did not
+     * explicitly set them — their defaults will be used at runtime and they will not be written to
+     * configuration by {@link #toConfiguration}, allowing downstream configuration (e.g., SQL SET
+     * statements or flink-conf.yaml) to take effect.
+     *
+     * @param savepointPath the savepoint path to restore from.
+     * @param allowNonRestoredState whether to allow non-restored state, or {@code null} if not
+     *     explicitly set by the user.
+     * @param recoveryClaimMode how to restore from the savepoint, or {@code null} if not explicitly
+     *     set by the user.
+     */
     public static SavepointRestoreSettings forPath(
-            String savepointPath,
-            boolean allowNonRestoredState,
-            @Nonnull RecoveryClaimMode recoveryClaimMode) {
+            @Nonnull String savepointPath,
+            @Nullable Boolean allowNonRestoredState,
+            @Nullable RecoveryClaimMode recoveryClaimMode) {
         checkNotNull(savepointPath, "Savepoint restore path.");
         return new SavepointRestoreSettings(
                 savepointPath, allowNonRestoredState, recoveryClaimMode);
@@ -176,11 +195,15 @@ public class SavepointRestoreSettings implements Serializable {
     public static void toConfiguration(
             final SavepointRestoreSettings savepointRestoreSettings,
             final Configuration configuration) {
-        configuration.set(
-                StateRecoveryOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE,
-                savepointRestoreSettings.allowNonRestoredState());
-        configuration.set(
-                StateRecoveryOptions.RESTORE_MODE, savepointRestoreSettings.getRecoveryClaimMode());
+        if (savepointRestoreSettings.allowNonRestoredStateExplicitlySet) {
+            configuration.set(
+                    StateRecoveryOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE,
+                    savepointRestoreSettings.allowNonRestoredState);
+        }
+        if (savepointRestoreSettings.recoveryClaimMode != null) {
+            configuration.set(
+                    StateRecoveryOptions.RESTORE_MODE, savepointRestoreSettings.recoveryClaimMode);
+        }
         final String savepointPath = savepointRestoreSettings.getRestorePath();
         if (savepointPath != null) {
             configuration.set(StateRecoveryOptions.SAVEPOINT_PATH, savepointPath);
@@ -189,13 +212,15 @@ public class SavepointRestoreSettings implements Serializable {
 
     public static SavepointRestoreSettings fromConfiguration(final ReadableConfig configuration) {
         final String savepointPath = configuration.get(StateRecoveryOptions.SAVEPOINT_PATH);
-        final boolean allowNonRestored =
-                configuration.get(StateRecoveryOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE);
+        if (savepointPath == null) {
+            return SavepointRestoreSettings.none();
+        }
+        final Boolean allowNonRestored =
+                configuration
+                        .getOptional(StateRecoveryOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE)
+                        .orElse(null);
         final RecoveryClaimMode recoveryClaimMode =
-                configuration.get(StateRecoveryOptions.RESTORE_MODE);
-        return savepointPath == null
-                ? SavepointRestoreSettings.none()
-                : SavepointRestoreSettings.forPath(
-                        savepointPath, allowNonRestored, recoveryClaimMode);
+                configuration.getOptional(StateRecoveryOptions.RESTORE_MODE).orElse(null);
+        return SavepointRestoreSettings.forPath(savepointPath, allowNonRestored, recoveryClaimMode);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobgraph/SavepointRestoreSettingsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobgraph/SavepointRestoreSettingsTest.java
@@ -18,10 +18,13 @@
 
 package org.apache.flink.runtime.jobgraph;
 
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.StateRecoveryOptions;
 import org.apache.flink.core.execution.RecoveryClaimMode;
 
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 /** Tests for {@link SavepointRestoreSettings}. */
@@ -34,5 +37,136 @@ public class SavepointRestoreSettingsTest {
         SavepointRestoreSettings noClaimSettings =
                 SavepointRestoreSettings.forPath("/tmp", false, RecoveryClaimMode.NO_CLAIM);
         assertNotEquals(claimSettings, noClaimSettings);
+    }
+
+    @Test
+    void testToConfigurationWritesExplicitlySetValues() {
+        SavepointRestoreSettings settings =
+                SavepointRestoreSettings.forPath("/tmp/savepoint", true, RecoveryClaimMode.CLAIM);
+
+        Configuration configuration = new Configuration();
+        SavepointRestoreSettings.toConfiguration(settings, configuration);
+
+        assertThat(configuration.get(StateRecoveryOptions.SAVEPOINT_PATH))
+                .isEqualTo("/tmp/savepoint");
+        assertThat(configuration.get(StateRecoveryOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE))
+                .isTrue();
+        assertThat(configuration.get(StateRecoveryOptions.RESTORE_MODE))
+                .isEqualTo(RecoveryClaimMode.CLAIM);
+    }
+
+    @Test
+    void testToConfigurationSkipsNonExplicitlySetValues() {
+        SavepointRestoreSettings settings = SavepointRestoreSettings.forPath("/tmp/savepoint");
+
+        Configuration configuration = new Configuration();
+        SavepointRestoreSettings.toConfiguration(settings, configuration);
+
+        // Only the savepoint path should be written
+        assertThat(configuration.get(StateRecoveryOptions.SAVEPOINT_PATH))
+                .isEqualTo("/tmp/savepoint");
+        // These should NOT be written since they were not explicitly set (null)
+        assertThat(configuration.containsKey(StateRecoveryOptions.RESTORE_MODE.key())).isFalse();
+        assertThat(
+                        configuration.containsKey(
+                                StateRecoveryOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE.key()))
+                .isFalse();
+    }
+
+    @Test
+    void testToConfigurationWithPartialExplicitSettings() {
+        // Only recoveryClaimMode is explicitly set, allowNonRestoredState is NOT explicitly set
+        SavepointRestoreSettings settings =
+                SavepointRestoreSettings.forPath(
+                        "/tmp/savepoint", (Boolean) null, RecoveryClaimMode.CLAIM);
+
+        Configuration configuration = new Configuration();
+        SavepointRestoreSettings.toConfiguration(settings, configuration);
+
+        assertThat(configuration.get(StateRecoveryOptions.SAVEPOINT_PATH))
+                .isEqualTo("/tmp/savepoint");
+        assertThat(configuration.get(StateRecoveryOptions.RESTORE_MODE))
+                .isEqualTo(RecoveryClaimMode.CLAIM);
+        assertThat(
+                        configuration.containsKey(
+                                StateRecoveryOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE.key()))
+                .isFalse();
+    }
+
+    @Test
+    void testNoneSettingsDoNotWriteAnything() {
+        Configuration configuration = new Configuration();
+        SavepointRestoreSettings.toConfiguration(SavepointRestoreSettings.none(), configuration);
+
+        assertThat(configuration.containsKey(StateRecoveryOptions.SAVEPOINT_PATH.key())).isFalse();
+        assertThat(configuration.containsKey(StateRecoveryOptions.RESTORE_MODE.key())).isFalse();
+        assertThat(
+                        configuration.containsKey(
+                                StateRecoveryOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE.key()))
+                .isFalse();
+    }
+
+    @Test
+    void testFromConfigurationWithAllValuesSet() {
+        Configuration configuration = new Configuration();
+        configuration.set(StateRecoveryOptions.SAVEPOINT_PATH, "/tmp/savepoint");
+        configuration.set(StateRecoveryOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE, true);
+        configuration.set(StateRecoveryOptions.RESTORE_MODE, RecoveryClaimMode.CLAIM);
+
+        SavepointRestoreSettings settings =
+                SavepointRestoreSettings.fromConfiguration(configuration);
+
+        assertThat(settings.restoreSavepoint()).isTrue();
+        assertThat(settings.getRestorePath()).isEqualTo("/tmp/savepoint");
+        assertThat(settings.allowNonRestoredState()).isTrue();
+        assertThat(settings.getRecoveryClaimMode()).isEqualTo(RecoveryClaimMode.CLAIM);
+    }
+
+    @Test
+    void testFromConfigurationWithNoPath() {
+        Configuration configuration = new Configuration();
+        configuration.set(StateRecoveryOptions.RESTORE_MODE, RecoveryClaimMode.CLAIM);
+
+        SavepointRestoreSettings settings =
+                SavepointRestoreSettings.fromConfiguration(configuration);
+
+        assertThat(settings.restoreSavepoint()).isFalse();
+        assertThat(settings).isEqualTo(SavepointRestoreSettings.none());
+    }
+
+    @Test
+    void testFromConfigurationWithOnlyPath() {
+        Configuration configuration = new Configuration();
+        configuration.set(StateRecoveryOptions.SAVEPOINT_PATH, "/tmp/savepoint");
+
+        SavepointRestoreSettings settings =
+                SavepointRestoreSettings.fromConfiguration(configuration);
+
+        assertThat(settings.restoreSavepoint()).isTrue();
+        assertThat(settings.getRestorePath()).isEqualTo("/tmp/savepoint");
+        // Fields use defaults since they were not explicitly configured
+        assertThat(settings.allowNonRestoredState())
+                .isEqualTo(StateRecoveryOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE.defaultValue());
+        assertThat(settings.getRecoveryClaimMode())
+                .isEqualTo(StateRecoveryOptions.RESTORE_MODE.defaultValue());
+    }
+
+    @Test
+    void testFromConfigurationRoundTripPreservesExplicitlySetFlags() {
+        // When only the path is set, fromConfiguration produces settings with
+        // explicitlySet=false. A subsequent toConfiguration should NOT write those fields.
+        Configuration configuration = new Configuration();
+        configuration.set(StateRecoveryOptions.SAVEPOINT_PATH, "/tmp/savepoint");
+
+        SavepointRestoreSettings settings =
+                SavepointRestoreSettings.fromConfiguration(configuration);
+
+        Configuration output = new Configuration();
+        SavepointRestoreSettings.toConfiguration(settings, output);
+
+        assertThat(output.get(StateRecoveryOptions.SAVEPOINT_PATH)).isEqualTo("/tmp/savepoint");
+        assertThat(output.containsKey(StateRecoveryOptions.RESTORE_MODE.key())).isFalse();
+        assertThat(output.containsKey(StateRecoveryOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE.key()))
+                .isFalse();
     }
 }

--- a/flink-table/flink-sql-client/src/test/resources/sql/set.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/set.q
@@ -74,22 +74,20 @@ reset 'table.resources.download-dir';
 
 # list the configured configuration
 set;
-+-------------------------------------------------+--------------+
-|                                             key |        value |
-+-------------------------------------------------+--------------+
-|                 $internal.deployment.config-dir | /dummy/conf/ |
-|                              execution.attached |         true |
-|             execution.shutdown-on-attached-exit |        false |
-|             execution.state-recovery.claim-mode |     NO_CLAIM |
-| execution.state-recovery.ignore-unclaimed-state |        false |
-|                                execution.target |       remote |
-|                          jobmanager.rpc.address |    $VAR_JOBMANAGER_RPC_ADDRESS |
-|                                       rest.port |        $VAR_REST_PORT |
-|              sql-client.display.print-time-cost |        false |
-|                sql-client.execution.result-mode |      tableau |
-|                table.exec.legacy-cast-behaviour |     DISABLED |
-+-------------------------------------------------+--------------+
-11 rows in set
++-------------------------------------+--------------+
+|                                 key |        value |
++-------------------------------------+--------------+
+|     $internal.deployment.config-dir | /dummy/conf/ |
+|                  execution.attached |         true |
+| execution.shutdown-on-attached-exit |        false |
+|                    execution.target |       remote |
+|              jobmanager.rpc.address |    $VAR_JOBMANAGER_RPC_ADDRESS |
+|                           rest.port |        $VAR_REST_PORT |
+|  sql-client.display.print-time-cost |        false |
+|    sql-client.execution.result-mode |      tableau |
+|    table.exec.legacy-cast-behaviour |     DISABLED |
++-------------------------------------+--------------+
+9 rows in set
 !ok
 
 # reset the configuration
@@ -98,19 +96,17 @@ reset;
 !info
 
 set;
-+-------------------------------------------------+--------------+
-|                                             key |        value |
-+-------------------------------------------------+--------------+
-|                 $internal.deployment.config-dir | /dummy/conf/ |
-|                              execution.attached |         true |
-|             execution.shutdown-on-attached-exit |        false |
-|             execution.state-recovery.claim-mode |     NO_CLAIM |
-| execution.state-recovery.ignore-unclaimed-state |        false |
-|                                execution.target |       remote |
-|                          jobmanager.rpc.address |    $VAR_JOBMANAGER_RPC_ADDRESS |
-|                                       rest.port |        $VAR_REST_PORT |
-+-------------------------------------------------+--------------+
-8 rows in set
++-------------------------------------+--------------+
+|                                 key |        value |
++-------------------------------------+--------------+
+|     $internal.deployment.config-dir | /dummy/conf/ |
+|                  execution.attached |         true |
+| execution.shutdown-on-attached-exit |        false |
+|                    execution.target |       remote |
+|              jobmanager.rpc.address |    $VAR_JOBMANAGER_RPC_ADDRESS |
+|                           rest.port |        $VAR_REST_PORT |
++-------------------------------------+--------------+
+6 rows in set
 !ok
 
 # should fail because default dialect doesn't support hive dialect
@@ -138,20 +134,18 @@ set 'sql-client.verbose' = 'true';
 !info
 
 set;
-+-------------------------------------------------+--------------+
-|                                             key |        value |
-+-------------------------------------------------+--------------+
-|                 $internal.deployment.config-dir | /dummy/conf/ |
-|                              execution.attached |         true |
-|             execution.shutdown-on-attached-exit |        false |
-|             execution.state-recovery.claim-mode |     NO_CLAIM |
-| execution.state-recovery.ignore-unclaimed-state |        false |
-|                                execution.target |       remote |
-|                          jobmanager.rpc.address |    $VAR_JOBMANAGER_RPC_ADDRESS |
-|                                       rest.port |        $VAR_REST_PORT |
-|                              sql-client.verbose |         true |
-+-------------------------------------------------+--------------+
-9 rows in set
++-------------------------------------+--------------+
+|                                 key |        value |
++-------------------------------------+--------------+
+|     $internal.deployment.config-dir | /dummy/conf/ |
+|                  execution.attached |         true |
+| execution.shutdown-on-attached-exit |        false |
+|                    execution.target |       remote |
+|              jobmanager.rpc.address |    $VAR_JOBMANAGER_RPC_ADDRESS |
+|                           rest.port |        $VAR_REST_PORT |
+|                  sql-client.verbose |         true |
++-------------------------------------+--------------+
+7 rows in set
 !ok
 
 set 'execution.attached' = 'false';
@@ -163,20 +157,18 @@ reset 'execution.attached';
 !info
 
 set;
-+-------------------------------------------------+--------------+
-|                                             key |        value |
-+-------------------------------------------------+--------------+
-|                 $internal.deployment.config-dir | /dummy/conf/ |
-|                              execution.attached |         true |
-|             execution.shutdown-on-attached-exit |        false |
-|             execution.state-recovery.claim-mode |     NO_CLAIM |
-| execution.state-recovery.ignore-unclaimed-state |        false |
-|                                execution.target |       remote |
-|                          jobmanager.rpc.address |    $VAR_JOBMANAGER_RPC_ADDRESS |
-|                                       rest.port |        $VAR_REST_PORT |
-|                              sql-client.verbose |         true |
-+-------------------------------------------------+--------------+
-9 rows in set
++-------------------------------------+--------------+
+|                                 key |        value |
++-------------------------------------+--------------+
+|     $internal.deployment.config-dir | /dummy/conf/ |
+|                  execution.attached |         true |
+| execution.shutdown-on-attached-exit |        false |
+|                    execution.target |       remote |
+|              jobmanager.rpc.address |    $VAR_JOBMANAGER_RPC_ADDRESS |
+|                           rest.port |        $VAR_REST_PORT |
+|                  sql-client.verbose |         true |
++-------------------------------------+--------------+
+7 rows in set
 !ok
 
 # test reset can work with add jar
@@ -194,20 +186,18 @@ SHOW JARS;
 !ok
 
 set;
-+-------------------------------------------------+--------------+
-|                                             key |        value |
-+-------------------------------------------------+--------------+
-|                 $internal.deployment.config-dir | /dummy/conf/ |
-|                              execution.attached |         true |
-|             execution.shutdown-on-attached-exit |        false |
-|             execution.state-recovery.claim-mode |     NO_CLAIM |
-| execution.state-recovery.ignore-unclaimed-state |        false |
-|                                execution.target |       remote |
-|                          jobmanager.rpc.address |    $VAR_JOBMANAGER_RPC_ADDRESS |
-|                                       rest.port |        $VAR_REST_PORT |
-|                              sql-client.verbose |         true |
-+-------------------------------------------------+--------------+
-9 rows in set
++-------------------------------------+--------------+
+|                                 key |        value |
++-------------------------------------+--------------+
+|     $internal.deployment.config-dir | /dummy/conf/ |
+|                  execution.attached |         true |
+| execution.shutdown-on-attached-exit |        false |
+|                    execution.target |       remote |
+|              jobmanager.rpc.address |    $VAR_JOBMANAGER_RPC_ADDRESS |
+|                           rest.port |        $VAR_REST_PORT |
+|                  sql-client.verbose |         true |
++-------------------------------------+--------------+
+7 rows in set
 !ok
 
 reset;

--- a/flink-table/flink-sql-gateway/src/test/resources/sql/set.q
+++ b/flink-table/flink-sql-gateway/src/test/resources/sql/set.q
@@ -27,19 +27,17 @@ reset table.resources.download-dir;
 
 set;
 !output
-+-------------------------------------------------+--------------+
-|                                             key |        value |
-+-------------------------------------------------+--------------+
-|                 $internal.deployment.config-dir | /dummy/conf/ |
-|                              execution.attached |         true |
-|             execution.shutdown-on-attached-exit |        false |
-|             execution.state-recovery.claim-mode |     NO_CLAIM |
-| execution.state-recovery.ignore-unclaimed-state |        false |
-|                                execution.target |       remote |
-|                          jobmanager.rpc.address |    localhost |
-|                                       rest.port |        $VAR_REST_PORT |
-+-------------------------------------------------+--------------+
-8 rows in set
++-------------------------------------+--------------+
+|                                 key |        value |
++-------------------------------------+--------------+
+|     $internal.deployment.config-dir | /dummy/conf/ |
+|                  execution.attached |         true |
+| execution.shutdown-on-attached-exit |        false |
+|                    execution.target |       remote |
+|              jobmanager.rpc.address |    localhost |
+|                           rest.port |        $VAR_REST_PORT |
++-------------------------------------+--------------+
+6 rows in set
 !ok
 
 # set illegal value
@@ -50,17 +48,15 @@ java.lang.IllegalArgumentException: No enum constant org.apache.flink.table.api.
 
 set;
 !output
-+-------------------------------------------------+--------------+
-|                                             key |        value |
-+-------------------------------------------------+--------------+
-|                 $internal.deployment.config-dir | /dummy/conf/ |
-|                              execution.attached |         true |
-|             execution.shutdown-on-attached-exit |        false |
-|             execution.state-recovery.claim-mode |     NO_CLAIM |
-| execution.state-recovery.ignore-unclaimed-state |        false |
-|                                execution.target |       remote |
-|                          jobmanager.rpc.address |    localhost |
-|                                       rest.port |        $VAR_REST_PORT |
-+-------------------------------------------------+--------------+
-8 rows in set
++-------------------------------------+--------------+
+|                                 key |        value |
++-------------------------------------+--------------+
+|     $internal.deployment.config-dir | /dummy/conf/ |
+|                  execution.attached |         true |
+| execution.shutdown-on-attached-exit |        false |
+|                    execution.target |       remote |
+|              jobmanager.rpc.address |    localhost |
+|                           rest.port |        $VAR_REST_PORT |
++-------------------------------------+--------------+
+6 rows in set
 !ok


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This PR fixes the issue in [FLINK-39673](https://issues.apache.org/jira/browse/FLINK-39673). It skips writing `RESTORE_MODE` and `SAVEPOINT_IGNORE_UNCLAIMED_STATE` from ```SavepointRestoreSettings``` into ```Configuration``` when they were not explicitly provided. If the user uses deprecated configuration keys for these options, this prevents the configurations from being overridden by default values.


## Brief change log

- In `SavepointRestoreSettings`, change the ```allowNonRestoredState``` and ```recoveryClaimMode``` from `NonNull` to `Nullable`, to tell whether they are explicitly provided.
- Modify `SavepointRestoreSettings.toConfiguration()` to skip writing `RESTORE_MODE` and
`SAVEPOINT_IGNORE_UNCLAIMED_STATE` when they were not explicitly provided by the user.


## Verifying this change

This change added tests and can be verified as follows:

  - *```SavepointRestoreSettingsTest.java``` Added test that validates that default/null values of SavepointRestoreSettings are correctly handled*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [X] Yes (please specify the tool below)

Generated-by: [Claude-4.6-Opus]
