### PR TITLE
[FLINK-39829][build] Bump scala to 2.12.21

### DIFF
--- a/flink-dist-scala/src/main/resources/META-INF/NOTICE
+++ b/flink-dist-scala/src/main/resources/META-INF/NOTICE
@@ -6,7 +6,7 @@ The Apache Software Foundation (http://www.apache.org/).
 
 The following dependencies all share the same BSD license which you find under licenses/LICENSE.scala.
 
-- org.scala-lang:scala-compiler:2.12.20
-- org.scala-lang:scala-library:2.12.20
-- org.scala-lang:scala-reflect:2.12.20
+- org.scala-lang:scala-compiler:2.12.21
+- org.scala-lang:scala-library:2.12.21
+- org.scala-lang:scala-reflect:2.12.21
 - org.scala-lang.modules:scala-xml_2.12:2.3.0

--- a/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/NOTICE
+++ b/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/NOTICE
@@ -28,7 +28,7 @@ This project bundles the following dependencies under the Apache Software Licens
 The following dependencies all share the same BSD license which you find under licenses/LICENSE.scala.
 
 - org.scala-lang.modules:scala-java8-compat_2.12:1.0.2
-- org.scala-lang:scala-library:2.12.20
+- org.scala-lang:scala-library:2.12.21
 
 This project bundles the following dependencies under the Creative Commons CC0 "No Rights Reserved".
 

--- a/flink-table/flink-table-planner-loader-bundle/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-table-planner-loader-bundle/src/main/resources/META-INF/NOTICE
@@ -6,6 +6,6 @@ The Apache Software Foundation (http://www.apache.org/).
 
 The following dependencies all share the same BSD license which you find under licenses/LICENSE.scala.
 
-- org.scala-lang:scala-compiler:2.12.20
-- org.scala-lang:scala-library:2.12.20
-- org.scala-lang:scala-reflect:2.12.20
+- org.scala-lang:scala-compiler:2.12.21
+- org.scala-lang:scala-library:2.12.21
+- org.scala-lang:scala-reflect:2.12.21

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@ under the License.
 		<maven.compiler.source>${source.java.version}</maven.compiler.source>
 		<maven.compiler.target>${target.java.version}</maven.compiler.target>
 		<scala.macros.version>2.1.1</scala.macros.version>
-		<scala.version>2.12.20</scala.version>
+		<scala.version>2.12.21</scala.version>
 		<scala.binary.version>2.12</scala.binary.version>
 		<!-- keep FlinkTestcontainersConfigurator.configureZookeeperContainer in sync -->
 		<zookeeper.version>3.7.2</zookeeper.version>
@@ -975,7 +975,7 @@ under the License.
 		<profile>
 			<id>scala-2.12</id>
 			<properties>
-				<scala.version>2.12.20</scala.version>
+				<scala.version>2.12.21</scala.version>
 				<scala.binary.version>2.12</scala.binary.version>
 			</properties>
 			<activation>


### PR DESCRIPTION

## What is the purpose of the change

Bumping scala to 2.12.21
as based on https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
it is better to have 2.12.21 for the case of java 25
also it is binary compatible (as mentioned at https://github.com/scala/scala/releases/tag/v2.12.21)

## Brief change log
pom, NOTICE


## Verifying this change
existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes )
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
