### PR TITLE
[FLINK-39858][rest] Fail orphaned in-flight request futures on RestClient close

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
@@ -139,11 +139,19 @@ public class RestClient implements AutoCloseableAsync {
 
     public static final String VERSION_PLACEHOLDER = "{{VERSION}}";
 
+    @VisibleForTesting
+    static final String CLOSED_BEFORE_REQUEST_COMPLETED_MESSAGE =
+            "RestClient closed before request completed";
+
     private final String urlPrefix;
 
-    // Used to track unresolved request futures in case they need to be resolved when the client is
-    // closed
     private final Collection<CompletableFuture<Channel>> responseChannelFutures =
+            ConcurrentHashMap.newKeySet();
+
+    // Unlike responseChannelFutures, which only covers the connect phase, this tracks the terminal
+    // response future for its whole lifetime so that close() can fail a request that is already
+    // in-flight (its response has not yet arrived).
+    private final Collection<CompletableFuture<?>> pendingRequestFutures =
             ConcurrentHashMap.newKeySet();
 
     private final List<OutboundChannelHandlerFactory> outboundChannelHandlerFactories;
@@ -317,6 +325,11 @@ public class RestClient implements AutoCloseableAsync {
     }
 
     @VisibleForTesting
+    Collection<CompletableFuture<?>> getPendingRequestFutures() {
+        return pendingRequestFutures;
+    }
+
+    @VisibleForTesting
     List<OutboundChannelHandlerFactory> getOutboundChannelHandlerFactories() {
         return outboundChannelHandlerFactories;
     }
@@ -369,8 +382,14 @@ public class RestClient implements AutoCloseableAsync {
                 future ->
                         future.completeExceptionally(
                                 new IllegalStateException(
-                                        "RestClient closed before request completed")));
+                                        CLOSED_BEFORE_REQUEST_COMPLETED_MESSAGE)));
         responseChannelFutures.clear();
+        pendingRequestFutures.forEach(
+                future ->
+                        future.completeExceptionally(
+                                new IllegalStateException(
+                                        CLOSED_BEFORE_REQUEST_COMPLETED_MESSAGE)));
+        pendingRequestFutures.clear();
     }
 
     public <
@@ -618,40 +637,59 @@ public class RestClient implements AutoCloseableAsync {
                     }
                 });
 
