### PR TITLE
[FLINK-39846][tests] Restore IPv6 guard and config in IPv6HostnamesITCase under AdaptiveScheduler

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/IPv6HostnamesITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/IPv6HostnamesITCase.java
@@ -38,7 +38,9 @@ import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.TestLoggerExtension;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
@@ -53,10 +55,15 @@ import java.net.ServerSocket;
 import java.util.Enumeration;
 import java.util.List;
 
-import static org.assertj.core.api.Assumptions.assumeThat;
-
 /** Test proper handling of IPv6 address literals in URLs. */
 @ExtendWith(TestLoggerExtension.class)
+// The job uses a GlobalWindow with an end-of-stream trigger, which results in a blocking
+// (non-pipelined) data exchange. The AdaptiveScheduler only supports pipelined data exchanges.
+@Tag("org.apache.flink.testutils.junit.FailsWithAdaptiveScheduler")
+// Skip the whole class when the host has no usable IPv6 address for the cluster to bind to.
+// Evaluating this condition triggers class initialization (and thus the address probing), but the
+// MiniCluster is only started afterwards in beforeAll, so a disabled class never starts one.
+@EnabledIf("hasBindableIpv6Address")
 class IPv6HostnamesITCase {
     private static final Logger LOG = LoggerFactory.getLogger(IPv6HostnamesITCase.class);
 
@@ -64,24 +71,26 @@ class IPv6HostnamesITCase {
     private static final MiniClusterExtension MINI_CLUSTER_RESOURCE =
             new MiniClusterExtension(
                     new MiniClusterResourceConfiguration.Builder()
+                            .setConfiguration(getConfiguration())
                             .setNumberTaskManagers(2)
                             .setNumberSlotsPerTaskManager(2)
                             .build());
 
-    private Configuration getConfiguration() {
-        final Inet6Address ipv6address = getLocalIPv6Address();
-        assumeThat(ipv6address)
-                .as(
-                        "--- Cannot find a non-loopback local IPv6 address that Pekko/Netty can bind to; skipping IPv6HostnamesITCase")
-                .isNotNull();
-        final String addressString = ipv6address.getHostAddress();
-        LOG.info("Test will use IPv6 address {} for connection tests", addressString);
-
+    private static Configuration getConfiguration() {
+        final Inet6Address ipv6Address = Ipv6AddressHolder.ADDRESS;
         Configuration config = new Configuration();
-        config.set(JobManagerOptions.ADDRESS, addressString);
-        config.set(TaskManagerOptions.HOST, addressString);
+        if (ipv6Address != null) {
+            final String addressString = ipv6Address.getHostAddress();
+            LOG.info("Test will use IPv6 address {} for connection tests", addressString);
+            config.set(JobManagerOptions.ADDRESS, addressString);
+            config.set(TaskManagerOptions.HOST, addressString);
+        }
         config.set(TaskManagerOptions.MANAGED_MEMORY_SIZE, MemorySize.parse("16m"));
         return config;
+    }
+
+    private static boolean hasBindableIpv6Address() {
+        return Ipv6AddressHolder.ADDRESS != null;
     }
 
     @Test
@@ -125,7 +134,14 @@ class IPv6HostnamesITCase {
         TestBaseUtils.compareResultAsText(result, WordCountData.COUNTS_AS_TUPLES);
     }
 
-    private Inet6Address getLocalIPv6Address() {
+    // Resolves a bindable non-loopback IPv6 address lazily and once. Holding it in a nested class
+    // lets getConfiguration() and the @EnabledIf guard share a single result without depending on
+    // the declaration order of the extension/config fields above.
+    private static final class Ipv6AddressHolder {
+        static final Inet6Address ADDRESS = getLocalIPv6Address();
+    }
+
+    private static Inet6Address getLocalIPv6Address() {
         try {
             Enumeration<NetworkInterface> e = NetworkInterface.getNetworkInterfaces();
             while (e.hasMoreElements()) {
@@ -174,6 +190,7 @@ class IPv6HostnamesITCase {
 
             return null;
         } catch (Exception e) {
+            LOG.debug("No bindable non-loopback IPv6 address available", e);
             return null;
         }
     }


### PR DESCRIPTION
## What is the purpose of the change

The JUnit5 migration (FLINK-39124, #27669) converted `IPv6HostnamesITCase` from a JUnit4 `@Rule MiniClusterWithClientResource(... .setConfiguration(getConfiguration()) ...)` to a static `@RegisterExtension MiniClusterExtension(...)` with a hardcoded configuration, dropping the call to `getConfiguration()`. That method (a) bound the cluster to a local IPv6 address and (b) skipped the test (via an IPv6 assumption) when no non-loopback IPv6 address is available.

After the migration `getConfiguration()` became dead code, so the test runs unconditionally and without IPv6 configuration, and fails under the AdaptiveScheduler because the job uses `GlobalWindows.createWithEndOfStreamTrigger()` -- a blocking (non-pipelined) data exchange the AdaptiveScheduler does not support. It has failed every nightly `test_cron_adaptive_scheduler` build on `master` since ~2026-04-15. `release-2.0`/`release-2.1` still call `getConfiguration()`, so they skip the test when IPv6 is unavailable and stay green.

This restores the IPv6 configuration and the skip behavior, and additionally tags the test so it is excluded from the adaptive profile even when an IPv6 address is available.

## Brief change log

  - Resolve the IPv6 address once in a nested holder class (so it does not depend on static field declaration order) and configure the `MiniClusterExtension` with it when present (restoring IPv6 binding).
  - Add a class-level `@EnabledIf("hasBindableIpv6Address")` condition so the class is skipped *before* the MiniCluster is started when no usable IPv6 address is available (this is evaluated before the extension's `beforeAll`, unlike an in-test `assumeThat`).
  - Tag the test with `@Tag("org.apache.flink.testutils.junit.FailsWithAdaptiveScheduler")`, since the blocking exchange is genuinely incompatible with the AdaptiveScheduler.

## Verifying this change

This change is already covered by the existing `IPv6HostnamesITCase.testClusterWithIPv6host`. It was verified locally:
  - Default scheduler on a host with a non-loopback IPv6 address: `Tests run: 1, Failures: 0, Errors: 0` (the test again exercises IPv6 binding); on a host without IPv6 the class is disabled by `@EnabledIf` (skipped).
  - `-Penable-adaptive-scheduler`: the test is excluded by the tag (`Tests run: 0`), so the adaptive nightly leg is green.
  - `checkstyle:check` and `spotless:check` pass.

Note on coverage: the IPv6 binding is exercised only under the default scheduler on an IPv6-capable host. Under the adaptive profile the test is excluded by design (the blocking exchange cannot run there); this exclusion is intentional and tracked in FLINK-39846, it should not be removed without also reworking the job to use a pipelined exchange.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no (test-only change)
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Code (Claude Opus 4.8))

Generated-by: Claude Code (Claude Opus 4.8)
