### PR TITLE
[FLINK-39825] Add support for State TTL and eviction in ProcessTableFunctionTestHarness

### DIFF
--- a/docs/content.zh/docs/dev/table/functions/ptfs.md
+++ b/docs/content.zh/docs/dev/table/functions/ptfs.md
@@ -2465,6 +2465,54 @@ void testStateMutation() throws Exception {
 {{< /tab >}}
 {{< /tabs >}}
 
+**State TTL**: Use `advanceSystemClock()` to simulate processing time and trigger TTL-based eviction.
+State entries whose time since last write meets or exceeds their configured TTL will be
+cleared. For value state, the entire value is reset. For ListView and MapView, expired
+elements/entries are removed individually:
+
+{{< tabs "state-ttl" >}}
+{{< tab "Java" >}}
+```java
+@DataTypeHint("ROW<count BIGINT>")
+public static class CounterWithTtl extends ProcessTableFunction<Row> {
+    public static class CounterState {
+        public long counter = 0L;
+    }
+
+    public void eval(
+            @StateHint(ttl = "5s") CounterState state,
+            @ArgumentHint(ArgumentTrait.SET_SEMANTIC_TABLE) Row input) {
+        state.counter++;
+        collect(Row.of(state.counter));
+    }
+}
+
+@Test
+void testStateTtlExpires() throws Exception {
+  try (ProcessTableFunctionTestHarness<Row> harness =
+    ProcessTableFunctionTestHarness.ofClass(CounterWithTtl.class)
+    .withTableArgument("input", DataTypes.of("ROW<name STRING, value INT>"))
+    .withPartitionBy("input", "name")
+    .build()) {
+
+    harness.processElement(Row.of("Alice", 1));
+
+    CounterWithTtl.CounterState state =
+      harness.getStateForKey("state", Row.of("Alice"));
+    assertThat(state.counter).isEqualTo(1L);
+
+    // Advance past the 5-second TTL
+    harness.advanceSystemClock(5000);
+
+    // State has been evicted
+    state = harness.getStateForKey("state", Row.of("Alice"));
+    assertThat(state.counter).isEqualTo(0L);
+  }
+}
+```
+{{< /tab >}}
+{{< /tabs >}}
+
 #### Optional Partitioning
 
 For PTFs with `OPTIONAL_PARTITION_BY`, you can omit `withPartitionBy()` during harness setup. The
@@ -2586,4 +2634,3 @@ void testPOJO() throws Exception {
 - Timers (`onTimer`)
 - `on_time` / `rowtime`
 - Update traits (`SUPPORTS_UPDATES`, `REQUIRE_UPDATE_BEFORE`)
-- State TTL (state is supported but TTL expiration is not yet implemented)

--- a/docs/content/docs/dev/table/functions/ptfs.md
+++ b/docs/content/docs/dev/table/functions/ptfs.md
@@ -2468,6 +2468,54 @@ void testStateMutation() throws Exception {
 {{< /tab >}}
 {{< /tabs >}}
 
+**State TTL**: Use `advanceSystemClock()` to simulate processing time and trigger TTL-based eviction.
+State entries whose time since last write meets or exceeds their configured TTL will be
+cleared. For value state, the entire value is reset. For ListView and MapView, expired
+elements/entries are removed individually:
+
+{{< tabs "state-ttl" >}}
+{{< tab "Java" >}}
+```java
+@DataTypeHint("ROW<count BIGINT>")
+public static class CounterWithTtl extends ProcessTableFunction<Row> {
+    public static class CounterState {
+        public long counter = 0L;
+    }
+
+    public void eval(
+            @StateHint(ttl = "5s") CounterState state,
+            @ArgumentHint(ArgumentTrait.SET_SEMANTIC_TABLE) Row input) {
+        state.counter++;
+        collect(Row.of(state.counter));
+    }
+}
+
+@Test
+void testStateTtlExpires() throws Exception {
+  try (ProcessTableFunctionTestHarness<Row> harness =
+    ProcessTableFunctionTestHarness.ofClass(CounterWithTtl.class)
+    .withTableArgument("input", DataTypes.of("ROW<name STRING, value INT>"))
+    .withPartitionBy("input", "name")
+    .build()) {
+
+    harness.processElement(Row.of("Alice", 1));
+
+    CounterWithTtl.CounterState state =
+      harness.getStateForKey("state", Row.of("Alice"));
+    assertThat(state.counter).isEqualTo(1L);
+
+    // Advance past the 5-second TTL
+    harness.advanceSystemClock(5000);
+
+    // State has been evicted
+    state = harness.getStateForKey("state", Row.of("Alice"));
+    assertThat(state.counter).isEqualTo(0L);
+  }
+}
+```
+{{< /tab >}}
+{{< /tabs >}}
+
 #### Optional Partitioning
 
 For PTFs with `OPTIONAL_PARTITION_BY`, you can omit `withPartitionBy()` during harness setup. The
@@ -2589,4 +2637,3 @@ void testPOJO() throws Exception {
 - Timers (`onTimer`)
 - `on_time` / `rowtime`
 - Update traits (`SUPPORTS_UPDATES`, `REQUIRE_UPDATE_BEFORE`)
-- State TTL (state is supported but TTL expiration is not yet implemented)

--- a/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/ListViewStateConverter.java
+++ b/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/ListViewStateConverter.java
@@ -19,61 +19,62 @@
 package org.apache.flink.table.runtime.functions;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.table.api.dataview.ListView;
-import org.apache.flink.table.data.ArrayData;
-import org.apache.flink.table.data.GenericArrayData;
 import org.apache.flink.table.data.conversion.DataStructureConverter;
-import org.apache.flink.table.types.logical.ArrayType;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
+import java.util.function.LongSupplier;
+import java.util.stream.Collectors;
 
 /**
  * Converter for ListView state.
  *
- * <p>Converts between external ListView objects and internal ArrayData representation.
+ * <p>Internal storage is always a {@link TtlAwareListView} with elements in converted form.
  */
 @Internal
 class ListViewStateConverter implements StateConverter {
 
     private final DataStructureConverter<Object, Object> elementConverter;
-    private final ArrayData.ElementGetter elementGetter;
+    private final LongSupplier clock;
 
     ListViewStateConverter(
-            ArrayType arrayType, DataStructureConverter<Object, Object> elementConverter) {
+            DataStructureConverter<Object, Object> elementConverter, LongSupplier clock) {
         this.elementConverter = elementConverter;
-        this.elementGetter = ArrayData.createElementGetter(arrayType.getElementType());
+        this.clock = clock;
     }
 
     @Override
     public Object toInternal(Object external) {
-        ListView<?> listView = (ListView<?>) external;
-        List<?> elements = listView.getList();
-
-        Object[] internalArray = new Object[elements.size()];
-        for (int i = 0; i < elements.size(); i++) {
-            internalArray[i] = elementConverter.toInternal(elements.get(i));
-        }
-        return new GenericArrayData(internalArray);
+        TtlAwareListView<?> view = (TtlAwareListView<?>) external;
+        TtlAwareListView<Object> newView = new TtlAwareListView<>(clock);
+        newView.setListWithTimestamps(
+                convertElements(view.getList(), elementConverter::toInternal),
+                new ArrayList<>(view.getTimestamps()));
+        return newView;
     }
 
     @Override
     public Object toExternal(Object internal) {
-        ArrayData arrayData = (ArrayData) internal;
-        ListView<Object> listView = new ListView<>();
-
-        List<Object> elements = new ArrayList<>();
-        for (int i = 0; i < arrayData.size(); i++) {
-            Object internalElement = elementGetter.getElementOrNull(arrayData, i);
-            Object externalElement = elementConverter.toExternal(internalElement);
-            elements.add(externalElement);
-        }
-        listView.setList(elements);
-        return listView;
+        TtlAwareListView<?> view = (TtlAwareListView<?>) internal;
+        TtlAwareListView<Object> newView = new TtlAwareListView<>(clock);
+        newView.setListWithTimestamps(
+                convertElements(view.getList(), elementConverter::toExternal),
+                new ArrayList<>(view.getTimestamps()));
+        return newView;
     }
 
     @Override
     public Object createNewInternalState() {
-        return new GenericArrayData(new Object[0]);
+        return new TtlAwareListView<>(clock);
+    }
+
+    @Override
+    public void evictExpired(Object internalState, long now, long ttlMillis) {
+        ((TtlAwareListView<?>) internalState).evictExpired(now, ttlMillis);
+    }
+
+    private List<Object> convertElements(List<?> elements, Function<Object, Object> converter) {
+        return elements.stream().map(converter).collect(Collectors.toList());
     }
 }

--- a/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/MapViewStateConverter.java
+++ b/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/MapViewStateConverter.java
@@ -19,74 +19,74 @@
 package org.apache.flink.table.runtime.functions;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.table.api.dataview.MapView;
-import org.apache.flink.table.data.ArrayData;
-import org.apache.flink.table.data.GenericMapData;
-import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.data.conversion.DataStructureConverter;
-import org.apache.flink.table.types.logical.MapType;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.function.LongSupplier;
+import java.util.stream.Collectors;
 
 /**
  * Converter for MapView state.
  *
- * <p>Converts between external MapView objects and internal MapData representation.
+ * <p>Internal storage is always a {@link TtlAwareMapView} with keys and values in converted form.
  */
 @Internal
 class MapViewStateConverter implements StateConverter {
 
     private final DataStructureConverter<Object, Object> keyConverter;
     private final DataStructureConverter<Object, Object> valueConverter;
-    private final ArrayData.ElementGetter keyGetter;
-    private final ArrayData.ElementGetter valueGetter;
+    private final LongSupplier clock;
 
     MapViewStateConverter(
-            MapType mapType,
             DataStructureConverter<Object, Object> keyConverter,
-            DataStructureConverter<Object, Object> valueConverter) {
+            DataStructureConverter<Object, Object> valueConverter,
+            LongSupplier clock) {
         this.keyConverter = keyConverter;
         this.valueConverter = valueConverter;
-        this.keyGetter = ArrayData.createElementGetter(mapType.getKeyType());
-        this.valueGetter = ArrayData.createElementGetter(mapType.getValueType());
+        this.clock = clock;
     }
 
     @Override
     public Object toInternal(Object external) {
-        MapView<?, ?> mapView = (MapView<?, ?>) external;
-        Map<?, ?> entries = mapView.getMap();
-
-        Map<Object, Object> internalMap = new HashMap<>();
-        for (Map.Entry<?, ?> entry : entries.entrySet()) {
-            Object internalKey = keyConverter.toInternal(entry.getKey());
-            Object internalValue = valueConverter.toInternal(entry.getValue());
-            internalMap.put(internalKey, internalValue);
-        }
-        return new GenericMapData(internalMap);
+        return convertView(
+                (TtlAwareMapView<?, ?>) external,
+                keyConverter::toInternal,
+                valueConverter::toInternal);
     }
 
     @Override
     public Object toExternal(Object internal) {
-        MapData mapData = (MapData) internal;
-        MapView<Object, Object> mapView = new MapView<>();
-
-        Map<Object, Object> entries = new HashMap<>();
-        ArrayData keyArray = mapData.keyArray();
-        ArrayData valueArray = mapData.valueArray();
-        for (int i = 0; i < keyArray.size(); i++) {
-            Object internalKey = keyGetter.getElementOrNull(keyArray, i);
-            Object internalValue = valueGetter.getElementOrNull(valueArray, i);
-            Object externalKey = keyConverter.toExternal(internalKey);
-            Object externalValue = valueConverter.toExternal(internalValue);
-            entries.put(externalKey, externalValue);
-        }
-        mapView.setMap(entries);
-        return mapView;
+        return convertView(
+                (TtlAwareMapView<?, ?>) internal,
+                keyConverter::toExternal,
+                valueConverter::toExternal);
     }
 
     @Override
     public Object createNewInternalState() {
-        return new GenericMapData(new HashMap<>());
+        return new TtlAwareMapView<>(clock);
+    }
+
+    @Override
+    public void evictExpired(Object internalState, long now, long ttlMillis) {
+        ((TtlAwareMapView<?, ?>) internalState).evictExpired(now, ttlMillis);
+    }
+
+    private TtlAwareMapView<Object, Object> convertView(
+            TtlAwareMapView<?, ?> source,
+            Function<Object, Object> convertKey,
+            Function<Object, Object> convertValue) {
+        Map<Object, Object> entries = new HashMap<>();
+        source.getMap().forEach((k, v) -> entries.put(convertKey.apply(k), convertValue.apply(v)));
+        Map<Object, Long> timestamps =
+                source.getTimestamps().entrySet().stream()
+                        .collect(
+                                Collectors.toMap(
+                                        e -> convertKey.apply(e.getKey()), Map.Entry::getValue));
+        TtlAwareMapView<Object, Object> newView = new TtlAwareMapView<>(clock);
+        newView.setMapWithTimestamps(entries, timestamps);
+        return newView;
     }
 }

--- a/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/ProcessTableFunctionTestHarness.java
+++ b/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/ProcessTableFunctionTestHarness.java
@@ -20,6 +20,8 @@ package org.apache.flink.table.runtime.functions;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.annotation.ArgumentTrait;
+import org.apache.flink.table.api.dataview.ListView;
+import org.apache.flink.table.api.dataview.MapView;
 import org.apache.flink.table.catalog.DataTypeFactory;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.conversion.DataStructureConverter;
@@ -60,6 +62,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -109,6 +113,7 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
     private boolean isOpen;
     private final HarnessCollector collector;
     private final TestHarnessStateManager stateManager;
+    private final AtomicLong systemClock;
 
     private final String defaultTableArgument;
     private final Method evalMethod;
@@ -128,7 +133,8 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
             List<ArgumentInfo> arguments,
             Map<String, TableArgumentConverters> argumentConverters,
             DataStructureConverter<Object, Object> harnessOutputConverter,
-            TestHarnessStateManager stateManager)
+            TestHarnessStateManager stateManager,
+            AtomicLong systemClock)
             throws Exception {
         this.function = function;
         this.functionContext = functionContext;
@@ -137,6 +143,7 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
         this.argumentConverters = argumentConverters;
         this.harnessOutputConverter = harnessOutputConverter;
         this.stateManager = stateManager;
+        this.systemClock = systemClock;
         this.output = new ArrayList<>();
         this.collector = new HarnessCollector();
         this.isOpen = false;
@@ -301,6 +308,30 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
     /** Clear specific state entry for a given partition key. */
     public void clearStateForKey(String stateName, Row partitionKey) {
         stateManager.clearStateForKey(stateName, partitionKey);
+    }
+
+    /**
+     * Advances the simulated system clock by the given number of milliseconds, which might trigger
+     * state TTL eviction.
+     */
+    public void advanceSystemClock(long milliseconds) {
+        checkState(isOpen, "Harness is not open");
+        checkArgument(
+                milliseconds >= 0,
+                "Cannot advance system clock by a negative amount: %s",
+                milliseconds);
+        systemClock.addAndGet(milliseconds);
+        stateManager.evictExpiredState();
+    }
+
+    /**
+     * Advances the simulated system clock by the given {@link Duration}, which might trigger state
+     * TTL eviction.
+     */
+    public void advanceSystemClock(Duration duration) {
+        checkNotNull(duration, "duration must not be null");
+        checkArgument(!duration.isNegative(), "duration must not be negative");
+        advanceSystemClock(duration.toMillis());
     }
 
     private void invokeEval(TableArgumentInfo activeTableArg, Row activeRow) throws Exception {
@@ -689,15 +720,21 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
             validatePartitionConsistency(arguments);
             validateInitialStateKeys(arguments);
 
+            AtomicLong systemClock = new AtomicLong(0L);
+
             Map<String, TableArgumentConverters> argumentConverters = new HashMap<>();
             Map<String, StateConverter> stateConverters = new HashMap<>();
-            createConverters(arguments, argumentConverters, stateConverters, classLoader);
+            createConverters(
+                    arguments, argumentConverters, stateConverters, classLoader, systemClock::get);
 
             // Create state manager
             List<StateArgumentInfo> stateArguments = ArgumentInfo.filterStateArguments(arguments);
             TestHarnessStateManager stateManager =
                     new TestHarnessStateManager(
-                            stateArguments, stateConverters, extractPartitionKeyInfo(arguments));
+                            stateArguments,
+                            stateConverters,
+                            extractPartitionKeyInfo(arguments),
+                            systemClock::get);
 
             // Populate initial state
             for (Map.Entry<String, StateArgumentConfiguration> entry : stateArgs.entrySet()) {
@@ -729,7 +766,8 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
                     arguments,
                     argumentConverters,
                     harnessOutputConverter,
-                    stateManager);
+                    stateManager,
+                    systemClock);
         }
 
         /**
@@ -755,11 +793,13 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
                 List<ArgumentInfo> arguments,
                 Map<String, TableArgumentConverters> argumentConverters,
                 Map<String, StateConverter> stateConverters,
-                ClassLoader classLoader)
+                ClassLoader classLoader,
+                LongSupplier systemClock)
                 throws Exception {
 
             for (StateArgumentInfo stateArg : ArgumentInfo.filterStateArguments(arguments)) {
-                StateConverter converter = createStateConverter(stateArg.dataType, classLoader);
+                StateConverter converter =
+                        createStateConverter(stateArg.dataType, classLoader, systemClock);
                 stateConverters.put(stateArg.name, converter);
             }
 
@@ -1164,40 +1204,44 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
         }
 
         /** Creates appropriate StateConverter for the given state data type. */
-        private StateConverter createStateConverter(DataType stateDataType, ClassLoader classLoader)
-                throws Exception {
-            LogicalType logicalType = stateDataType.getLogicalType();
+        private StateConverter createStateConverter(
+                DataType stateDataType, ClassLoader classLoader, LongSupplier clock) {
+            DataType resolvedType =
+                    ListView.class.isAssignableFrom(stateDataType.getConversionClass())
+                                    || MapView.class.isAssignableFrom(
+                                            stateDataType.getConversionClass())
+                            ? stateDataType.getChildren().get(0)
+                            : stateDataType;
+
+            LogicalType logicalType = resolvedType.getLogicalType();
 
             if (logicalType instanceof ArrayType) {
-                ArrayType arrayType = (ArrayType) logicalType;
-                DataType elementType = stateDataType.getChildren().get(0);
+                DataType elementType = resolvedType.getChildren().get(0);
                 DataStructureConverter<Object, Object> elementConverter =
                         DataStructureConverters.getConverter(elementType);
                 elementConverter.open(classLoader);
-                return new ListViewStateConverter(arrayType, elementConverter);
+                return new ListViewStateConverter(elementConverter, clock);
             } else if (logicalType instanceof MapType) {
-                MapType mapType = (MapType) logicalType;
-                DataType keyType = stateDataType.getChildren().get(0);
-                DataType valueType = stateDataType.getChildren().get(1);
+                DataType keyType = resolvedType.getChildren().get(0);
+                DataType valueType = resolvedType.getChildren().get(1);
                 DataStructureConverter<Object, Object> keyConverter =
                         DataStructureConverters.getConverter(keyType);
                 DataStructureConverter<Object, Object> valueConverter =
                         DataStructureConverters.getConverter(valueType);
                 keyConverter.open(classLoader);
                 valueConverter.open(classLoader);
-                return new MapViewStateConverter(mapType, keyConverter, valueConverter);
+                return new MapViewStateConverter(keyConverter, valueConverter, clock);
             } else if (logicalType instanceof RowType) {
-                RowType rowType = (RowType) logicalType;
                 DataStructureConverter<Object, Object> converter =
-                        DataStructureConverters.getConverter(stateDataType);
+                        DataStructureConverters.getConverter(resolvedType);
                 converter.open(classLoader);
-                return new RowStateConverter(converter, rowType);
+                return new RowStateConverter((RowType) logicalType, converter);
             } else {
                 DataStructureConverter<Object, Object> converter =
-                        DataStructureConverters.getConverter(stateDataType);
+                        DataStructureConverters.getConverter(resolvedType);
                 converter.open(classLoader);
-                Class<?> stateClass = stateDataType.getConversionClass();
-                return new StructuredTypeStateConverter(converter, stateClass);
+                return new StructuredTypeStateConverter(
+                        resolvedType.getConversionClass(), converter);
             }
         }
 
@@ -1531,6 +1575,22 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
         StateArgumentInfo(String name, DataType dataType, Duration ttl) {
             super(name, dataType);
             this.ttl = ttl;
+        }
+
+        boolean hasNonZeroTtl() {
+            return ttl != null && !ttl.isZero();
+        }
+
+        boolean isListViewState() {
+            return ListView.class.isAssignableFrom(dataType.getConversionClass());
+        }
+
+        boolean isMapViewState() {
+            return MapView.class.isAssignableFrom(dataType.getConversionClass());
+        }
+
+        boolean isValueState() {
+            return !isListViewState() && !isMapViewState();
         }
     }
 

--- a/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/RowStateConverter.java
+++ b/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/RowStateConverter.java
@@ -30,7 +30,7 @@ class RowStateConverter implements StateConverter {
     private final DataStructureConverter<Object, Object> converter;
     private final RowType rowType;
 
-    RowStateConverter(DataStructureConverter<Object, Object> converter, RowType rowType) {
+    RowStateConverter(RowType rowType, DataStructureConverter<Object, Object> converter) {
         this.converter = converter;
         this.rowType = rowType;
     }

--- a/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/StructuredTypeStateConverter.java
+++ b/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/StructuredTypeStateConverter.java
@@ -33,7 +33,7 @@ class StructuredTypeStateConverter implements StateConverter {
     private final Class<?> pojoClass;
 
     StructuredTypeStateConverter(
-            DataStructureConverter<Object, Object> converter, Class<?> pojoClass) {
+            Class<?> pojoClass, DataStructureConverter<Object, Object> converter) {
         this.converter = converter;
         this.pojoClass = pojoClass;
     }

--- a/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/TestHarnessStateManager.java
+++ b/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/TestHarnessStateManager.java
@@ -19,39 +19,57 @@
 package org.apache.flink.table.runtime.functions;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.dataview.ListView;
+import org.apache.flink.table.api.dataview.MapView;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.types.Row;
 
 import javax.annotation.Nullable;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.function.LongSupplier;
 import java.util.stream.Collectors;
 
 /**
  * State manager for {@link ProcessTableFunctionTestHarness}.
  *
  * <p>Handles state storage, lifecycle, and conversion between external and internal storage
- * formats.
+ * formats. Supports TTL-based eviction.
  */
 @Internal
 class TestHarnessStateManager {
 
-    private final Map<Row, Map<String, Object>> stateByKey = new HashMap<>();
+    private final Map<Row, Map<String, StateEntry>> stateByKey = new HashMap<>();
     private final List<ProcessTableFunctionTestHarness.StateArgumentInfo> stateArguments;
     private final Map<String, StateConverter> stateConverters;
     private final PartitionKeyInfo partitionKeyInfo;
+    private final LongSupplier systemClock;
+
+    private static class StateEntry {
+        final Object internalData;
+        @Nullable final Long lastWriteTime;
+
+        StateEntry(Object internalData, @Nullable Long lastWriteTime) {
+            this.internalData = internalData;
+            this.lastWriteTime = lastWriteTime;
+        }
+    }
 
     TestHarnessStateManager(
             List<ProcessTableFunctionTestHarness.StateArgumentInfo> stateArguments,
             Map<String, StateConverter> stateConverters,
-            PartitionKeyInfo partitionKeyInfo) {
+            PartitionKeyInfo partitionKeyInfo,
+            LongSupplier systemClock) {
         this.stateArguments = stateArguments;
         this.stateConverters = stateConverters;
         this.partitionKeyInfo = partitionKeyInfo;
+        this.systemClock = systemClock;
     }
 
     static class PartitionKeyInfo {
@@ -105,29 +123,43 @@ class TestHarnessStateManager {
      * storage to external objects (value state, ListView, MapView).
      */
     Map<String, Object> loadStateForKey(Row key) {
-        Map<String, Object> internalState =
+        Map<String, StateEntry> entries =
                 stateByKey.computeIfAbsent(key, k -> createEmptyKeyState());
 
         Map<String, Object> externalState = new HashMap<>();
         for (ProcessTableFunctionTestHarness.StateArgumentInfo stateArg : stateArguments) {
-            Object internalData = internalState.get(stateArg.name);
-            Object external = convertToExternal(internalData, stateArg);
-            externalState.put(stateArg.name, external);
+            StateEntry entry = entries.get(stateArg.name);
+            StateConverter converter = stateConverters.get(stateArg.name);
+            externalState.put(stateArg.name, converter.toExternal(entry.internalData));
         }
         return externalState;
     }
 
     /**
-     * Update mutated state after eval() invocation. Converts external objects to internal format.
+     * Update mutated state after eval() invocation. Converts external state back to internal format
+     * and detects value state writes for TTL tracking.
      */
     void updateStateForKey(Row key, Map<String, Object> externalState) throws Exception {
-        Map<String, Object> internalState = new HashMap<>();
+        Map<String, StateEntry> oldEntries = stateByKey.get(key);
+        Map<String, StateEntry> newEntries = new HashMap<>();
         for (ProcessTableFunctionTestHarness.StateArgumentInfo stateArg : stateArguments) {
             Object external = externalState.get(stateArg.name);
-            Object internalData = convertToInternal(external, stateArg);
-            internalState.put(stateArg.name, internalData);
+            StateEntry oldEntry = oldEntries != null ? oldEntries.get(stateArg.name) : null;
+
+            StateConverter converter = stateConverters.get(stateArg.name);
+            Object internalData = converter.toInternal(external);
+
+            Long lastWriteTime = oldEntry != null ? oldEntry.lastWriteTime : null;
+            if (stateArg.hasNonZeroTtl() && stateArg.isValueState()) {
+                Object oldInternal = oldEntry != null ? oldEntry.internalData : null;
+                if (!Objects.equals(oldInternal, internalData)) {
+                    lastWriteTime = systemClock.getAsLong();
+                }
+            }
+
+            newEntries.put(stateArg.name, new StateEntry(internalData, lastWriteTime));
         }
-        stateByKey.put(key, internalState);
+        stateByKey.put(key, newEntries);
     }
 
     /** Clear all state for a partition key. */
@@ -139,11 +171,11 @@ class TestHarnessStateManager {
     /** Clear specific state entry for a given partition key, resetting it to its default value. */
     void clearStateForKey(String stateName, Row key) {
         partitionKeyInfo.validate(key);
-        Map<String, Object> internalState = stateByKey.get(key);
-        if (internalState != null) {
+        Map<String, StateEntry> entries = stateByKey.get(key);
+        if (entries != null) {
             ProcessTableFunctionTestHarness.StateArgumentInfo stateArg =
                     findStateArgument(stateName);
-            internalState.put(stateName, createNewStateInternalData(stateArg));
+            entries.put(stateName, new StateEntry(createNewStateInternalData(stateArg), null));
         }
     }
 
@@ -151,26 +183,33 @@ class TestHarnessStateManager {
     void setStateForKey(String stateName, Row key, Object externalState) throws Exception {
         partitionKeyInfo.validate(key);
         ProcessTableFunctionTestHarness.StateArgumentInfo stateArg = findStateArgument(stateName);
-        Object internalData = convertToInternal(externalState, stateArg);
+        StateConverter converter = stateConverters.get(stateName);
+        Object internalData = converter.toInternal(wrapIfPlainDataView(externalState));
 
-        Map<String, Object> internalState =
+        Map<String, StateEntry> entries =
                 stateByKey.computeIfAbsent(key, k -> createEmptyKeyState());
-        internalState.put(stateName, internalData);
+
+        Long lastWriteTime = null;
+        if (stateArg.hasNonZeroTtl() && stateArg.isValueState()) {
+            lastWriteTime = systemClock.getAsLong();
+        }
+
+        entries.put(stateName, new StateEntry(internalData, lastWriteTime));
     }
 
     /** Get the state for a given partition key. */
     @SuppressWarnings("unchecked")
     <T> T getStateForKey(String stateName, Row key) {
         partitionKeyInfo.validate(key);
-        Map<String, Object> internalState = stateByKey.get(key);
-        if (internalState == null) {
+        Map<String, StateEntry> entries = stateByKey.get(key);
+        if (entries == null) {
             return null;
         }
-        Object internalData = internalState.get(stateName);
-        if (internalData == null) {
+        StateEntry entry = entries.get(stateName);
+        if (entry == null) {
             return null;
         }
-        return (T) convertToExternal(internalData, findStateArgument(stateName));
+        return (T) convertToExternal(entry.internalData, findStateArgument(stateName));
     }
 
     /** Get all partition keys that have a specific state entry. */
@@ -186,19 +225,48 @@ class TestHarnessStateManager {
     <T> Map<Row, T> getStateForAllKeys(String stateName) {
         ProcessTableFunctionTestHarness.StateArgumentInfo stateArg = findStateArgument(stateName);
         Map<Row, T> result = new HashMap<>();
-        for (Map.Entry<Row, Map<String, Object>> entry : stateByKey.entrySet()) {
-            Object internalData = entry.getValue().get(stateName);
-            if (internalData != null) {
-                result.put(entry.getKey(), (T) convertToExternal(internalData, stateArg));
+        for (Map.Entry<Row, Map<String, StateEntry>> entry : stateByKey.entrySet()) {
+            StateEntry stateEntry = entry.getValue().get(stateName);
+            if (stateEntry != null) {
+                result.put(
+                        entry.getKey(), (T) convertToExternal(stateEntry.internalData, stateArg));
             }
         }
         return result;
     }
 
-    private Map<String, Object> createEmptyKeyState() {
-        Map<String, Object> newState = new HashMap<>();
+    void evictExpiredState() {
+        long now = systemClock.getAsLong();
         for (ProcessTableFunctionTestHarness.StateArgumentInfo stateArg : stateArguments) {
-            newState.put(stateArg.name, createNewStateInternalData(stateArg));
+            if (!stateArg.hasNonZeroTtl()) {
+                continue;
+            }
+            long ttlMillis = stateArg.ttl.toMillis();
+
+            for (Row key : new ArrayList<>(stateByKey.keySet())) {
+                Map<String, StateEntry> entries = stateByKey.get(key);
+                if (entries == null) {
+                    continue;
+                }
+
+                StateEntry entry = entries.get(stateArg.name);
+                if (entry == null) {
+                    continue;
+                }
+
+                if (stateArg.isValueState()) {
+                    evictValueState(stateArg, entry, entries, now, ttlMillis);
+                } else {
+                    evictDataViewState(stateArg, entry, now, ttlMillis);
+                }
+            }
+        }
+    }
+
+    private Map<String, StateEntry> createEmptyKeyState() {
+        Map<String, StateEntry> newState = new HashMap<>();
+        for (ProcessTableFunctionTestHarness.StateArgumentInfo stateArg : stateArguments) {
+            newState.put(stateArg.name, new StateEntry(createNewStateInternalData(stateArg), null));
         }
         return newState;
     }
@@ -213,12 +281,6 @@ class TestHarnessStateManager {
         return stateConverters.get(stateArg.name).toExternal(internalData);
     }
 
-    private Object convertToInternal(
-            Object external, ProcessTableFunctionTestHarness.StateArgumentInfo stateArg)
-            throws Exception {
-        return stateConverters.get(stateArg.name).toInternal(external);
-    }
-
     private ProcessTableFunctionTestHarness.StateArgumentInfo findStateArgument(String stateName) {
         for (ProcessTableFunctionTestHarness.StateArgumentInfo stateArg : stateArguments) {
             if (stateArg.name.equals(stateName)) {
@@ -229,5 +291,39 @@ class TestHarnessStateManager {
                 stateArguments.stream().map(arg -> arg.name).collect(Collectors.joining(", "));
         throw new IllegalArgumentException(
                 "Unknown state: '" + stateName + "'. Available states: [" + available + "]");
+    }
+
+    @SuppressWarnings("unchecked")
+    private Object wrapIfPlainDataView(Object external) {
+        if (external instanceof ListView && !(external instanceof TtlAwareListView)) {
+            TtlAwareListView<Object> wrapped = new TtlAwareListView<>(systemClock);
+            wrapped.setList((List<Object>) ((ListView<?>) external).getList());
+            return wrapped;
+        }
+        if (external instanceof MapView && !(external instanceof TtlAwareMapView)) {
+            TtlAwareMapView<Object, Object> wrapped = new TtlAwareMapView<>(systemClock);
+            wrapped.setMap((Map<Object, Object>) ((MapView<?, ?>) external).getMap());
+            return wrapped;
+        }
+        return external;
+    }
+
+    private void evictValueState(
+            ProcessTableFunctionTestHarness.StateArgumentInfo stateArg,
+            StateEntry entry,
+            Map<String, StateEntry> entries,
+            long now,
+            long ttlMillis) {
+        if (entry.lastWriteTime != null && now - entry.lastWriteTime >= ttlMillis) {
+            entries.put(stateArg.name, new StateEntry(createNewStateInternalData(stateArg), null));
+        }
+    }
+
+    private void evictDataViewState(
+            ProcessTableFunctionTestHarness.StateArgumentInfo stateArg,
+            StateEntry entry,
+            long now,
+            long ttlMillis) {
+        stateConverters.get(stateArg.name).evictExpired(entry.internalData, now, ttlMillis);
     }
 }

--- a/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/TimestampedValue.java
+++ b/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/TimestampedValue.java
@@ -20,25 +20,14 @@ package org.apache.flink.table.runtime.functions;
 
 import org.apache.flink.annotation.Internal;
 
-/**
- * Converter between external state representations (ListView, MapView, Row & Pojo state) and
- * internal storage formats.
- */
+/** A value paired with a write timestamp for TTL tracking. */
 @Internal
-interface StateConverter {
+class TimestampedValue<T> {
+    final T value;
+    final long timestamp;
 
-    /** Converts an external state object to internal storage format. */
-    Object toInternal(Object external) throws Exception;
-
-    /** Converts an internal storage format to external state object. */
-    Object toExternal(Object internal);
-
-    /** Creates a new empty internal state instance. */
-    Object createNewInternalState();
-
-    /**
-     * Evicts expired elements/entries from a TTL-aware internal state object. Only DataView
-     * converters override this; value state eviction is handled by the state manager directly.
-     */
-    default void evictExpired(Object internalState, long now, long ttlMillis) {}
+    TimestampedValue(T value, long timestamp) {
+        this.value = value;
+        this.timestamp = timestamp;
+    }
 }

--- a/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/TtlAwareListView.java
+++ b/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/TtlAwareListView.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.dataview.ListView;
+
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.LongSupplier;
+import java.util.stream.Collectors;
+
+/**
+ * A {@link ListView} that tracks per-element write timestamps for TTL eviction.
+ *
+ * <p>Uses a {@link TimestampedList} as the backing list, which stores elements alongside their
+ * timestamps in a single {@code ArrayList}. All mutations automatically record timestamps.
+ */
+@Internal
+class TtlAwareListView<T> extends ListView<T> {
+
+    private final LongSupplier clock;
+
+    TtlAwareListView(LongSupplier clock) {
+        this.clock = clock;
+        super.setList(new TimestampedList<>(clock));
+    }
+
+    @Override
+    public void setList(List<T> list) {
+        TimestampedList<T> tsList = new TimestampedList<>(clock);
+        tsList.addAll(list);
+        super.setList(tsList);
+    }
+
+    void evictExpired(long currentTime, long ttlMillis) {
+        asTsList().evictExpired(currentTime, ttlMillis);
+    }
+
+    List<Long> getTimestamps() {
+        return asTsList().getTimestamps();
+    }
+
+    void setListWithTimestamps(List<T> list, List<Long> timestamps) {
+        TimestampedList<T> tsList = new TimestampedList<>(clock);
+        tsList.setDataAndTimestamps(list, timestamps);
+        super.setList(tsList);
+    }
+
+    @SuppressWarnings("unchecked")
+    private TimestampedList<T> asTsList() {
+        return (TimestampedList<T>) getList();
+    }
+
+    /** List backed by timestamped values; mutations maintain a timestamp with each element. */
+    private static class TimestampedList<E> extends AbstractList<E> {
+
+        private final ArrayList<TimestampedValue<E>> list = new ArrayList<>();
+        private final LongSupplier clock;
+
+        TimestampedList(LongSupplier clock) {
+            this.clock = clock;
+        }
+
+        @Override
+        public E get(int index) {
+            return list.get(index).value;
+        }
+
+        @Override
+        public int size() {
+            return list.size();
+        }
+
+        @Override
+        public E set(int index, E element) {
+            TimestampedValue<E> old =
+                    list.set(index, new TimestampedValue<>(element, clock.getAsLong()));
+            return old.value;
+        }
+
+        @Override
+        public void add(int index, E element) {
+            list.add(index, new TimestampedValue<>(element, clock.getAsLong()));
+        }
+
+        @Override
+        public E remove(int index) {
+            return list.remove(index).value;
+        }
+
+        @Override
+        public void clear() {
+            list.clear();
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public void sort(Comparator<? super E> c) {
+            list.sort(
+                    (a, b) -> {
+                        if (c != null) {
+                            return c.compare(a.value, b.value);
+                        }
+                        return ((Comparable<E>) a.value).compareTo(b.value);
+                    });
+        }
+
+        void evictExpired(long currentTime, long ttlMillis) {
+            list.removeIf(se -> currentTime - se.timestamp >= ttlMillis);
+        }
+
+        List<Long> getTimestamps() {
+            return list.stream().map(se -> se.timestamp).collect(Collectors.toList());
+        }
+
+        void setDataAndTimestamps(List<? extends E> elements, List<Long> timestamps) {
+            if (elements.size() != timestamps.size()) {
+                throw new IllegalArgumentException(
+                        "Elements and timestamps must have the same size: "
+                                + elements.size()
+                                + " vs "
+                                + timestamps.size());
+            }
+            list.clear();
+            for (int i = 0; i < elements.size(); i++) {
+                list.add(new TimestampedValue<>(elements.get(i), timestamps.get(i)));
+            }
+        }
+    }
+}

--- a/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/TtlAwareMapView.java
+++ b/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/TtlAwareMapView.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.dataview.MapView;
+
+import java.util.AbstractMap;
+import java.util.AbstractSet;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.LongSupplier;
+import java.util.stream.Collectors;
+
+/**
+ * A {@link MapView} subclass that tracks per-entry write timestamps for TTL eviction.
+ *
+ * <p>Uses a {@link TimestampedMap} as the backing map, which stores values alongside their
+ * timestamps in a single {@code HashMap}.
+ */
+@Internal
+class TtlAwareMapView<K, V> extends MapView<K, V> {
+
+    private final LongSupplier clock;
+
+    TtlAwareMapView(LongSupplier clock) {
+        this.clock = clock;
+        super.setMap(new TimestampedMap<>(clock));
+    }
+
+    @Override
+    public void setMap(Map<K, V> map) {
+        TimestampedMap<K, V> tsMap = new TimestampedMap<>(clock);
+        tsMap.putAll(map);
+        super.setMap(tsMap);
+    }
+
+    void evictExpired(long currentTime, long ttlMillis) {
+        asTsMap().evictExpired(currentTime, ttlMillis);
+    }
+
+    Map<K, Long> getTimestamps() {
+        return asTsMap().getTimestamps();
+    }
+
+    void setMapWithTimestamps(Map<K, V> map, Map<K, Long> timestamps) {
+        TimestampedMap<K, V> tsMap = new TimestampedMap<>(clock);
+        tsMap.setDataAndTimestamps(map, timestamps);
+        super.setMap(tsMap);
+    }
+
+    @SuppressWarnings("unchecked")
+    private TimestampedMap<K, V> asTsMap() {
+        return (TimestampedMap<K, V>) getMap();
+    }
+
+    /** Map backed by timestamped values; mutations maintain a timestamp with each entry. */
+    private static class TimestampedMap<K, V> extends AbstractMap<K, V> {
+
+        private final HashMap<K, TimestampedValue<V>> map = new HashMap<>();
+        private final LongSupplier clock;
+
+        TimestampedMap(LongSupplier clock) {
+            this.clock = clock;
+        }
+
+        @Override
+        public V get(Object key) {
+            TimestampedValue<V> sv = map.get(key);
+            return sv != null ? sv.value : null;
+        }
+
+        @Override
+        public V put(K key, V value) {
+            TimestampedValue<V> old =
+                    map.put(key, new TimestampedValue<>(value, clock.getAsLong()));
+            return old != null ? old.value : null;
+        }
+
+        @Override
+        public V remove(Object key) {
+            TimestampedValue<V> old = map.remove(key);
+            return old != null ? old.value : null;
+        }
+
+        @Override
+        public boolean containsKey(Object key) {
+            return map.containsKey(key);
+        }
+
+        @Override
+        public int size() {
+            return map.size();
+        }
+
+        @Override
+        public void clear() {
+            map.clear();
+        }
+
+        @Override
+        public Set<K> keySet() {
+            return map.keySet();
+        }
+
+        @Override
+        public Set<Entry<K, V>> entrySet() {
+            return new AbstractSet<Entry<K, V>>() {
+                @Override
+                public Iterator<Entry<K, V>> iterator() {
+                    Iterator<Entry<K, TimestampedValue<V>>> it = map.entrySet().iterator();
+                    return new Iterator<Entry<K, V>>() {
+                        @Override
+                        public boolean hasNext() {
+                            return it.hasNext();
+                        }
+
+                        @Override
+                        public Entry<K, V> next() {
+                            Entry<K, TimestampedValue<V>> e = it.next();
+                            return new SimpleImmutableEntry<>(e.getKey(), e.getValue().value);
+                        }
+
+                        @Override
+                        public void remove() {
+                            it.remove();
+                        }
+                    };
+                }
+
+                @Override
+                public int size() {
+                    return map.size();
+                }
+            };
+        }
+
+        void evictExpired(long currentTime, long ttlMillis) {
+            map.values().removeIf(sv -> currentTime - sv.timestamp >= ttlMillis);
+        }
+
+        Map<K, Long> getTimestamps() {
+            return map.entrySet().stream()
+                    .collect(Collectors.toMap(Entry::getKey, e -> e.getValue().timestamp));
+        }
+
+        void setDataAndTimestamps(Map<? extends K, ? extends V> data, Map<K, Long> timestamps) {
+            if (data.size() != timestamps.size()) {
+                throw new IllegalArgumentException(
+                        "Data and timestamps must have the same size: "
+                                + data.size()
+                                + " vs "
+                                + timestamps.size());
+            }
+            map.clear();
+            for (Entry<? extends K, ? extends V> e : data.entrySet()) {
+                Long ts = timestamps.get(e.getKey());
+                map.put(e.getKey(), new TimestampedValue<>(e.getValue(), ts != null ? ts : 0L));
+            }
+        }
+    }
+}

--- a/flink-table/flink-table-test-utils/src/test/java/org/apache/flink/table/runtime/functions/ProcessTableFunctionTestHarnessTest.java
+++ b/flink-table/flink-table-test-utils/src/test/java/org/apache/flink/table/runtime/functions/ProcessTableFunctionTestHarnessTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.types.RowKind;
 
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -315,7 +316,7 @@ class ProcessTableFunctionTestHarnessTest {
         }
 
         public void eval(
-                @StateHint CounterState state,
+                @StateHint(ttl = "5s") CounterState state,
                 @ArgumentHint(ArgumentTrait.SET_SEMANTIC_TABLE) Row input) {
             state.counter++;
             collect(Row.of(state.counter));
@@ -326,7 +327,8 @@ class ProcessTableFunctionTestHarnessTest {
     @DataTypeHint("ROW<values ARRAY<INT>>")
     public static class PTFWithListViewState extends ProcessTableFunction<Row> {
         public void eval(
-                @StateHint(type = @DataTypeHint("ARRAY<INT>")) ListView<Integer> listState,
+                @StateHint(ttl = "5s", type = @DataTypeHint("ARRAY<INT>"))
+                        ListView<Integer> listState,
                 @ArgumentHint(ArgumentTrait.SET_SEMANTIC_TABLE) Row input)
                 throws Exception {
             Integer value = input.getFieldAs("value");
@@ -345,7 +347,7 @@ class ProcessTableFunctionTestHarnessTest {
     @DataTypeHint("ROW<key STRING, count INT>")
     public static class PTFWithMapViewState extends ProcessTableFunction<Row> {
         public void eval(
-                @StateHint MapView<String, Integer> mapState,
+                @StateHint(ttl = "5s") MapView<String, Integer> mapState,
                 @ArgumentHint(ArgumentTrait.SET_SEMANTIC_TABLE) Row input)
                 throws Exception {
             String key = input.getFieldAs("key");
@@ -363,7 +365,7 @@ class ProcessTableFunctionTestHarnessTest {
     @DataTypeHint("ROW<count BIGINT>")
     public static class PTFWithRowState extends ProcessTableFunction<Row> {
         public void eval(
-                @StateHint(type = @DataTypeHint("ROW<count BIGINT>")) Row memory,
+                @StateHint(ttl = "5s", type = @DataTypeHint("ROW<count BIGINT>")) Row memory,
                 @ArgumentHint(ArgumentTrait.SET_SEMANTIC_TABLE) Row input) {
             Long newCount = 1L;
             if (memory.getField("count") != null) {
@@ -395,6 +397,60 @@ class ProcessTableFunctionTestHarnessTest {
                 sum += v;
             }
             collect(Row.of(counter.count, sum));
+        }
+    }
+
+    /** PTF with negative TTL for validation testing. */
+    @DataTypeHint("ROW<count BIGINT>")
+    public static class PTFWithNegativeTtl extends ProcessTableFunction<Row> {
+        public static class CounterState {
+            public long counter = 0L;
+        }
+
+        public void eval(
+                @StateHint(ttl = "-5s") CounterState state,
+                @ArgumentHint(ArgumentTrait.SET_SEMANTIC_TABLE) Row input) {
+            state.counter++;
+            collect(Row.of(state.counter));
+        }
+    }
+
+    /** PTF with one TTL value state and one permanent value state. */
+    @DataTypeHint("ROW<ttlCount BIGINT, permCount BIGINT>")
+    public static class PTFWithMixedTtlState extends ProcessTableFunction<Row> {
+        public static class TtlCounter {
+            public long counter = 0L;
+        }
+
+        public static class PermanentCounter {
+            public long counter = 0L;
+        }
+
+        public void eval(
+                @StateHint(ttl = "5s") TtlCounter ttlState,
+                @StateHint PermanentCounter permanentState,
+                @ArgumentHint(ArgumentTrait.SET_SEMANTIC_TABLE) Row input) {
+            ttlState.counter++;
+            permanentState.counter++;
+            collect(Row.of(ttlState.counter, permanentState.counter));
+        }
+    }
+
+    /** PTF with value state that only writes when the input value is positive. */
+    @DataTypeHint("ROW<count BIGINT>")
+    public static class PTFWithConditionalTtlUpdate extends ProcessTableFunction<Row> {
+        public static class CounterState {
+            public long counter = 0L;
+        }
+
+        public void eval(
+                @StateHint(ttl = "5s") CounterState state,
+                @ArgumentHint(ArgumentTrait.SET_SEMANTIC_TABLE) Row input) {
+            int value = input.getFieldAs("value");
+            if (value > 0) {
+                state.counter++;
+            }
+            collect(Row.of(state.counter));
         }
     }
 
@@ -1203,6 +1259,18 @@ class ProcessTableFunctionTestHarnessTest {
     }
 
     @Test
+    void testNegativeTtlRejected() {
+        assertThrows(
+                ValidationException.class,
+                () ->
+                        ProcessTableFunctionTestHarness.ofClass(PTFWithNegativeTtl.class)
+                                .withTableArgument(
+                                        "input", DataTypes.of("ROW<name STRING, value INT>"))
+                                .withPartitionBy("input", "name")
+                                .build());
+    }
+
+    @Test
     void testPartitionByInvalidColumnName() {
         Exception exception =
                 assertThrows(
@@ -1727,5 +1795,319 @@ class ProcessTableFunctionTestHarnessTest {
                 () -> harness.clearStateForKey("state", Row.of(42)));
 
         harness.close();
+    }
+
+    // -------------------------------------------------------------------------
+    // TTL Tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testTtlValueStateExpiresAtBoundary() throws Exception {
+        try (ProcessTableFunctionTestHarness<Row> harness =
+                ProcessTableFunctionTestHarness.ofClass(PTFWithValueState.class)
+                        .withTableArgument("input", DataTypes.of("ROW<name STRING, value INT>"))
+                        .withPartitionBy("input", "name")
+                        .build()) {
+
+            harness.processElement(Row.of("Alice", 1));
+
+            harness.advanceSystemClock(4999);
+            PTFWithValueState.CounterState state = harness.getStateForKey("state", Row.of("Alice"));
+            assertThat(state.counter).isEqualTo(1L);
+
+            harness.advanceSystemClock(1);
+            state = harness.getStateForKey("state", Row.of("Alice"));
+            assertThat(state.counter).isEqualTo(0L);
+        }
+    }
+
+    @Test
+    void testTtlMultiplePartitionsDifferentTiming() throws Exception {
+        try (ProcessTableFunctionTestHarness<Row> harness =
+                ProcessTableFunctionTestHarness.ofClass(PTFWithValueState.class)
+                        .withTableArgument("input", DataTypes.of("ROW<name STRING, value INT>"))
+                        .withPartitionBy("input", "name")
+                        .build()) {
+
+            harness.processElement(Row.of("Alice", 1));
+            harness.advanceSystemClock(3000);
+            harness.processElement(Row.of("Bob", 1));
+
+            harness.advanceSystemClock(2000);
+
+            PTFWithValueState.CounterState aliceState =
+                    harness.getStateForKey("state", Row.of("Alice"));
+            assertThat(aliceState.counter).isEqualTo(0L);
+
+            PTFWithValueState.CounterState bobState =
+                    harness.getStateForKey("state", Row.of("Bob"));
+            assertThat(bobState.counter).isEqualTo(1L);
+
+            // Verify getStateForAllKeys reflects eviction: both keys still present,
+            // but Alice's state is reset to default (counter=0)
+            Map<Row, PTFWithValueState.CounterState> allState = harness.getStateForAllKeys("state");
+            assertThat(allState).hasSize(2);
+            assertThat(allState.get(Row.of("Alice")).counter).isEqualTo(0L);
+            assertThat(allState.get(Row.of("Bob")).counter).isEqualTo(1L);
+        }
+    }
+
+    @Test
+    void testTtlMixedTtlAndNonTtlState() throws Exception {
+        try (ProcessTableFunctionTestHarness<Row> harness =
+                ProcessTableFunctionTestHarness.ofClass(PTFWithMixedTtlState.class)
+                        .withTableArgument("input", DataTypes.of("ROW<name STRING, value INT>"))
+                        .withPartitionBy("input", "name")
+                        .build()) {
+
+            harness.processElement(Row.of("Alice", 1));
+            harness.processElement(Row.of("Alice", 2));
+
+            harness.advanceSystemClock(5000);
+
+            PTFWithMixedTtlState.TtlCounter ttlState =
+                    harness.getStateForKey("ttlState", Row.of("Alice"));
+            assertThat(ttlState.counter).isEqualTo(0L);
+
+            PTFWithMixedTtlState.PermanentCounter permState =
+                    harness.getStateForKey("permanentState", Row.of("Alice"));
+            assertThat(permState.counter).isEqualTo(2L);
+        }
+    }
+
+    @Test
+    void testTtlListViewEviction() throws Exception {
+        try (ProcessTableFunctionTestHarness<Row> harness =
+                ProcessTableFunctionTestHarness.ofClass(PTFWithListViewState.class)
+                        .withTableArgument("input", DataTypes.of("ROW<key STRING, value INT>"))
+                        .withPartitionBy("input", "key")
+                        .build()) {
+
+            harness.processElement(Row.of("A", 1));
+            harness.advanceSystemClock(3000);
+            harness.processElement(Row.of("A", 2));
+
+            // Partial eviction: element 1 is 5000ms old, element 2 is 2000ms old
+            harness.advanceSystemClock(2000);
+            ListView<Integer> listState = harness.getStateForKey("listState", Row.of("A"));
+            assertThat(listState.get()).containsExactly(2);
+
+            // Full eviction
+            harness.advanceSystemClock(3000);
+            listState = harness.getStateForKey("listState", Row.of("A"));
+            assertThat(listState.get()).isEmpty();
+        }
+    }
+
+    @Test
+    void testTtlMapViewEviction() throws Exception {
+        try (ProcessTableFunctionTestHarness<Row> harness =
+                ProcessTableFunctionTestHarness.ofClass(PTFWithMapViewState.class)
+                        .withTableArgument(
+                                "input", DataTypes.of("ROW<partition STRING, key STRING>"))
+                        .withPartitionBy("input", "partition")
+                        .build()) {
+
+            harness.processElement(Row.of("P1", "foo"));
+            harness.advanceSystemClock(3000);
+            harness.processElement(Row.of("P1", "bar"));
+
+            // Partial eviction: "foo" is 5000ms old, "bar" is 2000ms old
+            harness.advanceSystemClock(2000);
+            MapView<String, Integer> mapState = harness.getStateForKey("mapState", Row.of("P1"));
+            assertThat(mapState.get("foo")).isNull();
+            assertThat(mapState.get("bar")).isEqualTo(1);
+
+            // Full eviction
+            harness.advanceSystemClock(3000);
+            mapState = harness.getStateForKey("mapState", Row.of("P1"));
+            assertThat(mapState.get("bar")).isNull();
+        }
+    }
+
+    @Test
+    void testTtlInitialStateExpires() throws Exception {
+        PTFWithValueState.CounterState initialState = new PTFWithValueState.CounterState();
+        initialState.counter = 100L;
+
+        try (ProcessTableFunctionTestHarness<Row> harness =
+                ProcessTableFunctionTestHarness.ofClass(PTFWithValueState.class)
+                        .withTableArgument("input", DataTypes.of("ROW<name STRING, value INT>"))
+                        .withPartitionBy("input", "name")
+                        .withInitialStateForKey("state", Row.of("Alice"), initialState)
+                        .build()) {
+
+            PTFWithValueState.CounterState state = harness.getStateForKey("state", Row.of("Alice"));
+            assertThat(state.counter).isEqualTo(100L);
+
+            harness.advanceSystemClock(5000);
+
+            state = harness.getStateForKey("state", Row.of("Alice"));
+            assertThat(state.counter).isEqualTo(0L);
+        }
+    }
+
+    @Test
+    void testAdvanceSystemClockEdgeCases() throws Exception {
+        try (ProcessTableFunctionTestHarness<Row> harness =
+                ProcessTableFunctionTestHarness.ofClass(PTFWithValueState.class)
+                        .withTableArgument("input", DataTypes.of("ROW<name STRING, value INT>"))
+                        .withPartitionBy("input", "name")
+                        .build()) {
+
+            harness.processElement(Row.of("Alice", 1));
+
+            // Zero delta is a no-op
+            harness.advanceSystemClock(0);
+            PTFWithValueState.CounterState state = harness.getStateForKey("state", Row.of("Alice"));
+            assertThat(state.counter).isEqualTo(1L);
+
+            // Negative delta throws
+            assertThrows(IllegalArgumentException.class, () -> harness.advanceSystemClock(-1));
+
+            // Duration overload works
+            harness.advanceSystemClock(Duration.ofMillis(5000));
+            state = harness.getStateForKey("state", Row.of("Alice"));
+            assertThat(state.counter).isEqualTo(0L);
+        }
+    }
+
+    @Test
+    void testTtlValueStateWriteDetection() throws Exception {
+        try (ProcessTableFunctionTestHarness<Row> harness =
+                ProcessTableFunctionTestHarness.ofClass(PTFWithConditionalTtlUpdate.class)
+                        .withTableArgument("input", DataTypes.of("ROW<name STRING, value INT>"))
+                        .withPartitionBy("input", "name")
+                        .build()) {
+
+            // Write at t=0 (positive value increments counter)
+            harness.processElement(Row.of("Alice", 1));
+            harness.advanceSystemClock(3000);
+
+            // Read-only at t=3000 (negative value skips write) — does not refresh TTL
+            harness.processElement(Row.of("Alice", -1));
+            harness.advanceSystemClock(2000);
+
+            PTFWithConditionalTtlUpdate.CounterState state =
+                    harness.getStateForKey("state", Row.of("Alice"));
+            assertThat(state.counter).isEqualTo(0L);
+
+            // Write at t=5000 — refreshes TTL
+            harness.processElement(Row.of("Alice", 1));
+            harness.advanceSystemClock(4999);
+
+            state = harness.getStateForKey("state", Row.of("Alice"));
+            assertThat(state.counter).isEqualTo(1L);
+
+            // Expires at t=10000
+            harness.advanceSystemClock(1);
+            state = harness.getStateForKey("state", Row.of("Alice"));
+            assertThat(state.counter).isEqualTo(0L);
+        }
+    }
+
+    @Test
+    void testTtlRowStateExpires() throws Exception {
+        try (ProcessTableFunctionTestHarness<Row> harness =
+                ProcessTableFunctionTestHarness.ofClass(PTFWithRowState.class)
+                        .withTableArgument("input", DataTypes.of("ROW<name STRING, value INT>"))
+                        .withPartitionBy("input", "name")
+                        .build()) {
+
+            harness.processElement(Row.of("Alice", 1));
+            harness.processElement(Row.of("Alice", 2));
+
+            Row state = harness.getStateForKey("memory", Row.of("Alice"));
+            assertThat((Long) state.getFieldAs("count")).isEqualTo(2L);
+
+            harness.advanceSystemClock(5000);
+
+            state = harness.getStateForKey("memory", Row.of("Alice"));
+            assertThat(state.getField("count")).isNull();
+        }
+    }
+
+    @Test
+    void testTtlSetStateForKeyWithListView() throws Exception {
+        try (ProcessTableFunctionTestHarness<Row> harness =
+                ProcessTableFunctionTestHarness.ofClass(PTFWithListViewState.class)
+                        .withTableArgument("input", DataTypes.of("ROW<key STRING, value INT>"))
+                        .withPartitionBy("input", "key")
+                        .build()) {
+
+            // Advance clock to t=2000, then set state — elements should get timestamp 2000
+            harness.advanceSystemClock(2000);
+            ListView<Integer> initialList = new ListView<>();
+            initialList.add(10);
+            initialList.add(20);
+            harness.setStateForKey("listState", Row.of("A"), initialList);
+
+            // At t=6999, elements are 4999ms old — should survive
+            harness.advanceSystemClock(4999);
+            ListView<Integer> listState = harness.getStateForKey("listState", Row.of("A"));
+            assertThat(listState.get()).containsExactly(10, 20);
+
+            // At t=7000, elements are 5000ms old — should expire
+            harness.advanceSystemClock(1);
+            listState = harness.getStateForKey("listState", Row.of("A"));
+            assertThat(listState.get()).isEmpty();
+        }
+    }
+
+    @Test
+    void testTtlClearStateForKeyThenReprocess() throws Exception {
+        try (ProcessTableFunctionTestHarness<Row> harness =
+                ProcessTableFunctionTestHarness.ofClass(PTFWithValueState.class)
+                        .withTableArgument("input", DataTypes.of("ROW<name STRING, value INT>"))
+                        .withPartitionBy("input", "name")
+                        .build()) {
+
+            harness.processElement(Row.of("Alice", 1));
+            harness.advanceSystemClock(3000);
+
+            // Clear TTL state, then process again — fresh timestamp from t=3000
+            harness.clearStateForKey("state", Row.of("Alice"));
+            harness.processElement(Row.of("Alice", 2));
+
+            // At t=7999, new write is 4999ms old — should survive
+            harness.advanceSystemClock(4999);
+            PTFWithValueState.CounterState state = harness.getStateForKey("state", Row.of("Alice"));
+            assertThat(state.counter).isEqualTo(1L);
+
+            // At t=8000, new write is 5000ms old — should expire
+            harness.advanceSystemClock(1);
+            state = harness.getStateForKey("state", Row.of("Alice"));
+            assertThat(state.counter).isEqualTo(0L);
+        }
+    }
+
+    @Test
+    void testTtlMapViewReputRefreshesTimestamp() throws Exception {
+        try (ProcessTableFunctionTestHarness<Row> harness =
+                ProcessTableFunctionTestHarness.ofClass(PTFWithMapViewState.class)
+                        .withTableArgument(
+                                "input", DataTypes.of("ROW<partition STRING, key STRING>"))
+                        .withPartitionBy("input", "partition")
+                        .build()) {
+
+            // Put "foo" at t=0
+            harness.processElement(Row.of("P1", "foo"));
+            harness.advanceSystemClock(3000);
+
+            // Re-put "foo" at t=3000 (increments count, refreshing its timestamp)
+            harness.processElement(Row.of("P1", "foo"));
+
+            // Advance to t=5000 — past the original write but within TTL of the re-put
+            harness.advanceSystemClock(2000);
+
+            MapView<String, Integer> mapState = harness.getStateForKey("mapState", Row.of("P1"));
+            assertThat(mapState.get("foo")).isEqualTo(2);
+
+            // Advance to t=8000 — past the re-put's TTL
+            harness.advanceSystemClock(3000);
+
+            mapState = harness.getStateForKey("mapState", Row.of("P1"));
+            assertThat(mapState.get("foo")).isNull();
+        }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Currently, the PTF harness supports state in partitioned PTFs, but ignores state TTL annotations and has no mechanism for simulating the passage of time and the expiration of state entries.

This PR adds support for handling state ttl annotations, tracking timestamped mutations to the state based on the harness' internal clock, and adds `advanceSystemClock` methods for advancing system time and triggering state eviction mechanisms.

For value state, the mutation tracking works by comparing the object before its passed into the eval, and afterwards. For Map and List view state, I've added TTL aware versions of these views that track the per-element timestamps (backed by timestamp aware implementations of list and map).

This forced a change to how the Map/List views were being stored using the internal/external serialisers. Before, the whole map/list was stored in an internal data format, but this would vaporise any internal timestamps attached to the entries. Instead, each element in the list view and each key/value pair in the map view are stored in an internal format (since these are what we really care about validating, we know that List/Map view serialises fine). 

The changes in `createStateConverter` were due to my misapprehension of how map/list view data types are returned from the system type inference. They were all being flung through the structuredtype/value state converters 🤦‍♀️ 
## Brief change log

- Added State TTL tracking and eviction support to `ProcessTableFunctionTestHarness`

## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

This change added tests and can be verified as follows:

- Added new State TTL focused tests in `ProcessTableFunctionTestHarnessTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [x] Yes (please specify the tool below)

2.1.156 (Claude Code)