### PR TITLE
[hotfix][tests] Pin MinIO test image by digest

### DIFF
--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/util/DockerImageVersions.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/util/DockerImageVersions.java
@@ -36,7 +36,8 @@ public class DockerImageVersions {
 
     public static final String LOCALSTACK = "localstack/localstack:0.13.3";
 
-    public static final String MINIO = "minio/minio:RELEASE.2022-02-07T08-17-33Z";
+    public static final String MINIO =
+            "minio/minio:RELEASE.2022-02-07T08-17-33Z@sha256:3d219e086f89efdcae7534a067f750a5db755f2c9e3eb41264f49c24b50409ed";
 
     public static final String ZOOKEEPER = "zookeeper:3.4.14";
 


### PR DESCRIPTION
## What is the purpose of the change

`MinioTestContainerTest` fails deterministically on `release-1.20`'s Azure CI (the self-hosted `Default` agent pool), while passing on GitHub Actions and on `release-2.0`+. Root cause:

- Those self-hosted agents serve a stale MinIO image whose `Created` timestamp uses a `+08:00` offset with sub-millisecond precision (e.g. `2022-09-25T13:46:35.209299016+08:00`).
- The Jackson bundled in testcontainers cannot parse that shape under **JDK 8** (it parses fine under JDK 17, which is why `release-2.0`+ are green). GitHub Actions' ephemeral UTC runners pull the current clean (`Z`) image, so they pass even on JDK 8.

A plain tag bump does not help: the agents already have the tag cached, and testcontainers reuses the locally-present image. Pinning by **digest** forces a content-addressed fresh pull of the current clean image, bypassing the stale cached tag.

## Brief change log

- Pin `DockerImageVersions.MINIO` to `minio/minio:RELEASE.2022-02-07T08-17-33Z@sha256:3d219e086f89efdcae7534a067f750a5db755f2c9e3eb41264f49c24b50409ed` (same release, current clean digest; amd64 `Created` is `2022-02-07T09:39:22Z`).

## Verifying this change

Covered by the existing `flink-s3-fs-base` container tests (`MinioTestContainerTest` and others), which currently fail on `release-1.20`'s Azure CI.

## Does this pull request potentially affect one of the following parts:

No.

## Documentation

No.

Generated-by: Claude Code (Opus 4.8)