-        return channelFuture
-                .thenComposeAsync(
-                        channel -> {
-                            ClientHandler handler = channel.pipeline().get(ClientHandler.class);
+        final CompletableFuture<P> responseFuture =
+                channelFuture
+                        .thenComposeAsync(
+                                channel -> {
+                                    ClientHandler handler =
+                                            channel.pipeline().get(ClientHandler.class);
 
-                            CompletableFuture<JsonResponse> future;
-                            boolean success = false;
+                                    CompletableFuture<JsonResponse> future;
+                                    boolean success = false;
 
-                            try {
-                                if (handler == null) {
-                                    throw new IOException(
-                                            "Netty pipeline was not properly initialized.");
-                                } else {
-                                    httpRequest.writeTo(channel);
-                                    future = handler.getJsonFuture();
-                                    success = true;
-                                }
-                            } catch (IOException e) {
-                                future =
-                                        FutureUtils.completedExceptionally(
-                                                new ConnectionException(
-                                                        "Could not write request.", e));
-                            } finally {
-                                if (!success) {
-                                    channel.close();
-                                }
-                            }
+                                    try {
+                                        if (handler == null) {
+                                            throw new IOException(
+                                                    "Netty pipeline was not properly initialized.");
+                                        } else {
+                                            httpRequest.writeTo(channel);
+                                            future = handler.getJsonFuture();
+                                            success = true;
+                                        }
+                                    } catch (IOException e) {
+                                        future =
+                                                FutureUtils.completedExceptionally(
+                                                        new ConnectionException(
+                                                                "Could not write request.", e));
+                                    } finally {
+                                        if (!success) {
+                                            channel.close();
+                                        }
+                                    }
 
-                            return future;
-                        },
-                        executor)
-                .thenComposeAsync(
-                        (JsonResponse rawResponse) -> parseResponse(rawResponse, responseType),
-                        executor);
+                                    return future;
+                                },
+                                executor)
+                        .thenComposeAsync(
+                                (JsonResponse rawResponse) ->
+                                        parseResponse(rawResponse, responseType),
+                                executor);
+
+        // Register for the whole request lifetime; deregister on completion to avoid leaking.
+        pendingRequestFutures.add(responseFuture);
+        responseFuture.whenComplete(
+                (ignored, throwable) -> pendingRequestFutures.remove(responseFuture));
+
+        // Re-check after registering to cover a close() that ran between the isRunning check at the
+        // top of this method and the registration above (such a close could not have seen this
+        // future). Only fail it if still registered, so we do not double-complete; completion is
+        // idempotent regardless.
+        if (!isRunning.get() && pendingRequestFutures.remove(responseFuture)) {
+            responseFuture.completeExceptionally(
+                    new IllegalStateException(CLOSED_BEFORE_REQUEST_COMPLETED_MESSAGE));
+        }
+
+        return responseFuture;
     }
 
     private static <P extends ResponseBody> CompletableFuture<P> parseResponse(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestClientTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.rest;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.core.testutils.FlinkAssertions;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
@@ -357,6 +358,82 @@ class RestClientTest {
                     .withCauseInstanceOf(IllegalStateException.class)
                     .extracting(Throwable::getCause, as(THROWABLE))
                     .hasMessage("executor not accepting a task");
+        }
+    }
+
+    /**
+     * Verifies that {@code close()} fails a request that is already in-flight (past the connect
+     * phase, so no longer tracked by {@code responseChannelFutures}). The request is driven against
+     * a local server that accepts the connection but never replies. Both expectations use bounded
+     * waits so a regression fails rather than hangs: the behavioral guard asserts {@code close()}
+     * fails the terminal future ({@code failsWithin}), and a secondary guard asserts the in-flight
+     * tracking invariant {@code pendingRequestFutures.size() == 1}.
+     */
+    @Test
+    void testCloseFailsInFlightRequestFutureAfterConnectPhase() throws Exception {
+        final Configuration config = new Configuration();
+
+        Socket connectionSocket = null;
+        try (final ServerSocket serverSocket = new ServerSocket(0);
+                final RestClient restClient =
+                        new RestClient(config, EXECUTOR_EXTENSION.getExecutor())) {
+
+            final String targetAddress = "localhost";
+            final int targetPort = serverSocket.getLocalPort();
+
+            // A server that accepts the connection but never sends a response, so the request stays
+            // in its in-flight (response) phase until the client is closed.
+            final CompletableFuture<Socket> acceptedSocket =
+                    CompletableFuture.supplyAsync(
+                            CheckedSupplier.unchecked(
+                                    () -> NetUtils.acceptWithoutTimeout(serverSocket)));
+
+            assertThat(restClient.getResponseChannelFutures()).isEmpty();
+            assertThat(restClient.getPendingRequestFutures()).isEmpty();
+
+            final CompletableFuture<EmptyResponseBody> responseFuture =
+                    restClient.sendRequest(
+                            targetAddress,
+                            targetPort,
+                            new TestMessageHeaders(),
+                            EmptyMessageParameters.getInstance(),
+                            EmptyRequestBody.getInstance(),
+                            Collections.emptyList());
+
+            // Once the server accepts, the connect listener has run and removed the connect-phase
+            // future from responseChannelFutures: the request is now in-flight.
+            connectionSocket = acceptedSocket.get(TIMEOUT, TimeUnit.SECONDS);
+
+            CommonTestUtils.waitUtil(
+                    () -> restClient.getResponseChannelFutures().isEmpty(),
+                    Duration.ofSeconds(TIMEOUT),
+                    "responseChannelFutures was not drained after the connect phase completed");
+
+            // Without the fix the in-flight future is tracked by nothing, so this bounded wait
+            // elapses and the assertion fails (it does not hang).
+            CommonTestUtils.waitUtil(
+                    () -> restClient.getPendingRequestFutures().size() == 1,
+                    Duration.ofSeconds(TIMEOUT),
+                    "Terminal response future must remain tracked by pendingRequestFutures while "
+                            + "the request is in-flight so that close can fail it");
+
+            restClient.close();
+
+            // The terminal future must be failed by close (bounded await, never hangs).
+            assertThat(responseFuture)
+                    .as("Closing the client must fail the in-flight request future")
+                    .failsWithin(Duration.ofSeconds(TIMEOUT))
+                    .withThrowableOfType(ExecutionException.class);
+
+            // After close, the tracking collection must be drained.
+            CommonTestUtils.waitUtil(
+                    () -> restClient.getPendingRequestFutures().isEmpty(),
+                    Duration.ofSeconds(TIMEOUT),
+                    "pendingRequestFutures was not drained after close");
+        } finally {
+            if (connectionSocket != null) {
+                connectionSocket.close();
+            }
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestClientTest.java
@@ -59,8 +59,11 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -362,12 +365,111 @@ class RestClientTest {
     }
 
     /**
-     * Verifies that {@code close()} fails a request that is already in-flight (past the connect
-     * phase, so no longer tracked by {@code responseChannelFutures}). The request is driven against
-     * a local server that accepts the connection but never replies. Both expectations use bounded
-     * waits so a regression fails rather than hangs: the behavioral guard asserts {@code close()}
-     * fails the terminal future ({@code failsWithin}), and a secondary guard asserts the in-flight
-     * tracking invariant {@code pendingRequestFutures.size() == 1}.
+     * Verifies that {@code close()} fails a request that is in-flight past the connect phase, and
+     * that it does so specifically through the {@code pendingRequestFutures} mechanism rather than
+     * through {@code ClientHandler#channelInactive}.
+     *
+     * <p>The terminal response future is only wired to the {@code ClientHandler}'s {@code
+     * jsonFuture} once the first response-composition stage runs on the client's executor. This
+     * test installs a <em>deferring</em> executor that captures those stages without ever running
+     * them, so:
+     *
+     * <ul>
+     *   <li>the connect phase still completes (the connect listener runs on the Netty event loop
+     *       and drains {@code responseChannelFutures}), leaving the request in-flight; but
+     *   <li>the {@code channelInactive} completion of {@code jsonFuture} triggered by {@code
+     *       close()} can never reach the terminal future, because the stage that would subscribe to
+     *       {@code jsonFuture} never runs.
+     * </ul>
+     *
+     * <p>The only mechanism left that can complete the terminal future is {@code
+     * pendingRequestFutures}. The test therefore asserts the <em>identity</em> of the failure
+     * ({@link IllegalStateException} with {@code CLOSED_BEFORE_REQUEST_COMPLETED_MESSAGE}), not
+     * merely that the future failed: a {@code ConnectionClosedException} here would indicate the
+     * {@code channelInactive} path completed it instead. Without the {@code pendingRequestFutures}
+     * tracking the terminal future would never complete and {@code failsWithin} would elapse.
+     */
+    @Test
+    void testCloseFailsInFlightRequestFutureViaPendingRequestFutures() throws Exception {
+        final Configuration config = new Configuration();
+
+        // Captures the response-composition stages without ever executing them, so the terminal
+        // future is never subscribed to the handler's jsonFuture.
+        final Queue<Runnable> deferredStages = new ConcurrentLinkedQueue<>();
+        final Executor deferringExecutor = deferredStages::add;
+
+        Socket connectionSocket = null;
+        try (final ServerSocket serverSocket = new ServerSocket(0);
+                final RestClient restClient = new RestClient(config, deferringExecutor)) {
+
+            final String targetAddress = "localhost";
+            final int targetPort = serverSocket.getLocalPort();
+
+            // A server that accepts the connection but never sends a response, so the request stays
+            // in its in-flight (response) phase until the client is closed.
+            final CompletableFuture<Socket> acceptedSocket =
+                    CompletableFuture.supplyAsync(
+                            CheckedSupplier.unchecked(
+                                    () -> NetUtils.acceptWithoutTimeout(serverSocket)));
+
+            assertThat(restClient.getResponseChannelFutures()).isEmpty();
+            assertThat(restClient.getPendingRequestFutures()).isEmpty();
+
+            final CompletableFuture<EmptyResponseBody> responseFuture =
+                    restClient.sendRequest(
+                            targetAddress,
+                            targetPort,
+                            new TestMessageHeaders(),
+                            EmptyMessageParameters.getInstance(),
+                            EmptyRequestBody.getInstance(),
+                            Collections.emptyList());
+
+            // Once the server accepts, the connect listener has run and removed the connect-phase
+            // future from responseChannelFutures: the request is now in-flight. The first
+            // composition stage has been submitted to the deferring executor (captured, not run).
+            connectionSocket = acceptedSocket.get(TIMEOUT, TimeUnit.SECONDS);
+
+            CommonTestUtils.waitUtil(
+                    () -> restClient.getResponseChannelFutures().isEmpty(),
+                    Duration.ofSeconds(TIMEOUT),
+                    "responseChannelFutures was not drained after the connect phase completed");
+
+            restClient.close();
+
+            // The terminal future can only have been completed by the pendingRequestFutures path:
+            // its composition stages never ran, so the channelInactive completion of jsonFuture
+            // could not reach it. Asserting the failure identity proves the change is exercised.
+            assertThat(responseFuture)
+                    .as("close() must fail the in-flight future via pendingRequestFutures")
+                    .failsWithin(Duration.ofSeconds(TIMEOUT))
+                    .withThrowableOfType(ExecutionException.class)
+                    .withCauseInstanceOf(IllegalStateException.class)
+                    .withMessageContaining(RestClient.CLOSED_BEFORE_REQUEST_COMPLETED_MESSAGE);
+
+            // After close, the tracking collection must be drained.
+            CommonTestUtils.waitUtil(
+                    () -> restClient.getPendingRequestFutures().isEmpty(),
+                    Duration.ofSeconds(TIMEOUT),
+                    "pendingRequestFutures was not drained after close");
+
+            // Sanity check: exactly the first composition stage was deferred (never executed),
+            // which is what isolates the pendingRequestFutures path from channelInactive. The
+            // second stage cannot be submitted until the first runs, which it never does.
+            assertThat(deferredStages).hasSize(1);
+        } finally {
+            if (connectionSocket != null) {
+                connectionSocket.close();
+            }
+        }
+    }
+
+    /**
+     * End-to-end companion to {@link #testCloseFailsInFlightRequestFutureViaPendingRequestFutures}:
+     * with the real executor running the response-composition stages, verifies that {@code close()}
+     * fails an in-flight request future. This exercises the normal production path (including the
+     * handler's {@code channelInactive} completion) rather than isolating a single mechanism. The
+     * request is driven against a local server that accepts the connection but never replies; all
+     * waits are bounded so a regression fails rather than hangs.
      */
     @Test
     void testCloseFailsInFlightRequestFutureAfterConnectPhase() throws Exception {


### PR DESCRIPTION
## What is the purpose of the change

`RestClient.close()` could leave a request that had already passed the connect phase with its terminal response future uncompleted, hanging the caller indefinitely. In-flight requests are tracked only via `responseChannelFutures`, which holds the connect-phase `CompletableFuture<Channel>`; the connect listener removes that entry the moment the TCP connection is established, before the request enters its in-flight (response) phase. A `close()` racing with such a request runs `notifyResponseFuturesOfShutdown()` over only `responseChannelFutures`, so the terminal future is never failed (the channel's `channelInactive` callback may not be dispatched once the event-loop group is torn down). This surfaced as a watchdog-killed surefire JVM on master for `RestClientTest.testRestClientClosedHandling` (see FLINK-39858). FLINK-39180 previously treated the same symptom as a benign assertion-type mismatch, which held only for the connect phase.

## Brief change log

  - Track each request's terminal response future for its whole lifetime in a new `pendingRequestFutures` set, deregistered on natural completion.
  - `notifyResponseFuturesOfShutdown()` now also fails the entries in `pendingRequestFutures`, so `close()` fails in-flight requests in any phase.
  - Re-check `isRunning` after registration (failing only a future still atomically registered) to close the check-then-act race with a concurrent `close()`.

## Verifying this change

This change added tests and can be verified as follows:

  - Added `RestClientTest.testCloseFailsInFlightRequestFutureAfterConnectPhase`, which drives a request past the connect phase against a local server that accepts but never replies, then asserts `close()` fails the in-flight future (behavioral guard) and the in-flight tracking invariant, both with bounded waits so a regression fails rather than hangs. Verified it fails without the production change and passes with it.
  - Covered by existing `RestClientTest` (`testRestClientClosedHandling`, `testCloseClientWhileProcessingRequest`, `testResponseChannelFuturesResolvedExceptionallyOnClose`); full `RestClientTest` is green.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: `RestClient` shutdown now reliably fails in-flight requests instead of potentially leaking them; no recovery semantics change
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Code (Claude Opus 4.8))

Generated-by: Claude Code (Claude Opus 4.8)
