### PR TITLE
[FLINK-39835][runtime] AsyncWaitOperator supports soft backpressure to avoid blocking unaligned checkpoint

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/CompositeAvailabilityProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/CompositeAvailabilityProvider.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io;
+
+import org.apache.flink.annotation.Internal;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/** Reports available only when all child {@link AvailabilityProvider}s are available. */
+@Internal
+public class CompositeAvailabilityProvider implements AvailabilityProvider {
+    private final List<AvailabilityProvider> providers;
+
+    private CompositeAvailabilityProvider(List<AvailabilityProvider> providers) {
+        this.providers = new ArrayList<>(providers);
+    }
+
+    @Override
+    public CompletableFuture<?> getAvailableFuture() {
+        CompletableFuture<?> result = AvailabilityProvider.AVAILABLE;
+        for (AvailabilityProvider p : providers) {
+            result = AvailabilityProvider.and(result, p.getAvailableFuture());
+        }
+        return result;
+    }
+
+    public static AvailabilityProvider of(List<AvailabilityProvider> providers) {
+        if (providers.size() == 1) {
+            return providers.get(0);
+        }
+        return new CompositeAvailabilityProvider(providers);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/SupportsChainAvailability.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/SupportsChainAvailability.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.io.AvailabilityProvider;
+
+/**
+ * Interface for operators that represent the availability of their chain segment. Such operators
+ * absorb downstream availability internally, handling back-pressure by deferring emits and yielding
+ * the mailbox rather than blocking.
+ *
+ * <p>{@code OperatorChain} injects the composite downstream {@link AvailabilityProvider} via {@link
+ * #setDownstreamAvailabilityProvider} and lets the operator represent the chain's availability.
+ */
+@Internal
+public interface SupportsChainAvailability extends AvailabilityProvider {
+
+    /**
+     * Called once by {@code OperatorChain} during construction to inject downstream availability.
+     */
+    void setDownstreamAvailabilityProvider(AvailabilityProvider provider);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/io/RecordWriterOutput.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/io/RecordWriterOutput.java
@@ -25,6 +25,7 @@ import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.event.WatermarkEvent;
+import org.apache.flink.runtime.io.AvailabilityProvider;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.api.writer.RecordWriter;
 import org.apache.flink.runtime.plugable.SerializationDelegate;
@@ -220,6 +221,10 @@ public class RecordWriterOutput<OUT>
 
     public void flush() throws IOException {
         recordWriter.flushAll();
+    }
+
+    public AvailabilityProvider getOutputAvailabilityProvider() {
+        return recordWriter;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
@@ -30,6 +30,8 @@ import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.io.AvailabilityProvider;
+import org.apache.flink.runtime.io.CompositeAvailabilityProvider;
 import org.apache.flink.runtime.io.network.api.StopMode;
 import org.apache.flink.runtime.io.network.api.writer.RecordWriter;
 import org.apache.flink.runtime.io.network.api.writer.RecordWriterDelegate;
@@ -61,6 +63,7 @@ import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactoryUtil;
 import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
+import org.apache.flink.streaming.api.operators.SupportsChainAvailability;
 import org.apache.flink.streaming.runtime.io.RecordWriterOutput;
 import org.apache.flink.streaming.runtime.io.StreamTaskSourceInput;
 import org.apache.flink.streaming.runtime.operators.sink.SinkWriterOperatorFactory;
@@ -153,6 +156,8 @@ public abstract class OperatorChain<OUT, OP extends StreamOperator<OUT>>
 
     protected boolean isClosed;
 
+    private AvailabilityProvider chainAvailabilityProvider = null;
+
     public OperatorChain(
             StreamTask<OUT, OP> containingTask,
             RecordWriterDelegate<SerializationDelegate<StreamRecord<OUT>>> recordWriterDelegate) {
@@ -198,6 +203,7 @@ public abstract class OperatorChain<OUT, OP extends StreamOperator<OUT>>
             // we create the chain of operators and grab the collector that leads into the chain
             List<StreamOperatorWrapper<?, ?>> allOpWrappers =
                     new ArrayList<>(chainedConfigs.size());
+            List<AvailabilityProvider> chainAvailProviders = new ArrayList<>();
             this.mainOperatorOutput =
                     createOutputCollector(
                             containingTask,
@@ -207,7 +213,8 @@ public abstract class OperatorChain<OUT, OP extends StreamOperator<OUT>>
                             recordWriterOutputs,
                             allOpWrappers,
                             containingTask.getMailboxExecutorFactory(),
-                            operatorFactory != null);
+                            operatorFactory != null,
+                            chainAvailProviders);
 
             if (operatorFactory != null) {
                 Tuple2<OP, Optional<ProcessingTimeService>> mainOperatorAndTimeService =
@@ -231,6 +238,26 @@ public abstract class OperatorChain<OUT, OP extends StreamOperator<OUT>>
                                 configuration,
                                 mainOperatorAndTimeService.f1,
                                 true);
+
+                // Chain-availability head absorbs downstream availability.
+                if (mainOperator instanceof SupportsChainAvailability) {
+                    SupportsChainAvailability head = (SupportsChainAvailability) mainOperator;
+                    if (!chainAvailProviders.isEmpty()) {
+                        head.setDownstreamAvailabilityProvider(
+                                CompositeAvailabilityProvider.of(chainAvailProviders));
+                    }
+                    chainAvailProviders = new ArrayList<>();
+                    chainAvailProviders.add(head);
+                }
+
+                boolean hasChainAvailabilityOperator =
+                        chainAvailProviders.stream()
+                                .anyMatch(
+                                        provider -> provider instanceof SupportsChainAvailability);
+                if (hasChainAvailabilityOperator) {
+                    chainAvailabilityProvider =
+                            CompositeAvailabilityProvider.of(chainAvailProviders);
+                }
 
                 // add main operator to end of chain
                 allOpWrappers.add(mainOperatorWrapper);
@@ -485,6 +512,10 @@ public abstract class OperatorChain<OUT, OP extends StreamOperator<OUT>>
         return isClosed;
     }
 
+    public AvailabilityProvider getChainAvailabilityProvider() {
+        return chainAvailabilityProvider;
+    }
+
     /** Wrapper class to access the chained sources and their's outputs. */
     public static class ChainedSource {
         private final WatermarkGaugeExposingOutput<StreamRecord<?>> chainedSourceOutput;
@@ -712,7 +743,8 @@ public abstract class OperatorChain<OUT, OP extends StreamOperator<OUT>>
             Map<IntermediateDataSetID, RecordWriterOutput<?>> recordWriterOutputs,
             List<StreamOperatorWrapper<?, ?>> allOperatorWrappers,
             MailboxExecutorFactory mailboxExecutorFactory,
-            boolean shouldAddMetric) {
+            boolean shouldAddMetric,
+            List<AvailabilityProvider> downstreamAvailProviders) {
         List<OutputWithChainingCheck<StreamRecord<T>>> allOutputs = new ArrayList<>(4);
 
         // create collectors for the network outputs
@@ -723,6 +755,9 @@ public abstract class OperatorChain<OUT, OP extends StreamOperator<OUT>>
                     (RecordWriterOutput<T>) recordWriterOutputs.get(streamOutput.getDataSetId());
 
             allOutputs.add(recordWriterOutput);
+            if (downstreamAvailProviders != null) {
+                downstreamAvailProviders.add(recordWriterOutput.getOutputAvailabilityProvider());
+            }
         }
 
         // Create collectors for the chained outputs
@@ -741,7 +776,8 @@ public abstract class OperatorChain<OUT, OP extends StreamOperator<OUT>>
                             allOperatorWrappers,
                             outputEdge.getOutputTag(),
                             mailboxExecutorFactory,
-                            shouldAddMetric);
+                            shouldAddMetric,
+                            downstreamAvailProviders);
             checkState(output instanceof OutputWithChainingCheck);
             allOutputs.add((OutputWithChainingCheck) output);
             // If the operator has multiple downstream chained operators, only one of them should
@@ -820,7 +856,10 @@ public abstract class OperatorChain<OUT, OP extends StreamOperator<OUT>>
             List<StreamOperatorWrapper<?, ?>> allOperatorWrappers,
             OutputTag<IN> outputTag,
             MailboxExecutorFactory mailboxExecutorFactory,
-            boolean shouldAddMetricForPrevOperator) {
+            boolean shouldAddMetricForPrevOperator,
+            @Nullable List<AvailabilityProvider> parentDownstreamAvailProviders) {
+        List<AvailabilityProvider> myDownstreamAvailProviders = new ArrayList<>();
+
         // create the output that the operator writes to first. this may recursively create more
         // operators
         WatermarkGaugeExposingOutput<StreamRecord<OUT>> chainedOperatorOutput =
@@ -832,7 +871,8 @@ public abstract class OperatorChain<OUT, OP extends StreamOperator<OUT>>
                         recordWriterOutputs,
                         allOperatorWrappers,
                         mailboxExecutorFactory,
-                        true);
+                        true,
+                        myDownstreamAvailProviders);
 
         OneInputStreamOperator<IN, OUT> chainedOperator =
                 createOperator(
@@ -842,6 +882,22 @@ public abstract class OperatorChain<OUT, OP extends StreamOperator<OUT>>
                         chainedOperatorOutput,
                         allOperatorWrappers,
                         false);
+
+        // Chain-availability operator absorbs downstream; only it is surfaced upward.
+        if (chainedOperator instanceof SupportsChainAvailability) {
+            SupportsChainAvailability op = (SupportsChainAvailability) chainedOperator;
+            if (!myDownstreamAvailProviders.isEmpty()) {
+                op.setDownstreamAvailabilityProvider(
+                        CompositeAvailabilityProvider.of(myDownstreamAvailProviders));
+            }
+            if (parentDownstreamAvailProviders != null) {
+                parentDownstreamAvailProviders.add(op);
+            }
+        } else {
+            if (parentDownstreamAvailProviders != null) {
+                parentDownstreamAvailProviders.addAll(myDownstreamAvailProviders);
+            }
+        }
 
         return wrapOperatorIntoOutput(
                 chainedOperator,

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -328,6 +328,8 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 
     @Nullable private final AvailabilityProvider changelogWriterAvailabilityProvider;
 
+    @Nullable private AvailabilityProvider chainAvailabilityProvider = null;
+
     private long initializeStateEndTs;
 
     // ------------------------------------------------------------------------
@@ -682,11 +684,21 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
         }
 
         TaskIOMetricGroup ioMetrics = getEnvironment().getMetricGroup().getIOMetricGroup();
-        PeriodTimer timer;
+        PeriodTimer timer = null;
         CompletableFuture<?> resumeFuture;
-        if (!recordWriter.isAvailable()) {
+        if (chainAvailabilityProvider == null && !recordWriter.isAvailable()) {
+            // No chain-availability operator; downstream is the direct backpressure source.
             timer = new GaugePeriodTimer(ioMetrics.getSoftBackPressuredTimePerSecond());
             resumeFuture = recordWriter.getAvailableFuture();
+        } else if (chainAvailabilityProvider != null && !chainAvailabilityProvider.isAvailable()) {
+            if (!recordWriter.isAvailable()) {
+                // Queue full AND downstream unavailable → backpressure (root cause: downstream).
+                timer = new GaugePeriodTimer(ioMetrics.getSoftBackPressuredTimePerSecond());
+                resumeFuture = recordWriter.getAvailableFuture();
+            } else {
+                // Queue full but downstream available → internal processing; fall back to busy.
+                resumeFuture = chainAvailabilityProvider.getAvailableFuture();
+            }
         } else if (!inputProcessor.isAvailable()) {
             timer = new GaugePeriodTimer(ioMetrics.getIdleTimeMsPerSecond());
             resumeFuture = inputProcessor.getAvailableFuture();
@@ -808,6 +820,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
                             ? new FinishedOperatorChain<>(this, recordWriter)
                             : new RegularOperatorChain<>(this, recordWriter);
             mainOperator = operatorChain.getMainOperator();
+            chainAvailabilityProvider = operatorChain.getChainAvailabilityProvider();
 
             getEnvironment()
                     .getTaskStateManager()
@@ -1186,6 +1199,11 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
     }
 
     private boolean taskIsAvailable() {
+        if (chainAvailabilityProvider != null) {
+            return chainAvailabilityProvider.isAvailable()
+                    && (changelogWriterAvailabilityProvider == null
+                            || changelogWriterAvailabilityProvider.isAvailable());
+        }
         return recordWriter.isAvailable()
                 && (changelogWriterAvailabilityProvider == null
                         || changelogWriterAvailabilityProvider.isAvailable());

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/operators/StreamOperatorChainingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/operators/StreamOperatorChainingTest.java
@@ -19,8 +19,11 @@
 package org.apache.flink.streaming.runtime.operators;
 
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.io.AvailabilityProvider;
+import org.apache.flink.runtime.io.network.api.writer.AvailabilityTestResultPartitionWriter;
 import org.apache.flink.runtime.io.network.api.writer.RecordWriterDelegate;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
@@ -37,6 +40,7 @@ import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.StreamMap;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
+import org.apache.flink.streaming.api.operators.SupportsChainAvailability;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.OperatorChain;
 import org.apache.flink.streaming.runtime.tasks.RegularOperatorChain;
@@ -49,7 +53,9 @@ import org.apache.flink.util.OutputTag;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.streaming.api.operators.StreamOperatorUtils.setupStreamOperator;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -273,6 +279,142 @@ class StreamOperatorChainingTest {
             assertThat(sink1Results).containsExactly("First 1: 1");
             assertThat(sink2Results).containsExactly("First 2: 1");
             assertThat(sink3Results).containsExactly("Second: 2", "Second: 3");
+        }
+    }
+
+    /**
+     * Exercises the head branch of {@link OperatorChain}: when the main operator implements {@link
+     * SupportsChainAvailability}, the chain availability provider must be the head operator itself.
+     */
+    @Test
+    void testChainAvailabilityProviderForHeadChainAvailabilityOperator() throws Exception {
+        JobVertex chainedVertex = buildChainedVertexWithChainAvailabilityOperator(true);
+
+        StreamConfig streamConfig = new StreamConfig(chainedVertex.getConfiguration());
+
+        try (MockEnvironment environment = createMockEnvironment(chainedVertex.getName())) {
+            environment.addOutputs(
+                    Collections.singletonList(new AvailabilityTestResultPartitionWriter(true)));
+            StreamTask<Integer, ChainAvailabilityMapOperator<Integer, Integer>> mockTask =
+                    createMockTask(streamConfig, environment);
+            OperatorChain<Integer, ChainAvailabilityMapOperator<Integer, Integer>> operatorChain =
+                    createOperatorChain(streamConfig, environment, mockTask);
+
+            AvailabilityProvider chainAvailability = operatorChain.getChainAvailabilityProvider();
+            assertThat(chainAvailability)
+                    .as("Head chain-availability operator should represent chain" + " availability")
+                    .isSameAs(operatorChain.getMainOperator());
+            assertThat(chainAvailability.isAvailable()).as("Operator starts available").isTrue();
+        }
+    }
+
+    /**
+     * Exercises the chained branch of {@link OperatorChain}: when a {@link
+     * SupportsChainAvailability} operator sits behind the head, it replaces the downstream leaves
+     * in the parent's collector, so the chain availability provider must be that chained operator.
+     */
+    @Test
+    void testChainAvailabilityProviderForChainedChainAvailabilityOperator() throws Exception {
+        JobVertex chainedVertex = buildChainedVertexWithChainAvailabilityOperator(false);
+
+        StreamConfig streamConfig = new StreamConfig(chainedVertex.getConfiguration());
+
+        try (MockEnvironment environment = createMockEnvironment(chainedVertex.getName())) {
+            environment.addOutputs(
+                    Collections.singletonList(new AvailabilityTestResultPartitionWriter(true)));
+            StreamTask<Integer, StreamMap<Integer, Integer>> mockTask =
+                    createMockTask(streamConfig, environment);
+            OperatorChain<Integer, StreamMap<Integer, Integer>> operatorChain =
+                    createOperatorChain(streamConfig, environment, mockTask);
+
+            SupportsChainAvailability chainedOp =
+                    findSingleChainAvailabilityOperator(operatorChain);
+            AvailabilityProvider chainAvailability = operatorChain.getChainAvailabilityProvider();
+            assertThat(chainAvailability)
+                    .as(
+                            "Chained chain-availability operator should replace downstream"
+                                    + " leaves and act as chain availability boundary")
+                    .isSameAs(chainedOp);
+            assertThat(chainAvailability)
+                    .as(
+                            "Head operator (not the chain-availability one) is not the chain"
+                                    + " availability provider")
+                    .isNotSameAs(operatorChain.getMainOperator());
+            assertThat(chainAvailability.isAvailable()).as("Operator starts available").isTrue();
+        }
+    }
+
+    private static JobVertex buildChainedVertexWithChainAvailabilityOperator(
+            boolean chainAvailabilityAtHead) {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(2);
+
+        DataStream<Integer> input = env.fromData(1, 2, 3);
+
+        if (chainAvailabilityAtHead) {
+            input =
+                    input.transform(
+                            "ChainAvailabilityMap",
+                            input.getType(),
+                            new ChainAvailabilityMapOperator<>(value -> value));
+            input = input.map(value -> value);
+        } else {
+            input = input.map(value -> value);
+            input =
+                    input.transform(
+                            "ChainAvailabilityMap",
+                            input.getType(),
+                            new ChainAvailabilityMapOperator<>(value -> value));
+        }
+
+        input.map(value -> value)
+                .startNewChain()
+                .addSink(
+                        new SinkFunction<Integer>() {
+                            @Override
+                            public void invoke(Integer value, Context ctx) {}
+                        });
+
+        JobGraph jobGraph = env.getStreamGraph().getJobGraph();
+        assertThat(jobGraph.getVerticesSortedTopologicallyFromSources()).hasSize(3);
+        return jobGraph.getVerticesSortedTopologicallyFromSources().get(1);
+    }
+
+    private static SupportsChainAvailability findSingleChainAvailabilityOperator(
+            OperatorChain<?, ?> chain) {
+        SupportsChainAvailability found = null;
+        for (StreamOperatorWrapper<?, ?> wrapper : chain.getAllOperators()) {
+            if (wrapper.getStreamOperator() instanceof SupportsChainAvailability) {
+                assertThat(found)
+                        .as("Expected exactly one SupportsChainAvailability operator in chain")
+                        .isNull();
+                found = (SupportsChainAvailability) wrapper.getStreamOperator();
+            }
+        }
+        assertThat(found).as("Expected a SupportsChainAvailability operator in chain").isNotNull();
+        return found;
+    }
+
+    /**
+     * A {@link StreamMap} that also implements {@link SupportsChainAvailability} for testing
+     * OperatorChain availability-provider wiring without depending on flink-streaming-java
+     * operators.
+     */
+    private static class ChainAvailabilityMapOperator<IN, OUT> extends StreamMap<IN, OUT>
+            implements SupportsChainAvailability {
+
+        private static final long serialVersionUID = 1L;
+
+        ChainAvailabilityMapOperator(MapFunction<IN, OUT> mapper) {
+            super(mapper);
+        }
+
+        @Override
+        public void setDownstreamAvailabilityProvider(AvailabilityProvider provider) {}
+
+        @Override
+        public CompletableFuture<?> getAvailableFuture() {
+            return AvailabilityProvider.AVAILABLE;
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/tasks/CompositeAvailabilityProviderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/tasks/CompositeAvailabilityProviderTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.runtime.io.AvailabilityProvider;
+import org.apache.flink.runtime.io.CompositeAvailabilityProvider;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link CompositeAvailabilityProvider}. */
+class CompositeAvailabilityProviderTest {
+
+    @Test
+    void testSingleChildReturnsChildDirectly() {
+        TestAvailabilityProvider child = new TestAvailabilityProvider();
+        AvailabilityProvider composite =
+                CompositeAvailabilityProvider.of(Collections.singletonList(child));
+
+        assertThat(composite).isSameAs(child);
+        assertThat(composite.getAvailableFuture()).isSameAs(child.future);
+        assertThat(composite.isAvailable()).isFalse();
+
+        child.future.complete(null);
+        assertThat(composite.isAvailable()).isTrue();
+    }
+
+    @Test
+    void testMultipleChildrenWrappedInComposite() {
+        TestAvailabilityProvider first = new TestAvailabilityProvider();
+        TestAvailabilityProvider second = new TestAvailabilityProvider();
+        List<AvailabilityProvider> children = Arrays.asList(first, second);
+
+        AvailabilityProvider composite = CompositeAvailabilityProvider.of(children);
+
+        assertThat(composite).isInstanceOf(CompositeAvailabilityProvider.class);
+        assertThat(composite.isAvailable()).isFalse();
+    }
+
+    @Test
+    void testGetAvailableFutureCompletesOnlyWhenAllChildrenComplete() {
+        TestAvailabilityProvider first = new TestAvailabilityProvider();
+        TestAvailabilityProvider second = new TestAvailabilityProvider();
+        AvailabilityProvider composite =
+                CompositeAvailabilityProvider.of(Arrays.asList(first, second));
+
+        CompletableFuture<?> available = composite.getAvailableFuture();
+        assertThat(available.isDone()).isFalse();
+
+        first.future.complete(null);
+        assertThat(available.isDone())
+                .as("composite future should remain incomplete while one child is pending")
+                .isFalse();
+
+        second.future.complete(null);
+        assertThat(available.isDone()).isTrue();
+        assertThat(composite.isAvailable()).isTrue();
+    }
+
+    /** Minimal {@link AvailabilityProvider} backed by a mutable {@link CompletableFuture}. */
+    private static final class TestAvailabilityProvider implements AvailabilityProvider {
+        private final CompletableFuture<Void> future = new CompletableFuture<>();
+
+        @Override
+        public CompletableFuture<?> getAvailableFuture() {
+            return future;
+        }
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.operators.MailboxExecutor;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.io.AvailabilityProvider;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.streaming.api.datastream.AsyncDataStream;
@@ -37,6 +38,7 @@ import org.apache.flink.streaming.api.operators.BoundedOneInput;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+import org.apache.flink.streaming.api.operators.SupportsChainAvailability;
 import org.apache.flink.streaming.api.operators.TimestampedCollector;
 import org.apache.flink.streaming.api.operators.async.queue.OrderedStreamElementQueue;
 import org.apache.flink.streaming.api.operators.async.queue.StreamElementQueue;
@@ -57,6 +59,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -92,7 +95,7 @@ import static org.apache.flink.streaming.util.retryable.AsyncRetryStrategies.NO_
 @Internal
 public class AsyncWaitOperator<IN, OUT>
         extends AbstractUdfStreamOperator<OUT, AsyncFunction<IN, OUT>>
-        implements OneInputStreamOperator<IN, OUT>, BoundedOneInput {
+        implements OneInputStreamOperator<IN, OUT>, BoundedOneInput, SupportsChainAvailability {
     private static final long serialVersionUID = 1L;
 
     private static final String STATE_NAME = "_async_wait_operator_state_";
@@ -138,6 +141,8 @@ public class AsyncWaitOperator<IN, OUT>
 
     /** Whether retry is disabled due to task finish, initially set to false. */
     private transient AtomicBoolean retryDisabledOnFinish;
+
+    private AvailabilityProvider downstreamAvailabilityProvider;
 
     public AsyncWaitOperator(
             StreamOperatorParameters<OUT> parameters,
@@ -390,6 +395,25 @@ public class AsyncWaitOperator<IN, OUT>
      */
     private void outputCompletedElement() {
         if (queue.hasCompletedElements()) {
+            // Defer emission until downstream becomes available.
+            if (downstreamAvailabilityProvider != null
+                    && !downstreamAvailabilityProvider.isAvailable()) {
+                downstreamAvailabilityProvider
+                        .getAvailableFuture()
+                        .thenRun(
+                                () -> {
+                                    try {
+                                        mailboxExecutor.execute(
+                                                this::outputCompletedElement,
+                                                "AsyncWaitOperator#outputCompletedElement(deferred)");
+                                    } catch (RejectedExecutionException e) {
+                                        LOG.debug(
+                                                "Deferred element emission is ignored since the mailbox rejected the execution.",
+                                                e);
+                                    }
+                                });
+                return;
+            }
             // emit only one element to not block the mailbox thread unnecessarily
             queue.emitCompletedElement(timestampedCollector);
             // if there are more completed elements, emit them with subsequent mails
@@ -429,6 +453,16 @@ public class AsyncWaitOperator<IN, OUT>
 
         return processingTimeService.registerTimer(
                 timeoutTimestamp, timestamp -> callback.accept(null));
+    }
+
+    @Override
+    public CompletableFuture<?> getAvailableFuture() {
+        return queue.getAvailableFuture();
+    }
+
+    @Override
+    public void setDownstreamAvailabilityProvider(AvailabilityProvider provider) {
+        this.downstreamAvailabilityProvider = provider;
     }
 
     /** A delegator holds the real {@link ResultHandler} to handle retries. */

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/queue/OrderedStreamElementQueue.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/queue/OrderedStreamElementQueue.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Ordered {@link StreamElementQueue} implementation. The ordered stream element queue provides
@@ -52,11 +53,14 @@ public final class OrderedStreamElementQueue<OUT> implements StreamElementQueue<
     /** Queue for the inserted StreamElementQueueEntries. */
     private final Queue<StreamElementQueueEntry<OUT>> queue;
 
+    private final AvailabilityHelper availabilityHelper = new AvailabilityHelper();
+
     public OrderedStreamElementQueue(int capacity) {
         Preconditions.checkArgument(capacity > 0, "The capacity must be larger than 0.");
 
         this.capacity = capacity;
         this.queue = new ArrayDeque<>(capacity);
+        this.availabilityHelper.resetAvailable();
     }
 
     @Override
@@ -67,8 +71,12 @@ public final class OrderedStreamElementQueue<OUT> implements StreamElementQueue<
     @Override
     public void emitCompletedElement(TimestampedCollector<OUT> output) {
         if (hasCompletedElements()) {
+            boolean isFullBefore = isFull();
             final StreamElementQueueEntry<OUT> head = queue.poll();
             head.emitResult(output);
+            if (isFullBefore && !isFull()) {
+                availabilityHelper.getUnavailableToResetAvailable().complete(null);
+            }
         }
     }
 
@@ -93,7 +101,7 @@ public final class OrderedStreamElementQueue<OUT> implements StreamElementQueue<
 
     @Override
     public Optional<ResultFuture<OUT>> tryPut(StreamElement streamElement) {
-        if (queue.size() < capacity) {
+        if (!isFull()) {
             StreamElementQueueEntry<OUT> queueEntry = createEntry(streamElement);
 
             queue.add(queueEntry);
@@ -103,6 +111,10 @@ public final class OrderedStreamElementQueue<OUT> implements StreamElementQueue<
                             + "({}/{}).",
                     queue.size(),
                     capacity);
+
+            if (isFull()) {
+                availabilityHelper.resetUnavailable();
+            }
 
             return Optional.of(queueEntry);
         } else {
@@ -114,6 +126,15 @@ public final class OrderedStreamElementQueue<OUT> implements StreamElementQueue<
 
             return Optional.empty();
         }
+    }
+
+    @Override
+    public CompletableFuture<?> getAvailableFuture() {
+        return availabilityHelper.getAvailableFuture();
+    }
+
+    private boolean isFull() {
+        return queue.size() >= capacity;
     }
 
     private StreamElementQueueEntry<OUT> createEntry(StreamElement streamElement) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/queue/StreamElementQueue.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/queue/StreamElementQueue.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.api.operators.async.queue;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.io.AvailabilityProvider;
 import org.apache.flink.streaming.api.functions.async.ResultFuture;
 import org.apache.flink.streaming.api.operators.TimestampedCollector;
 import org.apache.flink.streaming.api.operators.async.AsyncWaitOperator;
@@ -29,7 +30,7 @@ import java.util.Optional;
 
 /** Interface for stream element queues for the {@link AsyncWaitOperator}. */
 @Internal
-public interface StreamElementQueue<OUT> {
+public interface StreamElementQueue<OUT> extends AvailabilityProvider {
 
     /**
      * Tries to put the given element in the queue. This operation succeeds if the queue has

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/queue/UnorderedStreamElementQueue.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/queue/UnorderedStreamElementQueue.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Unordered implementation of the {@link StreamElementQueue}. The unordered stream element queue
@@ -63,6 +64,8 @@ public final class UnorderedStreamElementQueue<OUT> implements StreamElementQueu
 
     private int numberOfEntries;
 
+    private final AvailabilityHelper availabilityHelper = new AvailabilityHelper();
+
     public UnorderedStreamElementQueue(int capacity) {
         Preconditions.checkArgument(capacity > 0, "The capacity must be larger than 0.");
 
@@ -70,11 +73,12 @@ public final class UnorderedStreamElementQueue<OUT> implements StreamElementQueu
         // most likely scenario are 4 segments <elements, watermark, elements, watermark>
         this.segments = new ArrayDeque<>(4);
         this.numberOfEntries = 0;
+        this.availabilityHelper.resetAvailable();
     }
 
     @Override
     public Optional<ResultFuture<OUT>> tryPut(StreamElement streamElement) {
-        if (size() < capacity) {
+        if (!isFull()) {
             StreamElementQueueEntry<OUT> queueEntry;
             if (streamElement.isRecord()) {
                 queueEntry = addRecord((StreamRecord<?>) streamElement);
@@ -91,6 +95,10 @@ public final class UnorderedStreamElementQueue<OUT> implements StreamElementQueu
                             + "({}/{}).",
                     size(),
                     capacity);
+
+            if (isFull()) {
+                availabilityHelper.resetUnavailable();
+            }
 
             return Optional.of(queueEntry);
         } else {
@@ -155,6 +163,7 @@ public final class UnorderedStreamElementQueue<OUT> implements StreamElementQueu
         if (segments.isEmpty()) {
             return;
         }
+        boolean isFullBefore = isFull();
         final Segment currentSegment = segments.getFirst();
         numberOfEntries -= currentSegment.emitCompleted(output);
 
@@ -162,6 +171,9 @@ public final class UnorderedStreamElementQueue<OUT> implements StreamElementQueu
         // if empty
         if (segments.size() > 1 && currentSegment.isEmpty()) {
             segments.pop();
+        }
+        if (isFullBefore && !isFull()) {
+            availabilityHelper.getUnavailableToResetAvailable().complete(null);
         }
     }
 
@@ -182,6 +194,15 @@ public final class UnorderedStreamElementQueue<OUT> implements StreamElementQueu
     @Override
     public int size() {
         return numberOfEntries;
+    }
+
+    @Override
+    public CompletableFuture<?> getAvailableFuture() {
+        return availabilityHelper.getAvailableFuture();
+    }
+
+    private boolean isFull() {
+        return size() >= capacity;
     }
 
     /** An entry that notifies the respective segment upon completion. */

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
+import org.apache.flink.runtime.io.AvailabilityProvider;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
@@ -55,6 +56,7 @@ import org.apache.flink.streaming.runtime.tasks.OneInputStreamTask;
 import org.apache.flink.streaming.runtime.tasks.OneInputStreamTaskTestHarness;
 import org.apache.flink.streaming.runtime.tasks.StreamTaskMailboxTestHarness;
 import org.apache.flink.streaming.runtime.tasks.StreamTaskMailboxTestHarnessBuilder;
+import org.apache.flink.streaming.runtime.tasks.mailbox.Mail;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.TestHarnessUtil;
 import org.apache.flink.streaming.util.retryable.AsyncRetryStrategies;
@@ -483,6 +485,134 @@ public class AsyncWaitOperatorTest {
                     expectedOutput,
                     testHarness.getOutput(),
                     new StreamRecordComparator());
+        }
+    }
+
+    /**
+     * Tests that the OperatorChain availability provider exposed to {@link
+     * org.apache.flink.streaming.runtime.tasks.StreamTask} flips to unavailable when an {@link
+     * AsyncWaitOperator}'s queue is full, and recovers once a slot is freed by an emitted result.
+     * This is the integration that drives the chain-availability path in {@code
+     * StreamTask#processInput}.
+     */
+    @Test
+    void testStreamTaskChainAvailabilityFlipsWithAsyncQueueCapacity() throws Exception {
+        SharedReference<List<ResultFuture<?>>> resultFutures = sharedObjects.add(new ArrayList<>());
+
+        StreamTaskMailboxTestHarnessBuilder<Integer> builder =
+                new StreamTaskMailboxTestHarnessBuilder<>(
+                                OneInputStreamTask::new, BasicTypeInfo.INT_TYPE_INFO)
+                        .addInput(BasicTypeInfo.INT_TYPE_INFO);
+
+        try (StreamTaskMailboxTestHarness<Integer> harness =
+                builder.setupOutputForSingletonOperatorChain(
+                                new AsyncWaitOperatorFactory<>(
+                                        new CollectableFuturesAsyncFunction<>(resultFutures),
+                                        TIMEOUT,
+                                        2,
+                                        AsyncDataStream.OutputMode.ORDERED))
+                        .build()) {
+
+            AvailabilityProvider chainAvailability =
+                    harness.getOperatorChain().getChainAvailabilityProvider();
+            assertThat(chainAvailability)
+                    .as("Singleton AsyncWait chain must expose an availability provider")
+                    .isNotNull();
+            assertThat(chainAvailability.isAvailable())
+                    .as("Empty async queue starts available")
+                    .isTrue();
+
+            // Fill the capacity-2 queue. The async function never auto-completes.
+            harness.processElement(new StreamRecord<>(1, 0L));
+            harness.processElement(new StreamRecord<>(2, 1L));
+
+            assertThat(chainAvailability.isAvailable())
+                    .as(
+                            "After filling capacity, chain availability must drop to false so"
+                                    + " StreamTask#processInput enters the chain-availability"
+                                    + " branch")
+                    .isFalse();
+
+            // Complete one entry; the head emits and frees a slot, restoring availability.
+            completeWithSingle(resultFutures.get().get(0), 10);
+            harness.processAll();
+
+            assertThat(chainAvailability.isAvailable())
+                    .as("Freeing one slot must restore chain availability")
+                    .isTrue();
+
+            // Drain the rest to keep the harness clean.
+            completeWithSingle(resultFutures.get().get(1), 20);
+            harness.processAll();
+            assertThat(harness.getOutput())
+                    .containsExactly(new StreamRecord<>(10, 0L), new StreamRecord<>(20, 1L));
+        }
+    }
+
+    /**
+     * Tests that {@link AsyncWaitOperator} defers element emission while the configured downstream
+     * {@link AvailabilityProvider} is unavailable, and that completing the downstream's future
+     * schedules a deferred mail that finally drains the buffered element.
+     */
+    @Test
+    void testOutputCompletedElementDefersWhenDownstreamUnavailable() throws Exception {
+        final OneInputStreamOperatorTestHarness<Integer, Integer> testHarness =
+                createTestHarness(
+                        new ImmediateAsyncFunction(),
+                        TIMEOUT,
+                        2,
+                        AsyncDataStream.OutputMode.ORDERED);
+
+        testHarness.open();
+
+        final AsyncWaitOperator<Integer, Integer> operator =
+                (AsyncWaitOperator<Integer, Integer>) testHarness.getOneInputOperator();
+        final CompletableFuture<Void> downstreamFuture = new CompletableFuture<>();
+        operator.setDownstreamAvailabilityProvider(() -> downstreamFuture);
+
+        synchronized (testHarness.getCheckpointLock()) {
+            testHarness.processElement(new StreamRecord<>(7, 0L));
+        }
+
+        // ImmediateAsyncFunction completes synchronously; draining runs the resulting
+        // outputCompletedElement mail, which must observe the unavailable downstream
+        // and register a thenRun callback instead of emitting.
+        drainMailbox(testHarness);
+        assertThat(testHarness.getOutput())
+                .as("Element must not be emitted while downstream is unavailable")
+                .isEmpty();
+
+        // Signal downstream availability. The thenRun callback runs synchronously on
+        // this thread and enqueues a deferred outputCompletedElement mail.
+        downstreamFuture.complete(null);
+        drainMailbox(testHarness);
+        assertThat(testHarness.getOutput()).containsExactly(new StreamRecord<>(7, 0L));
+
+        synchronized (testHarness.getCheckpointLock()) {
+            testHarness.endInput();
+            testHarness.close();
+        }
+    }
+
+    private static void drainMailbox(OneInputStreamOperatorTestHarness<?, ?> testHarness)
+            throws Exception {
+        for (Mail mail : testHarness.getTaskMailbox().drain()) {
+            mail.run();
+        }
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static void completeWithSingle(ResultFuture<?> resultFuture, Object value) {
+        ((ResultFuture) resultFuture).complete(Collections.singletonList(value));
+    }
+
+    /** A synchronous {@link AsyncFunction} that completes the result on the calling thread. */
+    private static class ImmediateAsyncFunction implements AsyncFunction<Integer, Integer> {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public void asyncInvoke(Integer input, ResultFuture<Integer> resultFuture) {
+            resultFuture.complete(Collections.singletonList(input));
         }
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/queue/OrderedStreamElementQueueTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/queue/OrderedStreamElementQueueTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.streaming.api.operators.async.queue.QueueUtil.popCompleted;
 import static org.apache.flink.streaming.api.operators.async.queue.QueueUtil.putSuccessfully;
@@ -69,5 +70,55 @@ public class OrderedStreamElementQueueTest {
         assertThat(popCompleted(queue)).isEqualTo(expected);
         assertThat(queue.size()).isZero();
         assertThat(queue.isEmpty()).isTrue();
+    }
+
+    /**
+     * Tests that {@link OrderedStreamElementQueue#isAvailable()} flips to false once the queue is
+     * full and that {@link OrderedStreamElementQueue#getAvailableFuture()} returns an incomplete
+     * future in that state.
+     */
+    @Test
+    void testIsAvailableTogglesWithCapacity() {
+        final OrderedStreamElementQueue<Integer> queue = new OrderedStreamElementQueue<>(2);
+
+        assertThat(queue.isAvailable()).isTrue();
+        assertThat(queue.getAvailableFuture().isDone()).isTrue();
+
+        putSuccessfully(queue, new StreamRecord<>(1, 0L));
+        assertThat(queue.isAvailable())
+                .as("queue with one free slot remaining should still be available")
+                .isTrue();
+
+        putSuccessfully(queue, new StreamRecord<>(2, 1L));
+        assertThat(queue.isAvailable()).as("queue at capacity should be unavailable").isFalse();
+        assertThat(queue.getAvailableFuture().isDone()).isFalse();
+    }
+
+    /**
+     * Tests that the future returned by {@link OrderedStreamElementQueue#getAvailableFuture()}
+     * completes once a slot is freed by emitting a completed head element, and that the queue
+     * becomes available again.
+     */
+    @Test
+    void testGetAvailableFutureCompletesWhenSlotFreed() {
+        final OrderedStreamElementQueue<Integer> queue = new OrderedStreamElementQueue<>(2);
+
+        ResultFuture<Integer> entry1 = putSuccessfully(queue, new StreamRecord<>(1, 0L));
+        putSuccessfully(queue, new StreamRecord<>(2, 1L));
+
+        CompletableFuture<?> availableFuture = queue.getAvailableFuture();
+        assertThat(availableFuture.isDone()).isFalse();
+        assertThat(queue.isAvailable()).isFalse();
+
+        // Completing the head and emitting it frees one slot, which must complete the future
+        // captured while the queue was full.
+        entry1.complete(Collections.singleton(10));
+        assertThat(popCompleted(queue)).containsExactly(new StreamRecord<>(10, 0L));
+
+        assertThat(availableFuture.isDone())
+                .as("availability future should be completed when capacity is freed")
+                .isTrue();
+        assertThat(queue.isAvailable()).isTrue();
+        assertThat(queue.getAvailableFuture().isDone()).isTrue();
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/queue/UnorderedStreamElementQueueTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/queue/UnorderedStreamElementQueueTest.java
@@ -25,6 +25,8 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.streaming.api.operators.async.queue.QueueUtil.popCompleted;
 import static org.apache.flink.streaming.api.operators.async.queue.QueueUtil.putSuccessfully;
@@ -92,5 +94,55 @@ class UnorderedStreamElementQueueTest {
         assertThat(queue.size()).isZero();
         assertThat(queue.isEmpty()).isTrue();
         assertThat(popCompleted(queue)).isEmpty();
+    }
+
+    /**
+     * Tests that {@link UnorderedStreamElementQueue#isAvailable()} starts true, stays true while
+     * the queue has free capacity, and flips to false once it becomes full; the future returned by
+     * {@link UnorderedStreamElementQueue#getAvailableFuture()} mirrors this state.
+     */
+    @Test
+    void testIsAvailableTogglesWithCapacity() {
+        final UnorderedStreamElementQueue<Integer> queue = new UnorderedStreamElementQueue<>(2);
+
+        assertThat(queue.isAvailable()).isTrue();
+        assertThat(queue.getAvailableFuture().isDone()).isTrue();
+
+        putSuccessfully(queue, new StreamRecord<>(1, 0L));
+        assertThat(queue.isAvailable())
+                .as("queue with one free slot remaining should still be available")
+                .isTrue();
+
+        putSuccessfully(queue, new StreamRecord<>(2, 1L));
+        assertThat(queue.isAvailable()).as("queue at capacity should be unavailable").isFalse();
+        assertThat(queue.getAvailableFuture().isDone()).isFalse();
+    }
+
+    /**
+     * Tests that the future returned by {@link UnorderedStreamElementQueue#getAvailableFuture()}
+     * completes once a slot is freed by emitting a completed element from the head segment, and
+     * that the queue becomes available again.
+     */
+    @Test
+    void testGetAvailableFutureCompletesWhenSlotFreed() {
+        final UnorderedStreamElementQueue<Integer> queue = new UnorderedStreamElementQueue<>(2);
+
+        ResultFuture<Integer> entry1 = putSuccessfully(queue, new StreamRecord<>(1, 0L));
+        putSuccessfully(queue, new StreamRecord<>(2, 1L));
+
+        CompletableFuture<?> availableFuture = queue.getAvailableFuture();
+        assertThat(availableFuture.isDone()).isFalse();
+        assertThat(queue.isAvailable()).isFalse();
+
+        // Completing an entry in the head segment and emitting it frees one slot, which must
+        // complete the future captured while the queue was full.
+        entry1.complete(Collections.singleton(11));
+        assertThat(popCompleted(queue)).containsExactly(new StreamRecord<>(11, 0L));
+
+        assertThat(availableFuture.isDone())
+                .as("availability future should be completed when capacity is freed")
+                .isTrue();
+        assertThat(queue.isAvailable()).isTrue();
+        assertThat(queue.getAvailableFuture().isDone()).isTrue();
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarness.java
@@ -69,6 +69,10 @@ public class StreamTaskMailboxTestHarness<OUT> implements AutoCloseable {
         return streamTask;
     }
 
+    public OperatorChain<OUT, ?> getOperatorChain() {
+        return streamTask.operatorChain;
+    }
+
     public TimerService getTimerService() {
         return streamTask.getTimerService();
     }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

When AsyncWaitOperator processes input, if the async queue is full, it yields and waits for a callback to complete to free up a slot. During this time, unaligned checkpoints cannot be processed.

Soft backpressure is used to ensure UC can be processed in time. In the non-async path, `processInput` produces data written to the ResultPartition. If the RP is full, `processInput` can be blocked by soft backpressure so that mails can be executed.

The same idea applies to AsyncWaitOperator: on the async path, `processInput` produces requests written to the AsyncWaitOperator's queue — when the queue is full, `processInput` should be blocked. Similarly, results from AsyncWaitOperator produce data written to downstream (e.g., RP) — if downstream is full, AsyncWaitOperator's `emitResult` should also be blocked.


## Brief change log

  - Add `SupportsSoftBackpressure` interface extending AvailabilityProvider, allowing operators to declare soft-backpressure capability and receive a downstream AvailabilityProvider.
  - OperatorChain checks `instanceof SupportsSoftBackpressure` and wires downstream availability to the operator; StreamTask feeds it into the mailbox soft-backpressure path.
  - AsyncWaitOperator implements `SupportsSoftBackpressure`, checks downstream availability before emitting and re-yields if not available.


## Verifying this change

  - StreamOperatorChainingTest verifies chain availability provider wiring for both head and chained SupportsSoftBackpressure operators.
  - CompositeAvailabilityProviderTest covers the AND semantics.
  - AsyncWaitOperatorTest covers soft-backpressure pause/resume under simulated downstream unavailability.
  - Ordered/UnorderedStreamElementQueueTest cover the emit-side availability hook.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: yes
  - The S3 file system connector: no
 
## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable